### PR TITLE
 LRQA-42633 Fix poshi-execute for local release

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -1109,6 +1109,15 @@ war.path=${app.server.portal.dir}/</echo>
 			<if>
 				<equals arg1="${test.poshi.runner.local.release}" arg2="true" />
 				<then>
+					<if>
+						<not>
+							<available file="tools/sdk" />
+						</not>
+						<then>
+							<antcall inheritAll="false" target="setup-sdk" />
+						</then>
+					</if>
+
 					<gradle-execute dir="${test.poshi.runner.src.dir}" task="deploy" />
 				</then>
 			</if>


### PR DESCRIPTION
LRQA-42633 Fix poshi-execute for local release

7.1.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/21251

We will backport to 7.0.x later