### PR TITLE
COMMERCE-579

### DIFF
--- a/modules/etl/talend/README.markdown
+++ b/modules/etl/talend/README.markdown
@@ -3,16 +3,17 @@
 This project contains components for working with Liferay DXP from Talend
 Studio.
 
-Open Talend 6.5.1 (Components API v0.19.9).
+Open Talend 7.0.1
 
 ## Prerequisites
 
 * JDK 1.8+
 * Apache Maven 3.3+
-* Open Talend 6.5.1
-	* Components API v0.19.9
+* Open Talend 7.0.1
+	* Components API v0.23.1
 
-Download Talend Open Studio 6.5.1: https://www.talend.com/download/talend-open-studio/
+Download Talend Open Studio: https://www.talend.com/products/talend-open-studio/
+* Direct link: https://download-mirror2.talend.com/esb/release/V7.0.1/TOS_ESB-20180411_1414-V7.0.1.zip
 
 ## Build
 
@@ -34,7 +35,7 @@ Detailed steps of adding new components are described in the Talend Wiki:
 
 Here is a brief summary:
 
-1. From the root folder of the project, `/components-liferay/` in this example,
+1. From the root folder of the project, `liferay-portal/modules/etl/talend/` in this example,
 	execute `mvn clean install` to build the component.
 
 2. Let's assume that Studio has been extracted like this:
@@ -42,14 +43,14 @@ Here is a brief summary:
 	```sh
 	$ cd $HOME/tmp
 	... download distribution archive ...
-	$ unzip TOS_ESB-20180116_1512-V6.5.1.zip
-	$ STUDIO_ROOT=$HOME/tmp/TOS_ESB-20180116_1512-V6.5.1
+	$ unzip TOS_ESB-Version.zip
+	$ STUDIO_ROOT=$HOME/tmp/TOS_ESB-Version
 	```
 
 3. Now copy the component definition bundle into `$STUDIO_ROOT/plugins`
 
 	```sh
-	$ cp [COMPONENTS-LIFERAY]/talend-definition/target/com.liferay.talend.definition-0.1.0-SNAPSHOT.jar \
+	$ cp [liferay-portal/modules/etl/talend]/talend-definition/target/com.liferay.talend.definition-0.1.0-SNAPSHOT.jar \
 		 $STUDIO_ROOT/plugins
 	```
 
@@ -84,8 +85,16 @@ with `org.eclipse`.
 * Now start the Studio, and you should be able to see new components on palette
 under `Business/Liferay` category.
 
-7. There is a bug in Talend Open Studio 6.5.1 which requires you to manually add
+7. There is a bug in Talend Open Studio which requires you to manually add
 	the component dependency and runtime artifacts to the job's classpath in
 	order to be able to run the job with a custom component.
 
 	See bug report: https://community.talend.com/t5/Design-and-Development/Component-definition-is-not-added-to-the-job-s-classpath-in/m-p/49285/highlight/true#M15736
+
+	Alternative workaround:
+	```
+	1. Right mouse click on `.Java` project or if you use TOS 7.0.1+ the project
+		called `LOCAL_PROJECT_$ActualJobName$` in `Navigator` view
+	2. Maven -> Update Project
+	3. Uncheck "Offline" and run Update
+	```

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
@@ -261,6 +261,13 @@ public class LiferayConnectionProperties
 		testConnectionWidget.setLongRunning(true);
 		testConnectionWidget.setWidgetType(Widget.BUTTON_WIDGET_TYPE);
 
+		Widget advancedFormWizardWidget = Widget.widget(advanced);
+
+		advancedFormWizardWidget.setWidgetType(Widget.BUTTON_WIDGET_TYPE);
+
+		wizardForm.addRow(advancedFormWizardWidget);
+
+		wizardForm.addColumn(testConnectionWidget);
 
 		// Main form
 
@@ -355,6 +362,8 @@ public class LiferayConnectionProperties
 		advancedForm.addRow(followRedirects);
 
 		advancedForm.addRow(forceHttps);
+
+		advanced.setFormtoShow(advancedForm);
 	}
 
 	@Override
@@ -401,6 +410,7 @@ public class LiferayConnectionProperties
 		}
 	}
 
+	public PresentationItem advanced = new PresentationItem("advanced");
 	public Property<Boolean> anonymousLogin = PropertyFactory.newBoolean(
 		"anonymousLogin");
 	public Property<Integer> connectTimeout = PropertyFactory.newInteger(

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
@@ -292,6 +292,22 @@ public class LiferayConnectionProperties
 
 		wizardForm.addRow(anonymousLogin);
 
+		wizardForm.addRow(siteFilter);
+
+		Widget webSiteURLWizardWidget = Widget.widget(webSiteURL);
+
+		webSiteURLWizardWidget.setCallAfter(true);
+		webSiteURLWizardWidget.setWidgetType(
+			Widget.NAME_SELECTION_AREA_WIDGET_TYPE);
+
+		wizardForm.addRow(webSiteURLWizardWidget);
+
+		Widget webSiteWizardWidget = Widget.widget(webSite);
+
+		webSiteWizardWidget.setReadonly(true);
+
+		wizardForm.addColumn(webSiteWizardWidget);
+
 		Widget testConnectionWidget = Widget.widget(testConnection);
 
 		testConnectionWidget.setLongRunning(true);

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
@@ -285,6 +285,7 @@ public class LiferayConnectionProperties
 		Widget webSiteURLWidget = Widget.widget(webSiteURL);
 
 		webSiteURLWidget.setCallAfter(true);
+		webSiteURLWidget.setLongRunning(true);
 		webSiteURLWidget.setWidgetType(
 			Widget.NAME_SELECTION_REFERENCE_WIDGET_TYPE);
 

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
@@ -35,7 +35,6 @@ import org.talend.daikon.i18n.GlobalI18N;
 import org.talend.daikon.i18n.I18nMessageProvider;
 import org.talend.daikon.i18n.I18nMessages;
 import org.talend.daikon.properties.PresentationItem;
-import org.talend.daikon.properties.Properties;
 import org.talend.daikon.properties.ValidationResult;
 import org.talend.daikon.properties.ValidationResult.Result;
 import org.talend.daikon.properties.ValidationResultMutable;
@@ -44,7 +43,6 @@ import org.talend.daikon.properties.presentation.Widget;
 import org.talend.daikon.properties.property.Property;
 import org.talend.daikon.properties.property.PropertyFactory;
 import org.talend.daikon.properties.property.StringProperty;
-import org.talend.daikon.properties.service.Repository;
 import org.talend.daikon.sandbox.SandboxedInstance;
 
 /**
@@ -65,32 +63,6 @@ public class LiferayConnectionProperties
 		refreshLayout(getForm(FORM_WIZARD));
 	}
 
-	public ValidationResult afterFormFinishWizard(Repository<Properties> repo) {
-		try (SandboxedInstance sandboxedInstance =
-				getRuntimeSandboxedInstance()) {
-
-			LiferaySourceOrSinkRuntime liferaySourceOrSinkRuntime =
-				(LiferaySourceOrSinkRuntime)sandboxedInstance.getInstance();
-
-			liferaySourceOrSinkRuntime.initialize(null, this);
-
-			ValidationResult validationResult =
-				liferaySourceOrSinkRuntime.validateConnection(this);
-
-			if (validationResult.getStatus() != ValidationResult.Result.OK) {
-				return validationResult;
-			}
-
-			repo.storeProperties(
-				this, name.getValue(), repositoryLocation, null);
-
-			return ValidationResult.OK;
-		}
-		catch (Exception e) {
-			return new ValidationResult(Result.ERROR, e.getMessage());
-		}
-	}
-
 	public void afterReferencedComponent() {
 		refreshLayout(getForm(Form.MAIN));
 		refreshLayout(getForm(Form.REFERENCE));
@@ -99,6 +71,7 @@ public class LiferayConnectionProperties
 	public void afterSiteFilter() {
 		refreshLayout(getForm(Form.MAIN));
 		refreshLayout(getForm(Form.REFERENCE));
+		refreshLayout(getForm(FORM_WIZARD));
 	}
 
 	public ValidationResult afterWebSiteURL() {
@@ -148,12 +121,9 @@ public class LiferayConnectionProperties
 			}
 		}
 
-		if (validationResultMutable.getStatus() ==
-				ValidationResult.Result.ERROR) {
-		}
-
 		refreshLayout(getForm(Form.MAIN));
 		refreshLayout(getForm(Form.REFERENCE));
+		refreshLayout(getForm(FORM_WIZARD));
 
 		return validationResultMutable;
 	}
@@ -261,12 +231,6 @@ public class LiferayConnectionProperties
 		}
 	}
 
-	public LiferayConnectionProperties setRepositoryLocation(String location) {
-		repositoryLocation = location;
-
-		return this;
-	}
-
 	@Override
 	public void setupLayout() {
 		super.setupLayout();
@@ -292,28 +256,11 @@ public class LiferayConnectionProperties
 
 		wizardForm.addRow(anonymousLogin);
 
-		wizardForm.addRow(siteFilter);
-
-		Widget webSiteURLWizardWidget = Widget.widget(webSiteURL);
-
-		webSiteURLWizardWidget.setCallAfter(true);
-		webSiteURLWizardWidget.setWidgetType(
-			Widget.NAME_SELECTION_AREA_WIDGET_TYPE);
-
-		wizardForm.addRow(webSiteURLWizardWidget);
-
-		Widget webSiteWizardWidget = Widget.widget(webSite);
-
-		webSiteWizardWidget.setReadonly(true);
-
-		wizardForm.addColumn(webSiteWizardWidget);
-
 		Widget testConnectionWidget = Widget.widget(testConnection);
 
 		testConnectionWidget.setLongRunning(true);
 		testConnectionWidget.setWidgetType(Widget.BUTTON_WIDGET_TYPE);
 
-		wizardForm.addRow(testConnectionWidget);
 
 		// Main form
 
@@ -515,14 +462,6 @@ public class LiferayConnectionProperties
 		i18nMessages = i18nMessageProvider.getI18nMessages(
 			LiferayConnectionProperties.class);
 	}
-
-	/**
-	 * This must be named <code>repositoryLocation</code> since Talend uses
-	 * reflection to get a field named this. See <a
-	 * href="https://github.com/Talend/tdi-studio-se/blob/125a8144597e5d5faa1f7001ce345cdfd6dc1fe3/main/plugins/org.talend.repository.generic/src/main/java/org/talend/repository/generic/ui/GenericConnWizard.java#L111">here</a>
-	 * for more information.
-	 */
-	protected String repositoryLocation;
 
 	private static final int _CONNECT_TIMEOUT = 30;
 

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
@@ -71,7 +71,6 @@ public class LiferayConnectionProperties
 	public void afterSiteFilter() {
 		refreshLayout(getForm(Form.MAIN));
 		refreshLayout(getForm(Form.REFERENCE));
-		refreshLayout(getForm(FORM_WIZARD));
 	}
 
 	public ValidationResult afterWebSiteURL() {

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
@@ -241,19 +241,23 @@ public class LiferayConnectionProperties
 			useOtherConnection = true;
 		}
 
-		String formName = form.getName();
+		PropertiesUtils.setHidden(form, anonymousLogin, useOtherConnection);
+		PropertiesUtils.setHidden(form, endpoint, useOtherConnection);
+		PropertiesUtils.setHidden(form, loginType, useOtherConnection);
+		PropertiesUtils.setHidden(form, password, useOtherConnection);
+		PropertiesUtils.setHidden(form, siteFilter, useOtherConnection);
+		PropertiesUtils.setHidden(form, userId, useOtherConnection);
+		PropertiesUtils.setHidden(form, webSite, useOtherConnection);
+		PropertiesUtils.setHidden(form, webSiteURL, useOtherConnection);
 
-		if (formName.equals(Form.MAIN) || formName.equals(FORM_WIZARD)) {
-			PropertiesUtils.setHidden(form, endpoint, useOtherConnection);
-			PropertiesUtils.setHidden(form, loginType, useOtherConnection);
-			PropertiesUtils.setHidden(form, userId, useOtherConnection);
-			PropertiesUtils.setHidden(form, password, useOtherConnection);
-			PropertiesUtils.setHidden(form, anonymousLogin, useOtherConnection);
+		if (!useOtherConnection && anonymousLogin.getValue()) {
+			PropertiesUtils.setHidden(form, userId, true);
+			PropertiesUtils.setHidden(form, password, true);
+		}
 
-			if (!useOtherConnection && anonymousLogin.getValue()) {
-				PropertiesUtils.setHidden(form, userId, true);
-				PropertiesUtils.setHidden(form, password, true);
-			}
+		if (!useOtherConnection && !siteFilter.getValue()) {
+			PropertiesUtils.setHidden(form, webSite, true);
+			PropertiesUtils.setHidden(form, webSiteURL, true);
 		}
 	}
 

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
@@ -223,7 +223,7 @@ public class LiferayConnectionProperties
 				"null",
 			getReferencedComponentId());
 
-		return null;
+		return getLiferayConnectionProperties();
 	}
 
 	@Override

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
@@ -295,7 +295,7 @@ public class LiferayConnectionProperties
 		referencedComponent = new ComponentReferenceProperties<>(
 			"referencedComponent", TLiferayConnectionDefinition.COMPONENT_NAME);
 	public PresentationItem testConnection = new PresentationItem(
-		"testConnection", "Test Connection");
+		"testConnection");
 	public Property<String> userId = PropertyFactory.newString("userId");
 
 	public enum LoginType {

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionProperties.java
@@ -122,7 +122,6 @@ public class LiferayConnectionProperties
 
 		refreshLayout(getForm(Form.MAIN));
 		refreshLayout(getForm(Form.REFERENCE));
-		refreshLayout(getForm(FORM_WIZARD));
 
 		return validationResultMutable;
 	}

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferaySiteSelectorProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferaySiteSelectorProperties.java
@@ -52,7 +52,9 @@ public class LiferaySiteSelectorProperties
 		super(name);
 	}
 
-	public ValidationResult afterFormFinishMain(Repository<Properties> repo) {
+	public ValidationResult afterFormFinishMain(
+		Repository<Properties> repository) {
+
 		try (SandboxedInstance sandboxedInstance =
 				LiferayBaseComponentDefinition.getSandboxedInstance(
 					LiferayBaseComponentDefinition.
@@ -93,7 +95,7 @@ public class LiferaySiteSelectorProperties
 					webSiteURLSimpleNamedThing.getName());
 			}
 
-			repo.storeProperties(
+			repository.storeProperties(
 				connection, connection.name.getValue(), repositoryLocation,
 				null);
 
@@ -164,20 +166,14 @@ public class LiferaySiteSelectorProperties
 		return repositoryLocation;
 	}
 
-	public LiferaySiteSelectorProperties setConnection(
-		LiferayConnectionProperties connection) {
+	public void setConnection(
+		LiferayConnectionProperties liferayConnectionProperties) {
 
-		this.connection = connection;
-
-		return this;
+		connection = liferayConnectionProperties;
 	}
 
-	public LiferaySiteSelectorProperties setRepositoryLocation(
-		String location) {
-
-		repositoryLocation = location;
-
-		return this;
+	public void setRepositoryLocation(String repositoryLocation) {
+		this.repositoryLocation = repositoryLocation;
 	}
 
 	@Override

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferaySiteSelectorProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferaySiteSelectorProperties.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.talend.connection;
+
+import com.liferay.talend.LiferayBaseComponentDefinition;
+import com.liferay.talend.exception.ExceptionUtils;
+import com.liferay.talend.runtime.LiferaySourceOrSinkRuntime;
+
+import java.io.IOException;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.talend.components.api.exception.ComponentException;
+import org.talend.components.api.properties.ComponentPropertiesImpl;
+import org.talend.daikon.NamedThing;
+import org.talend.daikon.i18n.GlobalI18N;
+import org.talend.daikon.i18n.I18nMessageProvider;
+import org.talend.daikon.i18n.I18nMessages;
+import org.talend.daikon.properties.Properties;
+import org.talend.daikon.properties.ValidationResult;
+import org.talend.daikon.properties.ValidationResultMutable;
+import org.talend.daikon.properties.presentation.Form;
+import org.talend.daikon.properties.presentation.Widget;
+import org.talend.daikon.properties.property.PropertyFactory;
+import org.talend.daikon.properties.property.StringProperty;
+import org.talend.daikon.properties.service.Repository;
+import org.talend.daikon.sandbox.SandboxedInstance;
+
+/**
+ * @author Zoltán Takács
+ */
+public class LiferaySiteSelectorProperties
+	extends ComponentPropertiesImpl
+	implements LiferayConnectionPropertiesProvider {
+
+	public LiferaySiteSelectorProperties(String name) {
+		super(name);
+	}
+
+	public ValidationResult afterFormFinishMain(Repository<Properties> repo) {
+		try (SandboxedInstance sandboxedInstance =
+				LiferayBaseComponentDefinition.getSandboxedInstance(
+					LiferayBaseComponentDefinition.
+						RUNTIME_SOURCE_OR_SINK_CLASS_NAME)) {
+
+			LiferaySourceOrSinkRuntime liferaySourceOrSinkRuntime =
+				(LiferaySourceOrSinkRuntime)sandboxedInstance.getInstance();
+
+			liferaySourceOrSinkRuntime.initialize(null, this);
+
+			ValidationResult validationResult =
+				liferaySourceOrSinkRuntime.validateConnection(connection);
+
+			if (validationResult.getStatus() != ValidationResult.Result.OK) {
+				return validationResult;
+			}
+
+			repo.storeProperties(
+				connection, connection.name.getValue(), repositoryLocation,
+				null);
+
+			return ValidationResult.OK;
+		}
+		catch (Exception e) {
+			return new ValidationResult(
+				ValidationResult.Result.ERROR, e.getMessage());
+		}
+	}
+
+	public ValidationResult afterWebSiteURL() {
+		if (_log.isDebugEnabled()) {
+			_log.debug("Website URL: " + webSiteURL.getValue());
+		}
+
+		ValidationResultMutable validationResultMutable =
+			new ValidationResultMutable();
+
+		validationResultMutable.setStatus(ValidationResult.Result.OK);
+
+		try (SandboxedInstance sandboxedInstance =
+				LiferayBaseComponentDefinition.getSandboxedInstance(
+					LiferayBaseComponentDefinition.
+						RUNTIME_SOURCE_OR_SINK_CLASS_NAME)) {
+
+			LiferaySourceOrSinkRuntime liferaySourceOrSinkRuntime =
+				(LiferaySourceOrSinkRuntime)sandboxedInstance.getInstance();
+
+			liferaySourceOrSinkRuntime.initialize(null, connection);
+
+			ValidationResult validationResult =
+				liferaySourceOrSinkRuntime.validate(null);
+
+			validationResultMutable.setMessage(validationResult.getMessage());
+			validationResultMutable.setStatus(validationResult.getStatus());
+
+			if (validationResultMutable.getStatus() ==
+					ValidationResult.Result.OK) {
+
+				try {
+					connection.webSite.setValue(
+						liferaySourceOrSinkRuntime.getActualWebSiteName(
+							webSiteURL.getValue()));
+				}
+				catch (IOException ioe) {
+					validationResult =
+						ExceptionUtils.exceptionToValidationResult(ioe);
+
+					validationResultMutable.setMessage(
+						validationResult.getMessage());
+					validationResultMutable.setStatus(
+						validationResult.getStatus());
+				}
+			}
+		}
+
+		refreshLayout(getForm(Form.MAIN));
+
+		return validationResultMutable;
+	}
+
+	public void beforeFormPresentMain() throws Exception {
+		try (SandboxedInstance sandboxedInstance =
+				LiferayBaseComponentDefinition.getSandboxedInstance(
+					LiferayBaseComponentDefinition.
+						RUNTIME_SOURCE_OR_SINK_CLASS_NAME)) {
+
+			LiferaySourceOrSinkRuntime liferaySourceOrSinkRuntime =
+				(LiferaySourceOrSinkRuntime)sandboxedInstance.getInstance();
+
+			liferaySourceOrSinkRuntime.initialize(null, connection);
+
+			ValidationResultMutable validationResultMutable =
+				new ValidationResultMutable();
+
+			ValidationResult validationResult =
+				liferaySourceOrSinkRuntime.validate(null);
+
+			validationResultMutable.setStatus(validationResult.getStatus());
+
+			if (validationResultMutable.getStatus() ==
+					ValidationResult.Result.OK) {
+
+				try {
+					_sites = liferaySourceOrSinkRuntime.getAvailableWebSites();
+
+					if (_sites.isEmpty()) {
+						validationResultMutable.setMessage(
+							i18nMessages.getMessage(
+								"error.validation.websites"));
+						validationResultMutable.setStatus(
+							ValidationResult.Result.ERROR);
+					}
+
+					webSiteURL.setPossibleNamedThingValues(_sites);
+
+					connection.webSiteURL.setPossibleNamedThingValues(_sites);
+
+					getForm(Form.MAIN).setAllowBack(true);
+					getForm(Form.MAIN).setAllowFinish(true);
+				}
+				catch (Exception e) {
+					throw new ComponentException(e);
+				}
+			}
+		}
+	}
+
+	@Override
+	public LiferayConnectionProperties getLiferayConnectionProperties() {
+		return connection;
+	}
+
+	public String getRepositoryLocation() {
+		return repositoryLocation;
+	}
+
+	public LiferaySiteSelectorProperties setConnection(
+		LiferayConnectionProperties connection) {
+
+		this.connection = connection;
+
+		return this;
+	}
+
+	public LiferaySiteSelectorProperties setRepositoryLocation(
+		String location) {
+
+		repositoryLocation = location;
+
+		return this;
+	}
+
+	@Override
+	public void setupLayout() {
+		super.setupLayout();
+
+		Form siteForm = Form.create(this, Form.MAIN);
+
+		Widget webSiteURLWizardWidget = Widget.widget(webSiteURL);
+
+		webSiteURLWizardWidget.setWidgetType(
+			Widget.NAME_SELECTION_AREA_WIDGET_TYPE);
+
+		siteForm.addRow(webSiteURLWizardWidget);
+
+		refreshLayout(siteForm);
+	}
+
+	public LiferayConnectionProperties connection =
+		new LiferayConnectionProperties("connection");
+	public StringProperty webSiteURL = PropertyFactory.newString("webSiteURL");
+
+	protected static final I18nMessages i18nMessages;
+
+	static {
+		I18nMessageProvider i18nMessageProvider =
+			GlobalI18N.getI18nMessageProvider();
+
+		i18nMessages = i18nMessageProvider.getI18nMessages(
+			LiferaySiteSelectorProperties.class);
+	}
+
+	/**
+	 * This must be named <code>repositoryLocation</code> since Talend uses
+	 * reflection to get a field named this. See <a
+	 * href="https://github.com/Talend/tdi-studio-se/blob/125a8144597e5d5faa1f7001ce345cdfd6dc1fe3/main/plugins/org.talend.repository.generic/src/main/java/org/talend/repository/generic/ui/GenericConnWizard.java#L111">here</a>
+	 * for more information.
+	 */
+	protected String repositoryLocation;
+
+	private static final Logger _log = LoggerFactory.getLogger(
+		LiferaySiteSelectorProperties.class);
+
+	private List<NamedThing> _sites;
+
+}

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/resource/LiferayResourceProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/resource/LiferayResourceProperties.java
@@ -392,7 +392,7 @@ public class LiferayResourceProperties
 	public Property<Boolean> siteFilter = PropertyFactory.newBoolean(
 		"siteFilter");
 	public transient PresentationItem validateCondition = new PresentationItem(
-		"validateCondition", "Validate Condition");
+		"validateCondition");
 	public Property<String> webSite = PropertyFactory.newString("webSite");
 	public StringProperty webSiteURL = PropertyFactory.newString("webSiteURL");
 

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/tliferayinput/TLiferayInputProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/tliferayinput/TLiferayInputProperties.java
@@ -132,7 +132,7 @@ public class TLiferayInputProperties
 	}
 
 	public transient PresentationItem guessSchema = new PresentationItem(
-		"guessSchema", "Guess Schema");
+		"guessSchema");
 
 	@Override
 	protected Set<PropertyPathConnector> getAllSchemaPropertiesConnectors(

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/tliferayoutput/TLiferayOutputProperties.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/tliferayoutput/TLiferayOutputProperties.java
@@ -318,7 +318,7 @@ public class TLiferayOutputProperties
 	}
 
 	public transient PresentationItem calculateSchema = new PresentationItem(
-		"calculateSchema", "Calculate Schema");
+		"calculateSchema");
 	public Property<Boolean> dieOnError = PropertyFactory.newBoolean(
 		"dieOnError");
 	public Property<Action> operations = PropertyFactory.newEnum(

--- a/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/wizard/LiferayConnectionWizard.java
+++ b/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/wizard/LiferayConnectionWizard.java
@@ -15,10 +15,12 @@
 package com.liferay.talend.wizard;
 
 import com.liferay.talend.connection.LiferayConnectionProperties;
+import com.liferay.talend.connection.LiferaySiteSelectorProperties;
 
 import org.talend.components.api.properties.ComponentProperties;
 import org.talend.components.api.wizard.ComponentWizard;
 import org.talend.components.api.wizard.ComponentWizardDefinition;
+import org.talend.daikon.properties.presentation.Form;
 
 /**
  * @author Zoltán Takács
@@ -31,25 +33,30 @@ public class LiferayConnectionWizard extends ComponentWizard {
 
 		super(componentWizardDefinition, repositoryLocation);
 
-		liferayConnectionProperties = new LiferayConnectionProperties(
-			"connection");
+		connection = new LiferayConnectionProperties("connection");
 
-		liferayConnectionProperties.init();
+		connection.init();
 
-		liferayConnectionProperties.setRepositoryLocation(repositoryLocation);
+		addForm(connection.getForm(LiferayConnectionProperties.FORM_WIZARD));
 
-		addForm(
-			liferayConnectionProperties.getForm(
-				LiferayConnectionProperties.FORM_WIZARD));
+		siteSelector = new LiferaySiteSelectorProperties("siteSelector");
+
+		siteSelector.setConnection(connection);
+		siteSelector.setRepositoryLocation(getRepositoryLocation());
+
+		siteSelector.init();
+
+		addForm(siteSelector.getForm(Form.MAIN));
 	}
 
 	public void setupProperties(
 		LiferayConnectionProperties liferayConnectionProperties) {
 
-		this.liferayConnectionProperties.setupProperties();
+		this.connection.setupProperties();
 
-		this.liferayConnectionProperties.copyValuesFrom(
-			liferayConnectionProperties);
+		this.connection.copyValuesFrom(liferayConnectionProperties);
+
+		this.siteSelector.setConnection(liferayConnectionProperties);
 	}
 
 	public boolean supportsProperties(ComponentProperties componentProperties) {
@@ -60,6 +67,7 @@ public class LiferayConnectionWizard extends ComponentWizard {
 		return false;
 	}
 
-	protected LiferayConnectionProperties liferayConnectionProperties;
+	public LiferayConnectionProperties connection;
+	public LiferaySiteSelectorProperties siteSelector;
 
 }

--- a/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/connection/LiferayConnectionProperties.properties
+++ b/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/connection/LiferayConnectionProperties.properties
@@ -10,6 +10,7 @@ form.Wizard.displayName=Liferay Connection Settings
 form.Wizard.subtitle=Complete these fields in order to connect to your Liferay installation.
 form.Wizard.title=Liferay Connection Settings
 
+presItem.advanced.displayName=Advanced...
 presItem.testConnection.displayName=Test Connection
 
 property.anonymousLogin.displayName=Anonymous

--- a/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/connection/LiferayConnectionProperties.properties
+++ b/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/connection/LiferayConnectionProperties.properties
@@ -1,3 +1,5 @@
+error.validation.websites=Unable to find Website resources. Please check the endpoint URL specified for the server.
+
 form.Advanced.displayName=Advanced
 form.Advanced.title=Advanced
 form.Main.displayName=Main
@@ -19,4 +21,7 @@ property.name.displayName=Name
 property.password.displayName=Password
 property.readTimeout.displayName=REST Read Timeout (s)
 property.testConnection.displayName=Test Connection
+property.siteFilter.displayName=Site Filter
 property.userId.displayName=User
+property.webSite.displayName=Website Name
+property.webSiteURL.displayName=Website URL

--- a/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/connection/LiferayConnectionProperties.properties
+++ b/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/connection/LiferayConnectionProperties.properties
@@ -18,4 +18,5 @@ property.loginType.displayName=Connection Type
 property.name.displayName=Name
 property.password.displayName=Password
 property.readTimeout.displayName=REST Read Timeout (s)
+property.testConnection.displayName=Test Connection
 property.userId.displayName=User

--- a/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/connection/LiferayConnectionProperties.properties
+++ b/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/connection/LiferayConnectionProperties.properties
@@ -10,6 +10,8 @@ form.Wizard.displayName=Liferay Connection Settings
 form.Wizard.subtitle=Complete these fields in order to connect to your Liferay installation.
 form.Wizard.title=Liferay Connection Settings
 
+presItem.testConnection.displayName=Test Connection
+
 property.anonymousLogin.displayName=Anonymous
 property.connectTimeout.displayName=REST Connection Timeout (s)
 property.endpoint.displayName=Liferay URL
@@ -20,7 +22,6 @@ property.loginType.displayName=Connection Type
 property.name.displayName=Name
 property.password.displayName=Password
 property.readTimeout.displayName=REST Read Timeout (s)
-property.testConnection.displayName=Test Connection
 property.siteFilter.displayName=Site Filter
 property.userId.displayName=User
 property.webSite.displayName=Website Name

--- a/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/connection/LiferaySiteSelectorProperties.properties
+++ b/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/connection/LiferaySiteSelectorProperties.properties
@@ -1,0 +1,8 @@
+error.validation.websites=Unable to find Website resources. Please check the endpoint URL specified for the server.
+
+form.Advanced.displayName=Advanced
+form.Advanced.title=Advanced
+form.Main.displayName=Main
+form.Main.title=Main
+
+property.webSiteURL.displayName=Website URL

--- a/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/connection/LiferaySiteSelectorProperties.properties
+++ b/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/connection/LiferaySiteSelectorProperties.properties
@@ -2,7 +2,8 @@ error.validation.websites=Unable to find Website resources. Please check the end
 
 form.Advanced.displayName=Advanced
 form.Advanced.title=Advanced
-form.Main.displayName=Main
-form.Main.title=Main
+form.Main.displayName=Website Selector
+form.Main.subtitle=Select one Liferay site to work with
+form.Main.title=Website Selector
 
 property.webSiteURL.displayName=Website URL

--- a/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/resource/LiferayResourceProperties.properties
+++ b/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/resource/LiferayResourceProperties.properties
@@ -13,5 +13,6 @@ property.condition.displayName=Condition
 property.resource.displayName=Resource Type
 property.resourceURL.displayName=Resource URL
 property.siteFilter.displayName=Site Filter
+property.validateCondition.displayName=Validate Condition
 property.webSite.displayName=Website Name
 property.webSiteURL.displayName=Website URL

--- a/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/resource/LiferayResourceProperties.properties
+++ b/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/resource/LiferayResourceProperties.properties
@@ -8,7 +8,8 @@ form.Main.title=Main
 form.Reference.displayName=Reference
 form.Reference.title=Reference
 
+presItem.validateCondition.displayName=Validate Condition
+
 property.condition.displayName=Condition
 property.resource.displayName=Resource Type
-property.validateCondition.displayName=Validate Condition
 property.resourceURL.displayName=Resource URL

--- a/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/resource/LiferayResourceProperties.properties
+++ b/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/resource/LiferayResourceProperties.properties
@@ -1,6 +1,5 @@
 error.validation.resources=Unable to find any exposed resources. Please check the endpoint URL specified for the server.
 error.validation.resourceType=Unable to determine the resource''s type. The resource must have at least one entity.
-error.validation.websites=Unable to find Website resources. Please check the endpoint URL specified for the server.
 
 form.Advanced.displayName=Advanced
 form.Advanced.title=Advanced
@@ -11,8 +10,5 @@ form.Reference.title=Reference
 
 property.condition.displayName=Condition
 property.resource.displayName=Resource Type
-property.resourceURL.displayName=Resource URL
-property.siteFilter.displayName=Site Filter
 property.validateCondition.displayName=Validate Condition
-property.webSite.displayName=Website Name
-property.webSiteURL.displayName=Website URL
+property.resourceURL.displayName=Resource URL

--- a/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/tliferayinput/TLiferayInputProperties.properties
+++ b/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/tliferayinput/TLiferayInputProperties.properties
@@ -5,4 +5,4 @@ form.Main.title=Main
 form.Reference.displayName=Reference
 form.Reference.title=Reference
 
-property.guessSchema.displayName=Guess Schema
+presItem.guessSchema.displayName=Guess Schema

--- a/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/tliferayinput/TLiferayInputProperties.properties
+++ b/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/tliferayinput/TLiferayInputProperties.properties
@@ -4,3 +4,5 @@ form.Main.displayName=Main
 form.Main.title=Main
 form.Reference.displayName=Reference
 form.Reference.title=Reference
+
+property.guessSchema.displayName=Guess Schema

--- a/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/tliferayoutput/TLiferayOutputProperties.properties
+++ b/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/tliferayoutput/TLiferayOutputProperties.properties
@@ -7,8 +7,9 @@ form.Main.title=Main
 form.Reference.displayName=Reference
 form.Reference.title=Reference
 
+presItem.calculateSchema.displayName=Calculate Schema
+
 property.dieOnError.displayName=Die on Error
-property.calculateSchema.displayName=Calculate Schema
 property.operations.displayName=Operation
 
 success.validation.operation=Operation successfully validated.

--- a/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/tliferayoutput/TLiferayOutputProperties.properties
+++ b/modules/etl/talend/talend-definition/src/main/resources/com/liferay/talend/tliferayoutput/TLiferayOutputProperties.properties
@@ -8,6 +8,7 @@ form.Reference.displayName=Reference
 form.Reference.title=Reference
 
 property.dieOnError.displayName=Die on Error
+property.calculateSchema.displayName=Calculate Schema
 property.operations.displayName=Operation
 
 success.validation.operation=Operation successfully validated.


### PR DESCRIPTION
Hi Brian,

Continuation of https://github.com/brianchandotcom/liferay-portal/pull/62234#issuecomment-414103623

Talend has some restrictions on the property names; the property must be named identically as the instance name. (https://github.com/Talend/components/wiki/5.-Component-Properties#properties)

The reason for 
```
	public LiferayConnectionProperties connection;
	public LiferaySiteSelectorProperties siteSelector;
```
is the same we discussed in https://github.com/brianchandotcom/liferay-portal/pull/60222#issuecomment-396999421

Please see the other occurrence in https://github.com/brianchandotcom/liferay-portal/blob/master/modules/etl/talend/talend-definition/src/main/java/com/liferay/talend/connection/LiferayConnectionResourceBaseProperties.java#L133-L135

I renamed the other two you've mentioned.

Please let me know if you have further concerns on this PR.

Thank you,
Zoltán