### PR TITLE
LPS-86853 Organizations edit addresses and edit opening hours views are broken

### DIFF
--- a/modules/apps/users-admin/users-admin-web/source-formatter.properties
+++ b/modules/apps/users-admin/users-admin-web/source-formatter.properties
@@ -1,0 +1,6 @@
+##
+## Checkstyle Properties
+##
+
+    source.formatter.excludes=\
+        modules/apps/users-admin/users-admin-web/src/test/java/com/liferay/users/admin/web/internal/util/CSSClassNamesTest.java

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/util/CSSClassNames.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/util/CSSClassNames.java
@@ -16,7 +16,6 @@ package com.liferay.users.admin.web.internal.util;
 
 import com.liferay.petra.string.StringPool;
 
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -25,12 +24,12 @@ import java.util.stream.Stream;
  */
 public class CSSClassNames {
 
-	public static String build(Consumer<Builder> builderConsumer) {
+	public static Builder builder(String... cssClassNames) {
 		Builder builder = new Builder();
 
-		builderConsumer.accept(builder);
+		builder.add(cssClassNames);
 
-		return builder._build();
+		return builder;
 	}
 
 	public static class Builder {
@@ -49,6 +48,10 @@ public class CSSClassNames {
 
 		public Builder add(String cssClassName, boolean condition) {
 			return _add(cssClassName, condition);
+		}
+
+		public String build() {
+			return _build();
 		}
 
 		private Builder() {

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/addresses.jsp
@@ -72,12 +72,11 @@ List<Address> addresses = AddressServiceUtil.getAddresses(Organization.class.get
 
 <div
 	class="<%=
-		CSSClassNames.build(
-			builder -> builder.add(
-				"addresses-table-wrapper", "table-responsive"
-			).add(
-				"hide", addresses.isEmpty()
-			))
+		CSSClassNames.builder(
+			"addresses-table-wrapper", "table-responsive"
+		).add(
+			"hide", addresses.isEmpty()
+		).build()
 	%>"
 >
 	<table class="table table-autofit">

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/opening_hours.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/opening_hours.jsp
@@ -67,12 +67,11 @@ List<OrgLabor> orgLabors = OrgLaborServiceUtil.getOrgLabors(organizationId);
 
 <div
 	class="<%=
-		CSSClassNames.build(
-			builder -> builder.add(
-				"opening-hours-wrapper"
-			).add(
-				"hide", orgLabors.isEmpty()
-			))
+		CSSClassNames.builder(
+			"opening-hours-wrapper"
+		).add(
+			"hide", orgLabors.isEmpty()
+		).build()
 	%>"
 >
 

--- a/modules/apps/users-admin/users-admin-web/src/test/java/com/liferay/users/admin/web/internal/util/CSSClassNamesTest.java
+++ b/modules/apps/users-admin/users-admin-web/src/test/java/com/liferay/users/admin/web/internal/util/CSSClassNamesTest.java
@@ -24,79 +24,71 @@ public class CSSClassNamesTest {
 
 	@Test
 	public void testBasicOutput() {
+		Assert.assertEquals("hello", CSSClassNames.builder("hello").build());
 		Assert.assertEquals(
-			"hello", CSSClassNames.build(builder -> builder.add("hello")));
-		Assert.assertEquals(
-			"hello world",
-			CSSClassNames.build(builder -> builder.add("hello", "world")));
+			"hello world", CSSClassNames.builder("hello", "world").build());
 	}
 
 	@Test
 	public void testConditionalOutput() {
 		Assert.assertEquals(
 			"hello world",
-			CSSClassNames.build(
-				builder -> builder.add(
-					"hello"
-				).add(
-					"goodbye", false
-				).add(
-					"sad", false
-				).add(
-					"world", true
-				)));
+			CSSClassNames.builder(
+				"hello"
+			).add(
+				"goodbye", false
+			).add(
+				"sad", false
+			).add(
+				"world", true
+			).build());
 		Assert.assertEquals(
 			"foo hello world",
-			CSSClassNames.build(
-				builder -> builder.add(
-					"hello", "world"
-				).add(
-					"cruel", false
-				).add(
-					"foo", true
-				)));
+			CSSClassNames.builder(
+				"hello", "world"
+			).add(
+				"cruel", false
+			).add(
+				"foo", true
+			).build());
 	}
 
 	@Test
 	public void testDistinctOutput() {
 		Assert.assertEquals(
 			"hello world",
-			CSSClassNames.build(
-				builder -> builder.add(
-					"hello", "hello", "world", "world"
-				)));
+			CSSClassNames.builder(
+				"hello", "hello", "world", "world"
+			).build());
 		Assert.assertEquals(
 			"hello world",
-			CSSClassNames.build(
-				builder -> builder.add(
-					"hello"
-				).add(
-					"hello"
-				).add(
-					"world"
-				).add(
-					"world"
-				)));
+			CSSClassNames.builder(
+				"hello"
+			).add(
+				"hello"
+			).add(
+				"world"
+			).add(
+				"world"
+			).build());
 	}
 
 	@Test
 	public void testSortedOutput() {
 		Assert.assertEquals(
 			"hello world",
-			CSSClassNames.build(
-				builder -> builder.add(
-					"world", "hello"
-				)));
+			CSSClassNames.builder(
+				"world", "hello"
+			).build());
 		Assert.assertEquals(
 			"alpha beta gamma",
-			CSSClassNames.build(
-				builder -> builder.add(
-					"beta"
-				).add(
-					"gamma"
-				).add(
-					"alpha"
-				)));
+			CSSClassNames.builder(
+				"beta"
+			).add(
+				"gamma"
+			).add(
+				"alpha"
+			).build());
 	}
 
 }


### PR DESCRIPTION
This is an update for [LPS-86853](https://issues.liferay.com/browse/LPS-86853).

Hey Brian, this fixes an intermittent issue with the CSSClassNames utility.  For some reason the jsps have issues with the "consumer lambda being passed to a method as an argument" syntax.  

Also, I added a temporary SF exclusion to the test class, because it doesn't like chaining on a method called "builder".  I'm wondering if we can get an exclusion on methods called "builder".  @hhuijser https://github.com/brianchandotcom/liferay-portal/pull/64689/commits/6d5f6e51f311242575cc6671150bb9635dd8ad2e?

/cc @pei-jung @stsquared99 @alee8888