### PR TITLE
LPS-75431 Include content when JSONWS is discoverable

### DIFF
--- a/portal-web/docroot/html/portal/api/jsonws/index.jsp
+++ b/portal-web/docroot/html/portal/api/jsonws/index.jsp
@@ -16,7 +16,7 @@
 
 <%@ include file="/html/portal/api/jsonws/init.jsp" %>
 
-<c:if test="<%= !PropsValues.JSONWS_WEB_SERVICE_API_DISCOVERABLE %>">
+<c:if test="<%= PropsValues.JSONWS_WEB_SERVICE_API_DISCOVERABLE %>">
 	<style>
 		<%@ include file="/html/portal/api/jsonws/css.jspf" %>
 	</style>


### PR DESCRIPTION
CC @shuyangzhou

Hi Brian, this should fix the JSONWebServiceTrackerTest failure on upstream, thanks!