### PR TITLE
LPS-83920 Documentation

### DIFF
--- a/modules/README.markdown
+++ b/modules/README.markdown
@@ -123,6 +123,7 @@ File Name | Description
 --------- | -----------
 `.lfrbuild-release-src` | Includes the app's source code in the DXP release, when added to the root of an app.
 `.lfrbuild-releng-ignore` | Ignores checking the module for staleness, so the module is never publishable. A *stale* module has code that is different from the latest published release. If a `.lfrbuild-releng-ignore` file is added to a parent directory, the whole subtree is be ignored.
+`.lfrbuild-releng-skip-update-file-versions` | Prevents the `updateFileVersions` task from converting project dependencies into module dependencies. If a `.lfrbuild-releng-skip-update-file-versions` file is added to a parent directory, the whole subtree is skipped.
 
 ### Themes
 

--- a/modules/sdk/gradle-plugins-defaults/CHANGELOG.markdown
+++ b/modules/sdk/gradle-plugins-defaults/CHANGELOG.markdown
@@ -4194,6 +4194,13 @@ in the `aspectj` directory.
 `writeArtifactPublishCommands` task by setting the property
 `writeArtifactPublishCommands.ignore.project.regex`.
 
+## 5.4.97 - 2018-07-27
+
+### Added
+- [LPS-83920]: Skip replacements of the `updateFileVersions` task if a
+`.lfrbuild-releng-skip-update-file-versions` marker file is found in a parent
+directory.
+
 [Find Security Bugs]: https://github.com/liferay/liferay-portal/tree/master/modules/third-party/com-h3xstream-findsecbugs
 [Gradle License Report]: https://github.com/jk1/Gradle-License-Report
 [Liferay CDN]: https://repository-cdn.liferay.com/nexus/content/groups/public

--- a/modules/sdk/gradle-plugins-defaults/CHANGELOG.markdown
+++ b/modules/sdk/gradle-plugins-defaults/CHANGELOG.markdown
@@ -4184,8 +4184,8 @@ file.
 ## 5.4.95 - 2018-07-25
 
 ### Changed
-- [LPS-83920]: Skip replacements of the `updateFileVersions` task for projects in
-the `aspectj` directory.
+- [LPS-83920]: Skip replacements of the `updateFileVersions` task for projects
+in the `aspectj` directory.
 
 ## 5.4.96 - 2018-07-27
 


### PR DESCRIPTION
Hi Brian, the [ModulesStructureTest.java#L500-L504](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/test/unit/com/liferay/portal/modules/ModulesStructureTest.java#L500-L504) has a check to force documentation of marker files

