### PR TITLE
LPS-83494 Certain resource bundles cannot be overriden

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/portlet/configuration/icon/OptimizeImagesPortletConfigurationIcon.java
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/portlet/configuration/icon/OptimizeImagesPortletConfigurationIcon.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Collection;
@@ -44,6 +44,8 @@ import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Sergio González
@@ -83,8 +85,8 @@ public class OptimizeImagesPortletConfigurationIcon
 
 	@Override
 	public ResourceBundle getResourceBundle(Locale locale) {
-		ResourceBundle bundleResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle bundleResourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return new AggregateResourceBundle(
 			bundleResourceBundle, super.getResourceBundle(locale));
@@ -162,5 +164,12 @@ public class OptimizeImagesPortletConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.adaptive.media.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/apio-architect/.gitrepo
+++ b/modules/apps/apio-architect/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = true
 	cmdver = liferay
-	commit = a732642a3ae4b8a7de9e928ffb2ebb1c93323d3a
+	commit = 5ed4e3da2346fa25d9f24e3a4321cfdca96496d2
 	mergebuttonmergecommits = false
 	mode = pull
-	parent = b52456b7f12a4f9f45ceed58c849134cb02472d1
+	parent = c8d9304a972a868a6e3b940c9cb011d755c68a0a
 	remote = git@github.com:liferay/com-liferay-apio-architect.git

--- a/modules/apps/apio-architect/.travis.yml
+++ b/modules/apps/apio-architect/.travis.yml
@@ -29,9 +29,9 @@ before_cache:
     - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 
 cache:
-  directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
+    directories:
+        - $HOME/.gradle/caches/
+        - $HOME/.gradle/wrapper/
 
 after_success:
     - ./gradlew dumpJacoco

--- a/modules/apps/apio-architect/README.markdown
+++ b/modules/apps/apio-architect/README.markdown
@@ -138,7 +138,7 @@ Pull requests with contributions should be sent to the GitHub user *liferay*. Th
 ## Bug Reporting and Feature Requests
 Did you find a bug? Please file an issue for it at [https://issues.liferay.com](https://issues.liferay.com) following [Liferay's JIRA Guidelines](http://www.liferay.com/community/wiki/-/wiki/Main/JIRA), and select *Apio Architect* as the component.
 
-If you'd like to suggest a new feature for Liferay, visit the [Ideas Dashboard](https://dev.liferay.com/participate/ideas) to submit and track the progress of your idea!
+If you'd like to suggest a new feature for Liferay, visit the [list of issues and suggestions](https://issues.liferay.com/projects/APIO/issues) to submit and track the progress of your idea!
 
 ## License
 This library is free software ("Licensed Software"); you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version.

--- a/modules/apps/apio-architect/apio-architect-api/src/main/java/com/liferay/apio/architect/representor/BaseRepresentor.java
+++ b/modules/apps/apio-architect/apio-architect-api/src/main/java/com/liferay/apio/architect/representor/BaseRepresentor.java
@@ -146,6 +146,13 @@ public interface BaseRepresentor<T> {
 	public List<FieldFunction<T, List<Number>>> getNumberListFunctions();
 
 	/**
+	 * Returns the primary type.
+	 *
+	 * @return the primary type
+	 */
+	public String getPrimaryType();
+
+	/**
 	 * Returns the related models.
 	 *
 	 * @return the related models

--- a/modules/apps/apio-architect/apio-architect-api/src/main/resources/com/liferay/apio/architect/representor/packageinfo
+++ b/modules/apps/apio-architect/apio-architect-api/src/main/resources/com/liferay/apio/architect/representor/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/jaxrs/json/writer/EntryPointMessageBodyWriter.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/jaxrs/json/writer/EntryPointMessageBodyWriter.java
@@ -14,11 +14,14 @@
 
 package com.liferay.apio.architect.impl.jaxrs.json.writer;
 
+import static com.liferay.apio.architect.impl.unsafe.Unsafe.unsafeCast;
+
 import com.liferay.apio.architect.impl.entrypoint.EntryPoint;
 import com.liferay.apio.architect.impl.jaxrs.json.writer.base.BaseMessageBodyWriter;
 import com.liferay.apio.architect.impl.message.json.EntryPointMessageMapper;
 import com.liferay.apio.architect.impl.request.RequestInfo;
 import com.liferay.apio.architect.impl.wiring.osgi.manager.message.json.EntryPointMessageMapperManager;
+import com.liferay.apio.architect.impl.wiring.osgi.manager.representable.RepresentableManager;
 import com.liferay.apio.architect.impl.writer.EntryPointWriter;
 import com.liferay.apio.architect.impl.writer.EntryPointWriter.Builder;
 
@@ -77,6 +80,9 @@ public class EntryPointMessageBodyWriter
 			entryPoint
 		).entryPointMessageMapper(
 			entryPointMessageMapper
+		).representorFunction(
+			name -> unsafeCast(
+				_representableManager.getRepresentorOptional(name))
 		).requestInfo(
 			requestInfo
 		).build();
@@ -86,5 +92,8 @@ public class EntryPointMessageBodyWriter
 
 	@Reference
 	private EntryPointMessageMapperManager _entryPointMessageMapperManager;
+
+	@Reference
+	private RepresentableManager _representableManager;
 
 }

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/jaxrs/json/writer/EntryPointMessageBodyWriter.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/jaxrs/json/writer/EntryPointMessageBodyWriter.java
@@ -14,8 +14,6 @@
 
 package com.liferay.apio.architect.impl.jaxrs.json.writer;
 
-import static com.liferay.apio.architect.impl.unsafe.Unsafe.unsafeCast;
-
 import com.liferay.apio.architect.impl.entrypoint.EntryPoint;
 import com.liferay.apio.architect.impl.jaxrs.json.writer.base.BaseMessageBodyWriter;
 import com.liferay.apio.architect.impl.message.json.EntryPointMessageMapper;
@@ -24,6 +22,7 @@ import com.liferay.apio.architect.impl.wiring.osgi.manager.message.json.EntryPoi
 import com.liferay.apio.architect.impl.wiring.osgi.manager.representable.RepresentableManager;
 import com.liferay.apio.architect.impl.writer.EntryPointWriter;
 import com.liferay.apio.architect.impl.writer.EntryPointWriter.Builder;
+import com.liferay.apio.architect.representor.Representor;
 
 import java.lang.reflect.Type;
 
@@ -41,6 +40,7 @@ import org.osgi.service.component.annotations.Reference;
  * corresponds to the media type.
  *
  * @author Alejandro Hernández
+ * @author Zoltán Takács
  * @review
  */
 @Component(
@@ -80,11 +80,16 @@ public class EntryPointMessageBodyWriter
 			entryPoint
 		).entryPointMessageMapper(
 			entryPointMessageMapper
-		).representorFunction(
-			name -> unsafeCast(
-				_representableManager.getRepresentorOptional(name))
 		).requestInfo(
 			requestInfo
+		).typeFunction(
+			name -> _representableManager.getRepresentorOptional(
+				name
+			).map(
+				Representor::getTypes
+			).map(
+				types -> types.get(0)
+			)
 		).build();
 
 		return entryPointWriter.write();

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/jaxrs/json/writer/EntryPointMessageBodyWriter.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/jaxrs/json/writer/EntryPointMessageBodyWriter.java
@@ -86,9 +86,7 @@ public class EntryPointMessageBodyWriter
 			name -> _representableManager.getRepresentorOptional(
 				name
 			).map(
-				Representor::getTypes
-			).map(
-				types -> types.get(0)
+				Representor::getPrimaryType
 			)
 		).build();
 

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/EntryPointMessageMapper.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/EntryPointMessageMapper.java
@@ -60,6 +60,16 @@ public interface EntryPointMessageMapper extends MessageMapper<EntryPoint> {
 	}
 
 	/**
+	 * Maps the semantics to its JSON object representation.
+	 *
+	 * @param jsonObjectBuilder the JSON object builder for the page
+	 * @param semantics Semantics of each member provided by the collection
+	 */
+	public default void mapSemantics(
+		JSONObjectBuilder jsonObjectBuilder, String semantics) {
+	}
+
+	/**
 	 * Finishes the item. This is the final entry point message mapper method
 	 * the writer calls for the item.
 	 *

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/PageMessageMapper.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/PageMessageMapper.java
@@ -583,18 +583,6 @@ public interface PageMessageMapper<T>
 	}
 
 	/**
-	 * Maps the total number of elements in a nested collection to its JSON
-	 * object representation.
-	 *
-	 * @param jsonObjectBuilder the JSON object builder for the nested
-	 *        collection
-	 * @param totalCount the total number of elements in the collection
-	 */
-	public default void mapNestedPageItemTotalCount(
-		JSONObjectBuilder jsonObjectBuilder, int totalCount) {
-	}
-
-	/**
 	 * Maps the next page's URL to its JSON object representation.
 	 *
 	 * @param jsonObjectBuilder the JSON object builder for the page

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/PageMessageMapper.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/PageMessageMapper.java
@@ -638,6 +638,16 @@ public interface PageMessageMapper<T>
 	}
 
 	/**
+	 * Maps the semantics to its JSON object representation.
+	 *
+	 * @param jsonObjectBuilder the JSON object builder for the page
+	 * @param semantics Semantics of each member provided by the collection
+	 */
+	public default void mapSemantics(
+		JSONObjectBuilder jsonObjectBuilder, String semantics) {
+	}
+
+	/**
 	 * Finishes the operation. This is the final operation-mapper method the
 	 * writer calls.
 	 *

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/SingleModelMessageMapper.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/SingleModelMessageMapper.java
@@ -262,6 +262,16 @@ public interface SingleModelMessageMapper<T>
 	}
 
 	/**
+	 * Maps the semantics to its JSON object representation.
+	 *
+	 * @param jsonObjectBuilder the JSON object builder for the page
+	 * @param semantics Semantics of each member provided by the collection
+	 */
+	public default void mapNestedPageSemantics(
+		JSONObjectBuilder jsonObjectBuilder, String semantics) {
+	}
+
+	/**
 	 * Maps a resource's number field to its JSON object representation.
 	 *
 	 * @param jsonObjectBuilder the JSON object builder for the model

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/hal/HALPageMessageMapper.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/hal/HALPageMessageMapper.java
@@ -14,6 +14,7 @@
 
 package com.liferay.apio.architect.impl.message.json.hal;
 
+import com.liferay.apio.architect.impl.list.FunctionalList;
 import com.liferay.apio.architect.impl.message.json.JSONObjectBuilder;
 import com.liferay.apio.architect.impl.message.json.PageMessageMapper;
 import com.liferay.apio.architect.impl.message.json.SingleModelMessageMapper;
@@ -21,6 +22,7 @@ import com.liferay.apio.architect.impl.wiring.osgi.manager.representable.Represe
 import com.liferay.apio.architect.representor.Representor;
 import com.liferay.apio.architect.single.model.SingleModel;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.osgi.service.component.annotations.Component;
@@ -153,6 +155,34 @@ public class HALPageMessageMapper<T> implements PageMessageMapper<T> {
 			).add(
 				itemJSONObjectBuilder
 			)
+		);
+	}
+
+	@Override
+	public void onFinishNestedCollection(
+		JSONObjectBuilder singleModelJSONObjectBuilder,
+		JSONObjectBuilder collectionJsonObjectBuilder, String fieldName,
+		List<?> list, FunctionalList<String> embeddedPathElements) {
+
+		singleModelJSONObjectBuilder.field(
+			"_embedded"
+		).field(
+			fieldName
+		).objectValue(
+			collectionJsonObjectBuilder
+		);
+	}
+
+	@Override
+	public void onFinishNestedCollectionItem(
+		JSONObjectBuilder collectionJsonObjectBuilder,
+		JSONObjectBuilder itemJSONObjectBuilder, SingleModel<?> singleModel) {
+
+		collectionJsonObjectBuilder.field(
+			"_embedded"
+		).arrayValue(
+		).add(
+			itemJSONObjectBuilder
 		);
 	}
 

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/hal/HALSingleModelMessageMapper.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/hal/HALSingleModelMessageMapper.java
@@ -17,6 +17,7 @@ package com.liferay.apio.architect.impl.message.json.hal;
 import com.liferay.apio.architect.impl.list.FunctionalList;
 import com.liferay.apio.architect.impl.message.json.JSONObjectBuilder;
 import com.liferay.apio.architect.impl.message.json.SingleModelMessageMapper;
+import com.liferay.apio.architect.single.model.SingleModel;
 
 import java.util.List;
 import java.util.Optional;
@@ -243,6 +244,17 @@ public class HALSingleModelMessageMapper<T>
 	}
 
 	@Override
+	public void mapNestedPageItemTotalCount(
+		JSONObjectBuilder jsonObjectBuilder, int totalCount) {
+
+		jsonObjectBuilder.field(
+			"total"
+		).numberValue(
+			totalCount
+		);
+	}
+
+	@Override
 	public void mapNumberField(
 		JSONObjectBuilder jsonObjectBuilder, String fieldName, Number value) {
 
@@ -292,6 +304,34 @@ public class HALSingleModelMessageMapper<T>
 		).arrayValue(
 		).addAllStrings(
 			value
+		);
+	}
+
+	@Override
+	public void onFinishNestedCollection(
+		JSONObjectBuilder singleModelJSONObjectBuilder,
+		JSONObjectBuilder collectionJsonObjectBuilder, String fieldName,
+		List<?> list, FunctionalList<String> embeddedPathElements) {
+
+		singleModelJSONObjectBuilder.field(
+			"_embedded"
+		).field(
+			fieldName
+		).objectValue(
+			collectionJsonObjectBuilder
+		);
+	}
+
+	@Override
+	public void onFinishNestedCollectionItem(
+		JSONObjectBuilder collectionJsonObjectBuilder,
+		JSONObjectBuilder itemJSONObjectBuilder, SingleModel<?> singleModel) {
+
+		collectionJsonObjectBuilder.field(
+			"_embedded"
+		).arrayValue(
+		).add(
+			itemJSONObjectBuilder
 		);
 	}
 

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/ld/JSONLDEntryPointMessageMapper.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/ld/JSONLDEntryPointMessageMapper.java
@@ -57,6 +57,22 @@ public class JSONLDEntryPointMessageMapper implements EntryPointMessageMapper {
 	}
 
 	@Override
+	public void mapSemantics(
+		JSONObjectBuilder jsonObjectBuilder, String semantics) {
+
+		jsonObjectBuilder.nestedField(
+			"manages", "property"
+		).stringValue(
+			"rdf:type"
+		);
+		jsonObjectBuilder.nestedField(
+			"manages", "object"
+		).stringValue(
+			"schema:" + semantics
+		);
+	}
+
+	@Override
 	public void onFinish(
 		JSONObjectBuilder jsonObjectBuilder, EntryPoint entryPoint) {
 

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/ld/JSONLDPageMessageMapper.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/ld/JSONLDPageMessageMapper.java
@@ -148,6 +148,22 @@ public class JSONLDPageMessageMapper<T> implements PageMessageMapper<T> {
 	}
 
 	@Override
+	public void mapSemantics(
+		JSONObjectBuilder jsonObjectBuilder, String semantics) {
+
+		jsonObjectBuilder.nestedField(
+			"manages", "property"
+		).stringValue(
+			"rdf:type"
+		);
+		jsonObjectBuilder.nestedField(
+			"manages", "object"
+		).stringValue(
+			"schema:" + semantics
+		);
+	}
+
+	@Override
 	public void onFinish(JSONObjectBuilder jsonObjectBuilder, Page<T> page) {
 		jsonObjectBuilder.field(
 			"@context"

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/ld/JSONLDPageMessageMapper.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/ld/JSONLDPageMessageMapper.java
@@ -106,17 +106,6 @@ public class JSONLDPageMessageMapper<T> implements PageMessageMapper<T> {
 	}
 
 	@Override
-	public void mapNestedPageItemTotalCount(
-		JSONObjectBuilder jsonObjectBuilder, int totalCount) {
-
-		jsonObjectBuilder.field(
-			"totalItems"
-		).numberValue(
-			totalCount
-		);
-	}
-
-	@Override
 	public void mapNextPageURL(
 		JSONObjectBuilder jsonObjectBuilder, String url) {
 

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/ld/JSONLDSingleModelMessageMapper.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/ld/JSONLDSingleModelMessageMapper.java
@@ -315,6 +315,22 @@ public class JSONLDSingleModelMessageMapper<T>
 	}
 
 	@Override
+	public void mapNestedPageSemantics(
+		JSONObjectBuilder jsonObjectBuilder, String semantics) {
+
+		jsonObjectBuilder.nestedField(
+			"manages", "property"
+		).stringValue(
+			"rdf:type"
+		);
+		jsonObjectBuilder.nestedField(
+			"manages", "object"
+		).stringValue(
+			"schema:" + semantics
+		);
+	}
+
+	@Override
 	public void mapNumberField(
 		JSONObjectBuilder jsonObjectBuilder, String fieldName, Number value) {
 

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/plain/PlainJSONPageMessageMapper.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/plain/PlainJSONPageMessageMapper.java
@@ -14,12 +14,15 @@
 
 package com.liferay.apio.architect.impl.message.json.plain;
 
+import com.liferay.apio.architect.impl.list.FunctionalList;
 import com.liferay.apio.architect.impl.message.json.JSONObjectBuilder;
 import com.liferay.apio.architect.impl.message.json.PageMessageMapper;
 import com.liferay.apio.architect.impl.message.json.SingleModelMessageMapper;
 import com.liferay.apio.architect.single.model.SingleModel;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -138,6 +141,37 @@ public class PlainJSONPageMessageMapper<T> implements PageMessageMapper<T> {
 		).add(
 			itemJSONObjectBuilder
 		);
+	}
+
+	@Override
+	public void onFinishNestedCollection(
+		JSONObjectBuilder singleModelJSONObjectBuilder,
+		JSONObjectBuilder collectionJsonObjectBuilder, String fieldName,
+		List<?> list, FunctionalList<String> embeddedPathElements) {
+
+		singleModelJSONObjectBuilder.nestedField(
+			embeddedPathElements.head(), _getTail(embeddedPathElements)
+		).objectValue(
+			collectionJsonObjectBuilder
+		);
+	}
+
+	public void onFinishNestedCollectionItem(
+		JSONObjectBuilder collectionJsonObjectBuilder,
+		JSONObjectBuilder itemJSONObjectBuilder, SingleModel<?> singleModel) {
+
+		collectionJsonObjectBuilder.field(
+			"elements"
+		).arrayValue(
+		).add(
+			itemJSONObjectBuilder
+		);
+	}
+
+	private String[] _getTail(FunctionalList<String> embeddedPathElements) {
+		Stream<String> stream = embeddedPathElements.tailStream();
+
+		return stream.toArray(String[]::new);
 	}
 
 	private final SingleModelMessageMapper<T> _singleModelMessageMapper =

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/plain/PlainJSONSingleModelMessageMapper.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/message/json/plain/PlainJSONSingleModelMessageMapper.java
@@ -17,6 +17,7 @@ package com.liferay.apio.architect.impl.message.json.plain;
 import com.liferay.apio.architect.impl.list.FunctionalList;
 import com.liferay.apio.architect.impl.message.json.JSONObjectBuilder;
 import com.liferay.apio.architect.impl.message.json.SingleModelMessageMapper;
+import com.liferay.apio.architect.single.model.SingleModel;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -227,6 +228,17 @@ public class PlainJSONSingleModelMessageMapper<T>
 	}
 
 	@Override
+	public void mapNestedPageItemTotalCount(
+		JSONObjectBuilder jsonObjectBuilder, int count) {
+
+		jsonObjectBuilder.field(
+			"numberOfItems"
+		).numberValue(
+			count
+		);
+	}
+
+	@Override
 	public void mapNumberField(
 		JSONObjectBuilder jsonObjectBuilder, String fieldName, Number value) {
 
@@ -281,6 +293,36 @@ public class PlainJSONSingleModelMessageMapper<T>
 		).addAllStrings(
 			value
 		);
+	}
+
+	public void onFinishNestedCollection(
+		JSONObjectBuilder singleModelJSONObjectBuilder,
+		JSONObjectBuilder collectionJsonObjectBuilder, String fieldName,
+		List<?> list, FunctionalList<String> embeddedPathElements) {
+
+		singleModelJSONObjectBuilder.nestedField(
+			embeddedPathElements.head(), _getTail(embeddedPathElements)
+		).objectValue(
+			collectionJsonObjectBuilder
+		);
+	}
+
+	public void onFinishNestedCollectionItem(
+		JSONObjectBuilder collectionJsonObjectBuilder,
+		JSONObjectBuilder itemJSONObjectBuilder, SingleModel<?> singleModel) {
+
+		collectionJsonObjectBuilder.field(
+			"elements"
+		).arrayValue(
+		).add(
+			itemJSONObjectBuilder
+		);
+	}
+
+	private String[] _getTail(FunctionalList<String> embeddedPathElements) {
+		Stream<String> stream = embeddedPathElements.tailStream();
+
+		return stream.toArray(String[]::new);
 	}
 
 }

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/representor/BaseRepresentorImpl.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/representor/BaseRepresentorImpl.java
@@ -151,6 +151,11 @@ public abstract class BaseRepresentorImpl<T> implements BaseRepresentor<T> {
 	}
 
 	@Override
+	public String getPrimaryType() {
+		return primaryType;
+	}
+
+	@Override
 	public List<RelatedModel<T, ?>> getRelatedModels() {
 		return relatedModels;
 	}
@@ -447,6 +452,8 @@ public abstract class BaseRepresentorImpl<T> implements BaseRepresentor<T> {
 	 * @review
 	 */
 	protected void addTypes(String type, String... types) {
+		primaryType = type;
+
 		this.types.add(type);
 		Collections.addAll(this.types, types);
 	}
@@ -456,6 +463,7 @@ public abstract class BaseRepresentorImpl<T> implements BaseRepresentor<T> {
 	protected final List<NestedFieldFunction<T, ?>> nestedFieldFunctions;
 	protected final List<NestedListFieldFunction<T, ?>>
 		nestedListFieldFunctions;
+	protected String primaryType;
 	protected final List<RelatedModel<T, ?>> relatedModels;
 	protected final List<String> types;
 

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/EntryPointWriter.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/EntryPointWriter.java
@@ -26,8 +26,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.osgi.service.component.annotations.Component;
-
 /**
  * Writes the API entrypoint.
  *
@@ -35,7 +33,6 @@ import org.osgi.service.component.annotations.Component;
  * @author Zoltán Takács
  * @review
  */
-@Component
 public class EntryPointWriter {
 
 	/**

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/FieldsWriter.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/FieldsWriter.java
@@ -21,11 +21,15 @@ import static com.liferay.apio.architect.impl.url.URLCreator.createNestedCollect
 import static com.liferay.apio.architect.impl.url.URLCreator.createSingleURL;
 
 import com.liferay.apio.architect.alias.representor.FieldFunction;
+import com.liferay.apio.architect.alias.representor.NestedListFieldFunction;
+import com.liferay.apio.architect.consumer.TriConsumer;
 import com.liferay.apio.architect.identifier.Identifier;
+import com.liferay.apio.architect.impl.alias.BaseRepresentorFunction;
 import com.liferay.apio.architect.impl.alias.SingleModelFunction;
 import com.liferay.apio.architect.impl.list.FunctionalList;
 import com.liferay.apio.architect.impl.request.RequestInfo;
 import com.liferay.apio.architect.impl.response.control.Fields;
+import com.liferay.apio.architect.impl.single.model.SingleModelImpl;
 import com.liferay.apio.architect.impl.unsafe.Unsafe;
 import com.liferay.apio.architect.related.RelatedCollection;
 import com.liferay.apio.architect.related.RelatedModel;
@@ -34,6 +38,7 @@ import com.liferay.apio.architect.representor.Representor;
 import com.liferay.apio.architect.single.model.SingleModel;
 import com.liferay.apio.architect.uri.Path;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -271,6 +276,94 @@ public class FieldsWriter<T> {
 			writeField(
 				function -> function.apply(_requestInfo.getAcceptLanguage()),
 				biConsumer));
+	}
+
+	public <S> void writeNestedLists(
+		BaseRepresentorFunction baseRepresentorFunction,
+		SingleModel<S> singleModel,
+		BiConsumer<NestedListFieldFunction, List<?>> biConsumer) {
+
+		baseRepresentorFunction.apply(
+			singleModel.getResourceName()
+		).<BaseRepresentor<S>>map(
+			Unsafe::unsafeCast
+		).map(
+			BaseRepresentor::getNestedListFieldFunctions
+		).map(
+			List::stream
+		).orElseGet(
+			Stream::empty
+		).forEach(
+			nestedListFieldFunction -> {
+				Predicate<String> fieldsPredicate = getFieldsPredicate();
+
+				String key = nestedListFieldFunction.getKey();
+
+				if (!fieldsPredicate.test(key)) {
+					return;
+				}
+
+				List<?> list = nestedListFieldFunction.apply(
+					singleModel.getModel());
+
+				if (list == null) {
+					return;
+				}
+
+				biConsumer.accept(nestedListFieldFunction, list);
+			}
+		);
+	}
+
+	public <S, U> void writeNestedResources(
+		BaseRepresentorFunction baseRepresentorFunction,
+		SingleModel<U> singleModel, FunctionalList<String> embeddedPathElements,
+		TriConsumer<SingleModel<S>, FunctionalList<String>,
+			BaseRepresentorFunction> triConsumer) {
+
+		baseRepresentorFunction.apply(
+			singleModel.getResourceName()
+		).<BaseRepresentor<U>>map(
+			Unsafe::unsafeCast
+		).map(
+			BaseRepresentor::getNestedFieldFunctions
+		).map(
+			List::stream
+		).orElseGet(
+			Stream::empty
+		).forEach(
+			nestedFieldFunction -> {
+				Predicate<String> fieldsPredicate = getFieldsPredicate();
+
+				String key = nestedFieldFunction.getKey();
+
+				if (!fieldsPredicate.test(key)) {
+					return;
+				}
+
+				Object mappedModel = nestedFieldFunction.apply(
+					singleModel.getModel());
+
+				if (mappedModel == null) {
+					return;
+				}
+
+				FunctionalList<String> embeddedNestedPathElements =
+					new FunctionalList<>(
+						embeddedPathElements, nestedFieldFunction.getKey());
+
+				SingleModelImpl nestedSingleModel = new SingleModelImpl<>(
+					mappedModel, "", Collections.emptyList());
+
+				BaseRepresentorFunction nestedRepresentorFunction =
+					__ -> Optional.of(
+						nestedFieldFunction.getNestedRepresentor());
+
+				triConsumer.accept(
+					nestedSingleModel, embeddedNestedPathElements,
+					nestedRepresentorFunction);
+			}
+		);
 	}
 
 	/**

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/PageWriter.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/PageWriter.java
@@ -631,25 +631,26 @@ public class PageWriter<T> {
 	}
 
 	private <U> void _writeNestedList(
-		String fieldName, List<U> list, JSONObjectBuilder jsonObjectBuilder,
+		String fieldName, List<U> nestedList,
+		JSONObjectBuilder jsonObjectBuilder,
 		FunctionalList<String> embeddedPathElements,
 		BaseRepresentorFunction baseRepresentorFunction,
 		SingleModel singleModel) {
 
-		JSONObjectBuilder pageJSONObjectBuilder = new JSONObjectBuilder();
+		JSONObjectBuilder nestedPageJSONObjectBuilder = new JSONObjectBuilder();
 
-		_pageMessageMapper.mapNestedPageItemTotalCount(
-			pageJSONObjectBuilder, list.size());
+		_pageMessageMapper.mapItemTotalCount(
+			nestedPageJSONObjectBuilder, nestedList.size());
 
-		list.forEach(
+		nestedList.forEach(
 			model -> _writeItem(
-				pageJSONObjectBuilder,
+				nestedPageJSONObjectBuilder,
 				new SingleModelImpl<>(model, "", Collections.emptyList()),
 				embeddedPathElements, baseRepresentorFunction, singleModel));
 
 		_pageMessageMapper.onFinishNestedCollection(
-			jsonObjectBuilder, pageJSONObjectBuilder, fieldName, list,
-			embeddedPathElements);
+			jsonObjectBuilder, nestedPageJSONObjectBuilder, fieldName,
+			nestedList, embeddedPathElements);
 	}
 
 	private <S> void _writeNestedLists(

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/PageWriter.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/PageWriter.java
@@ -289,28 +289,15 @@ public class PageWriter<T> {
 	}
 
 	private void _getCollectionType(String resourceName) {
-		BaseRepresentorFunction baseRepresentorFunction =
-			_representorFunction::apply;
-
-		Optional<BaseRepresentor<T>> baseRepresentorOptional =
-			baseRepresentorFunction.apply(
-				resourceName
-			).<BaseRepresentor<T>>map(
-				Unsafe::unsafeCast
-			);
-
-		if (!baseRepresentorOptional.isPresent()) {
-			return;
-		}
-
-		BaseRepresentor<T> representor = baseRepresentorOptional.get();
-
-		List<String> types = representor.getTypes();
-
-		types.forEach(
-			type -> {
-				_pageMessageMapper.mapSemantics(_jsonObjectBuilder, type);
-			});
+		_representorFunction.apply(
+			resourceName
+		).map(
+			BaseRepresentor::getTypes
+		).map(
+			types -> types.get(0)
+		).ifPresent(
+			type -> _pageMessageMapper.mapSemantics(_jsonObjectBuilder, type)
+		);
 	}
 
 	private String _getCollectionURL() {

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/PageWriter.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/PageWriter.java
@@ -292,9 +292,7 @@ public class PageWriter<T> {
 		_representorFunction.apply(
 			resourceName
 		).map(
-			BaseRepresentor::getTypes
-		).map(
-			types -> types.get(0)
+			BaseRepresentor::getPrimaryType
 		).ifPresent(
 			type -> _pageMessageMapper.mapSemantics(_jsonObjectBuilder, type)
 		);

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/PageWriter.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/PageWriter.java
@@ -112,6 +112,8 @@ public class PageWriter<T> {
 
 		List<Operation> operations = _page.getOperations();
 
+		_getCollectionType(resourceName);
+
 		OperationWriter operationWriter = new OperationWriter(
 			_pageMessageMapper, _requestInfo, _jsonObjectBuilder);
 
@@ -284,6 +286,31 @@ public class PageWriter<T> {
 		private ResourceNameFunction _resourceNameFunction;
 		private SingleModelFunction _singleModelFunction;
 
+	}
+
+	private void _getCollectionType(String resourceName) {
+		BaseRepresentorFunction baseRepresentorFunction =
+			_representorFunction::apply;
+
+		Optional<BaseRepresentor<T>> baseRepresentorOptional =
+			baseRepresentorFunction.apply(
+				resourceName
+			).<BaseRepresentor<T>>map(
+				Unsafe::unsafeCast
+			);
+
+		if (!baseRepresentorOptional.isPresent()) {
+			return;
+		}
+
+		BaseRepresentor<T> representor = baseRepresentorOptional.get();
+
+		List<String> types = representor.getTypes();
+
+		types.forEach(
+			type -> {
+				_pageMessageMapper.mapSemantics(_jsonObjectBuilder, type);
+			});
 	}
 
 	private String _getCollectionURL() {

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/SingleModelWriter.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/SingleModelWriter.java
@@ -137,12 +137,12 @@ public class SingleModelWriter<T> {
 				_singleModelMessageMapper.mapLinkedResourceURL(
 					_jsonObjectBuilder, embeddedPathElements, url));
 
-		fieldsWriter.writeNestedResources(_representorFunction::apply,
-			_singleModel, null,
-			(nestedSingleModel, nestedPathElements, nestedRepresentorFunction) ->
-				writeEmbeddedModelFields(
-					nestedSingleModel, _jsonObjectBuilder, nestedPathElements,
-					nestedRepresentorFunction));
+		fieldsWriter.writeNestedResources(
+			_representorFunction::apply, _singleModel, null,
+			(nestedSingleModel, nestedPathElements, nestedRepresentorFunction)
+				-> writeEmbeddedModelFields(
+				nestedSingleModel, _jsonObjectBuilder, nestedPathElements,
+				nestedRepresentorFunction));
 
 		fieldsWriter.writeNestedLists(
 			_representorFunction::apply, _singleModel,
@@ -249,12 +249,12 @@ public class SingleModelWriter<T> {
 				_singleModelMessageMapper.mapLinkedResourceURL(
 					jsonObjectBuilder, resourceEmbeddedPathElements, url));
 
-		fieldsWriter.writeNestedResources(baseRepresentorFunction, singleModel,
-			embeddedPathElements,
-			(nestedSingleModel, nestedPathElements, nestedRepresentorFunction) ->
-				writeEmbeddedModelFields(
-					nestedSingleModel, jsonObjectBuilder, nestedPathElements,
-					nestedRepresentorFunction));
+		fieldsWriter.writeNestedResources(
+			baseRepresentorFunction, singleModel, embeddedPathElements,
+			(nestedSingleModel, nestedPathElements, nestedRepresentorFunction)
+				-> writeEmbeddedModelFields(
+				nestedSingleModel, jsonObjectBuilder, nestedPathElements,
+				nestedRepresentorFunction));
 
 		fieldsWriter.writeNestedLists(
 			baseRepresentorFunction, singleModel,
@@ -661,12 +661,12 @@ public class SingleModelWriter<T> {
 					itemJsonObjectBuilder, resourceEmbeddedPathElements,
 					resourceURL));
 
-		fieldsWriter.writeNestedResources(baseRepresentorFunction, singleModel,
-			embeddedPathElements,
-			(nestedSingleModel, nestedPathElements, nestedRepresentorFunction) ->
-				writeEmbeddedModelFields(
-					nestedSingleModel, itemJsonObjectBuilder, nestedPathElements,
-					nestedRepresentorFunction));
+		fieldsWriter.writeNestedResources(
+			baseRepresentorFunction, singleModel, embeddedPathElements,
+			(nestedSingleModel, nestedPathElements, nestedRepresentorFunction)
+				-> writeEmbeddedModelFields(
+				nestedSingleModel, itemJsonObjectBuilder, nestedPathElements,
+				nestedRepresentorFunction));
 
 		fieldsWriter.writeNestedLists(
 			baseRepresentorFunction, singleModel,

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/SingleModelWriter.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/impl/writer/SingleModelWriter.java
@@ -38,6 +38,7 @@ import com.liferay.apio.architect.uri.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -418,6 +419,17 @@ public class SingleModelWriter<T> {
 
 	}
 
+	private Consumer<BaseRepresentor> _mapPageSemantics(
+		JSONObjectBuilder jsonObjectBuilder) {
+
+		return baseRepresentor -> {
+			String type = baseRepresentor.getPrimaryType();
+
+			_singleModelMessageMapper.mapNestedPageSemantics(
+				jsonObjectBuilder, type);
+		};
+	}
+
 	private void _writeBasicFields(
 		FieldsWriter<?> fieldsWriter, JSONObjectBuilder jsonObjectBuilder) {
 
@@ -655,6 +667,12 @@ public class SingleModelWriter<T> {
 
 		_singleModelMessageMapper.mapNestedPageItemTotalCount(
 			pageJSONObjectBuilder, list.size());
+
+		baseRepresentorFunction.apply(
+			""
+		).ifPresent(
+			_mapPageSemantics(pageJSONObjectBuilder)
+		);
 
 		list.forEach(
 			model -> _writeItem(

--- a/modules/apps/apio-architect/apio-architect-impl/src/test/java/com/liferay/apio/architect/impl/representor/RepresentorTest.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/test/java/com/liferay/apio/architect/impl/representor/RepresentorTest.java
@@ -268,6 +268,10 @@ public class RepresentorTest {
 
 	@Test
 	public void testTypes() {
+		String primaryType = _representor.getPrimaryType();
+
+		assertThat(primaryType, is("Type 1"));
+
 		List<String> types = _representor.getTypes();
 
 		assertThat(types, contains("Type 1", "Type 2", "Type 3"));

--- a/modules/apps/apio-architect/apio-architect-impl/src/test/resources/hal/page.json
+++ b/modules/apps/apio-architect/apio-architect-impl/src/test/resources/hal/page.json
@@ -53,6 +53,50 @@
 						},
 						"number1": 42,
 						"string1": "1"
+					},
+					"nestedList": {
+						"_embedded": [
+							{
+								"_embedded": {
+									"nested4": {
+										"string1": "id 4"
+									},
+									"nestedList": {
+										"_embedded": [
+											{
+												"number1": 2017
+											}, {
+												"number1": 2017
+											}
+										],
+										"total": 2
+									}
+								},
+								"number1": 2017,
+								"string1": "id 1",
+								"string2": "string2"
+							}, {
+								"number1": 2017,
+								"string1": "id 2",
+								"string2": "string2",
+								"_embedded": {
+									"nested4": {
+										"string1": "id 4"
+									},
+									"nestedList": {
+										"_embedded": [
+											{
+												"number1": 2017
+											}, {
+												"number1": 2017
+											}
+										],
+										"total": 2
+									}
+								}
+							}
+						],
+						"total": 2
 					}
 				},
 				"_links": {
@@ -139,6 +183,50 @@
 						},
 						"number1": 42,
 						"string1": "2"
+					},
+					"nestedList": {
+						"_embedded": [
+							{
+								"_embedded": {
+									"nested4": {
+										"string1": "id 4"
+									},
+									"nestedList": {
+										"_embedded": [
+											{
+												"number1": 2017
+											}, {
+												"number1": 2017
+											}
+										],
+										"total": 2
+									}
+								},
+								"number1": 2017,
+								"string1": "id 1",
+								"string2": "string2"
+							}, {
+								"number1": 2017,
+								"string1": "id 2",
+								"string2": "string2",
+								"_embedded": {
+									"nested4": {
+										"string1": "id 4"
+									},
+									"nestedList": {
+										"_embedded": [
+											{
+												"number1": 2017
+											}, {
+												"number1": 2017
+											}
+										],
+										"total": 2
+									}
+								}
+							}
+						],
+						"total": 2
 					}
 				},
 				"_links": {
@@ -225,6 +313,50 @@
 						},
 						"number1": 42,
 						"string1": "3"
+					},
+					"nestedList": {
+						"_embedded": [
+							{
+								"_embedded": {
+									"nested4": {
+										"string1": "id 4"
+									},
+									"nestedList": {
+										"_embedded": [
+											{
+												"number1": 2017
+											}, {
+												"number1": 2017
+											}
+										],
+										"total": 2
+									}
+								},
+								"number1": 2017,
+								"string1": "id 1",
+								"string2": "string2"
+							}, {
+								"number1": 2017,
+								"string1": "id 2",
+								"string2": "string2",
+								"_embedded": {
+									"nested4": {
+										"string1": "id 4"
+									},
+									"nestedList": {
+										"_embedded": [
+											{
+												"number1": 2017
+											}, {
+												"number1": 2017
+											}
+										],
+										"total": 2
+									}
+								}
+							}
+						],
+						"total": 2
 					}
 				},
 				"_links": {

--- a/modules/apps/apio-architect/apio-architect-impl/src/test/resources/hal/single_model.json
+++ b/modules/apps/apio-architect/apio-architect-impl/src/test/resources/hal/single_model.json
@@ -50,6 +50,44 @@
 			},
 			"number1": 42,
 			"string1": "first"
+		},
+		"nestedList" : {
+			"total" : 2,
+			"_embedded" : [ {
+					"number1" : 2017,
+					"string1" : "id 1",
+					"string2" : "string2",
+					"_embedded" : {
+						"nested4" : {
+							"string1" : "id 4"
+						},
+						"nestedList" : {
+							"total" : 2,
+							"_embedded" : [ {
+									"number1" : 2017
+								}, {
+									"number1" : 2017
+								} ]
+						}
+					}
+				}, {
+					"_embedded" : {
+						"nested4" : {
+							"string1" : "id 4"
+						},
+						"nestedList" : {
+							"total" : 2,
+							"_embedded" : [ {
+									"number1" : 2017
+								}, {
+									"number1" : 2017
+								} ]
+						}
+					},
+					"number1" : 2017,
+					"string1" : "id 2",
+					"string2" : "string2"
+				} ]
 		}
 	},
 	"_links": {

--- a/modules/apps/apio-architect/apio-architect-impl/src/test/resources/ld/entrypoint.json
+++ b/modules/apps/apio-architect/apio-architect-impl/src/test/resources/ld/entrypoint.json
@@ -10,15 +10,33 @@
 	"collection": [
 		{
 			"@id": "localhost/o/api/p/type1",
-			"@type": ["Collection"]
+			"@type": [
+				"Collection"
+			],
+			"manages": {
+				"object": "schema:Type1",
+				"property": "rdf:type"
+			}
 		},
 		{
 			"@id": "localhost/o/api/p/type2",
-			"@type": ["Collection"]
+			"@type": [
+				"Collection"
+			],
+			"manages": {
+				"object": "schema:Type2",
+				"property": "rdf:type"
+			}
 		},
 		{
 			"@id": "localhost/o/api/p/type3",
-			"@type": ["Collection"]
+			"@type": [
+				"Collection"
+			],
+			"manages": {
+				"object": "schema:Type3",
+				"property": "rdf:type"
+			}
 		}
 	]
 }

--- a/modules/apps/apio-architect/apio-architect-impl/src/test/resources/ld/page.json
+++ b/modules/apps/apio-architect/apio-architect-impl/src/test/resources/ld/page.json
@@ -1,59 +1,133 @@
 {
 	"@context": [
-		{ "@vocab": "http://schema.org/" },
+		{
+			"@vocab": "http://schema.org/"
+		},
 		"https://www.w3.org/ns/hydra/core#"
 	],
 	"@id": "localhost/o/api/p/name/id/root",
-	"@type": ["Collection"],
+	"@type": [
+		"Collection"
+	],
+	"manages": {
+		"object": "schema:Type 1",
+		"property": "rdf:type"
+	},
 	"member": [
 		{
 			"@context": [
-				{ "embedded2": { "@type": "@id" } },
-				{ "linked1": { "@type": "@id" } },
-				{ "linked2": { "@type": "@id" } },
-				{ "relatedCollection1": { "@type": "@id" } },
-				{ "relatedCollection2": { "@type": "@id" } }
+				{
+					"embedded2": {
+						"@type": "@id"
+					}
+				},
+				{
+					"linked1": {
+						"@type": "@id"
+					}
+				},
+				{
+					"linked2": {
+						"@type": "@id"
+					}
+				},
+				{
+					"relatedCollection1": {
+						"@type": "@id"
+					}
+				},
+				{
+					"relatedCollection2": {
+						"@type": "@id"
+					}
+				}
 			],
 			"@id": "localhost/o/api/p/model/1",
-			"@type": ["Type 1", "Type 2"],
+			"@type": [
+				"Type 1",
+				"Type 2"
+			],
 			"applicationRelativeURL1": "localhost/o/api/first",
 			"binary1": "localhost/o/api/b/model/1/binary1",
 			"binary2": "localhost/o/api/b/model/1/binary2",
 			"boolean1": true,
 			"boolean2": false,
-			"booleanList1": [true, true, false, false],
-			"booleanList2": [true, false, true, false],
+			"booleanList1": [
+				true,
+				true,
+				false,
+				false
+			],
+			"booleanList2": [
+				true,
+				false,
+				true,
+				false
+			],
 			"date1": "2016-06-15T09:00Z",
 			"date2": "2017-04-03T18:36Z",
 			"embedded1": {
 				"@context": [
-					{ "linked": { "@type": "@id" } },
-					{ "relatedCollection": { "@type": "@id" } }
+					{
+						"linked": {
+							"@type": "@id"
+						}
+					},
+					{
+						"relatedCollection": {
+							"@type": "@id"
+						}
+					}
 				],
 				"@id": "localhost/o/api/p/first-inner-model/first",
-				"@type": ["Type"],
+				"@type": [
+					"Type"
+				],
 				"binary": "localhost/o/api/b/first-inner-model/first/binary",
 				"boolean": true,
-				"booleanList": [true, false],
+				"booleanList": [
+					true,
+					false
+				],
 				"embedded": {
 					"@context": [
-						{ "embedded": { "@type": "@id" } },
-						{ "linked": { "@type": "@id" } },
-						{ "relatedCollection": { "@type": "@id" } }
+						{
+							"embedded": {
+								"@type": "@id"
+							}
+						},
+						{
+							"linked": {
+								"@type": "@id"
+							}
+						},
+						{
+							"relatedCollection": {
+								"@type": "@id"
+							}
+						}
 					],
 					"@id": "localhost/o/api/p/second-inner-model/first",
-					"@type": ["Type"],
+					"@type": [
+						"Type"
+					],
 					"binary": "localhost/o/api/b/second-inner-model/first/binary",
 					"boolean": false,
-					"booleanList": [true],
+					"booleanList": [
+						true
+					],
 					"embedded": "localhost/o/api/p/third-inner-model/first",
 					"link": "community.liferay.com",
 					"linked": "localhost/o/api/p/third-inner-model/second",
 					"number": 2017,
-					"numberList": [1],
+					"numberList": [
+						1
+					],
 					"relatedCollection": "localhost/o/api/p/second-inner-model/first/models",
 					"string": "A string",
-					"stringList": ["a"]
+					"stringList": [
+						"a"
+					]
 				},
 				"link": "www.liferay.com",
 				"linked": "localhost/o/api/p/second-inner-model/second",
@@ -64,13 +138,17 @@
 					],
 					"member": [
 						{
-							"@type": ["Type 7"],
+							"@type": [
+								"Type 7"
+							],
 							"number1": 2018,
 							"string1": "id 1",
 							"string2": "string3"
 						},
 						{
-							"@type": ["Type 7"],
+							"@type": [
+								"Type 7"
+							],
 							"number1": 2018,
 							"string1": "id 2",
 							"string2": "string3"
@@ -79,10 +157,16 @@
 					"totalItems": 2
 				},
 				"number": 42,
-				"numberList": [1, 2],
+				"numberList": [
+					1,
+					2
+				],
 				"relatedCollection": "localhost/o/api/p/first-inner-model/first/models",
 				"string": "A string",
-				"stringList": ["a", "b"]
+				"stringList": [
+					"a",
+					"b"
+				]
 			},
 			"embedded2": "localhost/o/api/p/first-inner-model/second",
 			"link1": "www.liferay.com",
@@ -92,17 +176,29 @@
 			"localizedString1": "Translated 1",
 			"localizedString2": "Translated 2",
 			"nested1": {
-				"@type": ["Type 3"],
+				"@type": [
+					"Type 3"
+				],
 				"number1": 2017,
 				"string1": "id 1",
 				"string2": "string2"
 			},
 			"nested2": {
-				"@context": [ { "linked3": { "@type": "@id" } } ],
-				"@type": ["Type 4"],
+				"@context": [
+					{
+						"linked3": {
+							"@type": "@id"
+						}
+					}
+				],
+				"@type": [
+					"Type 4"
+				],
 				"linked3": "localhost/o/api/p/third-inner-model/fifth",
 				"nested3": {
-					"@type": ["Type 5"],
+					"@type": [
+						"Type 5"
+					],
 					"string1": "id 3"
 				},
 				"number1": 42,
@@ -114,17 +210,28 @@
 				],
 				"member": [
 					{
-						"@type": ["Type 6"],
+						"@type": [
+							"Type 6"
+						],
 						"nested4": {
-							"@type": ["Type 7"],
+							"@type": [
+								"Type 7"
+							],
 							"nestedList": {
-								"@type": ["Collection"],
+								"@type": [
+									"Collection"
+								],
 								"member": [
 									{
-										"@type": ["Type 8"],
+										"@type": [
+											"Type 8"
+										],
 										"number1": 2017
-									}, {
-										"@type": ["Type 8"],
+									},
+									{
+										"@type": [
+											"Type 8"
+										],
 										"number1": 2017
 									}
 								],
@@ -137,17 +244,28 @@
 						"string2": "string2"
 					},
 					{
-						"@type": ["Type 6"],
+						"@type": [
+							"Type 6"
+						],
 						"nested4": {
-							"@type": ["Type 7"],
+							"@type": [
+								"Type 7"
+							],
 							"nestedList": {
-								"@type": ["Collection"],
+								"@type": [
+									"Collection"
+								],
 								"member": [
 									{
-										"@type": ["Type 8"],
+										"@type": [
+											"Type 8"
+										],
 										"number1": 2017
-									}, {
-										"@type": ["Type 8"],
+									},
+									{
+										"@type": [
+											"Type 8"
+										],
 										"number1": 2017
 									}
 								],
@@ -164,65 +282,155 @@
 			},
 			"number1": 2017,
 			"number2": 42,
-			"numberList1": [1, 2, 3, 4, 5],
-			"numberList2": [6, 7, 8, 9, 10],
+			"numberList1": [
+				1,
+				2,
+				3,
+				4,
+				5
+			],
+			"numberList2": [
+				6,
+				7,
+				8,
+				9,
+				10
+			],
 			"relatedCollection1": "localhost/o/api/p/model/1/models",
 			"relatedCollection2": "localhost/o/api/p/model/1/models",
 			"relativeURL1": "localhost/first",
 			"relativeURL2": "localhost/second",
 			"string1": "Live long and prosper",
 			"string2": "Hypermedia",
-			"stringList1": ["a", "b", "c", "d", "e"],
-			"stringList2": ["f", "g", "h", "i", "j"]
+			"stringList1": [
+				"a",
+				"b",
+				"c",
+				"d",
+				"e"
+			],
+			"stringList2": [
+				"f",
+				"g",
+				"h",
+				"i",
+				"j"
+			]
 		},
 		{
 			"@context": [
-				{ "embedded2": { "@type": "@id" } },
-				{ "linked1": { "@type": "@id" } },
-				{ "linked2": { "@type": "@id" } },
-				{ "relatedCollection1": { "@type": "@id" } },
-				{ "relatedCollection2": { "@type": "@id" } }
+				{
+					"embedded2": {
+						"@type": "@id"
+					}
+				},
+				{
+					"linked1": {
+						"@type": "@id"
+					}
+				},
+				{
+					"linked2": {
+						"@type": "@id"
+					}
+				},
+				{
+					"relatedCollection1": {
+						"@type": "@id"
+					}
+				},
+				{
+					"relatedCollection2": {
+						"@type": "@id"
+					}
+				}
 			],
 			"@id": "localhost/o/api/p/model/2",
-			"@type": ["Type 1", "Type 2"],
+			"@type": [
+				"Type 1",
+				"Type 2"
+			],
 			"applicationRelativeURL1": "localhost/o/api/first",
 			"binary1": "localhost/o/api/b/model/2/binary1",
 			"binary2": "localhost/o/api/b/model/2/binary2",
 			"boolean1": true,
 			"boolean2": false,
-			"booleanList1": [true, true, false, false],
-			"booleanList2": [true, false, true, false],
+			"booleanList1": [
+				true,
+				true,
+				false,
+				false
+			],
+			"booleanList2": [
+				true,
+				false,
+				true,
+				false
+			],
 			"date1": "2016-06-15T09:00Z",
 			"date2": "2017-04-03T18:36Z",
 			"embedded1": {
 				"@context": [
-					{ "linked": { "@type": "@id" } },
-					{ "relatedCollection": { "@type": "@id" } }
+					{
+						"linked": {
+							"@type": "@id"
+						}
+					},
+					{
+						"relatedCollection": {
+							"@type": "@id"
+						}
+					}
 				],
 				"@id": "localhost/o/api/p/first-inner-model/first",
-				"@type": ["Type"],
+				"@type": [
+					"Type"
+				],
 				"binary": "localhost/o/api/b/first-inner-model/first/binary",
 				"boolean": true,
-				"booleanList": [true, false],
+				"booleanList": [
+					true,
+					false
+				],
 				"embedded": {
 					"@context": [
-						{ "embedded": { "@type": "@id" } },
-						{ "linked": { "@type": "@id" } },
-						{ "relatedCollection": { "@type": "@id" } }
+						{
+							"embedded": {
+								"@type": "@id"
+							}
+						},
+						{
+							"linked": {
+								"@type": "@id"
+							}
+						},
+						{
+							"relatedCollection": {
+								"@type": "@id"
+							}
+						}
 					],
 					"@id": "localhost/o/api/p/second-inner-model/first",
-					"@type": ["Type"],
+					"@type": [
+						"Type"
+					],
 					"binary": "localhost/o/api/b/second-inner-model/first/binary",
 					"boolean": false,
-					"booleanList": [true],
+					"booleanList": [
+						true
+					],
 					"embedded": "localhost/o/api/p/third-inner-model/first",
 					"link": "community.liferay.com",
 					"linked": "localhost/o/api/p/third-inner-model/second",
 					"number": 2017,
-					"numberList": [1],
+					"numberList": [
+						1
+					],
 					"relatedCollection": "localhost/o/api/p/second-inner-model/first/models",
 					"string": "A string",
-					"stringList": ["a"]
+					"stringList": [
+						"a"
+					]
 				},
 				"link": "www.liferay.com",
 				"linked": "localhost/o/api/p/second-inner-model/second",
@@ -233,13 +441,17 @@
 					],
 					"member": [
 						{
-							"@type": ["Type 7"],
+							"@type": [
+								"Type 7"
+							],
 							"number1": 2018,
 							"string1": "id 1",
 							"string2": "string3"
 						},
 						{
-							"@type": ["Type 7"],
+							"@type": [
+								"Type 7"
+							],
 							"number1": 2018,
 							"string1": "id 2",
 							"string2": "string3"
@@ -248,10 +460,16 @@
 					"totalItems": 2
 				},
 				"number": 42,
-				"numberList": [1, 2],
+				"numberList": [
+					1,
+					2
+				],
 				"relatedCollection": "localhost/o/api/p/first-inner-model/first/models",
 				"string": "A string",
-				"stringList": ["a", "b"]
+				"stringList": [
+					"a",
+					"b"
+				]
 			},
 			"embedded2": "localhost/o/api/p/first-inner-model/second",
 			"link1": "www.liferay.com",
@@ -261,17 +479,29 @@
 			"localizedString1": "Translated 1",
 			"localizedString2": "Translated 2",
 			"nested1": {
-				"@type": ["Type 3"],
+				"@type": [
+					"Type 3"
+				],
 				"number1": 2017,
 				"string1": "id 1",
 				"string2": "string2"
 			},
 			"nested2": {
-				"@context": [ { "linked3": { "@type": "@id" } } ],
-				"@type": ["Type 4"],
+				"@context": [
+					{
+						"linked3": {
+							"@type": "@id"
+						}
+					}
+				],
+				"@type": [
+					"Type 4"
+				],
 				"linked3": "localhost/o/api/p/third-inner-model/fifth",
 				"nested3": {
-					"@type": ["Type 5"],
+					"@type": [
+						"Type 5"
+					],
 					"string1": "id 3"
 				},
 				"number1": 42,
@@ -283,17 +513,28 @@
 				],
 				"member": [
 					{
-						"@type": ["Type 6"],
+						"@type": [
+							"Type 6"
+						],
 						"nested4": {
-							"@type": ["Type 7"],
+							"@type": [
+								"Type 7"
+							],
 							"nestedList": {
-								"@type": ["Collection"],
+								"@type": [
+									"Collection"
+								],
 								"member": [
 									{
-										"@type": ["Type 8"],
+										"@type": [
+											"Type 8"
+										],
 										"number1": 2017
-									}, {
-										"@type": ["Type 8"],
+									},
+									{
+										"@type": [
+											"Type 8"
+										],
 										"number1": 2017
 									}
 								],
@@ -306,17 +547,28 @@
 						"string2": "string2"
 					},
 					{
-						"@type": ["Type 6"],
+						"@type": [
+							"Type 6"
+						],
 						"nested4": {
-							"@type": ["Type 7"],
+							"@type": [
+								"Type 7"
+							],
 							"nestedList": {
-								"@type": ["Collection"],
+								"@type": [
+									"Collection"
+								],
 								"member": [
 									{
-										"@type": ["Type 8"],
+										"@type": [
+											"Type 8"
+										],
 										"number1": 2017
-									}, {
-										"@type": ["Type 8"],
+									},
+									{
+										"@type": [
+											"Type 8"
+										],
 										"number1": 2017
 									}
 								],
@@ -333,65 +585,155 @@
 			},
 			"number1": 2017,
 			"number2": 42,
-			"numberList1": [1, 2, 3, 4, 5],
-			"numberList2": [6, 7, 8, 9, 10],
+			"numberList1": [
+				1,
+				2,
+				3,
+				4,
+				5
+			],
+			"numberList2": [
+				6,
+				7,
+				8,
+				9,
+				10
+			],
 			"relatedCollection1": "localhost/o/api/p/model/2/models",
 			"relatedCollection2": "localhost/o/api/p/model/2/models",
 			"relativeURL1": "localhost/first",
 			"relativeURL2": "localhost/second",
 			"string1": "Live long and prosper",
 			"string2": "Hypermedia",
-			"stringList1": ["a", "b", "c", "d", "e"],
-			"stringList2": ["f", "g", "h", "i", "j"]
+			"stringList1": [
+				"a",
+				"b",
+				"c",
+				"d",
+				"e"
+			],
+			"stringList2": [
+				"f",
+				"g",
+				"h",
+				"i",
+				"j"
+			]
 		},
 		{
 			"@context": [
-				{ "embedded2": { "@type": "@id" } },
-				{ "linked1": { "@type": "@id" } },
-				{ "linked2": { "@type": "@id" } },
-				{ "relatedCollection1": { "@type": "@id" } },
-				{ "relatedCollection2": { "@type": "@id" } }
+				{
+					"embedded2": {
+						"@type": "@id"
+					}
+				},
+				{
+					"linked1": {
+						"@type": "@id"
+					}
+				},
+				{
+					"linked2": {
+						"@type": "@id"
+					}
+				},
+				{
+					"relatedCollection1": {
+						"@type": "@id"
+					}
+				},
+				{
+					"relatedCollection2": {
+						"@type": "@id"
+					}
+				}
 			],
 			"@id": "localhost/o/api/p/model/3",
-			"@type": ["Type 1", "Type 2"],
+			"@type": [
+				"Type 1",
+				"Type 2"
+			],
 			"applicationRelativeURL1": "localhost/o/api/first",
 			"binary1": "localhost/o/api/b/model/3/binary1",
 			"binary2": "localhost/o/api/b/model/3/binary2",
 			"boolean1": true,
 			"boolean2": false,
-			"booleanList1": [true, true, false, false],
-			"booleanList2": [true, false, true, false],
+			"booleanList1": [
+				true,
+				true,
+				false,
+				false
+			],
+			"booleanList2": [
+				true,
+				false,
+				true,
+				false
+			],
 			"date1": "2016-06-15T09:00Z",
 			"date2": "2017-04-03T18:36Z",
 			"embedded1": {
 				"@context": [
-					{ "linked": { "@type": "@id" } },
-					{ "relatedCollection": { "@type": "@id" } }
+					{
+						"linked": {
+							"@type": "@id"
+						}
+					},
+					{
+						"relatedCollection": {
+							"@type": "@id"
+						}
+					}
 				],
 				"@id": "localhost/o/api/p/first-inner-model/first",
-				"@type": ["Type"],
+				"@type": [
+					"Type"
+				],
 				"binary": "localhost/o/api/b/first-inner-model/first/binary",
 				"boolean": true,
-				"booleanList": [true, false],
+				"booleanList": [
+					true,
+					false
+				],
 				"embedded": {
 					"@context": [
-						{ "embedded": { "@type": "@id" } },
-						{ "linked": { "@type": "@id" } },
-						{ "relatedCollection": { "@type": "@id" } }
+						{
+							"embedded": {
+								"@type": "@id"
+							}
+						},
+						{
+							"linked": {
+								"@type": "@id"
+							}
+						},
+						{
+							"relatedCollection": {
+								"@type": "@id"
+							}
+						}
 					],
 					"@id": "localhost/o/api/p/second-inner-model/first",
-					"@type": ["Type"],
+					"@type": [
+						"Type"
+					],
 					"binary": "localhost/o/api/b/second-inner-model/first/binary",
 					"boolean": false,
-					"booleanList": [true],
+					"booleanList": [
+						true
+					],
 					"embedded": "localhost/o/api/p/third-inner-model/first",
 					"link": "community.liferay.com",
 					"linked": "localhost/o/api/p/third-inner-model/second",
 					"number": 2017,
-					"numberList": [1],
+					"numberList": [
+						1
+					],
 					"relatedCollection": "localhost/o/api/p/second-inner-model/first/models",
 					"string": "A string",
-					"stringList": ["a"]
+					"stringList": [
+						"a"
+					]
 				},
 				"link": "www.liferay.com",
 				"linked": "localhost/o/api/p/second-inner-model/second",
@@ -402,13 +744,17 @@
 					],
 					"member": [
 						{
-							"@type": ["Type 7"],
+							"@type": [
+								"Type 7"
+							],
 							"number1": 2018,
 							"string1": "id 1",
 							"string2": "string3"
 						},
 						{
-							"@type": ["Type 7"],
+							"@type": [
+								"Type 7"
+							],
 							"number1": 2018,
 							"string1": "id 2",
 							"string2": "string3"
@@ -417,10 +763,16 @@
 					"totalItems": 2
 				},
 				"number": 42,
-				"numberList": [1, 2],
+				"numberList": [
+					1,
+					2
+				],
 				"relatedCollection": "localhost/o/api/p/first-inner-model/first/models",
 				"string": "A string",
-				"stringList": ["a", "b"]
+				"stringList": [
+					"a",
+					"b"
+				]
 			},
 			"embedded2": "localhost/o/api/p/first-inner-model/second",
 			"link1": "www.liferay.com",
@@ -430,17 +782,29 @@
 			"localizedString1": "Translated 1",
 			"localizedString2": "Translated 2",
 			"nested1": {
-				"@type": ["Type 3"],
+				"@type": [
+					"Type 3"
+				],
 				"number1": 2017,
 				"string1": "id 1",
 				"string2": "string2"
 			},
 			"nested2": {
-				"@context": [ { "linked3": { "@type": "@id" } } ],
-				"@type": ["Type 4"],
+				"@context": [
+					{
+						"linked3": {
+							"@type": "@id"
+						}
+					}
+				],
+				"@type": [
+					"Type 4"
+				],
 				"linked3": "localhost/o/api/p/third-inner-model/fifth",
 				"nested3": {
-					"@type": ["Type 5"],
+					"@type": [
+						"Type 5"
+					],
 					"string1": "id 3"
 				},
 				"number1": 42,
@@ -452,17 +816,28 @@
 				],
 				"member": [
 					{
-						"@type": ["Type 6"],
+						"@type": [
+							"Type 6"
+						],
 						"nested4": {
-							"@type": ["Type 7"],
+							"@type": [
+								"Type 7"
+							],
 							"nestedList": {
-								"@type": ["Collection"],
+								"@type": [
+									"Collection"
+								],
 								"member": [
 									{
-										"@type": ["Type 8"],
+										"@type": [
+											"Type 8"
+										],
 										"number1": 2017
-									}, {
-										"@type": ["Type 8"],
+									},
+									{
+										"@type": [
+											"Type 8"
+										],
 										"number1": 2017
 									}
 								],
@@ -475,17 +850,28 @@
 						"string2": "string2"
 					},
 					{
-						"@type": ["Type 6"],
+						"@type": [
+							"Type 6"
+						],
 						"nested4": {
-							"@type": ["Type 7"],
+							"@type": [
+								"Type 7"
+							],
 							"nestedList": {
-								"@type": ["Collection"],
+								"@type": [
+									"Collection"
+								],
 								"member": [
 									{
-										"@type": ["Type 8"],
+										"@type": [
+											"Type 8"
+										],
 										"number1": 2017
-									}, {
-										"@type": ["Type 8"],
+									},
+									{
+										"@type": [
+											"Type 8"
+										],
 										"number1": 2017
 									}
 								],
@@ -502,23 +888,50 @@
 			},
 			"number1": 2017,
 			"number2": 42,
-			"numberList1": [1, 2, 3, 4, 5],
-			"numberList2": [6, 7, 8, 9, 10],
+			"numberList1": [
+				1,
+				2,
+				3,
+				4,
+				5
+			],
+			"numberList2": [
+				6,
+				7,
+				8,
+				9,
+				10
+			],
 			"relatedCollection1": "localhost/o/api/p/model/3/models",
 			"relatedCollection2": "localhost/o/api/p/model/3/models",
 			"relativeURL1": "localhost/first",
 			"relativeURL2": "localhost/second",
 			"string1": "Live long and prosper",
 			"string2": "Hypermedia",
-			"stringList1": ["a", "b", "c", "d", "e"],
-			"stringList2": ["f", "g", "h", "i", "j"]
+			"stringList1": [
+				"a",
+				"b",
+				"c",
+				"d",
+				"e"
+			],
+			"stringList2": [
+				"f",
+				"g",
+				"h",
+				"i",
+				"j"
+			]
 		}
 	],
 	"numberOfItems": 3,
 	"operation": [
 		{
 			"@id": "_:resource/create",
-			"@type": ["CreateAction", "Operation"],
+			"@type": [
+				"CreateAction",
+				"Operation"
+			],
 			"expects": "localhost/o/api/f/c/p",
 			"method": "POST"
 		}
@@ -526,7 +939,9 @@
 	"totalItems": 9,
 	"view": {
 		"@id": "localhost/o/api/p/name/id/root?page=2&per_page=3",
-		"@type": ["PartialCollectionView"],
+		"@type": [
+			"PartialCollectionView"
+		],
 		"first": "localhost/o/api/p/name/id/root?page=1&per_page=3",
 		"last": "localhost/o/api/p/name/id/root?page=3&per_page=3",
 		"next": "localhost/o/api/p/name/id/root?page=3&per_page=3",

--- a/modules/apps/apio-architect/apio-architect-impl/src/test/resources/ld/page.json
+++ b/modules/apps/apio-architect/apio-architect-impl/src/test/resources/ld/page.json
@@ -136,6 +136,10 @@
 					"@type": [
 						"Collection"
 					],
+					"manages": {
+						"object": "schema:Type 7",
+						"property": "rdf:type"
+					},
 					"member": [
 						{
 							"@type": [
@@ -208,6 +212,10 @@
 				"@type": [
 					"Collection"
 				],
+				"manages": {
+					"object": "schema:Type 6",
+					"property": "rdf:type"
+				},
 				"member": [
 					{
 						"@type": [
@@ -221,6 +229,10 @@
 								"@type": [
 									"Collection"
 								],
+								"manages": {
+									"object": "schema:Type 8",
+									"property": "rdf:type"
+								},
 								"member": [
 									{
 										"@type": [
@@ -255,6 +267,10 @@
 								"@type": [
 									"Collection"
 								],
+								"manages": {
+									"object": "schema:Type 8",
+									"property": "rdf:type"
+								},
 								"member": [
 									{
 										"@type": [
@@ -439,6 +455,10 @@
 					"@type": [
 						"Collection"
 					],
+					"manages": {
+						"object": "schema:Type 7",
+						"property": "rdf:type"
+					},
 					"member": [
 						{
 							"@type": [
@@ -511,6 +531,10 @@
 				"@type": [
 					"Collection"
 				],
+				"manages": {
+					"object": "schema:Type 6",
+					"property": "rdf:type"
+				},
 				"member": [
 					{
 						"@type": [
@@ -524,6 +548,10 @@
 								"@type": [
 									"Collection"
 								],
+								"manages": {
+									"object": "schema:Type 8",
+									"property": "rdf:type"
+								},
 								"member": [
 									{
 										"@type": [
@@ -558,6 +586,10 @@
 								"@type": [
 									"Collection"
 								],
+								"manages": {
+									"object": "schema:Type 8",
+									"property": "rdf:type"
+								},
 								"member": [
 									{
 										"@type": [
@@ -742,6 +774,10 @@
 					"@type": [
 						"Collection"
 					],
+					"manages": {
+						"object": "schema:Type 7",
+						"property": "rdf:type"
+					},
 					"member": [
 						{
 							"@type": [
@@ -814,6 +850,10 @@
 				"@type": [
 					"Collection"
 				],
+				"manages": {
+					"object": "schema:Type 6",
+					"property": "rdf:type"
+				},
 				"member": [
 					{
 						"@type": [
@@ -827,6 +867,10 @@
 								"@type": [
 									"Collection"
 								],
+								"manages": {
+									"object": "schema:Type 8",
+									"property": "rdf:type"
+								},
 								"member": [
 									{
 										"@type": [
@@ -861,6 +905,10 @@
 								"@type": [
 									"Collection"
 								],
+								"manages": {
+									"object": "schema:Type 8",
+									"property": "rdf:type"
+								},
 								"member": [
 									{
 										"@type": [

--- a/modules/apps/apio-architect/apio-architect-impl/src/test/resources/ld/single_model.json
+++ b/modules/apps/apio-architect/apio-architect-impl/src/test/resources/ld/single_model.json
@@ -56,6 +56,10 @@
 			"@type": [
 				"Collection"
 			],
+			"manages": {
+				"object": "schema:Type 7",
+				"property": "rdf:type"
+			},
 			"member": [
 				{
 					"@type": ["Type 7"],
@@ -113,6 +117,10 @@
 		"@type": [
 			"Collection"
 		],
+		"manages": {
+			"object": "schema:Type 6",
+			"property": "rdf:type"
+		},
 		"member": [
 			{
 				"@type": ["Type 6"],
@@ -120,6 +128,10 @@
 					"@type" : [ "Type 7" ],
 					"nestedList" : {
 						"totalItems" : 2,
+						"manages": {
+							"object": "schema:Type 8",
+							"property": "rdf:type"
+						},
 						"member" : [ {
 								"@type" : [ "Type 8" ],
 								"number1" : 2017
@@ -141,6 +153,10 @@
 					"@type" : [ "Type 7" ],
 					"nestedList" : {
 						"totalItems" : 2,
+						"manages": {
+							"object": "schema:Type 8",
+							"property": "rdf:type"
+						},
 						"member" : [ {
 								"@type" : [ "Type 8" ],
 								"number1" : 2017

--- a/modules/apps/apio-architect/apio-architect-impl/src/test/resources/plain/page.json
+++ b/modules/apps/apio-architect/apio-architect-impl/src/test/resources/plain/page.json
@@ -32,6 +32,20 @@
 				"link": "www.liferay.com",
 				"linked": "localhost/o/api/p/second-inner-model/second",
 				"localizedString": "Translated",
+				"nestedList": {
+					"elements": [
+						{
+							"number1": 2018,
+							"string1": "id 1",
+							"string2": "string3"
+						}, {
+							"number1": 2018,
+							"string1": "id 2",
+							"string2": "string3"
+						}
+					],
+					"totalNumberOfItems": 2
+				},
 				"number": 42,
 				"numberList": [1, 2],
 				"relatedCollection": "localhost/o/api/p/first-inner-model/first/models",
@@ -58,6 +72,46 @@
 				},
 				"number1": 42,
 				"string1": "1"
+			},
+			"nestedList": {
+				"elements": [
+					{
+						"nested4": {
+							"nestedList": {
+								"elements": [
+									{
+										"number1": 2017
+									}, {
+										"number1": 2017
+									}
+								],
+								"totalNumberOfItems": 2
+							},
+							"string1": "id 4"
+						},
+						"number1": 2017,
+						"string1": "id 1",
+						"string2": "string2"
+					}, {
+						"number1": 2017,
+						"string1": "id 2",
+						"string2": "string2",
+						"nested4": {
+							"nestedList": {
+								"elements": [
+									{
+										"number1": 2017
+									}, {
+										"number1": 2017
+									}
+								],
+								"totalNumberOfItems": 2
+							},
+							"string1": "id 4"
+						}
+					}
+				],
+				"totalNumberOfItems": 2
 			},
 			"number1": 2017,
 			"number2": 42,
@@ -104,6 +158,20 @@
 				"link": "www.liferay.com",
 				"linked": "localhost/o/api/p/second-inner-model/second",
 				"localizedString": "Translated",
+				"nestedList": {
+					"elements": [
+						{
+							"number1": 2018,
+							"string1": "id 1",
+							"string2": "string3"
+						}, {
+							"number1": 2018,
+							"string1": "id 2",
+							"string2": "string3"
+						}
+					],
+					"totalNumberOfItems": 2
+				},
 				"number": 42,
 				"numberList": [1, 2],
 				"relatedCollection": "localhost/o/api/p/first-inner-model/first/models",
@@ -131,6 +199,46 @@
 				"number1": 42,
 				"string1": "2"
 			},
+			"nestedList": {
+				"elements": [
+					{
+						"nested4": {
+							"nestedList": {
+								"elements": [
+									{
+										"number1": 2017
+									}, {
+										"number1": 2017
+									}
+								],
+								"totalNumberOfItems": 2
+							},
+							"string1": "id 4"
+						},
+						"number1": 2017,
+						"string1": "id 1",
+						"string2": "string2"
+					}, {
+						"number1": 2017,
+						"string1": "id 2",
+						"string2": "string2",
+						"nested4": {
+							"nestedList": {
+								"elements": [
+									{
+										"number1": 2017
+									}, {
+										"number1": 2017
+									}
+								],
+								"totalNumberOfItems": 2
+							},
+							"string1": "id 4"
+						}
+					}
+				],
+				"totalNumberOfItems": 2
+			},
 			"number1": 2017,
 			"number2": 42,
 			"numberList1": [1, 2, 3, 4, 5],
@@ -144,8 +252,7 @@
 			"string2": "Hypermedia",
 			"stringList1": ["a", "b", "c", "d", "e"],
 			"stringList2": ["f", "g", "h", "i", "j"]
-		},
-		{
+		}, {
 			"applicationRelativeURL1": "localhost/o/api/first",
 			"binary1": "localhost/o/api/b/model/3/binary1",
 			"binary2": "localhost/o/api/b/model/3/binary2",
@@ -176,6 +283,20 @@
 				"link": "www.liferay.com",
 				"linked": "localhost/o/api/p/second-inner-model/second",
 				"localizedString": "Translated",
+				"nestedList": {
+					"elements": [
+						{
+							"number1": 2018,
+							"string1": "id 1",
+							"string2": "string3"
+						}, {
+							"number1": 2018,
+							"string1": "id 2",
+							"string2": "string3"
+						}
+					],
+					"totalNumberOfItems": 2
+				},
 				"number": 42,
 				"numberList": [1, 2],
 				"relatedCollection": "localhost/o/api/p/first-inner-model/first/models",
@@ -202,6 +323,46 @@
 				},
 				"number1": 42,
 				"string1": "3"
+			},
+			"nestedList": {
+				"elements": [
+					{
+						"nested4": {
+							"nestedList": {
+								"elements": [
+									{
+										"number1": 2017
+									}, {
+										"number1": 2017
+									}
+								],
+								"totalNumberOfItems": 2
+							},
+							"string1": "id 4"
+						},
+						"number1": 2017,
+						"string1": "id 1",
+						"string2": "string2"
+					}, {
+						"number1": 2017,
+						"string1": "id 2",
+						"string2": "string2",
+						"nested4": {
+							"nestedList": {
+								"elements": [
+									{
+										"number1": 2017
+									}, {
+										"number1": 2017
+									}
+								],
+								"totalNumberOfItems": 2
+							},
+							"string1": "id 4"
+						}
+					}
+				],
+				"totalNumberOfItems": 2
 			},
 			"number1": 2017,
 			"number2": 42,

--- a/modules/apps/apio-architect/apio-architect-impl/src/test/resources/plain/single_model.json
+++ b/modules/apps/apio-architect/apio-architect-impl/src/test/resources/plain/single_model.json
@@ -29,6 +29,20 @@
 		"link": "www.liferay.com",
 		"linked": "localhost/o/api/p/second-inner-model/second",
 		"localizedString": "Translated",
+		"nestedList": {
+			"elements": [
+				{
+					"number1": 2018,
+					"string1": "id 1",
+					"string2": "string3"
+				}, {
+					"number1": 2018,
+					"string1": "id 2",
+					"string2": "string3"
+				}
+			],
+			"numberOfItems": 2
+		},
 		"number": 42,
 		"numberList": [1, 2],
 		"relatedCollection": "localhost/o/api/p/first-inner-model/first/models",
@@ -55,6 +69,46 @@
 		},
 		"number1": 42,
 		"string1": "first"
+	},
+	"nestedList": {
+		"elements": [
+			{
+				"nested4": {
+					"nestedList": {
+						"elements": [
+							{
+								"number1": 2017
+							}, {
+								"number1": 2017
+							}
+						],
+						"numberOfItems": 2
+					},
+					"string1": "id 4"
+				},
+				"number1": 2017,
+				"string1": "id 1",
+				"string2": "string2"
+			}, {
+				"number1": 2017,
+				"string1": "id 2",
+				"string2": "string2",
+				"nested4": {
+					"nestedList": {
+						"elements": [
+							{
+								"number1": 2017
+							}, {
+								"number1": 2017
+							}
+						],
+						"numberOfItems": 2
+					},
+					"string1": "id 4"
+				}
+			}
+		],
+		"numberOfItems": 2
 	},
 	"number1": 2017,
 	"number2": 42,

--- a/modules/apps/apio-architect/apio-architect-test-util/src/main/java/com/liferay/apio/architect/test/util/internal/writer/MockEntryPointWriter.java
+++ b/modules/apps/apio-architect/apio-architect-test-util/src/main/java/com/liferay/apio/architect/test/util/internal/writer/MockEntryPointWriter.java
@@ -21,6 +21,8 @@ import com.liferay.apio.architect.impl.writer.EntryPointWriter;
 import com.liferay.apio.architect.impl.writer.EntryPointWriter.Builder;
 
 import java.util.Arrays;
+import java.util.Locale;
+import java.util.Optional;
 
 /**
  * Provides methods that test {@code EntryPointMessageMapper} objects.
@@ -30,6 +32,7 @@ import java.util.Arrays;
  * </p>
  *
  * @author Alejandro Hernández
+ * @author Zoltán Takács
  */
 public class MockEntryPointWriter {
 
@@ -50,9 +53,19 @@ public class MockEntryPointWriter {
 			entryPointMessageMapper
 		).requestInfo(
 			getRequestInfo()
+		).typeFunction(
+			MockEntryPointWriter::_capitalize
 		).build();
 
 		return entryPointWriter.write();
+	}
+
+	private static Optional<String> _capitalize(String resourceName) {
+		String firstLetter = resourceName.substring(0, 1);
+
+		return Optional.of(
+			firstLetter.toUpperCase(Locale.getDefault()) +
+				resourceName.substring(1));
 	}
 
 	private MockEntryPointWriter() {

--- a/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/portlet/template/AssetCategoriesNavigationPortletDisplayTemplateHandler.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/portlet/template/AssetCategoriesNavigationPortletDisplayTemplateHandler.java
@@ -27,7 +27,7 @@ import com.liferay.portal.kernel.portletdisplaytemplate.BasePortletDisplayTempla
 import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateVariableGroup;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portlet.display.template.constants.PortletDisplayTemplateConstants;
 
 import java.util.List;
@@ -37,6 +37,8 @@ import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Juan Fernández
@@ -56,8 +58,8 @@ public class AssetCategoriesNavigationPortletDisplayTemplateHandler
 
 	@Override
 	public String getName(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		String portletTitle = _portal.getPortletTitle(
 			AssetCategoriesNavigationPortletKeys.ASSET_CATEGORIES_NAVIGATION,
@@ -118,5 +120,12 @@ public class AssetCategoriesNavigationPortletDisplayTemplateHandler
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.asset.categories.navigation.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/asset/asset-display-api/src/main/java/com/liferay/asset/display/contributor/BaseAssetDisplayContributor.java
+++ b/modules/apps/asset/asset-display-api/src/main/java/com/liferay/asset/display/contributor/BaseAssetDisplayContributor.java
@@ -141,7 +141,7 @@ public abstract class BaseAssetDisplayContributor<T>
 	protected abstract void setResourceBundleLoader(
 		ResourceBundleLoader resourceBundleLoader);
 
-	protected ResourceBundleLoader resourceBundleLoader;
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 	private Map<String, Object> _getDefaultParameterMap(
 		AssetEntry assetEntry, Locale locale) {

--- a/modules/apps/asset/asset-display-page-item-selector-web/src/main/java/com/liferay/asset/display/page/item/selector/web/internal/AssetDisplayPagesItemSelectorView.java
+++ b/modules/apps/asset/asset-display-page-item-selector-web/src/main/java/com/liferay/asset/display/page/item/selector/web/internal/AssetDisplayPagesItemSelectorView.java
@@ -44,6 +44,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jürgen Kappler
@@ -125,10 +127,11 @@ public class AssetDisplayPagesItemSelectorView
 	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
 
 	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.asset.display.page.item.selector.web)",
-		unbind = "-"
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.asset.display.page.item.selector.web)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	private ServletContext _servletContext;
 

--- a/modules/apps/asset/asset-entry-query-processor-custom-user-attributes/src/main/java/com/liferay/asset/entry/query/processor/custom/user/attributes/servlet/taglib/ui/CustomUserAttributesFormNavigatorEntry.java
+++ b/modules/apps/asset/asset-entry-query-processor-custom-user-attributes/src/main/java/com/liferay/asset/entry/query/processor/custom/user/attributes/servlet/taglib/ui/CustomUserAttributesFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.servlet.taglib.ui.FormNavigatorEntry;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import java.util.Locale;
 import java.util.Objects;
@@ -36,6 +36,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eudaldo Alonso
@@ -64,8 +66,8 @@ public class CustomUserAttributesFormNavigatorEntry
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return LanguageUtil.get(resourceBundle, "custom-user-attributes");
 	}
@@ -114,5 +116,12 @@ public class CustomUserAttributesFormNavigatorEntry
 
 		return false;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.asset.entry.query.processor.custom.user.attributes)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/template/AssetPublisherPortletDisplayTemplateHandler.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/template/AssetPublisherPortletDisplayTemplateHandler.java
@@ -31,7 +31,7 @@ import com.liferay.portal.kernel.portletdisplaytemplate.BasePortletDisplayTempla
 import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateVariableGroup;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portlet.display.template.constants.PortletDisplayTemplateConstants;
 
 import java.util.HashMap;
@@ -42,6 +42,8 @@ import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Juan Fernández
@@ -70,8 +72,8 @@ public class AssetPublisherPortletDisplayTemplateHandler
 
 	@Override
 	public String getName(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle = resourceBundleLoader.loadResourceBundle(
+			locale);
 
 		String portletTitle = portal.getPortletTitle(
 			AssetPublisherPortletKeys.ASSET_PUBLISHER, resourceBundle);
@@ -145,5 +147,12 @@ public class AssetPublisherPortletDisplayTemplateHandler
 
 	@Reference
 	protected Portal portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.asset.publisher.web)"
+	)
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 }

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/toolbar/contributor/AssetPublisherPortletToolbarContributor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/toolbar/contributor/AssetPublisherPortletToolbarContributor.java
@@ -38,7 +38,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PropsValues;
 
@@ -56,6 +56,8 @@ import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eduardo Garcia
@@ -141,8 +143,8 @@ public class AssetPublisherPortletToolbarContributor
 		data.put(
 			"id", HtmlUtil.escape(portletDisplay.getNamespace()) + "editAsset");
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", themeDisplay.getLocale(), getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		String title = LanguageUtil.get(
 			resourceBundle, "add-content-select-scope-and-type");
@@ -305,5 +307,12 @@ public class AssetPublisherPortletToolbarContributor
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.asset.publisher.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/internal/portlet/template/AssetTagsCloudPortletDisplayTemplateHandler.java
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/internal/portlet/template/AssetTagsCloudPortletDisplayTemplateHandler.java
@@ -18,7 +18,6 @@ import com.liferay.asset.tags.navigation.constants.AssetTagsNavigationPortletKey
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -39,8 +38,8 @@ public class AssetTagsCloudPortletDisplayTemplateHandler
 
 	@Override
 	public String getName(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle = resourceBundleLoader.loadResourceBundle(
+			locale);
 
 		String portletTitle = portal.getPortletTitle(
 			AssetTagsNavigationPortletKeys.ASSET_TAGS_CLOUD, resourceBundle);

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/internal/portlet/template/AssetTagsNavigationPortletDisplayTemplateHandler.java
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/internal/portlet/template/AssetTagsNavigationPortletDisplayTemplateHandler.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.portletdisplaytemplate.BasePortletDisplayTempla
 import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateVariableGroup;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portlet.display.template.constants.PortletDisplayTemplateConstants;
 
 import java.util.List;
@@ -34,6 +34,8 @@ import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Juan Fernández
@@ -53,8 +55,8 @@ public class AssetTagsNavigationPortletDisplayTemplateHandler
 
 	@Override
 	public String getName(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle = resourceBundleLoader.loadResourceBundle(
+			locale);
 
 		String portletTitle = portal.getPortletTitle(
 			AssetTagsNavigationPortletKeys.ASSET_TAGS_NAVIGATION,
@@ -111,5 +113,12 @@ public class AssetTagsNavigationPortletDisplayTemplateHandler
 
 	@Reference
 	protected Portal portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.asset.tags.navigation.web)"
+	)
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 }

--- a/modules/apps/blogs/blogs-layout-prototype/src/main/java/com/liferay/blogs/layout/prototype/internal/instance/lifecycle/AddLayoutPrototypePortalInstanceLifecycleListener.java
+++ b/modules/apps/blogs/blogs-layout-prototype/src/main/java/com/liferay/blogs/layout/prototype/internal/instance/lifecycle/AddLayoutPrototypePortalInstanceLifecycleListener.java
@@ -29,12 +29,10 @@ import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.DefaultLayoutPrototypesUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
-import com.liferay.portal.language.LanguageResources;
 
 import java.util.HashMap;
 import java.util.List;
@@ -43,6 +41,8 @@ import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Sergio González
@@ -69,17 +69,11 @@ public class AddLayoutPrototypePortalInstanceLifecycleListener
 			List<LayoutPrototype> layoutPrototypes)
 		throws Exception {
 
-		ResourceBundleLoader resourceBundleLoader =
-			new AggregateResourceBundleLoader(
-				ResourceBundleUtil.getResourceBundleLoader(
-					"content.Language", getClassLoader()),
-				LanguageResources.RESOURCE_BUNDLE_LOADER);
-
 		Map<Locale, String> descriptionMap =
 			ResourceBundleUtil.getLocalizationMap(
-				resourceBundleLoader, "layout-prototype-blog-description");
+				_resourceBundleLoader, "layout-prototype-blog-description");
 		Map<Locale, String> nameMap = ResourceBundleUtil.getLocalizationMap(
-			resourceBundleLoader, "layout-prototype-blog-title");
+			_resourceBundleLoader, "layout-prototype-blog-title");
 
 		Layout layout = LayoutPrototypeHelperUtil.addLayoutPrototype(
 			_layoutPrototypeLocalService, companyId, defaultUserId, nameMap,
@@ -152,6 +146,13 @@ public class AddLayoutPrototypePortalInstanceLifecycleListener
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.blogs.layout.prototype)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	private UserLocalService _userLocalService;
 

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/asset/BlogsEntryAssetRendererFactory.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/asset/BlogsEntryAssetRendererFactory.java
@@ -42,6 +42,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jorge Ferrer
@@ -160,9 +162,6 @@ public class BlogsEntryAssetRendererFactory
 			permissionChecker, classPK, actionId);
 	}
 
-	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.blogs.web)", unbind = "-"
-	)
 	public void setResourceBundleLoader(
 		ResourceBundleLoader resourceBundleLoader) {
 
@@ -202,7 +201,13 @@ public class BlogsEntryAssetRendererFactory
 	@Reference(target = "(resource.name=" + BlogsConstants.RESOURCE_NAME + ")")
 	private PortletResourcePermission _portletResourcePermission;
 
-	private ResourceBundleLoader _resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.blogs.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
+
 	private ServletContext _servletContext;
 
 }

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
@@ -27,7 +27,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.security.PermissionsURLTag;
 
@@ -39,6 +39,8 @@ import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Sergio González
@@ -60,8 +62,8 @@ public class PermissionsPortletConfigurationIcon
 
 	@Override
 	public ResourceBundle getResourceBundle(Locale locale) {
-		ResourceBundle bundleResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle bundleResourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return new AggregateResourceBundle(
 			bundleResourceBundle, super.getResourceBundle(locale));
@@ -136,5 +138,12 @@ public class PermissionsPortletConfigurationIcon
 
 	@Reference(target = "(resource.name=" + BlogsConstants.RESOURCE_NAME + ")")
 	private PortletResourcePermission _portletResourcePermission;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.blogs.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.security.PermissionsURLTag;
 
@@ -40,6 +40,9 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Sergio González
@@ -61,8 +64,8 @@ public class PermissionsPortletConfigurationIcon
 
 	@Override
 	public ResourceBundle getResourceBundle(Locale locale) {
-		ResourceBundle bundleResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle bundleResourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return new AggregateResourceBundle(
 			bundleResourceBundle, super.getResourceBundle(locale));
@@ -147,5 +150,12 @@ public class PermissionsPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PermissionsPortletConfigurationIcon.class);
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.bookmarks.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/notification/NotificationTemplateContextFactory.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/notification/NotificationTemplateContextFactory.java
@@ -54,6 +54,8 @@ import javax.portlet.WindowState;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eduardo Lundgren
@@ -120,7 +122,7 @@ public class NotificationTemplateContextFactory {
 		attributes.put("portalURL", portalURL);
 
 		ResourceBundle resourceBundle =
-			_resourceBundleLoader.loadResourceBundle(user.getLocale());
+			_bundleResourceBundleLoader.loadResourceBundle(user.getLocale());
 
 		attributes.put(
 			"portletName",
@@ -201,12 +203,22 @@ public class NotificationTemplateContextFactory {
 	}
 
 	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.calendar.web)", unbind = "-"
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.calendar.web)"
 	)
 	protected void setResourceBundleLoader(
 		ResourceBundleLoader resourceBundleLoader) {
 
-		_resourceBundleLoader = resourceBundleLoader;
+		_setBundleResourceBundleLoader(resourceBundleLoader);
+	}
+
+	protected void unsetResourceBundleLoader(
+		ResourceBundleLoader resourceBundleLoader) {
+
+		if (_bundleResourceBundleLoader == resourceBundleLoader) {
+			_setBundleResourceBundleLoader(null);
+		}
 	}
 
 	private static String _getCalendarBookingURL(
@@ -273,9 +285,17 @@ public class NotificationTemplateContextFactory {
 		return userTimezoneDisplayName;
 	}
 
+	private static void _setBundleResourceBundleLoader(
+		ResourceBundleLoader resourceBundleLoader) {
+
+		_bundleResourceBundleLoader = resourceBundleLoader;
+	}
+
+	private static volatile ResourceBundleLoader _bundleResourceBundleLoader;
 	private static CompanyLocalService _companyLocalService;
 	private static GroupLocalService _groupLocalService;
 	private static LayoutLocalService _layoutLocalService;
-	private static ResourceBundleLoader _resourceBundleLoader;
+
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/security/service/access/policy/CalendarSAPEntryActivator.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/security/service/access/policy/CalendarSAPEntryActivator.java
@@ -24,11 +24,9 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
-import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.security.service.access.policy.model.SAPEntry;
 import com.liferay.portal.security.service.access.policy.service.SAPEntryLocalService;
 
@@ -41,6 +39,8 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Tomas Polesovsky
@@ -73,15 +73,8 @@ public class CalendarSAPEntryActivator {
 
 		String allowedServiceSignatures = sb.toString();
 
-		ResourceBundleLoader resourceBundleLoader =
-			new AggregateResourceBundleLoader(
-				ResourceBundleUtil.getResourceBundleLoader(
-					"content.Language",
-					CalendarSAPEntryActivator.class.getClassLoader()),
-				LanguageResources.RESOURCE_BUNDLE_LOADER);
-
 		Map<Locale, String> titleMap = ResourceBundleUtil.getLocalizationMap(
-			resourceBundleLoader,
+			_resourceBundleLoader,
 			"service-access-policy-entry-default-calendar-title");
 
 		_sapEntryLocalService.addSAPEntry(
@@ -101,6 +94,13 @@ public class CalendarSAPEntryActivator {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CalendarSAPEntryActivator.class);
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.calendar.service)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(unbind = "-")
 	private SAPEntryLocalService _sapEntryLocalService;

--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -102,6 +102,7 @@ import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
@@ -148,6 +149,8 @@ import javax.portlet.WindowStateException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eduardo Lundgren
@@ -238,8 +241,9 @@ public class CalendarPortlet extends MVCPortlet {
 			}
 		}
 		else {
-			ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-				"content.Language", themeDisplay.getLocale(), getClass());
+			ResourceBundle resourceBundle =
+				_resourceBundleLoader.loadResourceBundle(
+					themeDisplay.getLocale());
 
 			String message = ResourceBundleUtil.getString(
 				resourceBundle, "failed-to-import-empty-file");
@@ -1867,6 +1871,13 @@ public class CalendarPortlet extends MVCPortlet {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.calendar.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	private UserLocalService _userLocalService;
 

--- a/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/configuration/CaptchaConfigurationModelListener.java
+++ b/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/configuration/CaptchaConfigurationModelListener.java
@@ -20,14 +20,17 @@ import com.liferay.portal.configuration.persistence.listener.ConfigurationModelL
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
 import com.liferay.portal.kernel.captcha.CaptchaConfigurationException;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Dictionary;
-import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pei-Jung Lan
@@ -61,14 +64,8 @@ public class CaptchaConfigurationModelListener
 	}
 
 	protected ResourceBundle getResourceBundle() {
-		if (_resourceBundle == null) {
-			Locale locale = LocaleThreadLocal.getThemeDisplayLocale();
-
-			return ResourceBundleUtil.getBundle(
-				"content.Language", locale, getClass());
-		}
-
-		return _resourceBundle;
+		return _resourceBundleLoader.loadResourceBundle(
+			LocaleThreadLocal.getThemeDisplayLocale());
 	}
 
 	protected void validateReCaptchaKeys(Dictionary<String, Object> properties)
@@ -94,6 +91,11 @@ public class CaptchaConfigurationModelListener
 		}
 	}
 
-	private ResourceBundle _resourceBundle;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.captcha.api)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/configuration/icon/ExportAllConfigurationIcon.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/configuration/icon/ExportAllConfigurationIcon.java
@@ -31,6 +31,8 @@ import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jorge Ferrer
@@ -86,8 +88,10 @@ public class ExportAllConfigurationIcon extends BasePortletConfigurationIcon {
 	private Portal _portal;
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.configuration.admin.web)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/configuration/icon/ExportFactoryInstancesIcon.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/configuration/icon/ExportFactoryInstancesIcon.java
@@ -34,6 +34,8 @@ import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jorge Ferrer
@@ -108,8 +110,10 @@ public class ExportFactoryInstancesIcon extends BasePortletConfigurationIcon {
 	private Portal _portal;
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.configuration.admin.web)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/notifications/ContactsCenterUserNotificationHandler.java
+++ b/modules/apps/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/notifications/ContactsCenterUserNotificationHandler.java
@@ -26,13 +26,11 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
-import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.language.LanguageResources;
 import com.liferay.social.kernel.model.SocialRelationConstants;
 import com.liferay.social.kernel.model.SocialRequest;
 import com.liferay.social.kernel.model.SocialRequestConstants;
@@ -46,6 +44,8 @@ import javax.portlet.WindowState;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jonathan Lee
@@ -196,21 +196,16 @@ public class ContactsCenterUserNotificationHandler
 		}
 	}
 
-	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.contacts.web)", unbind = "-"
-	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		_resourceBundleLoader = new AggregateResourceBundleLoader(
-			resourceBundleLoader, LanguageResources.RESOURCE_BUNDLE_LOADER);
-	}
-
 	private static final String _BODY =
 		"<div class=\"title\">[$TITLE$]</div><div class=\"body\">[$BODY$]" +
 			"</div>";
 
-	private ResourceBundleLoader _resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.contacts.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference
 	private SocialRequestLocalService _socialRequestLocalService;

--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/display/context/GoogleDocsDLDisplayContextFactory.java
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/display/context/GoogleDocsDLDisplayContextFactory.java
@@ -33,12 +33,15 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Iván Zaera
@@ -136,7 +139,8 @@ public class GoogleDocsDLDisplayContextFactory
 			if (googleDocsMetadataHelper.isGoogleDocs()) {
 				return new GoogleDocsDLViewFileVersionDisplayContext(
 					parentDLViewFileVersionDisplayContext, request, response,
-					fileVersion, googleDocsMetadataHelper);
+					fileVersion, googleDocsMetadataHelper,
+					_resourceBundleLoader);
 			}
 		}
 
@@ -186,6 +190,14 @@ public class GoogleDocsDLDisplayContextFactory
 	private DLAppService _dlAppService;
 	private DLFileEntryMetadataLocalService _dlFileEntryMetadataLocalService;
 	private FieldsToDDMFormValuesConverter _fieldsToDDMFormValuesConverter;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.document.library.google.docs)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
+
 	private StorageEngine _storageEngine;
 
 }

--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/display/context/GoogleDocsDLViewFileVersionDisplayContext.java
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/display/context/GoogleDocsDLViewFileVersionDisplayContext.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.servlet.taglib.ui.Menu;
 import com.liferay.portal.kernel.servlet.taglib.ui.MenuItem;
 import com.liferay.portal.kernel.servlet.taglib.ui.ToolbarItem;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -49,14 +50,16 @@ public class GoogleDocsDLViewFileVersionDisplayContext
 		DLViewFileVersionDisplayContext parentDLDisplayContext,
 		HttpServletRequest request, HttpServletResponse response,
 		FileVersion fileVersion,
-		GoogleDocsMetadataHelper googleDocsMetadataHelper) {
+		GoogleDocsMetadataHelper googleDocsMetadataHelper,
+		ResourceBundleLoader resourceBundleLoader) {
 
 		super(_UUID, parentDLDisplayContext, request, response, fileVersion);
 
 		_googleDocsMetadataHelper = googleDocsMetadataHelper;
+		_resourceBundleLoader = resourceBundleLoader;
 
 		_googleDocsUIItemsProcessor = new GoogleDocsUIItemsProcessor(
-			request, googleDocsMetadataHelper);
+			request, googleDocsMetadataHelper, _resourceBundleLoader);
 	}
 
 	@Override
@@ -153,8 +156,8 @@ public class GoogleDocsDLViewFileVersionDisplayContext
 			}
 		}
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", request.getLocale(), getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(request.getLocale());
 
 		printWriter.write("<div class=\"alert alert-info\">");
 		printWriter.write(
@@ -169,5 +172,6 @@ public class GoogleDocsDLViewFileVersionDisplayContext
 
 	private final GoogleDocsMetadataHelper _googleDocsMetadataHelper;
 	private final GoogleDocsUIItemsProcessor _googleDocsUIItemsProcessor;
+	private final ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/display/context/GoogleDocsIGDisplayContextFactory.java
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/display/context/GoogleDocsIGDisplayContextFactory.java
@@ -29,12 +29,15 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Iván Zaera
@@ -84,7 +87,7 @@ public class GoogleDocsIGDisplayContextFactory
 		if (googleDocsMetadataHelper.isGoogleDocs()) {
 			return new GoogleDocsIGViewFileVersionDisplayContext(
 				parentIGViewFileVersionDisplayContext, request, response,
-				fileVersion, googleDocsMetadataHelper);
+				fileVersion, googleDocsMetadataHelper, _resourceBundleLoader);
 		}
 
 		return parentIGViewFileVersionDisplayContext;
@@ -133,6 +136,14 @@ public class GoogleDocsIGDisplayContextFactory
 	private DLAppService _dlAppService;
 	private DLFileEntryMetadataLocalService _dlFileEntryMetadataLocalService;
 	private FieldsToDDMFormValuesConverter _fieldsToDDMFormValuesConverter;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.document.library.google.docs)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
+
 	private StorageEngine _storageEngine;
 
 }

--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/display/context/GoogleDocsIGViewFileVersionDisplayContext.java
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/display/context/GoogleDocsIGViewFileVersionDisplayContext.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.servlet.taglib.ui.Menu;
 import com.liferay.portal.kernel.servlet.taglib.ui.MenuItem;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import java.util.List;
 import java.util.UUID;
@@ -39,14 +40,17 @@ public class GoogleDocsIGViewFileVersionDisplayContext
 		IGViewFileVersionDisplayContext parentIGViewFileVersionDisplayContext,
 		HttpServletRequest request, HttpServletResponse response,
 		FileVersion fileVersion,
-		GoogleDocsMetadataHelper googleDocsMetadataHelper) {
+		GoogleDocsMetadataHelper googleDocsMetadataHelper,
+		ResourceBundleLoader resourceBundleLoader) {
 
 		super(
 			_UUID, parentIGViewFileVersionDisplayContext, request, response,
 			fileVersion);
 
+		_resourceBundleLoader = resourceBundleLoader;
+
 		_googleDocsUIItemsProcessor = new GoogleDocsUIItemsProcessor(
-			request, googleDocsMetadataHelper);
+			request, googleDocsMetadataHelper, _resourceBundleLoader);
 	}
 
 	@Override
@@ -71,5 +75,6 @@ public class GoogleDocsIGViewFileVersionDisplayContext
 		"D60D21C4-9626-4EDF-A658-336198DB4A34");
 
 	private final GoogleDocsUIItemsProcessor _googleDocsUIItemsProcessor;
+	private final ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/display/context/GoogleDocsUIItemsProcessor.java
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/display/context/GoogleDocsUIItemsProcessor.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.servlet.taglib.ui.URLMenuItem;
 import com.liferay.portal.kernel.servlet.taglib.ui.URLToolbarItem;
 import com.liferay.portal.kernel.servlet.taglib.ui.URLUIItem;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.List;
@@ -40,10 +40,12 @@ public class GoogleDocsUIItemsProcessor {
 
 	public GoogleDocsUIItemsProcessor(
 		HttpServletRequest request,
-		GoogleDocsMetadataHelper googleDocsMetadataHelper) {
+		GoogleDocsMetadataHelper googleDocsMetadataHelper,
+		ResourceBundleLoader resourceBundleLoader) {
 
 		_request = request;
 		_googleDocsMetadataHelper = googleDocsMetadataHelper;
+		_resourceBundleLoader = resourceBundleLoader;
 	}
 
 	public void processMenuItems(List<MenuItem> menuItems) {
@@ -94,8 +96,8 @@ public class GoogleDocsUIItemsProcessor {
 		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", themeDisplay.getLocale(), getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		String message = LanguageUtil.get(
 			resourceBundle, "edit-in-google-docs");
@@ -132,5 +134,6 @@ public class GoogleDocsUIItemsProcessor {
 
 	private final GoogleDocsMetadataHelper _googleDocsMetadataHelper;
 	private final HttpServletRequest _request;
+	private final ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/display/context/DLOpenerGoogleDriveDLDisplayContextFactory.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/display/context/DLOpenerGoogleDriveDLDisplayContextFactory.java
@@ -32,6 +32,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Adolfo Pérez
@@ -82,8 +84,10 @@ public class DLOpenerGoogleDriveDLDisplayContextFactory
 	private DLOpenerGoogleDriveManager _dlOpenerGoogleDriveManager;
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.document.library.opener.google.drive.web)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/dynamic/data/mapping/util/DLDDMDisplay.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/dynamic/data/mapping/util/DLDDMDisplay.java
@@ -23,6 +23,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,6 +32,8 @@ import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eduardo Garcia
@@ -98,6 +101,11 @@ public class DLDDMDisplay extends BaseDDMDisplay {
 		return true;
 	}
 
+	@Override
+	protected ResourceBundleLoader getResourceBundleLoader() {
+		return _resourceBundleLoader;
+	}
+
 	private final DDMDisplayTabItem _defaultTabItem =
 		(liferayPortletRequest, liferayPortletResponse) -> {
 			ResourceBundle resourceBundle = getResourceBundle(
@@ -112,5 +120,12 @@ public class DLDDMDisplay extends BaseDDMDisplay {
 
 	@Reference
 	private DocumentTypesDDMDisplayTabItem _documentTypesDDMDisplayTabItem;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.document.library.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/dynamic/data/mapping/util/DocumentTypesDDMDisplayTabItem.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/dynamic/data/mapping/util/DocumentTypesDDMDisplayTabItem.java
@@ -29,6 +29,8 @@ import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Alejandro Tardín
@@ -71,8 +73,10 @@ public class DocumentTypesDDMDisplayTabItem implements DDMDisplayTabItem {
 	private Portal _portal;
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.document.library.web)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/DeleteExpiredTemporaryFileEntriesPortletConfigurationIcon.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/DeleteExpiredTemporaryFileEntriesPortletConfigurationIcon.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ResourceBundle;
@@ -38,6 +38,8 @@ import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Roberto Díaz
@@ -55,8 +57,11 @@ public class DeleteExpiredTemporaryFileEntriesPortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(
 			resourceBundle, "delete-expired-temporary-files");
@@ -129,5 +134,12 @@ public class DeleteExpiredTemporaryFileEntriesPortletConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.document.library.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/OpenInMSOfficeFileEntryPortletConfigurationIcon.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/OpenInMSOfficeFileEntryPortletConfigurationIcon.java
@@ -41,6 +41,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Roberto Díaz
@@ -157,8 +159,10 @@ public class OpenInMSOfficeFileEntryPortletConfigurationIcon
 	private Portal _portal;
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.document.library.web)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portlet.documentlibrary.constants.DLConstants;
 import com.liferay.taglib.security.PermissionsURLTag;
@@ -39,6 +39,8 @@ import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Adolfo Pérez
@@ -60,8 +62,8 @@ public class PermissionsPortletConfigurationIcon
 
 	@Override
 	public ResourceBundle getResourceBundle(Locale locale) {
-		ResourceBundle bundleResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle bundleResourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return new AggregateResourceBundle(
 			bundleResourceBundle, super.getResourceBundle(locale));
@@ -136,5 +138,12 @@ public class PermissionsPortletConfigurationIcon
 
 	@Reference(target = "(resource.name=" + DLConstants.RESOURCE_NAME + ")")
 	private PortletResourcePermission _portletResourcePermission;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.document.library.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/dynamic/data/mapping/util/DDLDDMDisplay.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/dynamic/data/mapping/util/DDLDDMDisplay.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import java.util.Locale;
 import java.util.Objects;
@@ -32,6 +33,8 @@ import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eduardo Garcia
@@ -111,7 +114,19 @@ public class DDLDDMDisplay extends BaseDDMDisplay {
 		return true;
 	}
 
+	@Override
+	protected ResourceBundleLoader getResourceBundleLoader() {
+		return resourceBundleLoader;
+	}
+
 	@Reference
 	protected Portal portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.dynamic.data.lists.web)"
+	)
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/BaseDDMDisplay.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/BaseDDMDisplay.java
@@ -509,14 +509,9 @@ public abstract class BaseDDMDisplay implements DDMDisplay {
 	}
 
 	protected ResourceBundle getResourceBundle(Locale locale) {
-		Bundle bundle = FrameworkUtil.getBundle(getClass());
-
-		ResourceBundleLoader resourceBundleLoader =
-			ResourceBundleLoaderUtil.
-				getResourceBundleLoaderByBundleSymbolicName(
-					bundle.getSymbolicName());
-
 		ResourceBundle ddmDisplayResourceBundle = null;
+
+		ResourceBundleLoader resourceBundleLoader = getResourceBundleLoader();
 
 		if (resourceBundleLoader != null) {
 			ddmDisplayResourceBundle = resourceBundleLoader.loadResourceBundle(
@@ -540,6 +535,14 @@ public abstract class BaseDDMDisplay implements DDMDisplay {
 		return new AggregateResourceBundle(
 			ddmDisplayResourceBundle, baseDDMDisplayResourceBundle,
 			portalResourceBundleLoader.loadResourceBundle(locale));
+	}
+
+	protected ResourceBundleLoader getResourceBundleLoader() {
+		Bundle bundle = FrameworkUtil.getBundle(getClass());
+
+		return ResourceBundleLoaderUtil.
+			getResourceBundleLoaderByBundleSymbolicName(
+				bundle.getSymbolicName());
 	}
 
 	protected String getViewTemplatesURL(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/util/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.7.0
+version 1.8.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/servlet/DDMFormFunctionsServlet.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/servlet/DDMFormFunctionsServlet.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import java.io.IOException;
 
@@ -127,8 +127,8 @@ public class DDMFormFunctionsServlet extends HttpServlet {
 
 		JSONArray jsonArray = _jsonFactory.createJSONArray();
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		for (Map.Entry<String, DDMExpressionFunction> entry : entries) {
 			jsonArray.put(toJSONObject(entry, resourceBundle));
@@ -167,5 +167,12 @@ public class DDMFormFunctionsServlet extends HttpServlet {
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.dynamic.data.mapping.form.builder)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/util/DDMExpressionFunctionMetadataHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/util/DDMExpressionFunctionMetadataHelper.java
@@ -15,10 +15,7 @@
 package com.liferay.dynamic.data.mapping.form.builder.internal.util;
 
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
-import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,6 +25,9 @@ import java.util.Map;
 import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Rafael Praxedes
@@ -105,17 +105,7 @@ public class DDMExpressionFunctionMetadataHelper {
 	}
 
 	protected ResourceBundle getResourceBundle(Locale locale) {
-		ResourceBundleLoader portalResourceBundleLoader =
-			ResourceBundleLoaderUtil.getPortalResourceBundleLoader();
-
-		ResourceBundle portalResourceBundle =
-			portalResourceBundleLoader.loadResourceBundle(locale);
-
-		ResourceBundle portletResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
-
-		return new AggregateResourceBundle(
-			portletResourceBundle, portalResourceBundle);
+		return _resourceBundleLoader.loadResourceBundle(locale);
 	}
 
 	protected void populateMap(
@@ -231,5 +221,12 @@ public class DDMExpressionFunctionMetadataHelper {
 	private static final String _TYPE_TEXT = "text";
 
 	private static final String _TYPE_USER = "user";
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.dynamic.data.mapping.form.builder)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/DDMFormEvaluatorHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/DDMFormEvaluatorHelper.java
@@ -49,13 +49,10 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
-import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -83,6 +80,7 @@ public class DDMFormEvaluatorHelper {
 		DDMFormEvaluatorContext ddmFormEvaluatorContext,
 		DDMFormFieldTypeServicesTracker ddmFormFieldTypeServicesTracker,
 		JSONFactory jsonFactory, Portal portal,
+		ResourceBundleLoader resourceBundleLoader,
 		RoleLocalService roleLocalService,
 		UserGroupRoleLocalService userGroupRoleLocalService,
 		UserLocalService userLocalService) {
@@ -92,6 +90,7 @@ public class DDMFormEvaluatorHelper {
 		_ddmFormFieldTypeServicesTracker = ddmFormFieldTypeServicesTracker;
 		_jsonFactory = jsonFactory;
 		_portal = portal;
+		_resourceBundleLoader = resourceBundleLoader;
 		_roleLocalService = roleLocalService;
 		_userGroupRoleLocalService = userGroupRoleLocalService;
 		_userLocalService = userLocalService;
@@ -237,17 +236,7 @@ public class DDMFormEvaluatorHelper {
 	}
 
 	protected ResourceBundle createResourceBundle() {
-		ResourceBundleLoader portalResourceBundleLoader =
-			ResourceBundleLoaderUtil.getPortalResourceBundleLoader();
-
-		ResourceBundle portalResourceBundle =
-			portalResourceBundleLoader.loadResourceBundle(_locale);
-
-		ResourceBundle portletResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", _locale, getClass());
-
-		return new AggregateResourceBundle(
-			portletResourceBundle, portalResourceBundle);
+		return _resourceBundleLoader.loadResourceBundle(_locale);
 	}
 
 	protected void evaluateDDMFormRule(DDMFormRule ddmFormRule)
@@ -685,6 +674,7 @@ public class DDMFormEvaluatorHelper {
 	private final Portal _portal;
 	private final HttpServletRequest _request;
 	private final ResourceBundle _resourceBundle;
+	private final ResourceBundleLoader _resourceBundleLoader;
 	private final RoleLocalService _roleLocalService;
 	private final UserGroupRoleLocalService _userGroupRoleLocalService;
 	private final UserLocalService _userLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/DDMFormEvaluatorImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/DDMFormEvaluatorImpl.java
@@ -27,9 +27,12 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pablo Carvalho
@@ -47,8 +50,9 @@ public class DDMFormEvaluatorImpl implements DDMFormEvaluator {
 				new DDMFormEvaluatorHelper(
 					_ddmDataProviderInvoker, _ddmExpressionFactory,
 					ddmFormEvaluatorContext, _ddmFormFieldTypeServicesTracker,
-					_jsonFactory, _portal, _roleLocalService,
-					_userGroupRoleLocalService, _userLocalService);
+					_jsonFactory, _portal, _resourceBundleLoader,
+					_roleLocalService, _userGroupRoleLocalService,
+					_userLocalService);
 
 			return ddmFormRuleEvaluatorHelper.evaluate();
 		}
@@ -71,6 +75,13 @@ public class DDMFormEvaluatorImpl implements DDMFormEvaluator {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.dynamic.data.mapping.form.evaluator.impl)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference
 	private RoleLocalService _roleLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/DDMFormEvaluatorHelperTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/DDMFormEvaluatorHelperTest.java
@@ -48,7 +48,6 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
-import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
 
 import java.util.Arrays;
 import java.util.List;
@@ -68,27 +67,20 @@ import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * @author Leonardo Barros
  * @author Marcellus Tavares
  */
-@PrepareForTest(ResourceBundleLoaderUtil.class)
 @RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor(
-	"com.liferay.portal.kernel.util.ResourceBundleLoaderUtil"
-)
 public class DDMFormEvaluatorHelperTest {
 
 	@Before
 	public void setUp() throws Exception {
 		setUpLanguageUtil();
 		setUpPortalUtil();
-		setUpResourceBundleLoaderUtil();
+		setUpResourceBundleLoader();
 	}
 
 	@Test
@@ -142,7 +134,8 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, null, null, _userLocalService);
+				_jsonFactory, null, _resourceBundleLoader, null, null,
+				_userLocalService);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
 			ddmFormEvaluatorHelper.evaluate();
@@ -217,7 +210,7 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, _roleLocalService,
+				_jsonFactory, null, _resourceBundleLoader, _roleLocalService,
 				_userGroupRoleLocalService, _userLocalService);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
@@ -271,7 +264,7 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, null, null, null);
+				_jsonFactory, null, _resourceBundleLoader, null, null, null);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
 			ddmFormEvaluatorHelper.evaluate();
@@ -331,7 +324,8 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, null, null, _userLocalService);
+				_jsonFactory, null, _resourceBundleLoader, null, null,
+				_userLocalService);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
 			ddmFormEvaluatorHelper.evaluate();
@@ -392,7 +386,7 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, _roleLocalService,
+				_jsonFactory, null, _resourceBundleLoader, _roleLocalService,
 				_userGroupRoleLocalService, _userLocalService);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
@@ -446,7 +440,7 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, null, null, null);
+				_jsonFactory, null, _resourceBundleLoader, null, null, null);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
 			ddmFormEvaluatorHelper.evaluate();
@@ -505,8 +499,8 @@ public class DDMFormEvaluatorHelperTest {
 		DDMFormEvaluatorHelper ddmFormEvaluatorHelper =
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
-				ddmFormFieldTypeServicesTracker, _jsonFactory, null, null, null,
-				null);
+				ddmFormFieldTypeServicesTracker, _jsonFactory, null,
+				_resourceBundleLoader, null, null, null);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
 			ddmFormEvaluatorHelper.evaluate();
@@ -564,7 +558,7 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, null, null, null);
+				_jsonFactory, null, _resourceBundleLoader, null, null, null);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
 			ddmFormEvaluatorHelper.evaluate();
@@ -628,7 +622,7 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, null, null, null);
+				_jsonFactory, null, _resourceBundleLoader, null, null, null);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
 			ddmFormEvaluatorHelper.evaluate();
@@ -677,7 +671,7 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, null, null, null);
+				_jsonFactory, null, _resourceBundleLoader, null, null, null);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
 			ddmFormEvaluatorHelper.evaluate();
@@ -747,7 +741,7 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, null, null, null);
+				_jsonFactory, null, _resourceBundleLoader, null, null, null);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
 			ddmFormEvaluatorHelper.evaluate();
@@ -848,7 +842,7 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, null, null, null);
+				_jsonFactory, null, _resourceBundleLoader, null, null, null);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
 			ddmFormEvaluatorHelper.evaluate();
@@ -930,7 +924,7 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, null, null, null);
+				_jsonFactory, null, _resourceBundleLoader, null, null, null);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
 			ddmFormEvaluatorHelper.evaluate();
@@ -984,7 +978,7 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, null, null, null);
+				_jsonFactory, null, _resourceBundleLoader, null, null, null);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
 			ddmFormEvaluatorHelper.evaluate();
@@ -1039,7 +1033,7 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, null, null, null);
+				_jsonFactory, null, _resourceBundleLoader, null, null, null);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
 			ddmFormEvaluatorHelper.evaluate();
@@ -1096,7 +1090,7 @@ public class DDMFormEvaluatorHelperTest {
 			new DDMFormEvaluatorHelper(
 				null, _ddmExpressionFactory, ddmFormEvaluatorContext,
 				Mockito.mock(DDMFormFieldTypeServicesTracker.class),
-				_jsonFactory, null, null, null, null);
+				_jsonFactory, null, _resourceBundleLoader, null, null, null);
 
 		DDMFormEvaluationResult ddmFormEvaluationResult =
 			ddmFormEvaluatorHelper.evaluate();
@@ -1227,16 +1221,13 @@ public class DDMFormEvaluatorHelperTest {
 		portalUtil.setPortal(portal);
 	}
 
-	protected void setUpResourceBundleLoaderUtil() {
-		PowerMockito.mockStatic(ResourceBundleLoaderUtil.class);
-
-		ResourceBundleLoader portalResourceBundleLoader = Mockito.mock(
-			ResourceBundleLoader.class);
+	protected void setUpResourceBundleLoader() {
+		ResourceBundle resourceBundle = Mockito.mock(ResourceBundle.class);
 
 		Mockito.when(
-			ResourceBundleLoaderUtil.getPortalResourceBundleLoader()
+			_resourceBundleLoader.loadResourceBundle(Matchers.any(Locale.class))
 		).thenReturn(
-			portalResourceBundleLoader
+			resourceBundle
 		);
 	}
 
@@ -1250,6 +1241,9 @@ public class DDMFormEvaluatorHelperTest {
 
 	@Mock
 	private HttpServletRequest _request;
+
+	@Mock
+	private ResourceBundleLoader _resourceBundleLoader;
 
 	@Mock
 	private Role _role;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/document/library/internal/DocumentLibraryDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/document/library/internal/DocumentLibraryDDMFormFieldTemplateContextContributor.java
@@ -29,13 +29,10 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.Html;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
-import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.Validator;
@@ -50,6 +47,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pedro Queiroz
@@ -200,17 +199,7 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributor
 	}
 
 	protected ResourceBundle getResourceBundle(Locale locale) {
-		ResourceBundleLoader portalResourceBundleLoader =
-			ResourceBundleLoaderUtil.getPortalResourceBundleLoader();
-
-		ResourceBundle portalResourceBundle =
-			portalResourceBundleLoader.loadResourceBundle(locale);
-
-		ResourceBundle moduleResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
-
-		return new AggregateResourceBundle(
-			moduleResourceBundle, portalResourceBundle);
+		return resourceBundleLoader.loadResourceBundle(locale);
 	}
 
 	protected JSONObject getValueJSONObject(String value) {
@@ -237,6 +226,13 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributor
 
 	@Reference
 	protected Portal portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.dynamic.data.mapping.form.field.type)"
+	)
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DocumentLibraryDDMFormFieldTemplateContextContributor.class);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/options/internal/OptionsDDMFormFieldContextHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/options/internal/OptionsDDMFormFieldContextHelper.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
@@ -41,10 +41,12 @@ import java.util.ResourceBundle;
 public class OptionsDDMFormFieldContextHelper {
 
 	public OptionsDDMFormFieldContextHelper(
-		JSONFactory jsonFactory, DDMFormField ddmFormField, String value) {
+		JSONFactory jsonFactory, DDMFormField ddmFormField,
+		ResourceBundleLoader resourceBundleLoader, String value) {
 
 		_ddmForm = ddmFormField.getDDMForm();
 		_jsonFactory = jsonFactory;
+		_resourceBundleLoader = resourceBundleLoader;
 		_value = value;
 	}
 
@@ -124,10 +126,7 @@ public class OptionsDDMFormFieldContextHelper {
 	}
 
 	protected ResourceBundle getResourceBundle(Locale locale) {
-		Class<?> clazz = getClass();
-
-		return ResourceBundleUtil.getBundle(
-			"content.Language", locale, clazz.getClassLoader());
+		return _resourceBundleLoader.loadResourceBundle(locale);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -135,6 +134,7 @@ public class OptionsDDMFormFieldContextHelper {
 
 	private final DDMForm _ddmForm;
 	private final JSONFactory _jsonFactory;
+	private final ResourceBundleLoader _resourceBundleLoader;
 	private final String _value;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/options/internal/OptionsDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/options/internal/OptionsDDMFormFieldTemplateContextContributor.java
@@ -21,12 +21,15 @@ import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Marcellus Tavares
@@ -71,7 +74,7 @@ public class OptionsDDMFormFieldTemplateContextContributor
 
 		OptionsDDMFormFieldContextHelper optionsDDMFormFieldContextHelper =
 			new OptionsDDMFormFieldContextHelper(
-				jsonFactory, ddmFormField,
+				jsonFactory, ddmFormField, _resourceBundleLoader,
 				ddmFormFieldRenderingContext.getValue());
 
 		return optionsDDMFormFieldContextHelper.getValue();
@@ -79,5 +82,12 @@ public class OptionsDDMFormFieldTemplateContextContributor
 
 	@Reference
 	protected JSONFactory jsonFactory;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.dynamic.data.mapping.form.field.type)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/select/internal/SelectDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/select/internal/SelectDDMFormFieldTemplateContextContributor.java
@@ -27,12 +27,9 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
-import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,6 +40,8 @@ import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Marcellus Tavares
@@ -183,19 +182,7 @@ public class SelectDDMFormFieldTemplateContextContributor
 	}
 
 	protected ResourceBundle getResourceBundle(Locale locale) {
-		Class<?> clazz = getClass();
-
-		ResourceBundleLoader portalResourceBundleLoader =
-			ResourceBundleLoaderUtil.getPortalResourceBundleLoader();
-
-		ResourceBundle portalResourceBundle =
-			portalResourceBundleLoader.loadResourceBundle(locale);
-
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, clazz.getClassLoader());
-
-		return new AggregateResourceBundle(
-			resourceBundle, portalResourceBundle);
+		return resourceBundleLoader.loadResourceBundle(locale);
 	}
 
 	protected List<String> getValue(String valueString) {
@@ -226,6 +213,13 @@ public class SelectDDMFormFieldTemplateContextContributor
 
 	@Reference
 	protected JSONFactory jsonFactory;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.dynamic.data.mapping.form.field.type)"
+	)
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SelectDDMFormFieldTemplateContextContributor.class);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryImpl.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -63,6 +64,8 @@ import javax.servlet.http.HttpServletRequest;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Marcellus Tavares
@@ -104,8 +107,15 @@ public class DDMFormTemplateContextFactoryImpl
 			collectResourceBundles(interfaceClass, resourceBundles, locale);
 		}
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, clazz.getClassLoader());
+		ResourceBundle resourceBundle = null;
+
+		if (clazz == getClass()) {
+			resourceBundle = _resourceBundleLoader.loadResourceBundle(locale);
+		}
+		else {
+			resourceBundle = ResourceBundleUtil.getBundle(
+				"content.Language", locale, clazz.getClassLoader());
+		}
 
 		if (resourceBundle != null) {
 			resourceBundles.add(resourceBundle);
@@ -388,6 +398,13 @@ public class DDMFormTemplateContextFactoryImpl
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.dynamic.data.mapping.form.renderer)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference
 	private SoyHTMLSanitizer _soyHTMLSanitizer;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormPagesTemplateContextFactoryTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormPagesTemplateContextFactoryTest.java
@@ -68,6 +68,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 /**
  * @author Marcellus Tavares
@@ -500,10 +501,15 @@ public class DDMFormPagesTemplateContextFactoryTest extends PowerMockito {
 				String.format(_HTML_WRAPPER, "tip"),
 				String.format(_HTML_WRAPPER, "option")));
 
+		DDMFormFieldTemplateContextContributor
+			ddmFormFieldTemplateContextContributor =
+				_ddmFormFieldTemplateContextContributorTestHelper.
+					createSelectDDMFormFieldTemplateContextContributor();
+
 		mockDDMFormFieldTypeServicesTracker(
-			"select",
-			_ddmFormFieldTemplateContextContributorTestHelper.
-				createSelectDDMFormFieldTemplateContextContributor());
+			"select", ddmFormFieldTemplateContextContributor);
+
+		setUpResourceBundleLoader(ddmFormFieldTemplateContextContributor);
 
 		// Dynamic data mapping form layout
 
@@ -968,6 +974,26 @@ public class DDMFormPagesTemplateContextFactoryTest extends PowerMockito {
 		LanguageUtil languageUtil = new LanguageUtil();
 
 		languageUtil.setLanguage(language);
+	}
+
+	protected void setUpResourceBundleLoader(
+			DDMFormFieldTemplateContextContributor
+				ddmFormFieldTemplateContextContributor)
+		throws Exception {
+
+		ResourceBundleLoader resourceBundleLoader = mock(
+			ResourceBundleLoader.class);
+		ResourceBundle resourceBundle = mock(ResourceBundle.class);
+
+		when(
+			resourceBundleLoader.loadResourceBundle(Matchers.any(Locale.class))
+		).thenReturn(
+			resourceBundle
+		);
+
+		Whitebox.setInternalState(
+			ddmFormFieldTemplateContextContributor, "resourceBundleLoader",
+			resourceBundleLoader);
 	}
 
 	protected void setUpResourceBundleLoaderUtil() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormPagesTemplateContextFactoryTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormPagesTemplateContextFactoryTest.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
-import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -65,26 +64,20 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
 /**
  * @author Marcellus Tavares
  */
-@PrepareForTest(ResourceBundleLoaderUtil.class)
 @RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor(
-	"com.liferay.portal.kernel.util.ResourceBundleLoaderUtil"
-)
 public class DDMFormPagesTemplateContextFactoryTest extends PowerMockito {
 
 	@Before
 	public void setUp() {
 		setUpHtmlUtil();
 		setUpLanguageUtil();
-		setUpResourceBundleLoaderUtil();
+		setUpResourceBundleLoader();
 		setUpDDMFormTemplateContextFactoryUtil();
 	}
 
@@ -910,6 +903,12 @@ public class DDMFormPagesTemplateContextFactoryTest extends PowerMockito {
 			ddmFormEvaluator, _ddmFormFieldTypeServicesTracker
 		);
 
+		field(
+			DDMFormEvaluatorImpl.class, "_resourceBundleLoader"
+		).set(
+			ddmFormEvaluator, _resourceBundleLoader
+		);
+
 		return ddmFormEvaluator;
 	}
 
@@ -976,37 +975,24 @@ public class DDMFormPagesTemplateContextFactoryTest extends PowerMockito {
 		languageUtil.setLanguage(language);
 	}
 
+	protected void setUpResourceBundleLoader() {
+		ResourceBundle resourceBundle = mock(ResourceBundle.class);
+
+		when(
+			_resourceBundleLoader.loadResourceBundle(Matchers.any(Locale.class))
+		).thenReturn(
+			resourceBundle
+		);
+	}
+
 	protected void setUpResourceBundleLoader(
 			DDMFormFieldTemplateContextContributor
 				ddmFormFieldTemplateContextContributor)
 		throws Exception {
 
-		ResourceBundleLoader resourceBundleLoader = mock(
-			ResourceBundleLoader.class);
-		ResourceBundle resourceBundle = mock(ResourceBundle.class);
-
-		when(
-			resourceBundleLoader.loadResourceBundle(Matchers.any(Locale.class))
-		).thenReturn(
-			resourceBundle
-		);
-
 		Whitebox.setInternalState(
 			ddmFormFieldTemplateContextContributor, "resourceBundleLoader",
-			resourceBundleLoader);
-	}
-
-	protected void setUpResourceBundleLoaderUtil() {
-		mockStatic(ResourceBundleLoaderUtil.class);
-
-		ResourceBundleLoader portalResourceBundleLoader = mock(
-			ResourceBundleLoader.class);
-
-		when(
-			ResourceBundleLoaderUtil.getPortalResourceBundleLoader()
-		).thenReturn(
-			portalResourceBundleLoader
-		);
+			_resourceBundleLoader);
 	}
 
 	protected void whenLanguageGet(
@@ -1033,5 +1019,8 @@ public class DDMFormPagesTemplateContextFactoryTest extends PowerMockito {
 	private DDMFormFieldTypeServicesTracker _ddmFormFieldTypeServicesTracker;
 
 	private HttpServletRequest _request;
+
+	@Mock
+	private ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryTest.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.ReflectionUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.template.soy.utils.SoyHTMLSanitizer;
@@ -91,6 +92,7 @@ public class DDMFormTemplateContextFactoryTest extends PowerMockito {
 		setUpDDMFormLayoutJSONSerializer();
 
 		setUpJSONFactory();
+		setUpResourceBundleLoader();
 		setUpLanguageUtil();
 		setUpLocaleThreadLocal();
 		setUpPortal();
@@ -597,6 +599,22 @@ public class DDMFormTemplateContextFactoryTest extends PowerMockito {
 
 	protected void setUpPortalClassLoaderUtil() {
 		PortalClassLoaderUtil.setClassLoader(PortalImpl.class.getClassLoader());
+	}
+
+	protected void setUpResourceBundleLoader() throws Exception {
+		ResourceBundleLoader resourceBundleLoader = mock(
+			ResourceBundleLoader.class);
+
+		ResourceBundle resourceBundle = mock(ResourceBundle.class);
+
+		when(resourceBundleLoader.loadResourceBundle(Matchers.any(Locale.class))
+		).thenReturn(
+			resourceBundle
+		);
+
+		setDeclaredField(
+			_ddmFormTemplateContextFactory, "_resourceBundleLoader",
+			resourceBundleLoader);
 	}
 
 	private DDMFormTemplateContextFactoryImpl _ddmFormTemplateContextFactory;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/asset/DDMFormAssetRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/asset/DDMFormAssetRenderer.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Locale;
@@ -60,7 +61,8 @@ public class DDMFormAssetRenderer
 		DDMFormValuesFactory ddmFormValuesFactory,
 		DDMFormValuesMerger ddmFormValuesMerger,
 		ModelResourcePermission<DDMFormInstance>
-			ddmFormInstanceModelResourcePermission) {
+			ddmFormInstanceModelResourcePermission,
+		ResourceBundleLoader resourceBundleLoader) {
 
 		_formInstanceRecord = formInstanceRecord;
 		_formInstanceRecordVersion = formInstanceRecordVersion;
@@ -71,6 +73,7 @@ public class DDMFormAssetRenderer
 		_ddmFormValuesMerger = ddmFormValuesMerger;
 		_ddmFormInstanceModelResourcePermission =
 			ddmFormInstanceModelResourcePermission;
+		_resourceBundleLoader = resourceBundleLoader;
 
 		DDMFormInstance formInstance = null;
 
@@ -200,7 +203,8 @@ public class DDMFormAssetRenderer
 				new DDMFormViewFormInstanceRecordDisplayContext(
 					request, response, _ddmFormInstanceRecordLocalService,
 					_ddmFormInstanceVersionLocalService, _ddmFormRenderer,
-					_ddmFormValuesFactory, _ddmFormValuesMerger);
+					_ddmFormValuesFactory, _ddmFormValuesMerger,
+					_resourceBundleLoader);
 
 		request.setAttribute(
 			WebKeys.PORTLET_DISPLAY_CONTEXT,
@@ -224,5 +228,6 @@ public class DDMFormAssetRenderer
 	private final DDMFormInstance _formInstance;
 	private final DDMFormInstanceRecord _formInstanceRecord;
 	private final DDMFormInstanceRecordVersion _formInstanceRecordVersion;
+	private final ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/asset/DDMFormAssetRendererFactory.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/asset/DDMFormAssetRendererFactory.java
@@ -30,11 +30,14 @@ import com.liferay.dynamic.data.mapping.util.DDMFormValuesMerger;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Leonardo Barros
@@ -142,7 +145,7 @@ public class DDMFormAssetRendererFactory
 			_ddmFormInstanceRecordLocalService,
 			_ddmFormInstanceVersionLocalService, _ddmFormRenderer,
 			_ddmFormValuesFactory, _ddmFormValuesMerger,
-			_ddmFormInstanceModelResourcePermission);
+			_ddmFormInstanceModelResourcePermission, _resourceBundleLoader);
 
 		ddmFormAssetRenderer.setAssetRendererType(type);
 		ddmFormAssetRenderer.setServletContext(_servletContext);
@@ -176,6 +179,13 @@ public class DDMFormAssetRendererFactory
 
 	@Reference
 	private DDMFormValuesMerger _ddmFormValuesMerger;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.dynamic.data.mapping.form.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	private ServletContext _servletContext;
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
@@ -70,6 +70,7 @@ import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -107,7 +108,8 @@ public class DDMFormAdminDisplayContext {
 		DDMFormRenderer formRenderer, DDMFormValuesFactory formValuesFactory,
 		DDMFormValuesMerger formValuesMerger,
 		DDMStructureLocalService structureLocalService,
-		DDMStructureService structureService, JSONFactory jsonFactory) {
+		DDMStructureService structureService, JSONFactory jsonFactory,
+		ResourceBundleLoader resourceBundleLoader) {
 
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
@@ -127,6 +129,7 @@ public class DDMFormAdminDisplayContext {
 		_ddmStructureLocalService = structureLocalService;
 		_ddmStructureService = structureService;
 		_jsonFactory = jsonFactory;
+		_resourceBundleLoader = resourceBundleLoader;
 
 		formAdminRequestHelper = new DDMFormAdminRequestHelper(renderRequest);
 
@@ -487,7 +490,7 @@ public class DDMFormAdminDisplayContext {
 			PortalUtil.getHttpServletResponse(_renderResponse),
 			_ddmFormInstanceRecordLocalService,
 			_ddmFormInstanceVersionLocalService, _ddmFormRenderer,
-			_ddmFormValuesFactory, _ddmFormValuesMerger);
+			_ddmFormValuesFactory, _ddmFormValuesMerger, _resourceBundleLoader);
 	}
 
 	public DDMFormViewFormInstanceRecordsDisplayContext
@@ -1091,5 +1094,6 @@ public class DDMFormAdminDisplayContext {
 	private final JSONFactory _jsonFactory;
 	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;
+	private final ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminFieldSetDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminFieldSetDisplayContext.java
@@ -53,6 +53,7 @@ import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -87,7 +88,8 @@ public class DDMFormAdminFieldSetDisplayContext
 		DDMFormRenderer formRenderer, DDMFormValuesFactory formValuesFactory,
 		DDMFormValuesMerger formValuesMerger,
 		DDMStructureLocalService structureLocalService,
-		DDMStructureService structureService, JSONFactory jsonFactory) {
+		DDMStructureService structureService, JSONFactory jsonFactory,
+		ResourceBundleLoader resourceBundleLoader) {
 
 		super(
 			renderRequest, renderResponse,
@@ -97,7 +99,7 @@ public class DDMFormAdminFieldSetDisplayContext
 			formInstanceVersionLocalService, formFieldTypeServicesTracker,
 			formFieldTypesJSONSerializer, formRenderer, formValuesFactory,
 			formValuesMerger, structureLocalService, structureService,
-			jsonFactory);
+			jsonFactory, resourceBundleLoader);
 
 		_fieldSetPermissionCheckerHelper = new FieldSetPermissionCheckerHelper(
 			formAdminRequestHelper);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormViewFormInstanceRecordDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormViewFormInstanceRecordDisplayContext.java
@@ -36,7 +36,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.Locale;
@@ -61,7 +61,8 @@ public class DDMFormViewFormInstanceRecordDisplayContext {
 		DDMFormInstanceRecordLocalService formInstanceRecordLocalService,
 		DDMFormInstanceVersionLocalService formInstanceVersionLocalService,
 		DDMFormRenderer formRenderer, DDMFormValuesFactory formValuesFactory,
-		DDMFormValuesMerger formValuesMerger) {
+		DDMFormValuesMerger formValuesMerger,
+		ResourceBundleLoader resourceBundleLoader) {
 
 		_httpServletResponse = httpServletResponse;
 		_ddmFormInstanceRecordLocalService = formInstanceRecordLocalService;
@@ -69,6 +70,7 @@ public class DDMFormViewFormInstanceRecordDisplayContext {
 		_ddmFormRenderer = formRenderer;
 		_ddmFormValuesFactory = formValuesFactory;
 		_ddmFormValuesMerger = formValuesMerger;
+		_resourceBundleLoader = resourceBundleLoader;
 
 		_ddmFormAdminRequestHelper = new DDMFormAdminRequestHelper(
 			httpServletRequest);
@@ -201,8 +203,8 @@ public class DDMFormViewFormInstanceRecordDisplayContext {
 
 		String labelString = label.getString(locale);
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		label.addString(
 			locale,
@@ -255,5 +257,6 @@ public class DDMFormViewFormInstanceRecordDisplayContext {
 	private final DDMFormValuesFactory _ddmFormValuesFactory;
 	private final DDMFormValuesMerger _ddmFormValuesMerger;
 	private final HttpServletResponse _httpServletResponse;
+	private final ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/DDMFormAdminPortlet.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/DDMFormAdminPortlet.java
@@ -50,6 +50,7 @@ import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.io.IOException;
@@ -209,7 +210,7 @@ public class DDMFormAdminPortlet extends MVCPortlet {
 					_ddmFormFieldTypesJSONSerializer, _ddmFormRenderer,
 					_ddmFormValuesFactory, _ddmFormValuesMerger,
 					_ddmStructureLocalService, _ddmStructureService,
-					_jsonFactory));
+					_jsonFactory, _resourceBundleLoader));
 		}
 		else {
 			ThemeDisplay themeDisplay =
@@ -253,7 +254,7 @@ public class DDMFormAdminPortlet extends MVCPortlet {
 					_ddmFormFieldTypesJSONSerializer, _ddmFormRenderer,
 					_ddmFormValuesFactory, _ddmFormValuesMerger,
 					_ddmStructureLocalService, _ddmStructureService,
-					_jsonFactory));
+					_jsonFactory, _resourceBundleLoader));
 		}
 	}
 
@@ -323,5 +324,12 @@ public class DDMFormAdminPortlet extends MVCPortlet {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.dynamic.data.mapping.form.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/CopyFormInstanceMVCActionCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/CopyFormInstanceMVCActionCommand.java
@@ -27,12 +27,9 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.BaseTransactionalMVCActionC
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
-import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
-import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Locale;
 import java.util.Map;
@@ -44,6 +41,8 @@ import javax.portlet.ActionResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pedro Queiroz
@@ -118,17 +117,7 @@ public class CopyFormInstanceMVCActionCommand
 	}
 
 	protected ResourceBundle getResourceBundle(Locale locale) {
-		ResourceBundleLoader portalResourceBundleLoader =
-			ResourceBundleLoaderUtil.getPortalResourceBundleLoader();
-
-		ResourceBundle portalResourceBundle =
-			portalResourceBundleLoader.loadResourceBundle(locale);
-
-		ResourceBundle moduleResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
-
-		return new AggregateResourceBundle(
-			moduleResourceBundle, portalResourceBundle);
+		return resourceBundleLoader.loadResourceBundle(locale);
 	}
 
 	protected void setDefaultPublishedDDMFormFieldValue(
@@ -148,6 +137,13 @@ public class CopyFormInstanceMVCActionCommand
 
 	@Reference
 	protected DDMStructureService ddmStructureService;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.dynamic.data.mapping.form.web)"
+	)
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 	@Reference
 	protected SaveFormInstanceMVCCommandHelper saveFormInstanceMVCCommandHelper;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/configuration/icon/DDMDataProviderPortletConfigurationIcon.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/configuration/icon/DDMDataProviderPortletConfigurationIcon.java
@@ -38,6 +38,8 @@ import javax.portlet.WindowStateException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Rafael Praxedes
@@ -115,19 +117,14 @@ public class DDMDataProviderPortletConfigurationIcon
 		return "data-providers";
 	}
 
-	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.dynamic.data.mapping.data.provider.web)",
-		unbind = "-"
-	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		_resourceBundleLoader = resourceBundleLoader;
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		DDMDataProviderPortletConfigurationIcon.class);
 
-	private ResourceBundleLoader _resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.dynamic.data.mapping.data.provider.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContextTest.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
-import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.registry.collections.ServiceTrackerCollections;
@@ -70,12 +69,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 /**
  * @author Adam Brandizzi
  */
-@PrepareForTest(
-	{
-		LocaleUtil.class, ResourceBundleUtil.class,
-		ResourceBundleLoaderUtil.class, ServiceTrackerCollections.class
-	}
-)
+@PrepareForTest({LocaleUtil.class, ServiceTrackerCollections.class})
 @RunWith(PowerMockRunner.class)
 public class DDMFormAdminDisplayContextTest extends PowerMockito {
 
@@ -85,8 +79,7 @@ public class DDMFormAdminDisplayContextTest extends PowerMockito {
 		setUpServiceTrackerCollections();
 
 		setUpLanguageUtil();
-		setUpResourceBundleUtil();
-		setUpResourceBundleLoaderUtil();
+		setUpResourceBundleLoader();
 
 		setUpDDMFormDisplayContext();
 	}
@@ -288,7 +281,8 @@ public class DDMFormAdminDisplayContextTest extends PowerMockito {
 			mock(DDMFormRenderer.class), mock(DDMFormValuesFactory.class),
 			mock(DDMFormValuesMerger.class),
 			mock(DDMStructureLocalService.class),
-			mock(DDMStructureService.class), mock(JSONFactory.class));
+			mock(DDMStructureService.class), mock(JSONFactory.class),
+			_resourceBundleLoader);
 	}
 
 	protected void setUpLanguageUtil() {
@@ -315,27 +309,9 @@ public class DDMFormAdminDisplayContextTest extends PowerMockito {
 		portalUtil.setPortal(portal);
 	}
 
-	protected void setUpResourceBundleLoaderUtil() {
-		ResourceBundleLoader resourceBundleLoader = mock(
-			ResourceBundleLoader.class);
-
-		ResourceBundleLoaderUtil.setPortalResourceBundleLoader(
-			resourceBundleLoader);
-
+	protected void setUpResourceBundleLoader() {
 		when(
-			resourceBundleLoader.loadResourceBundle(Matchers.any(Locale.class))
-		).thenReturn(
-			ResourceBundleUtil.EMPTY_RESOURCE_BUNDLE
-		);
-	}
-
-	protected void setUpResourceBundleUtil() {
-		mockStatic(ResourceBundleUtil.class);
-
-		when(
-			ResourceBundleUtil.getBundle(
-				Matchers.anyString(), Matchers.any(Locale.class),
-				Matchers.any(ClassLoader.class))
+			_resourceBundleLoader.loadResourceBundle(Matchers.any(Locale.class))
 		).thenReturn(
 			ResourceBundleUtil.EMPTY_RESOURCE_BUNDLE
 		);
@@ -376,6 +352,9 @@ public class DDMFormAdminDisplayContextTest extends PowerMockito {
 
 	private DDMFormAdminDisplayContext _ddmFormAdminDisplayContext;
 	private RenderRequest _renderRequest;
+
+	@Mock
+	private ResourceBundleLoader _resourceBundleLoader;
 
 	@Mock
 	private ServiceTrackerMap<String, ResourceBundleLoader> _serviceTrackerMap;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/notification/DDMFormEmailNotificationSender.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/notification/DDMFormEmailNotificationSender.java
@@ -54,6 +54,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
@@ -79,6 +80,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Rafael Praxedes
@@ -389,8 +392,7 @@ public class DDMFormEmailNotificationSender {
 	}
 
 	protected ResourceBundle getResourceBundle(Locale locale) {
-		return ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		return _resourceBundleLoader.loadResourceBundle(locale);
 	}
 
 	protected String getSiteName(long groupId, Locale locale) {
@@ -568,6 +570,13 @@ public class DDMFormEmailNotificationSender {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.dynamic.data.mapping.service)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference
 	private SoyHTMLSanitizer _soyHTMLSanitizer;

--- a/modules/apps/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/internal/portlet/configuration/icon/ViewJournalSourcePortletConfigurationIcon.java
+++ b/modules/apps/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/internal/portlet/configuration/icon/ViewJournalSourcePortletConfigurationIcon.java
@@ -27,11 +27,10 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigura
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -47,6 +46,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Daniel Kocsis
@@ -86,11 +87,7 @@ public class ViewJournalSourcePortletConfigurationIcon
 
 	@Override
 	public ResourceBundle getResourceBundle(Locale locale) {
-		ResourceBundle classResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
-
-		return new AggregateResourceBundle(
-			classResourceBundle, _portal.getResourceBundle(locale));
+		return _resourceBundleLoader.loadResourceBundle(locale);
 	}
 
 	@Override
@@ -232,5 +229,12 @@ public class ViewJournalSourcePortletConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.exportimport.resources.importer)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/notifications/ExportImportUserNotificationHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/notifications/ExportImportUserNotificationHandler.java
@@ -48,6 +48,8 @@ import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Akos Thurzo
@@ -178,7 +180,11 @@ public class ExportImportUserNotificationHandler
 	@Reference
 	private PortletLocalService _portletLocalService;
 
-	@Reference(target = "(bundle.symbolic.name=com.liferay.staging.lang)")
-	private ResourceBundleLoader _resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.staging.lang)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -140,7 +140,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.util.Tuple;
@@ -185,6 +185,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Raymond Augé
@@ -750,8 +752,8 @@ public class StagingImpl implements Staging {
 		int errorType = 0;
 		JSONArray warningMessagesJSONArray = null;
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		Throwable cause = e.getCause();
 
@@ -4349,6 +4351,13 @@ public class StagingImpl implements Staging {
 	@Reference
 	private RecentLayoutSetBranchLocalService
 		_recentLayoutSetBranchLocalService;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.exportimport.service)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference
 	private StagedModelRepositoryHelper _stagedModelRepositoryHelper;

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/configuration/icon/ExportTemplatesConfigurationIcon.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/configuration/icon/ExportTemplatesConfigurationIcon.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigura
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ResourceBundle;
@@ -32,6 +32,8 @@ import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Mate Thurzo
@@ -46,8 +48,11 @@ public class ExportTemplatesConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "export-templates");
 	}
@@ -101,5 +106,12 @@ public class ExportTemplatesConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.exportimport.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/EditableFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/EditableFragmentEntryProcessor.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -47,6 +47,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pavel Savinov
@@ -224,8 +225,8 @@ public class EditableFragmentEntryProcessor implements FragmentEntryProcessor {
 			return;
 		}
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(Locale.getDefault());
 
 		throw new FragmentEntryContentException(
 			LanguageUtil.format(
@@ -269,8 +270,8 @@ public class EditableFragmentEntryProcessor implements FragmentEntryProcessor {
 		idsStream = idsStream.filter(id -> idsMap.get(id) > 1);
 
 		if (idsStream.count() > 0) {
-			ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-				"content.Language", getClass());
+			ResourceBundle resourceBundle =
+				_resourceBundleLoader.loadResourceBundle(Locale.getDefault());
 
 			throw new FragmentEntryContentException(
 				LanguageUtil.get(
@@ -306,8 +307,8 @@ public class EditableFragmentEntryProcessor implements FragmentEntryProcessor {
 			return;
 		}
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(Locale.getDefault());
 
 		throw new FragmentEntryContentException(
 			LanguageUtil.get(
@@ -321,5 +322,12 @@ public class EditableFragmentEntryProcessor implements FragmentEntryProcessor {
 
 	private final Map<String, EditableElementParser> _editableElementParsers =
 		new HashMap<>();
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.fragment.entry.processor.editable)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/parser/impl/ImageEditableElementParser.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/parser/impl/ImageEditableElementParser.java
@@ -18,15 +18,19 @@ import com.liferay.fragment.entry.processor.editable.EditableFragmentEntryProces
 import com.liferay.fragment.entry.processor.editable.parser.EditableElementParser;
 import com.liferay.fragment.exception.FragmentEntryContentException;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.jsoup.nodes.Element;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pavel Savinov
@@ -65,8 +69,8 @@ public class ImageEditableElementParser implements EditableElementParser {
 		List<Element> elements = element.getElementsByTag("img");
 
 		if (elements.size() != 1) {
-			ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-				"content.Language", getClass());
+			ResourceBundle resourceBundle =
+				_resourceBundleLoader.loadResourceBundle(Locale.getDefault());
 
 			throw new FragmentEntryContentException(
 				LanguageUtil.format(
@@ -80,5 +84,12 @@ public class ImageEditableElementParser implements EditableElementParser {
 		EditableFragmentEntryProcessor.class,
 		"/META-INF/resources/fragment/entry/processor/editable" +
 			"/image_field_template.tmpl");
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.fragment.entry.processor.editable)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-nullable/src/main/java/com/liferay/fragment/entry/processor/nullable/NullableFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-nullable/src/main/java/com/liferay/fragment/entry/processor/nullable/NullableFragmentEntryProcessor.java
@@ -19,12 +19,16 @@ import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.FragmentEntryProcessor;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eudaldo Alonso
@@ -45,8 +49,8 @@ public class NullableFragmentEntryProcessor implements FragmentEntryProcessor {
 	@Override
 	public void validateFragmentEntryHTML(String html) throws PortalException {
 		if (Validator.isNull(html)) {
-			ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-				"content.Language", getClass());
+			ResourceBundle resourceBundle =
+				_resourceBundleLoader.loadResourceBundle(Locale.getDefault());
 
 			String message = LanguageUtil.get(
 				resourceBundle, "html-content-must-not-be-empty");
@@ -54,5 +58,12 @@ public class NullableFragmentEntryProcessor implements FragmentEntryProcessor {
 			throw new FragmentEntryContentException(message);
 		}
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.fragment.entry.processor.nullable)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
@@ -44,13 +44,14 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portlet.configuration.kernel.util.PortletConfigurationApplicationType;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.ResourceBundle;
 
@@ -65,6 +66,8 @@ import org.jsoup.nodes.Element;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pavel Savinov
@@ -97,9 +100,13 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 			String portletName = _portletRegistry.getPortletName(alias);
 
 			if (Validator.isNull(portletName)) {
+				ResourceBundle resourceBundle =
+					_resourceBundleLoader.loadResourceBundle(
+						Locale.getDefault());
+
 				throw new FragmentEntryContentException(
 					LanguageUtil.format(
-						_resourceBundle,
+						resourceBundle,
 						"there-is-no-widget-available-for-alias-x", alias));
 			}
 
@@ -189,10 +196,13 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 			String alias = StringUtil.replace(
 				htmlTagName, "lfr-widget-", StringPool.BLANK);
 
+			ResourceBundle resourceBundle =
+				_resourceBundleLoader.loadResourceBundle(Locale.getDefault());
+
 			if (Validator.isNull(_portletRegistry.getPortletName(alias))) {
 				throw new FragmentEntryContentException(
 					LanguageUtil.format(
-						_resourceBundle,
+						resourceBundle,
 						"there-is-no-widget-available-for-alias-x", alias));
 			}
 
@@ -201,7 +211,7 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 
 				throw new FragmentEntryContentException(
 					LanguageUtil.format(
-						_resourceBundle,
+						resourceBundle,
 						"widget-id-must-contain-only-alphanumeric-characters",
 						alias));
 			}
@@ -438,7 +448,11 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 	@Reference
 	private PortletRegistry _portletRegistry;
 
-	private final ResourceBundle _resourceBundle = ResourceBundleUtil.getBundle(
-		"content.Language", getClass());
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.fragment.entry.processor.portlet)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/fragment/fragment-item-selector-web/src/main/java/com/liferay/fragment/item/selector/web/internal/FragmentItemSelectorView.java
+++ b/modules/apps/fragment/fragment-item-selector-web/src/main/java/com/liferay/fragment/item/selector/web/internal/FragmentItemSelectorView.java
@@ -48,6 +48,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pavel Savinov
@@ -155,10 +157,11 @@ public class FragmentItemSelectorView
 				}));
 
 	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.fragment.item.selector.web)",
-		unbind = "-"
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.fragment.item.selector.web)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	private ServletContext _servletContext;
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-brightness/src/main/java/com/liferay/frontend/image/editor/capability/brightness/internal/ImageEditorCapabilityBrightness.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-brightness/src/main/java/com/liferay/frontend/image/editor/capability/brightness/internal/ImageEditorCapabilityBrightness.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.image.editor.capability.brightness.internal;
 
 import com.liferay.frontend.image.editor.capability.BaseImageEditorCapability;
 import com.liferay.frontend.image.editor.capability.ImageEditorCapability;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Locale;
@@ -25,6 +26,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Bruno Basto
@@ -44,8 +47,8 @@ public class ImageEditorCapabilityBrightness extends BaseImageEditorCapability {
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return ResourceBundleUtil.getString(resourceBundle, "brightness");
 	}
@@ -59,6 +62,13 @@ public class ImageEditorCapabilityBrightness extends BaseImageEditorCapability {
 	public ServletContext getServletContext() {
 		return _servletContext;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.frontend.image.editor.capability.brightness)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.frontend.image.editor.capability.brightness)"

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-contrast/src/main/java/com/liferay/frontend/image/editor/capability/contrast/internal/ImageEditorCapabilityContrast.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-contrast/src/main/java/com/liferay/frontend/image/editor/capability/contrast/internal/ImageEditorCapabilityContrast.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.image.editor.capability.contrast.internal;
 
 import com.liferay.frontend.image.editor.capability.BaseImageEditorCapability;
 import com.liferay.frontend.image.editor.capability.ImageEditorCapability;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Locale;
@@ -25,6 +26,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Bruno Basto
@@ -44,8 +47,8 @@ public class ImageEditorCapabilityContrast extends BaseImageEditorCapability {
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return ResourceBundleUtil.getString(resourceBundle, "contrast");
 	}
@@ -59,6 +62,13 @@ public class ImageEditorCapabilityContrast extends BaseImageEditorCapability {
 	public ServletContext getServletContext() {
 		return _servletContext;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.frontend.image.editor.capability.contrast)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.frontend.image.editor.capability.contrast)"

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-crop/src/main/java/com/liferay/frontend/image/editor/capability/crop/internal/ImageEditorCapabilityCrop.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-crop/src/main/java/com/liferay/frontend/image/editor/capability/crop/internal/ImageEditorCapabilityCrop.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.image.editor.capability.crop.internal;
 
 import com.liferay.frontend.image.editor.capability.BaseImageEditorCapability;
 import com.liferay.frontend.image.editor.capability.ImageEditorCapability;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Locale;
@@ -25,6 +26,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Bruno Basto
@@ -44,8 +47,8 @@ public class ImageEditorCapabilityCrop extends BaseImageEditorCapability {
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return ResourceBundleUtil.getString(resourceBundle, "crop");
 	}
@@ -59,6 +62,13 @@ public class ImageEditorCapabilityCrop extends BaseImageEditorCapability {
 	public ServletContext getServletContext() {
 		return _servletContext;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.frontend.image.editor.capability.crop)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.frontend.image.editor.capability.crop)"

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-effects/src/main/java/com/liferay/frontend/image/editor/capability/effects/internal/ImageEditorCapabilityEffects.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-effects/src/main/java/com/liferay/frontend/image/editor/capability/effects/internal/ImageEditorCapabilityEffects.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.image.editor.capability.effects.internal;
 
 import com.liferay.frontend.image.editor.capability.BaseImageEditorCapability;
 import com.liferay.frontend.image.editor.capability.ImageEditorCapability;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Locale;
@@ -25,6 +26,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Bruno Basto
@@ -44,8 +47,8 @@ public class ImageEditorCapabilityEffects extends BaseImageEditorCapability {
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return ResourceBundleUtil.getString(resourceBundle, "effects");
 	}
@@ -59,6 +62,13 @@ public class ImageEditorCapabilityEffects extends BaseImageEditorCapability {
 	public ServletContext getServletContext() {
 		return _servletContext;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.frontend.image.editor.capability.effects)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.frontend.image.editor.capability.effects)"

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-resize/src/main/java/com/liferay/frontend/image/editor/capability/resize/internal/ImageEditorCapabilityResize.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-resize/src/main/java/com/liferay/frontend/image/editor/capability/resize/internal/ImageEditorCapabilityResize.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.image.editor.capability.resize.internal;
 
 import com.liferay.frontend.image.editor.capability.BaseImageEditorCapability;
 import com.liferay.frontend.image.editor.capability.ImageEditorCapability;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Locale;
@@ -25,6 +26,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Bruno Basto
@@ -44,8 +47,8 @@ public class ImageEditorCapabilityResize extends BaseImageEditorCapability {
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return ResourceBundleUtil.getString(resourceBundle, "resize");
 	}
@@ -59,6 +62,13 @@ public class ImageEditorCapabilityResize extends BaseImageEditorCapability {
 	public ServletContext getServletContext() {
 		return _servletContext;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.frontend.image.editor.capability.resize)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.frontend.image.editor.capability.resize)"

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-rotate/src/main/java/com/liferay/frontend/image/editor/capability/rotate/internal/ImageEditorCapabilityRotate.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-rotate/src/main/java/com/liferay/frontend/image/editor/capability/rotate/internal/ImageEditorCapabilityRotate.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.image.editor.capability.rotate.internal;
 
 import com.liferay.frontend.image.editor.capability.BaseImageEditorCapability;
 import com.liferay.frontend.image.editor.capability.ImageEditorCapability;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Locale;
@@ -25,6 +26,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Bruno Basto
@@ -44,8 +47,8 @@ public class ImageEditorCapabilityRotate extends BaseImageEditorCapability {
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return ResourceBundleUtil.getString(resourceBundle, "rotate");
 	}
@@ -59,6 +62,13 @@ public class ImageEditorCapabilityRotate extends BaseImageEditorCapability {
 	public ServletContext getServletContext() {
 		return _servletContext;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.frontend.image.editor.capability.rotate)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.frontend.image.editor.capability.rotate)"

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-saturation/src/main/java/com/liferay/frontend/image/editor/capability/saturation/internal/ImageEditorCapabilitySaturation.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-saturation/src/main/java/com/liferay/frontend/image/editor/capability/saturation/internal/ImageEditorCapabilitySaturation.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.image.editor.capability.saturation.internal;
 
 import com.liferay.frontend.image.editor.capability.BaseImageEditorCapability;
 import com.liferay.frontend.image.editor.capability.ImageEditorCapability;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Locale;
@@ -25,6 +26,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Bruno Basto
@@ -44,8 +47,8 @@ public class ImageEditorCapabilitySaturation extends BaseImageEditorCapability {
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return ResourceBundleUtil.getString(resourceBundle, "saturation");
 	}
@@ -59,6 +62,13 @@ public class ImageEditorCapabilitySaturation extends BaseImageEditorCapability {
 	public ServletContext getServletContext() {
 		return _servletContext;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.frontend.image.editor.capability.saturation)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.frontend.image.editor.capability.saturation)"

--- a/modules/apps/frontend-image-editor/frontend-image-editor-integration-document-library/src/main/java/com/liferay/frontend/image/editor/integration/document/library/internal/display/context/ImageEditorDLDisplayContextFactory.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-integration-document-library/src/main/java/com/liferay/frontend/image/editor/integration/document/library/internal/display/context/ImageEditorDLDisplayContextFactory.java
@@ -29,6 +29,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Ambrin Chaudhary
@@ -80,17 +82,13 @@ public class ImageEditorDLDisplayContextFactory
 		_dlAppService = dlAppService;
 	}
 
-	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.frontend.image.editor.integration.document.library)",
-		unbind = "-"
-	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		_resourceBundleLoader = resourceBundleLoader;
-	}
-
 	private DLAppService _dlAppService;
-	private ResourceBundleLoader _resourceBundleLoader;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.frontend.image.editor.integration.document.library)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/frontend-image-editor/frontend-image-editor-integration-document-library/src/main/java/com/liferay/frontend/image/editor/integration/document/library/internal/display/context/ImageEditorIGDisplayContextFactory.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-integration-document-library/src/main/java/com/liferay/frontend/image/editor/integration/document/library/internal/display/context/ImageEditorIGDisplayContextFactory.java
@@ -27,6 +27,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Ambrin Chaudhary
@@ -66,17 +68,13 @@ public class ImageEditorIGDisplayContextFactory
 		_dlAppService = dlAppService;
 	}
 
-	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.frontend.image.editor.integration.document.library)",
-		unbind = "-"
-	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		_resourceBundleLoader = resourceBundleLoader;
-	}
-
 	private DLAppService _dlAppService;
-	private ResourceBundleLoader _resourceBundleLoader;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.frontend.image.editor.integration.document.library)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/frontend-image-editor/frontend-image-editor-integration-document-library/src/main/java/com/liferay/frontend/image/editor/integration/document/library/internal/portlet/action/EditFileEntryImageEditorMVCActionCommand.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-integration-document-library/src/main/java/com/liferay/frontend/image/editor/integration/document/library/internal/portlet/action/EditFileEntryImageEditorMVCActionCommand.java
@@ -56,6 +56,8 @@ import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Ambrin Chaudhary
@@ -197,9 +199,10 @@ public class EditFileEntryImageEditorMVCActionCommand
 	private Portal _portal;
 
 	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.frontend.image.editor.integration.document.library)",
-		unbind = "-"
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.frontend.image.editor.integration.document.library)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/gogo-shell/gogo-shell-web/src/main/java/com/liferay/gogo/shell/web/internal/portlet/GogoShellPortlet.java
+++ b/modules/apps/gogo-shell/gogo-shell-web/src/main/java/com/liferay/gogo/shell/web/internal/portlet/GogoShellPortlet.java
@@ -52,6 +52,8 @@ import org.apache.felix.service.command.CommandSession;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Andrea Di Giorgi
@@ -259,7 +261,11 @@ public class GogoShellPortlet extends MVCPortlet {
 	@Reference
 	private Portal _portal;
 
-	@Reference(target = "(bundle.symbolic.name=com.liferay.gogo.shell.web)")
-	private ResourceBundleLoader _resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.gogo.shell.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/invitation/invitation-invite-members-web/src/main/java/com/liferay/invitation/invite/members/web/internal/notifications/InviteMembersUserNotificationHandler.java
+++ b/modules/apps/invitation/invitation-invite-members-web/src/main/java/com/liferay/invitation/invite/members/web/internal/notifications/InviteMembersUserNotificationHandler.java
@@ -31,14 +31,12 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
-import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.language.LanguageResources;
 
 import java.util.ResourceBundle;
 
@@ -48,6 +46,8 @@ import javax.portlet.WindowState;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jonathan Lee
@@ -228,17 +228,6 @@ public class InviteMembersUserNotificationHandler
 		_memberRequestLocalService = memberRequestLocalService;
 	}
 
-	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.invitation.invite.members.web)",
-		unbind = "-"
-	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		_resourceBundleLoader = new AggregateResourceBundleLoader(
-			resourceBundleLoader, LanguageResources.RESOURCE_BUNDLE_LOADER);
-	}
-
 	@Reference(unbind = "-")
 	protected void setUserLocalService(UserLocalService userLocalService) {
 		_userLocalService = userLocalService;
@@ -257,7 +246,13 @@ public class InviteMembersUserNotificationHandler
 	@Reference
 	private Portal _portal;
 
-	private ResourceBundleLoader _resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.invitation.invite.members.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
+
 	private UserLocalService _userLocalService;
 	private UserNotificationEventLocalService
 		_userNotificationEventLocalService;

--- a/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-conversions/src/main/java/com/liferay/journal/content/asset/addon/entry/conversions/internal/BaseConvertionUserToolAssetAddonEntry.java
+++ b/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-conversions/src/main/java/com/liferay/journal/content/asset/addon/entry/conversions/internal/BaseConvertionUserToolAssetAddonEntry.java
@@ -18,7 +18,6 @@ import com.liferay.journal.content.asset.addon.entry.UserToolAssetAddonEntry;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.servlet.taglib.ui.BaseJSPAssetAddonEntry;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portlet.documentlibrary.util.DocumentConversionUtil;
 
@@ -45,8 +44,7 @@ public abstract class BaseConvertionUserToolAssetAddonEntry
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle = getResourceBundle(locale);
 
 		return LanguageUtil.format(
 			resourceBundle, "download-as-x",
@@ -78,5 +76,7 @@ public abstract class BaseConvertionUserToolAssetAddonEntry
 
 		return super.isEnabled();
 	}
+
+	protected abstract ResourceBundle getResourceBundle(Locale locale);
 
 }

--- a/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-conversions/src/main/java/com/liferay/journal/content/asset/addon/entry/conversions/internal/DOCConvertionUserToolAssetAddonEntry.java
+++ b/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-conversions/src/main/java/com/liferay/journal/content/asset/addon/entry/conversions/internal/DOCConvertionUserToolAssetAddonEntry.java
@@ -15,11 +15,17 @@
 package com.liferay.journal.content.asset.addon.entry.conversions.internal;
 
 import com.liferay.journal.content.asset.addon.entry.UserToolAssetAddonEntry;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
 
 import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Julio Camarero
@@ -57,5 +63,16 @@ public class DOCConvertionUserToolAssetAddonEntry
 	public void setServletContext(ServletContext servletContext) {
 		super.setServletContext(servletContext);
 	}
+
+	protected ResourceBundle getResourceBundle(Locale locale) {
+		return _resourceBundleLoader.loadResourceBundle(locale);
+	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.journal.content.asset.addon.entry.conversions)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-conversions/src/main/java/com/liferay/journal/content/asset/addon/entry/conversions/internal/ODTConvertionUserToolAssetAddonEntry.java
+++ b/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-conversions/src/main/java/com/liferay/journal/content/asset/addon/entry/conversions/internal/ODTConvertionUserToolAssetAddonEntry.java
@@ -15,11 +15,17 @@
 package com.liferay.journal.content.asset.addon.entry.conversions.internal;
 
 import com.liferay.journal.content.asset.addon.entry.UserToolAssetAddonEntry;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
 
 import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Julio Camarero
@@ -57,5 +63,16 @@ public class ODTConvertionUserToolAssetAddonEntry
 	public void setServletContext(ServletContext servletContext) {
 		super.setServletContext(servletContext);
 	}
+
+	protected ResourceBundle getResourceBundle(Locale locale) {
+		return _resourceBundleLoader.loadResourceBundle(locale);
+	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.journal.content.asset.addon.entry.conversions)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-conversions/src/main/java/com/liferay/journal/content/asset/addon/entry/conversions/internal/PDFConvertionUserToolAssetAddonEntry.java
+++ b/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-conversions/src/main/java/com/liferay/journal/content/asset/addon/entry/conversions/internal/PDFConvertionUserToolAssetAddonEntry.java
@@ -15,11 +15,17 @@
 package com.liferay.journal.content.asset.addon.entry.conversions.internal;
 
 import com.liferay.journal.content.asset.addon.entry.UserToolAssetAddonEntry;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
 
 import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Julio Camarero
@@ -57,5 +63,16 @@ public class PDFConvertionUserToolAssetAddonEntry
 	public void setServletContext(ServletContext servletContext) {
 		super.setServletContext(servletContext);
 	}
+
+	protected ResourceBundle getResourceBundle(Locale locale) {
+		return _resourceBundleLoader.loadResourceBundle(locale);
+	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.journal.content.asset.addon.entry.conversions)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-conversions/src/main/java/com/liferay/journal/content/asset/addon/entry/conversions/internal/TXTConvertionUserToolAssetAddonEntry.java
+++ b/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-conversions/src/main/java/com/liferay/journal/content/asset/addon/entry/conversions/internal/TXTConvertionUserToolAssetAddonEntry.java
@@ -15,11 +15,17 @@
 package com.liferay.journal.content.asset.addon.entry.conversions.internal;
 
 import com.liferay.journal.content.asset.addon.entry.UserToolAssetAddonEntry;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
 
 import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Julio Camarero
@@ -57,5 +63,16 @@ public class TXTConvertionUserToolAssetAddonEntry
 	public void setServletContext(ServletContext servletContext) {
 		super.setServletContext(servletContext);
 	}
+
+	protected ResourceBundle getResourceBundle(Locale locale) {
+		return _resourceBundleLoader.loadResourceBundle(locale);
+	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.journal.content.asset.addon.entry.conversions)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/dynamic/data/mapping/util/JournalContentDDMDisplay.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/dynamic/data/mapping/util/JournalContentDDMDisplay.java
@@ -22,12 +22,15 @@ import com.liferay.journal.constants.JournalContentPortletKeys;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import java.util.Locale;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eudaldo Alonso
@@ -144,9 +147,21 @@ public class JournalContentDDMDisplay extends BaseDDMDisplay {
 		return _ddmDisplay.isShowStructureSelector();
 	}
 
+	@Override
+	protected ResourceBundleLoader getResourceBundleLoader() {
+		return _resourceBundleLoader;
+	}
+
 	@Reference(
 		target = "(javax.portlet.name=" + JournalPortletKeys.JOURNAL + ")"
 	)
 	private DDMDisplay _ddmDisplay;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.journal.content.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/dynamic/data/mapping/util/JournalDDMDisplay.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/dynamic/data/mapping/util/JournalDDMDisplay.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.webdav.WebDAVUtil;
@@ -62,6 +63,8 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eduardo Garcia
@@ -207,6 +210,11 @@ public class JournalDDMDisplay extends BaseDDMDisplay {
 			JournalWebConfiguration.class, properties);
 	}
 
+	@Override
+	protected ResourceBundleLoader getResourceBundleLoader() {
+		return resourceBundleLoader;
+	}
+
 	protected DDMDisplayTabItem getTemplatesTabItem() {
 		return new DDMDisplayTabItem() {
 
@@ -302,6 +310,13 @@ public class JournalDDMDisplay extends BaseDDMDisplay {
 
 	@Reference
 	protected PortletLocalService portletLocalService;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.journal.web)"
+	)
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 	private DDMDisplayTabItem _getFeedsTabItem() {
 		return new DDMDisplayTabItem() {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/display/contributor/JournalArticleAssetDisplayContributor.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/display/contributor/JournalArticleAssetDisplayContributor.java
@@ -44,6 +44,8 @@ import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jürgen Kappler
@@ -121,12 +123,22 @@ public class JournalArticleAssetDisplayContributor
 
 	@Override
 	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.journal.web)", unbind = "-"
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.journal.web)"
 	)
 	protected void setResourceBundleLoader(
 		ResourceBundleLoader resourceBundleLoader) {
 
 		this.resourceBundleLoader = resourceBundleLoader;
+	}
+
+	protected void unsetResourceBundleLoader(
+		ResourceBundleLoader resourceBundleLoader) {
+
+		if (this.resourceBundleLoader == resourceBundleLoader) {
+			this.resourceBundleLoader = null;
+		}
 	}
 
 	private String _transformFileEntryURL(String data) {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/notifications/BaseJournalUserNotificationDefinition.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/notifications/BaseJournalUserNotificationDefinition.java
@@ -23,6 +23,8 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Alejandro Tardín
@@ -53,8 +55,12 @@ public abstract class BaseJournalUserNotificationDefinition
 		return _description;
 	}
 
-	@Reference(target = "(bundle.symbolic.name=com.liferay.journal.web)")
-	protected ResourceBundleLoader resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.journal.web)"
+	)
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 	private final String _description;
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/notifications/JournalUserNotificationHandler.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/notifications/JournalUserNotificationHandler.java
@@ -35,6 +35,8 @@ import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Iván Zaera
@@ -127,18 +129,14 @@ public class JournalUserNotificationHandler
 		return title;
 	}
 
-	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.journal.web)", unbind = "-"
-	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		_resourceBundleLoader = resourceBundleLoader;
-	}
-
 	@Reference
 	private Portal _portal;
 
-	private ResourceBundleLoader _resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.journal.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/template/JournalTemplateHandler.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/template/JournalTemplateHandler.java
@@ -43,6 +43,8 @@ import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jorge Ferrer
@@ -144,15 +146,6 @@ public class JournalTemplateHandler extends BaseDDMTemplateHandler {
 		_journalContent = journalContent;
 	}
 
-	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.journal.web)", unbind = "-"
-	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		_resourceBundleLoader = resourceBundleLoader;
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalTemplateHandler.class);
 
@@ -188,7 +181,13 @@ public class JournalTemplateHandler extends BaseDDMTemplateHandler {
 	)
 	private Release _release;
 
-	private ResourceBundleLoader _resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.journal.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
+
 	private final TemplateVariableCodeHandler _templateVariableCodeHandler =
 		new DDMTemplateVariableCodeHandler(
 			JournalTemplateHandler.class.getClassLoader(),

--- a/modules/apps/knowledge-base/knowledge-base-editor-configuration/src/main/java/com/liferay/knowledge/base/editor/configuration/internal/KBAttachmentEditorConfigContributor.java
+++ b/modules/apps/knowledge-base/knowledge-base-editor-configuration/src/main/java/com/liferay/knowledge/base/editor/configuration/internal/KBAttachmentEditorConfigContributor.java
@@ -29,11 +29,9 @@ import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
-import com.liferay.portal.language.LanguageResources;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,6 +43,8 @@ import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Roberto Díaz
@@ -207,18 +207,13 @@ public class KBAttachmentEditorConfigContributor
 		return urlItemSelectorCriterion;
 	}
 
-	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.knowledge.base.item.selector.web)",
-		unbind = "-"
-	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		_resourceBundleLoader = new AggregateResourceBundleLoader(
-			resourceBundleLoader, LanguageResources.RESOURCE_BUNDLE_LOADER);
-	}
-
 	private ItemSelector _itemSelector;
-	private ResourceBundleLoader _resourceBundleLoader;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.knowledge.base.item.selector.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-item-selector-web/src/main/java/com/liferay/knowledge/base/item/selector/web/internal/KBAttachmentItemSelectorView.java
+++ b/modules/apps/knowledge-base/knowledge-base-item-selector-web/src/main/java/com/liferay/knowledge/base/item/selector/web/internal/KBAttachmentItemSelectorView.java
@@ -24,11 +24,9 @@ import com.liferay.knowledge.base.item.selector.criterion.KBAttachmentItemSelect
 import com.liferay.knowledge.base.item.selector.web.internal.constants.KBItemSelectorWebKeys;
 import com.liferay.knowledge.base.item.selector.web.internal.display.context.KBAttachmentItemSelectorViewDisplayContext;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
-import com.liferay.portal.language.LanguageResources;
 
 import java.io.IOException;
 
@@ -136,17 +134,6 @@ public class KBAttachmentItemSelectorView
 		_servletContext = servletContext;
 	}
 
-	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.knowledge.base.item.selector.web)",
-		unbind = "-"
-	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		_resourceBundleLoader = new AggregateResourceBundleLoader(
-			resourceBundleLoader, LanguageResources.RESOURCE_BUNDLE_LOADER);
-	}
-
 	private static final List<ItemSelectorReturnType>
 		_supportedItemSelectorReturnTypes = Collections.unmodifiableList(
 			ListUtil.fromArray(
@@ -164,7 +151,14 @@ public class KBAttachmentItemSelectorView
 
 	private ItemSelectorReturnTypeResolverHandler
 		_itemSelectorReturnTypeResolverHandler;
-	private ResourceBundleLoader _resourceBundleLoader;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.knowledge.base.item.selector.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
+
 	private ServletContext _servletContext;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/AddChildKBArticlePortletConfigurationIcon.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/AddChildKBArticlePortletConfigurationIcon.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ResourceBundle;
@@ -35,6 +35,8 @@ import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Ambrin Chaudhary
@@ -52,8 +54,11 @@ public class AddChildKBArticlePortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "add-child-article");
 	}
@@ -113,5 +118,12 @@ public class AddChildKBArticlePortletConfigurationIcon
 		target = "(resource.name=" + KBConstants.RESOURCE_NAME_ADMIN + ")"
 	)
 	private PortletResourcePermission _portletResourcePermission;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.knowledge.base.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.security.permission.resource.PortletResourcePer
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.security.PermissionsURLTag;
 
@@ -40,6 +40,8 @@ import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Roberto Díaz
@@ -61,8 +63,8 @@ public class PermissionsPortletConfigurationIcon
 
 	@Override
 	public ResourceBundle getResourceBundle(Locale locale) {
-		ResourceBundle bundleResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle bundleResourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return new AggregateResourceBundle(
 			bundleResourceBundle, super.getResourceBundle(locale));
@@ -137,5 +139,12 @@ public class PermissionsPortletConfigurationIcon
 		target = "(resource.name=" + KBConstants.RESOURCE_NAME_ADMIN + ")"
 	)
 	private PortletResourcePermission _portletResourcePermission;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.knowledge.base.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/UseKBTemplatePortletConfigurationIcon.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/UseKBTemplatePortletConfigurationIcon.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfiguration
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ResourceBundle;
@@ -36,6 +36,8 @@ import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Ambrin Chaudhary
@@ -53,8 +55,11 @@ public class UseKBTemplatePortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "use-this-template");
 	}
@@ -102,5 +107,12 @@ public class UseKBTemplatePortletConfigurationIcon
 		target = "(resource.name=" + KBConstants.RESOURCE_NAME_ADMIN + ")"
 	)
 	private PortletResourcePermission _portletResourcePermission;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.knowledge.base.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/control/menu/ManageLayoutProductNavigationControlMenuEntry.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/control/menu/ManageLayoutProductNavigationControlMenuEntry.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Html;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.product.navigation.control.menu.BaseProductNavigationControlMenuEntry;
@@ -50,6 +50,8 @@ import javax.servlet.jsp.PageContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Julio Camarero
@@ -85,8 +87,8 @@ public class ManageLayoutProductNavigationControlMenuEntry
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", themeDisplay.getLocale(), getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		values.put(
 			"configurePage",
@@ -180,5 +182,12 @@ public class ManageLayoutProductNavigationControlMenuEntry
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.layout.admin.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/control/menu/ToggleControlsProductNavigationControlMenuEntry.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/control/menu/ToggleControlsProductNavigationControlMenuEntry.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.SessionClicks;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PropsValues;
@@ -40,6 +40,9 @@ import java.util.ResourceBundle;
 import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Julio Camarero
@@ -82,8 +85,8 @@ public class ToggleControlsProductNavigationControlMenuEntry
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return LanguageUtil.get(resourceBundle, "toggle-controls");
 	}
@@ -173,5 +176,12 @@ public class ToggleControlsProductNavigationControlMenuEntry
 
 	private static final Map<String, Object> _data =
 		Collections.<String, Object>singletonMap("qa-id", "showControls");
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.layout.admin.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/handler/LayoutPageTemplateEntryExceptionRequestHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/handler/LayoutPageTemplateEntryExceptionRequestHandler.java
@@ -32,6 +32,8 @@ import javax.portlet.ActionResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jürgen Kappler
@@ -79,9 +81,10 @@ public class LayoutPageTemplateEntryExceptionRequestHandler {
 	}
 
 	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.layout.admin.web)",
-		unbind = "-"
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.layout.admin.web)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/theme/contributor/ToggleControlsTemplateContextContributor.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/theme/contributor/ToggleControlsTemplateContextContributor.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.template.TemplateContextContributor;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.SessionClicks;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -30,6 +30,9 @@ import java.util.ResourceBundle;
 import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Julio Camarero
@@ -74,8 +77,9 @@ public class ToggleControlsTemplateContextContributor
 		contextObjects.put("show_toggle_controls", themeDisplay.isSignedIn());
 
 		if (themeDisplay.isSignedIn()) {
-			ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-				"content.Language", themeDisplay.getLocale(), getClass());
+			ResourceBundle resourceBundle =
+				_resourceBundleLoader.loadResourceBundle(
+					themeDisplay.getLocale());
 
 			contextObjects.put(
 				"toggle_controls_text",
@@ -84,5 +88,12 @@ public class ToggleControlsTemplateContextContributor
 			contextObjects.put("toggle_controls_url", "javascript:;");
 		}
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.layout.admin.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/map/map-google-maps/src/main/java/com/liferay/map/google/maps/internal/GoogleMapsMapProvider.java
+++ b/modules/apps/map/map-google-maps/src/main/java/com/liferay/map/google/maps/internal/GoogleMapsMapProvider.java
@@ -18,7 +18,7 @@ import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.map.BaseJSPMapProvider;
 import com.liferay.map.MapProvider;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -28,6 +28,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jürgen Kappler
@@ -57,8 +59,8 @@ public class GoogleMapsMapProvider extends BaseJSPMapProvider {
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return LanguageUtil.get(resourceBundle, "google-maps");
 	}
@@ -84,5 +86,12 @@ public class GoogleMapsMapProvider extends BaseJSPMapProvider {
 
 	@Reference
 	private NPMResolver _npmResolver;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.map.google.maps)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/map/map-openstreetmap/src/main/java/com/liferay/map/openstreetmap/internal/OpenStreetMapMapProvider.java
+++ b/modules/apps/map/map-openstreetmap/src/main/java/com/liferay/map/openstreetmap/internal/OpenStreetMapMapProvider.java
@@ -18,7 +18,7 @@ import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.map.BaseJSPMapProvider;
 import com.liferay.map.MapProvider;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -28,6 +28,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jürgen Kappler
@@ -57,8 +59,8 @@ public class OpenStreetMapMapProvider extends BaseJSPMapProvider {
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return LanguageUtil.get(resourceBundle, "openstreetmap");
 	}
@@ -84,5 +86,12 @@ public class OpenStreetMapMapProvider extends BaseJSPMapProvider {
 
 	@Reference
 	private NPMResolver _npmResolver;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.map.openstreetmap)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/portlet/configuration/icon/InstallFromURLPortletConfigurationIcon.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/portlet/configuration/icon/InstallFromURLPortletConfigurationIcon.java
@@ -18,7 +18,9 @@ import com.liferay.marketplace.app.manager.web.internal.constants.MarketplaceApp
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BaseJSPPortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ResourceBundle;
 
@@ -29,6 +31,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Douglas Wong
@@ -48,8 +52,11 @@ public class InstallFromURLPortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "install-from-url");
 	}
@@ -84,5 +91,12 @@ public class InstallFromURLPortletConfigurationIcon
 	public void setServletContext(ServletContext servletContext) {
 		super.setServletContext(servletContext);
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.marketplace.app.manager.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/notifications/MentionsUserNotificationHandler.java
+++ b/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/notifications/MentionsUserNotificationHandler.java
@@ -28,13 +28,15 @@ import com.liferay.portal.kernel.notifications.UserNotificationHandler;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Iván Zaera
@@ -83,8 +85,9 @@ public class MentionsUserNotificationHandler
 		String typeName = assetRendererFactory.getTypeName(
 			serviceContext.getLocale());
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", serviceContext.getLocale(), getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(
+				serviceContext.getLocale());
 
 		if ((mbMessage != null) && mbMessage.isDiscussion()) {
 			return LanguageUtil.format(
@@ -121,5 +124,12 @@ public class MentionsUserNotificationHandler
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.mentions.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.security.PermissionsURLTag;
 
@@ -37,6 +37,9 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Sergio González
@@ -58,8 +61,8 @@ public class PermissionsPortletConfigurationIcon
 
 	@Override
 	public ResourceBundle getResourceBundle(Locale locale) {
-		ResourceBundle bundleResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle bundleResourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return new AggregateResourceBundle(
 			bundleResourceBundle, super.getResourceBundle(locale));
@@ -129,5 +132,12 @@ public class PermissionsPortletConfigurationIcon
 	public boolean isUseDialog() {
 		return true;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.message.boards.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/microblogs/microblogs-web/src/main/java/com/liferay/microblogs/web/internal/notifications/MicroblogsUserNotificationHandler.java
+++ b/modules/apps/microblogs/microblogs-web/src/main/java/com/liferay/microblogs/web/internal/notifications/MicroblogsUserNotificationHandler.java
@@ -35,6 +35,8 @@ import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jonathan Lee
@@ -123,16 +125,6 @@ public class MicroblogsUserNotificationHandler
 		_microblogsEntryLocalService = microblogsEntryLocalService;
 	}
 
-	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.microblogs.web)",
-		unbind = "-"
-	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		_resourceBundleLoader = resourceBundleLoader;
-	}
-
 	@Reference(unbind = "-")
 	protected void setUserLocalService(UserLocalService userLocalService) {
 		_userLocalService = userLocalService;
@@ -143,7 +135,13 @@ public class MicroblogsUserNotificationHandler
 	@Reference
 	private Portal _portal;
 
-	private ResourceBundleLoader _resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.microblogs.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
+
 	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/form/navigator/LayoutMobileDeviceRulesFormNavigatorEntry.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/form/navigator/LayoutMobileDeviceRulesFormNavigatorEntry.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.servlet.taglib.ui.BaseJSPFormNavigatorEntry;
 import com.liferay.portal.kernel.servlet.taglib.ui.FormNavigatorConstants;
 import com.liferay.portal.kernel.servlet.taglib.ui.FormNavigatorEntry;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -28,6 +28,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pei-Jung Lan
@@ -56,8 +58,8 @@ public class LayoutMobileDeviceRulesFormNavigatorEntry
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return LanguageUtil.get(resourceBundle, getKey());
 	}
@@ -75,5 +77,12 @@ public class LayoutMobileDeviceRulesFormNavigatorEntry
 	protected String getJspPath() {
 		return "/layout/mobile_device_rules.jsp";
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.mobile.device.rules.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/form/navigator/LayoutSetMobileDeviceRulesFormNavigatorEntry.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/form/navigator/LayoutSetMobileDeviceRulesFormNavigatorEntry.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.servlet.taglib.ui.BaseJSPFormNavigatorEntry;
 import com.liferay.portal.kernel.servlet.taglib.ui.FormNavigatorConstants;
 import com.liferay.portal.kernel.servlet.taglib.ui.FormNavigatorEntry;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -28,6 +28,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Sergio González
@@ -56,8 +58,8 @@ public class LayoutSetMobileDeviceRulesFormNavigatorEntry
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return LanguageUtil.get(resourceBundle, getKey());
 	}
@@ -75,5 +77,12 @@ public class LayoutSetMobileDeviceRulesFormNavigatorEntry
 	protected String getJspPath() {
 		return "/layout_set/mobile_device_rules.jsp";
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.mobile.device.rules.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -41,6 +41,8 @@ import javax.portlet.PortletException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Sergio González
@@ -343,10 +345,11 @@ public class NotificationsPortlet extends MVCPortlet {
 	}
 
 	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.notifications.web)",
-		unbind = "-"
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.notifications.web)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	private SubscriptionLocalService _subscriptionLocalService;
 	private UserNotificationDeliveryLocalService

--- a/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAllNotificationsAsReadPortletConfigurationIcon.java
+++ b/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAllNotificationsAsReadPortletConfigurationIcon.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfiguration
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ResourceBundle;
@@ -35,6 +35,8 @@ import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Alejandro Tardín
@@ -49,8 +51,11 @@ public class MarkAllNotificationsAsReadPortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(
 			resourceBundle, "mark-all-notifications-as-read");
@@ -101,6 +106,13 @@ public class MarkAllNotificationsAsReadPortletConfigurationIcon
 	public boolean isToolTip() {
 		return false;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.notifications.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference
 	private UserNotificationEventLocalService

--- a/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/scope/spi/application/descriptor/OAuth2JSONWSApplicationDescriptor.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/scope/spi/application/descriptor/OAuth2JSONWSApplicationDescriptor.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Tomas Polesovsky
@@ -64,8 +66,10 @@ public class OAuth2JSONWSApplicationDescriptor
 	private String _applicationDescription;
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.oauth2.provider.jsonws)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/OAuth2JSONWSSAPEntryActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/OAuth2JSONWSSAPEntryActivator.java
@@ -38,6 +38,8 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Tomas Polesovsky
@@ -113,9 +115,11 @@ public class OAuth2JSONWSSAPEntryActivator {
 		OAuth2JSONWSSAPEntryActivator.class);
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.oauth2.provider.jsonws)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference
 	private SAPEntryLocalService _sapEntryLocalService;

--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/service/internal/configuration/OrganizationTypeConfigurationModelListener.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/service/internal/configuration/OrganizationTypeConfigurationModelListener.java
@@ -17,6 +17,7 @@ package com.liferay.organizations.service.internal.configuration;
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -27,6 +28,8 @@ import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Drew Brokke
@@ -58,9 +61,8 @@ public class OrganizationTypeConfigurationModelListener
 	}
 
 	private ResourceBundle _getResourceBundle() {
-		return ResourceBundleUtil.getBundle(
-			"content.Language", LocaleThreadLocal.getThemeDisplayLocale(),
-			getClass());
+		return _resourceBundleLoader.loadResourceBundle(
+			LocaleThreadLocal.getThemeDisplayLocale());
 	}
 
 	private void _validateNameExists(String name) throws Exception {
@@ -107,5 +109,12 @@ public class OrganizationTypeConfigurationModelListener
 
 	@Reference
 	private ConfigurationAdmin _configurationAdmin;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.organizations.service)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/layout/prototype/SearchLayoutFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/layout/prototype/SearchLayoutFactoryImpl.java
@@ -29,12 +29,10 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
-import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.search.web.layout.prototype.SearchLayoutPrototypeCustomizer;
 
 import java.util.List;
@@ -199,18 +197,7 @@ public class SearchLayoutFactoryImpl implements SearchLayoutFactory {
 	}
 
 	protected Map<Locale, String> getLocalizationMap(String key) {
-		Class<?> clazz = getClass();
-
-		ResourceBundleLoader resourceBundleLoader =
-			ResourceBundleUtil.getResourceBundleLoader(
-				"content.Language", clazz.getClassLoader());
-
-		AggregateResourceBundleLoader aggregateResourceBundleLoader =
-			new AggregateResourceBundleLoader(
-				resourceBundleLoader, LanguageResources.RESOURCE_BUNDLE_LOADER);
-
-		return ResourceBundleUtil.getLocalizationMap(
-			aggregateResourceBundleLoader, key);
+		return ResourceBundleUtil.getLocalizationMap(resourceBundleLoader, key);
 	}
 
 	protected Map<Locale, String> getLocalizationMap(
@@ -279,6 +266,13 @@ public class SearchLayoutFactoryImpl implements SearchLayoutFactory {
 
 	@Reference
 	protected LayoutPrototypeLocalService layoutPrototypeLocalService;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.portal.search.web)"
+	)
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 	@Reference(
 		cardinality = ReferenceCardinality.OPTIONAL,

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/product/navigation/control/menu/IndexingProductNavigationControlMenuEntry.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/product/navigation/control/menu/IndexingProductNavigationControlMenuEntry.java
@@ -18,7 +18,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.search.IndexWriterHelper;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.product.navigation.control.menu.BaseProductNavigationControlMenuEntry;
 import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuEntry;
 import com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuCategoryKeys;
@@ -32,6 +32,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Julio Camarero
@@ -60,8 +62,8 @@ public class IndexingProductNavigationControlMenuEntry
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return LanguageUtil.get(
 			resourceBundle, "the-portal-is-currently-reindexing");
@@ -93,5 +95,12 @@ public class IndexingProductNavigationControlMenuEntry
 		Collections.<String, Object>singletonMap("qa-id", "indexing");
 
 	private IndexWriterHelper _indexWriterHelper;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.portal.search.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/insights/portlet/SearchInsightsPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/insights/portlet/SearchInsightsPortlet.java
@@ -17,8 +17,9 @@ package com.liferay.portal.search.web.internal.search.insights.portlet;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.service.permission.PortletPermission;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.web.internal.search.insights.constants.SearchInsightsPortletKeys;
 import com.liferay.portal.search.web.internal.search.insights.display.context.SearchInsightsDisplayContext;
@@ -39,6 +40,8 @@ import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Bryan Engler
@@ -116,8 +119,11 @@ public class SearchInsightsPortlet extends MVCPortlet {
 	}
 
 	protected String getHelp(RenderRequest renderRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", renderRequest.getLocale(), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle = resourceBundleLoader.loadResourceBundle(
+			themeDisplay.getLocale());
 
 		return language.get(resourceBundle, "search-insights-help");
 	}
@@ -133,5 +139,12 @@ public class SearchInsightsPortlet extends MVCPortlet {
 
 	@Reference
 	protected PortletSharedSearchRequest portletSharedSearchRequest;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.portal.search.web)"
+	)
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/portlet/action/BaseWorkflowDefinitionMVCActionCommand.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/portlet/action/BaseWorkflowDefinitionMVCActionCommand.java
@@ -37,6 +37,8 @@ import javax.portlet.ActionResponse;
 import javax.portlet.PortletException;
 
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jeyvison Nascimento
@@ -146,16 +148,11 @@ public abstract class BaseWorkflowDefinitionMVCActionCommand
 	}
 
 	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.portal.workflow.web)",
-		unbind = "-"
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.portal.workflow.web)"
 	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		this.resourceBundleLoader = resourceBundleLoader;
-	}
-
-	protected ResourceBundleLoader resourceBundleLoader;
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 	@Reference
 	protected WorkflowDefinitionManager workflowDefinitionManager;

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/portlet/tab/WorkflowDefinitionLinkPortletTab.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/portlet/tab/WorkflowDefinitionLinkPortletTab.java
@@ -29,6 +29,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Adam Brandizzi
@@ -84,8 +86,10 @@ public class WorkflowDefinitionLinkPortletTab extends BaseWorkflowPortletTab {
 		workflowDefinitionLinkLocalService;
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.portal.workflow.web)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/portlet/tab/WorkflowDefinitionPortletTab.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/portlet/tab/WorkflowDefinitionPortletTab.java
@@ -40,6 +40,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Adam Brandizzi
@@ -104,16 +106,6 @@ public class WorkflowDefinitionPortletTab extends BaseWorkflowPortletTab {
 		return "/definition/view.jsp";
 	}
 
-	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.portal.workflow.web)",
-		unbind = "-"
-	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		this.resourceBundleLoader = resourceBundleLoader;
-	}
-
 	@Override
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.portal.workflow.web)",
@@ -145,7 +137,12 @@ public class WorkflowDefinitionPortletTab extends BaseWorkflowPortletTab {
 			WebKeys.WORKFLOW_DEFINITION, workflowDefinition);
 	}
 
-	protected ResourceBundleLoader resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.portal.workflow.web)"
+	)
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 	@Reference
 	protected UserLocalService userLocalService;

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/java/com/liferay/portlet/configuration/css/web/internal/portlet/configuration/icon/PortletConfigurationCSSPortletConfigurationIcon.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/java/com/liferay/portlet/configuration/css/web/internal/portlet/configuration/icon/PortletConfigurationCSSPortletConfigurationIcon.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigura
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portlet.configuration.css.web.internal.constants.PortletConfigurationCSSPortletKeys;
 
@@ -33,6 +33,9 @@ import javax.portlet.PortletResponse;
 import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eudaldo Alonso
@@ -43,8 +46,11 @@ public class PortletConfigurationCSSPortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "look-and-feel-configuration");
 	}
@@ -103,5 +109,12 @@ public class PortletConfigurationCSSPortletConfigurationIcon
 	public boolean isUseDialog() {
 		return true;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.portlet.configuration.css.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/java/com/liferay/portlet/configuration/sharing/web/internal/portlet/configuration/icon/FacebookPortletConfigurationIcon.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/java/com/liferay/portlet/configuration/sharing/web/internal/portlet/configuration/icon/FacebookPortletConfigurationIcon.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfiguration
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -32,6 +32,9 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eudaldo Alonso
@@ -42,8 +45,11 @@ public class FacebookPortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "add-to-facebook");
 	}
@@ -109,5 +115,12 @@ public class FacebookPortletConfigurationIcon
 
 		return false;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.portlet.configuration.sharing.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/java/com/liferay/portlet/configuration/sharing/web/internal/portlet/configuration/icon/IGooglePortletConfigurationIcon.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/java/com/liferay/portlet/configuration/sharing/web/internal/portlet/configuration/icon/IGooglePortletConfigurationIcon.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portlet.configuration.sharing.web.internal.constants.PortletConfigurationSharingPortletKeys;
 
@@ -41,6 +41,8 @@ import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eudaldo Alonso
@@ -56,8 +58,11 @@ public class IGooglePortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(
 			resourceBundle, "add-to-an-open-social-platform");
@@ -139,5 +144,12 @@ public class IGooglePortletConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.portlet.configuration.sharing.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/java/com/liferay/portlet/configuration/sharing/web/internal/portlet/configuration/icon/NetvibesPortletConfigurationIcon.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/java/com/liferay/portlet/configuration/sharing/web/internal/portlet/configuration/icon/NetvibesPortletConfigurationIcon.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portlet.configuration.sharing.web.internal.constants.PortletConfigurationSharingPortletKeys;
 
@@ -41,6 +41,8 @@ import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eudaldo Alonso
@@ -51,8 +53,11 @@ public class NetvibesPortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "add-to-netvibes");
 	}
@@ -138,5 +143,12 @@ public class NetvibesPortletConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.portlet.configuration.sharing.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/java/com/liferay/portlet/configuration/sharing/web/internal/portlet/configuration/icon/WidgetPortletConfigurationIcon.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/java/com/liferay/portlet/configuration/sharing/web/internal/portlet/configuration/icon/WidgetPortletConfigurationIcon.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.configuration.sharing.web.internal.constants.PortletConfigurationSharingPortletKeys;
@@ -42,6 +42,8 @@ import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eudaldo Alonso
@@ -52,8 +54,11 @@ public class WidgetPortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "add-to-any-website");
 	}
@@ -128,5 +133,12 @@ public class WidgetPortletConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.portlet.configuration.sharing.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/java/com/liferay/product/navigation/simulation/device/internal/application/list/DevicePreviewPanelApp.java
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/java/com/liferay/product/navigation/simulation/device/internal/application/list/DevicePreviewPanelApp.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.product.navigation.simulation.constants.ProductNavigationSimulationConstants;
 import com.liferay.product.navigation.simulation.constants.ProductNavigationSimulationPortletKeys;
 
@@ -34,6 +34,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eduardo Garcia
@@ -56,8 +58,8 @@ public class DevicePreviewPanelApp extends BaseJSPPanelApp {
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return LanguageUtil.get(resourceBundle, "screen-size");
 	}
@@ -108,5 +110,12 @@ public class DevicePreviewPanelApp extends BaseJSPPanelApp {
 		return GroupPermissionUtil.contains(
 			permissionChecker, group, ActionKeys.PREVIEW_IN_DEVICE);
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.product.navigation.simulation.device)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/reading-time/reading-time-web/src/main/java/com/liferay/reading/time/web/internal/message/DescriptiveReadingTimeMessageProviderImpl.java
+++ b/modules/apps/reading-time/reading-time-web/src/main/java/com/liferay/reading/time/web/internal/message/DescriptiveReadingTimeMessageProviderImpl.java
@@ -26,6 +26,8 @@ import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Alejandro Tardín
@@ -59,7 +61,11 @@ public class DescriptiveReadingTimeMessageProviderImpl
 			Duration.ofMillis(readingTimeEntry.getReadingTime()), locale);
 	}
 
-	@Reference(target = "(bundle.symbolic.name=com.liferay.reading.time.web)")
-	private ResourceBundleLoader _resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.reading.time.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/reading-time/reading-time-web/src/main/java/com/liferay/reading/time/web/internal/message/SimpleReadingTimeMessageProviderImpl.java
+++ b/modules/apps/reading-time/reading-time-web/src/main/java/com/liferay/reading/time/web/internal/message/SimpleReadingTimeMessageProviderImpl.java
@@ -26,6 +26,8 @@ import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Alejandro Tardín
@@ -57,7 +59,11 @@ public class SimpleReadingTimeMessageProviderImpl
 			Duration.ofMillis(readingTimeEntry.getReadingTime()), locale);
 	}
 
-	@Reference(target = "(bundle.symbolic.name=com.liferay.reading.time.web)")
-	private ResourceBundleLoader _resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.reading.time.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/rss/rss-web/src/main/java/com/liferay/rss/web/internal/portlet/template/RSSPortletDisplayTemplateHandler.java
+++ b/modules/apps/rss/rss-web/src/main/java/com/liferay/rss/web/internal/portlet/template/RSSPortletDisplayTemplateHandler.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.portletdisplaytemplate.BasePortletDisplayTempla
 import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateVariableGroup;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portlet.display.template.constants.PortletDisplayTemplateConstants;
 import com.liferay.rss.constants.RSSPortletKeys;
 import com.liferay.rss.web.internal.display.context.RSSDisplayContext;
@@ -32,6 +32,8 @@ import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eudaldo Alonso
@@ -50,8 +52,8 @@ public class RSSPortletDisplayTemplateHandler
 
 	@Override
 	public String getName(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		String portletTitle = _portal.getPortletTitle(
 			RSSPortletKeys.RSS, resourceBundle);
@@ -95,5 +97,12 @@ public class RSSPortletDisplayTemplateHandler
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.rss.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/ViewChartMVCResourceCommand.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/ViewChartMVCResourceCommand.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -44,6 +45,9 @@ import org.jfree.data.general.DefaultValueDataset;
 import org.jfree.data.general.ValueDataset;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Matthew Kong
@@ -75,8 +79,8 @@ public class ViewChartMVCResourceCommand extends BaseMVCResourceCommand {
 
 		StringBundler sb = new StringBundler(5);
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", themeDisplay.getLocale(), getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		sb.append(ResourceBundleUtil.getString(resourceBundle, "used-memory"));
 
@@ -159,5 +163,12 @@ public class ViewChartMVCResourceCommand extends BaseMVCResourceCommand {
 
 		return meterPlot;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.server.admin.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/java/com/liferay/site/navigation/item/selector/web/internal/SiteNavigationMenuItemItemSelectorView.java
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/java/com/liferay/site/navigation/item/selector/web/internal/SiteNavigationMenuItemItemSelectorView.java
@@ -44,6 +44,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eudaldo Alonso
@@ -126,9 +128,11 @@ public class SiteNavigationMenuItemItemSelectorView
 				}));
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.site.navigation.item.selector.web)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.site.navigation.item.selector.web)"

--- a/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/java/com/liferay/site/navigation/item/selector/web/internal/SiteNavigationMenuItemSelectorView.java
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/java/com/liferay/site/navigation/item/selector/web/internal/SiteNavigationMenuItemSelectorView.java
@@ -43,6 +43,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pavel Savinov
@@ -119,9 +121,11 @@ public class SiteNavigationMenuItemSelectorView
 				}));
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.site.navigation.item.selector.web)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.site.navigation.item.selector.web)"

--- a/modules/apps/site-navigation/site-navigation-menu-item-node/src/main/java/com/liferay/site/navigation/menu/item/node/internal/type/NodeSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-node/src/main/java/com/liferay/site/navigation/menu/item/node/internal/type/NodeSiteNavigationMenuItemType.java
@@ -33,6 +33,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jürgen Kappler
@@ -90,10 +92,11 @@ public class NodeSiteNavigationMenuItemType
 	private JSPRenderer _jspRenderer;
 
 	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.site.navigation.menu.item.node)",
-		unbind = "-"
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.site.navigation.menu.item.node)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.site.navigation.menu.item.node)",

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/portlet/template/SiteNavigationMenuPortletDisplayTemplateHandler.java
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/portlet/template/SiteNavigationMenuPortletDisplayTemplateHandler.java
@@ -36,6 +36,8 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Juergen Kappler
@@ -144,9 +146,11 @@ public class SiteNavigationMenuPortletDisplayTemplateHandler
 	private Portal _portal;
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.site.navigation.lang)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	private volatile SiteNavigationMenuWebTemplateConfiguration
 		_siteNavigationMenuWebTemplateConfiguration;

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/portlet/configuration/icon/ViewMembershipRequestsPortletConfigurationIcon.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/portlet/configuration/icon/ViewMembershipRequestsPortletConfigurationIcon.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfiguration
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.memberships.web.internal.constants.SiteMembershipsPortletKeys;
 
@@ -34,6 +34,8 @@ import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Eudaldo Alonso
@@ -48,8 +50,11 @@ public class ViewMembershipRequestsPortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "view-membership-requests");
 	}
@@ -94,5 +99,12 @@ public class ViewMembershipRequestsPortletConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.site.memberships.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/social/social-bookmark-facebook/src/main/java/com/liferay/social/bookmark/facebook/FacebookSocialBookmark.java
+++ b/modules/apps/social/social-bookmark-facebook/src/main/java/com/liferay/social/bookmark/facebook/FacebookSocialBookmark.java
@@ -31,6 +31,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Alejandro Tardín
@@ -69,9 +71,11 @@ public class FacebookSocialBookmark implements SocialBookmark {
 	}
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.social.bookmark.facebook)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.social.bookmark.facebook)"

--- a/modules/apps/social/social-bookmark-linkedin/src/main/java/com/liferay/social/bookmark/linkedin/LinkedInSocialBookmark.java
+++ b/modules/apps/social/social-bookmark-linkedin/src/main/java/com/liferay/social/bookmark/linkedin/LinkedInSocialBookmark.java
@@ -32,6 +32,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Alejandro Tardín
@@ -73,9 +75,11 @@ public class LinkedInSocialBookmark implements SocialBookmark {
 	}
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.social.bookmark.linkedin)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.social.bookmark.linkedin)"

--- a/modules/apps/social/social-bookmark-plusone/src/main/java/com/liferay/social/bookmark/plusone/PlusoneSocialBookmark.java
+++ b/modules/apps/social/social-bookmark-plusone/src/main/java/com/liferay/social/bookmark/plusone/PlusoneSocialBookmark.java
@@ -31,6 +31,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Alejandro Tardín
@@ -68,9 +70,11 @@ public class PlusoneSocialBookmark implements SocialBookmark {
 	}
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.social.bookmark.plusone)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.social.bookmark.plusone)"

--- a/modules/apps/social/social-bookmark-twitter/src/main/java/com/liferay/social/bookmark/twitter/TwitterSocialBookmark.java
+++ b/modules/apps/social/social-bookmark-twitter/src/main/java/com/liferay/social/bookmark/twitter/TwitterSocialBookmark.java
@@ -32,6 +32,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Alejandro Tardín
@@ -71,9 +73,11 @@ public class TwitterSocialBookmark implements SocialBookmark {
 	}
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=com.liferay.social.bookmark.twitter)"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.social.bookmark.twitter)"

--- a/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/configuration/icon/PublishTemplatesConfigurationIcon.java
+++ b/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/configuration/icon/PublishTemplatesConfigurationIcon.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigura
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.staging.constants.StagingProcessesPortletKeys;
 
@@ -33,6 +33,8 @@ import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Mate Thurzo
@@ -47,8 +49,11 @@ public class PublishTemplatesConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "publish-templates");
 	}
@@ -112,5 +117,12 @@ public class PublishTemplatesConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.staging.processes.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/configuration/icon/StagingConfigurationPortletConfigurationIcon.java
+++ b/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/configuration/icon/StagingConfigurationPortletConfigurationIcon.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.staging.constants.StagingProcessesPortletKeys;
 
@@ -40,6 +40,8 @@ import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Levente Hudák
@@ -54,8 +56,11 @@ public class StagingConfigurationPortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "staging-configuration");
 	}
@@ -139,6 +144,13 @@ public class StagingConfigurationPortletConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.staging.processes.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference
 	private Staging _staging;

--- a/modules/apps/subscription/subscription-web/src/main/java/com/liferay/subscription/web/internal/portlet/action/UnsubscribeMVCActionCommand.java
+++ b/modules/apps/subscription/subscription-web/src/main/java/com/liferay/subscription/web/internal/portlet/action/UnsubscribeMVCActionCommand.java
@@ -31,7 +31,7 @@ import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.subscription.exception.NoSuchSubscriptionException;
 import com.liferay.subscription.model.Subscription;
 import com.liferay.subscription.service.SubscriptionLocalService;
@@ -49,6 +49,8 @@ import javax.portlet.WindowState;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Sergio González
@@ -144,8 +146,8 @@ public class UnsubscribeMVCActionCommand extends BaseMVCActionCommand {
 
 		Group group = _groupLocalService.fetchGroup(subscription.getClassPK());
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return LanguageUtil.format(
 			resourceBundle, "blog-at-x", group.getDescriptiveName(locale));
@@ -182,6 +184,13 @@ public class UnsubscribeMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.subscription.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference
 	private SubscriptionLocalService _subscriptionLocalService;

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/configuration/AnonymousUserConfigurationModelListener.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/configuration/AnonymousUserConfigurationModelListener.java
@@ -19,6 +19,7 @@ import com.liferay.portal.configuration.persistence.listener.ConfigurationModelL
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Dictionary;
@@ -28,6 +29,8 @@ import java.util.ResourceBundle;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Drew Brokke
@@ -77,9 +80,9 @@ public class AnonymousUserConfigurationModelListener
 			return;
 		}
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", LocaleThreadLocal.getThemeDisplayLocale(),
-			getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(
+				LocaleThreadLocal.getThemeDisplayLocale());
 
 		String message = ResourceBundleUtil.getString(
 			resourceBundle,
@@ -95,6 +98,13 @@ public class AnonymousUserConfigurationModelListener
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.user.associated.data.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/user/action/contributor/ErasePersonalDataUserActionContributor.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/user/action/contributor/ErasePersonalDataUserActionContributor.java
@@ -14,9 +14,16 @@
 
 package com.liferay.user.associated.data.web.internal.user.action.contributor;
 
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.users.admin.user.action.contributor.UserActionContributor;
 
+import java.util.Locale;
+import java.util.ResourceBundle;
+
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Drew Brokke
@@ -24,6 +31,11 @@ import org.osgi.service.component.annotations.Component;
 @Component(immediate = true, service = UserActionContributor.class)
 public class ErasePersonalDataUserActionContributor
 	extends BaseUADUserActionContributor {
+
+	@Override
+	public ResourceBundle getResourceBundle(Locale locale) {
+		return _resourceBundleLoader.loadResourceBundle(locale);
+	}
 
 	@Override
 	protected String getKey() {
@@ -34,5 +46,12 @@ public class ErasePersonalDataUserActionContributor
 	protected String getMVCRenderCommandName() {
 		return "/view_uad_summary";
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.user.associated.data.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/user/action/contributor/ExportPersonalDataUserActionContributor.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/user/action/contributor/ExportPersonalDataUserActionContributor.java
@@ -14,9 +14,16 @@
 
 package com.liferay.user.associated.data.web.internal.user.action.contributor;
 
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.users.admin.user.action.contributor.UserActionContributor;
 
+import java.util.Locale;
+import java.util.ResourceBundle;
+
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pei-Jung Lan
@@ -24,6 +31,11 @@ import org.osgi.service.component.annotations.Component;
 @Component(immediate = true, service = UserActionContributor.class)
 public class ExportPersonalDataUserActionContributor
 	extends BaseUADUserActionContributor {
+
+	@Override
+	public ResourceBundle getResourceBundle(Locale locale) {
+		return _resourceBundleLoader.loadResourceBundle(locale);
+	}
 
 	@Override
 	protected String getKey() {
@@ -34,5 +46,12 @@ public class ExportPersonalDataUserActionContributor
 	protected String getMVCRenderCommandName() {
 		return "/view_uad_export_processes";
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.user.associated.data.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/UserGroupPagesPermissionsPortletConfigurationIcon.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/UserGroupPagesPermissionsPortletConfigurationIcon.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfiguration
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.security.PermissionsURLTag;
 import com.liferay.user.groups.admin.constants.UserGroupsAdminPortletKeys;
@@ -36,6 +36,9 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pei-Jung Lan
@@ -53,8 +56,11 @@ public class UserGroupPagesPermissionsPortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "user-group-pages-permissions");
 	}
@@ -114,5 +120,12 @@ public class UserGroupPagesPermissionsPortletConfigurationIcon
 	public boolean isUseDialog() {
 		return true;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.user.groups.admin.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/users-admin/users-admin-api/src/main/java/com/liferay/users/admin/user/action/contributor/BaseUserActionContributor.java
+++ b/modules/apps/users-admin/users-admin-api/src/main/java/com/liferay/users/admin/user/action/contributor/BaseUserActionContributor.java
@@ -31,6 +31,12 @@ import javax.portlet.PortletRequest;
 public abstract class BaseUserActionContributor
 	implements UserActionContributor {
 
+	/**
+	 * @deprecated As of Wilberforce (7.0.x), in order to be able to override
+	 * the ResourceBundle a ResourceBundleLoader must be defined in the last
+	 * implemented class in the hierarchy
+	 */
+	@Deprecated
 	public ResourceBundle getResourceBundle(Locale locale) {
 		ResourceBundle bundleResourceBundle = ResourceBundleUtil.getBundle(
 			"content.Language", locale, getClass());

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/AssignOrganizationRolesPortletConfigurationIcon.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/AssignOrganizationRolesPortletConfigurationIcon.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 import com.liferay.users.admin.web.internal.portlet.action.ActionUtil;
@@ -40,6 +40,9 @@ import javax.portlet.PortletResponse;
 import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pei-Jung Lan
@@ -57,8 +60,11 @@ public class AssignOrganizationRolesPortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "assign-organization-roles");
 	}
@@ -127,5 +133,12 @@ public class AssignOrganizationRolesPortletConfigurationIcon
 	public boolean isUseDialog() {
 		return true;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.users.admin.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/ExportUsersPortletConfigurationIcon.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/ExportUsersPortletConfigurationIcon.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 
@@ -38,6 +38,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pei-Jung Lan
@@ -57,8 +59,11 @@ public class ExportUsersPortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "export-users");
 	}
@@ -117,5 +122,12 @@ public class ExportUsersPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ExportUsersPortletConfigurationIcon.class);
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.users.admin.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/ManageSitePortletConfigurationIcon.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/ManageSitePortletConfigurationIcon.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 import com.liferay.users.admin.web.internal.portlet.action.ActionUtil;
@@ -41,6 +41,8 @@ import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pei-Jung Lan
@@ -58,8 +60,11 @@ public class ManageSitePortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
 
 		return LanguageUtil.get(resourceBundle, "manage-site");
 	}
@@ -127,5 +132,12 @@ public class ManageSitePortletConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.users.admin.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/servlet/taglib/ui/navigation/user/entry/BaseUserScreenNavigationEntry.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/servlet/taglib/ui/navigation/user/entry/BaseUserScreenNavigationEntry.java
@@ -18,10 +18,8 @@ import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationEntry;
 import com.liferay.frontend.taglib.servlet.taglib.util.JSPRenderer;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.users.admin.constants.UserFormConstants;
 import com.liferay.users.admin.web.internal.constants.UsersAdminWebKeys;
 
@@ -34,6 +32,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pei-Jung Lan
@@ -81,11 +81,7 @@ public abstract class BaseUserScreenNavigationEntry
 	}
 
 	protected ResourceBundle getResourceBundle(Locale locale) {
-		ResourceBundle bundleResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
-
-		return new AggregateResourceBundle(
-			bundleResourceBundle, PortalUtil.getResourceBundle(locale));
+		return resourceBundleLoader.loadResourceBundle(locale);
 	}
 
 	@Reference
@@ -93,5 +89,12 @@ public abstract class BaseUserScreenNavigationEntry
 
 	@Reference
 	protected Portal portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.users.admin.web)"
+	)
+	protected volatile ResourceBundleLoader resourceBundleLoader;
 
 }

--- a/modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/CreoleWikiEngine.java
+++ b/modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/CreoleWikiEngine.java
@@ -17,10 +17,8 @@ package com.liferay.wiki.engine.creole.internal;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.language.LanguageResources;
 import com.liferay.wiki.configuration.WikiGroupServiceConfiguration;
 import com.liferay.wiki.engine.BaseWikiEngine;
 import com.liferay.wiki.engine.WikiEngine;
@@ -49,6 +47,8 @@ import org.antlr.runtime.RecognitionException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Miguel Pastor
@@ -169,17 +169,6 @@ public class CreoleWikiEngine extends BaseWikiEngine {
 	}
 
 	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.wiki.engine.lang)",
-		unbind = "-"
-	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		_resourceBundleLoader = new AggregateResourceBundleLoader(
-			resourceBundleLoader, LanguageResources.RESOURCE_BUNDLE_LOADER);
-	}
-
-	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.wiki.engine.creole)",
 		unbind = "-"
 	)
@@ -210,7 +199,13 @@ public class CreoleWikiEngine extends BaseWikiEngine {
 	private static final Log _log = LogFactoryUtil.getLog(
 		CreoleWikiEngine.class);
 
-	private ResourceBundleLoader _resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.wiki.engine.lang)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
+
 	private ServletContext _servletContext;
 
 	@Reference(

--- a/modules/apps/wiki/wiki-engine-text/src/main/java/com/liferay/wiki/engine/text/internal/TextEngine.java
+++ b/modules/apps/wiki/wiki-engine-text/src/main/java/com/liferay/wiki/engine/text/internal/TextEngine.java
@@ -15,9 +15,7 @@
 package com.liferay.wiki.engine.text.internal;
 
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
-import com.liferay.portal.language.LanguageResources;
 import com.liferay.wiki.engine.BaseWikiEngine;
 import com.liferay.wiki.engine.WikiEngine;
 import com.liferay.wiki.model.WikiPage;
@@ -31,6 +29,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Jorge Ferrer
@@ -87,17 +87,6 @@ public class TextEngine extends BaseWikiEngine {
 	}
 
 	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.wiki.engine.text)",
-		unbind = "-"
-	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		_resourceBundleLoader = new AggregateResourceBundleLoader(
-			resourceBundleLoader, LanguageResources.RESOURCE_BUNDLE_LOADER);
-	}
-
-	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.wiki.engine.text)",
 		unbind = "-"
 	)
@@ -105,7 +94,13 @@ public class TextEngine extends BaseWikiEngine {
 		_servletContext = servletContext;
 	}
 
-	private ResourceBundleLoader _resourceBundleLoader;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.wiki.engine.text)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
+
 	private ServletContext _servletContext;
 
 }

--- a/modules/apps/wiki/wiki-layout-prototype/src/main/java/com/liferay/wiki/layout/prototype/internal/instance/lifecycle/AddLayoutPrototypePortalInstanceLifecycleListener.java
+++ b/modules/apps/wiki/wiki-layout-prototype/src/main/java/com/liferay/wiki/layout/prototype/internal/instance/lifecycle/AddLayoutPrototypePortalInstanceLifecycleListener.java
@@ -27,12 +27,10 @@ import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.DefaultLayoutPrototypesUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
-import com.liferay.portal.language.LanguageResources;
 import com.liferay.wiki.constants.WikiPortletKeys;
 import com.liferay.wiki.model.WikiPage;
 
@@ -43,6 +41,8 @@ import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Adolfo Pérez
@@ -70,17 +70,11 @@ public class AddLayoutPrototypePortalInstanceLifecycleListener
 			List<LayoutPrototype> layoutPrototypes)
 		throws Exception {
 
-		ResourceBundleLoader resourceBundleLoader =
-			new AggregateResourceBundleLoader(
-				ResourceBundleUtil.getResourceBundleLoader(
-					"content.Language", getClassLoader()),
-				LanguageResources.RESOURCE_BUNDLE_LOADER);
-
 		Map<Locale, String> nameMap = ResourceBundleUtil.getLocalizationMap(
-			resourceBundleLoader, "layout-prototype-wiki-title");
+			_resourceBundleLoader, "layout-prototype-wiki-title");
 		Map<Locale, String> descriptionMap =
 			ResourceBundleUtil.getLocalizationMap(
-				resourceBundleLoader, "layout-prototype-wiki-description");
+				_resourceBundleLoader, "layout-prototype-wiki-description");
 
 		Layout layout = LayoutPrototypeHelperUtil.addLayoutPrototype(
 			_layoutPrototypeLocalService, companyId, defaultUserId, nameMap,
@@ -155,6 +149,13 @@ public class AddLayoutPrototypePortalInstanceLifecycleListener
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.wiki.layout.prototype)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	private UserLocalService _userLocalService;
 

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/item/selector/view/WikiPageItemSelectorView.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/item/selector/view/WikiPageItemSelectorView.java
@@ -18,11 +18,9 @@ import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorReturnTypeResolverHandler;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
-import com.liferay.portal.language.LanguageResources;
 import com.liferay.wiki.item.selector.WikiPageTitleItemSelectorReturnType;
 import com.liferay.wiki.item.selector.WikiPageURLItemSelectorReturnType;
 import com.liferay.wiki.item.selector.constants.WikiItemSelectorViewConstants;
@@ -48,6 +46,8 @@ import javax.servlet.ServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Roberto Díaz
@@ -131,16 +131,6 @@ public class WikiPageItemSelectorView
 		_servletContext = servletContext;
 	}
 
-	@Reference(
-		target = "(bundle.symbolic.name=com.liferay.wiki.web)", unbind = "-"
-	)
-	protected void setResourceBundleLoader(
-		ResourceBundleLoader resourceBundleLoader) {
-
-		_resourceBundleLoader = new AggregateResourceBundleLoader(
-			resourceBundleLoader, LanguageResources.RESOURCE_BUNDLE_LOADER);
-	}
-
 	@Reference(unbind = "-")
 	protected void setWikiNodeLocalService(
 		WikiNodeLocalService wikiNodeLocalService) {
@@ -158,7 +148,14 @@ public class WikiPageItemSelectorView
 
 	private ItemSelectorReturnTypeResolverHandler
 		_itemSelectorReturnTypeResolverHandler;
-	private ResourceBundleLoader _resourceBundleLoader;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.wiki.web)", unbind = "-"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
+
 	private ServletContext _servletContext;
 	private WikiNodeLocalService _wikiNodeLocalService;
 

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.security.PermissionsURLTag;
 import com.liferay.wiki.constants.WikiConstants;
@@ -39,6 +39,8 @@ import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Sergio González
@@ -59,8 +61,8 @@ public class PermissionsPortletConfigurationIcon
 
 	@Override
 	public ResourceBundle getResourceBundle(Locale locale) {
-		ResourceBundle bundleResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle bundleResourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		return new AggregateResourceBundle(
 			bundleResourceBundle, super.getResourceBundle(locale));
@@ -135,5 +137,12 @@ public class PermissionsPortletConfigurationIcon
 
 	@Reference(target = "(resource.name=" + WikiConstants.RESOURCE_NAME + ")")
 	private PortletResourcePermission _portletResourcePermission;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.wiki.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/portlet/template/WikiPortletDisplayTemplateHandler.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/portlet/template/WikiPortletDisplayTemplateHandler.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.portletdisplaytemplate.BasePortletDisplayTempla
 import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateVariableGroup;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portlet.display.template.constants.PortletDisplayTemplateConstants;
 import com.liferay.wiki.constants.WikiPortletKeys;
 import com.liferay.wiki.model.WikiPage;
@@ -36,6 +36,8 @@ import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Juan Fernández
@@ -54,8 +56,8 @@ public class WikiPortletDisplayTemplateHandler
 
 	@Override
 	public String getName(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
 
 		String portletTitle = _portal.getPortletTitle(
 			WikiPortletKeys.WIKI, resourceBundle);
@@ -119,5 +121,12 @@ public class WikiPortletDisplayTemplateHandler
 		target = "(&(release.bundle.symbolic.name=com.liferay.wiki.service)(release.schema.version=1.1.0))"
 	)
 	private Release _release;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=com.liferay.wiki.web)"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/sdk/project-templates/project-templates-content-targeting-rule/src/main/resources/archetype-resources/src/main/java/content/targeting/rule/__className__Rule.java
+++ b/modules/sdk/project-templates/project-templates-content-targeting-rule/src/main/resources/archetype-resources/src/main/java/content/targeting/rule/__className__Rule.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Locale;
@@ -26,6 +27,8 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author ${author}
@@ -81,8 +84,8 @@ public class ${className}Rule extends BaseJSPRule {
 
 		boolean matches = _getMatches(typeSettings);
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale.getLanguage());
 
 		if (matches) {
 			return LanguageUtil.get(
@@ -154,5 +157,13 @@ public class ${className}Rule extends BaseJSPRule {
 
 		return false;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=${package})"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
+
 
 }

--- a/modules/sdk/project-templates/project-templates-control-menu-entry/src/main/resources/archetype-resources/src/main/java/control/menu/__className__ProductNavigationControlMenuEntry.java
+++ b/modules/sdk/project-templates/project-templates-control-menu-entry/src/main/resources/archetype-resources/src/main/java/control/menu/__className__ProductNavigationControlMenuEntry.java
@@ -2,6 +2,7 @@ package ${package}.control.menu;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.product.navigation.control.menu.BaseProductNavigationControlMenuEntry;
 import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuEntry;
@@ -13,6 +14,9 @@ import java.util.ResourceBundle;
 import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author ${author}
@@ -36,8 +40,8 @@ public class ${className}ProductNavigationControlMenuEntry
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale.getLanguage());
 
 		return LanguageUtil.get(resourceBundle, "custom-message");
 	}
@@ -51,5 +55,13 @@ public class ${className}ProductNavigationControlMenuEntry
 	public boolean isShow(HttpServletRequest request) throws PortalException {
 		return true;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=${package})"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
+
 
 }

--- a/modules/sdk/project-templates/project-templates-panel-app/src/main/resources/archetype-resources/src/main/java/application/list/__className__PanelCategory.java
+++ b/modules/sdk/project-templates/project-templates-panel-app/src/main/resources/archetype-resources/src/main/java/application/list/__className__PanelCategory.java
@@ -6,12 +6,16 @@ import com.liferay.application.list.BasePanelCategory;
 import com.liferay.application.list.PanelCategory;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author ${author}
@@ -33,10 +37,17 @@ public class ${className}PanelCategory extends BasePanelCategory {
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale.getLanguage());
 
 		return LanguageUtil.get(resourceBundle, "category.custom.label");
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=${package})"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/sdk/project-templates/project-templates-portlet-configuration-icon/src/main/resources/archetype-resources/src/main/java/portlet/configuration/icon/__className__PortletConfigurationIcon.java
+++ b/modules/sdk/project-templates/project-templates-portlet-configuration-icon/src/main/resources/archetype-resources/src/main/java/portlet/configuration/icon/__className__PortletConfigurationIcon.java
@@ -3,14 +3,19 @@ package ${package}.portlet.configuration.icon;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
+import java.util.Locale;
 import java.util.ResourceBundle;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author ${author}
@@ -27,8 +32,10 @@ public class ${className}PortletConfigurationIcon
 
 	@Override
 	public String getMessage(PortletRequest portletRequest) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		Locale locale = getLocale(portletRequest);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale.getLanguage());
 
 		return LanguageUtil.get(resourceBundle, "sample-link");
 	}
@@ -59,5 +66,12 @@ public class ${className}PortletConfigurationIcon
 	public boolean isUseDialog() {
 		return false;
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=${package})"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/sdk/project-templates/project-templates-portlet-toolbar-contributor/src/main/resources/archetype-resources/src/main/java/portlet/toolbar/contributor/__className__PortletToolbarContributor.java
+++ b/modules/sdk/project-templates/project-templates-portlet-toolbar-contributor/src/main/resources/archetype-resources/src/main/java/portlet/toolbar/contributor/__className__PortletToolbarContributor.java
@@ -6,6 +6,7 @@ import com.liferay.portal.kernel.servlet.taglib.ui.Menu;
 import com.liferay.portal.kernel.servlet.taglib.ui.MenuItem;
 import com.liferay.portal.kernel.servlet.taglib.ui.URLMenuItem;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -18,6 +19,9 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author ${author}
@@ -56,8 +60,10 @@ public class ${className}PortletToolbarContributor
 		menu.setMarkupView("lexicon");
 		menu.setMenuItems(menuItems);
 
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", getLocale(portletRequest), getClass());
+		Locale locale = getLocale(portletRequest);
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale.getLanguage());
 
 		menu.setMessage(LanguageUtil.get(resourceBundle, "list-of-links"));
 
@@ -76,5 +82,12 @@ public class ${className}PortletToolbarContributor
 
 		return themeDisplay.getLocale();
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=${package})"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 }

--- a/modules/sdk/project-templates/project-templates-simulation-panel-entry/src/main/resources/archetype-resources/src/main/java/application/list/__className__SimulationPanelApp.java
+++ b/modules/sdk/project-templates/project-templates-simulation-panel-entry/src/main/resources/archetype-resources/src/main/java/application/list/__className__SimulationPanelApp.java
@@ -7,6 +7,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.product.navigation.simulation.application.list.SimulationPanelCategory;
 import com.liferay.product.navigation.simulation.constants.ProductNavigationSimulationPortletKeys;
@@ -18,6 +19,8 @@ import javax.servlet.ServletContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author ${author}
@@ -39,8 +42,8 @@ public class ${className}SimulationPanelApp extends BaseJSPPanelApp {
 
 	@Override
 	public String getLabel(Locale locale) {
-		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", locale, getClass());
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale.getLanguage());
 
 		return LanguageUtil.get(resourceBundle, "simulation-sample");
 	}
@@ -79,5 +82,13 @@ public class ${className}SimulationPanelApp extends BaseJSPPanelApp {
 	public void setServletContext(ServletContext servletContext) {
 		super.setServletContext(servletContext);
 	}
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(bundle.symbolic.name=${package})"
+	)
+	private volatile ResourceBundleLoader _resourceBundleLoader;
+
 
 }

--- a/modules/sdk/project-templates/project-templates-social-bookmark/src/main/resources/archetype-resources/src/main/java/social/bookmark/__className__SocialBookmark.java
+++ b/modules/sdk/project-templates/project-templates-social-bookmark/src/main/resources/archetype-resources/src/main/java/social/bookmark/__className__SocialBookmark.java
@@ -17,6 +17,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author ${author}
@@ -55,9 +57,11 @@ public class ${className}SocialBookmark implements SocialBookmark {
 	}
 
 	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		target = "(bundle.symbolic.name=${package})"
 	)
-	private ResourceBundleLoader _resourceBundleLoader;
+	private volatile ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=${package})"


### PR DESCRIPTION
Hi @sergiogonzalez, @arboliveira, @topolik, @jeyvison, @rafaprax, @matethurzo, @shuyangzhou, @ealonso, @jbalsas, @drewbrokke, @lionah, @gamerson, @csierra

This Pull Request solves a limitation at the time of overriding certain language keys when the corresponding classes or components use ResourceBundleUtil instead of using ResourceBundleLoader.

However, I have to clarify that this solution does not cover two cases that will be addressed in LPS-84074.

Please, take this into account for your new and ongoing developments and let me know if the proposed implementation was not completely valid for any of your components.

Best Regards,
Daniel