### PR TITLE
LPS-81837 7.1 Upgrades Organization - Avatar image not saved after upgrade on MySQL5.7, SQLServer2016, and Oracle12.2

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0


### PR DESCRIPTION
This is an update for [LPS-81837](https://issues.liferay.com/browse/LPS-81837).<br><br>/cc @pei-jung @stsquared99 @alee8888 @ChrisKian

From @ChrisKian:

https://issues.liferay.com/browse/LPS-81837

The difference between how we store org logos is between 62x and 7010, in which we add the "logoId" column to the Organization_ table.  So, 62x and lower, we are actually storing the logoId in the LayoutSet table, under both the public and private pages (it's a different logoId for each, but it points to the same image).  And in 7010 and up, we store it in the Organization_ table under the "logoId" column.

I chose to only include this fix as a 7.0 upgrade process because once the DB has been upgraded to 7000 and up, there is no way to know for sure if the user intended to set a logo for their org or for the layoutSet of their org.  This is because post 7000, the logoId field in the layoutSet table (which was previously used for the org's logo), is now used for the public/private layoutSet's logo.  In the off chance a user wants their layoutSets to have logos but not their org, we would mess that up.

The fix itself is pretty straight-forward.  We grab the logoId and groupId from the layoutSet table whenever the logoId is present and we are dealing with a public layoutSet (to avoid duplication).  Next, we match that groupId to the classPK (or organizationId) from the Group_ table, and lastly we take the classPK match it to the Organization_ table, and insert the logoId.  After that, the logo is successfully found.

Please let me know if you have any questions.