### PR TITLE
LPS-54815 Use published Service Builder

### DIFF
--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -307,7 +307,7 @@ svn://svn.liferay.com/repos/public/alloy/trunk/sandbox/taglibs.
 
 		<gradle-execute dir="../modules" task="buildService">
 			<arg value="-DbuildService.skipReadOnly=${build.services.skip.read.only}" />
-			<arg value="-Pcom.liferay.portal.tools.service.builder.ignore.local=false" />
+			<arg value="-Pcom.liferay.portal.tools.service.builder.ignore.local=true" />
 		</gradle-execute>
 	</target>
 


### PR DESCRIPTION
This commit reverts: https://github.com/liferay/liferay-portal/commit/1384dab

I think this was reverted before because only modules are forced to use the published version, the ones in portal-impl will use the one in the sdk directory.

If its helpful, I can take a look at seeing if the sdk directory can be reinitialized before the `build-services` task runs.