### PR TITLE
LPS-83112 Do high risk operation first, otherwise in case of jai fail…

### DIFF
--- a/portal-impl/src/com/liferay/portal/image/SpriteProcessorImpl.java
+++ b/portal-impl/src/com/liferay/portal/image/SpriteProcessorImpl.java
@@ -181,6 +181,8 @@ public class SpriteProcessorImpl implements SpriteProcessor {
 					renderedImage = TranslateDescriptor.create(
 						renderedImage, x, y, null, null);
 
+					y += renderedImage.getHeight();
+
 					renderedImages.add(renderedImage);
 
 					String key = ServletContextUtil.getResourcePath(imageURL);
@@ -200,8 +202,6 @@ public class SpriteProcessorImpl implements SpriteProcessor {
 						",", String.valueOf(width));
 
 					spriteProperties.setProperty(key, value);
-
-					y += renderedImage.getHeight();
 				}
 			}
 			catch (Exception e) {


### PR DESCRIPTION
…ure we will leave renderedImages in a inconsistent state which will lead to further failures.

It is NOT the fix to the JAI failure, as I still have no chance to catch it alive in order to see what exactly failed to initialize. However with this change, we shall have cleaner/consistent/less failures only at renderedImage.getHeight() rather than the following ImageIO.write().

One thing bothers me is, base on the error handling logic, even when this rare case happens, it should not stop the server from starting(which is proven by CI, we only get log scanning failure, the server starts and serves fine). However @alee8888 you said it stopped you from hitting homepage, that does not really make sense. Please apply https://github.com/brianchandotcom/liferay-portal/pull/60936 and this pull to test it again on your side. If you still can not hit homepage, paste me your full websphere system out log.

@jpince , if this is not stopping server from loading and serving, but only a startup warning log, it is NOT a release blocker. The only thing should be missing is the sprite image file, I am not sure how much it would affect the system. The worst case we can disable sprite image support in case of the failure.

Anyway, I would need someone from QA to give me a relatively stable way to see the failure on my desktop in order to find out what goes wrong with JAI.

I will be away from my computer most the time today, if you guys can find a way to reproduce it, set it up on my desktop and email me the details, I can look into it when I get a chance.