### PR TITLE
LPS-84479 HeaderResponse.addDependency() does not preserve the order …

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/util/OutputData.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/util/OutputData.java
@@ -22,8 +22,8 @@ import com.liferay.portal.kernel.util.Mergeable;
 
 import java.io.Serializable;
 
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -202,8 +202,8 @@ public class OutputData implements Mergeable<OutputData>, Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private final Map<DataKey, StringBundler> _dataMap = new HashMap<>();
-	private final Set<String> _outputKeys = new HashSet<>();
+	private final Map<DataKey, StringBundler> _dataMap = new LinkedHashMap<>();
+	private final Set<String> _outputKeys = new LinkedHashSet<>();
 
 	private static class DataKey implements Serializable {
 


### PR DESCRIPTION
…in which dependences are added