### PR TITLE
LPS-86245 Removing unthrown exceptions

### DIFF
--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/interpreter/SharingEntryInterpreter.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/interpreter/SharingEntryInterpreter.java
@@ -14,6 +14,7 @@
 
 package com.liferay.sharing.interpreter;
 
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.renderer.SharingEntryEditRenderer;
 import com.liferay.sharing.renderer.SharingEntryViewRenderer;
@@ -25,7 +26,8 @@ import java.util.Locale;
  */
 public interface SharingEntryInterpreter {
 
-	public String getAssetTypeTitle(SharingEntry sharingEntry, Locale locale);
+	public String getAssetTypeTitle(SharingEntry sharingEntry, Locale locale)
+		throws PortalException;
 
 	public SharingEntryEditRenderer getSharingEntryEditRenderer();
 

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/renderer/SharingEntryViewRenderer.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/renderer/SharingEntryViewRenderer.java
@@ -14,6 +14,7 @@
 
 package com.liferay.sharing.renderer;
 
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.sharing.model.SharingEntry;
 
 import java.io.IOException;
@@ -29,6 +30,6 @@ public interface SharingEntryViewRenderer {
 	public void render(
 			SharingEntry sharingEntry, HttpServletRequest request,
 			HttpServletResponse response)
-		throws IOException;
+		throws IOException, PortalException;
 
 }

--- a/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/service/NotificationsSharingEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/service/NotificationsSharingEntryLocalServiceWrapper.java
@@ -101,8 +101,7 @@ public class NotificationsSharingEntryLocalServiceWrapper
 	}
 
 	private String _getMessageBody(
-			SharingEntry sharingEntry, User user, String entryURL)
-		throws PortalException {
+		SharingEntry sharingEntry, User user, String entryURL) {
 
 		ResourceBundle resourceBundle =
 			_resourceBundleLoader.loadResourceBundle(user.getLocale());

--- a/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/service/NotificationsSharingEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/service/NotificationsSharingEntryLocalServiceWrapper.java
@@ -130,7 +130,7 @@ public class NotificationsSharingEntryLocalServiceWrapper
 
 			subscriptionSender.setSubject(message);
 
-			String entryURL = _sharingNotificationUtil.getEntryURL(
+			String entryURL = _sharingNotificationUtil.getNotificationURL(
 				sharingEntry, serviceContext.getLiferayPortletRequest());
 
 			subscriptionSender.setBody(

--- a/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/util/SharingNotificationUtil.java
+++ b/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/util/SharingNotificationUtil.java
@@ -43,7 +43,21 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = SharingNotificationUtil.class)
 public class SharingNotificationUtil {
 
-	public String getEntryURL(
+	public String getNotificationMessage(
+			SharingEntry sharingEntry, Locale locale)
+		throws PortalException {
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(locale);
+
+		return ResourceBundleUtil.getString(
+			resourceBundle, "x-has-shared-x-with-you-for-x",
+			_getUserName(sharingEntry, resourceBundle),
+			getSharingEntryObjectTitle(sharingEntry, locale),
+			_getActionName(sharingEntry, resourceBundle));
+	}
+
+	public String getNotificationURL(
 			SharingEntry sharingEntry,
 			LiferayPortletRequest liferayPortletRequest)
 		throws Exception {
@@ -61,20 +75,6 @@ public class SharingNotificationUtil {
 		}
 
 		return null;
-	}
-
-	public String getNotificationMessage(
-			SharingEntry sharingEntry, Locale locale)
-		throws PortalException {
-
-		ResourceBundle resourceBundle =
-			_resourceBundleLoader.loadResourceBundle(locale);
-
-		return ResourceBundleUtil.getString(
-			resourceBundle, "x-has-shared-x-with-you-for-x",
-			_getUserName(sharingEntry, resourceBundle),
-			getSharingEntryObjectTitle(sharingEntry, locale),
-			_getActionName(sharingEntry, resourceBundle));
 	}
 
 	public String getSharingEntryObjectTitle(

--- a/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/util/SharingNotificationUtil.java
+++ b/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/util/SharingNotificationUtil.java
@@ -14,7 +14,6 @@
 
 package com.liferay.sharing.notifications.internal.util;
 
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.PortletProvider;
@@ -44,8 +43,7 @@ import org.osgi.service.component.annotations.Reference;
 public class SharingNotificationUtil {
 
 	public String getNotificationMessage(
-			SharingEntry sharingEntry, Locale locale)
-		throws PortalException {
+		SharingEntry sharingEntry, Locale locale) {
 
 		ResourceBundle resourceBundle =
 			_resourceBundleLoader.loadResourceBundle(locale);

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/SharedWithMeViewDisplayContext.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/SharedWithMeViewDisplayContext.java
@@ -72,7 +72,9 @@ public class SharedWithMeViewDisplayContext {
 			WebKeys.THEME_DISPLAY);
 	}
 
-	public String getAssetTypeTitle(SharingEntry sharingEntry) {
+	public String getAssetTypeTitle(SharingEntry sharingEntry)
+		throws PortalException {
+
 		SharingEntryInterpreter sharingEntryInterpreter =
 			_sharingEntryInterpreterFunction.apply(sharingEntry);
 

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/interpreter/AssetRendererSharingEntryInterpreter.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/interpreter/AssetRendererSharingEntryInterpreter.java
@@ -47,7 +47,9 @@ public class AssetRendererSharingEntryInterpreter
 	implements SharingEntryInterpreter {
 
 	@Override
-	public String getAssetTypeTitle(SharingEntry sharingEntry, Locale locale) {
+	public String getAssetTypeTitle(SharingEntry sharingEntry, Locale locale)
+		throws PortalException {
+
 		AssetRenderer assetRenderer = AssetRendererSharingUtil.getAssetRenderer(
 			sharingEntry);
 

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/renderer/AssetRendererSharingEntryViewRenderer.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/renderer/AssetRendererSharingEntryViewRenderer.java
@@ -15,6 +15,7 @@
 package com.liferay.sharing.web.internal.renderer;
 
 import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.sharing.model.SharingEntry;
@@ -44,7 +45,7 @@ public class AssetRendererSharingEntryViewRenderer
 	public void render(
 			SharingEntry sharingEntry, HttpServletRequest request,
 			HttpServletResponse response)
-		throws IOException {
+		throws IOException, PortalException {
 
 		RequestDispatcher requestDispatcher =
 			_servletContext.getRequestDispatcher(_JSP_PATH);

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/util/AssetRendererSharingUtil.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/util/AssetRendererSharingUtil.java
@@ -17,6 +17,7 @@ package com.liferay.sharing.web.internal.util;
 import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.sharing.model.SharingEntry;
 
 /**
@@ -24,7 +25,9 @@ import com.liferay.sharing.model.SharingEntry;
  */
 public class AssetRendererSharingUtil {
 
-	public static AssetRenderer getAssetRenderer(SharingEntry sharingEntry) {
+	public static AssetRenderer getAssetRenderer(SharingEntry sharingEntry)
+		throws PortalException {
+
 		AssetRendererFactory<?> assetRendererFactory =
 			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
 				sharingEntry.getClassName());
@@ -35,12 +38,8 @@ public class AssetRendererSharingUtil {
 
 		AssetRenderer<?> assetRenderer = null;
 
-		try {
-			assetRenderer = assetRendererFactory.getAssetRenderer(
-				sharingEntry.getClassPK());
-		}
-		catch (Exception e) {
-		}
+		assetRenderer = assetRendererFactory.getAssetRenderer(
+			sharingEntry.getClassPK());
 
 		return assetRenderer;
 	}


### PR DESCRIPTION
Follow up of https://github.com/brianchandotcom/liferay-portal/pull/63984#issuecomment-428643103 and https://github.com/brianchandotcom/liferay-portal/pull/63984#issuecomment-428643520.

I think `getSharingEntryObjectTitle` is still a valid name for that method. However having a look at that class again made me reconsider other names (see https://github.com/brianchandotcom/liferay-portal/pull/64033/commits/fc7d024a493ff23c60ed857412ccadbcee00b4e4).

Thanks!