### PR TITLE
LPS-83841 Fix compile

### DIFF
--- a/modules/apps/asset/asset-link-test/build.gradle
+++ b/modules/apps/asset/asset-link-test/build.gradle
@@ -7,12 +7,12 @@ copyLibs {
 
 dependencies {
 	compileOnly project(":apps:bookmarks:bookmarks-test")
-	compileOnly project(":apps:journal:journal-test")
 
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testIntegrationCompile project(":apps:asset:asset-test-util")
 	testIntegrationCompile project(":apps:bookmarks:bookmarks-api")
 	testIntegrationCompile project(":apps:export-import:export-import-test-util")
 	testIntegrationCompile project(":apps:journal:journal-api")
+	testIntegrationCompile project(":apps:journal:journal-test")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }


### PR DESCRIPTION
Another example of how weak ci relevant is, caused by https://github.com/brianchandotcom/liferay-portal/pull/62268, where asset-link-test was not even invoked for compiling.