### PR TITLE
LPS-83185 Documents breaking change

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/portlet_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/portlet_header.jsp
@@ -25,6 +25,6 @@ String portletTitle = (String)request.getAttribute(ProductNavigationControlMenuW
 	<span class="control-menu-level-1-heading truncate-text" data-qa-id="headerTitle"><%= HtmlUtil.escape(portletTitle) %></span>
 
 	<c:if test="<%= Validator.isNotNull(portletDescription) %>">
-		<liferay-ui:icon-help message="<%= HtmlUtil.escape(portletDescription) %>" />
+		<liferay-ui:icon-help message="<%= portletDescription %>" />
 	</c:if>
 </li>

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/PortletDisplay.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/PortletDisplay.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIconMenu;
 import com.liferay.portal.kernel.portlet.toolbar.PortletToolbar;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -609,8 +608,6 @@ public class PortletDisplay implements Cloneable, Serializable {
 	}
 
 	public void setDescription(String description) {
-		description = HtmlUtil.escape(description);
-
 		_description = description;
 	}
 

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -994,3 +994,29 @@ This was done to strengthen Liferay Portal's security due to potential XXE/SSRF
 vulnerabilities.
 
 ---------------------------------------
+
+### Removed description html escaping in PortletDisplay
+- **Date:** 2018-Jul-17
+- **JIRA Ticket:** LPS-83185
+
+#### What changed?
+
+The portlet description stored inside `PortletDisplay.java` is no longer escaped
+automatically.
+
+#### Who is affected?
+
+This affects anyone who relied on the value of the portlet description being
+already escaped and using it to generate some html. In that case, a small UI
+change might be observed as some characters might become unescaped.
+
+#### How should I update my code?
+
+If you were using the `portletDescription` value to generate some html, you
+should escape it using the proper escape sequence using `HtmlUtil.escape`.
+
+#### Why was this change made?
+
+This change corrects a best practice violation regarding content escaping.
+
+---------------------------------------


### PR DESCRIPTION
Hey @brianchandotcom!

This change introduces a breaking change as we no longer will escape the portlet description automatically. This was incorrect and causing problems.

I've discussed this with @topolik, who thinks the affected surface is small and with @antonio-ortega who agrees that based on how early in `7.1.x` we are it's preferable to break it before we get any clients in. See backport to `7.1.x` -> https://github.com/brianchandotcom/liferay-portal-ee/pull/21058

For `7.0.x`, we will send a custom backport if necessary, avoiding the breaking change.

Thanks!