### PR TITLE
LPS-83040 App icon thumbnails in App Manager are incorrectly sized relative to the page

### DIFF
--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/icon.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/icon.jsp
@@ -28,7 +28,7 @@ String iconURL = ParamUtil.getString(request, "iconURL");
 			</svg>
 		</c:when>
 		<c:when test="<%= Validator.isUrl(iconURL) %>">
-			<img alt="thumbnail" src="<%= iconURL %>" />
+			<img alt="thumbnail" class="img-fluid" src="<%= iconURL %>" />
 		</c:when>
 	</c:choose>
 </div>


### PR DESCRIPTION
/cc @drewbrokke