### PR TITLE
LPS-88524 Fix update-gradle-cache

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -767,11 +767,17 @@ information.
 		<attribute default="${env.ANT_OPTS}" name="gradleopts" />
 		<attribute default="" name="outputproperty" />
 		<attribute default="" name="refreshdependencies" />
+		<attribute default="true" name="setupbinariescache" />
 		<attribute name="task" />
 		<element implicit="true" name="args" optional="true" />
 
 		<sequential>
-			<setup-binaries-cache unless:true="${setup.binaries.cache.executed}" />
+			<if>
+				<equals arg1="@{setupbinariescache}" arg2="true" />
+				<then>
+					<setup-binaries-cache unless:true="${setup.binaries.cache.executed}" />
+				</then>
+			</if>
 
 			<if>
 				<not>
@@ -1462,8 +1468,10 @@ artifact.url=${remote.repository.url}/com/liferay/portal/com.liferay.${processed
 	</macrodef>
 
 	<macrodef name="setup-sdk">
+		<attribute default="true" name="setupbinariescache" />
+
 		<sequential>
-			<gradle-execute forcedcacheenabled="true" outputproperty="sdk.zip.file" task="printDependencyPath">
+			<gradle-execute forcedcacheenabled="true" outputproperty="sdk.zip.file" setupbinariescache="@{setupbinariescache}" task="printDependencyPath">
 				<arg value="--build-file=${project.dir}/modules/util.gradle" />
 				<arg value="--quiet" />
 				<arg value="-Dorg.gradle.internal.launcher.welcomeMessageEnabled=false" />
@@ -1510,7 +1518,7 @@ artifact.url=${remote.repository.url}/com/liferay/portal/com.liferay.${processed
 
 			<update-gradle-properties />
 
-			<gradle-execute task="setUpPortalTools">
+			<gradle-execute setupbinariescache="@{setupbinariescache}" task="setUpPortalTools">
 				<arg value="--build-file=${project.dir}/modules/util.gradle" />
 			</gradle-execute>
 		</sequential>

--- a/build.xml
+++ b/build.xml
@@ -1381,19 +1381,16 @@ print AdminControl.invoke(appManager, 'startApplication', 'liferay-portal')
 
 		<gradle-execute dir="modules" forcedcacheenabled="false" task="clean">
 			<arg value="--parallel" />
-			<arg value="-Dmaven.local.ignore=true" />
 		</gradle-execute>
 
 		<gradle-execute dir="modules" forcedcacheenabled="false" task="classes">
 			<arg value="--parallel" />
-			<arg value="-Dmaven.local.ignore=true" />
 			<arg value="testClasses" />
 			<arg value="testIntegrationClasses" />
 		</gradle-execute>
 
 		<gradle-execute dir="modules/sdk/gradle-util" failonerror="false" forcedcacheenabled="false" task="findbugsMain">
 			<arg value="--parallel" />
-			<arg value="-Dmaven.local.ignore=true" />
 		</gradle-execute>
 
 		<ant dir="portal-web" inheritAll="false" target="update-gradle-cache" />

--- a/build.xml
+++ b/build.xml
@@ -1377,19 +1377,19 @@ print AdminControl.invoke(appManager, 'startApplication', 'liferay-portal')
 
 		<delete dir="${basedir}/.gradle" />
 
-		<setup-sdk />
+		<setup-sdk setupbinariescache="false" />
 
-		<gradle-execute dir="modules" forcedcacheenabled="false" task="clean">
+		<gradle-execute dir="modules" forcedcacheenabled="false" setupbinariescache="false" task="clean">
 			<arg value="--parallel" />
 		</gradle-execute>
 
-		<gradle-execute dir="modules" forcedcacheenabled="false" task="classes">
+		<gradle-execute dir="modules" forcedcacheenabled="false" setupbinariescache="false" task="classes">
 			<arg value="--parallel" />
 			<arg value="testClasses" />
 			<arg value="testIntegrationClasses" />
 		</gradle-execute>
 
-		<gradle-execute dir="modules/sdk/gradle-util" failonerror="false" forcedcacheenabled="false" task="findbugsMain">
+		<gradle-execute dir="modules/sdk/gradle-util" failonerror="false" forcedcacheenabled="false" setupbinariescache="false" task="findbugsMain">
 			<arg value="--parallel" />
 		</gradle-execute>
 

--- a/build.xml
+++ b/build.xml
@@ -1394,6 +1394,19 @@ print AdminControl.invoke(appManager, 'startApplication', 'liferay-portal')
 		</gradle-execute>
 
 		<ant dir="portal-web" inheritAll="false" target="update-gradle-cache" />
+
+		<property name="git.unignore.gradle.cache" value="**/.gradle/*${line.separator}/.gradle/caches/*${line.separator}/.gradle/caches/modules-2/*${line.separator}!/.gradle/caches${line.separator}!/.gradle/caches/modules-2${line.separator}!/.gradle/caches/modules-2/files-2.1" />
+
+		<replace
+			file="${basedir}/.gitignore"
+			token="**/.gradle"
+			value="${git.unignore.gradle.cache}"
+		/>
+
+		<execute>
+			git add --all
+			git checkout HEAD -- .gitignore
+		</execute>
 	</target>
 
 	<target name="validate-xml">

--- a/build.xml
+++ b/build.xml
@@ -1380,16 +1380,19 @@ print AdminControl.invoke(appManager, 'startApplication', 'liferay-portal')
 		<setup-sdk />
 
 		<gradle-execute dir="modules" forcedcacheenabled="false" task="clean">
+			<arg value="--parallel" />
 			<arg value="-Dmaven.local.ignore=true" />
 		</gradle-execute>
 
 		<gradle-execute dir="modules" forcedcacheenabled="false" task="classes">
+			<arg value="--parallel" />
 			<arg value="-Dmaven.local.ignore=true" />
 			<arg value="testClasses" />
 			<arg value="testIntegrationClasses" />
 		</gradle-execute>
 
 		<gradle-execute dir="modules/sdk/gradle-util" failonerror="false" forcedcacheenabled="false" task="findbugsMain">
+			<arg value="--parallel" />
 			<arg value="-Dmaven.local.ignore=true" />
 		</gradle-execute>
 

--- a/modules/apps/asset/asset-publisher-test/build.gradle
+++ b/modules/apps/asset/asset-publisher-test/build.gradle
@@ -15,5 +15,6 @@ dependencies {
 	testIntegrationCompile project(":apps:portal:portal-upgrade-api")
 	testIntegrationCompile project(":core:petra:petra-lang")
 	testIntegrationCompile project(":core:petra:petra-string")
+	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/build.gradle
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/build.gradle
@@ -18,5 +18,6 @@ dependencies {
 	testIntegrationCompile project(":apps:export-import:export-import-test-util")
 	testIntegrationCompile project(":apps:portal:portal-upgrade-api")
 	testIntegrationCompile project(":core:petra:petra-string")
+	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/export-import/export-import-test/build.gradle
+++ b/modules/apps/export-import/export-import-test/build.gradle
@@ -19,5 +19,6 @@ dependencies {
 	testIntegrationCompile project(":apps:xstream:xstream-configurator-api")
 	testIntegrationCompile project(":core:petra:petra-reflect")
 	testIntegrationCompile project(":core:petra:petra-string")
+	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless-apio/blog/blog-apio-test/build.gradle
+++ b/modules/apps/headless-apio/blog/blog-apio-test/build.gradle
@@ -12,5 +12,6 @@ dependencies {
 	testIntegrationCompile project(":apps:headless-apio:blog:blog-apio-api")
 	testIntegrationCompile project(":apps:headless-apio:portal:portal-apio-api")
 	testIntegrationCompile project(":apps:headless-apio:portal:portal-apio-test-util")
+	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless-apio/folder/folder-apio-test/build.gradle
+++ b/modules/apps/headless-apio/folder/folder-apio-test/build.gradle
@@ -18,5 +18,6 @@ dependencies {
 	testIntegrationCompile project(":apps:headless-apio:folder:folder-apio-api")
 	testIntegrationCompile project(":apps:headless-apio:portal:portal-apio-api")
 	testIntegrationCompile project(":apps:petra:petra-json-web-service-client")
+	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless-apio/person/person-apio-test/build.gradle
+++ b/modules/apps/headless-apio/person/person-apio-test/build.gradle
@@ -9,5 +9,6 @@ dependencies {
 	testIntegrationCompile project(":apps:apio-architect:apio-architect-api")
 	testIntegrationCompile project(":apps:headless-apio:portal:portal-apio-api")
 	testIntegrationCompile project(":apps:headless-apio:portal:portal-apio-test-util")
+	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless-apio/structure/structure-apio-test/build.gradle
+++ b/modules/apps/headless-apio/structure/structure-apio-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationCompile project(":apps:headless-apio:structure:structure-apio-api")
+	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless-apio/structured-content/structured-content-apio-test/build.gradle
+++ b/modules/apps/headless-apio/structured-content/structured-content-apio-test/build.gradle
@@ -22,5 +22,6 @@ dependencies {
 	testIntegrationCompile project(":apps:journal:journal-test-util")
 	testIntegrationCompile project(":apps:petra:petra-json-web-service-client")
 	testIntegrationCompile project(":apps:portal-odata:portal-odata-api")
+	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/core/portal-compat/message-boards/portal-message-boards-compat-test/build.gradle
+++ b/modules/core/portal-compat/message-boards/portal-message-boards-compat-test/build.gradle
@@ -4,5 +4,6 @@ dependencies {
 	testIntegrationCompile project(":apps:social:social-activity-test-util")
 	testIntegrationCompile project(":apps:trash:trash-api")
 	testIntegrationCompile project(":apps:trash:trash-test-util")
+	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/sdk/ant-jgit/build.gradle
+++ b/modules/sdk/ant-jgit/build.gradle
@@ -1,3 +1,9 @@
+clean {
+	ext {
+		cleanDeployed = false
+	}
+}
+
 dependencies {
 	compile group: "org.eclipse.jgit", name: "org.eclipse.jgit", version: "4.0.0.201505050340-m2"
 	compile group: "org.slf4j", name: "slf4j-log4j12", version: "1.7.2"

--- a/modules/sdk/gradle-plugins-workspace/build.gradle
+++ b/modules/sdk/gradle-plugins-workspace/build.gradle
@@ -24,6 +24,10 @@ tasks.eclipse {
 }
 
 copyDistBundleZipPluginsSdk {
+	ext {
+		autoClean = false
+	}
+
 	dependsOn downloadPluginsSdk
 	eachFile new StripPathSegmentsAction(1)
 

--- a/modules/sdk/gradle-util/build.gradle
+++ b/modules/sdk/gradle-util/build.gradle
@@ -4,6 +4,10 @@ tasks.eclipse {
 	ext.gradleVersion = gradleVersion
 }
 
+tasks.withType(FindBugs) {
+	excludeFilter = file("fb-exclude.xml")
+}
+
 dependencies {
 	compileOnly fileTree(builtBy: [rootProject.tasks.getByName("extractGradleApi" + gradleVersion.replace(".", ""))], dir: new File(rootProject.buildDir, "gradle-${gradleVersion}"))
 }

--- a/modules/sdk/gradle-util/fb-exclude.xml
+++ b/modules/sdk/gradle-util/fb-exclude.xml
@@ -1,0 +1,19 @@
+<FindBugsFilter>
+	<Match>
+		<Bug pattern="DM_DEFAULT_ENCODING" />
+		<Class name="com.liferay.gradle.util.FileUtil" />
+		<Method name="read" />
+	</Match>
+	<Match>
+		<Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
+		<Class name="com.liferay.gradle.util.FileUtil" />
+		<Or>
+			<Method name="_createClasspathJarFile" />
+			<Method name="get" />
+		</Or>
+	</Match>
+	<Match>
+		<Bug pattern="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS" />
+		<Class name="~com.liferay.gradle.util.FileUtil\$.*" />
+	</Match>
+</FindBugsFilter>

--- a/modules/sdk/gradle-util/src/main/java/com/liferay/gradle/util/FileUtil.java
+++ b/modules/sdk/gradle-util/src/main/java/com/liferay/gradle/util/FileUtil.java
@@ -182,7 +182,11 @@ public class FileUtil {
 			destinationPath = destinationPath.resolve(fileName);
 		}
 
-		Files.createDirectories(destinationPath.getParent());
+		Path destinationParentPath = destinationPath.getParent();
+
+		if (destinationParentPath != null) {
+			Files.createDirectories(destinationParentPath);
+		}
 
 		Files.copy(
 			mirrorsCacheArtifactFile.toPath(), destinationPath,

--- a/modules/third-party/com-google-gdata-sample-appsforyourdomain/build.gradle
+++ b/modules/third-party/com-google-gdata-sample-appsforyourdomain/build.gradle
@@ -46,7 +46,7 @@ downloadSrc {
 	}
 
 	from {
-		zipTree(FileUtil.get(project, "https://gdata-java-client.googlecode.com/files/gdata-samples.java-1.47.1.zip"))
+		zipTree(FileUtil.get(project, "https://storage.googleapis.com/gdata-java-client-binaries/gdata-samples.java-1.47.1.zip"))
 	}
 
 	include "gdata/java/lib/gdata-appsforyourdomain-1.0.jar"

--- a/modules/third-party/org-hibernate-core/patches/LPS-73047.patch
+++ b/modules/third-party/org-hibernate-core/patches/LPS-73047.patch
@@ -2,7 +2,7 @@ diff --git a/org/hibernate/engine/jdbc/BlobProxy.java b/org/hibernate/engine/jdb
 index f81e4b4..16e1d58 100644
 --- a/org/hibernate/engine/jdbc/BlobProxy.java
 +++ b/org/hibernate/engine/jdbc/BlobProxy.java
-@@ -192,10 +192,6 @@ public class BlobProxy implements InvocationHandler {
+@@ -192,10 +192,7 @@ public class BlobProxy implements InvocationHandler {
  	 * @return The class loader appropriate for proxy construction.
  	 */
  	private static ClassLoader getProxyClassLoader() {
@@ -20,7 +20,7 @@ diff --git a/org/hibernate/engine/jdbc/ClobProxy.java b/org/hibernate/engine/jdb
 index 97ae85a..0302dfd 100644
 --- a/org/hibernate/engine/jdbc/ClobProxy.java
 +++ b/org/hibernate/engine/jdbc/ClobProxy.java
-@@ -218,10 +218,6 @@ public class ClobProxy implements InvocationHandler {
+@@ -218,10 +218,7 @@ public class ClobProxy implements InvocationHandler {
  	 * @return The class loader appropriate for proxy construction.
  	 */
  	protected static ClassLoader getProxyClassLoader() {
@@ -38,7 +38,7 @@ diff --git a/org/hibernate/engine/jdbc/NClobProxy.java b/org/hibernate/engine/jd
 index e5a1739..a624b02 100644
 --- a/org/hibernate/engine/jdbc/NClobProxy.java
 +++ b/org/hibernate/engine/jdbc/NClobProxy.java
-@@ -96,10 +96,6 @@ public class NClobProxy extends ClobProxy {
+@@ -96,10 +96,7 @@ public class NClobProxy extends ClobProxy {
  	 * @return The class loader appropriate for proxy construction.
  	 */
  	protected static ClassLoader getProxyClassLoader() {
@@ -56,7 +56,7 @@ diff --git a/org/hibernate/engine/jdbc/SerializableBlobProxy.java b/org/hibernat
 index 1f857ee..2c4dfc8 100644
 --- a/org/hibernate/engine/jdbc/SerializableBlobProxy.java
 +++ b/org/hibernate/engine/jdbc/SerializableBlobProxy.java
-@@ -103,10 +103,6 @@ public class SerializableBlobProxy implements InvocationHandler, Serializable {
+@@ -103,10 +103,7 @@ public class SerializableBlobProxy implements InvocationHandler, Serializable {
  	 * @return The class loader appropriate for proxy construction.
  	 */
  	public static ClassLoader getProxyClassLoader() {
@@ -74,7 +74,7 @@ diff --git a/org/hibernate/engine/jdbc/SerializableClobProxy.java b/org/hibernat
 index 87ee1ee..7e63404 100644
 --- a/org/hibernate/engine/jdbc/SerializableClobProxy.java
 +++ b/org/hibernate/engine/jdbc/SerializableClobProxy.java
-@@ -102,10 +102,6 @@ public class SerializableClobProxy implements InvocationHandler, Serializable {
+@@ -102,10 +102,7 @@ public class SerializableClobProxy implements InvocationHandler, Serializable {
  	 * @return The class loader appropriate for proxy construction.
  	 */
  	public static ClassLoader getProxyClassLoader() {

--- a/modules/util/ruby-gems/README.markdown
+++ b/modules/util/ruby-gems/README.markdown
@@ -3,12 +3,12 @@
 The Ruby Gems module provides a set of Ruby gems that Liferay can access when
 using JRuby. The gems included with this module are listed below:
 
-- `chunky_png-1.3.8`
+- `chunky_png-1.3.11`
 - `compass-1.0.1`
 - `compass-core-1.0.3`
 - `compass-import-once-1.0.5`
-- `ffi-1.9.18-java`
-- `multi_json-1.12.2`
-- `rb-fsevent-0.10.2`
-- `rb-inotify-0.9.10`
+- `ffi-1.9.25-java`
+- `multi_json-1.13.1`
+- `rb-fsevent-0.10.3`
+- `rb-inotify-0.10.0`
 - `sass-3.4.25`

--- a/portal-web/build.xml
+++ b/portal-web/build.xml
@@ -372,7 +372,7 @@ ${oversize.files.jsp}</fail>
 	</target>
 
 	<target name="update-gradle-cache">
-		<gradle-execute forcedcacheenabled="false" task="updateGradleCache">
+		<gradle-execute forcedcacheenabled="false" setupbinariescache="false" task="updateGradleCache">
 			<arg value="--build-file=build-test.gradle" />
 			<arg value="-Dmaven.local.ignore=true" />
 		</gradle-execute>


### PR DESCRIPTION
Hi Brian, there's two `baseline` failures that aren't caused by changes in this pull (left those as-is for now).

The Ant `update-gradle-cache` target works, so the cache can be regenerated whenever its needed.  If you're interested in what changed, those changes are [here](https://github.com/brianchandotcom/liferay-portal/pull/66269#issue-241258328)