### PR TITLE
LPS-84708 LPS-80978 FIX SolrSpellCheckTest.testMultipleWords() breaks with Solr

### DIFF
--- a/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/SolrIndexingFixture.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/SolrIndexingFixture.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.search.IndexSearcher;
 import com.liferay.portal.kernel.search.IndexWriter;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
-import com.liferay.portal.kernel.test.util.TestDataConstants;
 import com.liferay.portal.kernel.util.Digester;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.Props;
@@ -173,7 +172,13 @@ public class SolrIndexingFixture implements IndexingFixture {
 		Digester digester = Mockito.mock(Digester.class);
 
 		Mockito.doAnswer(
-			invocation -> TestDataConstants.TEST_BYTE_ARRAY
+			invocation -> {
+				Object[] args = invocation.getArguments();
+
+				ByteBuffer byteBuffer = (ByteBuffer)args[1];
+
+				return byteBuffer.array();
+			}
 		).when(
 			digester
 		).digestRaw(


### PR DESCRIPTION
CI impossible. Solr unit tests are inert in regular CI. The affected unit test passed locally against a manually started Solr. This particular kind of fix needs a job that can react to changes to the Solr Connector module specifically, in order to start a throwaway Solr instance and run only this specific module's unit tests against it. (cc/ @xbrianlee)

Author: @mtambara 
Reviewer: @BryanEngler

https://issues.liferay.com/browse/LPS-84708