### PR TITLE
LPS-84629 When rdnEscape is false, we also need encode "\". 

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
@@ -89,11 +89,16 @@ public class DefaultPortalLDAP implements PortalLDAP {
 	@Override
 	public String encodeFilterAttribute(String attribute, boolean rdnEscape) {
 		String[] oldString = {
-			StringPool.STAR, StringPool.OPEN_PARENTHESIS,
+			StringPool.BACK_SLASH, StringPool.STAR, StringPool.OPEN_PARENTHESIS,
 			StringPool.CLOSE_PARENTHESIS, StringPool.NULL_CHAR
 		};
 
-		String[] newString = {"\\2a", "\\28", "\\29", "\\00"};
+		String[] newString = {"\\5c", "\\2a", "\\28", "\\29", "\\00"};
+
+		if (rdnEscape) {
+			ArrayUtil.remove(oldString, StringPool.BACK_SLASH);
+			ArrayUtil.remove(newString, "\\5c");
+		}
 
 		String newAttribute = StringUtil.replace(
 			attribute, oldString, newString);


### PR DESCRIPTION
Hi Brian,

https://issues.liferay.com/browse/LPS-84629

Thank you.

/cc @yxingwu @samuelkong

Tests run in https://github.com/topolik/liferay-portal/pull/593#issuecomment-414904377