### PR TITLE
LPS-87129 Progress bar styling is broken in the Search Admin Portlet

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/resources/com/liferay/portal/search/internal/background/task/display/dependencies/reindex_background_task_progress.ftl
+++ b/modules/apps/portal-search/portal-search/src/main/resources/com/liferay/portal/search/internal/background/task/display/dependencies/reindex_background_task_progress.ftl
@@ -1,9 +1,11 @@
 <#assign percentage = backgroundTaskDisplay.getPercentage() />
 
 <div class="background-task-status-in-progress">
-	<div class="active progress progress-lg progress-striped reindex-progress">
-		<div class="progress-bar" style="width:${percentage}%">
-			<span class="progress-percentage">${percentage}%</span>
+	<div class="progress-group">
+		<div class="progress">
+			<div aria-valuenow="${percentage}" aria-valuemin="0" aria-valuemax="100" class="progress-bar" role="progressbar" style="width: ${percentage}%;"></div>
 		</div>
+
+		<div class="progress-group-addon">${percentage}%</div>
 	</div>
 </div>


### PR DESCRIPTION
This is an update for [LPS-87129](https://issues.liferay.com/browse/LPS-87129).<br><br>/cc @pei-jung @stsquared99 @alee8888 @arboliveira

**From the pull to Andre:**

This is an update for [LPS-87129](https://issues.liferay.com/browse/LPS-87129).<br><br>Hey @arboliveira, this just updates the template markup for the progress bar that renders in the Seach Admin portlet.  It now uses Clay markup according to https://clayui.com/docs/components/progress-bars.html.

Here is the new look:
<img width="1420" alt="screen shot 2018-11-09 at 11 17 40 am" src="https://user-images.githubusercontent.com/6403097/48283551-b827e780-e411-11e8-8533-3a155fc3325e.png">

cc @pei-jung @stsquared99 @alee8888