### PR TITLE
LRQA-41905 Declare the jobProperties field within BaseJob

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseJob.java
@@ -58,6 +58,6 @@ public abstract class BaseJob implements Job {
 	}
 
 	protected String jobName;
-	protected Properties jobProperties;
+	protected final Properties jobProperties = new Properties();
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-41905

@pyoo47 - This should fix the null pointer error being thrown.