### PR TITLE
LPS-83841 Add test for getPageItems using Reflectivity

### DIFF
--- a/modules/apps/headless-apio/structured-content/structured-content-apio-test/bnd.bnd
+++ b/modules/apps/headless-apio/structured-content/structured-content-apio-test/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Structured Content Apio Test
+Bundle-SymbolicName: com.liferay.structured.content.apio.test
+Bundle-Version: 1.0.0
+-includeresource: test-classes/integration

--- a/modules/apps/headless-apio/structured-content/structured-content-apio-test/build.gradle
+++ b/modules/apps/headless-apio/structured-content/structured-content-apio-test/build.gradle
@@ -1,0 +1,13 @@
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
+dependencies {
+	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile project(":apps:apio-architect:apio-architect-api")
+	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
+	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
+	testIntegrationCompile project(":apps:headless-apio:structured-content:structured-content-apio-impl")
+	testIntegrationCompile project(":apps:journal:journal-api")
+	testIntegrationCompile project(":apps:journal:journal-test-util")
+	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/headless-apio/structured-content/structured-content-apio-test/src/testIntegration/java/com/liferay/structured/content/apio/architect/util/test/PaginationTestUtil.java
+++ b/modules/apps/headless-apio/structured-content/structured-content-apio-test/src/testIntegration/java/com/liferay/structured/content/apio/architect/util/test/PaginationTestUtil.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.structured.content.apio.architect.util.test;
+
+import com.liferay.apio.architect.pagination.Pagination;
+
+/**
+ * @author Julio Camarero
+ */
+public class PaginationTestUtil implements Pagination {
+
+	public static Pagination of(int itemsPerPage, int pageNumber) {
+		return new PaginationTestUtil(itemsPerPage, pageNumber);
+	}
+
+	@Override
+	public int getEndPosition() {
+		return _pageNumber * _itemsPerPage;
+	}
+
+	@Override
+	public int getItemsPerPage() {
+		return _itemsPerPage;
+	}
+
+	@Override
+	public int getPageNumber() {
+		return _pageNumber;
+	}
+
+	@Override
+	public int getStartPosition() {
+		return (_pageNumber - 1) * _itemsPerPage;
+	}
+
+	private PaginationTestUtil(int itemsPerPage, int pageNumber) {
+		_itemsPerPage = itemsPerPage;
+		_pageNumber = pageNumber;
+	}
+
+	private final int _itemsPerPage;
+	private final int _pageNumber;
+
+}

--- a/modules/apps/headless-apio/structured-content/structured-content-apio-test/src/testIntegration/java/com/liferay/structured/content/apio/internal/architect/resource/test/StructuredContentNestedCollectionResourceTest.java
+++ b/modules/apps/headless-apio/structured-content/structured-content-apio-test/src/testIntegration/java/com/liferay/structured/content/apio/internal/architect/resource/test/StructuredContentNestedCollectionResourceTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+import com.liferay.structured.content.apio.architect.util.test.PaginationTestUtil;
 
 import java.lang.reflect.Method;
 
@@ -90,30 +91,7 @@ public class StructuredContentNestedCollectionResourceTest {
 			LocaleUtil.getDefault(), null, true, true, serviceContext);
 
 		PageItems pageItems = _getPageItems(
-			new Pagination() {
-
-				@Override
-				public int getEndPosition() {
-					return 10;
-				}
-
-				@Override
-				public int getItemsPerPage() {
-					return 10;
-				}
-
-				@Override
-				public int getPageNumber() {
-					return 0;
-				}
-
-				@Override
-				public int getStartPosition() {
-					return 0;
-				}
-
-			},
-			_group.getGroupId(), null);
+			PaginationTestUtil.of(10, 1), _group.getGroupId(), null);
 
 		Assert.assertEquals(1, pageItems.getTotalCount());
 

--- a/modules/apps/headless-apio/structured-content/structured-content-apio-test/src/testIntegration/java/com/liferay/structured/content/apio/internal/architect/resource/test/StructuredContentNestedCollectionResourceTest.java
+++ b/modules/apps/headless-apio/structured-content/structured-content-apio-test/src/testIntegration/java/com/liferay/structured/content/apio/internal/architect/resource/test/StructuredContentNestedCollectionResourceTest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.structured.content.apio.internal.architect.resource.test;
+
+import com.liferay.apio.architect.pagination.PageItems;
+import com.liferay.apio.architect.pagination.Pagination;
+import com.liferay.apio.architect.resource.NestedCollectionResource;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.model.JournalArticleConstants;
+import com.liferay.journal.model.JournalFolderConstants;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+
+import java.lang.reflect.Method;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Cristina González
+ */
+@RunWith(Arquillian.class)
+public class StructuredContentNestedCollectionResourceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetPageItems() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		Map<Locale, String> keywordsMap = new HashMap<>();
+
+		String keywords = "keywords";
+
+		keywordsMap.put(LocaleUtil.getDefault(), keywords);
+		keywordsMap.put(LocaleUtil.GERMANY, keywords);
+		keywordsMap.put(LocaleUtil.SPAIN, keywords);
+
+		String articleId = "Article.Id";
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			JournalArticleConstants.CLASSNAME_ID_DEFAULT, articleId, false,
+			keywordsMap, keywordsMap, keywordsMap, null,
+			LocaleUtil.getDefault(), null, true, true, serviceContext);
+
+		PageItems pageItems = _getPageItems(
+			new Pagination() {
+
+				@Override
+				public int getEndPosition() {
+					return 10;
+				}
+
+				@Override
+				public int getItemsPerPage() {
+					return 10;
+				}
+
+				@Override
+				public int getPageNumber() {
+					return 0;
+				}
+
+				@Override
+				public int getStartPosition() {
+					return 0;
+				}
+
+			},
+			_group.getGroupId(), null);
+
+		Assert.assertEquals(1, pageItems.getTotalCount());
+
+		Collection items = pageItems.getItems();
+
+		Assert.assertTrue("Items " + items, items.contains(journalArticle));
+	}
+
+	private PageItems _getPageItems(
+			Pagination pagination, long contentSpaceId,
+			ThemeDisplay themeDisplay)
+		throws Exception {
+
+		Class<? extends NestedCollectionResource>
+			nestedCollectionResourceClass =
+				_nestedCollectionResource.getClass();
+
+		Method getPageItems = nestedCollectionResourceClass.getDeclaredMethod(
+			"_getPageItems", Pagination.class, long.class, ThemeDisplay.class);
+
+		getPageItems.setAccessible(true);
+
+		return (PageItems)getPageItems.invoke(
+			_nestedCollectionResource, pagination, contentSpaceId,
+			themeDisplay);
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.structured.content.apio.internal.architect.resource.StructuredContentNestedCollectionResource"
+	)
+	private NestedCollectionResource _nestedCollectionResource;
+
+}

--- a/modules/apps/headless-apio/structured-content/structured-content-apio-test/src/testIntegration/java/com/liferay/structured/content/apio/internal/architect/resource/test/StructuredContentNestedCollectionResourceTest.java
+++ b/modules/apps/headless-apio/structured-content/structured-content-apio-test/src/testIntegration/java/com/liferay/structured/content/apio/internal/architect/resource/test/StructuredContentNestedCollectionResourceTest.java
@@ -23,7 +23,9 @@ import com.liferay.journal.model.JournalArticleConstants;
 import com.liferay.journal.model.JournalFolderConstants;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -91,7 +93,8 @@ public class StructuredContentNestedCollectionResourceTest {
 			LocaleUtil.getDefault(), null, true, true, serviceContext);
 
 		PageItems pageItems = _getPageItems(
-			PaginationTestUtil.of(10, 1), _group.getGroupId(), null);
+			PaginationTestUtil.of(10, 1), _group.getGroupId(),
+			_getThemeDisplay(_group));
 
 		Assert.assertEquals(1, pageItems.getTotalCount());
 
@@ -117,6 +120,19 @@ public class StructuredContentNestedCollectionResourceTest {
 		return (PageItems)getPageItems.invoke(
 			_nestedCollectionResource, pagination, contentSpaceId,
 			themeDisplay);
+	}
+
+	private ThemeDisplay _getThemeDisplay(Group group) throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		Company company = CompanyLocalServiceUtil.getCompanyById(
+			group.getCompanyId());
+
+		themeDisplay.setCompany(company);
+
+		themeDisplay.setScopeGroupId(group.getGroupId());
+
+		return themeDisplay;
 	}
 
 	@DeleteAfterTestRun


### PR DESCRIPTION
Hi Brian,

We try to use the "-conditionalpackage:" in bnd.bnd. But this was not a good approach for us, since we need to register the component so we can test it.

Another problem that we found is that if we make public the method _getPageItems, the SF complains no matter if it is inside a internal package.

With all these issues, and as our only goal is to test the _getPageItem method, we decide that maybe we can use reflection to solve this issue.

Here you can check the new pull that add test for the _getPageItem method. What do you think?

Thanks a lot,
Cristina

@juliocamarero
