### PR TITLE
LPS-81411 FIX Classic Search Portlet crashing on results (follow up of Smart Facet Selections with Solr)

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexSearcher.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexSearcher.java
@@ -266,6 +266,8 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 				continue;
 			}
 
+			addFilterQuery(queryBuilders, facet, searchContext);
+
 			Optional<AggregationBuilder> optional = facetProcessor.processFacet(
 				facet);
 
@@ -275,8 +277,6 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 			).ifPresent(
 				searchRequestBuilder::addAggregation
 			);
-
-			addFilterQuery(queryBuilders, facet, searchContext);
 		}
 	}
 

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/facet/ClassicModifiedFacetTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/facet/ClassicModifiedFacetTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.facet;
+
+import com.liferay.portal.search.elasticsearch6.internal.ElasticsearchIndexingFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.LiferayIndexCreator;
+import com.liferay.portal.search.test.util.facet.BaseClassicModifiedFacetTestCase;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+
+/**
+ * @author André de Oliveira
+ */
+public class ClassicModifiedFacetTest extends BaseClassicModifiedFacetTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		ElasticsearchFixture elasticsearchFixture = new ElasticsearchFixture(
+			getClass());
+
+		ElasticsearchIndexingFixture elasticsearchIndexingFixture =
+			new ElasticsearchIndexingFixture(
+				elasticsearchFixture, BaseIndexingTestCase.COMPANY_ID,
+				new LiferayIndexCreator(elasticsearchFixture));
+
+		elasticsearchIndexingFixture.setFacetProcessor(
+			new ModifiedFacetProcessor());
+
+		return elasticsearchIndexingFixture;
+	}
+
+}

--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java
@@ -256,17 +256,17 @@ public class SolrIndexSearcher extends BaseIndexSearcher {
 				continue;
 			}
 
-			Map<String, JSONObject> facetParameters = getFacetParameters(facet);
-
 			String tag = FacetUtil.getAggregationName(facet);
+
+			addFilterQuery(postFilterQueries, facet, tag, searchContext);
+
+			Map<String, JSONObject> facetParameters = getFacetParameters(facet);
 
 			excludeTags(
 				facetParameters,
 				getExcludeTagsString(tag, facetProcessorContext));
 
 			jsonObjects.putAll(facetParameters);
-
-			addFilterQuery(postFilterQueries, facet, tag, searchContext);
 		}
 
 		if (!jsonObjects.isEmpty()) {

--- a/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/facet/ClassicModifiedFacetTest.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/facet/ClassicModifiedFacetTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.solr.internal.facet;
+
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.search.solr.internal.SolrIndexingFixture;
+import com.liferay.portal.search.test.util.facet.BaseClassicModifiedFacetTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+
+/**
+ * @author André de Oliveira
+ */
+public class ClassicModifiedFacetTest extends BaseClassicModifiedFacetTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() {
+		SolrIndexingFixture solrIndexingFixture = new SolrIndexingFixture();
+
+		solrIndexingFixture.setFacetProcessor(
+			new ModifiedFacetProcessor() {
+				{
+					jsonFactory = new JSONFactoryImpl();
+				}
+			});
+
+		return solrIndexingFixture;
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/facet/BaseAggregationFilteringTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/facet/BaseAggregationFilteringTestCase.java
@@ -38,7 +38,6 @@ import com.liferay.portal.search.internal.filter.FilterBuildersImpl;
 import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
-import com.liferay.portal.util.DateFormatFactoryImpl;
 
 import java.io.Serializable;
 
@@ -318,7 +317,6 @@ public abstract class BaseAggregationFilteringTestCase
 	protected ModifiedFacetFactoryImpl createModifiedFacetFactory() {
 		return new ModifiedFacetFactoryImpl() {
 			{
-				dateFormatFactory = new DateFormatFactoryImpl();
 				filterBuilders = new FilterBuildersImpl();
 			}
 		};

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/facet/BaseClassicModifiedFacetTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/facet/BaseClassicModifiedFacetTestCase.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.facet;
+
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.search.facet.ModifiedFacet;
+import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
+import com.liferay.portal.kernel.search.facet.collector.TermCollector;
+import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.util.DateFormatFactoryImpl;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author André de Oliveira
+ */
+public abstract class BaseClassicModifiedFacetTestCase
+	extends BaseFacetTestCase {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		setUpDateFormatFactoryUtil();
+	}
+
+	@Test
+	public void testBuiltInNamedRanges() throws Exception {
+		addDocument("17760704000000");
+		addDocument("27760704000000");
+
+		String[] configRanges = {
+			"[past-hour TO *]", "[past-24-hours TO *]", "[past-week TO *]",
+			"[past-month TO *]", "[past-year TO *]"
+		};
+
+		assertSearch(
+			helper -> {
+				Facet facet = helper.addFacet(this::createFacet);
+
+				setConfigurationRanges(facet, configRanges);
+
+				helper.search();
+
+				FacetCollector facetCollector = facet.getFacetCollector();
+
+				List<TermCollector> termCollectors =
+					facetCollector.getTermCollectors();
+
+				Assert.assertNotNull(termCollectors);
+
+				Assert.assertEquals(
+					termCollectors.toString(), configRanges.length,
+					termCollectors.size());
+
+				for (TermCollector termCollector : termCollectors) {
+					String term = termCollector.getTerm();
+
+					Assert.assertTrue(term.contains("00 TO 20"));
+				}
+			});
+	}
+
+	protected Facet createFacet(SearchContext searchContext) {
+		Facet facet = new ModifiedFacet(searchContext);
+
+		FacetConfiguration facetConfiguration = facet.getFacetConfiguration();
+
+		facetConfiguration.setDataJSONObject(jsonFactory.createJSONObject());
+
+		return facet;
+	}
+
+	protected JSONArray createRangeArray(String... ranges) {
+		JSONArray jsonArray = jsonFactory.createJSONArray();
+
+		for (String range : ranges) {
+			jsonArray.put(createRangeArrayElement(range));
+		}
+
+		return jsonArray;
+	}
+
+	protected JSONObject createRangeArrayElement(String range) {
+		JSONObject jsonObject = jsonFactory.createJSONObject();
+
+		jsonObject.put("range", range);
+
+		return jsonObject;
+	}
+
+	@Override
+	protected String getField() {
+		return Field.MODIFIED_DATE;
+	}
+
+	protected void setConfigurationRanges(Facet facet, String... ranges) {
+		FacetConfiguration facetConfiguration = facet.getFacetConfiguration();
+
+		JSONObject jsonObject = facetConfiguration.getData();
+
+		jsonObject.put("ranges", createRangeArray(ranges));
+	}
+
+	protected void setUpDateFormatFactoryUtil() {
+		DateFormatFactoryUtil dateFormatFactoryUtil =
+			new DateFormatFactoryUtil();
+
+		dateFormatFactoryUtil.setDateFormatFactory(new DateFormatFactoryImpl());
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/facet/BaseModifiedFacetTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/facet/BaseModifiedFacetTestCase.java
@@ -28,7 +28,6 @@ import com.liferay.portal.search.internal.facet.modified.ModifiedFacetFactoryImp
 import com.liferay.portal.search.internal.filter.FilterBuildersImpl;
 import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
-import com.liferay.portal.util.DateFormatFactoryImpl;
 
 import java.util.Arrays;
 import java.util.List;
@@ -109,7 +108,6 @@ public abstract class BaseModifiedFacetTestCase extends BaseFacetTestCase {
 		ModifiedFacetFactory modifiedFacetFactory =
 			new ModifiedFacetFactoryImpl() {
 				{
-					dateFormatFactory = new DateFormatFactoryImpl();
 					filterBuilders = new FilterBuildersImpl();
 				}
 			};

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/builder/DateRangeFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/builder/DateRangeFactory.java
@@ -15,6 +15,9 @@
 package com.liferay.portal.search.web.internal.modified.facet.builder;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.DateFormatFactory;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -58,6 +61,28 @@ public class DateRangeFactory {
 		}
 
 		return map;
+	}
+
+	public JSONArray replaceAliases(
+		JSONArray rangesJSONArray, Calendar calendar, JSONFactory jsonFactory) {
+
+		JSONArray normalizedRangesJSONArray = jsonFactory.createJSONArray();
+
+		for (int i = 0; i < rangesJSONArray.length(); i++) {
+			JSONObject rangeJSONObject = rangesJSONArray.getJSONObject(i);
+
+			JSONObject normalizedJSONObject = jsonFactory.createJSONObject();
+
+			normalizedJSONObject.put(
+				"label", rangeJSONObject.getString("label"));
+			normalizedJSONObject.put(
+				"range",
+				replaceAliases(rangeJSONObject.getString("range"), calendar));
+
+			normalizedRangesJSONArray.put(normalizedJSONObject);
+		}
+
+		return normalizedRangesJSONArray;
 	}
 
 	public String replaceAliases(String rangeString, Calendar calendar) {

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/builder/ModifiedFacetBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/builder/ModifiedFacetBuilder.java
@@ -15,7 +15,7 @@
 package com.liferay.portal.search.web.internal.modified.facet.builder;
 
 import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
@@ -37,10 +37,12 @@ public class ModifiedFacetBuilder {
 
 	public ModifiedFacetBuilder(
 		ModifiedFacetFactory modifiedFacetFactory,
-		CalendarFactory calendarFactory, DateFormatFactory dateFormatFactory) {
+		CalendarFactory calendarFactory, DateFormatFactory dateFormatFactory,
+		JSONFactory jsonFactory) {
 
 		_modifiedFacetFactory = modifiedFacetFactory;
 		_calendarFactory = calendarFactory;
+		_jsonFactory = jsonFactory;
 
 		_dateRangeFactory = new DateRangeFactory(dateFormatFactory);
 	}
@@ -82,6 +84,8 @@ public class ModifiedFacetBuilder {
 	protected FacetConfiguration buildFacetConfiguration(Facet facet) {
 		FacetConfiguration facetConfiguration = new FacetConfiguration();
 
+		facetConfiguration.setDataJSONObject(_jsonFactory.createJSONObject());
+
 		facetConfiguration.setFieldName(facet.getFieldName());
 		facetConfiguration.setLabel("any-time");
 		facetConfiguration.setOrder("OrderHitsDesc");
@@ -98,13 +102,13 @@ public class ModifiedFacetBuilder {
 	}
 
 	protected JSONArray getDefaultRangesJSONArray(Calendar calendar) {
-		JSONArray rangesJSONArray = JSONFactoryUtil.createJSONArray();
+		JSONArray rangesJSONArray = _jsonFactory.createJSONArray();
 
 		Map<String, String> map = _dateRangeFactory.getRangeStrings(calendar);
 
 		map.forEach(
 			(key, value) -> {
-				JSONObject range = JSONFactoryUtil.createJSONObject();
+				JSONObject range = _jsonFactory.createJSONObject();
 
 				range.put("label", key);
 				range.put("range", value);
@@ -166,6 +170,7 @@ public class ModifiedFacetBuilder {
 	private String _customRangeFrom;
 	private String _customRangeTo;
 	private final DateRangeFactory _dateRangeFactory;
+	private final JSONFactory _jsonFactory;
 	private final ModifiedFacetFactory _modifiedFacetFactory;
 	private JSONArray _rangesJSONArray;
 	private SearchContext _searchContext;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/portlet/shared/search/ModifiedFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/portlet/shared/search/ModifiedFacetPortletSharedSearchContributor.java
@@ -17,7 +17,6 @@ package com.liferay.portal.search.web.internal.modified.facet.portlet.shared.sea
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
-import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
@@ -32,8 +31,6 @@ import com.liferay.portal.search.web.internal.modified.facet.portlet.ModifiedFac
 import com.liferay.portal.search.web.internal.util.SearchOptionalUtil;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
-
-import java.util.Calendar;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -69,10 +66,12 @@ public class ModifiedFacetPortletSharedSearchContributor
 		PortletSharedSearchSettings portletSharedSearchSettings) {
 
 		ModifiedFacetBuilder modifiedFacetBuilder = new ModifiedFacetBuilder(
-			modifiedFacetFactory, getCalendarFactory(), getDateFormatFactory());
+			modifiedFacetFactory, getCalendarFactory(), getDateFormatFactory(),
+			getJSONFactory());
 
 		modifiedFacetBuilder.setRangesJSONArray(
-			getRangesJSONArray(modifiedFacetPortletPreferences));
+			replaceAliases(
+				modifiedFacetPortletPreferences.getRangesJSONArray()));
 
 		modifiedFacetBuilder.setSearchContext(
 			portletSharedSearchSettings.getSearchContext());
@@ -138,38 +137,13 @@ public class ModifiedFacetPortletSharedSearchContributor
 		return JSONFactoryUtil.getJSONFactory();
 	}
 
-	protected JSONArray getRangesJSONArray(
-		ModifiedFacetPortletPreferences modifiedFacetPortletPreferences) {
-
+	protected JSONArray replaceAliases(JSONArray rangesJSONArray) {
 		DateRangeFactory dateRangeFactory = getDateRangeFactory();
-
-		JSONArray rangesJSONArray =
-			modifiedFacetPortletPreferences.getRangesJSONArray();
-
-		JSONFactory jsonFactory = getJSONFactory();
-
-		JSONArray normalizedRangesJSONArray = jsonFactory.createJSONArray();
 
 		CalendarFactory calendarFactory = getCalendarFactory();
 
-		Calendar calendar = calendarFactory.getCalendar();
-
-		for (int i = 0; i < rangesJSONArray.length(); i++) {
-			JSONObject rangeJSONObject = rangesJSONArray.getJSONObject(i);
-			JSONObject normalizedJSONObject = jsonFactory.createJSONObject();
-
-			normalizedJSONObject.put(
-				"label", rangeJSONObject.getString("label"));
-
-			String range = dateRangeFactory.replaceAliases(
-				rangeJSONObject.getString("range"), calendar);
-
-			normalizedJSONObject.put("range", range);
-
-			normalizedRangesJSONArray.put(normalizedJSONObject);
-		}
-
-		return normalizedRangesJSONArray;
+		return dateRangeFactory.replaceAliases(
+			rangesJSONArray, calendarFactory.getCalendar(), getJSONFactory());
 	}
 
 	protected CalendarFactory calendarFactory;

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/modified/facet/builder/ModifiedFacetBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/modified/facet/builder/ModifiedFacetBuilderTest.java
@@ -16,9 +16,8 @@ package com.liferay.portal.search.web.internal.modified.facet.builder;
 
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
 import com.liferay.portal.kernel.search.facet.util.RangeParserUtil;
@@ -28,7 +27,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.facet.Facet;
 import com.liferay.portal.search.facet.modified.ModifiedFacetFactory;
 import com.liferay.portal.search.filter.FilterBuilders;
-import com.liferay.portal.search.internal.facet.ModifiedFacetImpl;
+import com.liferay.portal.search.internal.facet.modified.ModifiedFacetFactoryImpl;
 import com.liferay.portal.search.internal.filter.FilterBuildersImpl;
 import com.liferay.portal.util.DateFormatFactoryImpl;
 
@@ -54,8 +53,6 @@ public class ModifiedFacetBuilderTest {
 		dateFormatFactory = new DateFormatFactoryImpl();
 		filterBuilders = new FilterBuildersImpl();
 		jsonFactory = new JSONFactoryImpl();
-
-		setUpJSONFactoryUtil();
 	}
 
 	@Test
@@ -185,7 +182,8 @@ public class ModifiedFacetBuilderTest {
 			searchContext);
 
 		ModifiedFacetBuilder modifiedFacetBuilder = new ModifiedFacetBuilder(
-			modifiedFacetFactory, calendarFactory, dateFormatFactory);
+			modifiedFacetFactory, calendarFactory, dateFormatFactory,
+			jsonFactory);
 
 		modifiedFacetBuilder.setSearchContext(searchContext);
 
@@ -195,20 +193,13 @@ public class ModifiedFacetBuilderTest {
 	protected ModifiedFacetFactory createModifiedFacetFactory(
 		SearchContext searchContext) {
 
-		ModifiedFacetFactory modifiedFacetFactory = Mockito.mock(
-			ModifiedFacetFactory.class);
+		FilterBuilders filterBuilders1 = filterBuilders;
 
-		Mockito.doReturn(
-			new ModifiedFacetImpl(
-				Field.MODIFIED_DATE, searchContext, filterBuilders,
-				dateFormatFactory)
-		).when(
-			modifiedFacetFactory
-		).newInstance(
-			Mockito.anyObject()
-		);
-
-		return modifiedFacetFactory;
+		return new ModifiedFacetFactoryImpl() {
+			{
+				filterBuilders = filterBuilders1;
+			}
+		};
 	}
 
 	protected JSONArray createRangesJSONArray(String... labelsAndRanges) {
@@ -232,15 +223,9 @@ public class ModifiedFacetBuilderTest {
 		return Arrays.asList(dateStrings);
 	}
 
-	protected void setUpJSONFactoryUtil() {
-		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
-
-		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
-	}
-
 	protected CalendarFactory calendarFactory;
 	protected DateFormatFactory dateFormatFactory;
 	protected FilterBuilders filterBuilders;
-	protected JSONFactoryImpl jsonFactory;
+	protected JSONFactory jsonFactory;
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/facet/ModifiedFacetImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/facet/ModifiedFacetImpl.java
@@ -15,27 +15,18 @@
 package com.liferay.portal.search.internal.facet;
 
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.RangeFacet;
-import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
 import com.liferay.portal.kernel.search.facet.util.RangeParserUtil;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.generic.BooleanClauseImpl;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.DateFormatFactory;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.facet.Facet;
 import com.liferay.portal.search.filter.DateRangeFilterBuilder;
 import com.liferay.portal.search.filter.FilterBuilders;
-
-import java.text.DateFormat;
-
-import java.util.Calendar;
 
 /**
  * @author Bryan Engler
@@ -44,14 +35,13 @@ public class ModifiedFacetImpl extends RangeFacet implements Facet {
 
 	public ModifiedFacetImpl(
 		String fieldName, SearchContext searchContext,
-		FilterBuilders filterBuilders, DateFormatFactory dateFormatFactory) {
+		FilterBuilders filterBuilders) {
 
 		super(searchContext);
 
 		setFieldName(fieldName);
 
 		_filterBuilders = filterBuilders;
-		_dateFormatFactory = dateFormatFactory;
 	}
 
 	@Override
@@ -80,8 +70,6 @@ public class ModifiedFacetImpl extends RangeFacet implements Facet {
 
 	@Override
 	protected BooleanClause<Filter> doGetFacetFilterBooleanClause() {
-		normalizeDates(getFacetConfiguration());
-
 		if (ArrayUtil.isEmpty(_selections)) {
 			return null;
 		}
@@ -122,72 +110,7 @@ public class ModifiedFacetImpl extends RangeFacet implements Facet {
 			dateRangeFilterBuilder.build(), BooleanClauseOccur.MUST);
 	}
 
-	protected void normalizeDates(FacetConfiguration facetConfiguration) {
-		Calendar now = Calendar.getInstance();
-
-		now.set(Calendar.SECOND, 0);
-		now.set(Calendar.MINUTE, 0);
-
-		Calendar pastHour = (Calendar)now.clone();
-
-		pastHour.set(Calendar.HOUR_OF_DAY, now.get(Calendar.HOUR_OF_DAY) - 1);
-
-		Calendar past24Hours = (Calendar)now.clone();
-
-		past24Hours.set(
-			Calendar.DAY_OF_YEAR, now.get(Calendar.DAY_OF_YEAR) - 1);
-
-		Calendar pastWeek = (Calendar)now.clone();
-
-		pastWeek.set(Calendar.DAY_OF_YEAR, now.get(Calendar.DAY_OF_YEAR) - 7);
-
-		Calendar pastMonth = (Calendar)now.clone();
-
-		pastMonth.set(Calendar.MONTH, now.get(Calendar.MONTH) - 1);
-
-		Calendar pastYear = (Calendar)now.clone();
-
-		pastYear.set(Calendar.YEAR, now.get(Calendar.YEAR) - 1);
-
-		now.set(Calendar.HOUR_OF_DAY, now.get(Calendar.HOUR_OF_DAY) + 1);
-
-		DateFormat dateFormat = _dateFormatFactory.getSimpleDateFormat(
-			"yyyyMMddHHmmss");
-
-		JSONObject dataJSONObject = facetConfiguration.getData();
-
-		if (!dataJSONObject.has("ranges")) {
-			return;
-		}
-
-		JSONArray rangesJSONArray = dataJSONObject.getJSONArray("ranges");
-
-		for (int i = 0; i < rangesJSONArray.length(); i++) {
-			JSONObject rangeObject = rangesJSONArray.getJSONObject(i);
-
-			String rangeString = rangeObject.getString("range");
-
-			rangeString = StringUtil.replace(
-				rangeString,
-				new String[] {
-					"past-hour", "past-24-hours", "past-week", "past-month",
-					"past-year", "*"
-				},
-				new String[] {
-					dateFormat.format(pastHour.getTime()),
-					dateFormat.format(past24Hours.getTime()),
-					dateFormat.format(pastWeek.getTime()),
-					dateFormat.format(pastMonth.getTime()),
-					dateFormat.format(pastYear.getTime()),
-					dateFormat.format(now.getTime())
-				});
-
-			rangeObject.put("range", rangeString);
-		}
-	}
-
 	private String _aggregationName;
-	private final DateFormatFactory _dateFormatFactory;
 	private final FilterBuilders _filterBuilders;
 	private String[] _selections = {};
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/facet/modified/ModifiedFacetFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/facet/modified/ModifiedFacetFactoryImpl.java
@@ -16,8 +16,6 @@ package com.liferay.portal.search.internal.facet.modified;
 
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.util.DateFormatFactory;
-import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.search.facet.Facet;
 import com.liferay.portal.search.facet.FacetFactory;
 import com.liferay.portal.search.facet.modified.ModifiedFacetFactory;
@@ -43,22 +41,8 @@ public class ModifiedFacetFactoryImpl implements ModifiedFacetFactory {
 	@Override
 	public Facet newInstance(SearchContext searchContext) {
 		return new ModifiedFacetImpl(
-			Field.MODIFIED_DATE, searchContext, filterBuilders,
-			getDateFormatFactory());
+			Field.MODIFIED_DATE, searchContext, filterBuilders);
 	}
-
-	protected DateFormatFactory getDateFormatFactory() {
-
-		// See LPS-72507 and LPS-76500
-
-		if (dateFormatFactory != null) {
-			return dateFormatFactory;
-		}
-
-		return DateFormatFactoryUtil.getDateFormatFactory();
-	}
-
-	protected DateFormatFactory dateFormatFactory;
 
 	@Reference
 	protected FilterBuilders filterBuilders;


### PR DESCRIPTION
This is a follow-up to https://github.com/brianchandotcom/liferay-portal/pull/60691, which introduced a blocker bug where Classic Search Portlet always crashes when displaying search results with a Modified Facet. @xbrianlee this should fix all Classic Search Portlet functional tests such as `SearchUsecase#ViewUserSearchResult`.

CI results had too many `KaleoActivator` errors to analyze (https://github.com/arboliveira/liferay-portal/pull/546#issuecomment-400260653) but locally, all relevant tests passed.

https://issues.liferay.com/browse/LPS-81411