### PR TITLE
LPS-86368

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
@@ -72,6 +72,7 @@ import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
@@ -631,7 +632,15 @@ public class FileEntryStagedModelDataHandler
 				}
 
 				if (ExportImportThreadLocal.isStagingInProcess()) {
-					_overrideFileVersion(importedFileEntry, version);
+					ServiceContextThreadLocal.pushServiceContext(
+						serviceContext);
+
+					try {
+						_overrideFileVersion(importedFileEntry, version);
+					}
+					finally {
+						ServiceContextThreadLocal.popServiceContext();
+					}
 				}
 			}
 			else {

--- a/modules/test/poshi-runner/.gitrepo
+++ b/modules/test/poshi-runner/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = true
 	cmdver = liferay
-	commit = 5b244cfa35023282b6e668e4ac9651a4edc70b3a
+	commit = 1c28e81c3a258ea132d74aad1f782eae63b98932
 	mergebuttonmergecommits = false
 	mode = pull
-	parent = 3a1b21ab5ae0fa71dac671cbec890e85df08b559
+	parent = 65fe8acc9e83860143ba5b53508b959bf123f714
 	remote = git@github.com:liferay/com-liferay-poshi-runner.git

--- a/modules/test/poshi-runner/poshi-runner/bnd.bnd
+++ b/modules/test/poshi-runner/poshi-runner/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Poshi Runner
 Bundle-SymbolicName: com.liferay.poshi.runner
-Bundle-Version: 1.0.195
+Bundle-Version: 1.0.196

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -119,6 +119,10 @@ public class PoshiRunnerContext {
 			"function#" + namespace + "." + classCommandName);
 	}
 
+	public static Set<String> getFunctionFileNames() {
+		return _functionFileNames;
+	}
+
 	public static int getFunctionLocatorCount(
 		String className, String namespace) {
 
@@ -1422,6 +1426,10 @@ public class PoshiRunnerContext {
 
 			if (rootElement.attributeValue("override") == null) {
 				_filePaths.put(namespace + "." + fileName, filePath);
+
+				if (fileName.endsWith(".function")) {
+					_functionFileNames.add(fileName.replace(".function", ""));
+				}
 			}
 		}
 	}
@@ -1570,6 +1578,7 @@ public class PoshiRunnerContext {
 	private static final Set<String> _duplicateLocatorMessages =
 		new HashSet<>();
 	private static final Map<String, String> _filePaths = new HashMap<>();
+	private static final Set<String> _functionFileNames = new HashSet<>();
 	private static final Map<String, Integer> _functionLocatorCounts =
 		new HashMap<>();
 	private static final Pattern _namespaceClassCommandNamePattern =

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -97,10 +97,6 @@ public class PoshiRunnerContext {
 		return _filePaths.get(namespace + "." + fileName);
 	}
 
-	public static List<String> getFilePathKeys() {
-		return new ArrayList<>(_filePaths.keySet());
-	}
-
 	public static List<String> getFilePaths() {
 		return new ArrayList<>(_filePaths.values());
 	}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -1420,19 +1420,8 @@ public class PoshiRunnerContext {
 
 			_storeRootElement(rootElement, filePath, namespace);
 
-			if (OSDetector.isWindows()) {
-				if (filePath.startsWith("/")) {
-					filePath = filePath.substring(1);
-				}
-
-				filePath = filePath.replace("/", "\\");
-			}
-
 			if (rootElement.attributeValue("override") == null) {
-				_filePaths.put(
-					namespace + "." +
-						PoshiRunnerGetterUtil.getFileNameFromFilePath(filePath),
-					filePath);
+				_filePaths.put(namespace + "." + fileName, filePath);
 			}
 		}
 	}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerGetterUtil.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerGetterUtil.java
@@ -393,7 +393,8 @@ public class PoshiRunnerGetterUtil {
 		String filePath = url.getFile();
 
 		if (!fileContent.contains("<definition") &&
-			(filePath.endsWith(".macro") || filePath.endsWith(".testcase"))) {
+			(filePath.endsWith(".function") || filePath.endsWith(".macro") ||
+			 filePath.endsWith(".testcase"))) {
 
 			PoshiNode<?, ?> poshiNode = PoshiNodeFactory.newPoshiNodeFromFile(
 				filePath);

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -643,7 +643,9 @@ public abstract class PoshiElement
 	}
 
 	protected boolean isValidFunctionFileName(String poshiScriptInvocation) {
-		for (String functionFileName : functionFileNames) {
+		for (String functionFileName :
+				PoshiRunnerContext.getFunctionFileNames()) {
+
 			if (poshiScriptInvocation.matches(
 					"(?s)" + Pattern.quote(functionFileName) + "[\\.\\(]+.*")) {
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -28,9 +28,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Stack;
-import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -862,7 +860,6 @@ public abstract class PoshiElement
 	protected static final String VAR_NAME_REGEX =
 		"(static[\\s]*|)var([\\s]*[A-Z][\\w]*|)[\\s]*[\\w]*";
 
-	protected static final Set<String> functionFileNames = new TreeSet<>();
 	protected static final Pattern nestedVarAssignmentPattern = Pattern.compile(
 		"(\\w*\\s*=\\s*\".*?\"|\\w*\\s*=\\s*'''.*?'''|" +
 			"\\w*\\s=\\s*[\\w\\.]*\\(.*?\\))($|\\s|,)",
@@ -917,8 +914,6 @@ public abstract class PoshiElement
 				put('[', ']');
 			}
 		};
-	private static final Pattern _namespacedfunctionFileNamePattern =
-		Pattern.compile(".*?\\.(.*?)\\.function");
 	private static final Pattern _poshiScriptCommentPattern = Pattern.compile(
 		"^[\\s]*(\\/\\/.*?(\\n|$)|\\/\\*.*?\\*\\/)", Pattern.DOTALL);
 	private static final Pattern _varInvocationAssignmentStatementPattern;
@@ -930,17 +925,6 @@ public abstract class PoshiElement
 			"^" + VAR_NAME_REGEX + ASSIGNMENT_REGEX + INVOCATION_REGEX +
 				STATEMENT_END_REGEX,
 			Pattern.DOTALL);
-
-		for (String namespacedFunctionFileName :
-				PoshiRunnerContext.getFilePathKeys()) {
-
-			Matcher matcher = _namespacedfunctionFileNamePattern.matcher(
-				namespacedFunctionFileName);
-
-			if (matcher.find()) {
-				functionFileNames.add(matcher.group(1));
-			}
-		}
 	}
 
 	private String _poshiScript;

--- a/test.properties
+++ b/test.properties
@@ -1468,7 +1468,7 @@
         central-requirements-jdk8,\
         functional-smoke-tomcat90-mysql57-jdk8,\
         functional-tomcat90-mysql57-jdk8,\
-        functional-upgrade-tomcat90-mysql57-jdk8,\
+        #functional-upgrade-tomcat90-mysql57-jdk8,\
         integration-mysql57-jdk8,\
         lpkg-base-jdk8,\
         lpkg-controller-jdk8,\


### PR DESCRIPTION
Description in the original PR:

/cc @moltam89

Relevant tickets:
https://issues.liferay.com/browse/LPP-31765
https://issues.liferay.com/browse/LPS-86368

Forwarded from: moltam89#446

If a document is published to live that has had more than one version increment since the last time it was published, then the modified date for the DLFileEntry in the database (in the DLFileEntry table) will be updated with the current timestamp, instead of the date the document was actually modified. This is because, Liferay treats subsequent imported versions with Staging as updates, and while the modifiedDate was technically updated at the time of the document update (so before the export), it did not happen during the "update," so it assumes the modifiedDate still needs to be changed.

As it turns out, simply persisting the serviceContext available earlier in the import process for when it does the update allows it to keep access to the correct modifiedDate, eliminating the need for it to overwrite it with the current date.

I ended up putting this code change entirely outside of the call to overrideFileVersion() because I think it looks cleaner to keep the related logic for it one place. There is also an argument to be made for putting it inside the method though (see moltam89#446 (comment)), so if it is better, please feel free to go with that instead.

Also, if there are any other questions or concerns with this from a DL perspective or otherwise, please let me know. Thank you!