### PR TITLE
COMMERCE-541 Fixing a field name that Talend expects for storing repository location name

### DIFF
--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
@@ -72,7 +72,7 @@ public class LiferayConnectionProperties
 			}
 
 			repo.storeProperties(
-				this, this.name.getValue(), _repositoryLocation, null);
+				this, name.getValue(), repositoryLocation, null);
 
 			return ValidationResult.OK;
 		}
@@ -143,7 +143,7 @@ public class LiferayConnectionProperties
 	}
 
 	public LiferayConnectionProperties setRepositoryLocation(String location) {
-		_repositoryLocation = location;
+		repositoryLocation = location;
 
 		return this;
 	}
@@ -319,6 +319,14 @@ public class LiferayConnectionProperties
 			LiferayBaseComponentDefinition.RUNTIME_SOURCE_OR_SINK_CLASS_NAME);
 	}
 
+	/**
+	 * Must be named "repositoryLocation" as Talend uses a reflection to get a
+	 * field named like this.
+	 *
+	 * @see https://github.com/Talend/tdi-studio-se/blob/125a8144597e5d5faa1f7001ce345cdfd6dc1fe3/main/plugins/org.talend.repository.generic/src/main/java/org/talend/repository/generic/ui/GenericConnWizard.java#L111
+	 */
+	protected String repositoryLocation;
+
 	private static final int _CONNECT_TIMEOUT = 30;
 
 	private static final String _HOST = "\"http://localhost:8080/o/api\"";
@@ -335,7 +343,5 @@ public class LiferayConnectionProperties
 		LiferayConnectionProperties.class);
 
 	private static final long serialVersionUID = -746398918369840241L;
-
-	private String _repositoryLocation;
 
 }

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/wizard/LiferayConnectionWizard.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/wizard/LiferayConnectionWizard.java
@@ -46,9 +46,10 @@ public class LiferayConnectionWizard extends ComponentWizard {
 	public void setupProperties(
 		LiferayConnectionProperties liferayConnectionProperties) {
 
-		liferayConnectionProperties.setupProperties();
+		this.liferayConnectionProperties.setupProperties();
 
-		liferayConnectionProperties.copyValuesFrom(liferayConnectionProperties);
+		this.liferayConnectionProperties.copyValuesFrom(
+			liferayConnectionProperties);
 	}
 
 	public boolean supportsProperties(ComponentProperties componentProperties) {


### PR DESCRIPTION
https://issues.liferay.com/browse/COMMERCE-541

Follow-up of https://github.com/brianchandotcom/liferay-portal/pull/61406
Fix for a regression introduced by the Talend upgrade