### PR TITLE
LRQA-43986 Ignore github.message.redact.token values that are numeric and 5 characters or longer

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1423,8 +1423,21 @@ public class JenkinsResultsParserUtil {
 						key.substring(2, key.length() - 1));
 				}
 
-				if ((redactToken != null) && !redactToken.isEmpty()) {
-					_redactTokens.add(redactToken);
+				if (redactToken != null) {
+					if ((redactToken.length() < 5) &&
+						redactToken.matches("\\d+")) {
+
+						System.out.println(
+							combine(
+								"Ignoring ", key,
+								" because the value is numeric and ",
+								"less than 5 characters long."));
+					}
+					else {
+						if (!redactToken.isEmpty()) {
+							_redactTokens.add(redactToken);
+						}
+					}
 				}
 			}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1414,14 +1414,9 @@ public class JenkinsResultsParserUtil {
 			for (int i = 1; properties.containsKey(_getRedactTokenKey(i));
 				 i++) {
 
-				String key = properties.getProperty(_getRedactTokenKey(i));
+				String key = _getRedactTokenKey(i);
 
-				String redactToken = key;
-
-				if (key.startsWith("${") && key.endsWith("}")) {
-					redactToken = properties.getProperty(
-						key.substring(2, key.length() - 1));
-				}
+				String redactToken = getProperty(properties, key);
 
 				if (redactToken != null) {
 					if ((redactToken.length() < 5) &&


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-43986

When redact tokens are numeric and shorter than 5 characters, they tend to interfere with CI by redacting all or part of the Jenkins build number in the console log. This pull request will automatically remove redact tokens that fit this pattern and print a warning in the console log.

Please publish after merging