### PR TITLE
LRQA-42130 | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6157,6 +6157,15 @@ osb.lcs.portlet.oauth.consumer.secret=${osb.lcs.portlet.oauth.consumer.secret}</
 		<priority value="ERROR" />
 	</category>
 </log4j:configuration>]]></echo>
+
+		<echo file="${liferay.home}/osgi/log4j/org.apache.aries.jax.rs.whiteboard-log4j-ext.xml"><![CDATA[<?xml version="1.0"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+	<category name="org.apache.cxf.rs.security.oauth2.services.AbstractOAuthService">
+		<priority value="ERROR" />
+	</category>
+</log4j:configuration>]]></echo>
 	</target>
 
 	<target name="prepare-mobile-device">


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-42130

Fixes `PortalLogAssertorTest` failures for the following integration tests:
- com.liferay.oauth2.provider.client.test.TokenExpeditionTest
- com.liferay.oauth2.provider.client.test.NarrowDownScopeClientTest
- com.liferay.oauth2.provider.client.test.GrantedFlowsTest
- com.liferay.oauth2.provider.client.test.GrantAuthorizationCodePKCEKillSwitchTest
- com.liferay.oauth2.provider.client.test.GrantAuthorizationCodeKillSwitchTest

Passes testing in https://github.com/xbrianlee/liferay-portal/pull/224#issuecomment-402199853.

