### PR TITLE
LPS-88249 Cover up bad portlet action phase redirect. This is not fix…

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletContainerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletContainerUtil.java
@@ -130,7 +130,7 @@ public class PortletContainerUtil {
 			}
 		}
 
-		if (Validator.isNull(location)) {
+		if (Validator.isNull(location) || response.isCommitted()) {
 			return;
 		}
 


### PR DESCRIPTION
…ing the issue but covering it, a real fix should be stopping a portlet action sending redirect after it committed the response. However this is the safest way to deal with the problem, as it does not change any behavior. We prefer safer before fixpack release.