### PR TITLE
[Only for 7.1.x] LPS-87187 change dependency from odata to compileInclude

### DIFF
--- a/modules/apps/headless-apio/structured-content/structured-content-apio-impl/bnd.bnd
+++ b/modules/apps/headless-apio/structured-content/structured-content-apio-impl/bnd.bnd
@@ -1,3 +1,7 @@
 Bundle-Name: Liferay Structured Content Apio Implementation
 Bundle-SymbolicName: com.liferay.structured.content.apio.impl
 Bundle-Version: 2.0.0
+Import-Package:\
+	!com.fasterxml.jackson.*,\
+	\
+	*

--- a/modules/apps/headless-apio/structured-content/structured-content-apio-impl/build.gradle
+++ b/modules/apps/headless-apio/structured-content/structured-content-apio-impl/build.gradle
@@ -1,4 +1,13 @@
 dependencies {
+	compileInclude group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.8.3"
+	compileInclude group: "com.liferay", name: "com.liferay.portal.odata.api", version: "1.4.0"
+	compileInclude group: "com.liferay", name: "com.liferay.portal.odata.impl", version: "1.0.5"
+	compileInclude group: "org.apache.olingo", name: "odata-commons-api", version: "4.4.0"
+	compileInclude group: "org.apache.olingo", name: "odata-commons-core", version: "4.4.0"
+	compileInclude group: "org.apache.olingo", name: "odata-server-api", version: "4.4.0"
+	compileInclude group: "org.apache.olingo", name: "odata-server-core", version: "4.4.0"
+	compileInclude group: "org.apache.olingo", name: "odata-server-core-ext", version: "4.4.0"
+
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
@@ -16,7 +25,6 @@ dependencies {
 	compileOnly project(":apps:headless-apio:structure:structure-apio-api")
 	compileOnly project(":apps:headless-apio:structured-content:structured-content-apio-api")
 	compileOnly project(":apps:journal:journal-api")
-	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":core:petra:petra-string")
 
 	testCompile group: "org.apache.cxf", name: "cxf-rt-frontend-jaxrs", version: "3.2.4"


### PR DESCRIPTION
Hi Brian!

We want to release the APIs to the marketplace but they depend on the portal-odata module that is NOT available in the GA2 nor the FP3... We've discussed several options and the only one we have left is to depend directly on the jars with compileInclude.

This PR is needed ONLY for 7.1.x. I've sent it here to follow the PR lifecycle but it doesn't make sense in master (I can send it just to 7.1.x if you prefer).