### PR TITLE
LPS-85260 | master

### DIFF
--- a/portal-impl/src/com/liferay/portal/spring/hibernate/DialectDetector.java
+++ b/portal-impl/src/com/liferay/portal/spring/hibernate/DialectDetector.java
@@ -148,10 +148,10 @@ public class DialectDetector {
 			throw new RuntimeException("No dialect found");
 		}
 		else if (dialectKey != null) {
-			if (_log.isDebugEnabled()) {
+			if (_log.isInfoEnabled()) {
 				Class<?> clazz = dialect.getClass();
 
-				_log.debug("Using dialect " + clazz.getName());
+				_log.info("Using dialect " + clazz.getName());
 			}
 
 			_dialects.put(dialectKey, dialect);


### PR DESCRIPTION
After discussing with @shuyangzhou, we thought it would be better to keep showing the user the dialect that is used. A user might need to switch their database version or dialect and expect to have this information. It reads a bit strange in the logs because it says it will "Determine dialect for MY_DATABASE" but nothing else after. We do not think this has a performance impact worth the loss of information.