### PR TITLE
LPS-81861 LPS-83052 Fix several Eclipse compile errors: stale build.gradle files missing testCompile, testIntegrationCompile

### DIFF
--- a/modules/apps/calendar/calendar-test/build.gradle
+++ b/modules/apps/calendar/calendar-test/build.gradle
@@ -4,6 +4,8 @@ targetCompatibility = "1.8"
 dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.0"
+	testIntegrationCompile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	testIntegrationCompile project(":apps:calendar:calendar-api")
 	testIntegrationCompile project(":apps:export-import:export-import-test-util")
 	testIntegrationCompile project(":apps:portal-search:portal-search-test-util")

--- a/modules/apps/document-library/document-library-test/build.gradle
+++ b/modules/apps/document-library/document-library-test/build.gradle
@@ -5,6 +5,8 @@ dependencies {
 	testIntegrationCompile group: "com.liferay", name: "org.hibernate.core", version: "3.6.10.LIFERAY-PATCHED-3"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.0"
+	testIntegrationCompile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	testIntegrationCompile group: "org.jodd", name: "jodd-core", version: "3.6.4"
 	testIntegrationCompile project(":apps:document-library:document-library-api")
 	testIntegrationCompile project(":apps:document-library:document-library-content-api")

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/build.gradle
@@ -2,4 +2,6 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
 	compileOnly project(":core:petra:petra-string")
+
+	testCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 }

--- a/modules/apps/portal-search/portal-search-test/build.gradle
+++ b/modules/apps/portal-search/portal-search-test/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	testCompile project(":core:petra:petra-lang")
 
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	testIntegrationCompile project(":apps:blogs:blogs-api")
 	testIntegrationCompile project(":apps:blogs:blogs-service")
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")


### PR DESCRIPTION
Fixes several modules displaying compile errors when imported into Eclipse. 

CI can likely be dismissed for this pull request. Changes to `build.gradle` files only, on `testCompile` and `testIntegrationCompile` dependencies; versions used same as other modules.