### PR TITLE
[Backport to 7.1.x] Revert "LPS-84472 Cannot create document if both Overall Maximum Upload Request Size and Maximum File Size are set to 0"

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
@@ -29,7 +29,7 @@ AUI.add(
 			var nodeType = node.get('type').toLowerCase();
 
 			if (nodeType === 'file') {
-				return (ruleValue === 0 || node._node.files[0].size <= ruleValue);
+				return (node._node.files[0].size <= ruleValue);
 			}
 
 			return true;
@@ -336,7 +336,7 @@ AUI.add(
 						var fieldName = rule.fieldName;
 						var validatorName = rule.validatorName;
 
-						if (typeof rule.body !== 'undefined' && !rule.custom) {
+						if (rule.body && !rule.custom) {
 							value = rule.body;
 						}
 


### PR DESCRIPTION
Hey @brianchandotcom, this is causing a big regression in how we handle `required` validation on the client side, so I'd like to revert this quickly and then attempt the fix in a different way.

Could you please backport this to `7.1.x` automatically?

Thanks!