### PR TITLE
LPS-79753 Fix compile

### DIFF
--- a/modules/core/portal-compat/petra/portal-kernel-io-compat/imported-files.properties
+++ b/modules/core/portal-compat/petra/portal-kernel-io-compat/imported-files.properties
@@ -1,2 +1,2 @@
-com.liferay.portal\:com.liferay.portal.kernel\:3.0.0-20180426.173855-7=\
+com.liferay.portal\:com.liferay.portal.kernel\:3.45.0=\
     com/liferay/portal/kernel/io/AutoDeleteFileInputStream.class


### PR DESCRIPTION
Use by using an actual release not the snapshot for compat.

CC @shuyangzhou this was using a snapshot so that we could include a bug fix.  By using the latest release we're using the same class file and I've confirmed in contains the fix from LPS-79753.