### PR TITLE
LPS-82546 GDPR - Deleting a document file that is a related asset on message board does not remove document from related assets list

### DIFF
--- a/modules/apps/document-library/document-library-uad-test/build.gradle
+++ b/modules/apps/document-library/document-library-uad-test/build.gradle
@@ -2,6 +2,8 @@ dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testIntegrationCompile project(":apps:document-library:document-library-api")
 	testIntegrationCompile project(":apps:document-library:document-library-uad")
+	testIntegrationCompile project(":apps:message-boards:message-boards-api")
+	testIntegrationCompile project(":apps:message-boards:message-boards-test-util")
 	testIntegrationCompile project(":apps:user-associated-data:user-associated-data-api")
 	testIntegrationCompile project(":apps:user-associated-data:user-associated-data-test-util")
 	testIntegrationCompile project(":core:petra:petra-string")

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFileEntryUADAnonymizerTest.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFileEntryUADAnonymizerTest.java
@@ -71,8 +71,6 @@ public class DLFileEntryUADAnonymizerTest
 
 	@Test
 	public void testAnonymizeDLFileEntryVersions() throws Exception {
-		Assert.assertTrue(true);
-
 		DLFileEntry dlFileEntry = _dlFileEntryUADTestHelper.addDLFileEntry(
 			user.getUserId());
 

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFileEntryUADAnonymizerTest.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFileEntryUADAnonymizerTest.java
@@ -88,7 +88,7 @@ public class DLFileEntryUADAnonymizerTest
 			WorkflowConstants.STATUS_ANY);
 
 		Assert.assertEquals(
-			dlFileVersions.toString(), 3, dlFileVersions.size());
+			dlFileVersions.toString(), 4, dlFileVersions.size());
 
 		uadAnonymizer.autoAnonymize(
 			dlFileEntry, user.getUserId(), anonymousUser);

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileEntryUADTestHelper.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileEntryUADTestHelper.java
@@ -15,11 +15,12 @@
 package com.liferay.document.library.uad.test;
 
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -51,16 +52,22 @@ public class DLFileEntryUADTestHelper {
 			RandomTestUtil.randomString(), false, serviceContext);
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
+		long folderId = dlFolder.getFolderId();
+		long repositoryId = dlFolder.getRepositoryId();
+		String changeLog = StringPool.BLANK;
+		String description = StringPool.BLANK;
+		String mimeType = ContentTypes.TEXT_PLAIN;
+		String sourceFileName = RandomTestUtil.randomString();
+		String title = RandomTestUtil.randomString();
 
 		InputStream is = new ByteArrayInputStream(bytes);
 
-		return _dlFileEntryLocalService.addFileEntry(
-			userId, dlFolder.getGroupId(), dlFolder.getRepositoryId(),
-			dlFolder.getFolderId(), RandomTestUtil.randomString(),
-			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
-			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, is, bytes.length, serviceContext);
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			userId, repositoryId, folderId, sourceFileName, mimeType, title,
+			description, changeLog, is, bytes.length, serviceContext);
+
+		return _dlFileEntryLocalService.getFileEntry(
+			fileEntry.getFileEntryId());
 	}
 
 	public void cleanUpDependencies(List<DLFileEntry> dlFileEntries)
@@ -70,6 +77,9 @@ public class DLFileEntryUADTestHelper {
 			_dlFolderLocalService.deleteFolder(dlFileEntry.getFolderId());
 		}
 	}
+
+	@Reference
+	private DLAppLocalService _dlAppLocalService;
 
 	@Reference
 	private DLFileEntryLocalService _dlFileEntryLocalService;

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileEntryUADTestHelper.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileEntryUADTestHelper.java
@@ -74,6 +74,13 @@ public class DLFileEntryUADTestHelper {
 		throws Exception {
 
 		for (DLFileEntry dlFileEntry : dlFileEntries) {
+			if (_dlFileEntryLocalService.fetchDLFileEntry(
+					dlFileEntry.getFileEntryId()) != null) {
+
+				_dlAppLocalService.deleteFileEntry(
+					dlFileEntry.getFileEntryId());
+			}
+
 			_dlFolderLocalService.deleteFolder(dlFileEntry.getFolderId());
 		}
 	}

--- a/modules/apps/document-library/document-library-uad/src/main/java/com/liferay/document/library/uad/anonymizer/DLFileEntryUADAnonymizer.java
+++ b/modules/apps/document-library/document-library-uad/src/main/java/com/liferay/document/library/uad/anonymizer/DLFileEntryUADAnonymizer.java
@@ -16,6 +16,7 @@ package com.liferay.document.library.uad.anonymizer;
 
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileVersion;
+import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
@@ -50,6 +51,11 @@ public class DLFileEntryUADAnonymizer extends BaseDLFileEntryUADAnonymizer {
 		super.autoAnonymize(dlFileEntry, userId, anonymousUser);
 	}
 
+	@Override
+	public void delete(DLFileEntry dlFileEntry) throws PortalException {
+		_dlAppService.deleteFileEntry(dlFileEntry.getFileEntryId());
+	}
+
 	private void _anonymizeDLFileVersion(
 		DLFileVersion dlFileVersion, long userId, long anonymousUserId,
 		String anonymousUserFullName) {
@@ -69,6 +75,9 @@ public class DLFileEntryUADAnonymizer extends BaseDLFileEntryUADAnonymizer {
 
 	private static final String[] _DL_FILE_VERSION_USER_ID_FIELD_NAMES =
 		{"statusByUserId", "userId"};
+
+	@Reference
+	private DLAppService _dlAppService;
 
 	@Reference
 	private DLFileVersionLocalService _dlFileVersionLocalService;

--- a/modules/apps/document-library/document-library-uad/src/main/java/com/liferay/document/library/uad/anonymizer/DLFileEntryUADAnonymizer.java
+++ b/modules/apps/document-library/document-library-uad/src/main/java/com/liferay/document/library/uad/anonymizer/DLFileEntryUADAnonymizer.java
@@ -16,7 +16,7 @@ package com.liferay.document.library.uad.anonymizer;
 
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileVersion;
-import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
@@ -53,7 +53,7 @@ public class DLFileEntryUADAnonymizer extends BaseDLFileEntryUADAnonymizer {
 
 	@Override
 	public void delete(DLFileEntry dlFileEntry) throws PortalException {
-		_dlAppService.deleteFileEntry(dlFileEntry.getFileEntryId());
+		_dlAppLocalService.deleteFileEntry(dlFileEntry.getFileEntryId());
 	}
 
 	private void _anonymizeDLFileVersion(
@@ -77,7 +77,7 @@ public class DLFileEntryUADAnonymizer extends BaseDLFileEntryUADAnonymizer {
 		{"statusByUserId", "userId"};
 
 	@Reference
-	private DLAppService _dlAppService;
+	private DLAppLocalService _dlAppLocalService;
 
 	@Reference
 	private DLFileVersionLocalService _dlFileVersionLocalService;


### PR DESCRIPTION
This is an update for [LPS-82546](https://issues.liferay.com/browse/LPS-82546).<br><br>/cc @pei-jung @stsquared99