### PR TITLE
LPS-84007 Adding invalid LDAP server in System Settings prevents causes "entry not found" error

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
@@ -35,7 +35,7 @@ ConfigurationModel configurationModel = (ConfigurationModel)request.getAttribute
 
 viewFactoryInstancesURL.setParameter("factoryPid", configurationModel.getFactoryPid());
 
-if (configurationModel.isFactory()) {
+if (configurationModel.isFactory() && !configurationModel.isCompanyFactory()) {
 	bindRedirectURL = viewFactoryInstancesURL.toString();
 }
 


### PR DESCRIPTION
This is an update for [LPS-84007](https://issues.liferay.com/browse/LPS-84007).<br><br>/cc @pei-jung @stsquared99 @JorgeFerrer