### PR TITLE
LPS-83444 Skip redundant dependency check for subrepositories

### DIFF
--- a/portal-kernel/test/unit/com/liferay/portal/modules/ModulesStructureTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/modules/ModulesStructureTest.java
@@ -1341,13 +1341,17 @@ public class ModulesStructureTest {
 				Assert.fail(sb.toString());
 			}
 
-			GradleDependency activeGradleDependency =
-				_getActiveGradleDependency(
-					gradleDependencies, gradleDependency);
+			if (!_isInGitRepoReadOnly(path) &&
+				!_isInPrivateModulesCheckoutDir(path)) {
 
-			Assert.assertEquals(
-				"Redundant dependency detected in " + path,
-				activeGradleDependency, gradleDependency);
+				GradleDependency activeGradleDependency =
+					_getActiveGradleDependency(
+						gradleDependencies, gradleDependency);
+
+				Assert.assertEquals(
+					"Redundant dependency detected in " + path,
+					activeGradleDependency, gradleDependency);
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi Brian, this is a temp workaround to get the `osb-lcs` subrepository syncd.

Removing the redundant dependencies is `osb-lcs` resulted in compile errors

https://github.com/liferay/liferay-portal-ee/pull/8877#issuecomment-406664699