### PR TITLE
LRDOCS-5572 Fix elements' attribute formatting in DTDs

### DIFF
--- a/definitions/liferay-look-and-feel_7_1_0.dtd
+++ b/definitions/liferay-look-and-feel_7_1_0.dtd
@@ -117,12 +117,16 @@ portlet-decorator*)>
 <!--
 The id attribute specifies the unique key for a theme. For convenience, the id
 attribute can be referenced in the rest of the theme element as ${theme-id}.
+-->
+<!ATTLIST theme
+	id CDATA #REQUIRED
+>
 
+<!--
 The name attribute specifies the friendly name of a theme that is displayed to
 the user.
 -->
 <!ATTLIST theme
-	id CDATA #REQUIRED
 	name CDATA #REQUIRED
 >
 
@@ -229,18 +233,6 @@ theme display object at runtime. They are described with a key value pair.
 For example, you can access it with the command:
 themeDisplay.getThemeSetting("hello").
 
-Set the configurable attribute to true if the setting is configurable from the
-user interface at runtime. This allows administrators to change the settings for
-a page or a set of pages.
-
-Set the type attribute to designate whether the HTML input for the setting is a
-checkbox, select, text, or textarea.
-
-Set the options attribute with a comma delimited list to specify the options for
-the HTML input.
-
-Set the value attribute to specify the default value.
-
 Include a CDATA section containing JavaScript to alter the behavior of the
 field, to bind advanced controls such as a color picker, or to perform
 validation. Use the token [@NAMESPACE@] in conjunction with the key of the
@@ -257,13 +249,41 @@ See the comments in the settings element.
 <!ELEMENT setting (#PCDATA)>
 
 <!--
-See the comments in the settings element.
+Set the key attribute to specify the key.
 -->
 <!ATTLIST setting
 	key CDATA #REQUIRED
+>
+
+<!--
+Set the value attribute to specify the default value.
+-->
+<!ATTLIST setting
 	value CDATA #IMPLIED
+>
+
+<!--
+Set the configurable attribute to true if the setting is configurable from the
+user interface at runtime. This allows administrators to change the settings for
+a page or a set of pages.
+-->
+<!ATTLIST setting
 	configurable CDATA #IMPLIED
+>
+
+<!--
+Set the type attribute to designate whether the HTML input for the setting is a
+checkbox, select, text, or textarea.
+-->
+<!ATTLIST setting
 	type CDATA #IMPLIED
+>
+
+<!--
+Set the options attribute with a comma delimited list to specify the options for
+the HTML input.
+-->
+<!ATTLIST setting
 	options CDATA #IMPLIED
 >
 
@@ -303,12 +323,16 @@ and defines an image path for the location of the color scheme's images.
 The id attribute specifies the key for a color scheme that is unique for its
 parent theme. For convenience, the id attribute can be referenced in the rest of
 the color-scheme element as ${color-scheme-id}.
+-->
+<!ATTLIST color-scheme
+	id CDATA #REQUIRED
+>
 
+<!--
 The name attribute specifies the friendly name of a color scheme
 that is displayed to the user.
 -->
 <!ATTLIST color-scheme
-	id CDATA #REQUIRED
 	name CDATA #REQUIRED
 >
 
@@ -387,12 +411,16 @@ of the portlet borders.
 The id attribute specifies the key for a portlet decorator that is unique for
 its parent theme. For convenience, the id attribute can be referenced in the
 rest of the portlet decorator element as ${portlet-decorator-id}.
+-->
+<!ATTLIST portlet-decorator
+	id CDATA #REQUIRED
+>
 
+<!--
 The name attribute specifies the friendly name of a portlet decorator that is
 displayed to the user.
 -->
 <!ATTLIST portlet-decorator
-	id CDATA #REQUIRED
 	name CDATA #REQUIRED
 >
 

--- a/definitions/liferay-resource-action-mapping_7_1_0.dtd
+++ b/definitions/liferay-resource-action-mapping_7_1_0.dtd
@@ -93,12 +93,16 @@ The model-resource element defines the permissions of the model.
 <!--
 The organization value specifies if the model resource is an organization model
 resource. The default value is false.
+-->
+<!ATTLIST model-resource
+	organization CDATA #IMPLIED
+>
 
+<!--
 The portal value specifies if the model resource is a portal model resource. The
 default value is false.
 -->
 <!ATTLIST model-resource
-	organization CDATA #IMPLIED
 	portal CDATA #IMPLIED
 >
 

--- a/definitions/liferay-service-builder_7_1_0.dtd
+++ b/definitions/liferay-service-builder_7_1_0.dtd
@@ -16,21 +16,33 @@ service-builder-import*)>
 
 <!--
 The package-path value specifies the package of the generated code.
+-->
+<!ATTLIST service-builder
+	package-path CDATA #REQUIRED
+>
 
+<!--
 The auto-import-default-references value specifies whether or not to
 automatically default references. The default value is true.
+-->
+<!ATTLIST service-builder
+	auto-import-default-references CDATA #IMPLIED
+>
 
+<!--
 The auto-namespace-tables value specifies whether or not to automatically
 namespace tables. The default value is false for core services and true for
 plugin services.
+-->
+<!ATTLIST service-builder
+	auto-namespace-tables CDATA #IMPLIED
+>
 
+<!--
 The mvcc-enabled value specifies whether or not to enable MVCC by default for
 entities to prevent lost updates. The default value is false.
 -->
 <!ATTLIST service-builder
-	package-path CDATA #REQUIRED
-	auto-import-default-references CDATA #IMPLIED
-	auto-namespace-tables CDATA #IMPLIED
 	mvcc-enabled CDATA #IMPLIED
 >
 
@@ -63,115 +75,208 @@ based on the order and finder elements.
 
 <!--
 The name value specifies the name of the entity.
+-->
+<!ATTLIST entity
+	name CDATA #REQUIRED
+>
 
+<!--
 The human-name value specifies the readable name to use when generating
 documentation for this entity. If none is specified, one will be generated from
 the name.
+-->
+<!ATTLIST entity
+	human-name CDATA #IMPLIED
+>
 
+<!--
 The table value specifies the name of the table that this entity maps to in the
 database. If this value is not set, then the name of the table is the same as
 the name of the entity.
+-->
+<!ATTLIST entity
+	table CDATA #IMPLIED
+>
 
+<!--
 If the uuid value is true, then the service will generate a UUID column for the
 service. This column will automatically be populated with a UUID. Developers
 will also be able to find and remove based on that UUID. The default value is
 false.
+-->
+<!ATTLIST entity
+	uuid CDATA #IMPLIED
+>
 
+<!--
 If the uuid-accessor value is true, then the service will generate a UUID column
 accessor for the service. This accessor will provide a fast and type-safe way to
 access entity's UUID.
+-->
+<!ATTLIST entity
+	uuid-accessor CDATA #IMPLIED
+>
 
+<!--
 If the external-reference-code values is true, then the service will generate a
 externalReferenceCode column for the service. The default value is false.
+-->
+<!ATTLIST entity
+	external-reference-code CDATA #IMPLIED
+>
 
+<!--
 If the local-service value is true, then the service will generate the local
 interfaces for the service. The default value is false.
+-->
+<!ATTLIST entity
+	local-service CDATA #IMPLIED
+>
 
+<!--
 If the remote-service value is true, then the service will generate remote
 interfaces for the service. The default value is true.
+-->
+<!ATTLIST entity
+	remote-service CDATA #IMPLIED
+>
 
+<!--
 The persistence-class value specifies the name of your custom persistence class.
 This class must implement the generated persistence interface or extend the
 generated persistence class. This allows you to override default behavior
 without modifying the generated persistence class.
+-->
+<!ATTLIST entity
+	persistence-class CDATA #IMPLIED
+>
+
+<!--
+The data-source value specifies the data source target that is set to the
+persistence class. The default value is the Liferay data source. This is used in
+conjunction with session-factory. See data-source-spring.xml.
 
 You can generate classes to use a custom data source and session factory.
 Point "spring.configs" in portal.properties to load your custom Spring XML with
 the definitions of your custom data source and session factory. Then set the
 data-source and session-factory values to your custom values.
+-->
+<!ATTLIST entity
+	data-source CDATA #IMPLIED
+>
 
-The data-source value specifies the data source target that is set to the
-persistence class. The default value is the Liferay data source. This is used in
-conjunction with session-factory. See data-source-spring.xml.
-
+<!--
 The session-factory value specifies the session factory that is set to the
 persistence class. The default value is the Liferay session factory. This is
 used in conjunction with data-source. See data-source-spring.xml.
 
+You can generate classes to use a custom data source and session factory.
+Point "spring.configs" in portal.properties to load your custom Spring XML with
+the definitions of your custom data source and session factory. Then set the
+data-source and session-factory values to your custom values.
+-->
+<!ATTLIST entity
+	session-factory CDATA #IMPLIED
+>
+
+<!--
 The tx-manager value specifies the transaction manager that Spring uses. The
 default value is the Spring Hibernate transaction manager that wraps the Liferay
 data source and session factory. See data-source-spring.xml. Set this attribute
 to "none" to disable transaction management.
+-->
+<!ATTLIST entity
+	tx-manager CDATA #IMPLIED
+>
 
+<!--
 The cache-enabled value specifies whether or not to cache this queries for this
 entity. Set this to false if data in the table will be updated by other
 programs. The default value is true.
+-->
+<!ATTLIST entity
+	cache-enabled CDATA #IMPLIED
+>
 
+<!--
 The dynamic-update-enabled value specifies whether or not unmodified properties
 are excluded in the SQL update statement. The default value is the value of the
 attribute mvcc-enabled.
+-->
+<!ATTLIST entity
+	dynamic-update-enabled CDATA #IMPLIED
+>
 
-The mvcc-enabled value specifies whether or not to enable MVCC for this
-entity to prevent lost updates. The default value is based on the mvcc-enabled
-attribute in the service-builder element.
-
+<!--
 The json-enabled value specifies whether or not the entity should be annotated
 for JSON serialization. By default, if the remote-service value is true, then
 the json-enabled value is true.
+-->
+<!ATTLIST entity
+	json-enabled CDATA #IMPLIED
+>
 
+<!--
+The mvcc-enabled value specifies whether or not to enable MVCC for this
+entity to prevent lost updates. The default value is based on the mvcc-enabled
+attribute in the service-builder element.
+-->
+<!ATTLIST entity
+	mvcc-enabled CDATA #IMPLIED
+>
+
+<!--
 The trash-enabled value specifies whether trash related methods should be
 generated or not.
+-->
+<!ATTLIST entity
+	trash-enabled CDATA #IMPLIED
+>
 
+<!--
 The uad-application-name value specifies the name of the application that the
 entity type belongs to in the GDPR UI.
+-->
+<!ATTLIST entity
+	uad-applicaiton-name CDATA #IMPLIED
+>
 
+<!--
 The uad-auto-delete value specifies whether or not the entity should be
 automatically deleted during the auto-anonymization.
+-->
+<!ATTLIST entity
+	uad-auto-delete CDATA #IMPLIED
+>
 
+<!--
 The uad-dir-path value specifies the directory path of the generated UAD
 implementations.
+-->
+<!ATTLIST entity
+	uad-dir-path CDATA #IMPLIED
+>
 
+<!--
 The uad-package-path value specifies the package path for the generated UAD
 classes.
+-->
+<!ATTLIST entity
+	uad-package-path CDATA #IMPLIED
+>
 
+<!--
 If the versioned value is true, then the service will generate a version table,
 columns, and methods to version the entity.
+-->
+<!ATTLIST entity
+	versioned CDATA #IMPLIED
+>
 
+<!--
 The deprecated value specifies whether the entity's services are deprecated.
 -->
 <!ATTLIST entity
-	name CDATA #REQUIRED
-	human-name CDATA #IMPLIED
-	table CDATA #IMPLIED
-	uuid CDATA #IMPLIED
-	uuid-accessor CDATA #IMPLIED
-	external-reference-code CDATA #IMPLIED
-	local-service CDATA #IMPLIED
-	remote-service CDATA #IMPLIED
-	persistence-class CDATA #IMPLIED
-	data-source CDATA #IMPLIED
-	session-factory CDATA #IMPLIED
-	tx-manager CDATA #IMPLIED
-	cache-enabled CDATA #IMPLIED
-	dynamic-update-enabled CDATA #IMPLIED
-	json-enabled CDATA #IMPLIED
-	mvcc-enabled CDATA #IMPLIED
-	trash-enabled CDATA #IMPLIED
-	uad-applicaiton-name CDATA #IMPLIED
-	uad-auto-delete CDATA #IMPLIED
-	uad-dir-path CDATA #IMPLIED
-	uad-package-path CDATA #IMPLIED
-	versioned CDATA #IMPLIED
 	deprecated CDATA #IMPLIED
 >
 
@@ -180,9 +285,33 @@ The column element represents a column in the database.
 -->
 <!ELEMENT column (#PCDATA)>
 
+
+
+
+
+
+
+
+
+
+
+
 <!--
 The name value specifies the getter and setter name in the entity.
+-->
+<!ATTLIST column
+	name CDATA #REQUIRED
+>
 
+<!--
+Set db-name to map the field to a physical database column that is different
+from the column name.
+-->
+<!ATTLIST column
+	db-name CDATA #IMPLIED
+>
+
+<!--
 The type value specifies whether the column is a String, Boolean, or int, etc.
 
 For example:
@@ -191,18 +320,40 @@ For example:
 
 The above column specifies that there will be a getter called
 pojo.getCompanyId() that will return a String.
+-->
+<!ATTLIST column
+	type CDATA #REQUIRED
+>
 
-Set db-name to map the field to a physical database column that is different
-from the column name.
-
+<!--
 If the primary value is set to true, then this column is part of the primary key
 of the entity. If multiple columns have the primary value set to true, then a
 compound key will be created.
+-->
+<!ATTLIST column
+	primary CDATA #IMPLIED
+>
 
-The mapping-key attribute is no longer supported. See LPS-32250 for more
-information. The value of the mapping-key is now always assumed to be the column
-entity's primary key.
+<!--
+This accessor value specifies whether or not to generate an accessor for this
+column. This accessor will provide a fast and type-safe way to access column
+value.
+-->
+<!ATTLIST column
+	accessor CDATA #IMPLIED
+>
 
+<!--
+The filter-primary value specifies the column to use as the primary key column
+when using filter finders. Only one column should ever have this value set to
+true. If no column has this set to true, then the default primary column will be
+used.
+-->
+<!ATTLIST column
+	filter-primary CDATA #IMPLIED
+>
+
+<!--
 If the entity and mapping-table attributes are specified, then the Service
 Builder will assume you are specifying a many to many relationship.
 
@@ -231,7 +382,19 @@ For example:
 	entity="com.liferay.portal.Organization"
 	mapping-table="Foo_Organizations"
 />
+-->
+<!ATTLIST column
+	entity CDATA #IMPLIED
+>
 
+<!--
+See the entity attribute's description for more information.
+-->
+<!ATTLIST column
+	mapping-table CDATA #IMPLIED
+>
+
+<!--
 The id-type and id-param values are used in order to create an auto-generated,
 auto-incrementing primary key when inserting records into a table. This can be
 implemented in 4 different ways, depending on the type of database being used.
@@ -303,71 +466,92 @@ In this implementation, a create sequence SQL statement is created based on
 the id-param value (stored in /sql/sequences.sql). This sequence is then
 accessed to generate a unique identifier whenever an insert occurs. This
 implementation is only supported by DB2, Oracle, PostgreSQL, and SAP DB.
+-->
+<!ATTLIST column
+	id-type CDATA #IMPLIED
+>
 
-This accessor value specifies whether or not to generate an accessor for this
-column. This accessor will provide a fast and type-safe way to access column
-value.
+<!--
+See the id-type attribute's description for more information.
+-->
+<!ATTLIST column
+	id-param CDATA #IMPLIED
+>
 
-The filter-primary value specifies the column to use as the primary key column
-when using filter finders. Only one column should ever have this value set to
-true. If no column has this set to true, then the default primary column will be
-used.
-
+<!--
 The convert-null value specifies whether or not the column value is
 automatically converted to a non null value if it is null. This only applies if
 the type value is String. This is particularly useful if your entity is
 referencing a read only table or a database view so that Hibernate does not try
 to issue unnecessary updates. The default value is true.
+-->
+<!ATTLIST column
+	convert-null CDATA #IMPLIED
+>
 
+<!--
 The lazy value is only valid when type is Blob. It specifies whether or not to
 do a lazy fetch for Blob. The default value is true.
+-->
+<!ATTLIST column
+	lazy CDATA #IMPLIED
+>
 
+<!--
 The localized value specifies whether or not the value of the column can have
 different values for different locales. The default value is false. Localization
 can also be performed by using a generated localization table using the
 localized-entity and localized-column elements. The localized value cannot be
 set to true when the entity contains a localized-entity element. Using the
 localized-entity element with a separate table is recommended.
+-->
+<!ATTLIST column
+	localized CDATA #IMPLIED
+>
 
+<!--
 The json-enabled value specifies whether or not the column should be annotated
 for JSON serialization. By default, if the json-enabled value in the entity
 element is true, then the json-enabled value in the column element is true.
+-->
+<!ATTLIST column
+	json-enabled CDATA #IMPLIED
+>
 
+<!--
 The container-model value specifies whether the column represents the primary
 key of a container model.
+-->
+<!ATTLIST column
+	container-model CDATA #IMPLIED
+>
 
+<!--
 The parent-container-model value specifies whether the column represents the
 primary key of a parent container model.
+-->
+<!ATTLIST column
+	parent-container-model CDATA #IMPLIED
+>
 
+<!--
 The uad-anonymize-field-name value specifies the anonymous user field that
 should be used to replace this column's value during auto anonymization. For
 example, if "fullName" is specified, the anonymous user's full name will replace
 this column's value during auto anonymization. The uad-anonymize-field-name
 value should only be used with user name columns (e.g. "statusByUserName").
+-->
+<!ATTLIST column
+	uad-anonymize-field-name CDATA #IMPLIED
+>
 
+<!--
 The uad-nonanonymizable value specifies whether the column represents data
 associated with a specific user that should be reviewed by an administrator in
 the event of a GDPR compliance request. This implies the data cannot be
 anonymized automatically.
 -->
 <!ATTLIST column
-	name CDATA #REQUIRED
-	db-name CDATA #IMPLIED
-	type CDATA #REQUIRED
-	primary CDATA #IMPLIED
-	accessor CDATA #IMPLIED
-	filter-primary CDATA #IMPLIED
-	entity CDATA #IMPLIED
-	mapping-table CDATA #IMPLIED
-	id-type CDATA #IMPLIED
-	id-param CDATA #IMPLIED
-	convert-null CDATA #IMPLIED
-	lazy CDATA #IMPLIED
-	localized CDATA #IMPLIED
-	json-enabled CDATA #IMPLIED
-	container-model CDATA #IMPLIED
-	parent-container-model CDATA #IMPLIED
-	uad-anonymize-field-name CDATA #IMPLIED
 	uad-nonanonymizable CDATA #IMPLIED
 >
 
@@ -383,13 +567,17 @@ columns, finders, and update methods are generated for the localized entity.
 <!--
 The name value specifies the name of the localized entity. If this value is not
 set, then the parent entity's name is used with "Localization" appended.
+-->
+<!ATTLIST localized-entity
+	name CDATA #IMPLIED
+>
 
+<!--
 The table value specifies the name of the table that this localized entity maps
 to in the database. If this value is not set, then the name of the table is the
 same as the name of the localized entity.
 -->
 <!ATTLIST localized-entity
-	name CDATA #IMPLIED
 	table CDATA #IMPLIED
 >
 
@@ -401,12 +589,16 @@ The localized-column element represents a column in the localization table.
 <!--
 The name value specifies the getter and setter name in the entity and
 localization entity.
+-->
+<!ATTLIST localized-column
+	name CDATA #REQUIRED
+>
 
+<!--
 Set db-name to map the field to a physical database column that is different
 from the localized-column name.
 -->
 <!ATTLIST localized-column
-	name CDATA #REQUIRED
 	db-name CDATA #IMPLIED
 >
 
@@ -425,10 +617,7 @@ Set the by attribute to "asc" or "desc" to order by ascending or descending.
 
 <!--
 The order-column element allows you to order the entities by specific columns.
--->
-<!ELEMENT order-column (#PCDATA)>
 
-<!--
 The attributes of the order-column element allows you to fine tune the ordering
 of the entity.
 
@@ -460,9 +649,28 @@ For example:
 The above settings will order by articleId in an ascending manner and then by
 version in a descending manner.
 -->
+<!ELEMENT order-column (#PCDATA)>
+
+<!--
+The name value specifies the name of the entity.
+-->
 <!ATTLIST order-column
 	name CDATA #REQUIRED
+>
+
+<!--
+The case-sensitive value specifies whether or not the name is case sensitive.
+The default value is true.
+-->
+<!ATTLIST order-column
 	case-sensitive CDATA #IMPLIED
+>
+
+<!--
+The order-by value specifies how to order the entity names. Possible values for
+this attribute are "asc" (ascending) or "desc" (descending).
+-->
+<!ATTLIST order-column
 	order-by CDATA #IMPLIED
 >
 
@@ -473,22 +681,37 @@ The finder element represents a generated finder method.
 
 <!--
 The name value specifies the name of the finder method.
+-->
+<!ATTLIST finder
+	name CDATA #REQUIRED
+>
 
+<!--
 The return-type value specifies the return type of the finder. Valid values are
 "Collection" or the name of the entity. If the value is "Collection", then this
 finder returns a list of entities. If the value is the name of the entity, then
 this finder returns at most one entity.
+-->
+<!ATTLIST finder
+	return-type CDATA #REQUIRED
+>
 
+<!--
 If the unique value is true, then the finder must return a unique entity.
+-->
+<!ATTLIST finder
+	unique CDATA #IMPLIED
+>
 
+<!ATTLIST finder
+	where CDATA #IMPLIED
+>
+
+<!--
 If the db-index value is true, then the service will automatically generate a
 SQL index for this finder. The default value is true.
 -->
 <!ATTLIST finder
-	name CDATA #REQUIRED
-	return-type CDATA #REQUIRED
-	unique CDATA #IMPLIED
-	where CDATA #IMPLIED
 	db-index CDATA #IMPLIED
 >
 
@@ -515,28 +738,44 @@ generate removeByCompanyId and countByCompanyId.
 
 See com.liferay.portal.service.persistence.impl.LayoutPersistenceImpl for a good
 example.
+-->
+<!ATTLIST finder-column
+	name CDATA #REQUIRED
+>
 
+<!--
 The attribute case-sensitive is a boolean value and is only used if the column
 is a String value.
+-->
+<!ATTLIST finder-column
+	case-sensitive CDATA #IMPLIED
+>
 
+<!--
 The attribute comparator takes in the values =, !=, <, <=, >, >=, or LIKE and is
 used to compare this column.
+-->
+<!ATTLIST finder-column
+	comparator CDATA #IMPLIED
+>
 
+<!--
 The attribute arrayable-operator takes in the values AND or OR and will
 generate an additional finder where this column's parameter takes an array
 instead of a single value. Every value in this array will be compared with the
 column using the comparator, and the conditions will be combined with either an
 AND or OR operator. For example, a finder column with the = comparator and an
 arrayable-operator of OR will act like an IN clause.
+-->
+<!ATTLIST finder-column
+	arrayable-operator CDATA #IMPLIED
+>
 
+<!--
 The attribute arrayable-pagination is a boolean value and is used to signal if
 the entity column can be paginated.
 -->
 <!ATTLIST finder-column
-	name CDATA #REQUIRED
-	case-sensitive CDATA #IMPLIED
-	comparator CDATA #IMPLIED
-	arrayable-operator CDATA #IMPLIED
 	arrayable-pagination CDATA #IMPLIED
 >
 


### PR DESCRIPTION
The current DTD format structure lists **ALL** of an element's attribute descriptions for **EACH** attribute in the generated HTML. For example:

https://docs.liferay.com/portal/7.1-latest/definitions/liferay-service-builder_7_1_0.dtd.html#entity_name

This makes the generated HTML doc hard to read. I've reformatted the 7.1 DTDs so each attribute only lists its own description. This mainly affects the Service Builder DTD, but there were a couple others that required minor updates.