### PR TITLE
LPS-83857 7.1 Upgrades Organization - organization reminder query not saved after upgrade

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/PortalUpgradeProcessRegistryImpl.java
@@ -47,6 +47,9 @@ public class PortalUpgradeProcessRegistryImpl
 
 		upgradeProcesses.put(
 			new Version("2.0.2"), new UpgradePasswordPolicyRegex());
+
+		upgradeProcesses.put(
+			new Version("2.0.3"), new UpgradePortalPreferences());
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/UpgradePortalPreferences.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/UpgradePortalPreferences.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v7_1_x;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.xml.XMLUtil;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.xml.Document;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.Iterator;
+
+/**
+ * @author Christopher Kian
+ */
+public class UpgradePortalPreferences extends UpgradeProcess {
+
+	protected String convertDefaultReminderQueries(
+			String localizedPreference, String preferences)
+		throws Exception {
+
+		Document document = SAXReaderUtil.read(preferences);
+
+		Element rootElement = document.getRootElement();
+
+		Iterator<Element> iterator = rootElement.elementIterator();
+
+		while (iterator.hasNext()) {
+			Element preferenceElement = iterator.next();
+
+			String preferenceName = preferenceElement.elementText("name");
+
+			if (preferenceName.equals("reminderQueries")) {
+				Element defaultReminderQueryElement =
+					preferenceElement.createCopy();
+
+				Element nameElement = defaultReminderQueryElement.element(
+					"name");
+
+				defaultReminderQueryElement.remove(nameElement);
+
+				nameElement.setText(localizedPreference);
+
+				defaultReminderQueryElement.add(nameElement);
+
+				rootElement.add(defaultReminderQueryElement);
+
+				break;
+			}
+		}
+
+		return XMLUtil.formatXML(document);
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		upgradeOrganizationReminderQueries();
+	}
+
+	protected void upgradeOrganizationReminderQueries() throws Exception {
+		StringBundler sb1 = new StringBundler(7);
+
+		sb1.append("select PortalPreferences.portalPreferencesId, ");
+		sb1.append("PortalPreferences.preferences, Organization_.companyId ");
+		sb1.append("from PortalPreferences inner join Organization_ on ");
+		sb1.append("PortalPreferences.ownerId = Organization_.organizationId ");
+		sb1.append("where PortalPreferences.ownerType = ");
+		sb1.append(PortletKeys.PREFS_OWNER_TYPE_ORGANIZATION);
+		sb1.append(" and preferences like '%reminderQueries%'");
+
+		try (PreparedStatement ps1 = connection.prepareStatement(
+				sb1.toString());
+			ResultSet rs = ps1.executeQuery();
+			PreparedStatement ps2 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update PortalPreferences set preferences = ? where " +
+						"portalPreferencesId = ?")) {
+
+			while (rs.next()) {
+				long companyId = rs.getLong("companyId");
+
+				String preferences = rs.getString("preferences");
+
+				String defaultLanguageId =
+					UpgradeProcessUtil.getDefaultLanguageId(companyId);
+
+				String localizedPreference =
+					"reminderQueries_" + defaultLanguageId;
+
+				if (preferences.contains(localizedPreference)) {
+					continue;
+				}
+
+				long portalPreferencesId = rs.getLong("portalPreferencesId");
+
+				ps2.setString(
+					1,
+					convertDefaultReminderQueries(
+						localizedPreference, preferences));
+
+				ps2.setLong(2, portalPreferencesId);
+
+				ps2.addBatch();
+			}
+
+			ps2.executeBatch();
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/packageinfo
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/portal-impl/test/integration/com/liferay/portal/upgrade/v7_1_x/UpgradePortletPreferencesTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/upgrade/v7_1_x/UpgradePortletPreferencesTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v7_1_x;
+
+import com.liferay.portal.kernel.cache.CacheRegistryUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.OrganizationConstants;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
+import com.liferay.portal.kernel.service.PortalPreferencesLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Locale;
+import java.util.Set;
+
+import javax.portlet.PortletPreferences;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Christopher Kian
+ */
+public class UpgradePortletPreferencesTest extends UpgradePortalPreferences {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_availableLocales = LanguageUtil.getAvailableLocales();
+
+		String defaultLanguageId = UpgradeProcessUtil.getDefaultLanguageId(
+			CompanyThreadLocal.getCompanyId());
+
+		_defaultLocale = LanguageUtil.getLocale(defaultLanguageId);
+
+		CompanyTestUtil.resetCompanyLocales(
+			CompanyThreadLocal.getCompanyId(), "en_US,es_ES", "en_US");
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		CompanyTestUtil.resetCompanyLocales(
+			CompanyThreadLocal.getCompanyId(), _availableLocales,
+			_defaultLocale);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_organization = OrganizationLocalServiceUtil.addOrganization(
+			UserLocalServiceUtil.getDefaultUserId(
+				CompanyThreadLocal.getCompanyId()),
+			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID,
+			RandomTestUtil.randomString(), false);
+	}
+
+	@Test
+	public void testMissingDefaultLocale() throws Exception {
+		StringBundler sb = new StringBundler(4);
+
+		sb.append("<portlet-preferences><preference><name>reminderQueries");
+		sb.append("</name><value>defaultValue</value></preference>");
+		sb.append("<preference><name>reminderQueries_es_ES</name><value>");
+		sb.append("spanishValue</value></preference></portlet-preferences>");
+
+		PortletPreferences portletPreferences = _upgradePreferences(
+			sb.toString());
+
+		Assert.assertEquals(
+			"defaultValue",
+			portletPreferences.getValue("reminderQueries", null));
+
+		Assert.assertEquals(
+			"defaultValue",
+			portletPreferences.getValue("reminderQueries_en_US", null));
+
+		Assert.assertEquals(
+			"spanishValue",
+			portletPreferences.getValue("reminderQueries_es_ES", null));
+	}
+
+	@Test
+	public void testPresentDefaultLocale() throws Exception {
+		StringBundler sb = new StringBundler(6);
+
+		sb.append("<portlet-preferences><preference><name>reminderQueries");
+		sb.append("</name><value>defaultValue</value></preference>");
+		sb.append("<preference><name>reminderQueries_en_US</name><value>");
+		sb.append("englishValue</value></preference><preference><name>");
+		sb.append("reminderQueries_es_ES</name><value>spanishValue</value>");
+		sb.append("</preference></portlet-preferences>");
+
+		PortletPreferences portletPreferences = _upgradePreferences(
+			sb.toString());
+
+		Assert.assertEquals(
+			"defaultValue",
+			portletPreferences.getValue("reminderQueries", null));
+
+		Assert.assertEquals(
+			"englishValue",
+			portletPreferences.getValue("reminderQueries_en_US", null));
+
+		Assert.assertEquals(
+			"spanishValue",
+			portletPreferences.getValue("reminderQueries_es_ES", null));
+	}
+
+	private PortletPreferences _upgradePreferences(String preferences)
+		throws Exception {
+
+		PortalPreferencesLocalServiceUtil.addPortalPreferences(
+			_organization.getOrganizationId(),
+			PortletKeys.PREFS_OWNER_TYPE_ORGANIZATION, preferences);
+
+		upgrade();
+
+		CacheRegistryUtil.clear();
+
+		return _organization.getPreferences();
+	}
+
+	private static Set<Locale> _availableLocales;
+	private static Locale _defaultLocale;
+
+	@DeleteAfterTestRun
+	private Organization _organization;
+
+}


### PR DESCRIPTION
This is an update for [LPS-83857](https://issues.liferay.com/browse/LPS-83857).

_Upgrade_ test results here: https://github.com/brianchandotcom/liferay-portal/pull/66268.  We looked at it and the failures seem unrelated.
_Relevant_ test results here: https://github.com/drewbrokke/liferay-portal/pull/702#issuecomment-450237578.

/cc @pei-jung @stsquared99 @alee8888 @ChrisKian 

----------------------

From @ChrisKian:

https://issues.liferay.com/browse/LPS-83857

Hey Drew, I've added the tests as requested from [my last PR](https://github.com/drewbrokke/liferay-portal/pull/687#issuecomment-449194110).  Aside from that and a rebase, there are no changes.

Description from my last PR:

Looking at [this article, specifically item #2 here](https://grow.liferay.com/share/DXP-+How+to+code+upgrade+process+and+backport+rules#section-DXP-+How+to+code+upgrade+process+and+backport+rules-Master), I believe my upgrade process is in the correct spot.  I've ran it to verify it works properly from where it is.  It's also safe to be ran on any data; running it multiple times or on data which doesn't need to be fixed won't hurt anything.

As far as the fix goes, it's pretty straight-forward.  We get the preferences from PortalPreferences if it's an org's preferences and it contains "reminderQueries", which is the we store the reminder query values under.  Assuming those criteria are met, we determine the org's default locale using it's companyId, append it to "reminderQueries_", and make sure it doesn't exist in the preferences (because then there is no issue to resolve).  If it doesn't exist, we enter the convertDefaultReminderQueries() method, which finds the default property "reminderQueries", copies it, changes the name to the localized value, and inserts it into the preferences.  The preferences are then updated, and the issue is resolved.

Let me know if you have any questions.  Thanks!
