### PR TITLE
LPS-86357 UserGroupServiceTest#testGetUserGroupsLikeName will fail if there are leftover UserGroups from another test case

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/service/UserGroupServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/UserGroupServiceTest.java
@@ -85,32 +85,46 @@ public class UserGroupServiceTest {
 
 	@Test
 	public void testGetUserGroupsLikeName() throws Exception {
+		List<UserGroup> allUserGroups = new ArrayList<>();
+
+		allUserGroups.addAll(
+			UserGroupLocalServiceUtil.getUserGroups(
+				TestPropsValues.getCompanyId()));
+
+		List<UserGroup> likeNameUserGroups = new ArrayList<>();
+
 		String name = RandomTestUtil.randomString(10);
 
-		List<UserGroup> expectedUserGroups = new ArrayList<>();
-
 		for (int i = 0; i < 10; i++) {
-			UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+			UserGroup userGroup = addUserGroup();
 
 			userGroup.setName(name + i);
 
-			UserGroupLocalServiceUtil.updateUserGroup(userGroup);
+			userGroup = UserGroupLocalServiceUtil.updateUserGroup(userGroup);
 
-			expectedUserGroups.add(userGroup);
+			allUserGroups.add(userGroup);
+			likeNameUserGroups.add(userGroup);
 		}
 
-		_userGroups.addAll(expectedUserGroups);
-		_userGroups.add(UserGroupTestUtil.addUserGroup());
-		_userGroups.add(UserGroupTestUtil.addUserGroup());
-		_userGroups.add(UserGroupTestUtil.addUserGroup());
+		allUserGroups.add(addUserGroup());
+		allUserGroups.add(addUserGroup());
+		allUserGroups.add(addUserGroup());
 
-		assertExpectedUserGroups(expectedUserGroups, name + "%");
+		assertExpectedUserGroups(likeNameUserGroups, name + "%");
 		assertExpectedUserGroups(
-			expectedUserGroups, StringUtil.toLowerCase(name) + "%");
+			likeNameUserGroups, StringUtil.toLowerCase(name) + "%");
 		assertExpectedUserGroups(
-			expectedUserGroups, StringUtil.toUpperCase(name) + "%");
-		assertExpectedUserGroups(_userGroups, null);
-		assertExpectedUserGroups(_userGroups, "");
+			likeNameUserGroups, StringUtil.toUpperCase(name) + "%");
+		assertExpectedUserGroups(allUserGroups, null);
+		assertExpectedUserGroups(allUserGroups, "");
+	}
+
+	protected UserGroup addUserGroup() throws Exception {
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		_userGroups.add(userGroup);
+
+		return userGroup;
 	}
 
 	protected void assertExpectedUserGroups(

--- a/portal-impl/test/integration/com/liferay/portal/service/UserGroupServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/UserGroupServiceTest.java
@@ -93,7 +93,7 @@ public class UserGroupServiceTest {
 
 		List<UserGroup> likeNameUserGroups = new ArrayList<>();
 
-		String name = RandomTestUtil.randomString(10);
+		String name = RandomTestUtil.randomString(50);
 
 		for (int i = 0; i < 10; i++) {
 			UserGroup userGroup = addUserGroup();


### PR DESCRIPTION
This is an update for [LPS-86357](https://issues.liferay.com/browse/LPS-86357).<br><br>Hey Brian, this fixes the test case that was breaking intermittently in 7.0.x.  I removed the stale data test logging  tuil since @shuyangzhou let me know that his team is going to do more wide-spread fixing of the issue: https://github.com/shuyangzhou/liferay-portal/pull/7115#issuecomment-443098528.  Please let me know if you have any questions.<br><br>/cc @pei-jung @stsquared99 @alee8888 @ChrisKian