### PR TITLE
LPS-87728 Only show "Share" button when appropriate

### DIFF
--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLDisplayContextFactory.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLDisplayContextFactory.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.sharing.display.context.util.SharingMenuItemFactory;
 import com.liferay.sharing.display.context.util.SharingToolbarItemFactory;
+import com.liferay.sharing.document.library.internal.security.permission.SharingPermissionHelper;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -90,7 +91,8 @@ public class SharingDLDisplayContextFactory implements DLDisplayContextFactory {
 				ResourceBundleUtil.getBundle(
 					themeDisplay.getLocale(),
 					SharingDLDisplayContextFactory.class),
-				_sharingMenuItemFactory, _sharingToolbarItemFactory);
+				_sharingMenuItemFactory, _sharingToolbarItemFactory,
+				_sharingPermissionHelper);
 		}
 		catch (PortalException pe) {
 			throw new SystemException(
@@ -102,6 +104,9 @@ public class SharingDLDisplayContextFactory implements DLDisplayContextFactory {
 
 	@Reference
 	private SharingMenuItemFactory _sharingMenuItemFactory;
+
+	@Reference
+	private SharingPermissionHelper _sharingPermissionHelper;
 
 	@Reference
 	private SharingToolbarItemFactory _sharingToolbarItemFactory;

--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLViewFileVersionDisplayContext.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLViewFileVersionDisplayContext.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.sharing.display.context.util.SharingMenuItemFactory;
 import com.liferay.sharing.display.context.util.SharingToolbarItemFactory;
+import com.liferay.sharing.document.library.internal.security.permission.SharingPermissionHelper;
 
 import java.util.List;
 import java.util.ResourceBundle;
@@ -53,7 +54,8 @@ public class SharingDLViewFileVersionDisplayContext
 		FileEntry fileEntry, FileVersion fileVersion,
 		ResourceBundle resourceBundle,
 		SharingMenuItemFactory sharingMenuItemFactory,
-		SharingToolbarItemFactory sharingToolbarItemFactory) {
+		SharingToolbarItemFactory sharingToolbarItemFactory,
+		SharingPermissionHelper sharingPermissionHelper) {
 
 		super(_UUID, parentDLDisplayContext, request, response, fileVersion);
 
@@ -64,6 +66,7 @@ public class SharingDLViewFileVersionDisplayContext
 			WebKeys.THEME_DISPLAY);
 		_sharingMenuItemFactory = sharingMenuItemFactory;
 		_sharingToolbarItemFactory = sharingToolbarItemFactory;
+		_sharingPermissionHelper = sharingPermissionHelper;
 	}
 
 	@Override
@@ -125,7 +128,11 @@ public class SharingDLViewFileVersionDisplayContext
 
 		_showImageEditorAction = false;
 
-		if (_themeDisplay.isSignedIn() && _isShowActions()) {
+		if (_themeDisplay.isSignedIn() && _isShowActions() &&
+			_sharingPermissionHelper.isShareable(
+				_themeDisplay.getPermissionChecker(),
+				_fileEntry.getFileEntryId())) {
+
 			_showImageEditorAction = true;
 		}
 
@@ -139,6 +146,7 @@ public class SharingDLViewFileVersionDisplayContext
 	private final HttpServletRequest _request;
 	private final ResourceBundle _resourceBundle;
 	private final SharingMenuItemFactory _sharingMenuItemFactory;
+	private final SharingPermissionHelper _sharingPermissionHelper;
 	private final SharingToolbarItemFactory _sharingToolbarItemFactory;
 	private Boolean _showImageEditorAction;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/security/permission/SharingPermissionHelper.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/security/permission/SharingPermissionHelper.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.sharing.document.library.internal.security.permission;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryConstants;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.sharing.document.library.internal.security.permission.resource.SharingEntryDLFileEntryModelResourcePermissionRegistrar;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(immediate = true, service = SharingPermissionHelper.class)
+public class SharingPermissionHelper {
+
+	public boolean isShareable(
+			PermissionChecker permissionChecker, long fileEntryId)
+		throws PortalException {
+
+		if (_dlFileEntryModelResourcePermission.contains(
+				permissionChecker, fileEntryId, ActionKeys.VIEW)) {
+
+			return true;
+		}
+
+		List<SharingEntry> sharingEntries =
+			_sharingEntryLocalService.getToUserClassPKSharingEntries(
+				permissionChecker.getUserId(),
+				_classNameLocalService.getClassNameId(
+					DLFileEntryConstants.getClassName()),
+				fileEntryId);
+
+		for (SharingEntry sharingEntry : sharingEntries) {
+			if (sharingEntry.isShareable()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference(
+		target = "(&(model.class.name=com.liferay.document.library.kernel.model.DLFileEntry)(!(component.name=" + SharingEntryDLFileEntryModelResourcePermissionRegistrar.COMPONENT_NAME + ")))"
+	)
+	private ModelResourcePermission<DLFileEntry>
+		_dlFileEntryModelResourcePermission;
+
+	@Reference
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+}


### PR DESCRIPTION
The user should have some shareable sharing entry or the VIEW permission.

@brianchandotcom I'm okay with this change I've been emailing @4lejandrito about adding something to the permission resource API once they have two sharing examples working to reduce duplication and clean up the implementation.  @adolfopa I'll CC you to make sure you're included.

@4lejandrito @adolfopa while looking at these changes I found a nasty bug [here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/security/permission/SharingEntryAction.java#L31).  While it's known that VIEW will always be 1 all other values are unknown.  Customers upgrading from different versions (like before ADD_DISCUSSION was added) will likely have different bitwise values.  We cannot take for granted that the values we have when booting up master for the first time will always match what the customer has. In the future we may add new actions or changes our parsing logic for the XML and silently break what is actually being shared (sharing the wrong permission).  Can you open a ticket and send a fix for this when you can?