### PR TITLE
LPS-86357 UserGroupServiceTest#testGetUserGroupsLikeName will fail if there are leftover UserGroups from another test case

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/service/UserGroupServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/UserGroupServiceTest.java
@@ -14,21 +14,31 @@
 
 package com.liferay.portal.service;
 
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserGroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserGroupServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerTestRule;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -87,13 +97,28 @@ public class UserGroupServiceTest {
 	public void testGetUserGroupsLikeName() throws Exception {
 		UserGroup markerUserGroup = UserGroupTestUtil.addUserGroup();
 
+		Company company = CompanyTestUtil.addCompany();
+
+		long companyId = company.getCompanyId();
+
+		User user = UserTestUtil.getAdminUser(company.getCompanyId());
+
+		Group group = GroupTestUtil.addGroup(
+			company.getCompanyId(), user.getUserId(),
+			GroupConstants.DEFAULT_PARENT_GROUP_ID);
+
+		long groupId = group.getGroupId();
+
+		UnsafeSupplier<UserGroup, Exception> userGroupSupplier =
+			() -> UserGroupTestUtil.addUserGroup(groupId);
+
 		try {
 			String name = RandomTestUtil.randomString(10);
 
 			List<UserGroup> expectedUserGroups = new ArrayList<>();
 
 			for (int i = 0; i < 10; i++) {
-				UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+				UserGroup userGroup = userGroupSupplier.get();
 
 				userGroup.setName(name + i);
 
@@ -102,43 +127,49 @@ public class UserGroupServiceTest {
 				expectedUserGroups.add(userGroup);
 			}
 
-			_userGroups.addAll(expectedUserGroups);
-			_userGroups.add(UserGroupTestUtil.addUserGroup());
-			_userGroups.add(UserGroupTestUtil.addUserGroup());
-			_userGroups.add(UserGroupTestUtil.addUserGroup());
+			List<UserGroup> allUserGroups = new ArrayList<>();
 
-			assertExpectedUserGroups(expectedUserGroups, name + "%");
-			assertExpectedUserGroups(
+			allUserGroups.addAll(expectedUserGroups);
+			allUserGroups.add(userGroupSupplier.get());
+			allUserGroups.add(userGroupSupplier.get());
+			allUserGroups.add(userGroupSupplier.get());
+
+			BiConsumer<List<UserGroup>, String> assertor = _getAssertor(
+				companyId);
+
+			assertor.accept(expectedUserGroups, name + "%");
+			assertor.accept(
 				expectedUserGroups, StringUtil.toLowerCase(name) + "%");
-			assertExpectedUserGroups(
+			assertor.accept(
 				expectedUserGroups, StringUtil.toUpperCase(name) + "%");
-			assertExpectedUserGroups(_userGroups, null);
-			assertExpectedUserGroups(_userGroups, "");
+			assertor.accept(allUserGroups, null);
+			assertor.accept(allUserGroups, "");
 		}
 		finally {
+			CompanyLocalServiceUtil.deleteCompany(company);
+
 			UserGroupLocalServiceUtil.deleteUserGroup(markerUserGroup);
 		}
 	}
 
-	protected void assertExpectedUserGroups(
-			List<UserGroup> expectedUserGroups, String nameSearch)
-		throws Exception {
+	private BiConsumer<List<UserGroup>, String> _getAssertor(long companyId) {
+		return (expectedUserGroups, nameSearch) -> {
+			List<UserGroup> actualUserGroups =
+				UserGroupServiceUtil.getUserGroups(
+					companyId, nameSearch, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS);
 
-		List<UserGroup> actualUserGroups = UserGroupServiceUtil.getUserGroups(
-			TestPropsValues.getCompanyId(), nameSearch, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			Assert.assertEquals(
+				actualUserGroups.toString(), expectedUserGroups.size(),
+				actualUserGroups.size());
+			Assert.assertTrue(
+				actualUserGroups.toString(),
+				actualUserGroups.containsAll(expectedUserGroups));
 
-		Assert.assertEquals(
-			actualUserGroups.toString(), expectedUserGroups.size(),
-			actualUserGroups.size());
-		Assert.assertTrue(
-			actualUserGroups.toString(),
-			actualUserGroups.containsAll(expectedUserGroups));
-
-		Assert.assertEquals(
-			expectedUserGroups.size(),
-			UserGroupServiceUtil.getUserGroupsCount(
-				TestPropsValues.getCompanyId(), nameSearch));
+			Assert.assertEquals(
+				expectedUserGroups.size(),
+				UserGroupServiceUtil.getUserGroupsCount(companyId, nameSearch));
+		};
 	}
 
 	@DeleteAfterTestRun

--- a/portal-impl/test/integration/com/liferay/portal/service/UserGroupServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/UserGroupServiceTest.java
@@ -85,32 +85,39 @@ public class UserGroupServiceTest {
 
 	@Test
 	public void testGetUserGroupsLikeName() throws Exception {
-		String name = RandomTestUtil.randomString(10);
+		UserGroup markerUserGroup = UserGroupTestUtil.addUserGroup();
 
-		List<UserGroup> expectedUserGroups = new ArrayList<>();
+		try {
+			String name = RandomTestUtil.randomString(10);
 
-		for (int i = 0; i < 10; i++) {
-			UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+			List<UserGroup> expectedUserGroups = new ArrayList<>();
 
-			userGroup.setName(name + i);
+			for (int i = 0; i < 10; i++) {
+				UserGroup userGroup = UserGroupTestUtil.addUserGroup();
 
-			UserGroupLocalServiceUtil.updateUserGroup(userGroup);
+				userGroup.setName(name + i);
 
-			expectedUserGroups.add(userGroup);
+				UserGroupLocalServiceUtil.updateUserGroup(userGroup);
+
+				expectedUserGroups.add(userGroup);
+			}
+
+			_userGroups.addAll(expectedUserGroups);
+			_userGroups.add(UserGroupTestUtil.addUserGroup());
+			_userGroups.add(UserGroupTestUtil.addUserGroup());
+			_userGroups.add(UserGroupTestUtil.addUserGroup());
+
+			assertExpectedUserGroups(expectedUserGroups, name + "%");
+			assertExpectedUserGroups(
+				expectedUserGroups, StringUtil.toLowerCase(name) + "%");
+			assertExpectedUserGroups(
+				expectedUserGroups, StringUtil.toUpperCase(name) + "%");
+			assertExpectedUserGroups(_userGroups, null);
+			assertExpectedUserGroups(_userGroups, "");
 		}
-
-		_userGroups.addAll(expectedUserGroups);
-		_userGroups.add(UserGroupTestUtil.addUserGroup());
-		_userGroups.add(UserGroupTestUtil.addUserGroup());
-		_userGroups.add(UserGroupTestUtil.addUserGroup());
-
-		assertExpectedUserGroups(expectedUserGroups, name + "%");
-		assertExpectedUserGroups(
-			expectedUserGroups, StringUtil.toLowerCase(name) + "%");
-		assertExpectedUserGroups(
-			expectedUserGroups, StringUtil.toUpperCase(name) + "%");
-		assertExpectedUserGroups(_userGroups, null);
-		assertExpectedUserGroups(_userGroups, "");
+		finally {
+			UserGroupLocalServiceUtil.deleteUserGroup(markerUserGroup);
+		}
 	}
 
 	protected void assertExpectedUserGroups(


### PR DESCRIPTION
This is an update for [LPS-86357](https://issues.liferay.com/browse/LPS-86357).<br><br>@jpince once this is backported it should fix the failures on 7.0.x<br><br>/cc @pei-jung @stsquared99 @alee8888