### PR TITLE
LPS-84894 The field is always the ServletContextDelegate. We can do e…

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/ModifiableServletContextAdapter.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/ModifiableServletContextAdapter.java
@@ -324,7 +324,7 @@ public class ModifiableServletContextAdapter
 				modifiableServletContext.getWrappedServletContext();
 		}
 
-		return servletContext.equals(_servletContext);
+		return _servletContext.equals(servletContext);
 	}
 
 	@Override


### PR DESCRIPTION
…quals to ServletContextDelegate.equals(ServletContextAdaptor) but ServleContextAdaptor.equals(ServletContextDelegate) does not work. This is a limitation of the whiteboard adaptor not being able to test equality with other ServiceContext wrappers.