### PR TITLE
LPS-85124 Embedded Elasticsearch logging should be minimal by default: also when Elasticsearch plugins are installed on first run

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/elasticsearch-optional-defaults.yml
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/elasticsearch-optional-defaults.yml
@@ -1,5 +1,7 @@
 http.host: _local_
 
+monitor.jvm.gc.enabled: false
+
 thread_pool:
     bulk:
         queue_size: 100


### PR DESCRIPTION
`ci:test:search` passed all tests except `DeclarativeServiceDependencyManagerTest`, a known problem already being handled by QA. (https://github.com/arboliveira/liferay-portal/pull/591#issuecomment-422286115)

cc/ @BryanEngler see https://github.com/brianchandotcom/liferay-portal/pull/63200/commits/5c74e4f83b10e87889842bae20c37d1f46448e29

https://issues.liferay.com/browse/LPS-85124