### PR TITLE
LRQA-40017 Add additional wait for port *099 when stopping app server | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -3698,26 +3698,41 @@ org.apache.catalina.startup.ClassLoaderFactory.level=INFO]]>
 						<equals arg1="@{app.server.bin.dir}" arg2="${app.server.tcat.admin.bin.dir}" />
 						<then>
 							<waitfor maxwait="5" maxwaitunit="minute" timeoutproperty="app.server.stopping.timeout">
-								<not>
-									<http url="http://localhost:${test.app.server.leading.port.number}180/console" />
-								</not>
+								<and>
+									<not>
+										<http url="http://localhost:${test.app.server.leading.port.number}180/console" />
+									</not>
+									<not>
+										<http url="http://localhost:${test.app.server.leading.port.number}099" />
+									</not>
+								</and>
 							</waitfor>
 						</then>
 						<elseif>
 							<equals arg1="@{app.server.bin.dir}" arg2="${app.server.tcat.agent.bin.dir}" />
 							<then>
 								<waitfor maxwait="5" maxwaitunit="minute" timeoutproperty="app.server.stopping.timeout">
-									<not>
-										<http url="http://localhost:${test.app.server.leading.port.number}080" />
-									</not>
+									<and>
+										<not>
+											<http url="http://localhost:${test.app.server.leading.port.number}080" />
+										</not>
+										<not>
+											<http url="http://localhost:${test.app.server.leading.port.number}099" />
+										</not>
+									</and>
 								</waitfor>
 							</then>
 						</elseif>
 						<else>
 							<waitfor maxwait="5" maxwaitunit="minute" timeoutproperty="app.server.stopping.timeout">
-								<not>
-									<http url="http://localhost:${test.app.server.leading.port.number}080/web/guest" />
-								</not>
+								<and>
+									<not>
+										<http url="http://localhost:${test.app.server.leading.port.number}080/web/guest" />
+									</not>
+									<not>
+										<http url="http://localhost:${test.app.server.leading.port.number}099" />
+									</not>
+								</and>
 							</waitfor>
 
 							<if>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-40017

@brianwulbern @jpince

Shuyang told us that the reason this will fail out is that there is a process within OSGi that has a hard-coded pause that will hold on to the JMX service.  He did say though that the JMX service running on the 8099 port will eventually terminate, but it's not immediately.

So his solution was to add a wait to ensure that the 8099 port has been terminated before moving on to the next step.