### PR TITLE
LPS-86291 Update to datetime2 in Form and Worflows modules

### DIFF
--- a/modules/apps/calendar/calendar-service/bnd.bnd
+++ b/modules/apps/calendar/calendar-service/bnd.bnd
@@ -11,5 +11,5 @@ Import-Package:\
 	!org.codehaus.*,\
 	\
 	*
-Liferay-Require-SchemaVersion: 3.0.0
+Liferay-Require-SchemaVersion: 4.0.0
 Liferay-Service: true

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/CalendarServiceUpgrade.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/CalendarServiceUpgrade.java
@@ -93,7 +93,8 @@ public class CalendarServiceUpgrade implements UpgradeStepRegistrator {
 			"3.0.0", "4.0.0",
 			new BaseUpgradeSQLServerDatetime(
 				new Class<?>[] {
-					CalendarBookingTable.class, CalendarNotificationTemplateTable.class,
+					CalendarBookingTable.class,
+					CalendarNotificationTemplateTable.class,
 					CalendarResourceTable.class, CalendarTable.class
 				}));
 	}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/CalendarServiceUpgrade.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/CalendarServiceUpgrade.java
@@ -24,12 +24,17 @@ import com.liferay.calendar.internal.upgrade.v2_0_0.UpgradeSchema;
 import com.liferay.calendar.internal.upgrade.v3_0_0.UpgradeCalendarBookingResourceBlock;
 import com.liferay.calendar.internal.upgrade.v3_0_0.UpgradeCalendarResourceBlock;
 import com.liferay.calendar.internal.upgrade.v3_0_0.UpgradeCalendarResourceResourceBlock;
+import com.liferay.calendar.internal.upgrade.v4_0_0.util.CalendarBookingTable;
+import com.liferay.calendar.internal.upgrade.v4_0_0.util.CalendarNotificationTemplateTable;
+import com.liferay.calendar.internal.upgrade.v4_0_0.util.CalendarResourceTable;
+import com.liferay.calendar.internal.upgrade.v4_0_0.util.CalendarTable;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
@@ -83,6 +88,14 @@ public class CalendarServiceUpgrade implements UpgradeStepRegistrator {
 			"2.0.0", "3.0.0", new UpgradeCalendarBookingResourceBlock(),
 			new UpgradeCalendarResourceBlock(),
 			new UpgradeCalendarResourceResourceBlock());
+
+		registry.register(
+			"3.0.0", "4.0.0",
+			new BaseUpgradeSQLServerDatetime(
+				new Class<?>[] {
+					CalendarBookingTable.class, CalendarNotificationTemplateTable.class,
+					CalendarResourceTable.class, CalendarTable.class
+				}));
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarBookingTable.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarBookingTable.java
@@ -1,5 +1,139 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.calendar.internal.upgrade.v4_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class CalendarBookingTable {
+
+	public static final String TABLE_NAME = "CalendarBooking";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"calendarBookingId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"calendarId", Types.BIGINT},
+		{"calendarResourceId", Types.BIGINT},
+		{"parentCalendarBookingId", Types.BIGINT},
+		{"recurringCalendarBookingId", Types.BIGINT},
+		{"vEventUid", Types.VARCHAR},
+		{"title", Types.VARCHAR},
+		{"description", Types.CLOB},
+		{"location", Types.VARCHAR},
+		{"startTime", Types.BIGINT},
+		{"endTime", Types.BIGINT},
+		{"allDay", Types.BOOLEAN},
+		{"recurrence", Types.VARCHAR},
+		{"firstReminder", Types.BIGINT},
+		{"firstReminderType", Types.VARCHAR},
+		{"secondReminder", Types.BIGINT},
+		{"secondReminderType", Types.VARCHAR},
+		{"lastPublishDate", Types.TIMESTAMP},
+		{"status", Types.INTEGER},
+		{"statusByUserId", Types.BIGINT},
+		{"statusByUserName", Types.VARCHAR},
+		{"statusDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("calendarBookingId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("calendarId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("calendarResourceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("parentCalendarBookingId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("recurringCalendarBookingId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("vEventUid", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("title", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("location", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("startTime", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("endTime", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("allDay", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("recurrence", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("firstReminder", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("firstReminderType", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("secondReminder", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("secondReminderType", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("statusByUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("statusByUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table CalendarBooking (uuid_ VARCHAR(75) null,calendarBookingId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,calendarId LONG,calendarResourceId LONG,parentCalendarBookingId LONG,recurringCalendarBookingId LONG,vEventUid VARCHAR(255) null,title STRING null,description TEXT null,location STRING null,startTime LONG,endTime LONG,allDay BOOLEAN,recurrence STRING null,firstReminder LONG,firstReminderType VARCHAR(75) null,secondReminder LONG,secondReminderType VARCHAR(75) null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table CalendarBooking";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create unique index IX_113A264E on CalendarBooking (calendarId, parentCalendarBookingId)",
+		"create index IX_470170B4 on CalendarBooking (calendarId, status)",
+		"create unique index IX_8B23DA0E on CalendarBooking (calendarId, vEventUid[$COLUMN_LENGTH:255$])",
+		"create index IX_B198FFC on CalendarBooking (calendarResourceId)",
+		"create index IX_F7B8A941 on CalendarBooking (parentCalendarBookingId, status)",
+		"create index IX_14ADC52E on CalendarBooking (recurringCalendarBookingId)",
+		"create index IX_A21D9FD5 on CalendarBooking (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_F4C61797 on CalendarBooking (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarBookingTable.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarBookingTable.java
@@ -1,0 +1,5 @@
+package com.liferay.calendar.internal.upgrade.v4_0_0.util;
+
+public class CalendarBookingTable {
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarNotificationTemplateTable.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarNotificationTemplateTable.java
@@ -1,0 +1,5 @@
+package com.liferay.calendar.internal.upgrade.v4_0_0.util;
+
+public class CalendarNotificationTemplateTable {
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarNotificationTemplateTable.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarNotificationTemplateTable.java
@@ -1,5 +1,92 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.calendar.internal.upgrade.v4_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class CalendarNotificationTemplateTable {
+
+	public static final String TABLE_NAME = "CalendarNotificationTemplate";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"calendarNotificationTemplateId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"calendarId", Types.BIGINT},
+		{"notificationType", Types.VARCHAR},
+		{"notificationTypeSettings", Types.VARCHAR},
+		{"notificationTemplateType", Types.VARCHAR},
+		{"subject", Types.VARCHAR},
+		{"body", Types.CLOB},
+		{"lastPublishDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("calendarNotificationTemplateId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("calendarId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("notificationType", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("notificationTypeSettings", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("notificationTemplateType", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("subject", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("body", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table CalendarNotificationTemplate (uuid_ VARCHAR(75) null,calendarNotificationTemplateId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,calendarId LONG,notificationType VARCHAR(75) null,notificationTypeSettings VARCHAR(75) null,notificationTemplateType VARCHAR(75) null,subject VARCHAR(75) null,body TEXT null,lastPublishDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table CalendarNotificationTemplate";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_7727A482 on CalendarNotificationTemplate (calendarId, notificationType[$COLUMN_LENGTH:75$], notificationTemplateType[$COLUMN_LENGTH:75$])",
+		"create index IX_4D7D97BD on CalendarNotificationTemplate (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_4012E97F on CalendarNotificationTemplate (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarResourceTable.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarResourceTable.java
@@ -1,5 +1,99 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.calendar.internal.upgrade.v4_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class CalendarResourceTable {
+
+	public static final String TABLE_NAME = "CalendarResource";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"calendarResourceId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"classNameId", Types.BIGINT},
+		{"classPK", Types.BIGINT},
+		{"classUuid", Types.VARCHAR},
+		{"code_", Types.VARCHAR},
+		{"name", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"active_", Types.BOOLEAN},
+		{"lastPublishDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("calendarResourceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("classNameId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("classUuid", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("code_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("active_", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table CalendarResource (uuid_ VARCHAR(75) null,calendarResourceId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,classNameId LONG,classPK LONG,classUuid VARCHAR(75) null,code_ VARCHAR(75) null,name STRING null,description STRING null,active_ BOOLEAN,lastPublishDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table CalendarResource";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_76DDD0F7 on CalendarResource (active_)",
+		"create unique index IX_16A12327 on CalendarResource (classNameId, classPK)",
+		"create index IX_4470A59D on CalendarResource (companyId, code_[$COLUMN_LENGTH:75$], active_)",
+		"create index IX_40678371 on CalendarResource (groupId, active_)",
+		"create index IX_55C2F8AA on CalendarResource (groupId, code_[$COLUMN_LENGTH:75$])",
+		"create index IX_56A06BC6 on CalendarResource (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_4ABD2BC8 on CalendarResource (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarResourceTable.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarResourceTable.java
@@ -1,0 +1,5 @@
+package com.liferay.calendar.internal.upgrade.v4_0_0.util;
+
+public class CalendarResourceTable {
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarTable.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarTable.java
@@ -1,0 +1,5 @@
+package com.liferay.calendar.internal.upgrade.v4_0_0.util;
+
+public class CalendarTable {
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarTable.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v4_0_0/util/CalendarTable.java
@@ -1,5 +1,98 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.calendar.internal.upgrade.v4_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class CalendarTable {
+
+	public static final String TABLE_NAME = "Calendar";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"calendarId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"calendarResourceId", Types.BIGINT},
+		{"name", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"timeZoneId", Types.VARCHAR},
+		{"color", Types.INTEGER},
+		{"defaultCalendar", Types.BOOLEAN},
+		{"enableComments", Types.BOOLEAN},
+		{"enableRatings", Types.BOOLEAN},
+		{"lastPublishDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("calendarId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("calendarResourceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("timeZoneId", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("color", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("defaultCalendar", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("enableComments", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("enableRatings", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table Calendar (uuid_ VARCHAR(75) null,calendarId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,calendarResourceId LONG,name STRING null,description STRING null,timeZoneId VARCHAR(75) null,color INTEGER,defaultCalendar BOOLEAN,enableComments BOOLEAN,enableRatings BOOLEAN,lastPublishDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table Calendar";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_97FC174E on Calendar (groupId, calendarResourceId, defaultCalendar)",
+		"create index IX_97656498 on Calendar (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_3AE311A on Calendar (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/bnd.bnd
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/bnd.bnd
@@ -6,6 +6,6 @@ Import-Package:\
 	!org.apache.poi.ss.usermodel.*,\
 	\
 	*
-Liferay-Require-SchemaVersion: 1.1.0
+Liferay-Require-SchemaVersion: 2.0.0
 Liferay-Service: true
 -includeresource: @poi-[0-9]*.jar

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/DDLServiceUpgrade.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/DDLServiceUpgrade.java
@@ -19,7 +19,12 @@ import com.liferay.dynamic.data.lists.internal.upgrade.v1_0_0.UpgradeKernelPacka
 import com.liferay.dynamic.data.lists.internal.upgrade.v1_0_0.UpgradeLastPublishDate;
 import com.liferay.dynamic.data.lists.internal.upgrade.v1_0_0.UpgradeSchema;
 import com.liferay.dynamic.data.lists.internal.upgrade.v1_0_1.UpgradeRecordGroup;
+import com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util.DDLRecordSetTable;
+import com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util.DDLRecordSetVersionTable;
+import com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util.DDLRecordTable;
+import com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util.DDLRecordVersionTable;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -58,6 +63,14 @@ public class DDLServiceUpgrade implements UpgradeStepRegistrator {
 			new com.liferay.dynamic.data.lists.internal.upgrade.v1_1_0.
 				UpgradeDDLRecordSetVersion(
 					_counterLocalService, _userLocalService));
+
+		registry.register(
+			"1.1.0", "2.0.0",
+			new BaseUpgradeSQLServerDatetime(
+				new Class<?>[] {
+					DDLRecordSetTable.class, DDLRecordSetVersionTable.class,
+					DDLRecordTable.class, DDLRecordVersionTable.class
+				}));
 	}
 
 	@Reference

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordSetTable.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordSetTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util;
+
+public class DDLRecordSetTable {
+
+}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordSetTable.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordSetTable.java
@@ -1,5 +1,104 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDLRecordSetTable {
+
+	public static final String TABLE_NAME = "DDLRecordSet";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"recordSetId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"versionUserId", Types.BIGINT},
+		{"versionUserName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"DDMStructureId", Types.BIGINT},
+		{"recordSetKey", Types.VARCHAR},
+		{"version", Types.VARCHAR},
+		{"name", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"minDisplayRows", Types.INTEGER},
+		{"scope", Types.INTEGER},
+		{"settings_", Types.CLOB},
+		{"lastPublishDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("recordSetId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("versionUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("versionUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("DDMStructureId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("recordSetKey", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("minDisplayRows", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("scope", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("settings_", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDLRecordSet (uuid_ VARCHAR(75) null,recordSetId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,versionUserId LONG,versionUserName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,DDMStructureId LONG,recordSetKey VARCHAR(75) null,version VARCHAR(75) null,name STRING null,description STRING null,minDisplayRows INTEGER,scope INTEGER,settings_ TEXT null,lastPublishDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDLRecordSet";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create unique index IX_56DAB121 on DDLRecordSet (groupId, recordSetKey[$COLUMN_LENGTH:75$])",
+		"create index IX_5938C39F on DDLRecordSet (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_270BA5E1 on DDLRecordSet (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordSetVersionTable.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordSetVersionTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util;
+
+public class DDLRecordSetVersionTable {
+
+}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordSetVersionTable.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordSetVersionTable.java
@@ -1,5 +1,94 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDLRecordSetVersionTable {
+
+	public static final String TABLE_NAME = "DDLRecordSetVersion";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"recordSetVersionId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"recordSetId", Types.BIGINT},
+		{"DDMStructureVersionId", Types.BIGINT},
+		{"name", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"settings_", Types.CLOB},
+		{"version", Types.VARCHAR},
+		{"status", Types.INTEGER},
+		{"statusByUserId", Types.BIGINT},
+		{"statusByUserName", Types.VARCHAR},
+		{"statusDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("recordSetVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("recordSetId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("DDMStructureVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("settings_", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("statusByUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("statusByUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDLRecordSetVersion (recordSetVersionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,recordSetId LONG,DDMStructureVersionId LONG,name STRING null,description STRING null,settings_ TEXT null,version VARCHAR(75) null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDLRecordSetVersion";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_1C4E1CC9 on DDLRecordSetVersion (recordSetId, status)",
+		"create unique index IX_94FC5485 on DDLRecordSetVersion (recordSetId, version[$COLUMN_LENGTH:75$])"
+	};
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordTable.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util;
+
+public class DDLRecordTable {
+
+}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordTable.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordTable.java
@@ -1,5 +1,97 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDLRecordTable {
+
+	public static final String TABLE_NAME = "DDLRecord";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"recordId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"versionUserId", Types.BIGINT},
+		{"versionUserName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"DDMStorageId", Types.BIGINT},
+		{"recordSetId", Types.BIGINT},
+		{"recordSetVersion", Types.VARCHAR},
+		{"version", Types.VARCHAR},
+		{"displayIndex", Types.INTEGER},
+		{"lastPublishDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("recordId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("versionUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("versionUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("DDMStorageId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("recordSetId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("recordSetVersion", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("displayIndex", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDLRecord (uuid_ VARCHAR(75) null,recordId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,versionUserId LONG,versionUserName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,DDMStorageId LONG,recordSetId LONG,recordSetVersion VARCHAR(75) null,version VARCHAR(75) null,displayIndex INTEGER,lastPublishDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDLRecord";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_6A6C1C85 on DDLRecord (companyId)",
+		"create index IX_F12C61D4 on DDLRecord (recordSetId, recordSetVersion[$COLUMN_LENGTH:75$])",
+		"create index IX_AAC564D3 on DDLRecord (recordSetId, userId)",
+		"create index IX_384AB6F7 on DDLRecord (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_B4328F39 on DDLRecord (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordVersionTable.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordVersionTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util;
+
+public class DDLRecordVersionTable {
+
+}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordVersionTable.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_0_0/util/DDLRecordVersionTable.java
@@ -1,5 +1,96 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDLRecordVersionTable {
+
+	public static final String TABLE_NAME = "DDLRecordVersion";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"recordVersionId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"DDMStorageId", Types.BIGINT},
+		{"recordSetId", Types.BIGINT},
+		{"recordSetVersion", Types.VARCHAR},
+		{"recordId", Types.BIGINT},
+		{"version", Types.VARCHAR},
+		{"displayIndex", Types.INTEGER},
+		{"status", Types.INTEGER},
+		{"statusByUserId", Types.BIGINT},
+		{"statusByUserName", Types.VARCHAR},
+		{"statusDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("recordVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("DDMStorageId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("recordSetId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("recordSetVersion", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("recordId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("displayIndex", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("statusByUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("statusByUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDLRecordVersion (recordVersionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,DDMStorageId LONG,recordSetId LONG,recordSetVersion VARCHAR(75) null,recordId LONG,version VARCHAR(75) null,displayIndex INTEGER,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDLRecordVersion";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_762ADC7 on DDLRecordVersion (recordId, status)",
+		"create unique index IX_C79E347 on DDLRecordVersion (recordId, version[$COLUMN_LENGTH:75$])",
+		"create index IX_19AD75F6 on DDLRecordVersion (recordSetId, recordSetVersion[$COLUMN_LENGTH:75$])",
+		"create index IX_28202A62 on DDLRecordVersion (userId, recordSetId, recordSetVersion[$COLUMN_LENGTH:75$], status)"
+	};
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping Service
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.service
 Bundle-Version: 4.0.0
-Liferay-Require-SchemaVersion: 2.0.3
+Liferay-Require-SchemaVersion: 3.0.0
 Liferay-Service: true
 Web-ContextPath: /dynamic-data-mapping-data-service

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/DDMServiceUpgrade.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/DDMServiceUpgrade.java
@@ -205,10 +205,12 @@ public class DDMServiceUpgrade implements UpgradeStepRegistrator {
 				new Class<?>[] {
 					DDMContentTable.class, DDMDataProviderInstanceTable.class,
 					DDMFormInstanceRecordTable.class,
-					DDMFormInstanceRecordVersionTable.class, DDMFormInstanceTable.class,
-					DDMFormInstanceVersionTable.class, DDMStructureLayoutTable.class,
-					DDMStructureTable.class, DDMStructureVersionTable.class,
-					DDMTemplateTable.class, DDMTemplateVersionTable.class
+					DDMFormInstanceRecordVersionTable.class,
+					DDMFormInstanceTable.class,
+					DDMFormInstanceVersionTable.class,
+					DDMStructureLayoutTable.class, DDMStructureTable.class,
+					DDMStructureVersionTable.class, DDMTemplateTable.class,
+					DDMTemplateVersionTable.class
 				}));
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/DDMServiceUpgrade.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/DDMServiceUpgrade.java
@@ -32,6 +32,17 @@ import com.liferay.dynamic.data.mapping.internal.upgrade.v1_1_0.UpgradeCheckboxF
 import com.liferay.dynamic.data.mapping.internal.upgrade.v1_1_1.UpgradeDDMFormFieldSettings;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v2_0_3.UpgradeDDMFormInstanceDefinition;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v2_0_3.UpgradeDDMFormInstanceEntries;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMContentTable;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMDataProviderInstanceTable;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMFormInstanceRecordTable;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMFormInstanceRecordVersionTable;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMFormInstanceTable;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMFormInstanceVersionTable;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMStructureLayoutTable;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMStructureTable;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMStructureVersionTable;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMTemplateTable;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util.DDMTemplateVersionTable;
 import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormDeserializerTracker;
 import com.liferay.dynamic.data.mapping.io.DDMFormLayoutSerializer;
@@ -53,6 +64,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
+import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -186,6 +198,18 @@ public class DDMServiceUpgrade implements UpgradeStepRegistrator {
 			new UpgradeDDMFormInstanceEntries(_jsonFactory),
 			new com.liferay.dynamic.data.mapping.internal.upgrade.v2_0_3.
 				UpgradeDDMFormInstanceSettings(_jsonFactory));
+
+		registry.register(
+			"2.0.3", "3.0.0",
+			new BaseUpgradeSQLServerDatetime(
+				new Class<?>[] {
+					DDMContentTable.class, DDMDataProviderInstanceTable.class,
+					DDMFormInstanceRecordTable.class,
+					DDMFormInstanceRecordVersionTable.class, DDMFormInstanceTable.class,
+					DDMFormInstanceVersionTable.class, DDMStructureLayoutTable.class,
+					DDMStructureTable.class, DDMStructureVersionTable.class,
+					DDMTemplateTable.class, DDMTemplateVersionTable.class
+				}));
 	}
 
 	protected DDMFormDeserializer getDDMFormJSONDeserializer() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMContentTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMContentTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
+
+public class DDMContentTable {
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMContentTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMContentTable.java
@@ -1,5 +1,81 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDMContentTable {
+
+	public static final String TABLE_NAME = "DDMContent";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"contentId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"name", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"data_", Types.CLOB}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("contentId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("data_", Types.CLOB);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDMContent (uuid_ VARCHAR(75) null,contentId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,name STRING null,description STRING null,data_ TEXT null)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDMContent";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_E3BAF436 on DDMContent (companyId)",
+		"create index IX_50BF1038 on DDMContent (groupId)",
+		"create index IX_3A9C0626 on DDMContent (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_EB9BDE28 on DDMContent (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMDataProviderInstanceTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMDataProviderInstanceTable.java
@@ -1,5 +1,84 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDMDataProviderInstanceTable {
+
+	public static final String TABLE_NAME = "DDMDataProviderInstance";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"dataProviderInstanceId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"name", Types.VARCHAR},
+		{"description", Types.CLOB},
+		{"definition", Types.CLOB},
+		{"type_", Types.VARCHAR}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("dataProviderInstanceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("definition", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("type_", Types.VARCHAR);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDMDataProviderInstance (uuid_ VARCHAR(75) null,dataProviderInstanceId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,name STRING null,description TEXT null,definition TEXT null,type_ VARCHAR(75) null)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDMDataProviderInstance";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_DB54A6E5 on DDMDataProviderInstance (companyId)",
+		"create index IX_1333A2A7 on DDMDataProviderInstance (groupId)",
+		"create index IX_C903C097 on DDMDataProviderInstance (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_B4E180D9 on DDMDataProviderInstance (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMDataProviderInstanceTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMDataProviderInstanceTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
+
+public class DDMDataProviderInstanceTable {
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceRecordTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceRecordTable.java
@@ -1,5 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDMFormInstanceRecordTable {
+
+	public static final String TABLE_NAME = "DDMFormInstanceRecord";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"formInstanceRecordId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"versionUserId", Types.BIGINT},
+		{"versionUserName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"formInstanceId", Types.BIGINT},
+		{"formInstanceVersion", Types.VARCHAR},
+		{"storageId", Types.BIGINT},
+		{"version", Types.VARCHAR},
+		{"lastPublishDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("formInstanceRecordId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("versionUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("versionUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("formInstanceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("formInstanceVersion", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("storageId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDMFormInstanceRecord (uuid_ VARCHAR(75) null,formInstanceRecordId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,versionUserId LONG,versionUserName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,formInstanceId LONG,formInstanceVersion VARCHAR(75) null,storageId LONG,version VARCHAR(75) null,lastPublishDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDMFormInstanceRecord";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_5BC982B on DDMFormInstanceRecord (companyId)",
+		"create index IX_242301EA on DDMFormInstanceRecord (formInstanceId, formInstanceVersion[$COLUMN_LENGTH:75$])",
+		"create index IX_3C8DBDFF on DDMFormInstanceRecord (formInstanceId, userId)",
+		"create index IX_E1971FF on DDMFormInstanceRecord (userId, formInstanceId)",
+		"create index IX_CF8CF491 on DDMFormInstanceRecord (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_AA3B6B53 on DDMFormInstanceRecord (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceRecordTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceRecordTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
+
+public class DDMFormInstanceRecordTable {
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceRecordVersionTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceRecordVersionTable.java
@@ -1,5 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDMFormInstanceRecordVersionTable {
+
+	public static final String TABLE_NAME = "DDMFormInstanceRecordVersion";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"formInstanceRecordVersionId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"formInstanceId", Types.BIGINT},
+		{"formInstanceVersion", Types.VARCHAR},
+		{"formInstanceRecordId", Types.BIGINT},
+		{"version", Types.VARCHAR},
+		{"status", Types.INTEGER},
+		{"statusByUserId", Types.BIGINT},
+		{"statusByUserName", Types.VARCHAR},
+		{"statusDate", Types.TIMESTAMP},
+		{"storageId", Types.BIGINT}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("formInstanceRecordVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("formInstanceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("formInstanceVersion", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("formInstanceRecordId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("statusByUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("statusByUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("storageId", Types.BIGINT);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDMFormInstanceRecordVersion (formInstanceRecordVersionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,formInstanceId LONG,formInstanceVersion VARCHAR(75) null,formInstanceRecordId LONG,version VARCHAR(75) null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,storageId LONG)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDMFormInstanceRecordVersion";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_EAAF6D80 on DDMFormInstanceRecordVersion (formInstanceId, formInstanceVersion[$COLUMN_LENGTH:75$])",
+		"create index IX_B5A3FAC6 on DDMFormInstanceRecordVersion (formInstanceRecordId, status)",
+		"create unique index IX_26623628 on DDMFormInstanceRecordVersion (formInstanceRecordId, version[$COLUMN_LENGTH:75$])",
+		"create index IX_57CA016C on DDMFormInstanceRecordVersion (userId, formInstanceId, formInstanceVersion[$COLUMN_LENGTH:75$], status)"
+	};
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceRecordVersionTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceRecordVersionTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
+
+public class DDMFormInstanceRecordVersionTable {
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceTable.java
@@ -1,5 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDMFormInstanceTable {
+
+	public static final String TABLE_NAME = "DDMFormInstance";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"formInstanceId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"versionUserId", Types.BIGINT},
+		{"versionUserName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"structureId", Types.BIGINT},
+		{"version", Types.VARCHAR},
+		{"name", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"settings_", Types.CLOB},
+		{"lastPublishDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("formInstanceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("versionUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("versionUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("structureId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("settings_", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDMFormInstance (uuid_ VARCHAR(75) null,formInstanceId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,versionUserId LONG,versionUserName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,structureId LONG,version VARCHAR(75) null,name STRING null,description STRING null,settings_ TEXT null,lastPublishDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDMFormInstance";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_9E1C31FE on DDMFormInstance (groupId)",
+		"create index IX_E418320 on DDMFormInstance (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_AA9051A2 on DDMFormInstance (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
+
+public class DDMFormInstanceTable {
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceVersionTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceVersionTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
+
+public class DDMFormInstanceVersionTable {
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceVersionTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMFormInstanceVersionTable.java
@@ -1,5 +1,94 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDMFormInstanceVersionTable {
+
+	public static final String TABLE_NAME = "DDMFormInstanceVersion";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"formInstanceVersionId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"formInstanceId", Types.BIGINT},
+		{"structureVersionId", Types.BIGINT},
+		{"name", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"settings_", Types.CLOB},
+		{"version", Types.VARCHAR},
+		{"status", Types.INTEGER},
+		{"statusByUserId", Types.BIGINT},
+		{"statusByUserName", Types.VARCHAR},
+		{"statusDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("formInstanceVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("formInstanceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("structureVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("settings_", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("statusByUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("statusByUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDMFormInstanceVersion (formInstanceVersionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,formInstanceId LONG,structureVersionId LONG,name STRING null,description STRING null,settings_ TEXT null,version VARCHAR(75) null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDMFormInstanceVersion";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_EB92EF26 on DDMFormInstanceVersion (formInstanceId, status)",
+		"create unique index IX_AE51CDC8 on DDMFormInstanceVersion (formInstanceId, version[$COLUMN_LENGTH:75$])"
+	};
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMStructureLayoutTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMStructureLayoutTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
+
+public class DDMStructureLayoutTable {
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMStructureLayoutTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMStructureLayoutTable.java
@@ -1,5 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDMStructureLayoutTable {
+
+	public static final String TABLE_NAME = "DDMStructureLayout";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"structureLayoutId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"structureVersionId", Types.BIGINT},
+		{"definition", Types.CLOB}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("structureLayoutId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("structureVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("definition", Types.CLOB);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDMStructureLayout (uuid_ VARCHAR(75) null,structureLayoutId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,structureVersionId LONG,definition TEXT null)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDMStructureLayout";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create unique index IX_B7158C0A on DDMStructureLayout (structureVersionId)",
+		"create index IX_A90FF72A on DDMStructureLayout (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_C9A0402C on DDMStructureLayout (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMStructureTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMStructureTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
+
+public class DDMStructureTable {
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMStructureTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMStructureTable.java
@@ -1,5 +1,112 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDMStructureTable {
+
+	public static final String TABLE_NAME = "DDMStructure";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"structureId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"versionUserId", Types.BIGINT},
+		{"versionUserName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"parentStructureId", Types.BIGINT},
+		{"classNameId", Types.BIGINT},
+		{"structureKey", Types.VARCHAR},
+		{"version", Types.VARCHAR},
+		{"name", Types.VARCHAR},
+		{"description", Types.CLOB},
+		{"definition", Types.CLOB},
+		{"storageType", Types.VARCHAR},
+		{"type_", Types.INTEGER},
+		{"lastPublishDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("structureId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("versionUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("versionUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("parentStructureId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("classNameId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("structureKey", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("definition", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("storageType", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("type_", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDMStructure (uuid_ VARCHAR(75) null,structureId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,versionUserId LONG,versionUserName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,parentStructureId LONG,classNameId LONG,structureKey VARCHAR(75) null,version VARCHAR(75) null,name STRING null,description TEXT null,definition TEXT null,storageType VARCHAR(75) null,type_ INTEGER,lastPublishDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDMStructure";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_31817A62 on DDMStructure (classNameId)",
+		"create index IX_4FBAC092 on DDMStructure (companyId, classNameId)",
+		"create unique index IX_C8785130 on DDMStructure (groupId, classNameId, structureKey[$COLUMN_LENGTH:75$])",
+		"create index IX_43395316 on DDMStructure (groupId, parentStructureId)",
+		"create index IX_657899A8 on DDMStructure (parentStructureId)",
+		"create index IX_20FDE04C on DDMStructure (structureKey[$COLUMN_LENGTH:75$])",
+		"create index IX_F9FB8D60 on DDMStructure (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_85C7EBE2 on DDMStructure (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMStructureVersionTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMStructureVersionTable.java
@@ -1,5 +1,100 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDMStructureVersionTable {
+
+	public static final String TABLE_NAME = "DDMStructureVersion";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"structureVersionId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"structureId", Types.BIGINT},
+		{"version", Types.VARCHAR},
+		{"parentStructureId", Types.BIGINT},
+		{"name", Types.VARCHAR},
+		{"description", Types.CLOB},
+		{"definition", Types.CLOB},
+		{"storageType", Types.VARCHAR},
+		{"type_", Types.INTEGER},
+		{"status", Types.INTEGER},
+		{"statusByUserId", Types.BIGINT},
+		{"statusByUserName", Types.VARCHAR},
+		{"statusDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("structureVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("structureId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("parentStructureId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("definition", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("storageType", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("type_", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("statusByUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("statusByUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDMStructureVersion (structureVersionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,structureId LONG,version VARCHAR(75) null,parentStructureId LONG,name STRING null,description TEXT null,definition TEXT null,storageType VARCHAR(75) null,type_ INTEGER,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDMStructureVersion";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_17B3C96C on DDMStructureVersion (structureId, status)",
+		"create unique index IX_64C3C42 on DDMStructureVersion (structureId, version[$COLUMN_LENGTH:75$])"
+	};
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMStructureVersionTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMStructureVersionTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
+
+public class DDMStructureVersionTable {
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMTemplateTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMTemplateTable.java
@@ -1,5 +1,133 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDMTemplateTable {
+
+	public static final String TABLE_NAME = "DDMTemplate";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"templateId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"versionUserId", Types.BIGINT},
+		{"versionUserName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"classNameId", Types.BIGINT},
+		{"classPK", Types.BIGINT},
+		{"resourceClassNameId", Types.BIGINT},
+		{"templateKey", Types.VARCHAR},
+		{"version", Types.VARCHAR},
+		{"name", Types.CLOB},
+		{"description", Types.CLOB},
+		{"type_", Types.VARCHAR},
+		{"mode_", Types.VARCHAR},
+		{"language", Types.VARCHAR},
+		{"script", Types.CLOB},
+		{"cacheable", Types.BOOLEAN},
+		{"smallImage", Types.BOOLEAN},
+		{"smallImageId", Types.BIGINT},
+		{"smallImageURL", Types.VARCHAR},
+		{"lastPublishDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("templateId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("versionUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("versionUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("classNameId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("resourceClassNameId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("templateKey", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("name", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("description", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("type_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("mode_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("language", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("script", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("cacheable", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("smallImage", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("smallImageId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("smallImageURL", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDMTemplate (uuid_ VARCHAR(75) null,templateId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,versionUserId LONG,versionUserName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,classNameId LONG,classPK LONG,resourceClassNameId LONG,templateKey VARCHAR(75) null,version VARCHAR(75) null,name TEXT null,description TEXT null,type_ VARCHAR(75) null,mode_ VARCHAR(75) null,language VARCHAR(75) null,script TEXT null,cacheable BOOLEAN,smallImage BOOLEAN,smallImageId LONG,smallImageURL STRING null,lastPublishDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDMTemplate";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_B6356F93 on DDMTemplate (classNameId, classPK, type_[$COLUMN_LENGTH:75$])",
+		"create index IX_32F83D16 on DDMTemplate (classPK)",
+		"create index IX_F0C3449 on DDMTemplate (groupId, classNameId, classPK, type_[$COLUMN_LENGTH:75$], mode_[$COLUMN_LENGTH:75$])",
+		"create unique index IX_E6DFAB84 on DDMTemplate (groupId, classNameId, templateKey[$COLUMN_LENGTH:75$])",
+		"create index IX_B1C33EA6 on DDMTemplate (groupId, classPK)",
+		"create index IX_33BEF579 on DDMTemplate (language[$COLUMN_LENGTH:75$])",
+		"create index IX_127A35B0 on DDMTemplate (smallImageId)",
+		"create index IX_CAE41A28 on DDMTemplate (templateKey[$COLUMN_LENGTH:75$])",
+		"create index IX_C4F283C8 on DDMTemplate (type_[$COLUMN_LENGTH:75$])",
+		"create index IX_D4C2C221 on DDMTemplate (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_1AA75CE3 on DDMTemplate (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMTemplateTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMTemplateTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
+
+public class DDMTemplateTable {
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMTemplateVersionTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMTemplateVersionTable.java
@@ -1,5 +1,100 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class DDMTemplateVersionTable {
+
+	public static final String TABLE_NAME = "DDMTemplateVersion";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"templateVersionId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"classNameId", Types.BIGINT},
+		{"classPK", Types.BIGINT},
+		{"templateId", Types.BIGINT},
+		{"version", Types.VARCHAR},
+		{"name", Types.CLOB},
+		{"description", Types.CLOB},
+		{"language", Types.VARCHAR},
+		{"script", Types.CLOB},
+		{"status", Types.INTEGER},
+		{"statusByUserId", Types.BIGINT},
+		{"statusByUserName", Types.VARCHAR},
+		{"statusDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("templateVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("classNameId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("templateId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("name", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("description", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("language", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("script", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("statusByUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("statusByUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table DDMTemplateVersion (templateVersionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,classNameId LONG,classPK LONG,templateId LONG,version VARCHAR(75) null,name TEXT null,description TEXT null,language VARCHAR(75) null,script TEXT null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table DDMTemplateVersion";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_66382FC6 on DDMTemplateVersion (templateId, status)",
+		"create unique index IX_8854A128 on DDMTemplateVersion (templateId, version[$COLUMN_LENGTH:75$])"
+	};
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMTemplateVersionTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_0_0/util/DDMTemplateVersionTable.java
@@ -1,0 +1,5 @@
+package com.liferay.dynamic.data.mapping.internal.upgrade.v3_0_0.util;
+
+public class DDMTemplateVersionTable {
+
+}

--- a/modules/apps/polls/polls-service/bnd.bnd
+++ b/modules/apps/polls/polls-service/bnd.bnd
@@ -5,5 +5,5 @@ Import-Package:\
 	com.liferay.polls.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 1.0.4
+Liferay-Require-SchemaVersion: 2.0.0
 Liferay-Service: true

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/upgrade/PollsServiceUpgrade.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/upgrade/PollsServiceUpgrade.java
@@ -17,6 +17,10 @@ package com.liferay.polls.internal.upgrade;
 import com.liferay.polls.internal.upgrade.v1_0_0.UpgradeKernelPackage;
 import com.liferay.polls.internal.upgrade.v1_0_0.UpgradeLastPublishDate;
 import com.liferay.polls.internal.upgrade.v1_0_0.UpgradePortletId;
+import com.liferay.polls.internal.upgrade.v2_0_0.util.PollsChoiceTable;
+import com.liferay.polls.internal.upgrade.v2_0_0.util.PollsQuestionTable;
+import com.liferay.polls.internal.upgrade.v2_0_0.util.PollsVoteTable;
+import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
@@ -41,6 +45,14 @@ public class PollsServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"1.0.3", "1.0.4",
 			new com.liferay.polls.internal.upgrade.v1_0_4.UpgradePortletId());
+
+		registry.register(
+			"1.0.4", "2.0.0",
+			new BaseUpgradeSQLServerDatetime(
+				new Class<?>[] {
+					PollsChoiceTable.class, PollsQuestionTable.class,
+					PollsVoteTable.class
+				}));
 	}
 
 }

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/upgrade/v2_0_0/util/PollsChoiceTable.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/upgrade/v2_0_0/util/PollsChoiceTable.java
@@ -1,0 +1,5 @@
+package com.liferay.polls.internal.upgrade.v2_0_0.util;
+
+public class PollsChoiceTable {
+
+}

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/upgrade/v2_0_0/util/PollsChoiceTable.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/upgrade/v2_0_0/util/PollsChoiceTable.java
@@ -1,5 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.polls.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class PollsChoiceTable {
+
+	public static final String TABLE_NAME = "PollsChoice";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"choiceId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"questionId", Types.BIGINT},
+		{"name", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"lastPublishDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("choiceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("questionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table PollsChoice (uuid_ VARCHAR(75) null,choiceId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,questionId LONG,name VARCHAR(75) null,description STRING null,lastPublishDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table PollsChoice";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create unique index IX_D76DD2CF on PollsChoice (questionId, name[$COLUMN_LENGTH:75$])",
+		"create index IX_8AE746EF on PollsChoice (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_C222BD31 on PollsChoice (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/upgrade/v2_0_0/util/PollsQuestionTable.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/upgrade/v2_0_0/util/PollsQuestionTable.java
@@ -1,0 +1,5 @@
+package com.liferay.polls.internal.upgrade.v2_0_0.util;
+
+public class PollsQuestionTable {
+
+}

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/upgrade/v2_0_0/util/PollsQuestionTable.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/upgrade/v2_0_0/util/PollsQuestionTable.java
@@ -1,5 +1,86 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.polls.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class PollsQuestionTable {
+
+	public static final String TABLE_NAME = "PollsQuestion";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"questionId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"title", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"expirationDate", Types.TIMESTAMP},
+		{"lastPublishDate", Types.TIMESTAMP},
+		{"lastVoteDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("questionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("title", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("expirationDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("lastVoteDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table PollsQuestion (uuid_ VARCHAR(75) null,questionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,title STRING null,description STRING null,expirationDate DATE null,lastPublishDate DATE null,lastVoteDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table PollsQuestion";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_9FF342EA on PollsQuestion (groupId)",
+		"create index IX_F910BBB4 on PollsQuestion (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_F3C9F36 on PollsQuestion (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/upgrade/v2_0_0/util/PollsVoteTable.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/upgrade/v2_0_0/util/PollsVoteTable.java
@@ -1,0 +1,5 @@
+package com.liferay.polls.internal.upgrade.v2_0_0.util;
+
+public class PollsVoteTable {
+
+}

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/upgrade/v2_0_0/util/PollsVoteTable.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/upgrade/v2_0_0/util/PollsVoteTable.java
@@ -1,5 +1,84 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.polls.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class PollsVoteTable {
+
+	public static final String TABLE_NAME = "PollsVote";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"uuid_", Types.VARCHAR},
+		{"voteId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"questionId", Types.BIGINT},
+		{"choiceId", Types.BIGINT},
+		{"lastPublishDate", Types.TIMESTAMP},
+		{"voteDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("voteId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("questionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("choiceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("voteDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table PollsVote (uuid_ VARCHAR(75) null,voteId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,questionId LONG,choiceId LONG,lastPublishDate DATE null,voteDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table PollsVote";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_D5DF7B54 on PollsVote (choiceId)",
+		"create index IX_1BBFD4D3 on PollsVote (questionId, userId)",
+		"create index IX_7D8E92B8 on PollsVote (uuid_[$COLUMN_LENGTH:75$], companyId)",
+		"create unique index IX_A88C673A on PollsVote (uuid_[$COLUMN_LENGTH:75$], groupId)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/bnd.bnd
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow Kaleo Service
 Bundle-SymbolicName: com.liferay.portal.workflow.kaleo.service
 Bundle-Version: 4.0.0
-Liferay-Require-SchemaVersion: 1.4.1
+Liferay-Require-SchemaVersion: 2.0.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/KaleoServiceUpgrade.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/KaleoServiceUpgrade.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.workflow.kaleo.internal.upgrade;
 
+import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.workflow.kaleo.internal.upgrade.v1_0_0.UpgradeKaleoTaskInstanceToken;
 import com.liferay.portal.workflow.kaleo.internal.upgrade.v1_1_0.UpgradeWorkflowContext;
@@ -25,6 +26,25 @@ import com.liferay.portal.workflow.kaleo.internal.upgrade.v1_3_0.UpgradeKaleoDef
 import com.liferay.portal.workflow.kaleo.internal.upgrade.v1_3_2.UpgradeKaleoClassNameAndKaleoClassPK;
 import com.liferay.portal.workflow.kaleo.internal.upgrade.v1_3_3.UpgradeBlogsEntryClassName;
 import com.liferay.portal.workflow.kaleo.internal.upgrade.v1_4_1.UpgradeKaleoDefinitionVersion;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoActionTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoConditionTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoDefinitionTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoDefinitionVersionTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoInstanceTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoInstanceTokenTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoLogTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoNodeTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoNotificationRecipientTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoNotificationTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoTaskAssignmentInstanceTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoTaskAssignmentTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoTaskFormInstanceTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoTaskFormTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoTaskInstanceTokenTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoTaskTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoTimerInstanceTokenTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoTimerTable;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util.KaleoTransitionTable;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -76,6 +96,23 @@ public class KaleoServiceUpgrade implements UpgradeStepRegistrator {
 
 		registry.register(
 			"1.4.0", "1.4.1", new UpgradeKaleoDefinitionVersion());
+
+		registry.register(
+			"1.4.1", "2.0.0",
+			new BaseUpgradeSQLServerDatetime(
+				new Class<?>[] {
+					KaleoActionTable.class, KaleoConditionTable.class,
+					KaleoDefinitionTable.class, KaleoDefinitionVersionTable.class,
+					KaleoInstanceTable.class, KaleoInstanceTokenTable.class,
+					KaleoLogTable.class, KaleoNodeTable.class,
+					KaleoNotificationRecipientTable.class, KaleoNotificationTable.class,
+					KaleoTaskAssignmentInstanceTable.class,
+					KaleoTaskAssignmentTable.class, KaleoTaskFormInstanceTable.class,
+					KaleoTaskFormTable.class, KaleoTaskInstanceTokenTable.class,
+					KaleoTaskTable.class, KaleoTimerInstanceTokenTable.class,
+					KaleoTimerTable.class, KaleoTransitionTable.class
+				}
+			));
 	}
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoActionTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoActionTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoActionTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoActionTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoActionTable.java
@@ -1,5 +1,101 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoActionTable {
+
+	public static final String TABLE_NAME = "KaleoAction";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoActionId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoClassName", Types.VARCHAR},
+		{"kaleoClassPK", Types.BIGINT},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoNodeName", Types.VARCHAR},
+		{"name", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"executionType", Types.VARCHAR},
+		{"script", Types.CLOB},
+		{"scriptLanguage", Types.VARCHAR},
+		{"scriptRequiredContexts", Types.VARCHAR},
+		{"priority", Types.INTEGER}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoActionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoClassName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("kaleoClassPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoNodeName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("executionType", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("script", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("scriptLanguage", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("scriptRequiredContexts", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("priority", Types.INTEGER);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoAction (kaleoActionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoClassName VARCHAR(200) null,kaleoClassPK LONG,kaleoDefinitionVersionId LONG,kaleoNodeName VARCHAR(200) null,name VARCHAR(200) null,description STRING null,executionType VARCHAR(20) null,script TEXT null,scriptLanguage VARCHAR(75) null,scriptRequiredContexts STRING null,priority INTEGER)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoAction";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_50E9112C on KaleoAction (companyId)",
+		"create index IX_4B2545E8 on KaleoAction (kaleoClassName[$COLUMN_LENGTH:200$], kaleoClassPK, executionType[$COLUMN_LENGTH:20$])",
+		"create index IX_F8808C50 on KaleoAction (kaleoDefinitionVersionId)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoConditionTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoConditionTable.java
@@ -1,5 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoConditionTable {
+
+	public static final String TABLE_NAME = "KaleoCondition";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoConditionId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoNodeId", Types.BIGINT},
+		{"script", Types.CLOB},
+		{"scriptLanguage", Types.VARCHAR},
+		{"scriptRequiredContexts", Types.VARCHAR}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoConditionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoNodeId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("script", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("scriptLanguage", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("scriptRequiredContexts", Types.VARCHAR);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoCondition (kaleoConditionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoDefinitionVersionId LONG,kaleoNodeId LONG,script TEXT null,scriptLanguage VARCHAR(75) null,scriptRequiredContexts STRING null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoCondition";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_FEE46067 on KaleoCondition (companyId)",
+		"create index IX_353B7FB5 on KaleoCondition (kaleoDefinitionVersionId)",
+		"create index IX_86CBD4C on KaleoCondition (kaleoNodeId)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoConditionTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoConditionTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoConditionTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoDefinitionTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoDefinitionTable.java
@@ -1,5 +1,86 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoDefinitionTable {
+
+	public static final String TABLE_NAME = "KaleoDefinition";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoDefinitionId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"name", Types.VARCHAR},
+		{"title", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"content", Types.CLOB},
+		{"version", Types.INTEGER},
+		{"active_", Types.BOOLEAN}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoDefinitionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("title", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("content", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("version", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("active_", Types.BOOLEAN);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoDefinition (kaleoDefinitionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,name VARCHAR(200) null,title STRING null,description STRING null,content TEXT null,version INTEGER,active_ BOOLEAN)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoDefinition";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_408542BA on KaleoDefinition (companyId, active_)",
+		"create index IX_4C23F11B on KaleoDefinition (companyId, name[$COLUMN_LENGTH:200$], active_)",
+		"create index IX_EC14F81A on KaleoDefinition (companyId, name[$COLUMN_LENGTH:200$], version)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoDefinitionTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoDefinitionTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoDefinitionTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoDefinitionVersionTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoDefinitionVersionTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoDefinitionVersionTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoDefinitionVersionTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoDefinitionVersionTable.java
@@ -1,5 +1,96 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoDefinitionVersionTable {
+
+	public static final String TABLE_NAME = "KaleoDefinitionVersion";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"statusByUserId", Types.BIGINT},
+		{"statusByUserName", Types.VARCHAR},
+		{"statusDate", Types.TIMESTAMP},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"name", Types.VARCHAR},
+		{"title", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"content", Types.CLOB},
+		{"version", Types.VARCHAR},
+		{"startKaleoNodeId", Types.BIGINT},
+		{"status", Types.INTEGER}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusByUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("statusByUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("title", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("content", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("startKaleoNodeId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoDefinitionVersion (kaleoDefinitionVersionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,createDate DATE null,modifiedDate DATE null,name VARCHAR(200) null,title STRING null,description STRING null,content TEXT null,version VARCHAR(75) null,startKaleoNodeId LONG,status INTEGER)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoDefinitionVersion";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create unique index IX_AE02DCC on KaleoDefinitionVersion (companyId, name[$COLUMN_LENGTH:200$], version[$COLUMN_LENGTH:75$])"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoInstanceTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoInstanceTable.java
@@ -1,5 +1,96 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoInstanceTable {
+
+	public static final String TABLE_NAME = "KaleoInstance";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoInstanceId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoDefinitionName", Types.VARCHAR},
+		{"kaleoDefinitionVersion", Types.INTEGER},
+		{"rootKaleoInstanceTokenId", Types.BIGINT},
+		{"className", Types.VARCHAR},
+		{"classPK", Types.BIGINT},
+		{"completed", Types.BOOLEAN},
+		{"completionDate", Types.TIMESTAMP},
+		{"workflowContext", Types.CLOB}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoInstanceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersion", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("rootKaleoInstanceTokenId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("className", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("completed", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("completionDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("workflowContext", Types.CLOB);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoInstance (kaleoInstanceId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoDefinitionVersionId LONG,kaleoDefinitionName VARCHAR(200) null,kaleoDefinitionVersion INTEGER,rootKaleoInstanceTokenId LONG,className VARCHAR(200) null,classPK LONG,completed BOOLEAN,completionDate DATE null,workflowContext TEXT null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoInstance";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_58D85ECB on KaleoInstance (className[$COLUMN_LENGTH:200$], classPK)",
+		"create index IX_BF5839F8 on KaleoInstance (companyId, kaleoDefinitionName[$COLUMN_LENGTH:200$], kaleoDefinitionVersion, completionDate)",
+		"create index IX_C6D7A867 on KaleoInstance (companyId, userId)",
+		"create index IX_3DA1A5AC on KaleoInstance (kaleoDefinitionVersionId, completed)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoInstanceTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoInstanceTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoInstanceTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoInstanceTokenTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoInstanceTokenTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoInstanceTokenTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoInstanceTokenTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoInstanceTokenTable.java
@@ -1,5 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoInstanceTokenTable {
+
+	public static final String TABLE_NAME = "KaleoInstanceToken";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoInstanceTokenId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoInstanceId", Types.BIGINT},
+		{"parentKaleoInstanceTokenId", Types.BIGINT},
+		{"currentKaleoNodeId", Types.BIGINT},
+		{"currentKaleoNodeName", Types.VARCHAR},
+		{"className", Types.VARCHAR},
+		{"classPK", Types.BIGINT},
+		{"completed", Types.BOOLEAN},
+		{"completionDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoInstanceTokenId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoInstanceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("parentKaleoInstanceTokenId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("currentKaleoNodeId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("currentKaleoNodeName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("className", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("completed", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("completionDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoInstanceToken (kaleoInstanceTokenId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoDefinitionVersionId LONG,kaleoInstanceId LONG,parentKaleoInstanceTokenId LONG,currentKaleoNodeId LONG,currentKaleoNodeName VARCHAR(200) null,className VARCHAR(200) null,classPK LONG,completed BOOLEAN,completionDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoInstanceToken";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_360D34D9 on KaleoInstanceToken (companyId, parentKaleoInstanceTokenId, completionDate)",
+		"create index IX_1181057E on KaleoInstanceToken (kaleoDefinitionVersionId)",
+		"create index IX_F42AAFF6 on KaleoInstanceToken (kaleoInstanceId)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoLogTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoLogTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoLogTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoLogTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoLogTable.java
@@ -1,5 +1,140 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoLogTable {
+
+	public static final String TABLE_NAME = "KaleoLog";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoLogId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoClassName", Types.VARCHAR},
+		{"kaleoClassPK", Types.BIGINT},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoInstanceId", Types.BIGINT},
+		{"kaleoInstanceTokenId", Types.BIGINT},
+		{"kaleoTaskInstanceTokenId", Types.BIGINT},
+		{"kaleoNodeName", Types.VARCHAR},
+		{"terminalKaleoNode", Types.BOOLEAN},
+		{"kaleoActionId", Types.BIGINT},
+		{"kaleoActionName", Types.VARCHAR},
+		{"kaleoActionDescription", Types.VARCHAR},
+		{"previousKaleoNodeId", Types.BIGINT},
+		{"previousKaleoNodeName", Types.VARCHAR},
+		{"previousAssigneeClassName", Types.VARCHAR},
+		{"previousAssigneeClassPK", Types.BIGINT},
+		{"currentAssigneeClassName", Types.VARCHAR},
+		{"currentAssigneeClassPK", Types.BIGINT},
+		{"type_", Types.VARCHAR},
+		{"comment_", Types.CLOB},
+		{"startDate", Types.TIMESTAMP},
+		{"endDate", Types.TIMESTAMP},
+		{"duration", Types.BIGINT},
+		{"workflowContext", Types.CLOB}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoLogId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoClassName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("kaleoClassPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoInstanceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoInstanceTokenId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoTaskInstanceTokenId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoNodeName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("terminalKaleoNode", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("kaleoActionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoActionName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("kaleoActionDescription", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("previousKaleoNodeId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("previousKaleoNodeName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("previousAssigneeClassName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("previousAssigneeClassPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("currentAssigneeClassName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("currentAssigneeClassPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("type_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("comment_", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("startDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("endDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("duration", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("workflowContext", Types.CLOB);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoLog (kaleoLogId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoClassName VARCHAR(200) null,kaleoClassPK LONG,kaleoDefinitionVersionId LONG,kaleoInstanceId LONG,kaleoInstanceTokenId LONG,kaleoTaskInstanceTokenId LONG,kaleoNodeName VARCHAR(200) null,terminalKaleoNode BOOLEAN,kaleoActionId LONG,kaleoActionName VARCHAR(200) null,kaleoActionDescription STRING null,previousKaleoNodeId LONG,previousKaleoNodeName VARCHAR(200) null,previousAssigneeClassName VARCHAR(200) null,previousAssigneeClassPK LONG,currentAssigneeClassName VARCHAR(200) null,currentAssigneeClassPK LONG,type_ VARCHAR(50) null,comment_ TEXT null,startDate DATE null,endDate DATE null,duration LONG,workflowContext TEXT null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoLog";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_73B5F4DE on KaleoLog (companyId)",
+		"create index IX_E66A153A on KaleoLog (kaleoClassName[$COLUMN_LENGTH:200$], kaleoClassPK, kaleoInstanceTokenId, type_[$COLUMN_LENGTH:50$])",
+		"create index IX_935D8E5E on KaleoLog (kaleoDefinitionVersionId)",
+		"create index IX_5BC6AB16 on KaleoLog (kaleoInstanceId)",
+		"create index IX_470B9FF8 on KaleoLog (kaleoInstanceTokenId, type_[$COLUMN_LENGTH:50$])",
+		"create index IX_B0CDCA38 on KaleoLog (kaleoTaskInstanceTokenId)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoNodeTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoNodeTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoNodeTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoNodeTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoNodeTable.java
@@ -1,5 +1,88 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoNodeTable {
+
+	public static final String TABLE_NAME = "KaleoNode";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoNodeId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"name", Types.VARCHAR},
+		{"metadata", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"type_", Types.VARCHAR},
+		{"initial_", Types.BOOLEAN},
+		{"terminal", Types.BOOLEAN}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoNodeId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("metadata", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("type_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("initial_", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("terminal", Types.BOOLEAN);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoNode (kaleoNodeId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoDefinitionVersionId LONG,name VARCHAR(200) null,metadata STRING null,description STRING null,type_ VARCHAR(20) null,initial_ BOOLEAN,terminal BOOLEAN)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoNode";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_4B1D16B4 on KaleoNode (companyId, kaleoDefinitionVersionId)",
+		"create index IX_F066921C on KaleoNode (kaleoDefinitionVersionId)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoNotificationRecipientTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoNotificationRecipientTable.java
@@ -1,5 +1,98 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoNotificationRecipientTable {
+
+	public static final String TABLE_NAME = "KaleoNotificationRecipient";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoNotificationRecipientId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoNotificationId", Types.BIGINT},
+		{"recipientClassName", Types.VARCHAR},
+		{"recipientClassPK", Types.BIGINT},
+		{"recipientRoleType", Types.INTEGER},
+		{"recipientScript", Types.CLOB},
+		{"recipientScriptLanguage", Types.VARCHAR},
+		{"recipientScriptContexts", Types.VARCHAR},
+		{"address", Types.VARCHAR},
+		{"notificationReceptionType", Types.VARCHAR}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoNotificationRecipientId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoNotificationId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("recipientClassName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("recipientClassPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("recipientRoleType", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("recipientScript", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("recipientScriptLanguage", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("recipientScriptContexts", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("address", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("notificationReceptionType", Types.VARCHAR);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoNotificationRecipient (kaleoNotificationRecipientId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoDefinitionVersionId LONG,kaleoNotificationId LONG,recipientClassName VARCHAR(200) null,recipientClassPK LONG,recipientRoleType INTEGER,recipientScript TEXT null,recipientScriptLanguage VARCHAR(75) null,recipientScriptContexts STRING null,address VARCHAR(255) null,notificationReceptionType VARCHAR(3) null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoNotificationRecipient";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_2C8C4AF4 on KaleoNotificationRecipient (companyId)",
+		"create index IX_B6D98988 on KaleoNotificationRecipient (kaleoDefinitionVersionId)",
+		"create index IX_7F4FED02 on KaleoNotificationRecipient (kaleoNotificationId)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoNotificationRecipientTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoNotificationRecipientTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoNotificationRecipientTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoNotificationTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoNotificationTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoNotificationTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoNotificationTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoNotificationTable.java
@@ -1,5 +1,98 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoNotificationTable {
+
+	public static final String TABLE_NAME = "KaleoNotification";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoNotificationId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoClassName", Types.VARCHAR},
+		{"kaleoClassPK", Types.BIGINT},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoNodeName", Types.VARCHAR},
+		{"name", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"executionType", Types.VARCHAR},
+		{"template", Types.CLOB},
+		{"templateLanguage", Types.VARCHAR},
+		{"notificationTypes", Types.VARCHAR}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoNotificationId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoClassName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("kaleoClassPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoNodeName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("executionType", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("template", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("templateLanguage", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("notificationTypes", Types.VARCHAR);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoNotification (kaleoNotificationId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoClassName VARCHAR(200) null,kaleoClassPK LONG,kaleoDefinitionVersionId LONG,kaleoNodeName VARCHAR(200) null,name VARCHAR(200) null,description STRING null,executionType VARCHAR(20) null,template TEXT null,templateLanguage VARCHAR(75) null,notificationTypes VARCHAR(25) null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoNotification";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_38829497 on KaleoNotification (companyId)",
+		"create index IX_F3362E93 on KaleoNotification (kaleoClassName[$COLUMN_LENGTH:200$], kaleoClassPK, executionType[$COLUMN_LENGTH:20$])",
+		"create index IX_B8486585 on KaleoNotification (kaleoDefinitionVersionId)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskAssignmentInstanceTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskAssignmentInstanceTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoTaskAssignmentInstanceTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskAssignmentInstanceTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskAssignmentInstanceTable.java
@@ -1,5 +1,101 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoTaskAssignmentInstanceTable {
+
+	public static final String TABLE_NAME = "KaleoTaskAssignmentInstance";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoTaskAssignmentInstanceId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoInstanceId", Types.BIGINT},
+		{"kaleoInstanceTokenId", Types.BIGINT},
+		{"kaleoTaskInstanceTokenId", Types.BIGINT},
+		{"kaleoTaskId", Types.BIGINT},
+		{"kaleoTaskName", Types.VARCHAR},
+		{"assigneeClassName", Types.VARCHAR},
+		{"assigneeClassPK", Types.BIGINT},
+		{"completed", Types.BOOLEAN},
+		{"completionDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoTaskAssignmentInstanceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoInstanceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoInstanceTokenId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoTaskInstanceTokenId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoTaskId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoTaskName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("assigneeClassName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("assigneeClassPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("completed", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("completionDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoTaskAssignmentInstance (kaleoTaskAssignmentInstanceId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoDefinitionVersionId LONG,kaleoInstanceId LONG,kaleoInstanceTokenId LONG,kaleoTaskInstanceTokenId LONG,kaleoTaskId LONG,kaleoTaskName VARCHAR(200) null,assigneeClassName VARCHAR(200) null,assigneeClassPK LONG,completed BOOLEAN,completionDate DATE null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoTaskAssignmentInstance";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_3BD436FD on KaleoTaskAssignmentInstance (assigneeClassName[$COLUMN_LENGTH:200$], assigneeClassPK)",
+		"create index IX_6E3CDA1B on KaleoTaskAssignmentInstance (companyId)",
+		"create index IX_38A47B17 on KaleoTaskAssignmentInstance (groupId, assigneeClassPK)",
+		"create index IX_B751E781 on KaleoTaskAssignmentInstance (kaleoDefinitionVersionId)",
+		"create index IX_67A9EE93 on KaleoTaskAssignmentInstance (kaleoInstanceId)",
+		"create index IX_D4C2235B on KaleoTaskAssignmentInstance (kaleoTaskInstanceTokenId)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskAssignmentTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskAssignmentTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoTaskAssignmentTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskAssignmentTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskAssignmentTable.java
@@ -1,5 +1,98 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoTaskAssignmentTable {
+
+	public static final String TABLE_NAME = "KaleoTaskAssignment";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoTaskAssignmentId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoClassName", Types.VARCHAR},
+		{"kaleoClassPK", Types.BIGINT},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoNodeId", Types.BIGINT},
+		{"assigneeClassName", Types.VARCHAR},
+		{"assigneeClassPK", Types.BIGINT},
+		{"assigneeActionId", Types.VARCHAR},
+		{"assigneeScript", Types.CLOB},
+		{"assigneeScriptLanguage", Types.VARCHAR},
+		{"assigneeScriptRequiredContexts", Types.VARCHAR}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoTaskAssignmentId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoClassName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("kaleoClassPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoNodeId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("assigneeClassName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("assigneeClassPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("assigneeActionId", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("assigneeScript", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("assigneeScriptLanguage", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("assigneeScriptRequiredContexts", Types.VARCHAR);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoTaskAssignment (kaleoTaskAssignmentId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoClassName VARCHAR(200) null,kaleoClassPK LONG,kaleoDefinitionVersionId LONG,kaleoNodeId LONG,assigneeClassName VARCHAR(200) null,assigneeClassPK LONG,assigneeActionId VARCHAR(75) null,assigneeScript TEXT null,assigneeScriptLanguage VARCHAR(75) null,assigneeScriptRequiredContexts STRING null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoTaskAssignment";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_611732B0 on KaleoTaskAssignment (companyId)",
+		"create index IX_1087068E on KaleoTaskAssignment (kaleoClassName[$COLUMN_LENGTH:200$], kaleoClassPK, assigneeClassName[$COLUMN_LENGTH:200$])",
+		"create index IX_E362B24C on KaleoTaskAssignment (kaleoDefinitionVersionId)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskFormInstanceTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskFormInstanceTable.java
@@ -1,5 +1,101 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoTaskFormInstanceTable {
+
+	public static final String TABLE_NAME = "KaleoTaskFormInstance";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoTaskFormInstanceId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoInstanceId", Types.BIGINT},
+		{"kaleoTaskId", Types.BIGINT},
+		{"kaleoTaskInstanceTokenId", Types.BIGINT},
+		{"kaleoTaskFormId", Types.BIGINT},
+		{"formValues", Types.VARCHAR},
+		{"formValueEntryGroupId", Types.BIGINT},
+		{"formValueEntryId", Types.BIGINT},
+		{"formValueEntryUuid", Types.VARCHAR},
+		{"metadata", Types.VARCHAR}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoTaskFormInstanceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoInstanceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoTaskId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoTaskInstanceTokenId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoTaskFormId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("formValues", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("formValueEntryGroupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("formValueEntryId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("formValueEntryUuid", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("metadata", Types.VARCHAR);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoTaskFormInstance (kaleoTaskFormInstanceId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,kaleoDefinitionVersionId LONG,kaleoInstanceId LONG,kaleoTaskId LONG,kaleoTaskInstanceTokenId LONG,kaleoTaskFormId LONG,formValues STRING null,formValueEntryGroupId LONG,formValueEntryId LONG,formValueEntryUuid VARCHAR(75) null,metadata STRING null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoTaskFormInstance";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_77B26CC4 on KaleoTaskFormInstance (companyId)",
+		"create index IX_F118DB8 on KaleoTaskFormInstance (kaleoDefinitionVersionId)",
+		"create index IX_FF271E7C on KaleoTaskFormInstance (kaleoInstanceId)",
+		"create index IX_E7F42BD0 on KaleoTaskFormInstance (kaleoTaskFormId)",
+		"create index IX_2A86346C on KaleoTaskFormInstance (kaleoTaskId)",
+		"create index IX_2C81C992 on KaleoTaskFormInstance (kaleoTaskInstanceTokenId)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskFormInstanceTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskFormInstanceTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoTaskFormInstanceTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskFormTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskFormTable.java
@@ -1,5 +1,108 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoTaskFormTable {
+
+	public static final String TABLE_NAME = "KaleoTaskForm";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoTaskFormId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoNodeId", Types.BIGINT},
+		{"kaleoTaskId", Types.BIGINT},
+		{"kaleoTaskName", Types.VARCHAR},
+		{"name", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"formCompanyId", Types.BIGINT},
+		{"formDefinition", Types.VARCHAR},
+		{"formGroupId", Types.BIGINT},
+		{"formId", Types.BIGINT},
+		{"formUuid", Types.VARCHAR},
+		{"metadata", Types.VARCHAR},
+		{"priority", Types.INTEGER}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoTaskFormId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoNodeId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoTaskId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoTaskName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("formCompanyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("formDefinition", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("formGroupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("formId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("formUuid", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("metadata", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("priority", Types.INTEGER);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoTaskForm (kaleoTaskFormId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,kaleoDefinitionVersionId LONG,kaleoNodeId LONG,kaleoTaskId LONG,kaleoTaskName VARCHAR(200) null,name VARCHAR(200) null,description STRING null,formCompanyId LONG,formDefinition STRING null,formGroupId LONG,formId LONG,formUuid VARCHAR(75) null,metadata STRING null,priority INTEGER)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoTaskForm";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_EFDA7E59 on KaleoTaskForm (companyId)",
+		"create index IX_3B8B7F83 on KaleoTaskForm (kaleoDefinitionVersionId)",
+		"create index IX_945326BE on KaleoTaskForm (kaleoNodeId)",
+		"create index IX_E38A5954 on KaleoTaskForm (kaleoTaskId, formUuid[$COLUMN_LENGTH:75$])"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskFormTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskFormTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoTaskFormTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskInstanceTokenTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskInstanceTokenTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoTaskInstanceTokenTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskInstanceTokenTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskInstanceTokenTable.java
@@ -1,5 +1,105 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoTaskInstanceTokenTable {
+
+	public static final String TABLE_NAME = "KaleoTaskInstanceToken";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoTaskInstanceTokenId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoInstanceId", Types.BIGINT},
+		{"kaleoInstanceTokenId", Types.BIGINT},
+		{"kaleoTaskId", Types.BIGINT},
+		{"kaleoTaskName", Types.VARCHAR},
+		{"className", Types.VARCHAR},
+		{"classPK", Types.BIGINT},
+		{"completionUserId", Types.BIGINT},
+		{"completed", Types.BOOLEAN},
+		{"completionDate", Types.TIMESTAMP},
+		{"dueDate", Types.TIMESTAMP},
+		{"workflowContext", Types.CLOB}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoTaskInstanceTokenId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoInstanceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoInstanceTokenId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoTaskId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoTaskName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("className", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("completionUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("completed", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("completionDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("dueDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("workflowContext", Types.CLOB);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoTaskInstanceToken (kaleoTaskInstanceTokenId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoDefinitionVersionId LONG,kaleoInstanceId LONG,kaleoInstanceTokenId LONG,kaleoTaskId LONG,kaleoTaskName VARCHAR(200) null,className VARCHAR(200) null,classPK LONG,completionUserId LONG,completed BOOLEAN,completionDate DATE null,dueDate DATE null,workflowContext TEXT null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoTaskInstanceToken";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_A3271995 on KaleoTaskInstanceToken (className[$COLUMN_LENGTH:200$], classPK)",
+		"create index IX_997FE723 on KaleoTaskInstanceToken (companyId)",
+		"create index IX_B2822979 on KaleoTaskInstanceToken (kaleoDefinitionVersionId)",
+		"create index IX_B857A115 on KaleoTaskInstanceToken (kaleoInstanceId, kaleoTaskId)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskTable.java
@@ -1,5 +1,80 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoTaskTable {
+
+	public static final String TABLE_NAME = "KaleoTask";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoTaskId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoNodeId", Types.BIGINT},
+		{"name", Types.VARCHAR},
+		{"description", Types.VARCHAR}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoTaskId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoNodeId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoTask (kaleoTaskId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoDefinitionVersionId LONG,kaleoNodeId LONG,name VARCHAR(200) null,description STRING null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoTask";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_E1F8B23D on KaleoTask (companyId)",
+		"create index IX_FECA871F on KaleoTask (kaleoDefinitionVersionId)",
+		"create index IX_77B3F1A2 on KaleoTask (kaleoNodeId)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTaskTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoTaskTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTimerInstanceTokenTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTimerInstanceTokenTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoTimerInstanceTokenTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTimerInstanceTokenTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTimerInstanceTokenTable.java
@@ -1,5 +1,108 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoTimerInstanceTokenTable {
+
+	public static final String TABLE_NAME = "KaleoTimerInstanceToken";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoTimerInstanceTokenId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoClassName", Types.VARCHAR},
+		{"kaleoClassPK", Types.BIGINT},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoInstanceId", Types.BIGINT},
+		{"kaleoInstanceTokenId", Types.BIGINT},
+		{"kaleoTaskInstanceTokenId", Types.BIGINT},
+		{"kaleoTimerId", Types.BIGINT},
+		{"kaleoTimerName", Types.VARCHAR},
+		{"blocking", Types.BOOLEAN},
+		{"completionUserId", Types.BIGINT},
+		{"completed", Types.BOOLEAN},
+		{"completionDate", Types.TIMESTAMP},
+		{"workflowContext", Types.CLOB}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoTimerInstanceTokenId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoClassName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("kaleoClassPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoInstanceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoInstanceTokenId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoTaskInstanceTokenId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoTimerId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoTimerName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("blocking", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("completionUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("completed", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("completionDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("workflowContext", Types.CLOB);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoTimerInstanceToken (kaleoTimerInstanceTokenId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoClassName VARCHAR(200) null,kaleoClassPK LONG,kaleoDefinitionVersionId LONG,kaleoInstanceId LONG,kaleoInstanceTokenId LONG,kaleoTaskInstanceTokenId LONG,kaleoTimerId LONG,kaleoTimerName VARCHAR(200) null,blocking BOOLEAN,completionUserId LONG,completed BOOLEAN,completionDate DATE null,workflowContext TEXT null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoTimerInstanceToken";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_DB96C55B on KaleoTimerInstanceToken (kaleoInstanceId)",
+		"create index IX_F904A89A on KaleoTimerInstanceToken (kaleoInstanceTokenId, blocking, completed)",
+		"create index IX_DB279423 on KaleoTimerInstanceToken (kaleoInstanceTokenId, completed)",
+		"create index IX_13A5BA2C on KaleoTimerInstanceToken (kaleoInstanceTokenId, kaleoTimerId)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTimerTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTimerTable.java
@@ -1,5 +1,96 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoTimerTable {
+
+	public static final String TABLE_NAME = "KaleoTimer";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoTimerId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoClassName", Types.VARCHAR},
+		{"kaleoClassPK", Types.BIGINT},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"name", Types.VARCHAR},
+		{"blocking", Types.BOOLEAN},
+		{"description", Types.VARCHAR},
+		{"duration", Types.DOUBLE},
+		{"scale", Types.VARCHAR},
+		{"recurrenceDuration", Types.DOUBLE},
+		{"recurrenceScale", Types.VARCHAR}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoTimerId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoClassName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("kaleoClassPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("blocking", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("duration", Types.DOUBLE);
+
+TABLE_COLUMNS_MAP.put("scale", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("recurrenceDuration", Types.DOUBLE);
+
+TABLE_COLUMNS_MAP.put("recurrenceScale", Types.VARCHAR);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoTimer (kaleoTimerId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoClassName VARCHAR(200) null,kaleoClassPK LONG,kaleoDefinitionVersionId LONG,name VARCHAR(75) null,blocking BOOLEAN,description STRING null,duration DOUBLE,scale VARCHAR(75) null,recurrenceDuration DOUBLE,recurrenceScale VARCHAR(75) null)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoTimer";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_1A479F32 on KaleoTimer (kaleoClassName[$COLUMN_LENGTH:200$], kaleoClassPK, blocking)"
+	};
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTimerTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTimerTable.java
@@ -1,0 +1,5 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoTimerTable {
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTransitionTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTransitionTable.java
@@ -1,0 +1,4 @@
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
+
+public class KaleoTransitionTable {
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTransitionTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v2_0_0/util/KaleoTransitionTable.java
@@ -1,4 +1,96 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v2_0_0.util;
 
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
 public class KaleoTransitionTable {
+
+	public static final String TABLE_NAME = "KaleoTransition";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"kaleoTransitionId", Types.BIGINT},
+		{"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
+		{"kaleoDefinitionVersionId", Types.BIGINT},
+		{"kaleoNodeId", Types.BIGINT},
+		{"name", Types.VARCHAR},
+		{"description", Types.VARCHAR},
+		{"sourceKaleoNodeId", Types.BIGINT},
+		{"sourceKaleoNodeName", Types.VARCHAR},
+		{"targetKaleoNodeId", Types.BIGINT},
+		{"targetKaleoNodeName", Types.VARCHAR},
+		{"defaultTransition", Types.BOOLEAN}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("kaleoTransitionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoNodeId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("sourceKaleoNodeId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("sourceKaleoNodeName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("targetKaleoNodeId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("targetKaleoNodeName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("defaultTransition", Types.BOOLEAN);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table KaleoTransition (kaleoTransitionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,modifiedDate DATE null,kaleoDefinitionVersionId LONG,kaleoNodeId LONG,name VARCHAR(200) null,description STRING null,sourceKaleoNodeId LONG,sourceKaleoNodeName VARCHAR(200) null,targetKaleoNodeId LONG,targetKaleoNodeName VARCHAR(200) null,defaultTransition BOOLEAN)";
+
+	public static final String TABLE_SQL_DROP = "drop table KaleoTransition";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_41D6C6D on KaleoTransition (companyId)",
+		"create index IX_16B426EF on KaleoTransition (kaleoDefinitionVersionId)",
+		"create index IX_A38E2194 on KaleoTransition (kaleoNodeId, defaultTransition)",
+		"create index IX_85268A11 on KaleoTransition (kaleoNodeId, name[$COLUMN_LENGTH:200$])"
+	};
+
 }


### PR DESCRIPTION
Hi @brianchandotcom, @jpince,

We will get some issues in the CI like these:
```
junit.framework.AssertionFailedError: 
Declarative Service Unsatisfied Component Checker check result: 
Bundle {id: 256, name: com.liferay.portal.workflow.kaleo.designer.web, version: 2.0.0}
	Declarative Service {id: 814, name: com.liferay.portal.workflow.kaleo.designer.web.internal.verify.KaleoDesignerWebVerifyProcess, unsatisfied references: 
		{name: _release, target: (&(release.bundle.symbolic.name=com.liferay.portal.workflow.kaleo.designer.web)(release.schema.version=1.0.2))}
	}
	Declarative Service {id: 813, name: com.liferay.portal.workflow.kaleo.designer.web.internal.upgrade.KaleoDesignerWebUpgrade, unsatisfied references: 
		{name: _release, target: (&(release.bundle.symbolic.name=com.liferay.portal.workflow.kaleo.service)(release.schema.version=1.4.1))}
	}
```

The reason is because we need the changes for https://github.com/brianchandotcom/liferay-portal-ee/pull/22246 too. So please, commit both together.

Thanks.

cc/ @jcampoy @rafaprax @jeyvison
