### PR TITLE
LPS-86202 Create a utility to make it easier to conditionally add css class names to elements in a JSP

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/CSSClassNames.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/CSSClassNames.java
@@ -14,8 +14,11 @@
 
 package com.liferay.users.admin.web.internal;
 
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Drew Brokke
@@ -43,23 +46,31 @@ public class CSSClassNames {
 		}
 
 		public String build() {
-			return _sb.toString();
+			return _cssClassNamesStreamBuilder.build(
+			).distinct(
+			).sorted(
+			).collect(
+				_JOIN_BY_SPACE_COLLECTOR
+			);
 		}
 
 		private Builder _add(String cssClassName, boolean condition) {
 			if (condition) {
-				_sb.append(cssClassName);
-				_sb.append(StringPool.SPACE);
+				_cssClassNamesStreamBuilder.accept(cssClassName);
 			}
 
 			return this;
 		}
 
-		private final StringBundler _sb = new StringBundler();
+		private final Stream.Builder<String> _cssClassNamesStreamBuilder =
+			Stream.builder();
 
 	}
 
 	private CSSClassNames() {
 	}
+
+	private static final Collector<CharSequence, ?, String>
+		_JOIN_BY_SPACE_COLLECTOR = Collectors.joining(StringPool.SPACE);
 
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/util/CSSClassNames.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/util/CSSClassNames.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.users.admin.web.internal;
+package com.liferay.users.admin.web.internal.util;
 
 import com.liferay.petra.string.StringPool;
 

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/util/CSSClassNames.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/util/CSSClassNames.java
@@ -16,6 +16,7 @@ package com.liferay.users.admin.web.internal.util;
 
 import com.liferay.petra.string.StringPool;
 
+import java.util.function.Consumer;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -25,14 +26,12 @@ import java.util.stream.Stream;
  */
 public class CSSClassNames {
 
-	public static Builder builder(String... cssClassNames) {
+	public static String build(Consumer<Builder> builderConsumer) {
 		Builder builder = new Builder();
 
-		for (String cssClassName : cssClassNames) {
-			builder.add(cssClassName);
-		}
+		builderConsumer.accept(builder);
 
-		return builder;
+		return builder.build();
 	}
 
 	public static class Builder {
@@ -41,11 +40,22 @@ public class CSSClassNames {
 			return _add(cssClassName, true);
 		}
 
+		public Builder add(String... cssClassNames) {
+			for (String cssClassName : cssClassNames) {
+				_add(cssClassName, true);
+			}
+
+			return this;
+		}
+
 		public Builder add(String cssClassName, boolean condition) {
 			return _add(cssClassName, condition);
 		}
 
-		public String build() {
+		protected Builder() {
+		}
+
+		protected String build() {
 			return _cssClassNamesStreamBuilder.build(
 			).distinct(
 			).sorted(

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/util/CustomFieldsUtil.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/util/CustomFieldsUtil.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.users.admin.web.internal;
+package com.liferay.users.admin.web.internal.util;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.model.ExpandoColumnConstants;

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -167,7 +167,6 @@ page import="com.liferay.users.admin.constants.UsersAdminPortletKeys" %><%@
 page import="com.liferay.users.admin.kernel.util.UsersAdmin" %><%@
 page import="com.liferay.users.admin.kernel.util.UsersAdminUtil" %><%@
 page import="com.liferay.users.admin.user.action.contributor.UserActionContributor" %><%@
-page import="com.liferay.users.admin.web.internal.CustomFieldsUtil" %><%@
 page import="com.liferay.users.admin.web.internal.constants.UsersAdminWebKeys" %><%@
 page import="com.liferay.users.admin.web.internal.display.context.InitDisplayContext" %><%@
 page import="com.liferay.users.admin.web.internal.display.context.OrgLaborDisplay" %><%@
@@ -183,6 +182,7 @@ page import="com.liferay.users.admin.web.internal.display.context.ViewTreeManage
 page import="com.liferay.users.admin.web.internal.display.context.ViewUsersManagementToolbarDisplayContext" %><%@
 page import="com.liferay.users.admin.web.internal.search.OrganizationResultRowSplitter" %><%@
 page import="com.liferay.users.admin.web.internal.util.CSSClassNames" %><%@
+page import="com.liferay.users.admin.web.internal.util.CustomFieldsUtil" %><%@
 page import="com.liferay.users.admin.web.internal.util.UsersAdminPortletURLUtil" %>
 
 <%@ page import="java.text.Format" %>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -167,7 +167,6 @@ page import="com.liferay.users.admin.constants.UsersAdminPortletKeys" %><%@
 page import="com.liferay.users.admin.kernel.util.UsersAdmin" %><%@
 page import="com.liferay.users.admin.kernel.util.UsersAdminUtil" %><%@
 page import="com.liferay.users.admin.user.action.contributor.UserActionContributor" %><%@
-page import="com.liferay.users.admin.web.internal.CSSClassNames" %><%@
 page import="com.liferay.users.admin.web.internal.CustomFieldsUtil" %><%@
 page import="com.liferay.users.admin.web.internal.constants.UsersAdminWebKeys" %><%@
 page import="com.liferay.users.admin.web.internal.display.context.InitDisplayContext" %><%@
@@ -183,6 +182,7 @@ page import="com.liferay.users.admin.web.internal.display.context.ViewOrganizati
 page import="com.liferay.users.admin.web.internal.display.context.ViewTreeManagementToolbarDisplayContext" %><%@
 page import="com.liferay.users.admin.web.internal.display.context.ViewUsersManagementToolbarDisplayContext" %><%@
 page import="com.liferay.users.admin.web.internal.search.OrganizationResultRowSplitter" %><%@
+page import="com.liferay.users.admin.web.internal.util.CSSClassNames" %><%@
 page import="com.liferay.users.admin.web.internal.util.UsersAdminPortletURLUtil" %>
 
 <%@ page import="java.text.Format" %>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/addresses.jsp
@@ -72,11 +72,12 @@ List<Address> addresses = AddressServiceUtil.getAddresses(Organization.class.get
 
 <div
 	class="<%=
-		CSSClassNames.builder(
-			"addresses-table-wrapper", "table-responsive"
-		).add(
-			"hide", addresses.isEmpty()
-		).build()
+		CSSClassNames.build(
+			builder -> builder.add(
+				"addresses-table-wrapper", "table-responsive"
+			).add(
+				"hide", addresses.isEmpty()
+			))
 	%>"
 >
 	<table class="table table-autofit">

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/opening_hours.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/opening_hours.jsp
@@ -67,11 +67,12 @@ List<OrgLabor> orgLabors = OrgLaborServiceUtil.getOrgLabors(organizationId);
 
 <div
 	class="<%=
-		CSSClassNames.builder(
-			"opening-hours-wrapper"
-		).add(
-			"hide", orgLabors.isEmpty()
-		).build()
+		CSSClassNames.build(
+			builder -> builder.add(
+				"opening-hours-wrapper"
+			).add(
+				"hide", orgLabors.isEmpty()
+			))
 	%>"
 >
 

--- a/modules/apps/users-admin/users-admin-web/src/test/java/com/liferay/users/admin/web/internal/CSSClassNamesTest.java
+++ b/modules/apps/users-admin/users-admin-web/src/test/java/com/liferay/users/admin/web/internal/CSSClassNamesTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.users.admin.web.internal;
+
+import com.liferay.users.admin.web.internal.util.CSSClassNames;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class CSSClassNamesTest {
+
+	@Test
+	public void testBasicOutput() {
+		Assert.assertEquals(
+			"hello", CSSClassNames.build(builder -> builder.add("hello")));
+
+		Assert.assertEquals(
+			"hello world",
+			CSSClassNames.build(builder -> builder.add("hello", "world")));
+	}
+
+	@Test
+	public void testConditionalOutput() {
+		Assert.assertEquals(
+			"hello world",
+			CSSClassNames.build(
+				builder -> builder.add(
+					"hello"
+				).add(
+					"goodbye", false
+				).add(
+					"sad", false
+				).add(
+					"world", true
+				)));
+
+		Assert.assertEquals(
+			"foo hello world",
+			CSSClassNames.build(
+				builder -> builder.add(
+					"hello", "world"
+				).add(
+					"cruel", false
+				).add(
+					"foo", true
+				)));
+	}
+
+	@Test
+	public void testDistinctOutput() {
+		Assert.assertEquals(
+			"hello world",
+			CSSClassNames.build(
+				builder -> builder.add(
+					"hello", "hello", "world", "world"
+				)));
+
+		Assert.assertEquals(
+			"hello world",
+			CSSClassNames.build(
+				builder -> builder.add(
+					"hello"
+				).add(
+					"hello"
+				).add(
+					"world"
+				).add(
+					"world"
+				)));
+	}
+
+	@Test
+	public void testSortedOutput() {
+		Assert.assertEquals(
+			"hello world",
+			CSSClassNames.build(
+				builder -> builder.add(
+					"world", "hello"
+				)));
+
+		Assert.assertEquals(
+			"alpha beta gamma",
+			CSSClassNames.build(
+				builder -> builder.add(
+					"beta"
+				).add(
+					"gamma"
+				).add(
+					"alpha"
+				)));
+	}
+
+}


### PR DESCRIPTION
This is an update for [LPS-86202](https://issues.liferay.com/browse/LPS-86202).

Hey @brianchandotcom, this pull adds the following updates for the CSSClassNames utility:

1. Sorts and distincts the output
2. Forces the consumer pattern for the builder so that the caller never has to manually call `.build()`
3. Moves the class inside the *Util package
4. Adds test cases

/cc @pei-jung @stsquared99 @alee8888