### PR TITLE
LRQA-42811 Prevent the creation of extra timestamp branches in local-git when a local git node is down

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -812,15 +812,6 @@ public class GitWorkingDirectory {
 						localRepository, branchName,
 						getLocalGitBranchSHA(branchName)));
 			}
-			else {
-				LocalGitBranch currentLocalGitBranch =
-					getCurrentLocalGitBranch();
-
-				localGitBranches.add(
-					GitBranchFactory.newLocalGitBranch(
-						localRepository, branchName,
-						currentLocalGitBranch.getSHA()));
-			}
 
 			return localGitBranches;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -353,7 +353,7 @@ public class GitWorkingDirectory {
 		for (List<String> branchNames :
 				Lists.partition(
 					new ArrayList<>(localGitBranchNames),
-					_DELETE_BRANCHES_BATCH_SIZE)) {
+						_DELETE_BRANCHES_BATCH_SIZE)) {
 
 			_deleteLocalGitBranches(
 				branchNames.toArray(new String[branchNames.size()]));
@@ -784,7 +784,8 @@ public class GitWorkingDirectory {
 		String branchName, boolean required) {
 
 		if ((branchName != null) && !branchName.isEmpty()) {
-			List<LocalGitBranch> localGitBranches = getLocalGitBranches(branchName);
+			List<LocalGitBranch> localGitBranches = getLocalGitBranches(
+				branchName);
 
 			if (localGitBranches.isEmpty()) {
 				return null;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -340,7 +340,11 @@ public class GitWorkingDirectory {
 	}
 
 	public void deleteLocalGitBranches(List<LocalGitBranch> localGitBranches) {
-		List<String> localGitBranchNames = new ArrayList<>();
+		if (localGitBranches.isEmpty()) {
+			return;
+		}
+
+		Set<String> localGitBranchNames = new HashSet<>();
 
 		for (LocalGitBranch localGitBranch : localGitBranches) {
 			localGitBranchNames.add(localGitBranch.getName());
@@ -348,7 +352,8 @@ public class GitWorkingDirectory {
 
 		for (List<String> branchNames :
 				Lists.partition(
-					localGitBranchNames, _DELETE_BRANCHES_BATCH_SIZE)) {
+					new ArrayList<>(localGitBranchNames),
+					_DELETE_BRANCHES_BATCH_SIZE)) {
 
 			_deleteLocalGitBranches(
 				branchNames.toArray(new String[branchNames.size()]));
@@ -778,9 +783,17 @@ public class GitWorkingDirectory {
 	public LocalGitBranch getLocalGitBranch(
 		String branchName, boolean required) {
 
-		List<LocalGitBranch> localGitBranches = getLocalGitBranches(branchName);
+		if ((branchName != null) && !branchName.isEmpty()) {
+			List<LocalGitBranch> localGitBranches = getLocalGitBranches(branchName);
 
-		for (LocalGitBranch localGitBranch : localGitBranches) {
+			if (localGitBranches.isEmpty()) {
+				return null;
+			}
+
+			return localGitBranches.get(0);
+		}
+
+		for (LocalGitBranch localGitBranch : getLocalGitBranches(null)) {
 			if (branchName.equals(localGitBranch.getName())) {
 				return localGitBranch;
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -501,7 +501,7 @@ public class LocalGitSyncUtil {
 			catch (Exception e) {
 				e.printStackTrace();
 
-				return false;
+				continue;
 			}
 
 			return false;


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-42811

This is just the first pull to prevent the problem from happening. I'll be sending a later pull that adds logic to keep the local-git repos clean.

Please publish after merging.