### PR TITLE
CLDSVCS-3573 Change the JspBundleClassloader fallback to super in ord…

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspBundleClassloader.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspBundleClassloader.java
@@ -87,24 +87,24 @@ public class JspBundleClassloader extends URLClassLoader {
 	}
 
 	@Override
-	protected Class<?> findClass(String name) throws ClassNotFoundException {
-		for (Bundle bundle : _bundles) {
-			try {
-				return bundle.loadClass(name);
-			}
-			catch (ClassNotFoundException cnfe) {
-				continue;
-			}
-		}
-
-		throw new ClassNotFoundException(name);
-	}
-
-	@Override
 	protected Class<?> loadClass(String name, boolean resolve)
 		throws ClassNotFoundException {
 
-		Class<?> clazz = findClass(name);
+		Class<?> clazz = null;
+
+		for (Bundle bundle : _bundles) {
+			try {
+				clazz = bundle.loadClass(name);
+
+				break;
+			}
+			catch (ClassNotFoundException cnfe) {
+			}
+		}
+
+		if (clazz == null) {
+			return super.loadClass(name, resolve);
+		}
 
 		if (resolve) {
 			resolveClass(clazz);


### PR DESCRIPTION
…er to cover incomplete jsp api usages bnd scanning.

This is a HIGH RISK fix.
@jrhoun @jhendley please make the best to run through all the regression tests we have that is related to wab handling.

@rotty3000 @mhan810 , this is not the best way to fix, or even the right way. However at this phase we really have no other choice. The real problem is inside JspAnalyzerPlugin. LCS used to work, because it was saved a bug that Neil fixed at dd20350ed020d24a74ce8552f3e29304319ec938 . And we can not go back to add the bug back, at that will expose incomplete portlet 3.0 to war wab bundle. It is JspAnalyzerPlugin that failed to scan through all the possible packages it needs at runtime. There is no time for us to update it to scan jsp better, so I am just allowing it delegating to super classloader. If QA can confirm no new regressions on this, let's just settle with it for this release, and revisit it later with a formal solution.