### PR TITLE
LPS-86473 Add dependency to OAuth2ApplicationLocalServiceImpl so that…

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
+import com.liferay.portal.kernel.repository.capabilities.PortalCapabilityLocator;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -54,6 +55,7 @@ import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.spring.extender.service.ServiceReference;
 
 import java.awt.image.RenderedImage;
 
@@ -528,6 +530,9 @@ public class OAuth2ApplicationLocalServiceImpl
 			}
 		}
 	}
+
+	@ServiceReference(type = PortalCapabilityLocator.class)
+	protected PortalCapabilityLocator portalCapabilityLocator;
 
 	private static Set<String> _ianaRegisteredUriSchemes = SetUtil.fromArray(
 		new String[] {


### PR DESCRIPTION
… is waits for the PortalCapabilityLocator before being published. This is only safe because the tracker for this is always registered after the tracker in PortletRepositoryDefiner. A long term solution would be to pull out enough of the kernel repository services so normal service dependency resolution works.