### PR TITLE
LPS-87008 Restore snapshot-bundle exclude functionality

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1138,7 +1138,18 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 		<un7z
 			dest="${liferay.home}"
 			src="${project.dir}/tmp/${snapshot.bundle.file}"
-		/>
+		>
+			<mapper>
+				<globmapper
+					from="liferay-portal-${git.working.branch.name}/*"
+					to="*"
+				/>
+			</mapper>
+			<patternset
+				excludes="${snapshot.bundle.excludes}"
+			/>
+		</un7z>
+>
 
 		<move
 			file="${liferay.home}/liferay-portal-${git.working.branch.name}"


### PR DESCRIPTION
Lost when we originally transitioned to 7z https://github.com/liferay/liferay-portal/commit/9e0763571ced11aa22595aa3941af43b0c5978f3