### PR TITLE
LPS-84665 assetTagNames* fields always language aware now, so test them as such

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/mappings/AssetTagNamesFieldQueryBuilderTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/mappings/AssetTagNamesFieldQueryBuilderTest.java
@@ -21,6 +21,9 @@ import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.search.test.util.mappings.BaseAssetTagNamesFieldQueryBuilderTestCase;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
 
 /**
@@ -33,35 +36,50 @@ public class AssetTagNamesFieldQueryBuilderTest
 	public void testMultiwordPhrasePrefixesElasticsearch() throws Exception {
 		addDocument("Name Tags");
 		addDocument("Names Tab");
-		addDocument("Tag Names");
 		addDocument("Tabs Names Tags");
+		addDocument("Tag Names");
 
-		assertSearch("\"name ta*\"", 1);
-		assertSearch("\"name tag*\"", 1);
-		assertSearch("\"name tags*\"", 1);
-		assertSearch("\"names ta*\"", 2);
-		assertSearch("\"names tab*\"", 1);
-		assertSearch("\"names tag*\"", 1);
-		assertSearch("\"names tags*\"", 1);
-		assertSearch("\"tabs name*\"", 1);
-		assertSearch("\"tabs names ta*\"", 1);
-		assertSearch("\"tabs names tag*\"", 1);
-		assertSearch("\"tabs names tags*\"", 1);
-		assertSearch("\"tabs names*\"", 1);
-		assertSearch("\"tag na*\"", 1);
-		assertSearch("\"tag name*\"", 1);
-		assertSearch("\"tag names*\"", 1);
+		List<String> results1 = Arrays.asList(
+			"Name Tags", "Names Tab", "Tabs Names Tags");
 
-		assertSearchNoHits("\"name tab*\"");
-		assertSearchNoHits("\"name tabs*\"");
-		assertSearchNoHits("\"names tabs*\"");
-		assertSearchNoHits("\"tab na*\"");
-		assertSearchNoHits("\"tab names*\"");
+		assertSearch("\"name ta*\"", results1);
+		assertSearch("\"names ta*\"", results1);
+
+		List<String> results2 = Arrays.asList("Name Tags", "Tabs Names Tags");
+
+		assertSearch("\"name tag*\"", results2);
+		assertSearch("\"name tags*\"", results2);
+		assertSearch("\"names tag*\"", results2);
+		assertSearch("\"names tags*\"", results2);
+
+		List<String> results3 = Arrays.asList("Names Tab");
+
+		assertSearch("\"name tab*\"", results3);
+		assertSearch("\"name tabs*\"", results3);
+		assertSearch("\"names tab*\"", results3);
+		assertSearch("\"names tabs*\"", results3);
+
+		List<String> results4 = Arrays.asList("Tabs Names Tags");
+
+		assertSearch("\"tab na*\"", results4);
+		assertSearch("\"tab names*\"", results4);
+		assertSearch("\"tabs name*\"", results4);
+		assertSearch("\"tabs names ta*\"", results4);
+		assertSearch("\"tabs names tag*\"", results4);
+		assertSearch("\"tabs names tags*\"", results4);
+		assertSearch("\"tabs names*\"", results4);
+		assertSearch("\"tabs name ta*\"", results4);
+
+		List<String> results5 = Arrays.asList("Tag Names");
+
+		assertSearch("\"tag na*\"", results5);
+		assertSearch("\"tag name*\"", results5);
+		assertSearch("\"tag names*\"", results5);
+		assertSearch("\"tags names*\"", results5);
+
 		assertSearchNoHits("\"tabs na ta*\"");
-		assertSearchNoHits("\"tabs name ta*\"");
 		assertSearchNoHits("\"tags na ta*\"");
 		assertSearchNoHits("\"tags names tabs*\"");
-		assertSearchNoHits("\"tags names*\"");
 		assertSearchNoHits("\"zz na*\"");
 		assertSearchNoHits("\"zz name*\"");
 		assertSearchNoHits("\"zz names*\"");

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/BaseAssetTagNamesFieldQueryBuilderTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/BaseAssetTagNamesFieldQueryBuilderTestCase.java
@@ -15,6 +15,15 @@
 package com.liferay.portal.search.test.util.mappings;
 
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.util.LocalizationImpl;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Test;
 
 /**
  * @author André de Oliveira
@@ -23,8 +32,128 @@ public abstract class BaseAssetTagNamesFieldQueryBuilderTestCase
 	extends BaseTitleFieldQueryBuilderTestCase {
 
 	@Override
-	protected String getField() {
-		return Field.ASSET_TAG_NAMES;
+	@Test
+	public void testMultiwordPrefixes() throws Exception {
+		addDocument("Name Tags");
+		addDocument("Names Tab");
+		addDocument("Tabs Names Tags");
+		addDocument("Tag Names");
+
+		List<String> results1 = Arrays.asList(
+			"Name Tags", "Names Tab", "Tabs Names Tags", "Tag Names");
+
+		assertSearch("name ta", results1);
+		assertSearch("names ta", results1);
+
+		List<String> results2 = Arrays.asList(
+			"Names Tab", "Tabs Names Tags", "Name Tags", "Tag Names");
+
+		assertSearch("name tab", results2);
+		assertSearch("name tabs", results2);
+		assertSearch("names tab", results2);
+		assertSearch("names tabs", results2);
+
+		List<String> results3 = Arrays.asList(
+			"Name Tags", "Tabs Names Tags", "Tag Names", "Names Tab");
+
+		assertSearch("name tag", results3);
+		assertSearch("name tags", results3);
+		assertSearch("names tag", results3);
+		assertSearch("names tags", results3);
+
+		List<String> results4 = Arrays.asList("Tabs Names Tags", "Names Tab");
+
+		assertSearch("tab na", results4);
+
+		List<String> results5 = Arrays.asList(
+			"Tabs Names Tags", "Names Tab", "Name Tags", "Tag Names");
+
+		assertSearch("tab names", results5);
+		assertSearch("tabs names", results5);
+		assertSearch("tabs names tags", results5);
+		assertSearch("tags names tabs", results5);
+
+		List<String> results6 = Arrays.asList("Names Tab", "Tabs Names Tags");
+
+		assertSearch("tabs na ta", results6);
+
+		List<String> results7 = Arrays.asList(
+			"Tag Names", "Name Tags", "Tabs Names Tags");
+
+		assertSearch("tag na", results7);
+
+		List<String> results8 = Arrays.asList(
+			"Tag Names", "Name Tags", "Tabs Names Tags", "Names Tab");
+
+		assertSearch("tag name", results8);
+		assertSearch("tag names", results8);
+		assertSearch("tags names", results8);
+
+		List<String> results9 = Arrays.asList(
+			"Name Tags", "Tag Names", "Tabs Names Tags");
+
+		assertSearch("tags na ta", results9);
+
+		assertSearch("zz name", 4);
+		assertSearch("zz names", 4);
+		assertSearch("zz tab", 2);
+		assertSearch("zz tabs", 2);
+		assertSearch("zz tag", 3);
+		assertSearch("zz tags", 3);
+
+		assertSearchNoHits("zz na");
+		assertSearchNoHits("zz ta");
 	}
+
+	@Override
+	@Test
+	public void testPhrases() throws Exception {
+		addDocument("Names of Tags");
+		addDocument("More names of tags here");
+
+		assertSearch("\"HERE\"", 1);
+		assertSearch("\"more\"   names   \"here\"", 1);
+		assertSearch("\"More\"", 1);
+		assertSearch("\"more\"", 1);
+		assertSearch("\"names of tags\"", 2);
+		assertSearch("\"NAmes\" \"TAGS\"", 2);
+		assertSearch("\"names\" MORE \"tags\"", 1);
+		assertSearch("\"Tags here\"", 1);
+		assertSearch("\"Tags\" here", 1);
+		assertSearch("\"TAGS\"", 2);
+
+		assertSearch("\"   more   \"   tags   \"   here   \"", 1);
+
+		assertSearchNoHits("\"more\" other \"here\"");
+		assertSearchNoHits("\"name\" of \"tags\"");
+		assertSearchNoHits("\"names\" of \"tAgs\"");
+	}
+
+	@Override
+	@Test
+	public void testStopwords() throws Exception {
+		addDocument("Names of Tags");
+		addDocument("More names of tags");
+
+		assertSearchNoHits("of");
+
+		assertSearch("Names of tags", 2);
+		assertSearch("tags names", 2);
+	}
+
+	@Override
+	protected String getField() {
+		return _FIELD;
+	}
+
+	private static String _getLocalizedName(String name, Locale locale) {
+		Localization localization = new LocalizationImpl();
+
+		return localization.getLocalizedName(
+			name, LocaleUtil.toLanguageId(locale));
+	}
+
+	private static final String _FIELD = _getLocalizedName(
+		Field.ASSET_TAG_NAMES, Locale.US);
 
 }

--- a/modules/apps/portal-search/portal-search-web/build.gradle
+++ b/modules/apps/portal-search/portal-search-web/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 
+	testCompile group: "commons-configuration", name: "commons-configuration", version: "1.10"
 	testCompile group: "commons-httpclient", name: "commons-httpclient", version: "3.1"
 	testCompile group: "easyconf", name: "easyconf", version: "0.9.5"
 	testCompile group: "org.jabsorb", name: "jabsorb", version: "1.3.1"
@@ -37,4 +38,6 @@ dependencies {
 	testCompile group: "org.slf4j", name: "slf4j-api", version: "1.7.7"
 	testCompile group: "org.springframework", name: "spring-web", version: "4.1.9.RELEASE"
 	testCompile project(":apps:portal-search:portal-search")
+	testCompile project(":core:petra:petra-memory")
+	testCompile project(":core:petra:petra-reflect")
 }

--- a/modules/apps/portal-search/portal-search/build.gradle
+++ b/modules/apps/portal-search/portal-search/build.gradle
@@ -23,5 +23,6 @@ dependencies {
 	compileOnly project(":core:petra:petra-string")
 
 	testCompile project(":core:petra:petra-memory")
+	testCompile project(":core:petra:petra-reflect")
 	testCompile project(":core:registry-api")
 }


### PR DESCRIPTION
After the bug fix was werged, I noticed the previous unit tests we had were still testing with the plain `assetTagNames` field name. Updated them to test with the new language aware pattern `assetTagNames_en_US`.

cc/ @brandizzi @wcao20170619

https://issues.liferay.com/browse/LPS-84665
https://issues.liferay.com/browse/LPS-84666