### PR TITLE
OAUTH2-42 Partly reverse wordsmithing (1b5cc3c3)

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseClientTestCase.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseClientTestCase.java
@@ -602,7 +602,7 @@ public abstract class BaseClientTestCase {
 		if (uri == null) {
 			throw new IllegalArgumentException(
 				"Authorization service response missing \"Location\" header " +
-					"from which code is extracted");
+					"from which error is extracted");
 		}
 
 		Map<String, String[]> parameterMap = HttpUtil.getParameterMap(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
@@ -212,7 +212,7 @@ public class SecurityTest extends BaseClientTestCase {
 		if (uri == null) {
 			throw new IllegalArgumentException(
 				"Authorization service response missing \"Location\" header " +
-					"from which code is extracted");
+					"from which state is extracted");
 		}
 
 		Map<String, String[]> parameterMap = HttpUtil.getParameterMap(


### PR DESCRIPTION
Hi Brian. Reviewed you changes upstream. All fine except that the "Location" header does contain multiple parameters (code, state, error).