### PR TITLE
LPS-85176 portal-search-test: changed DocumentsAssert.assertValues to be DocumentsAssert.assertValuesIgnoreRelevance

### DIFF
--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/post/processor/test/IndexerPostProcessorTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/post/processor/test/IndexerPostProcessorTest.java
@@ -133,7 +133,7 @@ public class IndexerPostProcessorTest {
 
 		Hits results = _indexer.search(searchContext);
 
-		DocumentsAssert.assertValues(
+		DocumentsAssert.assertValuesIgnoreRelevance(
 			(String)searchContext.getAttribute("queryString"),
 			results.getDocs(), _TEST_FIELD, expectedFieldValues);
 	}


### PR DESCRIPTION
This is the LPS-85176 follow-up, test ONLY, small change