### PR TITLE
LPS-83171 Do not extract the global group id from the map. It also contains regular live groups that could drive the targetGroupId variable to get the wrong value (in this case the live group instead of the staged group)

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMStructureStagedModelDataHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMStructureStagedModelDataHandler.java
@@ -316,14 +316,12 @@ public class DDMStructureStagedModelDataHandler
 
 		DDMStructure importedStructure = null;
 
-		Map<Long, Long> groupIds =
-			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
-				Group.class);
+		long groupId = portletDataContext.getScopeGroupId();
 
-		long targetGroupId = portletDataContext.getScopeGroupId();
+		long structureGroupId = structure.getGroupId();
 
-		if (groupIds.containsKey(structure.getGroupId())) {
-			targetGroupId = groupIds.get(structure.getGroupId());
+		if (structureGroupId == portletDataContext.getSourceCompanyGroupId()) {
+			groupId = portletDataContext.getCompanyGroupId();
 		}
 
 		if (portletDataContext.isDataStrategyMirror()) {
@@ -334,14 +332,14 @@ public class DDMStructureStagedModelDataHandler
 				element.attributeValue("preloaded"));
 
 			DDMStructure existingStructure = fetchExistingStructure(
-				structure.getUuid(), targetGroupId, structure.getClassNameId(),
+				structure.getUuid(), groupId, structure.getClassNameId(),
 				structure.getStructureKey(), preloaded);
 
 			if (existingStructure == null) {
 				serviceContext.setUuid(structure.getUuid());
 
 				existingStructure = _ddmStructureLocalService.fetchStructure(
-					targetGroupId, structure.getClassNameId(),
+					groupId, structure.getClassNameId(),
 					structure.getStructureKey());
 
 				String structureKey = null;
@@ -351,7 +349,7 @@ public class DDMStructureStagedModelDataHandler
 				}
 
 				importedStructure = _ddmStructureLocalService.addStructure(
-					userId, targetGroupId, parentStructureId,
+					userId, groupId, parentStructureId,
 					structure.getClassNameId(), structureKey,
 					structure.getNameMap(), structure.getDescriptionMap(),
 					ddmForm, ddmFormLayout, structure.getStorageType(),
@@ -377,11 +375,10 @@ public class DDMStructureStagedModelDataHandler
 		}
 		else {
 			importedStructure = _ddmStructureLocalService.addStructure(
-				userId, targetGroupId, parentStructureId,
-				structure.getClassNameId(), null, structure.getNameMap(),
-				structure.getDescriptionMap(), ddmForm, ddmFormLayout,
-				structure.getStorageType(), structure.getType(),
-				serviceContext);
+				userId, groupId, parentStructureId, structure.getClassNameId(),
+				null, structure.getNameMap(), structure.getDescriptionMap(),
+				ddmForm, ddmFormLayout, structure.getStorageType(),
+				structure.getType(), serviceContext);
 		}
 
 		portletDataContext.importClassedModel(structure, importedStructure);


### PR DESCRIPTION
Hi @pedroqueiroz and @ealonso,

@robertoDiaz has sent this fix for review and I believe that would be nice both of you take a look to it, once the fix impacts DDM and Journal Article.

Thanks in advance for your time.