### PR TITLE
LPS-74544 Add temporary suppressions

### DIFF
--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -157,6 +157,11 @@
 		<suppress checks="JavaInnerClassImportsCheck" files="modules/apps/commerce/.*" />
 		<suppress checks="JavaInnerClassImportsCheck" files="modules/private/.*" />
 		<suppress checks="JavaInnerClassImportsCheck" files="modules/test/poshi-runner/.*" />
+		<suppress checks="JSONLineBreakCheck" files="modules/apps/apio-architect/.*" />
+		<suppress checks="JSONLineBreakCheck" files="modules/apps/commerce/.*" />
+		<suppress checks="JSONLineBreakCheck" files="modules/private/apps/commerce/.*" />
+		<suppress checks="JSONLineBreakCheck" files="modules/private/apps/lcs/.*" />
+		<suppress checks="JSONLineBreakCheck" files="modules/test/poshi-runner/.*" />
 		<suppress checks="PropertiesLiferayPluginPackageLiferayVersionsCheck" files="modules/private/apio-architect/.*" />
 		<suppress checks="PropertiesLiferayPluginPackageLiferayVersionsCheck" files="modules/private/commerce/.*" />
 		<suppress checks="XMLLookAndFeelCompatibilityVersionCheck" files="modules/private/apio-architect/.*" />

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -70,6 +70,11 @@
 		<!-- Temporary suppressions for private repos and subrepos -->
 
 		<suppress checks="ReferenceAnnotationCheck" files="modules/private/.*" />
+		<suppress checks="UnprocessedExceptionCheck" files="modules/apps/apio-architect/.*" />
+		<suppress checks="UnprocessedExceptionCheck" files="modules/apps/commerce/.*" />
+		<suppress checks="UnprocessedExceptionCheck" files="modules/private/apps/commerce/.*" />
+		<suppress checks="UnprocessedExceptionCheck" files="modules/private/apps/lcs/.*" />
+		<suppress checks="UnprocessedExceptionCheck" files="modules/test/poshi-runner/.*" />
 		<suppress checks="VariableNameCheck" files="modules/private/.*" />
 	</checkstyle>
 	<source-check>


### PR DESCRIPTION
Hi @hhuijser,

A temp suppression was added for `JSONLineBreakCheck` since its only supposed to be enabled on master.  The `UnprocessedExceptionCheck` is showing different results on CI vs when its run in the [`com-liferay-commerce`](https://github.com/liferay/com-liferay-commerce) subrepo so I added a suppression for that check too.

Please check the subrepos before adding new SF rules.

@pyoo47