### PR TITLE
LPS-85008 portal-search-web: build.gradle: PropsTestUtil needs petra-concurrent for strict OOTB "gradlew test" (no "ant all" at all)

### DIFF
--- a/modules/apps/document-library/document-library-test/build.gradle
+++ b/modules/apps/document-library/document-library-test/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	testIntegrationCompile project(":apps:trash:trash-api")
 	testIntegrationCompile project(":apps:trash:trash-test-util")
 	testIntegrationCompile project(":apps:users-admin:users-admin-test-util")
+	testIntegrationCompile project(":core:petra:petra-function")
 	testIntegrationCompile project(":core:petra:petra-reflect")
 	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":core:registry-api")

--- a/modules/apps/portal-search/portal-search-web/build.gradle
+++ b/modules/apps/portal-search/portal-search-web/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	testCompile group: "org.slf4j", name: "slf4j-api", version: "1.7.7"
 	testCompile group: "org.springframework", name: "spring-web", version: "4.1.9.RELEASE"
 	testCompile project(":apps:portal-search:portal-search")
+	testCompile project(":core:petra:petra-concurrent")
 	testCompile project(":core:petra:petra-memory")
 	testCompile project(":core:petra:petra-reflect")
 }


### PR DESCRIPTION
Tests pass locally. A separate PR is running `ci:test:search`, but this can be safely merged already; risk is minimal, revert is trivial.

@4lejandrito FYI https://github.com/brianchandotcom/liferay-portal/pull/65649/commits/36951e281f713110dde155df45d6cd7a9037e5ed

@tinatian FYI https://github.com/brianchandotcom/liferay-portal/pull/65649/commits/f11c4675eac5a8246475500a997a925274d283bc

I'd advise Build Infrastructure to consider removing `petra` projects from the implicit Gradle classpath, thus requiring them to be always declared explicitly. Currently, dependencies as expressed in `build.gradle` files can easily turn inaccurate, causing sudden problems for Eclipse and Jenkins users.

https://issues.liferay.com/browse/LPS-85008
https://issues.liferay.com/browse/LPS-86009