### PR TITLE
LPS-85380 Another place where classPKs are not needed

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
@@ -1087,13 +1087,9 @@ public class DDMDisplayContext {
 		long[] groupIds = ddmDisplay.getTemplateGroupIds(
 			themeDisplay, showAncestorScopes());
 
-		long[] classPKs = ddmDisplay.getTemplateClassPKs(
-			_ddmWebRequestHelper.getCompanyId(), getStructureClassNameId(),
-			getClassPK());
-
 		List<DDMTemplate> results = _ddmTemplateService.search(
 			_ddmWebRequestHelper.getCompanyId(), groupIds,
-			getTemplateClassNameIds(), classPKs, getResourceClassNameId(),
+			getTemplateClassNameIds(), null, getResourceClassNameId(),
 			searchTerms.getKeywords(), searchTerms.getType(), getTemplateMode(),
 			searchTerms.getStatus(), templateSearch.getStart(),
 			templateSearch.getEnd(), templateSearch.getOrderByComparator());
@@ -1115,13 +1111,9 @@ public class DDMDisplayContext {
 		long[] groupIds = ddmDisplay.getTemplateGroupIds(
 			themeDisplay, showAncestorScopes());
 
-		long[] classPKs = ddmDisplay.getTemplateClassPKs(
-			_ddmWebRequestHelper.getCompanyId(), getStructureClassNameId(),
-			getClassPK());
-
 		int total = _ddmTemplateService.searchCount(
 			_ddmWebRequestHelper.getCompanyId(), groupIds,
-			getTemplateClassNameIds(), classPKs, getResourceClassNameId(),
+			getTemplateClassNameIds(), null, getResourceClassNameId(),
 			searchTerms.getKeywords(), searchTerms.getType(), getTemplateMode(),
 			searchTerms.getStatus());
 


### PR DESCRIPTION
/cc @joshuacords

Notes from Josh:

> https://issues.liferay.com/browse/LPS-85380
> 
> When backporting the original commit for this ticket to 7.1.x, I found that 7.1.x and 7.0.x did not have the JournalDDMTemplateDisplayContext.java class or the view_template.jsp which was added by technical task [LPS-84919](https://issues.liferay.com/browse/LPS-84919). Instead they relied on DDMDisplayContext.java and calls from template_management_bar.jsp and view_template.jsp to perform the search (which also used the unnecessary classPKs which could result in errors when using Oracle DB). However, even though these older files are not used in the process of reproducing LPS-85380 in master - they are still present. I've made the same change to this search parameter as the last LPS-85380 [commit](https://github.com/brianchandotcom/liferay-portal/pull/63344/files) in order to backport these changes to 7.1.x and 7.0.x.