### PR TITLE
LPS-86335

### DIFF
--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/model/SharingEntry.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/model/SharingEntry.java
@@ -53,4 +53,14 @@ public interface SharingEntry extends SharingEntryModel, PersistedModel {
 				return SharingEntry.class;
 			}
 		};
+
+	/**
+	* Returns {@code true} if the sharing entry has the sharing entry action.
+	*
+	* @param sharingEntryAction the sharing entry action
+	* @return {@code true} if the sharing entry has the sharing entry action;
+	{@code false} otherwise
+	*/
+	public boolean hasSharingPermission(
+		com.liferay.sharing.security.permission.SharingEntryAction sharingEntryAction);
 }

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/model/SharingEntryWrapper.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/model/SharingEntryWrapper.java
@@ -353,6 +353,19 @@ public class SharingEntryWrapper implements SharingEntry,
 		return _sharingEntry.hashCode();
 	}
 
+	/**
+	* Returns {@code true} if the sharing entry has the sharing entry action.
+	*
+	* @param sharingEntryAction the sharing entry action
+	* @return {@code true} if the sharing entry has the sharing entry action;
+	{@code false} otherwise
+	*/
+	@Override
+	public boolean hasSharingPermission(
+		com.liferay.sharing.security.permission.SharingEntryAction sharingEntryAction) {
+		return _sharingEntry.hasSharingPermission(sharingEntryAction);
+	}
+
 	@Override
 	public boolean isCachedModel() {
 		return _sharingEntry.isCachedModel();

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalService.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalService.java
@@ -598,18 +598,6 @@ public interface SharingEntryLocalService extends BaseLocalService,
 		long classPK, SharingEntryAction sharingEntryAction);
 
 	/**
-	* Returns {@code true} if the sharing entry has the sharing entry action.
-	*
-	* @param sharingEntry the sharing entry
-	* @param sharingEntryAction the sharing entry action
-	* @return {@code true} if the sharing entry has the sharing entry action;
-	{@code false} otherwise
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public boolean hasSharingPermission(SharingEntry sharingEntry,
-		SharingEntryAction sharingEntryAction);
-
-	/**
 	* Updates the sharing entry in the database.
 	*
 	* @param sharingEntryId the primary key of the sharing entry

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceUtil.java
@@ -680,21 +680,6 @@ public class SharingEntryLocalServiceUtil {
 	}
 
 	/**
-	* Returns {@code true} if the sharing entry has the sharing entry action.
-	*
-	* @param sharingEntry the sharing entry
-	* @param sharingEntryAction the sharing entry action
-	* @return {@code true} if the sharing entry has the sharing entry action;
-	{@code false} otherwise
-	*/
-	public static boolean hasSharingPermission(
-		com.liferay.sharing.model.SharingEntry sharingEntry,
-		com.liferay.sharing.security.permission.SharingEntryAction sharingEntryAction) {
-		return getService()
-				   .hasSharingPermission(sharingEntry, sharingEntryAction);
-	}
-
-	/**
 	* Updates the sharing entry in the database.
 	*
 	* @param sharingEntryId the primary key of the sharing entry

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceWrapper.java
@@ -715,22 +715,6 @@ public class SharingEntryLocalServiceWrapper implements SharingEntryLocalService
 	}
 
 	/**
-	* Returns {@code true} if the sharing entry has the sharing entry action.
-	*
-	* @param sharingEntry the sharing entry
-	* @param sharingEntryAction the sharing entry action
-	* @return {@code true} if the sharing entry has the sharing entry action;
-	{@code false} otherwise
-	*/
-	@Override
-	public boolean hasSharingPermission(
-		com.liferay.sharing.model.SharingEntry sharingEntry,
-		com.liferay.sharing.security.permission.SharingEntryAction sharingEntryAction) {
-		return _sharingEntryLocalService.hasSharingPermission(sharingEntry,
-			sharingEntryAction);
-	}
-
-	/**
 	* Updates the sharing entry in the database.
 	*
 	* @param sharingEntryId the primary key of the sharing entry

--- a/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/util/SharingNotificationUtil.java
+++ b/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/util/SharingNotificationUtil.java
@@ -144,19 +144,15 @@ public class SharingNotificationUtil {
 	private String _getActionName(
 		SharingEntry sharingEntry, ResourceBundle resourceBundle) {
 
-		if (_sharingEntryLocalService.hasSharingPermission(
-				sharingEntry, SharingEntryAction.UPDATE)) {
-
+		if (sharingEntry.hasSharingPermission(SharingEntryAction.UPDATE)) {
 			return ResourceBundleUtil.getString(resourceBundle, "updating");
 		}
-		else if (_sharingEntryLocalService.hasSharingPermission(
-					sharingEntry, SharingEntryAction.ADD_DISCUSSION)) {
+		else if (sharingEntry.hasSharingPermission(
+					SharingEntryAction.ADD_DISCUSSION)) {
 
 			return ResourceBundleUtil.getString(resourceBundle, "commenting");
 		}
-		else if (_sharingEntryLocalService.hasSharingPermission(
-					sharingEntry, SharingEntryAction.VIEW)) {
-
+		else if (sharingEntry.hasSharingPermission(SharingEntryAction.VIEW)) {
 			return ResourceBundleUtil.getString(resourceBundle, "viewing");
 		}
 

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/security/permission/SharingPermissionImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/security/permission/SharingPermissionImpl.java
@@ -122,12 +122,9 @@ public class SharingPermissionImpl implements SharingPermission {
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
 			bundleContext, SharingPermissionChecker.class,
 			"(model.class.name=*)",
-			(serviceReference, emitter) -> {
-				emitter.emit(
-					_classNameLocalService.getClassNameId(
-						(String)serviceReference.getProperty(
-							"model.class.name")));
-			});
+			(serviceReference, emitter) -> emitter.emit(
+				_classNameLocalService.getClassNameId(
+					(String)serviceReference.getProperty("model.class.name"))));
 	}
 
 	@Deactivate

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/model/impl/SharingEntryImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/model/impl/SharingEntryImpl.java
@@ -16,6 +16,8 @@ package com.liferay.sharing.model.impl;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.sharing.security.permission.SharingEntryAction;
+
 /**
  * The extended model implementation for the {@code SharingEntry} service.
  * Represents a row in the {@code SharingEntry} database table, with each column
@@ -33,13 +35,19 @@ import aQute.bnd.annotation.ProviderType;
 public class SharingEntryImpl extends SharingEntryBaseImpl {
 
 	/**
-	 * NOTE FOR DEVELOPERS:
+	 * Returns {@code true} if the sharing entry has the sharing entry action.
 	 *
-	 * Never reference this class directly. All methods that expect a sharing
-	 * entry model instance should use the {@link
-	 * com.liferay.sharing.model.SharingEntry} interface instead.
+	 * @param  sharingEntryAction the sharing entry action
+	 * @return {@code true} if the sharing entry has the sharing entry action;
+	 *         {@code false} otherwise
 	 */
-	public SharingEntryImpl() {
+	@Override
+	public boolean hasSharingPermission(SharingEntryAction sharingEntryAction) {
+		if ((getActionIds() & sharingEntryAction.getBitwiseValue()) != 0) {
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -566,7 +566,7 @@ public class SharingEntryLocalServiceImpl
 				continue;
 			}
 
-			if (hasSharingPermission(sharingEntry, sharingEntryAction)) {
+			if (sharingEntry.hasSharingPermission(sharingEntryAction)) {
 				return true;
 			}
 		}
@@ -596,7 +596,7 @@ public class SharingEntryLocalServiceImpl
 				toUserId, classNameId, classPK);
 
 		for (SharingEntry sharingEntry : sharingEntries) {
-			if (hasSharingPermission(sharingEntry, sharingEntryAction)) {
+			if (sharingEntry.hasSharingPermission(sharingEntryAction)) {
 				return true;
 			}
 		}
@@ -604,14 +604,6 @@ public class SharingEntryLocalServiceImpl
 		return false;
 	}
 
-	/**
-	 * Returns {@code true} if the sharing entry has the sharing entry action.
-	 *
-	 * @param  sharingEntry the sharing entry
-	 * @param  sharingEntryAction the sharing entry action
-	 * @return {@code true} if the sharing entry has the sharing entry action;
-	 *         {@code false} otherwise
-	 */
 	@Override
 	public boolean hasSharingPermission(
 		SharingEntry sharingEntry, SharingEntryAction sharingEntryAction) {

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -604,19 +604,6 @@ public class SharingEntryLocalServiceImpl
 		return false;
 	}
 
-	@Override
-	public boolean hasSharingPermission(
-		SharingEntry sharingEntry, SharingEntryAction sharingEntryAction) {
-
-		long actionIds = sharingEntry.getActionIds();
-
-		if ((actionIds & sharingEntryAction.getBitwiseValue()) != 0) {
-			return true;
-		}
-
-		return false;
-	}
-
 	/**
 	 * Updates the sharing entry in the database.
 	 *

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/SharedWithMeViewDisplayContext.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/SharedWithMeViewDisplayContext.java
@@ -197,9 +197,7 @@ public class SharedWithMeViewDisplayContext {
 				_themeDisplay.getUserId(), classNameId, classPK);
 
 		for (SharingEntry sharingEntry : toUserSharingEntries) {
-			if (_sharingEntryLocalService.hasSharingPermission(
-					sharingEntry, SharingEntryAction.UPDATE)) {
-
+			if (sharingEntry.hasSharingPermission(SharingEntryAction.UPDATE)) {
 				return true;
 			}
 		}

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/util/SharingUtil.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/util/SharingUtil.java
@@ -17,7 +17,6 @@ package com.liferay.sharing.web.internal.util;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.sharing.model.SharingEntry;
@@ -90,11 +89,6 @@ public class SharingUtil {
 
 		return SharingEntryPermissionDisplay.getSharingEntryPermissionDisplays(
 			sharingEntryActions, resourceBundle);
-	}
-
-	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED, unbind = "-")
-	public void setModuleServiceLifecycle(
-		ModuleServiceLifecycle moduleServiceLifecycle) {
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(SharingUtil.class);

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/util/SharingUtil.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/util/SharingUtil.java
@@ -28,7 +28,7 @@ import com.liferay.sharing.web.internal.display.SharingEntryPermissionDisplay;
 import com.liferay.sharing.web.internal.display.SharingEntryPermissionDisplayAction;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -75,7 +75,7 @@ public class SharingUtil {
 			try {
 				if (_sharingPermission.contains(
 						permissionChecker, classNameId, classPK, groupId,
-						Arrays.asList(sharingEntryAction))) {
+						Collections.singletonList(sharingEntryAction))) {
 
 					sharingEntryActions.add(sharingEntryAction);
 				}

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/util/SharingUtil.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/util/SharingUtil.java
@@ -45,21 +45,17 @@ public class SharingUtil {
 	public SharingEntryPermissionDisplayAction
 		getSharingEntryPermissionDisplayActionKey(SharingEntry sharingEntry) {
 
-		if (_sharingEntryLocalService.hasSharingPermission(
-				sharingEntry, SharingEntryAction.UPDATE)) {
-
+		if (sharingEntry.hasSharingPermission(SharingEntryAction.UPDATE)) {
 			return SharingEntryPermissionDisplayAction.UPDATE;
 		}
 
-		if (_sharingEntryLocalService.hasSharingPermission(
-				sharingEntry, SharingEntryAction.ADD_DISCUSSION)) {
+		if (sharingEntry.hasSharingPermission(
+				SharingEntryAction.ADD_DISCUSSION)) {
 
 			return SharingEntryPermissionDisplayAction.COMMENTS;
 		}
 
-		if (_sharingEntryLocalService.hasSharingPermission(
-				sharingEntry, SharingEntryAction.VIEW)) {
-
+		if (sharingEntry.hasSharingPermission(SharingEntryAction.VIEW)) {
 			return SharingEntryPermissionDisplayAction.VIEW;
 		}
 

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/util/SharingUtil.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/util/SharingUtil.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
 import com.liferay.sharing.security.permission.SharingPermission;
@@ -89,8 +89,8 @@ public class SharingUtil {
 			}
 		}
 
-		ResourceBundle resourceBundle =
-			_resourceBundleLoader.loadResourceBundle(locale);
+		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
+			locale, SharingUtil.class);
 
 		return SharingEntryPermissionDisplay.getSharingEntryPermissionDisplays(
 			sharingEntryActions, resourceBundle);
@@ -102,9 +102,6 @@ public class SharingUtil {
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(SharingUtil.class);
-
-	@Reference(target = "(bundle.symbolic.name=com.liferay.sharing.web)")
-	private ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference
 	private SharingEntryLocalService _sharingEntryLocalService;


### PR DESCRIPTION
CC @4lejandrito @adolfopa

@brianchandotcom I think it's okay for sharing to use the .security.permission package.  If they were extending or using portal-kernel's .security.permission.resource API I would say to put it there but this is a whole separate API.

The current design is to create java code to map the different services permissions using in memory maps and wrapping the permission logic, see DLFileEntrySharingPermissionChecker.  If sharing is only going to be for document library then this is good enough.

But if we plan on doing this for multiple modules I think a better design would be to just interact with the ResourcePermission API and have an update and reset implementation for sharing (copy the changes made to the ResourcePermission into a sharing table, updating the ResourcePermission table and undo the change when sharing expires or is revoked).  Doing it this way would mean you could share anything with permissions.

These are some small changes I made while reading the code in the pull.