### PR TITLE
LPS-87075 UserTracker table shows duplicate records for each session/sessionid

### DIFF
--- a/portal-impl/src/com/liferay/portal/liveusers/LiveUsers.java
+++ b/portal-impl/src/com/liferay/portal/liveusers/LiveUsers.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.liveusers;
 
 import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
+import com.liferay.portal.kernel.cluster.ClusterMasterExecutorUtil;
 import com.liferay.portal.kernel.cluster.ClusterNode;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -242,11 +243,13 @@ public class LiveUsers {
 		}
 
 		try {
-			UserTrackerLocalServiceUtil.addUserTracker(
-				userTracker.getCompanyId(), userTracker.getUserId(),
-				userTracker.getModifiedDate(), sessionId,
-				userTracker.getRemoteAddr(), userTracker.getRemoteHost(),
-				userTracker.getUserAgent(), userTracker.getPaths());
+			if (ClusterMasterExecutorUtil.isMaster()) {
+				UserTrackerLocalServiceUtil.addUserTracker(
+					userTracker.getCompanyId(), userTracker.getUserId(),
+					userTracker.getModifiedDate(), sessionId,
+					userTracker.getRemoteAddr(), userTracker.getRemoteHost(),
+					userTracker.getUserAgent(), userTracker.getPaths());
+			}
 		}
 		catch (Exception e) {
 			if (_log.isWarnEnabled()) {


### PR DESCRIPTION
This is an update for [LPS-87075](https://issues.liferay.com/browse/LPS-87075).

The summary I wrote in my conversation with @ChrisKian: 

> from what I can tell, there are two scenarios where the `signOut` method would be called: when the `LiveUsersMessageListener` receives a "signOut" message, and when a cluster node is removed
in the case of the message, the fix would work fine because all nodes would execute the `signOut`, including the master node
and when a node is removed, it does not necessarily end a user's session, so we don't want to add an entry to the UserTracker table yet.

/cc @pei-jung @stsquared99 @alee8888 @ChrisKian

Links to passing tests: https://github.com/drewbrokke/liferay-portal/pull/710#issuecomment-452130554

-----------
From @ChrisKian:

> https://issues.liferay.com/browse/LPS-87075
>
> cc@amadeafejes
>
> Hey Drew,
> There has been ongoing discussion, specifically on LPP-31934 regarding how live users should function.  This is the best solution imo.
> Let me know if you have any questions.  Thanks!
