### PR TITLE
LPS-88524 Ant update-gradle-cache

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -767,11 +767,17 @@ information.
 		<attribute default="${env.ANT_OPTS}" name="gradleopts" />
 		<attribute default="" name="outputproperty" />
 		<attribute default="" name="refreshdependencies" />
+		<attribute default="true" name="setupbinariescache" />
 		<attribute name="task" />
 		<element implicit="true" name="args" optional="true" />
 
 		<sequential>
-			<setup-binaries-cache unless:true="${setup.binaries.cache.executed}" />
+			<if>
+				<equals arg1="@{setupbinariescache}" arg2="true" />
+				<then>
+					<setup-binaries-cache unless:true="${setup.binaries.cache.executed}" />
+				</then>
+			</if>
 
 			<if>
 				<not>
@@ -1462,8 +1468,10 @@ artifact.url=${remote.repository.url}/com/liferay/portal/com.liferay.${processed
 	</macrodef>
 
 	<macrodef name="setup-sdk">
+		<attribute default="true" name="setupbinariescache" />
+
 		<sequential>
-			<gradle-execute forcedcacheenabled="true" outputproperty="sdk.zip.file" task="printDependencyPath">
+			<gradle-execute forcedcacheenabled="true" outputproperty="sdk.zip.file" setupbinariescache="@{setupbinariescache}" task="printDependencyPath">
 				<arg value="--build-file=${project.dir}/modules/util.gradle" />
 				<arg value="--quiet" />
 				<arg value="-Dorg.gradle.internal.launcher.welcomeMessageEnabled=false" />
@@ -1510,7 +1518,7 @@ artifact.url=${remote.repository.url}/com/liferay/portal/com.liferay.${processed
 
 			<update-gradle-properties />
 
-			<gradle-execute task="setUpPortalTools">
+			<gradle-execute setupbinariescache="@{setupbinariescache}" task="setUpPortalTools">
 				<arg value="--build-file=${project.dir}/modules/util.gradle" />
 			</gradle-execute>
 		</sequential>

--- a/build.xml
+++ b/build.xml
@@ -1377,19 +1377,19 @@ print AdminControl.invoke(appManager, 'startApplication', 'liferay-portal')
 
 		<delete dir="${basedir}/.gradle" />
 
-		<setup-sdk />
+		<setup-sdk setupbinariescache="false" />
 
-		<gradle-execute dir="modules" forcedcacheenabled="false" task="clean">
+		<gradle-execute dir="modules" forcedcacheenabled="false" setupbinariescache="false" task="clean">
 			<arg value="-Dmaven.local.ignore=true" />
 		</gradle-execute>
 
-		<gradle-execute dir="modules" forcedcacheenabled="false" task="classes">
+		<gradle-execute dir="modules" forcedcacheenabled="false" setupbinariescache="false" task="classes">
 			<arg value="-Dmaven.local.ignore=true" />
 			<arg value="testClasses" />
 			<arg value="testIntegrationClasses" />
 		</gradle-execute>
 
-		<gradle-execute dir="modules/sdk/gradle-util" failonerror="false" forcedcacheenabled="false" task="findbugsMain">
+		<gradle-execute dir="modules/sdk/gradle-util" failonerror="false" forcedcacheenabled="false" setupbinariescache="false" task="findbugsMain">
 			<arg value="-Dmaven.local.ignore=true" />
 		</gradle-execute>
 

--- a/build.xml
+++ b/build.xml
@@ -1394,6 +1394,24 @@ print AdminControl.invoke(appManager, 'startApplication', 'liferay-portal')
 		</gradle-execute>
 
 		<ant dir="portal-web" inheritAll="false" target="update-gradle-cache" />
+
+		<property name="git.unignore.gradle.cache" value="**/.gradle/*${line.separator}/.gradle/caches/*${line.separator}/.gradle/caches/modules-2/*${line.separator}!/.gradle/caches${line.separator}!/.gradle/caches/modules-2${line.separator}!/.gradle/caches/modules-2/files-2.1" />
+
+		<replace
+			file="${basedir}/.gitignore"
+			token="**/.gradle"
+			value="${git.unignore.gradle.cache}"
+		/>
+
+		<execute>
+			git add --all
+		</execute>
+
+		<replace
+			file="${basedir}/.gitignore"
+			token="${git.unignore.gradle.cache}"
+			value="**/.gradle"
+		/>
 	</target>
 
 	<target name="validate-xml">

--- a/modules/sdk/ant-jgit/build.gradle
+++ b/modules/sdk/ant-jgit/build.gradle
@@ -1,3 +1,9 @@
+clean {
+	ext {
+		cleanDeployed = false
+	}
+}
+
 dependencies {
 	compile group: "org.eclipse.jgit", name: "org.eclipse.jgit", version: "4.0.0.201505050340-m2"
 	compile group: "org.slf4j", name: "slf4j-log4j12", version: "1.7.2"

--- a/modules/third-party/com-google-gdata-sample-appsforyourdomain/build.gradle
+++ b/modules/third-party/com-google-gdata-sample-appsforyourdomain/build.gradle
@@ -46,7 +46,7 @@ downloadSrc {
 	}
 
 	from {
-		zipTree(FileUtil.get(project, "https://gdata-java-client.googlecode.com/files/gdata-samples.java-1.47.1.zip"))
+		zipTree(FileUtil.get(project, "https://storage.googleapis.com/gdata-java-client-binaries/gdata-samples.java-1.47.1.zip"))
 	}
 
 	include "gdata/java/lib/gdata-appsforyourdomain-1.0.jar"

--- a/portal-web/build.xml
+++ b/portal-web/build.xml
@@ -372,7 +372,7 @@ ${oversize.files.jsp}</fail>
 	</target>
 
 	<target name="update-gradle-cache">
-		<gradle-execute forcedcacheenabled="false" task="updateGradleCache">
+		<gradle-execute forcedcacheenabled="false" setupbinariescache="false" task="updateGradleCache">
 			<arg value="--build-file=build-test.gradle" />
 			<arg value="-Dmaven.local.ignore=true" />
 		</gradle-execute>


### PR DESCRIPTION
Hi Brian, if possible, please publish the snapshots below to Nexus.

They're used by the `update-gradle-cache` task

```
com.liferay.portal.impl.version=4.0.0-SNAPSHOT
com.liferay.portal.kernel.version=4.0.0-SNAPSHOT
com.liferay.portal.test.version=6.0.0-SNAPSHOT
com.liferay.portal.test.integration.version=6.0.0-SNAPSHOT
com.liferay.util.bridges.version=6.0.0-SNAPSHOT
com.liferay.util.java.version=4.0.0-SNAPSHOT
com.liferay.util.taglib.version=4.0.0-SNAPSHOT
```