### PR TITLE
LPS-78447 FIX Portal takes a long time to start up

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/PluginJarConflictCheckSuppression.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/PluginJarConflictCheckSuppression.java
@@ -31,19 +31,15 @@ public class PluginJarConflictCheckSuppression {
 	}
 
 	public static <T> T execute(Supplier<T> supplier) {
-		String old = System.getProperty("java.class.path");
+		String javaClassPath = System.getProperty("java.class.path");
 
-		System.setProperty("java.class.path", ".");
-
-		String replaced = System.getProperty("java.class.path");
+		System.setProperty("java.class.path", System.getProperty("java.home"));
 
 		try {
 			return supplier.get();
 		}
 		finally {
-			System.setProperty("java.class.path", replaced);
-
-			System.setProperty("java.class.path", old);
+			System.setProperty("java.class.path", javaClassPath);
 		}
 	}
 


### PR DESCRIPTION
This fixes a bad slowdown on Portal startup that happens on certain servers. 

Not running CI since it's an extremely simple change with a single commit that can be easily reversed. Tested locally.

cc/ @shuyangzhou

https://issues.liferay.com/browse/LPS-78447