### PR TITLE
LPS-88176 Add logging for Jenkins

### DIFF
--- a/modules/init.gradle
+++ b/modules/init.gradle
@@ -9,6 +9,20 @@ if (System.properties["http.proxyHost"] == "squid.lax.liferay.com") {
 	System.setProperty "repository.url", "http://repository-cdn.liferay.com/nexus/content/groups/public"
 }
 
+if (System.getenv("JENKINS_HOME")) {
+	logger.lifecycle "SSL cipher {}", ClassLoader.getSystemResource("javax/crypto/Cipher.class")
+
+	String path = System.getProperty("java.home") + File.separator + "lib" + File.separator + "security" + File.separator
+
+	File jar = new File(path, "US_export_policy.jar")
+
+	logger.lifecycle "SSL export policy {}:{}", jar, jar.exists()
+
+	jar = new File(path, "local_policy.jar")
+
+	logger.lifecycle "SSL local policy {}:{}", jar, jar.exists()
+}
+
 gradle.buildFinished {
 	if (System.getenv("JENKINS_HOME")) {
 		Date now = new Date()


### PR DESCRIPTION
Added logging to see why the [SecurityException](http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/tip/src/share/classes/javax/crypto/JceSecurity.java#l254) is thrown on Jenkins.  Please backport to `7.0.x`. 

https://test-1-23.liferay.com/job/test-portal-acceptance-pullrequest(7.1.x)/126/consoleFull