### PR TITLE
 LRQA-43089 Follow object hierarchy pattern

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
@@ -308,7 +308,7 @@ public class AutoCloseUtil {
 
 		String propertyNameTemplate = JenkinsResultsParserUtil.combine(
 			"test.batch.names.auto.close[",
-			pullRequest.getGitHubRemoteRepositoryName(), "?]");
+			pullRequest.getGitHubRemoteGitRepositoryName(), "?]");
 
 		String repositoryBranchAutoClosePropertyName =
 			propertyNameTemplate.replace(
@@ -343,8 +343,8 @@ public class AutoCloseUtil {
 	}
 
 	public static boolean isAutoCloseBranch(PullRequest pullRequest) {
-		String gitHubRemoteRepositoryName =
-			pullRequest.getGitHubRemoteRepositoryName();
+		String gitHubRemoteGitRepositoryName =
+			pullRequest.getGitHubRemoteGitRepositoryName();
 
 		Properties localLiferayJenkinsEEBuildProperties =
 			JenkinsResultsParserUtil.getLocalLiferayJenkinsEEBuildProperties();
@@ -352,7 +352,7 @@ public class AutoCloseUtil {
 		String testBranchNamesAutoClose = JenkinsResultsParserUtil.getProperty(
 			localLiferayJenkinsEEBuildProperties,
 			JenkinsResultsParserUtil.combine(
-				"test.branch.names.auto.close[", gitHubRemoteRepositoryName,
+				"test.branch.names.auto.close[", gitHubRemoteGitRepositoryName,
 				"]"));
 
 		if (testBranchNamesAutoClose == null) {
@@ -378,7 +378,7 @@ public class AutoCloseUtil {
 				localLiferayJenkinsEEBuildProperties,
 				JenkinsResultsParserUtil.combine(
 					"test.branch.names.critical.test[",
-					pullRequest.getGitHubRemoteRepositoryName(), "]"));
+					pullRequest.getGitHubRemoteGitRepositoryName(), "]"));
 
 		if ((criticalTestBranchesString == null) ||
 			criticalTestBranchesString.isEmpty()) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseCommit.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseCommit.java
@@ -23,7 +23,7 @@ import org.json.JSONObject;
 /**
  * @author Michael Hashimoto
  */
-public class BaseCommit implements Commit {
+public abstract class BaseCommit implements Commit {
 
 	@Override
 	public boolean equals(Object object) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseGitRepository.java
@@ -17,8 +17,21 @@ package com.liferay.jenkins.results.parser;
 /**
  * @author Peter Yoo
  */
-public interface Repository {
+public class BaseGitRepository implements GitRepository {
 
-	public String getName();
+	public BaseGitRepository(String name) {
+		if ((name == null) || name.isEmpty()) {
+			throw new IllegalArgumentException("Name is null");
+		}
+
+		this.name = name;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	protected final String name;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspace.java
@@ -20,10 +20,10 @@ package com.liferay.jenkins.results.parser;
 public abstract class BaseWorkspace implements Workspace {
 
 	@Override
-	public abstract void setupWorkspace();
+	public abstract void setJobProperties(Job job);
 
 	@Override
-	public abstract void setJobProperties(Job job);
+	public abstract void setupWorkspace();
 
 	protected void checkoutBranch(LocalGitBranch localGitBranch) {
 		System.out.println();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspace.java
@@ -22,6 +22,9 @@ public abstract class BaseWorkspace implements Workspace {
 	@Override
 	public abstract void setupWorkspace();
 
+	@Override
+	public abstract void setJobProperties(Job job);
+
 	protected void checkoutBranch(LocalGitBranch localGitBranch) {
 		System.out.println();
 		System.out.println("##");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspace.java
@@ -17,8 +17,9 @@ package com.liferay.jenkins.results.parser;
 /**
  * @author Michael Hashimoto
  */
-public abstract class BaseWorkspace {
+public abstract class BaseWorkspace implements Workspace {
 
+	@Override
 	public abstract void setupWorkspace();
 
 	protected void checkoutBranch(LocalGitBranch localGitBranch) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchPortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchPortalWorkspace.java
@@ -17,8 +17,8 @@ package com.liferay.jenkins.results.parser;
 /**
  * @author Peter Yoo
  */
-public class BatchPortalWorkspace extends PortalWorkspace
-	implements BatchWorkspace {
+public class BatchPortalWorkspace
+	extends PortalWorkspace implements BatchWorkspace {
 
 	protected BatchPortalWorkspace(
 		String portalGitHubURL, String portalUpstreamBranchName) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchPortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchPortalWorkspace.java
@@ -14,31 +14,23 @@
 
 package com.liferay.jenkins.results.parser;
 
-import java.util.Properties;
-
 /**
- * @author Michael Hashimoto
+ * @author Peter Yoo
  */
-public class FunctionalBatchPortalWorkspace extends PortalWorkspace implements BatchWorkspace{
+public class BatchPortalWorkspace extends PortalWorkspace
+	implements BatchWorkspace {
 
-	protected FunctionalBatchPortalWorkspace(
+	protected BatchPortalWorkspace(
 		String portalGitHubURL, String portalUpstreamBranchName) {
 
 		super(portalGitHubURL, portalUpstreamBranchName, false);
-
-		_setPortalBuildProperties();
 	}
 
-	private void _setPortalBuildProperties() {
-		Properties properties = new Properties();
+	protected BatchPortalWorkspace(
+		String portalGitHubURL, String portalUpstreamBranchName,
+		boolean synchronizeBranches) {
 
-		properties.put("jsp.precompile", "on");
-		properties.put("jsp.precompile.parallel", "on");
-
-		PortalLocalRepository portalLocalRepository =
-			getPrimaryPortalRepository();
-
-		portalLocalRepository.setBuildProperties(properties);
+		super(portalGitHubURL, portalUpstreamBranchName, synchronizeBranches);
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchWorkspace.java
@@ -18,5 +18,4 @@ package com.liferay.jenkins.results.parser;
  * @author Peter Yoo
  */
 public interface BatchWorkspace extends Workspace {
-
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchWorkspace.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+/**
+ * @author Peter Yoo
+ */
+public interface BatchWorkspace extends Workspace {
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildRunner.java
@@ -17,32 +17,10 @@ package com.liferay.jenkins.results.parser;
 /**
  * @author Michael Hashimoto
  */
-public abstract class BaseBuildRunner implements BuildRunner {
+public interface BuildRunner {
 
-	@Override
-	public void setup() {
-		setupWorkspace();
-	}
+	public void setup();
 
-	@Override
-	public void setupWorkspace() {
-		if (baseWorkspace == null) {
-			throw new RuntimeException("Workspace is null");
-		}
-
-		baseWorkspace.setupWorkspace();
-	}
-
-	protected BaseBuildRunner(Job job) {
-		_job = job;
-	}
-
-	protected Job getJob() {
-		return _job;
-	}
-
-	protected BaseWorkspace baseWorkspace;
-
-	private final Job _job;
+	public void setupWorkspace();
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CommitFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CommitFactory.java
@@ -66,7 +66,7 @@ public class CommitFactory {
 			type = Commit.Type.LEGACY_ARCHIVE;
 		}
 
-		Commit commit = new BaseCommit(
+		Commit commit = new DefaultCommit(
 			gitHubUserName, message, repositoryName, sha, type);
 
 		_commits.put(commitURL, commit);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultCommit.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultCommit.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+/**
+ * @author Michael Hashimoto
+ */
+public class DefaultCommit extends BaseCommit {
+
+	protected DefaultCommit(
+		String gitHubUserName, String message, String repositoryName,
+		String sha, Type type) {
+
+		super(gitHubUserName, message, repositoryName, sha, type);
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FunctionalBatchPortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FunctionalBatchPortalWorkspace.java
@@ -36,7 +36,7 @@ public class FunctionalBatchPortalWorkspace
 		properties.put("jsp.precompile", "on");
 		properties.put("jsp.precompile.parallel", "on");
 
-		PortalLocalRepository portalLocalRepository =
+		PortalLocalGitRepository portalLocalRepository =
 			getPrimaryPortalRepository();
 
 		portalLocalRepository.setBuildProperties(properties);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FunctionalBatchPortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FunctionalBatchPortalWorkspace.java
@@ -36,10 +36,10 @@ public class FunctionalBatchPortalWorkspace
 		properties.put("jsp.precompile", "on");
 		properties.put("jsp.precompile.parallel", "on");
 
-		PortalLocalGitRepository portalLocalRepository =
+		PortalLocalGitRepository portalLocalGitRepository =
 			getPrimaryPortalRepository();
 
-		portalLocalRepository.setBuildProperties(properties);
+		portalLocalGitRepository.setBuildProperties(properties);
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FunctionalBatchPortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FunctionalBatchPortalWorkspace.java
@@ -19,7 +19,8 @@ import java.util.Properties;
 /**
  * @author Michael Hashimoto
  */
-public class FunctionalBatchPortalWorkspace extends PortalWorkspace implements BatchWorkspace{
+public class FunctionalBatchPortalWorkspace
+	extends PortalWorkspace implements BatchWorkspace {
 
 	protected FunctionalBatchPortalWorkspace(
 		String portalGitHubURL, String portalUpstreamBranchName) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitBranchFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitBranchFactory.java
@@ -20,16 +20,16 @@ package com.liferay.jenkins.results.parser;
 public class GitBranchFactory {
 
 	public static LocalGitBranch newLocalGitBranch(
-		LocalGitRepository localRepository, String name, String sha) {
+		LocalGitRepository localGitRepository, String name, String sha) {
 
-		if (localRepository instanceof PluginsLocalGitRepository) {
-			return new PluginsLocalGitBranch(localRepository, name, sha);
+		if (localGitRepository instanceof PluginsLocalGitRepository) {
+			return new PluginsLocalGitBranch(localGitRepository, name, sha);
 		}
-		else if (localRepository instanceof PortalLocalGitRepository) {
-			return new PortalLocalGitBranch(localRepository, name, sha);
+		else if (localGitRepository instanceof PortalLocalGitRepository) {
+			return new PortalLocalGitBranch(localGitRepository, name, sha);
 		}
 
-		return new LocalGitBranch(localRepository, name, sha);
+		return new LocalGitBranch(localGitRepository, name, sha);
 	}
 
 	public static RemoteGitRef newRemoteGitRef(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitBranchFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitBranchFactory.java
@@ -20,12 +20,12 @@ package com.liferay.jenkins.results.parser;
 public class GitBranchFactory {
 
 	public static LocalGitBranch newLocalGitBranch(
-		LocalRepository localRepository, String name, String sha) {
+		LocalGitRepository localRepository, String name, String sha) {
 
-		if (localRepository instanceof PluginsLocalRepository) {
+		if (localRepository instanceof PluginsLocalGitRepository) {
 			return new PluginsLocalGitBranch(localRepository, name, sha);
 		}
-		else if (localRepository instanceof PortalLocalRepository) {
+		else if (localRepository instanceof PortalLocalGitRepository) {
 			return new PortalLocalGitBranch(localRepository, name, sha);
 		}
 
@@ -33,14 +33,14 @@ public class GitBranchFactory {
 	}
 
 	public static RemoteGitRef newRemoteGitRef(
-		RemoteRepository remoteRepository, String name, String sha,
+		RemoteGitRepository remoteGitRepository, String name, String sha,
 		String type) {
 
 		if (type.equals("heads")) {
-			return new RemoteGitBranch(remoteRepository, name, sha);
+			return new RemoteGitBranch(remoteGitRepository, name, sha);
 		}
 
-		return new RemoteGitRef(remoteRepository, name, sha);
+		return new RemoteGitRef(remoteGitRepository, name, sha);
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubDevSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubDevSyncUtil.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 public class GitHubDevSyncUtil {
 
 	public static LocalGitBranch createCachedLocalGitBranch(
-		LocalRepository localRepository, LocalGitBranch localGitBranch,
+		LocalGitRepository localRepository, LocalGitBranch localGitBranch,
 		boolean synchronize) {
 
 		return _createCachedLocalGitBranch(
@@ -44,7 +44,7 @@ public class GitHubDevSyncUtil {
 	}
 
 	public static LocalGitBranch createCachedLocalGitBranch(
-		LocalRepository localRepository, PullRequest pullRequest,
+		LocalGitRepository localRepository, PullRequest pullRequest,
 		boolean synchronize) {
 
 		return _createCachedLocalGitBranch(
@@ -55,7 +55,7 @@ public class GitHubDevSyncUtil {
 	}
 
 	public static LocalGitBranch createCachedLocalGitBranch(
-		LocalRepository localRepository, RemoteGitRef remoteGitRef,
+		LocalGitRepository localRepository, RemoteGitRef remoteGitRef,
 		boolean synchronize) {
 
 		return _createCachedLocalGitBranch(
@@ -65,7 +65,7 @@ public class GitHubDevSyncUtil {
 	}
 
 	public static LocalGitBranch createCachedLocalGitBranch(
-		LocalRepository localRepository, String name, String sha,
+		LocalGitRepository localRepository, String name, String sha,
 		boolean synchronize) {
 
 		return _createCachedLocalGitBranch(
@@ -1201,7 +1201,7 @@ public class GitHubDevSyncUtil {
 
 				@Override
 				public String safeCall() {
-					if (gitWorkingDirectory.isRemoteRepositoryAlive(
+					if (gitWorkingDirectory.isRemoteGitRepositoryAlive(
 							gitHubDevRemoteURL)) {
 
 						return gitHubDevRemoteURL;
@@ -1230,7 +1230,7 @@ public class GitHubDevSyncUtil {
 	}
 
 	private static LocalGitBranch _createCachedLocalGitBranch(
-		LocalRepository localRepository, String receiverUsername,
+		LocalGitRepository localRepository, String receiverUsername,
 		String senderBranchName, String senderUsername, String senderBranchSHA,
 		String upstreamBranchSHA, boolean synchronize) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubDevSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubDevSyncUtil.java
@@ -35,41 +35,42 @@ import java.util.regex.Pattern;
 public class GitHubDevSyncUtil {
 
 	public static LocalGitBranch createCachedLocalGitBranch(
-		LocalGitRepository localRepository, LocalGitBranch localGitBranch,
+		LocalGitRepository localGitRepository, LocalGitBranch localGitBranch,
 		boolean synchronize) {
 
 		return _createCachedLocalGitBranch(
-			localRepository, "liferay", localGitBranch.getName(), "liferay",
+			localGitRepository, "liferay", localGitBranch.getName(), "liferay",
 			localGitBranch.getSHA(), localGitBranch.getSHA(), synchronize);
 	}
 
 	public static LocalGitBranch createCachedLocalGitBranch(
-		LocalGitRepository localRepository, PullRequest pullRequest,
+		LocalGitRepository localGitRepository, PullRequest pullRequest,
 		boolean synchronize) {
 
 		return _createCachedLocalGitBranch(
-			localRepository, pullRequest.getReceiverUsername(),
+			localGitRepository, pullRequest.getReceiverUsername(),
 			pullRequest.getSenderBranchName(), pullRequest.getSenderUsername(),
 			pullRequest.getSenderSHA(), pullRequest.getLiferayRemoteBranchSHA(),
 			synchronize);
 	}
 
 	public static LocalGitBranch createCachedLocalGitBranch(
-		LocalGitRepository localRepository, RemoteGitRef remoteGitRef,
+		LocalGitRepository localGitRepository, RemoteGitRef remoteGitRef,
 		boolean synchronize) {
 
 		return _createCachedLocalGitBranch(
-			localRepository, remoteGitRef.getUsername(), remoteGitRef.getName(),
-			remoteGitRef.getUsername(), remoteGitRef.getSHA(),
-			remoteGitRef.getSHA(), synchronize);
+			localGitRepository, remoteGitRef.getUsername(),
+			remoteGitRef.getName(), remoteGitRef.getUsername(),
+			remoteGitRef.getSHA(), remoteGitRef.getSHA(), synchronize);
 	}
 
 	public static LocalGitBranch createCachedLocalGitBranch(
-		LocalGitRepository localRepository, String name, String sha,
+		LocalGitRepository localGitRepository, String name, String sha,
 		boolean synchronize) {
 
 		return _createCachedLocalGitBranch(
-			localRepository, "liferay", name, "liferay", sha, sha, synchronize);
+			localGitRepository, "liferay", name, "liferay", sha, sha,
+			synchronize);
 	}
 
 	public static List<GitRemote> getGitHubDevGitRemotes(
@@ -117,10 +118,10 @@ public class GitHubDevSyncUtil {
 		GitWorkingDirectory gitWorkingDirectory, LocalGitBranch localGitBranch,
 		GitRemote gitRemote, long timestamp) {
 
-		gitWorkingDirectory.pushToRemoteRepository(
+		gitWorkingDirectory.pushToRemoteGitRepository(
 			true, localGitBranch, localGitBranch.getName(), gitRemote);
 
-		gitWorkingDirectory.pushToRemoteRepository(
+		gitWorkingDirectory.pushToRemoteGitRepository(
 			true, localGitBranch,
 			JenkinsResultsParserUtil.combine(
 				localGitBranch.getName(), "-", String.valueOf(timestamp)),
@@ -164,7 +165,7 @@ public class GitHubDevSyncUtil {
 							gitWorkingDirectory.getLocalGitBranch(
 								upstreamRemoteGitBranch.getName(), true);
 
-						gitWorkingDirectory.pushToRemoteRepository(
+						gitWorkingDirectory.pushToRemoteGitRepository(
 							true, upstreamLocalGitBranch,
 							upstreamRemoteGitBranch.getName(),
 							gitHubDevGitRemote);
@@ -707,8 +708,8 @@ public class GitHubDevSyncUtil {
 			gitHubDevRemoteURLs.add(
 				JenkinsResultsParserUtil.combine(
 					"git@", gitCacheHostname, ":",
-					gitWorkingDirectory.getRepositoryUsername(), "/",
-					gitWorkingDirectory.getRepositoryName(), ".git"));
+					gitWorkingDirectory.getGitRepositoryUsername(), "/",
+					gitWorkingDirectory.getGitRepositoryName(), ".git"));
 		}
 
 		return validateGitHubDevRemoteURLs(
@@ -767,7 +768,7 @@ public class GitHubDevSyncUtil {
 						gitRemote.getGitWorkingDirectory();
 
 					RemoteGitBranch remoteGitBranch =
-						gitWorkingDirectory.pushToRemoteRepository(
+						gitWorkingDirectory.pushToRemoteGitRepository(
 							force, localGitBranch, remoteGitBranchName,
 							gitRemote);
 
@@ -858,7 +859,7 @@ public class GitHubDevSyncUtil {
 			senderGitRemote = gitWorkingDirectory.addGitRemote(
 				true, "sender-temp",
 				getGitHubRemoteURL(
-					gitWorkingDirectory.getRepositoryName(), senderUsername));
+					gitWorkingDirectory.getGitRepositoryName(), senderUsername));
 
 			String cacheBranchName = getCacheBranchName(
 				receiverUsername, senderUsername, senderBranchSHA,
@@ -1230,13 +1231,13 @@ public class GitHubDevSyncUtil {
 	}
 
 	private static LocalGitBranch _createCachedLocalGitBranch(
-		LocalGitRepository localRepository, String receiverUsername,
+		LocalGitRepository localGitRepository, String receiverUsername,
 		String senderBranchName, String senderUsername, String senderBranchSHA,
 		String upstreamBranchSHA, boolean synchronize) {
 
 		if (!JenkinsResultsParserUtil.isCINode()) {
 			GitWorkingDirectory gitWorkingDirectory =
-				localRepository.getGitWorkingDirectory();
+				localGitRepository.getGitWorkingDirectory();
 
 			return gitWorkingDirectory.getRebasedLocalGitBranch(
 				JenkinsResultsParserUtil.combine(
@@ -1245,13 +1246,13 @@ public class GitHubDevSyncUtil {
 				senderBranchName,
 				JenkinsResultsParserUtil.combine(
 					"git@github.com:", senderUsername, "/",
-					localRepository.getName()),
+					localGitRepository.getName()),
 				senderBranchSHA, gitWorkingDirectory.getUpstreamBranchName(),
 				upstreamBranchSHA);
 		}
 
 		GitWorkingDirectory gitWorkingDirectory =
-			localRepository.getGitWorkingDirectory();
+			localGitRepository.getGitWorkingDirectory();
 
 		if (synchronize) {
 			synchronizeToGitHubDev(
@@ -1276,7 +1277,7 @@ public class GitHubDevSyncUtil {
 
 		LocalGitBranch cachedLocalGitBranch =
 			GitBranchFactory.newLocalGitBranch(
-				localRepository,
+				localGitRepository,
 				JenkinsResultsParserUtil.combine(
 					gitWorkingDirectory.getUpstreamBranchName(), "-temp-",
 					String.valueOf(System.currentTimeMillis())),

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubDevSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubDevSyncUtil.java
@@ -859,7 +859,8 @@ public class GitHubDevSyncUtil {
 			senderGitRemote = gitWorkingDirectory.addGitRemote(
 				true, "sender-temp",
 				getGitHubRemoteURL(
-					gitWorkingDirectory.getGitRepositoryName(), senderUsername));
+					gitWorkingDirectory.getGitRepositoryName(),
+					senderUsername));
 
 			String cacheBranchName = getCacheBranchName(
 				receiverUsername, senderUsername, senderBranchSHA,

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubRemoteGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubRemoteGitRepository.java
@@ -29,7 +29,7 @@ import org.json.JSONObject;
 /**
  * @author Peter Yoo
  */
-public class GitHubRemoteRepository extends RemoteRepository {
+public class GitHubRemoteGitRepository extends RemoteGitRepository {
 
 	public boolean addLabel(String color, String description, String name) {
 		if (hasLabel(name)) {
@@ -187,10 +187,10 @@ public class GitHubRemoteRepository extends RemoteRepository {
 
 		public Label(
 			JSONObject jsonObject,
-			GitHubRemoteRepository gitHubRemoteRepository) {
+			GitHubRemoteGitRepository gitHubRemoteGitRepository) {
 
 			_jsonObject = jsonObject;
-			_gitHubRemoteRepository = gitHubRemoteRepository;
+			_gitHubRemoteGitRepository = gitHubRemoteGitRepository;
 		}
 
 		@Override
@@ -225,8 +225,8 @@ public class GitHubRemoteRepository extends RemoteRepository {
 			return _jsonObject.optString("description");
 		}
 
-		public GitHubRemoteRepository getGitHubRemoteRepository() {
-			return _gitHubRemoteRepository;
+		public GitHubRemoteGitRepository getGitHubRemoteGitRepository() {
+			return _gitHubRemoteGitRepository;
 		}
 
 		public String getName() {
@@ -245,12 +245,12 @@ public class GitHubRemoteRepository extends RemoteRepository {
 			return _jsonObject.toString(4);
 		}
 
-		private final GitHubRemoteRepository _gitHubRemoteRepository;
+		private final GitHubRemoteGitRepository _gitHubRemoteGitRepository;
 		private final JSONObject _jsonObject;
 
 	}
 
-	protected GitHubRemoteRepository(GitRemote gitRemote) {
+	protected GitHubRemoteGitRepository(GitRemote gitRemote) {
 		super(gitRemote);
 
 		if (!hostname.equals("github.com")) {
@@ -259,10 +259,10 @@ public class GitHubRemoteRepository extends RemoteRepository {
 		}
 	}
 
-	protected GitHubRemoteRepository(
-		String gitHubRemoteRepositoryName, String username) {
+	protected GitHubRemoteGitRepository(
+		String gitHubRemoteGitRepositoryName, String username) {
 
-		super("github.com", gitHubRemoteRepositoryName, username);
+		super("github.com", gitHubRemoteGitRepositoryName, username);
 	}
 
 	private String _getLabelRequestURL() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRef.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRef.java
@@ -17,36 +17,10 @@ package com.liferay.jenkins.results.parser;
 /**
  * @author Michael Hashimoto
  */
-public abstract class BaseGitRef implements GitRef {
+public interface GitRef {
 
-	@Override
-	public String getName() {
-		return _name;
-	}
+	public String getName();
 
-	@Override
-	public String getSHA() {
-		return _sha;
-	}
-
-	protected BaseGitRef(String name, String sha) {
-		if ((name == null) || name.isEmpty()) {
-			throw new IllegalArgumentException("Name is null");
-		}
-
-		if ((sha == null) || sha.isEmpty()) {
-			throw new IllegalArgumentException("SHA is null");
-		}
-
-		if (!sha.matches("[0-9a-f]{7,40}")) {
-			throw new IllegalArgumentException("SHA is invalid");
-		}
-
-		_name = name;
-		_sha = sha;
-	}
-
-	private final String _name;
-	private final String _sha;
+	public String getSHA();
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRepository.java
@@ -17,21 +17,8 @@ package com.liferay.jenkins.results.parser;
 /**
  * @author Peter Yoo
  */
-public class BaseRepository implements Repository {
+public interface GitRepository {
 
-	public BaseRepository(String name) {
-		if ((name == null) || name.isEmpty()) {
-			throw new IllegalArgumentException("Name is null");
-		}
-
-		this.name = name;
-	}
-
-	@Override
-	public String getName() {
-		return name;
-	}
-
-	protected final String name;
+	public String getName();
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRepositoryFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRepositoryFactory.java
@@ -20,9 +20,9 @@ import java.util.Map;
 /**
  * @author Peter Yoo
  */
-public class RepositoryFactory {
+public class GitRepositoryFactory {
 
-	public static LocalRepository getLocalRepository(
+	public static LocalGitRepository getLocalRepository(
 		String repositoryName, String upstreamBranchName) {
 
 		String key = repositoryName + "/" + upstreamBranchName;
@@ -31,22 +31,22 @@ public class RepositoryFactory {
 			return _localRepositories.get(key);
 		}
 
-		LocalRepository localRepository = null;
+		LocalGitRepository localRepository = null;
 
 		if (repositoryName.startsWith("com-liferay-")) {
-			localRepository = new SubrepositoryLocalRepository(
+			localRepository = new SubrepositoryLocalGitRepository(
 				repositoryName, upstreamBranchName);
 		}
 		else if (repositoryName.startsWith("liferay-plugins")) {
-			localRepository = new PluginsLocalRepository(
+			localRepository = new PluginsLocalGitRepository(
 				repositoryName, upstreamBranchName);
 		}
 		else if (repositoryName.startsWith("liferay-portal")) {
-			localRepository = new PortalLocalRepository(
+			localRepository = new PortalLocalGitRepository(
 				repositoryName, upstreamBranchName);
 		}
 		else {
-			localRepository = new LocalRepository(
+			localRepository = new LocalGitRepository(
 				repositoryName, upstreamBranchName);
 		}
 
@@ -55,27 +55,27 @@ public class RepositoryFactory {
 		return _localRepositories.get(key);
 	}
 
-	public static RemoteRepository getRemoteRepository(GitRemote gitRemote) {
-		String hostname = gitRemote.getHostname();
+	public static RemoteGitRepository getRemoteGitRepository(GitRemote remote) {
+		String hostname = remote.getHostname();
 
 		if (hostname.equalsIgnoreCase("github.com")) {
-			return new GitHubRemoteRepository(gitRemote);
+			return new GitHubRemoteGitRepository(remote);
 		}
 
-		return new RemoteRepository(gitRemote);
+		return new RemoteGitRepository(remote);
 	}
 
-	public static RemoteRepository getRemoteRepository(
+	public static RemoteGitRepository getRemoteGitRepository(
 		String hostname, String repositoryName, String username) {
 
 		if (hostname.equalsIgnoreCase("github.com")) {
-			return new GitHubRemoteRepository(repositoryName, username);
+			return new GitHubRemoteGitRepository(repositoryName, username);
 		}
 
-		return new RemoteRepository(hostname, repositoryName, username);
+		return new RemoteGitRepository(hostname, repositoryName, username);
 	}
 
-	private static final Map<String, LocalRepository> _localRepositories =
+	private static final Map<String, LocalGitRepository> _localRepositories =
 		new HashMap<>();
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRepositoryFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRepositoryFactory.java
@@ -22,37 +22,37 @@ import java.util.Map;
  */
 public class GitRepositoryFactory {
 
-	public static LocalGitRepository getLocalRepository(
+	public static LocalGitRepository getLocalGitRepository(
 		String repositoryName, String upstreamBranchName) {
 
 		String key = repositoryName + "/" + upstreamBranchName;
 
-		if (_localRepositories.containsKey(key)) {
-			return _localRepositories.get(key);
+		if (_localGitRepositories.containsKey(key)) {
+			return _localGitRepositories.get(key);
 		}
 
-		LocalGitRepository localRepository = null;
+		LocalGitRepository localGitRepository = null;
 
 		if (repositoryName.startsWith("com-liferay-")) {
-			localRepository = new SubrepositoryLocalGitRepository(
+			localGitRepository = new SubrepositoryLocalGitRepository(
 				repositoryName, upstreamBranchName);
 		}
 		else if (repositoryName.startsWith("liferay-plugins")) {
-			localRepository = new PluginsLocalGitRepository(
+			localGitRepository = new PluginsLocalGitRepository(
 				repositoryName, upstreamBranchName);
 		}
 		else if (repositoryName.startsWith("liferay-portal")) {
-			localRepository = new PortalLocalGitRepository(
+			localGitRepository = new PortalLocalGitRepository(
 				repositoryName, upstreamBranchName);
 		}
 		else {
-			localRepository = new LocalGitRepository(
+			localGitRepository = new LocalGitRepository(
 				repositoryName, upstreamBranchName);
 		}
 
-		_localRepositories.put(key, localRepository);
+		_localGitRepositories.put(key, localGitRepository);
 
-		return _localRepositories.get(key);
+		return _localGitRepositories.get(key);
 	}
 
 	public static RemoteGitRepository getRemoteGitRepository(GitRemote remote) {
@@ -75,7 +75,7 @@ public class GitRepositoryFactory {
 		return new RemoteGitRepository(hostname, repositoryName, username);
 	}
 
-	private static final Map<String, LocalGitRepository> _localRepositories =
+	private static final Map<String, LocalGitRepository> _localGitRepositories =
 		new HashMap<>();
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitUtil.java
@@ -68,12 +68,12 @@ public class GitUtil {
 			throw new RuntimeException("Invalid GitHub URL " + gitHubURL);
 		}
 
-		String remoteRepositoryURL = JenkinsResultsParserUtil.combine(
+		String remoteGitRepositoryURL = JenkinsResultsParserUtil.combine(
 			"git@github.com:", matcher.group("username"), "/",
 			matcher.group("repositoryName"), ".git");
 
 		return getRemoteGitRef(
-			matcher.group("refName"), new File("."), remoteRepositoryURL);
+			matcher.group("refName"), new File("."), remoteGitRepositoryURL);
 	}
 
 	public static RemoteGitRef getRemoteGitRef(
@@ -122,8 +122,8 @@ public class GitUtil {
 
 		List<RemoteGitRef> remoteGitRefs = new ArrayList<>();
 
-		RemoteRepository remoteRepository =
-			RepositoryFactory.getRemoteRepository(
+		RemoteGitRepository remoteGitRepository =
+			GitRepositoryFactory.getRemoteGitRepository(
 				remoteURLMatcher.group("hostname"),
 				remoteURLMatcher.group("repositoryName"),
 				remoteURLMatcher.group("username"));
@@ -139,7 +139,7 @@ public class GitUtil {
 
 			remoteGitRefs.add(
 				GitBranchFactory.newRemoteGitRef(
-					remoteRepository, gitLsRemoteMatcher.group("name"),
+					remoteGitRepository, gitLsRemoteMatcher.group("name"),
 					gitLsRemoteMatcher.group("sha"),
 					gitLsRemoteMatcher.group("type")));
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -919,6 +919,14 @@ public class GitWorkingDirectory {
 		return gitRemotes;
 	}
 
+	public String getGitRepositoryName() {
+		return _gitRepositoryName;
+	}
+
+	public String getGitRepositoryUsername() {
+		return _gitRepositoryUsername;
+	}
+
 	public File getJavaFileFromFullClassName(String fullClassName) {
 		if (_javaDirPaths == null) {
 			List<File> javaFiles = JenkinsResultsParserUtil.findFiles(
@@ -1359,14 +1367,6 @@ public class GitWorkingDirectory {
 		}
 
 		return null;
-	}
-
-	public String getGitRepositoryName() {
-		return _gitRepositoryName;
-	}
-
-	public String getGitRepositoryUsername() {
-		return _gitRepositoryUsername;
 	}
 
 	public String getUpstreamBranchName() {
@@ -2082,9 +2082,9 @@ public class GitWorkingDirectory {
 			"git.working.directory.public.only.repository.names");
 
 	private File _gitDirectory;
-	private Set<String> _javaDirPaths;
 	private final String _gitRepositoryName;
 	private final String _gitRepositoryUsername;
+	private Set<String> _javaDirPaths;
 	private final String _upstreamBranchName;
 	private File _workingDirectory;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -380,9 +380,9 @@ public class GitWorkingDirectory {
 	}
 
 	public void deleteRemoteGitBranch(
-		String branchName, RemoteRepository remoteRepository) {
+		String branchName, RemoteGitRepository remoteGitRepository) {
 
-		deleteRemoteGitBranch(branchName, remoteRepository.getRemoteURL());
+		deleteRemoteGitBranch(branchName, remoteGitRepository.getRemoteURL());
 	}
 
 	public void deleteRemoteGitBranch(String branchName, String remoteURL) {
@@ -395,10 +395,10 @@ public class GitWorkingDirectory {
 		Map<String, Set<String>> remoteURLGitBranchNameMap = new HashMap<>();
 
 		for (RemoteGitBranch remoteGitBranch : remoteGitBranches) {
-			RemoteRepository remoteRepository =
-				remoteGitBranch.getRemoteRepository();
+			RemoteGitRepository remoteGitRepository =
+				remoteGitBranch.getRemoteGitRepository();
 
-			String remoteURL = remoteRepository.getRemoteURL();
+			String remoteURL = remoteGitRepository.getRemoteURL();
 
 			if (!remoteURLGitBranchNameMap.containsKey(remoteURL)) {
 				remoteURLGitBranchNameMap.put(remoteURL, new HashSet<String>());
@@ -479,10 +479,10 @@ public class GitWorkingDirectory {
 			return null;
 		}
 
-		RemoteRepository remoteRepository =
-			remoteGitBranch.getRemoteRepository();
+		RemoteGitRepository remoteGitRepository =
+			remoteGitBranch.getRemoteGitRepository();
 
-		String remoteURL = remoteRepository.getRemoteURL();
+		String remoteURL = remoteGitRepository.getRemoteURL();
 
 		if (JenkinsResultsParserUtil.isCINode()) {
 			if (remoteURL.contains("github-dev.liferay.com")) {
@@ -571,8 +571,8 @@ public class GitWorkingDirectory {
 		return fetch(null, true, remoteGitBranch);
 	}
 
-	public void fetch(RemoteRepository remoteRepository) {
-		fetch(remoteRepository.getRemoteURL());
+	public void fetch(RemoteGitRepository remoteGitRepository) {
+		fetch(remoteGitRepository.getRemoteURL());
 	}
 
 	public void fetch(String remoteURL) {
@@ -1005,8 +1005,9 @@ public class GitWorkingDirectory {
 		List<LocalGitBranch> localGitBranches = new ArrayList<>(
 			localGitBranchNames.size());
 
-		LocalRepository localRepository = RepositoryFactory.getLocalRepository(
-			getRepositoryName(), getUpstreamBranchName());
+		LocalGitRepository localRepository =
+			GitRepositoryFactory.getLocalRepository(
+				getRepositoryName(), getUpstreamBranchName());
 
 		if (branchName != null) {
 			if (localGitBranchNames.contains(branchName)) {
@@ -1200,18 +1201,18 @@ public class GitWorkingDirectory {
 	}
 
 	public RemoteGitBranch getRemoteGitBranch(
-		String remoteGitBranchName, RemoteRepository remoteRepository) {
+		String remoteGitBranchName, RemoteGitRepository remoteGitRepository) {
 
 		return getRemoteGitBranch(
-			remoteGitBranchName, remoteRepository.getRemoteURL(), false);
+			remoteGitBranchName, remoteGitRepository.getRemoteURL(), false);
 	}
 
 	public RemoteGitBranch getRemoteGitBranch(
-		String remoteGitBranchName, RemoteRepository remoteRepository,
+		String remoteGitBranchName, RemoteGitRepository remoteGitRepository,
 		boolean required) {
 
 		return getRemoteGitBranch(
-			remoteGitBranchName, remoteRepository.getRemoteURL(), required);
+			remoteGitBranchName, remoteGitRepository.getRemoteURL(), required);
 	}
 
 	public RemoteGitBranch getRemoteGitBranch(
@@ -1247,9 +1248,9 @@ public class GitWorkingDirectory {
 	}
 
 	public List<RemoteGitBranch> getRemoteGitBranches(
-		RemoteRepository remoteRepository) {
+		RemoteGitRepository remoteGitRepository) {
 
-		return getRemoteGitBranches(null, remoteRepository.getRemoteURL());
+		return getRemoteGitBranches(null, remoteGitRepository.getRemoteURL());
 	}
 
 	public List<RemoteGitBranch> getRemoteGitBranches(String remoteURL) {
@@ -1264,10 +1265,10 @@ public class GitWorkingDirectory {
 	}
 
 	public List<RemoteGitBranch> getRemoteGitBranches(
-		String remoteGitBranchName, RemoteRepository remoteRepository) {
+		String remoteGitBranchName, RemoteGitRepository remoteGitRepository) {
 
 		return getRemoteGitBranches(
-			remoteGitBranchName, remoteRepository.getRemoteURL());
+			remoteGitBranchName, remoteGitRepository.getRemoteURL());
 	}
 
 	public List<RemoteGitBranch> getRemoteGitBranches(
@@ -1282,9 +1283,9 @@ public class GitWorkingDirectory {
 	}
 
 	public List<String> getRemoteGitBranchNames(
-		RemoteRepository remoteRepository) {
+		RemoteGitRepository remoteGitRepository) {
 
-		return getRemoteGitBranchNames(remoteRepository.getRemoteURL());
+		return getRemoteGitBranchNames(remoteGitRepository.getRemoteURL());
 	}
 
 	public List<String> getRemoteGitBranchNames(String remoteURL) {
@@ -1308,10 +1309,10 @@ public class GitWorkingDirectory {
 	}
 
 	public String getRemoteGitBranchSHA(
-		String remoteGitBranchName, RemoteRepository remoteRepository) {
+		String remoteGitBranchName, RemoteGitRepository remoteGitRepository) {
 
 		return getRemoteGitBranchSHA(
-			remoteGitBranchName, remoteRepository.getRemoteURL());
+			remoteGitBranchName, remoteGitRepository.getRemoteURL());
 	}
 
 	public String getRemoteGitBranchSHA(
@@ -1391,7 +1392,7 @@ public class GitWorkingDirectory {
 		return false;
 	}
 
-	public boolean isRemoteRepositoryAlive(String remoteURL) {
+	public boolean isRemoteGitRepositoryAlive(String remoteURL) {
 		String command = JenkinsResultsParserUtil.combine(
 			"git ls-remote -h ", remoteURL, " HEAD");
 
@@ -1461,11 +1462,11 @@ public class GitWorkingDirectory {
 
 	public RemoteGitBranch pushToRemoteRepository(
 		boolean force, LocalGitBranch localGitBranch,
-		String remoteGitBranchName, RemoteRepository remoteRepository) {
+		String remoteGitBranchName, RemoteGitRepository remoteGitRepository) {
 
 		return pushToRemoteRepository(
 			force, localGitBranch, remoteGitBranchName,
-			remoteRepository.getRemoteURL());
+			remoteGitRepository.getRemoteURL());
 	}
 
 	public RemoteGitBranch pushToRemoteRepository(
@@ -1585,10 +1586,10 @@ public class GitWorkingDirectory {
 	}
 
 	public boolean remoteGitBranchExists(
-		String branchName, RemoteRepository remoteRepository) {
+		String branchName, RemoteGitRepository remoteGitRepository) {
 
 		return remoteGitBranchExists(
-			branchName, remoteRepository.getRemoteURL());
+			branchName, remoteGitRepository.getRemoteURL());
 	}
 
 	public boolean remoteGitBranchExists(String branchName, String remoteURL) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -198,7 +198,7 @@ public class GitWorkingDirectory {
 		if (executionResult.getExitValue() != 0) {
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(
-					"Unable to clean repository\n",
+					"Unable to clean git repository\n",
 					executionResult.getStandardError()));
 		}
 	}
@@ -469,7 +469,7 @@ public class GitWorkingDirectory {
 
 		if (localSHAExists(remoteGitBranchSHA)) {
 			System.out.println(
-				remoteGitBranchSHA + " already exists in repository");
+				remoteGitBranchSHA + " already exists in git repository");
 
 			if (localGitBranch != null) {
 				return createLocalGitBranch(
@@ -648,7 +648,7 @@ public class GitWorkingDirectory {
 		if (executionResult.getExitValue() != 0) {
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(
-					"Unable to fetch from local repository ",
+					"Unable to fetch from local git repository ",
 					String.valueOf(localGitBranch.getDirectory()), "\n",
 					executionResult.getStandardError()));
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -601,7 +601,7 @@ public class JenkinsResultsParserUtil {
 		return "";
 	}
 
-	public static File getBaseRepositoryDir() {
+	public static File getBaseGitRepositoryDir() {
 		Properties buildProperties = null;
 
 		try {
@@ -753,8 +753,9 @@ public class JenkinsResultsParserUtil {
 	}
 
 	public static GitWorkingDirectory getJenkinsGitWorkingDirectory() {
-		LocalRepository localRepository = RepositoryFactory.getLocalRepository(
-			"liferay-jenkins-ee", "master");
+		LocalGitRepository localRepository =
+			GitRepositoryFactory.getLocalRepository(
+				"liferay-jenkins-ee", "master");
 
 		return localRepository.getGitWorkingDirectory();
 	}
@@ -976,8 +977,9 @@ public class JenkinsResultsParserUtil {
 			portalRepositoryName += "-ee";
 		}
 
-		LocalRepository localRepository = RepositoryFactory.getLocalRepository(
-			portalRepositoryName, portalBranchName);
+		LocalGitRepository localRepository =
+			GitRepositoryFactory.getLocalRepository(
+				portalRepositoryName, portalBranchName);
 
 		GitWorkingDirectory gitWorkingDirectory =
 			localRepository.getGitWorkingDirectory();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -753,11 +753,11 @@ public class JenkinsResultsParserUtil {
 	}
 
 	public static GitWorkingDirectory getJenkinsGitWorkingDirectory() {
-		LocalGitRepository localRepository =
-			GitRepositoryFactory.getLocalRepository(
+		LocalGitRepository localGitRepository =
+			GitRepositoryFactory.getLocalGitRepository(
 				"liferay-jenkins-ee", "master");
 
-		return localRepository.getGitWorkingDirectory();
+		return localGitRepository.getGitWorkingDirectory();
 	}
 
 	public static List<JenkinsMaster> getJenkinsMasters(
@@ -977,12 +977,12 @@ public class JenkinsResultsParserUtil {
 			portalRepositoryName += "-ee";
 		}
 
-		LocalGitRepository localRepository =
-			GitRepositoryFactory.getLocalRepository(
+		LocalGitRepository localGitRepository =
+			GitRepositoryFactory.getLocalGitRepository(
 				portalRepositoryName, portalBranchName);
 
 		GitWorkingDirectory gitWorkingDirectory =
-			localRepository.getGitWorkingDirectory();
+			localGitRepository.getGitWorkingDirectory();
 
 		return (PortalGitWorkingDirectory)gitWorkingDirectory;
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JunitBatchPortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JunitBatchPortalWorkspace.java
@@ -44,10 +44,10 @@ public class JunitBatchPortalWorkspace
 			"release.versions.test.other.dir",
 			String.valueOf(otherPortalLocalGitBranch.getDirectory()));
 
-		PortalLocalGitRepository portalLocalRepository =
+		PortalLocalGitRepository portalLocalGitRepository =
 			getPrimaryPortalRepository();
 
-		portalLocalRepository.setBuildProperties(properties);
+		portalLocalGitRepository.setBuildProperties(properties);
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JunitBatchPortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JunitBatchPortalWorkspace.java
@@ -19,7 +19,7 @@ import java.util.Properties;
 /**
  * @author Michael Hashimoto
  */
-public class JunitBatchPortalWorkspace extends PortalWorkspace {
+public class JunitBatchPortalWorkspace extends PortalWorkspace implements BatchWorkspace{
 
 	protected JunitBatchPortalWorkspace(
 		String portalGitHubURL, String portalUpstreamBranchName) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JunitBatchPortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JunitBatchPortalWorkspace.java
@@ -19,7 +19,8 @@ import java.util.Properties;
 /**
  * @author Michael Hashimoto
  */
-public class JunitBatchPortalWorkspace extends PortalWorkspace implements BatchWorkspace{
+public class JunitBatchPortalWorkspace
+	extends PortalWorkspace implements BatchWorkspace {
 
 	protected JunitBatchPortalWorkspace(
 		String portalGitHubURL, String portalUpstreamBranchName) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JunitBatchPortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JunitBatchPortalWorkspace.java
@@ -44,7 +44,7 @@ public class JunitBatchPortalWorkspace
 			"release.versions.test.other.dir",
 			String.valueOf(otherPortalLocalGitBranch.getDirectory()));
 
-		PortalLocalRepository portalLocalRepository =
+		PortalLocalGitRepository portalLocalRepository =
 			getPrimaryPortalRepository();
 
 		portalLocalRepository.setBuildProperties(properties);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LegacyDataArchiveUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LegacyDataArchiveUtil.java
@@ -88,7 +88,7 @@ public class LegacyDataArchiveUtil {
 		}
 
 		RemoteGitBranch remoteGitBranch =
-			_legacyGitWorkingDirectory.pushToRemoteRepository(
+			_legacyGitWorkingDirectory.pushToRemoteGitRepository(
 				true, _dataArchiveLocalGitBranch, dataArchiveBranchName,
 				_legacyGitWorkingDirectory.getUpstreamGitRemote());
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitBranch.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitBranch.java
@@ -22,34 +22,34 @@ import java.io.File;
 public class LocalGitBranch extends BaseGitRef {
 
 	public File getDirectory() {
-		LocalGitRepository localRepository = getLocalRepository();
+		LocalGitRepository localGitRepository = getLocalGitRepository();
 
-		return localRepository.getDirectory();
+		return localGitRepository.getDirectory();
 	}
 
 	public GitWorkingDirectory getGitWorkingDirectory() {
-		LocalGitRepository localRepository = getLocalRepository();
+		LocalGitRepository localGitRepository = getLocalGitRepository();
 
-		return localRepository.getGitWorkingDirectory();
+		return localGitRepository.getGitWorkingDirectory();
 	}
 
-	public LocalGitRepository getLocalRepository() {
-		return _localRepository;
+	public LocalGitRepository getLocalGitRepository() {
+		return _localGitRepository;
 	}
 
 	public String getUpstreamBranchName() {
-		LocalGitRepository localRepository = getLocalRepository();
+		LocalGitRepository localGitRepository = getLocalGitRepository();
 
-		return localRepository.getUpstreamBranchName();
+		return localGitRepository.getUpstreamBranchName();
 	}
 
 	@Override
 	public String toString() {
-		LocalGitRepository localRepository = getLocalRepository();
+		LocalGitRepository localGitRepository = getLocalGitRepository();
 
 		StringBuilder sb = new StringBuilder();
 
-		sb.append(localRepository.getDirectory());
+		sb.append(localGitRepository.getDirectory());
 		sb.append(" (");
 		sb.append(getName());
 		sb.append(" - ");
@@ -60,17 +60,17 @@ public class LocalGitBranch extends BaseGitRef {
 	}
 
 	protected LocalGitBranch(
-		LocalGitRepository localRepository, String name, String sha) {
+		LocalGitRepository localGitRepository, String name, String sha) {
 
 		super(name, sha);
 
-		if (localRepository == null) {
+		if (localGitRepository == null) {
 			throw new IllegalArgumentException("Local repository is null");
 		}
 
-		_localRepository = localRepository;
+		_localGitRepository = localGitRepository;
 	}
 
-	private final LocalGitRepository _localRepository;
+	private final LocalGitRepository _localGitRepository;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitBranch.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitBranch.java
@@ -22,30 +22,30 @@ import java.io.File;
 public class LocalGitBranch extends BaseGitRef {
 
 	public File getDirectory() {
-		LocalRepository localRepository = getLocalRepository();
+		LocalGitRepository localRepository = getLocalRepository();
 
 		return localRepository.getDirectory();
 	}
 
 	public GitWorkingDirectory getGitWorkingDirectory() {
-		LocalRepository localRepository = getLocalRepository();
+		LocalGitRepository localRepository = getLocalRepository();
 
 		return localRepository.getGitWorkingDirectory();
 	}
 
-	public LocalRepository getLocalRepository() {
+	public LocalGitRepository getLocalRepository() {
 		return _localRepository;
 	}
 
 	public String getUpstreamBranchName() {
-		LocalRepository localRepository = getLocalRepository();
+		LocalGitRepository localRepository = getLocalRepository();
 
 		return localRepository.getUpstreamBranchName();
 	}
 
 	@Override
 	public String toString() {
-		LocalRepository localRepository = getLocalRepository();
+		LocalGitRepository localRepository = getLocalRepository();
 
 		StringBuilder sb = new StringBuilder();
 
@@ -60,7 +60,7 @@ public class LocalGitBranch extends BaseGitRef {
 	}
 
 	protected LocalGitBranch(
-		LocalRepository localRepository, String name, String sha) {
+		LocalGitRepository localRepository, String name, String sha) {
 
 		super(name, sha);
 
@@ -71,6 +71,6 @@ public class LocalGitBranch extends BaseGitRef {
 		_localRepository = localRepository;
 	}
 
-	private final LocalRepository _localRepository;
+	private final LocalGitRepository _localRepository;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitRepository.java
@@ -23,7 +23,7 @@ import java.util.Properties;
 /**
  * @author Peter Yoo
  */
-public class LocalRepository extends BaseRepository {
+public class LocalGitRepository extends BaseGitRepository {
 
 	public File getDirectory() {
 		return directory;
@@ -37,14 +37,14 @@ public class LocalRepository extends BaseRepository {
 		return _upstreamBranchName;
 	}
 
-	public RemoteRepository getUpstreamRemoteRepository() {
+	public RemoteGitRepository getUpstreamRemoteGitRepository() {
 		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
 
-		return RepositoryFactory.getRemoteRepository(
+		return GitRepositoryFactory.getRemoteGitRepository(
 			gitWorkingDirectory.getGitRemote("upstream"));
 	}
 
-	public void writeRepositoryPropertiesFiles() {
+	public void writeGitRepositoryPropertiesFiles() {
 		for (Map.Entry<String, Properties> entry :
 				_propertiesFilesMap.entrySet()) {
 
@@ -54,7 +54,7 @@ public class LocalRepository extends BaseRepository {
 		}
 	}
 
-	protected LocalRepository(String name, String upstreamBranchName) {
+	protected LocalGitRepository(String name, String upstreamBranchName) {
 		super(name);
 
 		if ((upstreamBranchName == null) || upstreamBranchName.isEmpty()) {
@@ -63,18 +63,19 @@ public class LocalRepository extends BaseRepository {
 
 		_upstreamBranchName = upstreamBranchName;
 
-		Properties repositoryProperties = _getProperties();
+		Properties gitRepositoryProperties = _getProperties();
 
-		String repositoryDirPropertyKey = getRepositoryDirPropertyKey();
+		String gitRepositoryDirPropertyKey = getGitRepositoryDirPropertyKey();
 
-		if (repositoryProperties.containsKey(repositoryDirPropertyKey)) {
+		if (gitRepositoryProperties.containsKey(gitRepositoryDirPropertyKey)) {
 			directory = new File(
-				repositoryProperties.getProperty(repositoryDirPropertyKey));
+				gitRepositoryProperties.getProperty(
+					gitRepositoryDirPropertyKey));
 		}
 		else {
 			directory = new File(
-				JenkinsResultsParserUtil.getBaseRepositoryDir(),
-				getDefaultRelativeRepositoryDirPath());
+				JenkinsResultsParserUtil.getBaseGitRepositoryDir(),
+				getDefaultRelativeGitRepositoryDirPath());
 		}
 
 		if (!directory.exists()) {
@@ -96,17 +97,17 @@ public class LocalRepository extends BaseRepository {
 				upstreamBranchName, getDirectory(), getName());
 	}
 
-	protected String getDefaultRelativeRepositoryDirPath() {
+	protected String getDefaultRelativeGitRepositoryDirPath() {
 		return getName();
+	}
+
+	protected String getGitRepositoryDirPropertyKey() {
+		return JenkinsResultsParserUtil.combine(
+			"repository.dir[", name, "/" + getUpstreamBranchName(), "]");
 	}
 
 	protected Properties getProperties(String filePath) {
 		return _propertiesFilesMap.get(filePath);
-	}
-
-	protected String getRepositoryDirPropertyKey() {
-		return JenkinsResultsParserUtil.combine(
-			"repository.dir[", name, "/" + getUpstreamBranchName(), "]");
 	}
 
 	protected void setProperties(String filePath, Properties properties) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralSubrepositoryUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralSubrepositoryUtil.java
@@ -314,7 +314,7 @@ public class MergeCentralSubrepositoryUtil {
 
 			while (page < 10) {
 				String url = JenkinsResultsParserUtil.getGitHubApiUrl(
-					centralGitWorkingDirectory.getRepositoryName(),
+					centralGitWorkingDirectory.getGitRepositoryName(),
 					receiverUserName, "pulls?page=" + String.valueOf(page));
 
 				JSONArray jsonArray = JenkinsResultsParserUtil.toJSONArray(url);
@@ -421,7 +421,7 @@ public class MergeCentralSubrepositoryUtil {
 		LocalGitBranch mergeLocalGitBranch, String receiverUserName) {
 
 		String centralRepositoryName =
-			centralGitWorkingDirectory.getRepositoryName();
+			centralGitWorkingDirectory.getGitRepositoryName();
 
 		String originRemoteURL = JenkinsResultsParserUtil.combine(
 			"git@github.com:", receiverUserName, "/", centralRepositoryName,
@@ -431,7 +431,7 @@ public class MergeCentralSubrepositoryUtil {
 			true, "tempRemote", originRemoteURL);
 
 		try {
-			centralGitWorkingDirectory.pushToRemoteRepository(
+			centralGitWorkingDirectory.pushToRemoteGitRepository(
 				false, mergeLocalGitBranch, mergeLocalGitBranch.getName(),
 				originGitRemote);
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PluginsGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PluginsGitWorkingDirectory.java
@@ -42,7 +42,7 @@ public class PluginsGitWorkingDirectory extends GitWorkingDirectory {
 	}
 
 	@Override
-	protected void setUpstreamGitRemoteToPrivateRepository() {
+	protected void setUpstreamGitRemoteToPrivateGitRepository() {
 		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		String remoteURL = upstreamGitRemote.getRemoteURL();
@@ -55,7 +55,7 @@ public class PluginsGitWorkingDirectory extends GitWorkingDirectory {
 	}
 
 	@Override
-	protected void setUpstreamGitRemoteToPublicRepository() {
+	protected void setUpstreamGitRemoteToPublicGitRepository() {
 		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		String remoteURL = upstreamGitRemote.getRemoteURL();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PluginsLocalGitBranch.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PluginsLocalGitBranch.java
@@ -25,18 +25,18 @@ public class PluginsLocalGitBranch extends LocalGitBranch {
 		return (PluginsGitWorkingDirectory)gitWorkingDirectory;
 	}
 
-	public PluginsLocalRepository getPluginsLocalRepository() {
-		LocalRepository localRepository = getLocalRepository();
+	public PluginsLocalGitRepository getPluginsLocalRepository() {
+		LocalGitRepository localRepository = getLocalRepository();
 
-		return (PluginsLocalRepository)localRepository;
+		return (PluginsLocalGitRepository)localRepository;
 	}
 
 	protected PluginsLocalGitBranch(
-		LocalRepository localRepository, String name, String sha) {
+		LocalGitRepository localRepository, String name, String sha) {
 
 		super(localRepository, name, sha);
 
-		if (!(localRepository instanceof PluginsLocalRepository)) {
+		if (!(localRepository instanceof PluginsLocalGitRepository)) {
 			throw new IllegalArgumentException(
 				"Local repository is not a plugins repository");
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PluginsLocalGitBranch.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PluginsLocalGitBranch.java
@@ -25,18 +25,18 @@ public class PluginsLocalGitBranch extends LocalGitBranch {
 		return (PluginsGitWorkingDirectory)gitWorkingDirectory;
 	}
 
-	public PluginsLocalGitRepository getPluginsLocalRepository() {
-		LocalGitRepository localRepository = getLocalRepository();
+	public PluginsLocalGitRepository getPluginsLocalGitRepository() {
+		LocalGitRepository localGitRepository = getLocalGitRepository();
 
-		return (PluginsLocalGitRepository)localRepository;
+		return (PluginsLocalGitRepository)localGitRepository;
 	}
 
 	protected PluginsLocalGitBranch(
-		LocalGitRepository localRepository, String name, String sha) {
+		LocalGitRepository localGitRepository, String name, String sha) {
 
-		super(localRepository, name, sha);
+		super(localGitRepository, name, sha);
 
-		if (!(localRepository instanceof PluginsLocalGitRepository)) {
+		if (!(localGitRepository instanceof PluginsLocalGitRepository)) {
 			throw new IllegalArgumentException(
 				"Local repository is not a plugins repository");
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PluginsLocalGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PluginsLocalGitRepository.java
@@ -17,9 +17,11 @@ package com.liferay.jenkins.results.parser;
 /**
  * @author Michael Hashimoto
  */
-public class PluginsLocalRepository extends LocalRepository {
+public class PluginsLocalGitRepository extends LocalGitRepository {
 
-	protected PluginsLocalRepository(String name, String upstreamBranchName) {
+	protected PluginsLocalGitRepository(
+		String name, String upstreamBranchName) {
+
 		super(name, upstreamBranchName);
 
 		if (upstreamBranchName.startsWith("ee-") ||
@@ -46,7 +48,7 @@ public class PluginsLocalRepository extends LocalRepository {
 	}
 
 	@Override
-	protected String getDefaultRelativeRepositoryDirPath() {
+	protected String getDefaultRelativeGitRepositoryDirPath() {
 		String upstreamBranchName = getUpstreamBranchName();
 
 		if (upstreamBranchName.equals("master")) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalBatchBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalBatchBuildRunner.java
@@ -44,9 +44,7 @@ public class PortalBatchBuildRunner extends BatchBuildRunner {
 			throw new RuntimeException("Invalid workspace");
 		}
 
-		PortalWorkspace portalWorkspace = (PortalWorkspace)workspace;
-
-		portalWorkspace.setPortalJobProperties(getJob());
+		workspace.setJobProperties(getJob());
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalBatchBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalBatchBuildRunner.java
@@ -36,15 +36,15 @@ public class PortalBatchBuildRunner extends BatchBuildRunner {
 		PortalGitWorkingDirectory portalGitWorkingDirectory =
 			portalTestClassJob.getPortalGitWorkingDirectory();
 
-		baseWorkspace = WorkspaceFactory.newBatchWorkspace(
+		workspace = WorkspaceFactory.newBatchWorkspace(
 			portalGitHubURL, portalGitWorkingDirectory.getUpstreamBranchName(),
 			batchName);
 
-		if (!(baseWorkspace instanceof PortalWorkspace)) {
+		if (!(workspace instanceof PortalWorkspace)) {
 			throw new RuntimeException("Invalid workspace");
 		}
 
-		PortalWorkspace portalWorkspace = (PortalWorkspace)baseWorkspace;
+		PortalWorkspace portalWorkspace = (PortalWorkspace)workspace;
 
 		portalWorkspace.setPortalJobProperties(getJob());
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
@@ -243,7 +243,7 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 	}
 
 	@Override
-	protected void setUpstreamGitRemoteToPrivateRepository() {
+	protected void setUpstreamGitRemoteToPrivateGitRepository() {
 		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		String remoteURL = upstreamGitRemote.getRemoteURL();
@@ -256,7 +256,7 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 	}
 
 	@Override
-	protected void setUpstreamGitRemoteToPublicRepository() {
+	protected void setUpstreamGitRemoteToPublicGitRepository() {
 		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		String remoteURL = upstreamGitRemote.getRemoteURL();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalLocalGitBranch.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalLocalGitBranch.java
@@ -25,18 +25,18 @@ public class PortalLocalGitBranch extends LocalGitBranch {
 		return (PortalGitWorkingDirectory)gitWorkingDirectory;
 	}
 
-	public PortalLocalRepository getPortalLocalRepository() {
-		LocalRepository localRepository = getLocalRepository();
+	public PortalLocalGitRepository getPortalLocalRepository() {
+		LocalGitRepository localRepository = getLocalRepository();
 
-		return (PortalLocalRepository)localRepository;
+		return (PortalLocalGitRepository)localRepository;
 	}
 
 	protected PortalLocalGitBranch(
-		LocalRepository localRepository, String name, String sha) {
+		LocalGitRepository localRepository, String name, String sha) {
 
 		super(localRepository, name, sha);
 
-		if (!(localRepository instanceof PortalLocalRepository)) {
+		if (!(localRepository instanceof PortalLocalGitRepository)) {
 			throw new IllegalArgumentException(
 				"Local repository is not a portal repository");
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalLocalGitBranch.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalLocalGitBranch.java
@@ -25,18 +25,18 @@ public class PortalLocalGitBranch extends LocalGitBranch {
 		return (PortalGitWorkingDirectory)gitWorkingDirectory;
 	}
 
-	public PortalLocalGitRepository getPortalLocalRepository() {
-		LocalGitRepository localRepository = getLocalRepository();
+	public PortalLocalGitRepository getPortalLocalGitRepository() {
+		LocalGitRepository localGitRepository = getLocalGitRepository();
 
-		return (PortalLocalGitRepository)localRepository;
+		return (PortalLocalGitRepository)localGitRepository;
 	}
 
 	protected PortalLocalGitBranch(
-		LocalGitRepository localRepository, String name, String sha) {
+		LocalGitRepository localGitRepository, String name, String sha) {
 
-		super(localRepository, name, sha);
+		super(localGitRepository, name, sha);
 
-		if (!(localRepository instanceof PortalLocalGitRepository)) {
+		if (!(localGitRepository instanceof PortalLocalGitRepository)) {
 			throw new IllegalArgumentException(
 				"Local repository is not a portal repository");
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalLocalGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalLocalGitRepository.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 /**
  * @author Michael Hashimoto
  */
-public class PortalLocalRepository extends LocalRepository {
+public class PortalLocalGitRepository extends LocalGitRepository {
 
 	public void setAppServerProperties(Properties properties) {
 		setProperties(_FILE_PATH_APP_SERVER_PROPERTIES, properties);
@@ -61,7 +61,7 @@ public class PortalLocalRepository extends LocalRepository {
 		setProperties(_FILE_PATH_TEST_PROPERTIES, properties);
 	}
 
-	protected PortalLocalRepository(String name, String upstreamBranchName) {
+	protected PortalLocalGitRepository(String name, String upstreamBranchName) {
 		super(name, upstreamBranchName);
 
 		if (upstreamBranchName.startsWith("ee-") ||
@@ -81,7 +81,7 @@ public class PortalLocalRepository extends LocalRepository {
 	}
 
 	@Override
-	protected String getDefaultRelativeRepositoryDirPath() {
+	protected String getDefaultRelativeGitRepositoryDirPath() {
 		String upstreamBranchName = getUpstreamBranchName();
 
 		if (upstreamBranchName.equals("master")) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalTopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalTopLevelBuildRunner.java
@@ -34,16 +34,16 @@ public class PortalTopLevelBuildRunner extends TopLevelBuildRunner {
 		PortalGitWorkingDirectory portalGitWorkingDirectory =
 			portalTestClassJob.getPortalGitWorkingDirectory();
 
-		workspace = WorkspaceFactory.newTopLevelWorkspace(
+		Workspace topLevelWorkspace = WorkspaceFactory.newTopLevelWorkspace(
 			portalGitHubURL, portalGitWorkingDirectory.getUpstreamBranchName());
 
-		if (!(workspace instanceof PortalWorkspace)) {
+		if (!(topLevelWorkspace instanceof TopLevelPortalWorkspace)) {
 			throw new RuntimeException("Invalid workspace");
 		}
 
-		PortalWorkspace portalWorkspace = (PortalWorkspace)workspace;
+		topLevelWorkspace.setJobProperties(getJob());
 
-		portalWorkspace.setPortalJobProperties(getJob());
+		workspace = topLevelWorkspace;
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalTopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalTopLevelBuildRunner.java
@@ -34,14 +34,14 @@ public class PortalTopLevelBuildRunner extends TopLevelBuildRunner {
 		PortalGitWorkingDirectory portalGitWorkingDirectory =
 			portalTestClassJob.getPortalGitWorkingDirectory();
 
-		baseWorkspace = WorkspaceFactory.newTopLevelWorkspace(
+		workspace = WorkspaceFactory.newTopLevelWorkspace(
 			portalGitHubURL, portalGitWorkingDirectory.getUpstreamBranchName());
 
-		if (!(baseWorkspace instanceof PortalWorkspace)) {
+		if (!(workspace instanceof PortalWorkspace)) {
 			throw new RuntimeException("Invalid workspace");
 		}
 
-		PortalWorkspace portalWorkspace = (PortalWorkspace)baseWorkspace;
+		PortalWorkspace portalWorkspace = (PortalWorkspace)workspace;
 
 		portalWorkspace.setPortalJobProperties(getJob());
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspace.java
@@ -51,7 +51,7 @@ public class PortalWorkspace extends BaseWorkspace {
 
 		_checkoutPluginsLocalGitBranch();
 
-		_primaryPortalLocalRepository.writeRepositoryPropertiesFiles();
+		_primaryPortalLocalRepository.writeGitRepositoryPropertiesFiles();
 	}
 
 	protected PortalWorkspace(
@@ -95,8 +95,8 @@ public class PortalWorkspace extends BaseWorkspace {
 			repositoryName = repositoryName.replace("-ee", "");
 		}
 
-		LocalRepository localRepository = RepositoryFactory.getLocalRepository(
-			repositoryName, branchName);
+		LocalGitRepository localRepository =
+			GitRepositoryFactory.getLocalRepository(repositoryName, branchName);
 
 		LocalGitBranch localGitBranch = _getLocalGitBranchFromGitCommit(
 			"git-commit-portal", localRepository, _synchronizeBranches);
@@ -123,8 +123,9 @@ public class PortalWorkspace extends BaseWorkspace {
 
 		String branchName = portalUpstreamBranchName + "-private";
 
-		LocalRepository localRepository = RepositoryFactory.getLocalRepository(
-			"liferay-portal-ee", branchName);
+		LocalGitRepository localRepository =
+			GitRepositoryFactory.getLocalRepository(
+				"liferay-portal-ee", branchName);
 
 		LocalGitBranch localGitBranch = _getLocalGitBranchFromGitCommit(
 			"git-commit-portal-private", localRepository, _synchronizeBranches);
@@ -161,8 +162,8 @@ public class PortalWorkspace extends BaseWorkspace {
 			repositoryName = repositoryName.replace("-ee", "");
 		}
 
-		LocalRepository localRepository = RepositoryFactory.getLocalRepository(
-			repositoryName, branchName);
+		LocalGitRepository localRepository =
+			GitRepositoryFactory.getLocalRepository(repositoryName, branchName);
 
 		RemoteGitRef remoteGitRef = GitUtil.getRemoteGitRef(
 			JenkinsResultsParserUtil.combine(
@@ -192,8 +193,9 @@ public class PortalWorkspace extends BaseWorkspace {
 			branchName = "7.0.x";
 		}
 
-		LocalRepository localRepository = RepositoryFactory.getLocalRepository(
-			"liferay-plugins-ee", branchName);
+		LocalGitRepository localRepository =
+			GitRepositoryFactory.getLocalRepository(
+				"liferay-plugins-ee", branchName);
 
 		LocalGitBranch localGitBranch = _getLocalGitBranchFromGitCommit(
 			"git-commit-plugins", localRepository, _synchronizeBranches);
@@ -203,7 +205,7 @@ public class PortalWorkspace extends BaseWorkspace {
 		return _pluginsLocalGitBranch;
 	}
 
-	protected PortalLocalRepository getPrimaryPortalRepository() {
+	protected PortalLocalGitRepository getPrimaryPortalRepository() {
 		return _primaryPortalLocalRepository;
 	}
 
@@ -287,7 +289,8 @@ public class PortalWorkspace extends BaseWorkspace {
 	}
 
 	private PortalLocalGitBranch _getCachedPortalLocalGitBranch(
-		PortalLocalRepository portalLocalRepository, String portalGitHubURL) {
+		PortalLocalGitRepository portalLocalRepository,
+		String portalGitHubURL) {
 
 		LocalGitBranch localGitBranch;
 
@@ -318,7 +321,7 @@ public class PortalWorkspace extends BaseWorkspace {
 	}
 
 	private LocalGitBranch _getLocalGitBranchFromGitCommit(
-		String gitCommitFileName, LocalRepository localRepository,
+		String gitCommitFileName, LocalGitRepository localRepository,
 		boolean synchronizeBranches) {
 
 		String gitCommitFileContent = _getPortalRepositoryFileContent(
@@ -356,18 +359,19 @@ public class PortalWorkspace extends BaseWorkspace {
 		return localGitBranch;
 	}
 
-	private PortalLocalRepository _getPortalLocalRepository(
+	private PortalLocalGitRepository _getPortalLocalRepository(
 		String portalRepositoryName, String portalUpstreamBranchName) {
 
-		LocalRepository localRepository = RepositoryFactory.getLocalRepository(
-			portalRepositoryName, portalUpstreamBranchName);
+		LocalGitRepository localRepository =
+			GitRepositoryFactory.getLocalRepository(
+				portalRepositoryName, portalUpstreamBranchName);
 
-		if (!(localRepository instanceof PortalLocalRepository)) {
+		if (!(localRepository instanceof PortalLocalGitRepository)) {
 			throw new RuntimeException(
 				"Invalid local repository " + localRepository);
 		}
 
-		return (PortalLocalRepository)localRepository;
+		return (PortalLocalGitRepository)localRepository;
 	}
 
 	private String _getPortalRepositoryFileContent(
@@ -406,7 +410,7 @@ public class PortalWorkspace extends BaseWorkspace {
 	private PortalLocalGitBranch _otherPortalLocalGitBranch;
 	private PluginsLocalGitBranch _pluginsLocalGitBranch;
 	private final PortalLocalGitBranch _primaryPortalLocalGitBranch;
-	private final PortalLocalRepository _primaryPortalLocalRepository;
+	private final PortalLocalGitRepository _primaryPortalLocalRepository;
 	private final boolean _synchronizeBranches;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspace.java
@@ -35,7 +35,7 @@ public class PortalWorkspace extends BaseWorkspace {
 		return false;
 	}
 
-	public void setPortalJobProperties(Job job) {
+	public void setJobProperties(Job job) {
 		_primaryPortalLocalRepository.setJobProperties(job);
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -14,7 +14,7 @@
 
 package com.liferay.jenkins.results.parser;
 
-import com.liferay.jenkins.results.parser.GitHubRemoteRepository.Label;
+import com.liferay.jenkins.results.parser.GitHubRemoteGitRepository.Label;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HttpRequestMethod;
 
 import java.io.File;
@@ -68,8 +68,8 @@ public class PullRequest {
 			throw new RuntimeException("Invalid GitHub URL " + gitHubURL);
 		}
 
-		_gitHubRemoteRepositoryName = matcher.group(
-			"gitHubRemoteRepositoryName");
+		_gitHubRemoteGitRepositoryName = matcher.group(
+			"gitHubRemoteGitRepositoryName");
 		_number = Integer.parseInt(matcher.group("number"));
 		_ownerUsername = matcher.group("owner");
 
@@ -105,17 +105,17 @@ public class PullRequest {
 			return true;
 		}
 
-		GitHubRemoteRepository gitHubRemoteRepository =
-			getGitHubRemoteRepository();
+		GitHubRemoteGitRepository gitHubRemoteGitRepository =
+			getGitHubRemoteGitRepository();
 
-		Label repositoryLabel = gitHubRemoteRepository.getLabel(
+		Label repositoryLabel = gitHubRemoteGitRepository.getLabel(
 			label.getName());
 
 		if (repositoryLabel == null) {
 			System.out.println(
 				JenkinsResultsParserUtil.combine(
 					"Label ", label.getName(), " does not exist in ",
-					getGitHubRemoteRepositoryName()));
+					getGitHubRemoteGitRepositoryName()));
 
 			return false;
 		}
@@ -125,7 +125,7 @@ public class PullRequest {
 		jsonArray.put(label.getName());
 
 		String gitHubApiUrl = JenkinsResultsParserUtil.getGitHubApiUrl(
-			getGitHubRemoteRepositoryName(), getOwnerUsername(),
+			getGitHubRemoteGitRepositoryName(), getOwnerUsername(),
 			"issues/" + getNumber() + "/labels");
 
 		try {
@@ -160,7 +160,7 @@ public class PullRequest {
 		List<Comment> comments = new ArrayList<>();
 
 		String gitHubApiUrl = JenkinsResultsParserUtil.getGitHubApiUrl(
-			getGitHubRemoteRepositoryName(), getOwnerUsername(),
+			getGitHubRemoteGitRepositoryName(), getOwnerUsername(),
 			"issues/" + getNumber() + "/comments?page=");
 
 		int page = 1;
@@ -191,23 +191,24 @@ public class PullRequest {
 
 	public Commit getCommit() {
 		return CommitFactory.newCommit(
-			getOwnerUsername(), getGitHubRemoteRepositoryName(),
+			getOwnerUsername(), getGitHubRemoteGitRepositoryName(),
 			getSenderSHA());
 	}
 
-	public GitHubRemoteRepository getGitHubRemoteRepository() {
-		if (_gitHubRemoteRepository == null) {
-			_gitHubRemoteRepository =
-				(GitHubRemoteRepository)RepositoryFactory.getRemoteRepository(
-					"github.com", _gitHubRemoteRepositoryName,
-					getOwnerUsername());
+	public GitHubRemoteGitRepository getGitHubRemoteGitRepository() {
+		if (_gitHubRemoteGitRepository == null) {
+			_gitHubRemoteGitRepository =
+				(GitHubRemoteGitRepository)GitRepositoryFactory.
+					getRemoteGitRepository(
+						"github.com", _gitHubRemoteGitRepositoryName,
+						getOwnerUsername());
 		}
 
-		return _gitHubRemoteRepository;
+		return _gitHubRemoteGitRepository;
 	}
 
-	public String getGitHubRemoteRepositoryName() {
-		return _gitHubRemoteRepositoryName;
+	public String getGitHubRemoteGitRepositoryName() {
+		return _gitHubRemoteGitRepositoryName;
 	}
 
 	public String getHtmlURL() {
@@ -264,7 +265,7 @@ public class PullRequest {
 	}
 
 	public String getRepositoryName() {
-		return getGitHubRemoteRepositoryName();
+		return getGitHubRemoteGitRepositoryName();
 	}
 
 	public String getSenderBranchName() {
@@ -276,7 +277,7 @@ public class PullRequest {
 	public String getSenderRemoteURL() {
 		return JenkinsResultsParserUtil.combine(
 			"git@github.com:", getSenderUsername(), "/",
-			getGitHubRemoteRepositoryName());
+			getGitHubRemoteGitRepositoryName());
 	}
 
 	public String getSenderSHA() {
@@ -315,7 +316,7 @@ public class PullRequest {
 
 	public String getURL() {
 		return JenkinsResultsParserUtil.getGitHubApiUrl(
-			_gitHubRemoteRepositoryName, _ownerUsername, "pulls/" + _number);
+			_gitHubRemoteGitRepositoryName, _ownerUsername, "pulls/" + _number);
 	}
 
 	public boolean hasLabel(String labelName) {
@@ -355,7 +356,7 @@ public class PullRequest {
 				JSONObject labelJSONObject = labelJSONArray.getJSONObject(i);
 
 				_labels.add(
-					new Label(labelJSONObject, getGitHubRemoteRepository()));
+					new Label(labelJSONObject, getGitHubRemoteGitRepository()));
 			}
 		}
 		catch (IOException ioe) {
@@ -372,7 +373,7 @@ public class PullRequest {
 			"issues/", getNumber(), "/labels/", labelName);
 
 		String gitHubApiUrl = JenkinsResultsParserUtil.getGitHubApiUrl(
-			getGitHubRemoteRepositoryName(), getOwnerUsername(), path);
+			getGitHubRemoteGitRepositoryName(), getOwnerUsername(), path);
 
 		try {
 			JenkinsResultsParserUtil.toString(
@@ -424,16 +425,18 @@ public class PullRequest {
 		sb.append(" - ");
 		sb.append(StringUtils.lowerCase(testSuiteStatus.toString()));
 
-		GitHubRemoteRepository gitHubRemoteRepository =
-			getGitHubRemoteRepository();
+		GitHubRemoteGitRepository gitHubRemoteGitRepository =
+			getGitHubRemoteGitRepository();
 
-		Label testSuiteLabel = gitHubRemoteRepository.getLabel(sb.toString());
+		Label testSuiteLabel = gitHubRemoteGitRepository.getLabel(
+			sb.toString());
 
 		if (testSuiteLabel == null) {
-			if (gitHubRemoteRepository.addLabel(
+			if (gitHubRemoteGitRepository.addLabel(
 					testSuiteStatus.getColor(), "", sb.toString())) {
 
-				testSuiteLabel = gitHubRemoteRepository.getLabel(sb.toString());
+				testSuiteLabel = gitHubRemoteGitRepository.getLabel(
+					sb.toString());
 			}
 		}
 
@@ -585,10 +588,10 @@ public class PullRequest {
 	private static final Pattern _gitHubPullRequestURLPattern = Pattern.compile(
 		JenkinsResultsParserUtil.combine(
 			"https://github.com/(?<owner>[^/]+)/",
-			"(?<gitHubRemoteRepositoryName>[^/]+)/pull/(?<number>\\d+)"));
+			"(?<gitHubRemoteGitRepositoryName>[^/]+)/pull/(?<number>\\d+)"));
 
-	private GitHubRemoteRepository _gitHubRemoteRepository;
-	private String _gitHubRemoteRepositoryName;
+	private GitHubRemoteGitRepository _gitHubRemoteGitRepository;
+	private String _gitHubRemoteGitRepositoryName;
 	private JSONObject _jsonObject;
 	private final List<Label> _labels = new ArrayList<>();
 	private RemoteGitBranch _liferayRemoteGitBranch;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteGitBranch.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteGitBranch.java
@@ -20,9 +20,9 @@ package com.liferay.jenkins.results.parser;
 public class RemoteGitBranch extends RemoteGitRef {
 
 	protected RemoteGitBranch(
-		RemoteRepository remoteRepository, String name, String sha) {
+		RemoteGitRepository remoteGitRepository, String name, String sha) {
 
-		super(remoteRepository, name, sha);
+		super(remoteGitRepository, name, sha);
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteGitRef.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteGitRef.java
@@ -27,23 +27,23 @@ public class RemoteGitRef
 		return name.compareTo(o.getName());
 	}
 
-	public RemoteRepository getRemoteRepository() {
-		return _remoteRepository;
+	public RemoteGitRepository getRemoteGitRepository() {
+		return _remoteGitRepository;
 	}
 
 	public String getUsername() {
-		RemoteRepository remoteRepository = getRemoteRepository();
+		RemoteGitRepository remoteGitRepository = getRemoteGitRepository();
 
-		return remoteRepository.getUsername();
+		return remoteGitRepository.getUsername();
 	}
 
 	@Override
 	public String toString() {
-		RemoteRepository remoteRepository = getRemoteRepository();
+		RemoteGitRepository remoteGitRepository = getRemoteGitRepository();
 
 		StringBuilder sb = new StringBuilder();
 
-		sb.append(remoteRepository.getRemoteURL());
+		sb.append(remoteGitRepository.getRemoteURL());
 		sb.append(" (");
 		sb.append(getName());
 		sb.append(" - ");
@@ -54,17 +54,17 @@ public class RemoteGitRef
 	}
 
 	protected RemoteGitRef(
-		RemoteRepository remoteRepository, String name, String sha) {
+		RemoteGitRepository remoteGitRepository, String name, String sha) {
 
 		super(name, sha);
 
-		if (remoteRepository == null) {
+		if (remoteGitRepository == null) {
 			throw new IllegalArgumentException("Remote repository is null");
 		}
 
-		_remoteRepository = remoteRepository;
+		_remoteGitRepository = remoteGitRepository;
 	}
 
-	private final RemoteRepository _remoteRepository;
+	private final RemoteGitRepository _remoteGitRepository;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteGitRepository.java
@@ -17,7 +17,7 @@ package com.liferay.jenkins.results.parser;
 /**
  * @author Peter Yoo
  */
-public class RemoteRepository extends BaseRepository {
+public class RemoteGitRepository extends BaseGitRepository {
 
 	public String getHostname() {
 		return hostname;
@@ -32,13 +32,13 @@ public class RemoteRepository extends BaseRepository {
 		return username;
 	}
 
-	protected RemoteRepository(GitRemote gitRemote) {
+	protected RemoteGitRepository(GitRemote gitRemote) {
 		this(
 			gitRemote.getHostname(), gitRemote.getRepositoryName(),
 			gitRemote.getUsername());
 	}
 
-	protected RemoteRepository(
+	protected RemoteGitRepository(
 		String hostname, String repositoryName, String username) {
 
 		super(repositoryName);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Repository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Repository.java
@@ -17,21 +17,8 @@ package com.liferay.jenkins.results.parser;
 /**
  * @author Peter Yoo
  */
-public class BaseRepository implements Repository {
+public interface Repository {
 
-	public BaseRepository(String name) {
-		if ((name == null) || name.isEmpty()) {
-			throw new IllegalArgumentException("Name is null");
-		}
-
-		this.name = name;
-	}
-
-	@Override
-	public String getName() {
-		return name;
-	}
-
-	protected final String name;
+	public String getName();
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SourceFormatBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SourceFormatBuild.java
@@ -28,7 +28,7 @@ public class SourceFormatBuild extends TopLevelBuild {
 
 	@Override
 	public String getBaseRepositoryName() {
-		return _pullRequest.getGitHubRemoteRepositoryName();
+		return _pullRequest.getGitHubRemoteGitRepositoryName();
 	}
 
 	@Override
@@ -123,20 +123,20 @@ public class SourceFormatBuild extends TopLevelBuild {
 	}
 
 	protected Element getSenderBranchDetailsElement() {
-		String gitHubRemoteRepositoryName =
-			_pullRequest.getGitHubRemoteRepositoryName();
+		String gitHubRemoteGitRepositoryName =
+			_pullRequest.getGitHubRemoteGitRepositoryName();
 		String senderBranchName = _pullRequest.getSenderBranchName();
 		String senderUsername = _pullRequest.getSenderUsername();
 
 		String senderBranchURL = JenkinsResultsParserUtil.combine(
 			"https://github.com/", senderUsername, "/",
-			gitHubRemoteRepositoryName, "/tree/", senderBranchName);
+			gitHubRemoteGitRepositoryName, "/tree/", senderBranchName);
 
 		String senderSHA = _pullRequest.getSenderSHA();
 
 		String senderCommitURL = JenkinsResultsParserUtil.combine(
 			"https://github.com/", senderUsername, "/",
-			gitHubRemoteRepositoryName, "/commit/", senderSHA);
+			gitHubRemoteGitRepositoryName, "/commit/", senderSHA);
 
 		Element senderBranchDetailsElement = Dom4JUtil.getNewElement(
 			"p", null, "Branch Name: ",

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SubrepositoryGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SubrepositoryGitWorkingDirectory.java
@@ -38,7 +38,7 @@ public class SubrepositoryGitWorkingDirectory extends GitWorkingDirectory {
 	}
 
 	@Override
-	protected void setUpstreamGitRemoteToPrivateRepository() {
+	protected void setUpstreamGitRemoteToPrivateGitRepository() {
 		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		String remoteURL = upstreamGitRemote.getRemoteURL();
@@ -51,7 +51,7 @@ public class SubrepositoryGitWorkingDirectory extends GitWorkingDirectory {
 	}
 
 	@Override
-	protected void setUpstreamGitRemoteToPublicRepository() {
+	protected void setUpstreamGitRemoteToPublicGitRepository() {
 		GitRemote upstreamGitRemote = getUpstreamGitRemote();
 
 		String remoteURL = upstreamGitRemote.getRemoteURL();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SubrepositoryLocalGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SubrepositoryLocalGitRepository.java
@@ -17,9 +17,9 @@ package com.liferay.jenkins.results.parser;
 /**
  * @author Michael Hashimoto
  */
-public class SubrepositoryLocalRepository extends LocalRepository {
+public class SubrepositoryLocalGitRepository extends LocalGitRepository {
 
-	protected SubrepositoryLocalRepository(
+	protected SubrepositoryLocalGitRepository(
 		String name, String upstreamBranchName) {
 
 		super(name, upstreamBranchName);
@@ -36,7 +36,7 @@ public class SubrepositoryLocalRepository extends LocalRepository {
 	}
 
 	@Override
-	protected String getDefaultRelativeRepositoryDirPath() {
+	protected String getDefaultRelativeGitRepositoryDirPath() {
 		String name = getName();
 
 		if (!name.endsWith("-private")) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelPortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelPortalWorkspace.java
@@ -15,11 +15,22 @@
 package com.liferay.jenkins.results.parser;
 
 /**
- * @author Michael Hashimoto
+ * @author Peter Yoo
  */
-public interface Workspace {
+public class TopLevelPortalWorkspace
+	extends PortalWorkspace implements TopLevelWorkspace {
 
-	public void setupWorkspace();
+	protected TopLevelPortalWorkspace(
+		String portalGitHubURL, String portalUpstreamBranchName) {
 
-	public void setJobProperties(Job job);
+		super(portalGitHubURL, portalUpstreamBranchName, false);
+	}
+
+	protected TopLevelPortalWorkspace(
+		String portalGitHubURL, String portalUpstreamBranchName,
+		boolean synchronizeBranches) {
+
+		super(portalGitHubURL, portalUpstreamBranchName, synchronizeBranches);
+	}
+
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelWorkspace.java
@@ -18,5 +18,4 @@ package com.liferay.jenkins.results.parser;
  * @author Peter Yoo
  */
 public interface TopLevelWorkspace extends Workspace {
-
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelWorkspace.java
@@ -15,11 +15,8 @@
 package com.liferay.jenkins.results.parser;
 
 /**
- * @author Michael Hashimoto
+ * @author Peter Yoo
  */
-public interface Workspace {
+public interface TopLevelWorkspace extends Workspace {
 
-	public void setupWorkspace();
-
-	public void setJobProperties(Job job);
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Workspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Workspace.java
@@ -17,32 +17,8 @@ package com.liferay.jenkins.results.parser;
 /**
  * @author Michael Hashimoto
  */
-public abstract class BaseBuildRunner implements BuildRunner {
+public interface Workspace {
 
-	@Override
-	public void setup() {
-		setupWorkspace();
-	}
-
-	@Override
-	public void setupWorkspace() {
-		if (workspace == null) {
-			throw new RuntimeException("Workspace is null");
-		}
-
-		workspace.setupWorkspace();
-	}
-
-	protected BaseBuildRunner(Job job) {
-		_job = job;
-	}
-
-	protected Job getJob() {
-		return _job;
-	}
-
-	protected Workspace workspace;
-
-	private final Job _job;
+	public void setupWorkspace();
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Workspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Workspace.java
@@ -19,7 +19,8 @@ package com.liferay.jenkins.results.parser;
  */
 public interface Workspace {
 
+	public void setJobProperties(Job job);
+
 	public void setupWorkspace();
 
-	public void setJobProperties(Job job);
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/WorkspaceFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/WorkspaceFactory.java
@@ -42,14 +42,14 @@ public abstract class WorkspaceFactory {
 		return new PortalWorkspace(gitHubURL, upstreamBranchName, false);
 	}
 
-	public static Workspace newTopLevelWorkspace(
+	public static TopLevelWorkspace newTopLevelWorkspace(
 		String gitHubURL, String upstreamBranchName) {
 
 		if (!PortalWorkspace.isPortalGitHubURL(gitHubURL)) {
 			throw new RuntimeException("Unsupported GitHub URL " + gitHubURL);
 		}
 
-		return new PortalWorkspace(gitHubURL, upstreamBranchName, true);
+		return new TopLevelPortalWorkspace(gitHubURL, upstreamBranchName, true);
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/WorkspaceFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/WorkspaceFactory.java
@@ -19,7 +19,7 @@ package com.liferay.jenkins.results.parser;
  */
 public abstract class WorkspaceFactory {
 
-	public static Workspace newBatchWorkspace(
+	public static BatchWorkspace newBatchWorkspace(
 		String gitHubURL, String upstreamBranchName, String batchName) {
 
 		if (!PortalWorkspace.isPortalGitHubURL(gitHubURL)) {
@@ -31,15 +31,15 @@ public abstract class WorkspaceFactory {
 		}
 
 		if (batchName.contains("functional")) {
-			new FunctionalBatchPortalWorkspace(gitHubURL, upstreamBranchName);
+			return new FunctionalBatchPortalWorkspace(gitHubURL, upstreamBranchName);
 		}
 		else if (batchName.contains("integration") ||
 				 batchName.contains("unit")) {
 
-			new JunitBatchPortalWorkspace(gitHubURL, upstreamBranchName);
+			return new JunitBatchPortalWorkspace(gitHubURL, upstreamBranchName);
 		}
 
-		return new PortalWorkspace(gitHubURL, upstreamBranchName, false);
+		return new BatchPortalWorkspace(gitHubURL, upstreamBranchName, false);
 	}
 
 	public static TopLevelWorkspace newTopLevelWorkspace(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/WorkspaceFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/WorkspaceFactory.java
@@ -19,7 +19,7 @@ package com.liferay.jenkins.results.parser;
  */
 public abstract class WorkspaceFactory {
 
-	public static BaseWorkspace newBatchWorkspace(
+	public static Workspace newBatchWorkspace(
 		String gitHubURL, String upstreamBranchName, String batchName) {
 
 		if (!PortalWorkspace.isPortalGitHubURL(gitHubURL)) {
@@ -42,7 +42,7 @@ public abstract class WorkspaceFactory {
 		return new PortalWorkspace(gitHubURL, upstreamBranchName, false);
 	}
 
-	public static BaseWorkspace newTopLevelWorkspace(
+	public static Workspace newTopLevelWorkspace(
 		String gitHubURL, String upstreamBranchName) {
 
 		if (!PortalWorkspace.isPortalGitHubURL(gitHubURL)) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/WorkspaceFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/WorkspaceFactory.java
@@ -31,7 +31,8 @@ public abstract class WorkspaceFactory {
 		}
 
 		if (batchName.contains("functional")) {
-			return new FunctionalBatchPortalWorkspace(gitHubURL, upstreamBranchName);
+			return new FunctionalBatchPortalWorkspace(
+				gitHubURL, upstreamBranchName);
 		}
 		else if (batchName.contains("integration") ||
 				 batchName.contains("unit")) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-43089

@brianchandotcom I've verified that the change I made to the group name, "gitHubRemoteRepositoryName" has a corresponding change to the usage of the group name.

```
	private static final Pattern _gitHubPullRequestURLPattern = Pattern.compile(
		JenkinsResultsParserUtil.combine(
			"https://github.com/(?<owner>[^/]+)/",
			"(?<gitHubRemoteGitRepositoryName>[^/]+)/pull/(?<number>\\d+)"));
```
```
	_gitHubRemoteGitRepositoryName = matcher.group("gitHubRemoteGitRepositoryName");

```

CC @michaelhashimoto