### PR TITLE
LPS-86369 Translate all language keys to the correct default language…

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -128,7 +128,7 @@ public class FriendlyURLServlet extends HttpServlet {
 			throw new NoSuchGroupException(sb.toString());
 		}
 
-		Locale locale = portal.getLocale(request);
+		Locale locale = portal.getLocale(request, null, false);
 
 		SiteFriendlyURL siteFriendlyURL =
 			siteFriendlyURLLocalService.fetchSiteFriendlyURL(

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -1033,7 +1033,7 @@ public class LanguageImpl implements Language, Serializable {
 			}
 		}
 
-		Locale locale = PortalUtil.getLocale(request);
+		Locale locale = PortalUtil.getLocale(request, null, false);
 
 		return getLanguageId(locale);
 	}


### PR DESCRIPTION
… on initial render

CC @shuyangzhou Problem was we were populating the request level cache before knowing which group the page is on, so the group's configuration wasn't taking effect for the whole page.