### PR TITLE
LPS-86942 portal-search-elasticsearch6-impl: Search Insights requires queryString to be in SearchContext

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexSearcher.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexSearcher.java
@@ -160,6 +160,10 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 				SearchSearchResponse searchSearchResponse =
 					searchEngineAdapter.execute(searchSearchRequest);
 
+				searchContext.setAttribute(
+					"queryString",
+					searchSearchResponse.getSearchRequestString());
+
 				hits = searchSearchResponse.getHits();
 
 				Document[] documents = hits.getDocs();
@@ -228,6 +232,9 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 
 			CountSearchResponse countSearchResponse =
 				searchEngineAdapter.execute(countSearchRequest);
+
+			searchContext.setAttribute(
+				"queryString", countSearchResponse.getSearchRequestString());
 
 			return countSearchResponse.getCount();
 		}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/query/string/QueryStringTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/query/string/QueryStringTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.query.string;
+
+import com.liferay.portal.search.elasticsearch6.internal.ElasticsearchIndexingFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.query.string.BaseQueryStringTestCase;
+
+/**
+ * @author Wade Cao
+ */
+public class QueryStringTest extends BaseQueryStringTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		return new ElasticsearchIndexingFixture(
+			new ElasticsearchFixture(getClass()),
+			BaseIndexingTestCase.COMPANY_ID);
+	}
+
+}

--- a/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/test/java/com/liferay/portal/search/solr7/internal/query/string/QueryStringTest.java
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/test/java/com/liferay/portal/search/solr7/internal/query/string/QueryStringTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.solr7.internal.query.string;
+
+import com.liferay.portal.search.solr7.internal.SolrIndexingFixture;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.query.string.BaseQueryStringTestCase;
+
+/**
+ * @author Wade Cao
+ */
+public class QueryStringTest extends BaseQueryStringTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		return new SolrIndexingFixture();
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/string/BaseQueryStringTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/string/BaseQueryStringTestCase.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.query.string;
+
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+
+import org.hamcrest.CoreMatchers;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Wade Cao
+ * @author André de Oliveira
+ */
+public abstract class BaseQueryStringTestCase extends BaseIndexingTestCase {
+
+	@Test
+	public void testPresentAfterSearch() throws Exception {
+		assertSearch(
+			indexingTestHelper -> {
+				indexingTestHelper.search();
+
+				assertQueryStringPresent(indexingTestHelper);
+			});
+	}
+
+	@Test
+	public void testPresentAfterSearchCount() throws Exception {
+		assertSearch(
+			indexingTestHelper -> {
+				indexingTestHelper.searchCount();
+
+				assertQueryStringPresent(indexingTestHelper);
+			});
+	}
+
+	protected void assertQueryStringPresent(
+		IndexingTestHelper indexingTestHelper) {
+
+		Assert.assertThat(
+			indexingTestHelper.getQueryString(),
+			CoreMatchers.containsString(Field.ENTRY_CLASS_NAME));
+	}
+
+}


### PR DESCRIPTION
ci:test:search PASSED [ arboliveira#623](https://github.com/arboliveira/liferay-portal/pull/623 )

Author: @arboliveira  @wcao20170619 
Reviewer: @arboliveira 

https://issues.liferay.com/browse/LPS-86942