### PR TITLE
LPS-83970 baseline with new API class

### DIFF
--- a/modules/apps/headless-apio/forms/forms-apio-impl/build.gradle
+++ b/modules/apps/headless-apio/forms/forms-apio-impl/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 	compileOnly group: "com.liferay", name: "com.liferay.person.apio.api", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.portal.apio.api", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.structure.apio.api", version: "1.0.0"
-	compileOnly group: "com.liferay", name: "com.liferay.structured.content.apio.api", version: "1.0.0"
+	compileOnly group: "com.liferay", name: "com.liferay.structured.content.apio.api", version: "1.1.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "3.0.0"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/apps/headless-apio/structured-content/structured-content-apio-api/bnd.bnd
+++ b/modules/apps/headless-apio/structured-content/structured-content-apio-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Structured Content Apio API
 Bundle-SymbolicName: com.liferay.structured.content.apio.api
-Bundle-Version: 1.0.2
+Bundle-Version: 1.1.0
 Export-Package:\
 	com.liferay.structured.content.apio.architect.identifier,\
 	com.liferay.structured.content.apio.architect.util

--- a/modules/apps/headless-apio/structured-content/structured-content-apio-impl/build.gradle
+++ b/modules/apps/headless-apio/structured-content/structured-content-apio-impl/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 	compileOnly group: "com.liferay", name: "com.liferay.person.apio.api", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.portal.apio.api", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.structure.apio.api", version: "1.0.0"
-	compileOnly group: "com.liferay", name: "com.liferay.structured.content.apio.api", version: "1.0.0"
+	compileOnly group: "com.liferay", name: "com.liferay.structured.content.apio.api", version: "1.1.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "3.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 }


### PR DESCRIPTION
I don't know how to solve this... adding the Util class in API forces a new version (1.1) but just in 7.1.x because master uses 2.0.0 versioning.

Second commit (using 1.1.0 in gradle files) needs jar publishing.