### PR TITLE
LPS-84327 Add new build property that will deploy ci specific modules if set | master

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -302,6 +302,12 @@
     db.build.java.maxpermsize=256m
 
 ##
+## Deploy
+##
+
+    #deploy.ci.profile.modules=
+
+##
 ## Endorsed Libraries
 ##
 

--- a/build.xml
+++ b/build.xml
@@ -420,7 +420,7 @@ message.
 				</gradle-execute>
 
 				<if>
-					<isset property="env.JENKINS_HOME" />
+					<equals arg1="${deploy.ci.profile.modules}" arg2="true" />
 					<then>
 						<if>
 							<resourcecount count="0" when="gt">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-84327

@petershin - This new property should only be set in tests ran on Liferay's CI.  So nightly builds should skip this process, unless you explicitly set this property as well.

@brianchandotcom - Can you sync the `git-commit-portal` files if this looks okay?