### PR TITLE
LRQA-42624 Use get instead of mirrors-get to always get the latest version | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -1685,7 +1685,7 @@ passthrough=&quot;true&quot;</echo>
 			<local name="patching.tool.name" />
 			<local name="patching.tool.version" />
 
-			<mirrors-get
+			<get
 				dest="${basedir}"
 				src="${test.fix.pack.base.url}/patching-tool/${patching.tool.latest.txt}"
 			/>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-42624

@brianchandotcom - After merging this can you sync the `git-commit-portal` files, I think this is needed to test the Fix Packs properly.  Thanks!