### PR TITLE
LPS-86779

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/RawMetadataProcessorImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/RawMetadataProcessorImpl.java
@@ -185,7 +185,9 @@ public class RawMetadataProcessorImpl
 
 			LiferayFileEntry liferayFileEntry = (LiferayFileEntry)fileEntry;
 
-			indexer.reindex(liferayFileEntry.getDLFileEntry());
+			if (indexer != null) {
+				indexer.reindex(liferayFileEntry.getDLFileEntry());
+			}
 		}
 	}
 


### PR DESCRIPTION
Hey @brianchandotcom, @jpince

This should fix the NPE that is making some test runs fail.  The
problem is that this logic is sometimes executed before the
document-library-service module has been activated, so the indexer is
null.