### PR TITLE
[TECHNICAL SUPPORT] LPS-85971 Incorrect notification on UI at requesting a Password Reset Link

### DIFF
--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/login.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/login.jsp
@@ -73,7 +73,7 @@
 				<c:choose>
 					<c:when test='<%= SessionMessages.contains(request, "passwordSent") %>'>
 						<div class="alert alert-success">
-							<liferay-ui:message key="your-password-was-sent-to-the-provided-email-address" />
+							<liferay-ui:message key="An-email-has-been-sent-to-the-provided-email-address" />
 						</div>
 					</c:when>
 					<c:when test='<%= SessionMessages.contains(request, "userAdded") %>'>

--- a/modules/apps/login/login-web/src/main/resources/content/Language.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address.
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Fast Sign In
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Sign In
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>.
 you-are-signed-in-as-x=You are signed in as {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}.
-your-password-was-sent-to-the-provided-email-address=Your password was sent to the provided email address.
 your-password-was-sent-to-x=Your password was sent to {0}.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ar.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=سيتم إرسال كلمة مرور جديدة إلى {0} إذا استطعت الإجابة بشكل صحيح على السؤال التالي.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=تسجيل دخول سريع
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=تسجيل الدخول
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=نشكرك على إنشاء الحساب. كلمة المرور الخاصة بك <strong>{0}</strong>.
 you-are-signed-in-as-x=لقد تم دخولك بإسم {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=أرسل كلمة المرور الخاصة بك إلى عنوان البريد الإلكتروني المتوفر. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_bg.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Нова парола ще бъде изпратена на {0} ако отговорите успешно на следващия въпрос.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Бърз вход (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Вход
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>. (Automatic Copy)
 you-are-signed-in-as-x=Влезли сте като {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Вашата парола е изпратена на предоставения имейл адрес. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ca.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=S'enviarà una nova contrasenya a {0} si responeu correctament la pregunta següent.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Inici de sessió ràpid
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Inicia la sessió
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Gràcies per crear un compte. La vostra contrasenya és <strong>{0}</strong>.
 you-are-signed-in-as-x=Us heu validat com a {0}.
 your-email-verification-code-was-sent-to-x=Us hem enviat el codi de verificació de correu electrònic a {0}.
-your-password-was-sent-to-the-provided-email-address=Us hem enviat la contrasenya al correu electrònic que vau proporcionar.
 your-password-was-sent-to-x=La contrasenya s'ha enviat a {0}.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_cs.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Pokud správně zodpovíte následující otázku, na adresu {0} bude zasláno nové heslo.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Rychlé přihlášení
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Přihlášení
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Děkujeme za vytvoření účtu. Vaše heslo je <strong>{0}</strong>.
 you-are-signed-in-as-x=Nyní jste přihlášen(a) jako {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Vaše heslo bylo odesláno na zadané e-mailovou adresu. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_da.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=En ny adgangskode sendes til {0} hvis du svarer korrekt på følgende spørgsmål.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Hurtig log på
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Log ind
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Din adgangskode is <strong>{0}</strong>.
 you-are-signed-in-as-x=Du er logget ind som {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Your password was sent to the provided email address. (Automatic Copy)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_de.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Ein neues Kennwort wird an {0} geschickt werden, wenn Sie die folgende Frage richtig beantworten können.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Schnelle Anmeldung
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Anmeldung
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Vielen Dank, dass Sie ein Konto erstellt haben. Ihr Kennwort lautet <strong>{0}</strong>.
 you-are-signed-in-as-x=Sie sind angemeldet als {0}.
 your-email-verification-code-was-sent-to-x=Ihr Bestätigungscode wurde an {0} gesendet.
-your-password-was-sent-to-the-provided-email-address=Ihr Kennwort wurde an die hinterlegte E-Mail-Adresse gesendet.
 your-password-was-sent-to-x=Ihr Kennwort wurde an {0} gesendet.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_el.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Ένα νέο password θα σταλεί στο {0} αν απαντήσετε σωστά την επόμενη ερώτηση
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Γρήγορη είσοδος
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Είσοδος
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Ευχαριστούμε που δημιουργήσατε λογαριασμό στο site μας. Ο κωδικός πρόσβασής σας είνι <strong>{0}</strong>.
 you-are-signed-in-as-x=Έχετε εισέλθει στο σύστημα ως {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Τον κωδικό πρόσβασής σας εστάλη η ηλεκτρονική διεύθυνση που δηλώσατε. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_en.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address.
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Fast Sign In
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Sign In
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>.
 you-are-signed-in-as-x=You are signed in as {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}.
-your-password-was-sent-to-the-provided-email-address=Your password was sent to the provided email address.
 your-password-was-sent-to-x=Your password was sent to {0}.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_es.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Se enviará una nueva contraseña a {0} si puede responder correctamente a la siguiente pregunta.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Acceso rápido
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Login
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Gracias por crear una cuenta. Tu contraseña es <strong>{0}</strong>.
 you-are-signed-in-as-x=Está conectado como {0}.
 your-email-verification-code-was-sent-to-x=El código de verificación de su correo electrónico fue enviado a {0}.
-your-password-was-sent-to-the-provided-email-address=Su contraseña fue enviada a la dirección de correo electrónico proporcionado.
 your-password-was-sent-to-x=Su contraseña fue enviada a {0}.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_et.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Kasutajale {0} saadetakse uus parool juhul, kui vastad õigesti järgnevale küsimusele.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Kiire sisselogimine (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Logi sisse
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>. (Automatic Copy)
 you-are-signed-in-as-x=Oled sisse logitud kui {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Sinu salasõna saadeti sisestatud meiliaadress. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_eu.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Hurrengo galdera zuzen erantzuteko gai baldin bazara pasahitz berri bat {0}-(r)i bidaliko zaio.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Izen emate azkarra
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Izena ematea
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Mila esker kontua sortzeagatik. Zure pasahitza <strong>{0}</strong> da.
 you-are-signed-in-as-x={0} gisa baimenduta zaude.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Your password was sent to the provided email address. (Automatic Copy)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_fa.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=اگر به سوال زیر پاسخ دهید،‌ رمز عبور جدید به صورت {0} تنظیم می‌شود.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=ورود سریع
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=ورود
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=با تشکر از شما برای ایجاد حساب کاربری. رمز عبور شما <strong>{0}</strong> می‌باشد.
 you-are-signed-in-as-x=شما با نام {0} به سایت وارد شدهاید.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=رمز عبور شما به آدرس ایمیل ارائه شده فرستاده می شد. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_fi.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Uusi salasana lähetetään osoitteeseen {0}, jos vastaat seuraavaan kysymykseen oikein.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Pikakirjautuminen
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Kirjaudu sisään
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Kiitos tilin luonnista. Salasanasi on <strong>{0}</strong>.
 you-are-signed-in-as-x=Olet kirjautunut sisään nimellä {0}.
 your-email-verification-code-was-sent-to-x=Sähköpostin tarkastuskoodisi lähetettiin osoitteeseen {0}.
-your-password-was-sent-to-the-provided-email-address=Salasanasi on lähetetty annettuun sähköpostiosoitteeseen.
 your-password-was-sent-to-x=Salasanasi on lähetetty osoitteeseen {0}.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_fr.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Un nouveau mot de passe sera envoyé à {0} si vous répondez correctement à la question suivante.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Connexion rapide
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Authentification
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Merci d'avoir créé un compte. Votre mot de passe est <strong>{0}</strong>.
 you-are-signed-in-as-x=Vous êtes connecté en tant que {0}.
 your-email-verification-code-was-sent-to-x=Le code de vérification par e-mail a été envoyé à {0}.
-your-password-was-sent-to-the-provided-email-address=Votre mot de passe a été envoyé à l'adresse e-mail fournie.
 your-password-was-sent-to-x=Votre mot de passe a été envoyé à {0}.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_gl.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Unha nova contraseña vai ser enviada a {0} si podes responder correctamente á seguinte pregunta.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Identificación rápida
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Rexistro
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Grazas por crear unha conta. A túa clave é <strong>{0}</strong>.
 you-are-signed-in-as-x=Estás identificado como {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Your password was sent to the provided email address. (Automatic Copy)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_hi_IN.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=निम्नलिखित प्रश्न का सही जवाब देने पर एक नया पासवर्ड आपके इस पते (0) पर भेजा जाएगा.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=में तेजी से साइन इन करें (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=साइन इन करें
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>. (Automatic Copy)
 you-are-signed-in-as-x=आपने {0} के रूप में साइन इन किया हैं|
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=अपना पासवर्ड प्रदान किया गया ईमेल पता करने के लिए भेजा गया था। (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_hr.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Nova lozinka bit će poslana na {0} ukoliko ispravno odgovorite na slijedeće pitanje.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Brza prijava
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Prijava
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Hvala vam na stvaranju računa. Vaša lozinka je <strong>{0}</strong>.
 you-are-signed-in-as-x=Upisali ste se kao {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Your password was sent to the provided email address. (Automatic Copy)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_hu.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Új jelszót kapsz({0}), ha helyesen válaszolsz a következő kérdésre.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Gyors bejelentkezés
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Bejelentkezés
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Köszönjük, hogy fiókot hozott létre. A fiókhoz tartozó jelszó: <strong>{0}</strong>.
 you-are-signed-in-as-x=Ön {0} néven jelentkezett be.
 your-email-verification-code-was-sent-to-x=Az ellenőrző kódot elküldtük e-mailben a {0} címre.
-your-password-was-sent-to-the-provided-email-address=Jelszavát elküldtük a megadott e-mail címre.
 your-password-was-sent-to-x=Jelszavát elküldtük a {0} címre.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_in.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Sebuah password baru akan dikirim ke {0} jika Anda benar dapat menjawab pertanyaan berikut.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Sign In Instan
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Masuk
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Terima kasih untuk membuat akun. Kata sandi Anda <strong>{0}</strong>.
 you-are-signed-in-as-x=Anda masuk sebagai {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Password dikirim ke alamat email yang disediakan. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_it.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Una nuova password verrà inviata a {0} se rispondi correttamente alla seguente domanda.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Accesso veloce
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Login
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Grazie per aver creato un account. La password è <strong>{0}</strong>.
 you-are-signed-in-as-x=Sei autenticato come {0}.
 your-email-verification-code-was-sent-to-x=Il codice di verifica email è stato inviato a {0}.
-your-password-was-sent-to-the-provided-email-address=La password è stata inviata all'indirizzo di posta elettronica fornito.
 your-password-was-sent-to-x=La password è stata inviata a {0}.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_iw.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=סיסמא חדשה תישלח ל-{0} אם תענה נכונה על השאלה הבאה.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=כניסה מהירה
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=התחבר
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=תודה על יצירת חשבון. הסיסמה שלך היא <strong>{0}</strong>.
 you-are-signed-in-as-x=אתה מחובר בתור {0}.
 your-email-verification-code-was-sent-to-x=קוד אימות הדוא"ל שלך נשלח אל {0}.
-your-password-was-sent-to-the-provided-email-address=הסיסמה שלך נשלחה לכתובת הדוא"ל שסופקה.
 your-password-was-sent-to-x=הסיסמה שלך נשלחה ל-{0}.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ja.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=以下の質問に正しく答えると、新規パスワードが {0} に送信されます。
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=簡易サインイン
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=ログイン
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=アカウントを作成していただきありがとうございます。パスワードは<strong>{0}</strong>です。
 you-are-signed-in-as-x={0}さんでログインしています。
 your-email-verification-code-was-sent-to-x=メール確認コードが {0} に送信されました。
-your-password-was-sent-to-the-provided-email-address=指定されたメールアドレスにパスワードが送信されました。
 your-password-was-sent-to-x=パスワードが {0} に送信されました。

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ko.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=빠른 로그인 (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=안으로 서명하십시요
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>. (Automatic Copy)
 you-are-signed-in-as-x=You are signed in as {0}. (Automatic Copy)
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=비밀 번호를 제공 된 이메일 주소로 보냈습니다. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_lo.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=ລະຫັດຜ່ານຈະຖືກສົ່ງໄປຍັງ {0} ຖ້າທ່ານຕອບຄຳຖາມຕໍ່ໄປນີ້ໄດ້ຖືກຕ້ອງ.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=ການເຂົ້າດວ່ນ
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=ເຂົ້າສູ່
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=ຂອບໃຈສຳລັບການສ້າງບັນຊີຂອງທ່ານ. ລະຫັດຜ່ານຂອງທ່ານແມ່ນ<strong>{0}</strong>.
 you-are-signed-in-as-x=ທ່ານເຂົ້າໃນນາມຂອງ{0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Your password was sent to the provided email address. (Automatic Copy)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_lt.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Greitai prisijungti (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Įeiti į sistemą
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>. (Automatic Copy)
 you-are-signed-in-as-x=You are signed in as {0}. (Automatic Copy)
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Jūsų slaptažodis buvo išsiųstas į nurodytą elektroninio pašto adresą. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_nb.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Et nytt passord vil bli sendt til {0} dersom du besvarer følgende spørsmål korrekt.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Hurtiginnlogging
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Logg inn
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Takk for at du opprettet en konto. Ditt passord er <strong>{0}</strong>.
 you-are-signed-in-as-x=Du er innlogget som {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Passordet ble sendt til den angitte e-postadressen. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_nl.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Als u de volgende vraag juist beantwoordt, wordt er een nieuw wachtwoord verzonden naar {0}.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Snel aanmelden
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Aanmelden
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Dank voor het aanmaken van uw account. Uw wachtwoord is <strong>{0}</strong>.
 you-are-signed-in-as-x=U bent ingelogd als {0}.
 your-email-verification-code-was-sent-to-x=De verificatiecode van uw e-mail is verzonden naar {0}.
-your-password-was-sent-to-the-provided-email-address=Uw wachtwoord is verzonden naar het opgegeven e-mailadres.
 your-password-was-sent-to-x=Uw wachtwoord is verzonden naar {0}.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_nl_BE.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Indien je een juist antwoord geeft op de volgende vraag zal een nieuw wachtwoord worden verzonden naar {0}.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Snel inloggen
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Aanmelden
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Bedankt voor het aanmaken van een account. Uw wachtwoord is <strong>{0}</strong>.
 you-are-signed-in-as-x=Aangemeld als {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Your password was sent to the provided email address. (Automatic Copy)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_pl.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Nowe hasło zostanie wysłane do {0} jeśli poprawnie odpowiesz na następujące pytanie.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Szybkie logowanie
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Logowanie
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Dziękujemy za założenie konta. Twoje hasło to <strong>{0}</strong>.
 you-are-signed-in-as-x=Jesteś zalogowany jako {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Twoje hasło został wysłany na podany adres. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_pt_BR.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Uma nova senha será enviada para {0} se você poder responder corretamente a seguinte questão.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Acesso Rápido
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Autenticação
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Obrigado por criar uma conta. Sua senha é <strong>{0}</strong>.
 you-are-signed-in-as-x=Você entrou como {0}.
 your-email-verification-code-was-sent-to-x=Seu código de verificação por e-mail foi enviado para {0}.
-your-password-was-sent-to-the-provided-email-address=Sua senha foi enviada para o endereço de e-mail fornecido.
 your-password-was-sent-to-x=Sua senha foi enviada para {0}.

--- a/modules/apps/login/login-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_pt_PT.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Uma nova Palavra-chave será enviada para {0} se responder correctamente à seguinte questão.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Acesso Rápido
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Entrar
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Obrigado por criar uma conta. A sua senha é <strong>{0}</strong>.
 you-are-signed-in-as-x=Está logado como {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Sua senha foi enviada para o endereço de e-mail fornecido. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ro.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=O parolă nouă va fi trimisă la {0} dacă poți răspunde corect la
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Autentificare rapidă
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Autentificare
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>. (Automatic Copy)
 you-are-signed-in-as-x=Esti autentiicat ca {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Parola a fost trimis la adresa de e-mail furnizată. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_ru.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Будет выслан новый пароль по адресу {0}, если вы правильно ответите на следующий вопрос.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Быстрый вход
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Вход в систему
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Спасибо за создание учетной записи. Ваш пароль <strong>{0}</strong>.
 you-are-signed-in-as-x=Вы зашли как {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Ваш пароль был отправлен на указанный электронный адрес. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sk.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Ak správne zodpoviete nasledovnú otázku, bude vám zaslané nové heslo na adresu {0}.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Rýchle prihlásenie
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Prihlásenie
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Ďakujeme za vytvorenie účtu. Vaše heslo je <strong>{0}</strong>.
 you-are-signed-in-as-x=Ste prihlásený ako {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Vaše heslo bolo odoslané na uvedené adresy. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sl.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Novo geslo bo poslano na {0} če boste pravilno odgovorili na naslednje vprašanje.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Hitra prijava (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Registracija
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>. (Automatic Copy)
 you-are-signed-in-as-x=Vpisani ste kot {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Vaše geslo je bilo poslano na naslov, ki e-pošto. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sr_RS.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Нова лозинка ће бити послата на {0} ако исправно одговорите на следеће питање.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Брзо Пријављивање
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Пријавите се
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Хвала вам за креирање налога. Ваша лозинка је <strong>{0}</strong>.
 you-are-signed-in-as-x=Пријављени сте као {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Your password was sent to the provided email address. (Automatic Copy)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Nova lozinka će biti poslata na {0} ako ispravno odgovorite na sledeće pitanje.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Brzo Prijavljivanje
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Prijavite se
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Hvala vam za kreiranje naloga. Vaša lozinka je <strong>{0}</strong>.
 you-are-signed-in-as-x=Prijavljeni ste kao {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Your password was sent to the provided email address. (Automatic Copy)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_sv.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Ett nytt lösenord kommer att skickas till {0} om följande fråga kan besvaras korrekt.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Snabbinloggning
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Logga in
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>. (Automatic Copy)
 you-are-signed-in-as-x=Du är inloggad som {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Your password was sent to the provided email address. (Automatic Copy)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_th.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=A new password will be sent to {0} if you can correctly answer the following question. (Automatic Copy)
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=เข้าสู่ระบบอย่างรวดเร็ว (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=เข้าสู่ระบบ (Automatic Translation)
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>. (Automatic Copy)
 you-are-signed-in-as-x=You are signed in as {0}. (Automatic Copy)
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=รหัสผ่านของคุณถูกส่งไปยังที่อยู่อีเมลให้ (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_tr.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Soruya doğru cevap verirseniz yeni şifre {0}'a gönderilecek.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Hızlı oturum açma (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Oturum Aç
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>. (Automatic Copy)
 you-are-signed-in-as-x={0} olarak giriş yaptınız.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Parolanızı sağlanan e-posta adresine gönderildi. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_uk.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Нова пароля буде вислана на адресу {0}, якщо ви дасте правильну відповідь на наступне запитання:
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Швидкий увійти (Automatic Translation)
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Вхід до системи
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>. (Automatic Copy)
 you-are-signed-in-as-x=Ви зайшли як {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Ваш пароль був відправлений до наданого електронну адресу. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_vi.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=Một mật khẩu mới sẽ được gửi tới {0} nếu bạn trả lời đúng các câu hỏi sau.
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=Đăng nhập nhanh
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=Đăng nhập
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Cảm ơn bạn đã đăng ký tạo tài khoản. Mật khẩu của bạn là <strong>{0}</strong>.
 you-are-signed-in-as-x=Bạn đang truy cập với tài khoản {0}.
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=Mật khẩu của bạn đã được gửi đến địa chỉ email được cung cấp. (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)

--- a/modules/apps/login/login-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_zh_CN.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=如果您可以正确回答以下问题，新密码将发送到{0}。
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=快速登录
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=登录
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=感谢您创建账户。您的密码是<strong>{0}</strong>。
 you-are-signed-in-as-x=您已经以{0}身份登录。
 your-email-verification-code-was-sent-to-x=您的邮件验证码已被发送至{0}。
-your-password-was-sent-to-the-provided-email-address=您的密码已被发送至提供的电子邮件地址。
 your-password-was-sent-to-x=您的密码已被发送至 {0}。

--- a/modules/apps/login/login-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/login/login-web/src/main/resources/content/Language_zh_TW.properties
@@ -1,3 +1,4 @@
+An-email-has-been-sent-to-the-provided-email-address=An email has been sent to the provided email address. (Automatic Copy)
 a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question=如果您能正確解答下列問題，一個新密碼將會傳送到 {0}。
 javax.portlet.title.com_liferay_login_web_portlet_FastLoginPortlet=快速登入
 javax.portlet.title.com_liferay_login_web_portlet_LoginPortlet=登入
@@ -7,5 +8,4 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=謝謝您創建一個帳戶。您的密碼是<strong>{0}</strong>。
 you-are-signed-in-as-x=您以 {0} 登入。
 your-email-verification-code-was-sent-to-x=Your email verification code was sent to {0}. (Automatic Copy)
-your-password-was-sent-to-the-provided-email-address=您的密碼被發送到提供的電子郵件地址。 (Automatic Translation)
 your-password-was-sent-to-x=Your password was sent to {0}. (Automatic Copy)


### PR DESCRIPTION
Dear @brianchandotcom ,

Please find the related LPS here: [LPS-85971](https://issues.liferay.com/browse/LPS-85971)
I modified the current language key, as It made more sense and made it viable for both of the scenarios at password reset. Reset via link in email or request new password via email.

Thanks,