### PR TITLE
LRQA-42796 Move all references to GitWorkingDirectory.Remote to GitRemote

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CentralSubrepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CentralSubrepository.java
@@ -84,8 +84,8 @@ public class CentralSubrepository {
 
 			gitWorkingDirectory.checkoutLocalGitBranch(tempLocalGitBranch);
 
-			GitWorkingDirectory.Remote upstreamRemote =
-				gitWorkingDirectory.getRemote("upstream");
+			BaseGitRemote upstreamGitRemote = gitWorkingDirectory.getGitRemote(
+				"upstream");
 
 			upstreamLocalGitBranch = gitWorkingDirectory.getLocalGitBranch(
 				_subrepositoryUpstreamBranchName, true);
@@ -93,7 +93,7 @@ public class CentralSubrepository {
 			gitWorkingDirectory.fetch(
 				upstreamLocalGitBranch,
 				gitWorkingDirectory.getRemoteGitBranch(
-					_subrepositoryUpstreamBranchName, upstreamRemote, true));
+					_subrepositoryUpstreamBranchName, upstreamGitRemote, true));
 		}
 		finally {
 			if ((upstreamLocalGitBranch != null) &&

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CentralSubrepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CentralSubrepository.java
@@ -84,7 +84,7 @@ public class CentralSubrepository {
 
 			gitWorkingDirectory.checkoutLocalGitBranch(tempLocalGitBranch);
 
-			BaseGitRemote upstreamGitRemote = gitWorkingDirectory.getGitRemote(
+			GitRemote upstreamGitRemote = gitWorkingDirectory.getGitRemote(
 				"upstream");
 
 			upstreamLocalGitBranch = gitWorkingDirectory.getLocalGitBranch(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubDevSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubDevSyncUtil.java
@@ -29,9 +29,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
+ * @author Michael Hashimoto
  * @author Peter Yoo
  */
-public class LocalGitSyncUtil {
+public class GitHubDevSyncUtil {
 
 	public static LocalGitBranch createCachedLocalGitBranch(
 		LocalRepository localRepository, LocalGitBranch localGitBranch,
@@ -71,43 +72,43 @@ public class LocalGitSyncUtil {
 			localRepository, "liferay", name, "liferay", sha, sha, synchronize);
 	}
 
-	public static List<BaseGitRemote> getLocalGitGitRemotes(
+	public static List<BaseGitRemote> getGitHubDevGitRemotes(
 		GitWorkingDirectory gitWorkingDirectory) {
 
-		List<String> localGitRemoteURLs = getLocalGitRemoteURLs(
+		List<String> gitHubDevRemoteURLs = getGitHubDevRemoteURLs(
 			gitWorkingDirectory);
 
-		List<BaseGitRemote> localGitGitRemotes = new ArrayList<>(
-			localGitRemoteURLs.size());
+		List<BaseGitRemote> gitHubDevGitRemotes = new ArrayList<>(
+			gitHubDevRemoteURLs.size());
 
-		for (String localGitRemoteURL : localGitRemoteURLs) {
-			String localGitRemoteName =
-				"local-git-remote-" +
-					localGitRemoteURLs.indexOf(localGitRemoteURL);
+		for (String gitHubDevRemoteURL : gitHubDevRemoteURLs) {
+			String gitHubDevRemoteName =
+				"git-hub-dev-remote-" +
+					gitHubDevRemoteURLs.indexOf(gitHubDevRemoteURL);
 
 			BaseGitRemote baseGitRemote = gitWorkingDirectory.getGitRemote(
-				localGitRemoteName);
+				gitHubDevRemoteName);
 
 			if ((baseGitRemote == null) ||
-				!localGitRemoteURL.equals(baseGitRemote.getRemoteURL())) {
+				!gitHubDevRemoteURL.equals(baseGitRemote.getRemoteURL())) {
 
 				baseGitRemote = gitWorkingDirectory.addGitRemote(
-					true, localGitRemoteName, localGitRemoteURL);
+					true, gitHubDevRemoteName, gitHubDevRemoteURL);
 			}
 
-			localGitGitRemotes.add(baseGitRemote);
+			gitHubDevGitRemotes.add(baseGitRemote);
 		}
 
-		return localGitGitRemotes;
+		return gitHubDevGitRemotes;
 	}
 
-	public static String synchronizeToLocalGit(
+	public static String synchronizeToGitHubDev(
 			GitWorkingDirectory gitWorkingDirectory, String receiverUsername,
 			String senderBranchName, String senderUsername,
 			String senderBranchSHA, String upstreamBranchSHA)
 		throws IOException {
 
-		return synchronizeToLocalGit(
+		return synchronizeToGitHubDev(
 			gitWorkingDirectory, receiverUsername, 0, senderBranchName,
 			senderUsername, senderBranchSHA, upstreamBranchSHA);
 	}
@@ -129,7 +130,8 @@ public class LocalGitSyncUtil {
 	protected static void cacheBranches(
 		final GitWorkingDirectory gitWorkingDirectory,
 		final LocalGitBranch localGitBranch,
-		List<BaseGitRemote> localGitGitRemotes, final String upstreamUsername) {
+		List<BaseGitRemote> gitHubDevGitRemotes,
+		final String upstreamUsername) {
 
 		String currentBranchName = gitWorkingDirectory.getCurrentBranchName();
 		String localGitBranchName = localGitBranch.getName();
@@ -149,13 +151,13 @@ public class LocalGitSyncUtil {
 
 		List<Callable<Object>> callables = new ArrayList<>();
 
-		for (final BaseGitRemote localGitGitRemote : localGitGitRemotes) {
+		for (final BaseGitRemote gitHubDevGitRemote : gitHubDevGitRemotes) {
 			Callable<Object> callable = new SafeCallable<Object>() {
 
 				@Override
 				public Object safeCall() {
 					cacheBranch(
-						gitWorkingDirectory, localGitBranch, localGitGitRemote,
+						gitWorkingDirectory, localGitBranch, gitHubDevGitRemote,
 						start);
 
 					if (upstreamUsername.equals("liferay")) {
@@ -166,7 +168,7 @@ public class LocalGitSyncUtil {
 						gitWorkingDirectory.pushToRemoteRepository(
 							true, upstreamLocalGitBranch,
 							upstreamRemoteGitBranch.getName(),
-							localGitGitRemote);
+							gitHubDevGitRemote);
 					}
 
 					return null;
@@ -340,18 +342,18 @@ public class LocalGitSyncUtil {
 
 	protected static void deleteExpiredRemoteGitBranches(
 		final GitWorkingDirectory gitWorkingDirectory,
-		List<BaseGitRemote> localGitGitRemotes) {
+		List<BaseGitRemote> gitHubDevGitRemotes) {
 
 		final long start = System.currentTimeMillis();
 
 		List<Callable<Object>> callables = new ArrayList<>();
 
-		for (final BaseGitRemote localGitGitRemote : localGitGitRemotes) {
+		for (final BaseGitRemote gitHubDevGitRemote : gitHubDevGitRemotes) {
 			Callable<Object> callable = new SafeCallable<Object>() {
 
 				@Override
 				public Object safeCall() {
-					deleteExpiredCacheBranches(localGitGitRemote, start);
+					deleteExpiredCacheBranches(gitHubDevGitRemote, start);
 
 					return null;
 				}
@@ -374,13 +376,13 @@ public class LocalGitSyncUtil {
 	}
 
 	protected static void deleteExtraTimestampBranches(
-		BaseGitRemote localGitGitRemote) {
+		BaseGitRemote gitHubDevGitRemote) {
 
 		GitWorkingDirectory gitWorkingDirectory =
-			localGitGitRemote.getGitWorkingDirectory();
+			gitHubDevGitRemote.getGitWorkingDirectory();
 
 		List<RemoteGitBranch> remoteGitBranches =
-			gitWorkingDirectory.getRemoteGitBranches(localGitGitRemote);
+			gitWorkingDirectory.getRemoteGitBranches(gitHubDevGitRemote);
 
 		Collections.sort(remoteGitBranches);
 
@@ -425,18 +427,18 @@ public class LocalGitSyncUtil {
 	}
 
 	protected static void deleteExtraTimestampBranches(
-		List<BaseGitRemote> localGitGitRemotes) {
+		List<BaseGitRemote> gitHubDevGitRemotes) {
 
 		long start = System.currentTimeMillis();
 
 		List<Callable<Object>> callables = new ArrayList<>();
 
-		for (final BaseGitRemote localGitGitRemote : localGitGitRemotes) {
+		for (final BaseGitRemote gitHubDevGitRemote : gitHubDevGitRemotes) {
 			Callable<Object> callable = new SafeCallable<Object>() {
 
 				@Override
 				public Object safeCall() {
-					deleteExtraTimestampBranches(localGitGitRemote);
+					deleteExtraTimestampBranches(gitHubDevGitRemote);
 
 					return null;
 				}
@@ -686,14 +688,7 @@ public class LocalGitSyncUtil {
 		return cacheRemoteGitBranches;
 	}
 
-	protected static String getGitHubRemoteURL(
-		String repositoryName, String userName) {
-
-		return JenkinsResultsParserUtil.combine(
-			"git@github.com:", userName, "/", repositoryName, ".git");
-	}
-
-	protected static List<String> getLocalGitRemoteURLs(
+	protected static List<String> getGitHubDevRemoteURLs(
 		GitWorkingDirectory gitWorkingDirectory) {
 
 		Properties buildProperties;
@@ -710,19 +705,26 @@ public class LocalGitSyncUtil {
 
 		String[] gitCacheHostnames = gitCacheHostnamesPropertyValue.split(",");
 
-		List<String> localGitRemoteURLs = new ArrayList<>(
+		List<String> gitHubDevRemoteURLs = new ArrayList<>(
 			gitCacheHostnames.length);
 
 		for (String gitCacheHostname : gitCacheHostnames) {
-			localGitRemoteURLs.add(
+			gitHubDevRemoteURLs.add(
 				JenkinsResultsParserUtil.combine(
 					"git@", gitCacheHostname, ":",
 					gitWorkingDirectory.getRepositoryUsername(), "/",
 					gitWorkingDirectory.getRepositoryName(), ".git"));
 		}
 
-		return validateLocalGitRemoteURLs(
-			localGitRemoteURLs, gitWorkingDirectory);
+		return validateGitHubDevRemoteURLs(
+			gitHubDevRemoteURLs, gitWorkingDirectory);
+	}
+
+	protected static String getGitHubRemoteURL(
+		String repositoryName, String userName) {
+
+		return JenkinsResultsParserUtil.combine(
+			"git@github.com:", userName, "/", repositoryName, ".git");
 	}
 
 	protected static BaseGitRemote getRandomGitRemote(
@@ -842,7 +844,7 @@ public class LocalGitSyncUtil {
 		return true;
 	}
 
-	protected static String synchronizeToLocalGit(
+	protected static String synchronizeToGitHubDev(
 		GitWorkingDirectory gitWorkingDirectory, String receiverUsername,
 		int retryCount, String senderBranchName, String senderUsername,
 		String senderBranchSHA, String upstreamBranchSHA) {
@@ -875,36 +877,37 @@ public class LocalGitSyncUtil {
 			String upstreamBranchName =
 				gitWorkingDirectory.getUpstreamBranchName();
 
-			List<BaseGitRemote> localGitGitRemotes = null;
+			List<BaseGitRemote> gitHubDevGitRemotes = null;
 
 			try {
-				localGitGitRemotes = getLocalGitGitRemotes(gitWorkingDirectory);
+				gitHubDevGitRemotes = getGitHubDevGitRemotes(
+					gitWorkingDirectory);
 
 				deleteCacheLocalGitBranches(
 					cacheBranchName, gitWorkingDirectory);
 
-				deleteExtraTimestampBranches(localGitGitRemotes);
+				deleteExtraTimestampBranches(gitHubDevGitRemotes);
 
-				deleteOrphanedCacheBranches(localGitGitRemotes);
+				deleteOrphanedCacheBranches(gitHubDevGitRemotes);
 
 				deleteExpiredRemoteGitBranches(
-					gitWorkingDirectory, localGitGitRemotes);
+					gitWorkingDirectory, gitHubDevGitRemotes);
 
 				if (remoteGitBranchExists(
 						cacheBranchName, gitWorkingDirectory,
-						localGitGitRemotes)) {
+						gitHubDevGitRemotes)) {
 
 					System.out.println(
 						JenkinsResultsParserUtil.combine(
 							"Cache branch ", cacheBranchName,
 							" already exists"));
 
-					BaseGitRemote localGitGitRemote = getRandomGitRemote(
-						localGitGitRemotes);
+					BaseGitRemote gitHubDevGitRemote = getRandomGitRemote(
+						gitHubDevGitRemotes);
 
 					RemoteGitBranch cacheRemoteGitBranch =
 						gitWorkingDirectory.getRemoteGitBranch(
-							cacheBranchName, localGitGitRemote, true);
+							cacheBranchName, gitHubDevGitRemote, true);
 
 					gitWorkingDirectory.fetch(cacheRemoteGitBranch);
 
@@ -922,7 +925,7 @@ public class LocalGitSyncUtil {
 
 					updateCacheRemoteGitBranchTimestamp(
 						cacheBranchName, gitWorkingDirectory,
-						localGitGitRemotes);
+						gitHubDevGitRemotes);
 
 					return cacheBranchName;
 				}
@@ -937,7 +940,7 @@ public class LocalGitSyncUtil {
 
 				cacheBranches(
 					gitWorkingDirectory, cacheLocalGitBranch,
-					localGitGitRemotes, "liferay");
+					gitHubDevGitRemotes, "liferay");
 
 				return cacheBranchName;
 			}
@@ -946,7 +949,7 @@ public class LocalGitSyncUtil {
 					throw e;
 				}
 
-				localGitGitRemotes = null;
+				gitHubDevGitRemotes = null;
 				senderGitRemote = null;
 
 				System.out.println(
@@ -957,16 +960,16 @@ public class LocalGitSyncUtil {
 				gitWorkingDirectory.checkoutLocalGitBranch(
 					currentLocalGitBranch);
 
-				return synchronizeToLocalGit(
+				return synchronizeToGitHubDev(
 					gitWorkingDirectory, receiverUsername, retryCount + 1,
 					senderBranchName, senderUsername, senderBranchSHA,
 					upstreamBranchSHA);
 			}
 			finally {
-				if (localGitGitRemotes != null) {
+				if (gitHubDevGitRemotes != null) {
 					try {
 						gitWorkingDirectory.removeGitRemotes(
-							localGitGitRemotes);
+							gitHubDevGitRemotes);
 					}
 					catch (Exception e) {
 						e.printStackTrace();
@@ -1007,26 +1010,26 @@ public class LocalGitSyncUtil {
 	protected static void updateCacheRemoteGitBranchTimestamp(
 		final String cacheBranchName,
 		final GitWorkingDirectory gitWorkingDirectory,
-		List<BaseGitRemote> localGitGitRemotes) {
+		List<BaseGitRemote> gitHubDevGitRemotes) {
 
 		long start = System.currentTimeMillis();
 
 		List<RemoteGitBranch> cacheRemoteGitBranches = null;
-		BaseGitRemote localGitGitRemote = null;
+		BaseGitRemote gitHubDevGitRemote = null;
 
 		while (cacheRemoteGitBranches == null) {
 			try {
-				localGitGitRemote = getRandomGitRemote(localGitGitRemotes);
+				gitHubDevGitRemote = getRandomGitRemote(gitHubDevGitRemotes);
 
 				cacheRemoteGitBranches = getCacheRemoteGitBranches(
-					localGitGitRemote);
+					gitHubDevGitRemote);
 			}
 			catch (Exception e) {
 				e.printStackTrace();
 
-				localGitGitRemotes.remove(localGitGitRemote);
+				gitHubDevGitRemotes.remove(gitHubDevGitRemote);
 
-				if (localGitGitRemotes.isEmpty()) {
+				if (gitHubDevGitRemotes.isEmpty()) {
 					throw new RuntimeException(
 						"No remote repositories could be reached", e);
 				}
@@ -1055,7 +1058,7 @@ public class LocalGitSyncUtil {
 
 			if (updated) {
 				deleteFromAllRemotes(
-					cacheRemoteGitBranchName, localGitGitRemotes);
+					cacheRemoteGitBranchName, gitHubDevGitRemotes);
 
 				continue;
 			}
@@ -1095,10 +1098,10 @@ public class LocalGitSyncUtil {
 			try {
 				pushToAllRemotes(
 					true, newTimestampLocalGitBranch, newTimestampBranchName,
-					localGitGitRemotes);
+					gitHubDevGitRemotes);
 
 				deleteFromAllRemotes(
-					cacheRemoteGitBranchName, localGitGitRemotes);
+					cacheRemoteGitBranchName, gitHubDevGitRemotes);
 
 				updated = true;
 			}
@@ -1197,21 +1200,21 @@ public class LocalGitSyncUtil {
 		return upstreamLocalGitBranch;
 	}
 
-	protected static List<String> validateLocalGitRemoteURLs(
-		List<String> localGitRemoteURLs,
+	protected static List<String> validateGitHubDevRemoteURLs(
+		List<String> gitHubDevRemoteURLs,
 		final GitWorkingDirectory gitWorkingDirectory) {
 
 		List<Callable<String>> callables = new ArrayList<>();
 
-		for (final String localGitRemoteURL : localGitRemoteURLs) {
+		for (final String gitHubDevRemoteURL : gitHubDevRemoteURLs) {
 			Callable<String> callable = new SafeCallable<String>() {
 
 				@Override
 				public String safeCall() {
 					if (gitWorkingDirectory.isRemoteRepositoryAlive(
-							localGitRemoteURL)) {
+							gitHubDevRemoteURL)) {
 
-						return localGitRemoteURL;
+						return gitHubDevRemoteURL;
 					}
 
 					return null;
@@ -1225,15 +1228,15 @@ public class LocalGitSyncUtil {
 		ParallelExecutor<String> parallelExecutor = new ParallelExecutor<>(
 			callables, _threadPoolExecutor);
 
-		List<String> validatedLocalGitRemoteURLs = new ArrayList<>();
+		List<String> validatedGitHubDevRemoteURLs = new ArrayList<>();
 
-		for (String validatedLocalGitRemoteURL : parallelExecutor.execute()) {
-			if (validatedLocalGitRemoteURL != null) {
-				validatedLocalGitRemoteURLs.add(validatedLocalGitRemoteURL);
+		for (String validatedGitHubDevRemoteURL : parallelExecutor.execute()) {
+			if (validatedGitHubDevRemoteURL != null) {
+				validatedGitHubDevRemoteURLs.add(validatedGitHubDevRemoteURL);
 			}
 		}
 
-		return validatedLocalGitRemoteURLs;
+		return validatedGitHubDevRemoteURLs;
 	}
 
 	private static LocalGitBranch _createCachedLocalGitBranch(
@@ -1261,7 +1264,7 @@ public class LocalGitSyncUtil {
 			localRepository.getGitWorkingDirectory();
 
 		if (synchronize) {
-			synchronizeToLocalGit(
+			synchronizeToGitHubDev(
 				gitWorkingDirectory, receiverUsername, 0, senderBranchName,
 				senderUsername, senderBranchSHA, upstreamBranchSHA);
 		}
@@ -1270,12 +1273,12 @@ public class LocalGitSyncUtil {
 			receiverUsername, senderUsername, senderBranchSHA,
 			upstreamBranchSHA);
 
-		List<BaseGitRemote> localGitGitRemotes = getLocalGitGitRemotes(
+		List<BaseGitRemote> gitHubDevGitRemotes = getGitHubDevGitRemotes(
 			gitWorkingDirectory);
 
 		RemoteGitBranch remoteGitBranch =
 			gitWorkingDirectory.getRemoteGitBranch(
-				cacheBranchName, getRandomGitRemote(localGitGitRemotes));
+				cacheBranchName, getRandomGitRemote(gitHubDevGitRemotes));
 
 		if (!gitWorkingDirectory.localSHAExists(remoteGitBranch.getSHA())) {
 			gitWorkingDirectory.fetch(remoteGitBranch);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubRemoteRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubRemoteRepository.java
@@ -250,8 +250,8 @@ public class GitHubRemoteRepository extends RemoteRepository {
 
 	}
 
-	protected GitHubRemoteRepository(BaseGitRemote baseGitRemote) {
-		super(baseGitRemote);
+	protected GitHubRemoteRepository(GitRemote gitRemote) {
+		super(gitRemote);
 
 		if (!hostname.equals("github.com")) {
 			throw new IllegalArgumentException(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubRemoteRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubRemoteRepository.java
@@ -14,7 +14,6 @@
 
 package com.liferay.jenkins.results.parser;
 
-import com.liferay.jenkins.results.parser.GitWorkingDirectory.Remote;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HttpRequestMethod;
 
 import java.io.IOException;
@@ -251,8 +250,8 @@ public class GitHubRemoteRepository extends RemoteRepository {
 
 	}
 
-	protected GitHubRemoteRepository(Remote remote) {
-		super(remote);
+	protected GitHubRemoteRepository(BaseGitRemote baseGitRemote) {
+		super(baseGitRemote);
 
 		if (!hostname.equals("github.com")) {
 			throw new IllegalArgumentException(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRemote.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRemote.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 /**
  * @author Peter Yoo
  */
-public class BaseGitRemote implements Comparable<BaseGitRemote> {
+public class GitRemote implements Comparable<GitRemote> {
 
 	public static final Pattern gitLsRemotePattern = Pattern.compile(
 		"(?<sha>[^\\s]{40}+)[\\s]+refs/(?<type>[^/]+)+/(?<name>[^\\s]+)");
@@ -31,7 +31,7 @@ public class BaseGitRemote implements Comparable<BaseGitRemote> {
 			"(?<repositoryName>[^\\.]+)(.git)?"));
 
 	@Override
-	public int compareTo(BaseGitRemote otherGitRemote) {
+	public int compareTo(GitRemote otherGitRemote) {
 		int result = _name.compareTo(otherGitRemote._name);
 
 		if (result != 0) {
@@ -78,7 +78,7 @@ public class BaseGitRemote implements Comparable<BaseGitRemote> {
 			getName(), " (", getRemoteURL(), ")");
 	}
 
-	protected BaseGitRemote(
+	protected GitRemote(
 		GitWorkingDirectory gitWorkingDirectory, String[] remoteInputLines) {
 
 		_gitWorkingDirectory = gitWorkingDirectory;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitUtil.java
@@ -88,7 +88,7 @@ public class GitUtil {
 	public static List<RemoteGitRef> getRemoteGitRefs(
 		String remoteGitBranchName, File workingDirectory, String remoteURL) {
 
-		Matcher remoteURLMatcher = BaseGitRemote.remoteURLPattern.matcher(
+		Matcher remoteURLMatcher = GitRemote.remoteURLPattern.matcher(
 			remoteURL);
 
 		if (!remoteURLMatcher.find()) {
@@ -129,7 +129,7 @@ public class GitUtil {
 				remoteURLMatcher.group("username"));
 
 		for (String line : input.split("\n")) {
-			Pattern gitLsRemotePattern = BaseGitRemote.gitLsRemotePattern;
+			Pattern gitLsRemotePattern = GitRemote.gitLsRemotePattern;
 
 			Matcher gitLsRemoteMatcher = gitLsRemotePattern.matcher(line);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -41,13 +41,13 @@ import org.json.JSONObject;
  */
 public class GitWorkingDirectory {
 
-	public static String getGitHubUserName(BaseGitRemote baseGitRemote) {
-		String remoteURL = baseGitRemote.getRemoteURL();
+	public static String getGitHubUserName(GitRemote gitRemote) {
+		String remoteURL = gitRemote.getRemoteURL();
 
 		if (!remoteURL.contains("github.com")) {
 			throw new IllegalArgumentException(
 				JenkinsResultsParserUtil.combine(
-					baseGitRemote.getName(),
+					gitRemote.getName(),
 					" does not point to a GitHub repository"));
 		}
 
@@ -63,7 +63,7 @@ public class GitWorkingDirectory {
 		return userName.substring(0, userName.indexOf("/"));
 	}
 
-	public BaseGitRemote addGitRemote(
+	public GitRemote addGitRemote(
 		boolean force, String gitRemoteName, String remoteURL) {
 
 		if (gitRemoteExists(gitRemoteName)) {
@@ -375,10 +375,8 @@ public class GitWorkingDirectory {
 		deleteRemoteGitBranches(Arrays.asList(remoteGitBranch));
 	}
 
-	public void deleteRemoteGitBranch(
-		String branchName, BaseGitRemote baseGitRemote) {
-
-		deleteRemoteGitBranch(branchName, baseGitRemote.getRemoteURL());
+	public void deleteRemoteGitBranch(String branchName, GitRemote gitRemote) {
+		deleteRemoteGitBranch(branchName, gitRemote.getRemoteURL());
 	}
 
 	public void deleteRemoteGitBranch(
@@ -451,8 +449,8 @@ public class GitWorkingDirectory {
 		System.out.println();
 	}
 
-	public void fetch(BaseGitRemote baseGitRemote) {
-		fetch(baseGitRemote.getRemoteURL());
+	public void fetch(GitRemote gitRemote) {
+		fetch(gitRemote.getRemoteURL());
 	}
 
 	public LocalGitBranch fetch(LocalGitBranch localGitBranch) {
@@ -586,7 +584,7 @@ public class GitWorkingDirectory {
 			throw new IllegalArgumentException("Remote URL is null");
 		}
 
-		Matcher remoteURLMatcher = BaseGitRemote.remoteURLPattern.matcher(
+		Matcher remoteURLMatcher = GitRemote.remoteURLPattern.matcher(
 			remoteURL);
 
 		if (!remoteURLMatcher.find()) {
@@ -802,16 +800,16 @@ public class GitWorkingDirectory {
 		return _gitDirectory;
 	}
 
-	public BaseGitRemote getGitRemote(String name) {
+	public GitRemote getGitRemote(String name) {
 		if (name.equals("upstream")) {
 			name = "upstream-temp";
 		}
 
-		Map<String, BaseGitRemote> gitRemotes = getGitRemotes();
+		Map<String, GitRemote> gitRemotes = getGitRemotes();
 
 		name = name.trim();
 
-		BaseGitRemote gitRemote = gitRemotes.get(name);
+		GitRemote gitRemote = gitRemotes.get(name);
 
 		if ((gitRemote == null) && name.equals("upstream-temp")) {
 			JenkinsResultsParserUtil.sleep(1000);
@@ -825,13 +823,13 @@ public class GitWorkingDirectory {
 	}
 
 	public Set<String> getGitRemoteNames() {
-		Map<String, BaseGitRemote> gitRemotes = getGitRemotes();
+		Map<String, GitRemote> gitRemotes = getGitRemotes();
 
 		return gitRemotes.keySet();
 	}
 
-	public Map<String, BaseGitRemote> getGitRemotes() {
-		Map<String, BaseGitRemote> gitRemotes = new HashMap<>();
+	public Map<String, GitRemote> getGitRemotes() {
+		Map<String, GitRemote> gitRemotes = new HashMap<>();
 
 		int retries = 0;
 
@@ -898,16 +896,16 @@ public class GitWorkingDirectory {
 			sb.append("Found git remotes: ");
 
 			for (int i = 0; i < lines.length; i = i + 2) {
-				BaseGitRemote baseGitRemote = new BaseGitRemote(
+				GitRemote gitRemote = new GitRemote(
 					this, Arrays.copyOfRange(lines, i, i + 2));
 
 				if (i > 0) {
 					sb.append(", ");
 				}
 
-				sb.append(baseGitRemote.getName());
+				sb.append(gitRemote.getName());
 
-				gitRemotes.put(baseGitRemote.getName(), baseGitRemote);
+				gitRemotes.put(gitRemote.getName(), gitRemote);
 			}
 
 			System.out.println(sb);
@@ -1188,18 +1186,17 @@ public class GitWorkingDirectory {
 	}
 
 	public RemoteGitBranch getRemoteGitBranch(
-		String remoteGitBranchName, BaseGitRemote baseGitRemote) {
+		String remoteGitBranchName, GitRemote gitRemote) {
 
 		return getRemoteGitBranch(
-			remoteGitBranchName, baseGitRemote.getRemoteURL(), false);
+			remoteGitBranchName, gitRemote.getRemoteURL(), false);
 	}
 
 	public RemoteGitBranch getRemoteGitBranch(
-		String remoteGitBranchName, BaseGitRemote baseGitRemote,
-		boolean required) {
+		String remoteGitBranchName, GitRemote gitRemote, boolean required) {
 
 		return getRemoteGitBranch(
-			remoteGitBranchName, baseGitRemote.getRemoteURL(), required);
+			remoteGitBranchName, gitRemote.getRemoteURL(), required);
 	}
 
 	public RemoteGitBranch getRemoteGitBranch(
@@ -1245,10 +1242,8 @@ public class GitWorkingDirectory {
 		return null;
 	}
 
-	public List<RemoteGitBranch> getRemoteGitBranches(
-		BaseGitRemote baseGitRemote) {
-
-		return getRemoteGitBranches(null, baseGitRemote.getRemoteURL());
+	public List<RemoteGitBranch> getRemoteGitBranches(GitRemote gitRemote) {
+		return getRemoteGitBranches(null, gitRemote.getRemoteURL());
 	}
 
 	public List<RemoteGitBranch> getRemoteGitBranches(
@@ -1262,10 +1257,10 @@ public class GitWorkingDirectory {
 	}
 
 	public List<RemoteGitBranch> getRemoteGitBranches(
-		String remoteGitBranchName, BaseGitRemote baseGitRemote) {
+		String remoteGitBranchName, GitRemote gitRemote) {
 
 		return getRemoteGitBranches(
-			remoteGitBranchName, baseGitRemote.getRemoteURL());
+			remoteGitBranchName, gitRemote.getRemoteURL());
 	}
 
 	public List<RemoteGitBranch> getRemoteGitBranches(
@@ -1282,8 +1277,8 @@ public class GitWorkingDirectory {
 			remoteGitBranchName, _workingDirectory, remoteURL);
 	}
 
-	public List<String> getRemoteGitBranchNames(BaseGitRemote baseGitRemote) {
-		return getRemoteGitBranchNames(baseGitRemote.getRemoteURL());
+	public List<String> getRemoteGitBranchNames(GitRemote gitRemote) {
+		return getRemoteGitBranchNames(gitRemote.getRemoteURL());
 	}
 
 	public List<String> getRemoteGitBranchNames(
@@ -1306,10 +1301,10 @@ public class GitWorkingDirectory {
 	}
 
 	public String getRemoteGitBranchSHA(
-		String remoteGitBranchName, BaseGitRemote baseGitRemote) {
+		String remoteGitBranchName, GitRemote gitRemote) {
 
 		return getRemoteGitBranchSHA(
-			remoteGitBranchName, baseGitRemote.getRemoteURL());
+			remoteGitBranchName, gitRemote.getRemoteURL());
 	}
 
 	public String getRemoteGitBranchSHA(
@@ -1330,7 +1325,7 @@ public class GitWorkingDirectory {
 			throw new IllegalArgumentException("Remote URL is null");
 		}
 
-		Matcher remoteURLMatcher = BaseGitRemote.remoteURLPattern.matcher(
+		Matcher remoteURLMatcher = GitRemote.remoteURLPattern.matcher(
 			remoteURL);
 
 		if (!remoteURLMatcher.find()) {
@@ -1355,7 +1350,7 @@ public class GitWorkingDirectory {
 		String input = executionResult.getStandardOut();
 
 		for (String line : input.split("\n")) {
-			Matcher matcher = BaseGitRemote.gitLsRemotePattern.matcher(line);
+			Matcher matcher = GitRemote.gitLsRemotePattern.matcher(line);
 
 			if (matcher.find()) {
 				return matcher.group("sha");
@@ -1457,11 +1452,11 @@ public class GitWorkingDirectory {
 
 	public RemoteGitBranch pushToRemoteRepository(
 		boolean force, LocalGitBranch localGitBranch,
-		String remoteGitBranchName, BaseGitRemote baseGitRemote) {
+		String remoteGitBranchName, GitRemote gitRemote) {
 
 		return pushToRemoteRepository(
 			force, localGitBranch, remoteGitBranchName,
-			baseGitRemote.getRemoteURL());
+			gitRemote.getRemoteURL());
 	}
 
 	public RemoteGitBranch pushToRemoteRepository(
@@ -1485,7 +1480,7 @@ public class GitWorkingDirectory {
 			throw new IllegalArgumentException("Remote URL is null");
 		}
 
-		Matcher remoteURLMatcher = BaseGitRemote.remoteURLPattern.matcher(
+		Matcher remoteURLMatcher = GitRemote.remoteURLPattern.matcher(
 			remoteURL);
 
 		if (!remoteURLMatcher.find()) {
@@ -1584,9 +1579,9 @@ public class GitWorkingDirectory {
 	}
 
 	public boolean remoteGitBranchExists(
-		String branchName, BaseGitRemote baseGitRemote) {
+		String branchName, GitRemote gitRemote) {
 
-		return remoteGitBranchExists(branchName, baseGitRemote.getRemoteURL());
+		return remoteGitBranchExists(branchName, gitRemote.getRemoteURL());
 	}
 
 	public boolean remoteGitBranchExists(
@@ -1604,28 +1599,26 @@ public class GitWorkingDirectory {
 		return false;
 	}
 
-	public void removeGitRemote(BaseGitRemote baseGitRemote) {
-		if ((baseGitRemote == null) ||
-			!gitRemoteExists(baseGitRemote.getName())) {
-
+	public void removeGitRemote(GitRemote gitRemote) {
+		if ((gitRemote == null) || !gitRemoteExists(gitRemote.getName())) {
 			return;
 		}
 
 		ExecutionResult executionResult = executeBashCommands(
 			GitUtil.MAX_RETRIES, GitUtil.RETRY_DELAY, GitUtil.TIMEOUT,
-			"git remote rm " + baseGitRemote.getName());
+			"git remote rm " + gitRemote.getName());
 
 		if (executionResult.getExitValue() != 0) {
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(
-					"Unable to remove git remote ", baseGitRemote.getName(),
-					"\n", executionResult.getStandardError()));
+					"Unable to remove git remote ", gitRemote.getName(), "\n",
+					executionResult.getStandardError()));
 		}
 	}
 
-	public void removeGitRemotes(List<BaseGitRemote> baseGitRemotes) {
-		for (BaseGitRemote baseGitRemote : baseGitRemotes) {
-			removeGitRemote(baseGitRemote);
+	public void removeGitRemotes(List<GitRemote> gitRemotes) {
+		for (GitRemote gitRemote : gitRemotes) {
+			removeGitRemote(gitRemote);
 		}
 	}
 
@@ -1693,7 +1686,7 @@ public class GitWorkingDirectory {
 
 		_upstreamBranchName = upstreamBranchName;
 
-		BaseGitRemote upstreamTempGitRemote = getGitRemote("upstream-temp");
+		GitRemote upstreamTempGitRemote = getGitRemote("upstream-temp");
 
 		if (upstreamTempGitRemote != null) {
 			removeGitRemote(upstreamTempGitRemote);
@@ -1792,16 +1785,16 @@ public class GitWorkingDirectory {
 			"Real Git directory could not be found in " + gitFile.getPath());
 	}
 
-	protected BaseGitRemote getUpstreamGitRemote() {
-		Map<String, BaseGitRemote> gitRemotes = getGitRemotes();
+	protected GitRemote getUpstreamGitRemote() {
+		Map<String, GitRemote> gitRemotes = getGitRemotes();
 
-		BaseGitRemote gitRemote = gitRemotes.get("upstream");
+		GitRemote gitRemote = gitRemotes.get("upstream");
 
 		return gitRemote;
 	}
 
 	protected String loadRepositoryName() {
-		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
+		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		String remoteURL = upstreamGitRemote.getRemoteURL();
 
@@ -1836,7 +1829,7 @@ public class GitWorkingDirectory {
 	}
 
 	protected String loadRepositoryUsername() {
-		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
+		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		String remoteURL = upstreamGitRemote.getRemoteURL();
 
@@ -1847,13 +1840,13 @@ public class GitWorkingDirectory {
 	}
 
 	protected void setUpstreamGitRemoteToPrivateRepository() {
-		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
+		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		addGitRemote(true, "upstream-temp", upstreamGitRemote.getRemoteURL());
 	}
 
 	protected void setUpstreamGitRemoteToPublicRepository() {
-		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
+		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		addGitRemote(true, "upstream-temp", upstreamGitRemote.getRemoteURL());
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1661,17 +1661,6 @@ public class GitWorkingDirectory {
 		throw new RuntimeException("Unable to run: git status");
 	}
 
-	public static class Remote extends BaseGitRemote {
-
-		protected Remote(
-			GitWorkingDirectory gitWorkingDirectory,
-			String[] remoteInputLines) {
-
-			super(gitWorkingDirectory, remoteInputLines);
-		}
-
-	}
-
 	protected GitWorkingDirectory(
 			String upstreamBranchName, String workingDirectoryPath)
 		throws IOException {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LegacyDataArchiveUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LegacyDataArchiveUtil.java
@@ -88,9 +88,9 @@ public class LegacyDataArchiveUtil {
 		}
 
 		RemoteGitBranch remoteGitBranch =
-			_legacyGitWorkingDirectory.pushToRemote(
+			_legacyGitWorkingDirectory.pushToRemoteRepository(
 				true, _dataArchiveLocalGitBranch, dataArchiveBranchName,
-				_legacyGitWorkingDirectory.getUpstreamRemote());
+				_legacyGitWorkingDirectory.getUpstreamGitRemote());
 
 		if (remoteGitBranch == null) {
 			throw new RuntimeException(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -85,8 +85,8 @@ public class LocalGitSyncUtil {
 				"local-git-remote-" +
 					localGitRemoteURLs.indexOf(localGitRemoteURL);
 
-			BaseGitRemote baseGitRemote =
-				gitWorkingDirectory.getGitRemote(localGitRemoteName);
+			BaseGitRemote baseGitRemote = gitWorkingDirectory.getGitRemote(
+				localGitRemoteName);
 
 			if ((baseGitRemote == null) ||
 				!localGitRemoteURL.equals(baseGitRemote.getRemoteURL())) {
@@ -128,8 +128,8 @@ public class LocalGitSyncUtil {
 
 	protected static void cacheBranches(
 		final GitWorkingDirectory gitWorkingDirectory,
-		final LocalGitBranch localGitBranch, List<BaseGitRemote> localGitGitRemotes,
-		final String upstreamUsername) {
+		final LocalGitBranch localGitBranch,
+		List<BaseGitRemote> localGitGitRemotes, final String upstreamUsername) {
 
 		String currentBranchName = gitWorkingDirectory.getCurrentBranchName();
 		String localGitBranchName = localGitBranch.getName();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalRepository.java
@@ -41,7 +41,7 @@ public class LocalRepository extends BaseRepository {
 		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
 
 		return RepositoryFactory.getRemoteRepository(
-			gitWorkingDirectory.getRemote("upstream"));
+			gitWorkingDirectory.getGitRemote("upstream"));
 	}
 
 	public void writeRepositoryPropertiesFiles() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralSubrepositoryUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralSubrepositoryUtil.java
@@ -90,11 +90,11 @@ public class MergeCentralSubrepositoryUtil {
 					centralSubrepository.getSubrepositoryUpstreamCommit());
 
 				if (centralSubrepository.isCentralPullRequestCandidate()) {
-					GitWorkingDirectory.Remote upstreamRemote =
-						centralGitWorkingDirectory.getRemote("upstream");
+					BaseGitRemote upstreamGitRemote =
+						centralGitWorkingDirectory.getGitRemote("upstream");
 
 					if (!centralGitWorkingDirectory.remoteGitBranchExists(
-							mergeBranchName, upstreamRemote)) {
+							mergeBranchName, upstreamGitRemote)) {
 
 						LocalGitBranch topLevelLocalGitBranch =
 							centralGitWorkingDirectory.getLocalGitBranch(
@@ -269,13 +269,13 @@ public class MergeCentralSubrepositoryUtil {
 			CentralSubrepository centralSubrepository, String mergeBranchName)
 		throws IOException {
 
-		GitWorkingDirectory.Remote upstreamRemote =
-			centralGitWorkingDirectory.getRemote("upstream");
+		BaseGitRemote upstreamGitRemote =
+			centralGitWorkingDirectory.getGitRemote("upstream");
 
 		if (_upstreamRemoteGitBranchNames == null) {
 			_upstreamRemoteGitBranchNames =
 				centralGitWorkingDirectory.getRemoteGitBranchNames(
-					upstreamRemote);
+					upstreamGitRemote);
 		}
 
 		String mergeBranchNamePrefix = mergeBranchName.substring(
@@ -297,7 +297,7 @@ public class MergeCentralSubrepositoryUtil {
 			}
 
 			centralGitWorkingDirectory.deleteRemoteGitBranch(
-				upstreamRemoteGitBranchName, upstreamRemote);
+				upstreamRemoteGitBranchName, upstreamGitRemote);
 		}
 	}
 
@@ -427,17 +427,17 @@ public class MergeCentralSubrepositoryUtil {
 			"git@github.com:", receiverUserName, "/", centralRepositoryName,
 			".git");
 
-		GitWorkingDirectory.Remote originRemote =
-			centralGitWorkingDirectory.addRemote(
+		BaseGitRemote originGitRemote =
+			centralGitWorkingDirectory.addGitRemote(
 				true, "tempRemote", originRemoteURL);
 
 		try {
-			centralGitWorkingDirectory.pushToRemote(
+			centralGitWorkingDirectory.pushToRemoteRepository(
 				false, mergeLocalGitBranch, mergeLocalGitBranch.getName(),
-				originRemote);
+				originGitRemote);
 		}
 		finally {
-			centralGitWorkingDirectory.removeRemote(originRemote);
+			centralGitWorkingDirectory.removeGitRemote(originGitRemote);
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralSubrepositoryUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralSubrepositoryUtil.java
@@ -90,7 +90,7 @@ public class MergeCentralSubrepositoryUtil {
 					centralSubrepository.getSubrepositoryUpstreamCommit());
 
 				if (centralSubrepository.isCentralPullRequestCandidate()) {
-					BaseGitRemote upstreamGitRemote =
+					GitRemote upstreamGitRemote =
 						centralGitWorkingDirectory.getGitRemote("upstream");
 
 					if (!centralGitWorkingDirectory.remoteGitBranchExists(
@@ -269,8 +269,8 @@ public class MergeCentralSubrepositoryUtil {
 			CentralSubrepository centralSubrepository, String mergeBranchName)
 		throws IOException {
 
-		BaseGitRemote upstreamGitRemote =
-			centralGitWorkingDirectory.getGitRemote("upstream");
+		GitRemote upstreamGitRemote = centralGitWorkingDirectory.getGitRemote(
+			"upstream");
 
 		if (_upstreamRemoteGitBranchNames == null) {
 			_upstreamRemoteGitBranchNames =
@@ -427,7 +427,7 @@ public class MergeCentralSubrepositoryUtil {
 			"git@github.com:", receiverUserName, "/", centralRepositoryName,
 			".git");
 
-		BaseGitRemote originGitRemote = centralGitWorkingDirectory.addGitRemote(
+		GitRemote originGitRemote = centralGitWorkingDirectory.addGitRemote(
 			true, "tempRemote", originRemoteURL);
 
 		try {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralSubrepositoryUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralSubrepositoryUtil.java
@@ -427,9 +427,8 @@ public class MergeCentralSubrepositoryUtil {
 			"git@github.com:", receiverUserName, "/", centralRepositoryName,
 			".git");
 
-		BaseGitRemote originGitRemote =
-			centralGitWorkingDirectory.addGitRemote(
-				true, "tempRemote", originRemoteURL);
+		BaseGitRemote originGitRemote = centralGitWorkingDirectory.addGitRemote(
+			true, "tempRemote", originRemoteURL);
 
 		try {
 			centralGitWorkingDirectory.pushToRemoteRepository(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PluginsGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PluginsGitWorkingDirectory.java
@@ -42,29 +42,29 @@ public class PluginsGitWorkingDirectory extends GitWorkingDirectory {
 	}
 
 	@Override
-	protected void setUpstreamRemoteToPrivateRepository() {
-		Remote upstreamRemote = getUpstreamRemote();
+	protected void setUpstreamGitRemoteToPrivateRepository() {
+		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
 
-		String remoteURL = upstreamRemote.getRemoteURL();
+		String remoteURL = upstreamGitRemote.getRemoteURL();
 
 		if (!remoteURL.contains("-ee")) {
 			remoteURL = remoteURL.replace(".git", "-ee.git");
 		}
 
-		addRemote(true, "upstream-temp", remoteURL);
+		addGitRemote(true, "upstream-temp", remoteURL);
 	}
 
 	@Override
-	protected void setUpstreamRemoteToPublicRepository() {
-		Remote upstreamRemote = getUpstreamRemote();
+	protected void setUpstreamGitRemoteToPublicRepository() {
+		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
 
-		String remoteURL = upstreamRemote.getRemoteURL();
+		String remoteURL = upstreamGitRemote.getRemoteURL();
 
 		if (remoteURL.contains("-ee")) {
 			remoteURL = remoteURL.replace("-ee", "");
 		}
 
-		addRemote(true, "upstream-temp", remoteURL);
+		addGitRemote(true, "upstream-temp", remoteURL);
 	}
 
 	private static String _getPluginsUpstreamBranchName(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PluginsGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PluginsGitWorkingDirectory.java
@@ -43,7 +43,7 @@ public class PluginsGitWorkingDirectory extends GitWorkingDirectory {
 
 	@Override
 	protected void setUpstreamGitRemoteToPrivateRepository() {
-		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
+		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		String remoteURL = upstreamGitRemote.getRemoteURL();
 
@@ -56,7 +56,7 @@ public class PluginsGitWorkingDirectory extends GitWorkingDirectory {
 
 	@Override
 	protected void setUpstreamGitRemoteToPublicRepository() {
-		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
+		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		String remoteURL = upstreamGitRemote.getRemoteURL();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
@@ -243,29 +243,29 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 	}
 
 	@Override
-	protected void setUpstreamRemoteToPrivateRepository() {
-		Remote upstreamRemote = getUpstreamRemote();
+	protected void setUpstreamGitRemoteToPrivateRepository() {
+		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
 
-		String remoteURL = upstreamRemote.getRemoteURL();
+		String remoteURL = upstreamGitRemote.getRemoteURL();
 
 		if (!remoteURL.contains("-ee")) {
 			remoteURL = remoteURL.replace(".git", "-ee.git");
 		}
 
-		addRemote(true, "upstream-temp", remoteURL);
+		addGitRemote(true, "upstream-temp", remoteURL);
 	}
 
 	@Override
-	protected void setUpstreamRemoteToPublicRepository() {
-		Remote upstreamRemote = getUpstreamRemote();
+	protected void setUpstreamGitRemoteToPublicRepository() {
+		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
 
-		String remoteURL = upstreamRemote.getRemoteURL();
+		String remoteURL = upstreamGitRemote.getRemoteURL();
 
 		if (remoteURL.contains("-ee")) {
 			remoteURL = remoteURL.replace("-ee", "");
 		}
 
-		addRemote(true, "upstream-temp", remoteURL);
+		addGitRemote(true, "upstream-temp", remoteURL);
 	}
 
 	private boolean _isNPMTestModuleDir(File moduleDir) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
@@ -244,7 +244,7 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 
 	@Override
 	protected void setUpstreamGitRemoteToPrivateRepository() {
-		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
+		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		String remoteURL = upstreamGitRemote.getRemoteURL();
 
@@ -257,7 +257,7 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 
 	@Override
 	protected void setUpstreamGitRemoteToPublicRepository() {
-		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
+		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		String remoteURL = upstreamGitRemote.getRemoteURL();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspace.java
@@ -170,7 +170,7 @@ public class PortalWorkspace extends BaseWorkspace {
 				branchName));
 
 		LocalGitBranch localGitBranch =
-			LocalGitSyncUtil.createCachedLocalGitBranch(
+			GitHubDevSyncUtil.createCachedLocalGitBranch(
 				localRepository, remoteGitRef, _synchronizeBranches);
 
 		_otherPortalLocalGitBranch = (PortalLocalGitBranch)localGitBranch;
@@ -294,14 +294,14 @@ public class PortalWorkspace extends BaseWorkspace {
 		if (PullRequest.isValidGitHubPullRequestURL(portalGitHubURL)) {
 			PullRequest pullRequest = new PullRequest(portalGitHubURL);
 
-			localGitBranch = LocalGitSyncUtil.createCachedLocalGitBranch(
+			localGitBranch = GitHubDevSyncUtil.createCachedLocalGitBranch(
 				portalLocalRepository, pullRequest, _synchronizeBranches);
 		}
 		else if (GitUtil.isValidGitHubRefURL(portalGitHubURL)) {
 			RemoteGitRef remoteGitRef = GitUtil.getRemoteGitRef(
 				portalGitHubURL);
 
-			localGitBranch = LocalGitSyncUtil.createCachedLocalGitBranch(
+			localGitBranch = GitHubDevSyncUtil.createCachedLocalGitBranch(
 				portalLocalRepository, remoteGitRef, _synchronizeBranches);
 		}
 		else {
@@ -327,7 +327,7 @@ public class PortalWorkspace extends BaseWorkspace {
 		LocalGitBranch localGitBranch = null;
 
 		if (gitCommitFileContent.matches("[0-9a-f]{5,40}")) {
-			localGitBranch = LocalGitSyncUtil.createCachedLocalGitBranch(
+			localGitBranch = GitHubDevSyncUtil.createCachedLocalGitBranch(
 				localRepository, localRepository.getUpstreamBranchName(),
 				gitCommitFileContent, synchronizeBranches);
 		}
@@ -336,14 +336,14 @@ public class PortalWorkspace extends BaseWorkspace {
 
 			PullRequest pullRequest = new PullRequest(gitCommitFileContent);
 
-			localGitBranch = LocalGitSyncUtil.createCachedLocalGitBranch(
+			localGitBranch = GitHubDevSyncUtil.createCachedLocalGitBranch(
 				localRepository, pullRequest, synchronizeBranches);
 		}
 		else if (GitUtil.isValidGitHubRefURL(gitCommitFileContent)) {
 			RemoteGitRef remoteGitRef = GitUtil.getRemoteGitRef(
 				gitCommitFileContent);
 
-			localGitBranch = LocalGitSyncUtil.createCachedLocalGitBranch(
+			localGitBranch = GitHubDevSyncUtil.createCachedLocalGitBranch(
 				localRepository, remoteGitRef, synchronizeBranches);
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteRepository.java
@@ -14,8 +14,6 @@
 
 package com.liferay.jenkins.results.parser;
 
-import com.liferay.jenkins.results.parser.GitWorkingDirectory.Remote;
-
 /**
  * @author Peter Yoo
  */
@@ -34,10 +32,10 @@ public class RemoteRepository extends BaseRepository {
 		return username;
 	}
 
-	protected RemoteRepository(Remote remote) {
+	protected RemoteRepository(BaseGitRemote baseGitRemote) {
 		this(
-			remote.getHostname(), remote.getRepositoryName(),
-			remote.getUsername());
+			baseGitRemote.getHostname(), baseGitRemote.getRepositoryName(),
+			baseGitRemote.getUsername());
 	}
 
 	protected RemoteRepository(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteRepository.java
@@ -32,10 +32,10 @@ public class RemoteRepository extends BaseRepository {
 		return username;
 	}
 
-	protected RemoteRepository(BaseGitRemote baseGitRemote) {
+	protected RemoteRepository(GitRemote gitRemote) {
 		this(
-			baseGitRemote.getHostname(), baseGitRemote.getRepositoryName(),
-			baseGitRemote.getUsername());
+			gitRemote.getHostname(), gitRemote.getRepositoryName(),
+			gitRemote.getUsername());
 	}
 
 	protected RemoteRepository(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RepositoryFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RepositoryFactory.java
@@ -55,16 +55,14 @@ public class RepositoryFactory {
 		return _localRepositories.get(key);
 	}
 
-	public static RemoteRepository getRemoteRepository(
-		BaseGitRemote baseGitRemote) {
-
-		String hostname = baseGitRemote.getHostname();
+	public static RemoteRepository getRemoteRepository(GitRemote gitRemote) {
+		String hostname = gitRemote.getHostname();
 
 		if (hostname.equalsIgnoreCase("github.com")) {
-			return new GitHubRemoteRepository(baseGitRemote);
+			return new GitHubRemoteRepository(gitRemote);
 		}
 
-		return new RemoteRepository(baseGitRemote);
+		return new RemoteRepository(gitRemote);
 	}
 
 	public static RemoteRepository getRemoteRepository(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RepositoryFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RepositoryFactory.java
@@ -14,8 +14,6 @@
 
 package com.liferay.jenkins.results.parser;
 
-import com.liferay.jenkins.results.parser.GitWorkingDirectory.Remote;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -57,14 +55,16 @@ public class RepositoryFactory {
 		return _localRepositories.get(key);
 	}
 
-	public static RemoteRepository getRemoteRepository(Remote remote) {
-		String hostname = remote.getHostname();
+	public static RemoteRepository getRemoteRepository(
+		BaseGitRemote baseGitRemote) {
+
+		String hostname = baseGitRemote.getHostname();
 
 		if (hostname.equalsIgnoreCase("github.com")) {
-			return new GitHubRemoteRepository(remote);
+			return new GitHubRemoteRepository(baseGitRemote);
 		}
 
-		return new RemoteRepository(remote);
+		return new RemoteRepository(baseGitRemote);
 	}
 
 	public static RemoteRepository getRemoteRepository(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SubrepositoryGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SubrepositoryGitWorkingDirectory.java
@@ -38,29 +38,29 @@ public class SubrepositoryGitWorkingDirectory extends GitWorkingDirectory {
 	}
 
 	@Override
-	protected void setUpstreamRemoteToPrivateRepository() {
-		Remote upstreamRemote = getUpstreamRemote();
+	protected void setUpstreamGitRemoteToPrivateRepository() {
+		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
 
-		String remoteURL = upstreamRemote.getRemoteURL();
+		String remoteURL = upstreamGitRemote.getRemoteURL();
 
 		if (!remoteURL.contains("-private")) {
 			remoteURL = remoteURL.replace(".git", "-private.git");
 		}
 
-		addRemote(true, "upstream-temp", remoteURL);
+		addGitRemote(true, "upstream-temp", remoteURL);
 	}
 
 	@Override
-	protected void setUpstreamRemoteToPublicRepository() {
-		Remote upstreamRemote = getUpstreamRemote();
+	protected void setUpstreamGitRemoteToPublicRepository() {
+		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
 
-		String remoteURL = upstreamRemote.getRemoteURL();
+		String remoteURL = upstreamGitRemote.getRemoteURL();
 
 		if (remoteURL.contains("-private")) {
 			remoteURL = remoteURL.replace("-private", "");
 		}
 
-		addRemote(true, "upstream-temp", remoteURL);
+		addGitRemote(true, "upstream-temp", remoteURL);
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SubrepositoryGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SubrepositoryGitWorkingDirectory.java
@@ -39,7 +39,7 @@ public class SubrepositoryGitWorkingDirectory extends GitWorkingDirectory {
 
 	@Override
 	protected void setUpstreamGitRemoteToPrivateRepository() {
-		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
+		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		String remoteURL = upstreamGitRemote.getRemoteURL();
 
@@ -52,7 +52,7 @@ public class SubrepositoryGitWorkingDirectory extends GitWorkingDirectory {
 
 	@Override
 	protected void setUpstreamGitRemoteToPublicRepository() {
-		BaseGitRemote upstreamGitRemote = getUpstreamGitRemote();
+		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		String remoteURL = upstreamGitRemote.getRemoteURL();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-42796

@brianchandotcom - Here's a pull that has been refactored to use GitRemote instead of BaseGitRemote.

After talking with @pyoo47, we thought that we are probably not going to build a whole hierarchy around this class.  Therefore, we thought it would safe to name it generically.