### PR TITLE
LPS-88176 Fix compileJava task for CI

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -67,7 +67,7 @@
     build.binaries.cache.dir=../${build.binaries.cache.repository.name}
     build.binaries.cache.repository.name=liferay-binaries-cache-2017
     build.binaries.cache.url=https://github.com/liferay/${build.binaries.cache.repository.name}.git
-    build.binaries.gradle.file=gradle-4.10.2.LIFERAY-PATCHED-2-bin.zip
+    build.binaries.gradle.file=gradle-4.10.2.LIFERAY-PATCHED-3-bin.zip
     build.binaries.gradle.url=https://github.com/liferay/${build.binaries.cache.repository.name}/raw/master/${build.binaries.gradle.file}
     build.bnd.print.enabled=false
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=../../tools/gradle-4.10.2.LIFERAY-PATCHED-2-bin.zip
+distributionUrl=../../tools/gradle-4.10.2.LIFERAY-PATCHED-3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0

--- a/modules/init.gradle
+++ b/modules/init.gradle
@@ -9,20 +9,6 @@ if (System.properties["http.proxyHost"] == "squid.lax.liferay.com") {
 	System.setProperty "repository.url", "http://repository-cdn.liferay.com/nexus/content/groups/public"
 }
 
-if (System.getenv("JENKINS_HOME")) {
-	logger.lifecycle "SSL cipher {}", ClassLoader.getSystemResource("javax/crypto/Cipher.class")
-
-	String path = System.getProperty("java.home") + File.separator + "lib" + File.separator + "security" + File.separator
-
-	File jar = new File(path, "US_export_policy.jar")
-
-	logger.lifecycle "SSL export policy {}:{}", jar, jar.exists()
-
-	jar = new File(path, "local_policy.jar")
-
-	logger.lifecycle "SSL local policy {}:{}", jar, jar.exists()
-}
-
 gradle.buildFinished {
 	if (System.getenv("JENKINS_HOME")) {
 		Date now = new Date()

--- a/modules/init.gradle
+++ b/modules/init.gradle
@@ -14,13 +14,13 @@ if (System.getenv("JENKINS_HOME")) {
 
 	String path = System.getProperty("java.home") + File.separator + "lib" + File.separator + "security" + File.separator
 
-	File jarFile = new File(path, "US_export_policy.jar")
+	File jar = new File(path, "US_export_policy.jar")
 
-	logger.lifecycle "SSL export policy {}:{}", jarFile, jarFile.exists()
+	logger.lifecycle "SSL export policy {}:{}", jar, jar.exists()
 
-	jarFile = new File(path, "local_policy.jar")
+	jar = new File(path, "local_policy.jar")
 
-	logger.lifecycle "SSL local policy {}:{}", jarFile, jarFile.exists()
+	logger.lifecycle "SSL local policy {}:{}", jar, jar.exists()
 }
 
 gradle.buildFinished {

--- a/modules/third-party/org-gradle/org-gradle-resources-http/bnd.bnd
+++ b/modules/third-party/org-gradle/org-gradle-resources-http/bnd.bnd
@@ -1,2 +1,2 @@
 Bundle-SymbolicName: org-gradle-resources-http
-Bundle-Version: 4.10.2.LIFERAY-PATCHED-2
+Bundle-Version: 4.10.2.LIFERAY-PATCHED-3

--- a/modules/util.gradle
+++ b/modules/util.gradle
@@ -79,7 +79,7 @@ repositories {
 wrapper {
 	File wrapperDir = projectDir.parentFile
 
-	distributionUrl = "../../tools/gradle-${gradle.gradleVersion}.LIFERAY-PATCHED-2-bin.zip"
+	distributionUrl = "../../tools/gradle-${gradle.gradleVersion}.LIFERAY-PATCHED-3-bin.zip"
 	dependsOn wrapperSubrepo
 
 	doLast {


### PR DESCRIPTION
There have been multiple failures in [CI with the text](https://test-1-13.liferay.com/job/test-portal-acceptance-upstream-batch(7.1.x)/AXIS_VARIABLE=3,label_exp=!master/3074/consoleFull) "Could not initialize class sun.security.ssl.SSLContextImpl$"

When Gradle is running in parallel, the `java.home` system property is not always set properly.