### PR TITLE
LPS-80391 OpenID Connect icon is missing from Sign In portlet

### DIFF
--- a/modules/apps/login/login-authentication-openid-connect-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.login.web/navigation/openid_connect.jsp
+++ b/modules/apps/login/login-authentication-openid-connect-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.login.web/navigation/openid_connect.jsp
@@ -22,6 +22,6 @@
 
 <liferay-ui:icon
 	message="openid-connect"
-	src='<%= themeDisplay.getPathThemeImages() + "/common/openid_connect.gif" %>'
+	src='<%= themeDisplay.getPathThemeImages() + "/common/openid.gif" %>'
 	url="<%= openIdConnectURL %>"
 />


### PR DESCRIPTION
Hi Brian,

https://issues.liferay.com/browse/LPS-80391

Thanks.

/cc @stian-sigvartsen 