### PR TITLE
LPS-86541 Make compile time lpkg index validation fail if validation …

### DIFF
--- a/modules/util/portal-tools-target-platform-indexer-client/src/main/java/com/liferay/portal/tools/target/platform/indexer/client/TargetPlatformIndexerClient.java
+++ b/modules/util/portal-tools-target-platform-indexer-client/src/main/java/com/liferay/portal/tools/target/platform/indexer/client/TargetPlatformIndexerClient.java
@@ -59,7 +59,7 @@ public class TargetPlatformIndexerClient {
 			System.err.println(
 				"== -Dliferay.home must point to a valid directory");
 
-			return;
+			System.exit(12);
 		}
 
 		String portalLibDirName = System.getProperty("portal.lib.dir");
@@ -68,7 +68,7 @@ public class TargetPlatformIndexerClient {
 			System.err.println(
 				"== -Dportal.lib.dir must point to a valid directory");
 
-			return;
+			System.exit(13);
 		}
 
 		BytesURLSupport.init();
@@ -106,6 +106,9 @@ public class TargetPlatformIndexerClient {
 
 			_updateIntegrityProperties(
 				uris, Paths.get(integrityPropertiesFileName));
+		}
+		else {
+			System.exit(16);
 		}
 	}
 


### PR DESCRIPTION
…is not successful

@brianchandotcom this is just a CI improvement for LPKG batch, in case of index/validation failures, the batchs will fail earlier rather than running the rest logic only knowing it will fail for sure.