### PR TITLE
LRQA-45922 | master

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1023,7 +1023,6 @@
     test.batch.axis.max.size[modules-semantic-versioning-jdk8]=30
     test.batch.axis.max.size[modules-unit-jdk8]=250
     test.batch.axis.max.size[modules-unit-project-templates-jdk8]=250
-    test.batch.axis.max.size[plugins-compile-jdk8]=200
     test.batch.axis.max.size[semantic-versioning-jdk8]=50
     test.batch.axis.max.size[tck-jdk8]=50
     test.batch.axis.max.size[unit-jdk8]=5000
@@ -1202,9 +1201,6 @@
         modules-semantic-versioning-jdk8,\
         modules-unit-jdk8,\
         modules-unit-project-templates-jdk8,\
-        plugins-compile-jdk8,\
-        plugins-functional-bundle-tomcat-mysql57-jdk8,\
-        plugins-functional-tomcat90-mysql57-jdk8,\
         pmd-jdk8,\
         #portal-frontend-js-lint-jdk8,\
         portal-license-jdk8,\
@@ -1229,14 +1225,6 @@
         subrepository-pmd-jdk8,\
         subrepository-source-format-jdk8,\
         subrepository-unit-jdk8
-
-    test.batch.plugin.names.includes[plugins-compile-jdk8]=\
-        hooks/*/build.xml,\
-        layoutpl/*/build.xml,\
-        portlets/*/build.xml,\
-        shared/*/build.xml,\
-        themes/*/build.xml,\
-        webs/*/build.xml
 
     #test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk8]=(portal.smoke == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mysql)
     test.batch.run.property.query[functional-smoke-jboss71-mysql57-jdk8]=(portal.smoke == true) AND (app.server.types ~ jboss) AND (database.types == null OR database.types ~ mysql)
@@ -1328,7 +1316,6 @@
     test.batch.size[modules-integration-postgresql10-jdk8]=20
     test.batch.size[modules-integration-sybase160-jdk8]=20
     test.batch.size[modules-unit-jdk8]=3
-    test.batch.size[plugins-compile-jdk8]=1
     test.batch.size[pmd-jdk8]=1
     test.batch.size[portal-frontend-js-lint-jdk8]=1
     test.batch.size[portal-license-jdk8]=1


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-45922

Backport https://github.com/brianchandotcom/liferay-portal-ee/pull/22945

The only current usage I can find for the 7.0 plugins on 7.1+ is for some specific QA testing. Those tests will remain, but we do not need to continue to maintain compile of all the 7.0 plugins on the newer releases

CC @shuyangzhou