### PR TITLE
[Read Inside] LPS-88891 SF

### DIFF
--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -29,6 +29,6 @@ context.put("viewType", "tree");
 
 <soy:component-renderer
 	context="<%= context %>"
-	module='<%= npmResolvedPackageName + "/js/SelectCategory.es" %>'
+	module="js/SelectCategory.es"
 	templateNamespace="com.liferay.asset.categories.selector.web.SelectCategory.render"
 />

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/filter.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/filter.jsp
@@ -69,7 +69,7 @@
 
 				<soy:component-renderer
 					context="<%= context %>"
-					module='<%= npmResolvedPackageName + "/js/AutoField.es" %>'
+					module="js/AutoField.es"
 					templateNamespace="com.liferay.asset.list.web.AutoField.render"
 				/>
 			</liferay-frontend:fieldset>

--- a/modules/apps/document-library/document-library-preview-image/src/main/resources/META-INF/resources/preview/view.jsp
+++ b/modules/apps/document-library/document-library-preview-image/src/main/resources/META-INF/resources/preview/view.jsp
@@ -41,6 +41,6 @@ context.put("spritemap", themeDisplay.getPathThemeImages() + "/lexicon/icons.svg
 
 <soy:component-renderer
 	context="<%= context %>"
-	module='<%= npmResolvedPackageName + "/preview/js/ImagePreviewer.es" %>'
+	module="preview/js/ImagePreviewer.es"
 	templateNamespace="com.liferay.document.library.preview.ImagePreviewer.render"
 />

--- a/modules/apps/document-library/document-library-preview-pdf/src/main/resources/META-INF/resources/preview/view.jsp
+++ b/modules/apps/document-library/document-library-preview-pdf/src/main/resources/META-INF/resources/preview/view.jsp
@@ -54,6 +54,6 @@ context.put("totalPages", previewFileCount);
 <soy:component-renderer
 	componentId='<%= renderResponse.getNamespace() + randomNamespace + "previewFile" %>'
 	context="<%= context %>"
-	module='<%= npmResolvedPackageName + "/preview/js/PdfPreviewer.es" %>'
+	module="preview/js/PdfPreviewer.es"
 	templateNamespace="com.liferay.document.library.preview.PdfPreviewer.render"
 />

--- a/modules/apps/document-library/document-library-preview-video/src/main/resources/META-INF/resources/preview/view.jsp
+++ b/modules/apps/document-library/document-library-preview-video/src/main/resources/META-INF/resources/preview/view.jsp
@@ -51,6 +51,6 @@ context.put("videoPosterURL", (String)request.getAttribute(DLPreviewVideoWebKeys
 <soy:component-renderer
 	componentId='<%= renderResponse.getNamespace() + randomNamespace + "previewVideo" %>'
 	context="<%= context %>"
-	module='<%= npmResolvedPackageName + "/preview/js/VideoPreviewer.es" %>'
+	module="preview/js/VideoPreviewer.es"
 	templateNamespace="com.liferay.document.library.preview.VideoPreviewer.render"
 />

--- a/modules/apps/fragment/fragment-display-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/fragment/fragment-display-web/src/main/resources/META-INF/resources/view.jsp
@@ -47,7 +47,7 @@ if (fragmentEntryLink == null) {
 
 				<soy:component-renderer
 					context="<%= fragmentEntryDisplayContext.getSoyContext() %>"
-					module='<%= npmResolvedPackageName + "/js/FragmentEntryDisplay.es" %>'
+					module="js/FragmentEntryDisplay.es"
 					templateNamespace="com.liferay.fragment.display.web.FragmentEntryDisplay.render"
 				/>
 			</c:when>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_entry.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_entry.jsp
@@ -33,6 +33,6 @@ renderResponse.setTitle(title);
 
 <soy:component-renderer
 	context="<%= fragmentDisplayContext.getFragmentEditorDisplayContext() %>"
-	module='<%= npmResolvedPackageName + "/js/FragmentEditor.es" %>'
+	module="js/FragmentEditor.es"
 	templateNamespace="com.liferay.fragment.web.FragmentEditor.render"
 />

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/JSBundleTracker.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/JSBundleTracker.java
@@ -25,8 +25,10 @@ import org.osgi.framework.Bundle;
  */
 public interface JSBundleTracker {
 
-	public void addedBundle(Bundle bundle, JSBundle jsBundle);
+	public void addedJSBundle(
+		JSBundle jsBundle, Bundle bundle, NPMRegistry npmRegistry);
 
-	public void removedBundle(Bundle bundle, JSBundle jsBundle);
+	public void removedJSBundle(
+		JSBundle jsBundle, Bundle bundle, NPMRegistry npmRegistry);
 
 }

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/JSBundleTracker.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/JSBundleTracker.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.loader.modules.extender.npm;
+
+import org.osgi.framework.Bundle;
+
+/**
+ * This is an interface for registering OSGi services that get notified whenever
+ * the {@link NPMRegistry} is updated.
+ *
+ * @author Iván Zaera
+ * @review
+ */
+public interface JSBundleTracker {
+
+	public void addedBundle(Bundle bundle, JSBundle jsBundle);
+
+	public void removedBundle(Bundle bundle, JSBundle jsBundle);
+
+}

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/NPMResolvedPackageNameUtil.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/NPMResolvedPackageNameUtil.java
@@ -34,6 +34,10 @@ public class NPMResolvedPackageNameUtil {
 				NPMResolvedPackageNameUtil.class.getName(),
 				npmResolvedPackageName);
 		}
+		else {
+			servletContext.removeAttribute(
+				NPMResolvedPackageNameUtil.class.getName());
+		}
 	}
 
 }

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/NPMRegistryImpl.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/NPMRegistryImpl.java
@@ -444,7 +444,8 @@ public class NPMRegistryImpl implements NPMRegistry {
 			if (jsBundle != null) {
 				for (JSBundleTracker jsBundleTracker : _jsBundleTrackers) {
 					try {
-						jsBundleTracker.addedBundle(bundle, jsBundle);
+						jsBundleTracker.addedJSBundle(
+							jsBundle, bundle, NPMRegistryImpl.this);
 					}
 					catch (Exception e) {
 						_log.error(
@@ -470,7 +471,8 @@ public class NPMRegistryImpl implements NPMRegistry {
 
 			for (JSBundleTracker jsBundleTracker : _jsBundleTrackers) {
 				try {
-					jsBundleTracker.removedBundle(bundle, jsBundle);
+					jsBundleTracker.removedJSBundle(
+						jsBundle, bundle, NPMRegistryImpl.this);
 				}
 				catch (Exception e) {
 					_log.error(

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/NPMResolvedPackageNameRegistrar.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/NPMResolvedPackageNameRegistrar.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.loader.modules.extender.internal.npm;
+
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolvedPackageNameUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+
+import javax.servlet.ServletContext;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Filter;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+/**
+ * @author Iván Zaera Avellón
+ */
+public class NPMResolvedPackageNameRegistrar
+	implements ServiceTrackerCustomizer<ServletContext, ServletContext> {
+
+	public NPMResolvedPackageNameRegistrar(
+			BundleContext bundleContext, Bundle bundle,
+			String npmResolvedPackageName)
+		throws InvalidSyntaxException {
+
+		_bundleContext = bundleContext;
+		_npmResolvedPackageName = npmResolvedPackageName;
+
+		_serviceTracker = new ServiceTracker<>(
+			_bundleContext, _getServletContextFilter(bundle), this);
+	}
+
+	@Override
+	public ServletContext addingService(
+		ServiceReference<ServletContext> serviceReference) {
+
+		try {
+			ServletContext servletContext = _bundleContext.getService(
+				serviceReference);
+
+			NPMResolvedPackageNameUtil.set(
+				servletContext, _npmResolvedPackageName);
+		}
+		finally {
+			_bundleContext.ungetService(serviceReference);
+		}
+
+		close();
+
+		return null;
+	}
+
+	public void close() {
+		_serviceTracker.close();
+	}
+
+	@Override
+	public void modifiedService(
+		ServiceReference<ServletContext> reference, ServletContext service) {
+	}
+
+	public void open() {
+		_serviceTracker.open();
+	}
+
+	@Override
+	public void removedService(
+		ServiceReference<ServletContext> reference, ServletContext service) {
+	}
+
+	private Filter _getServletContextFilter(Bundle bundle)
+		throws InvalidSyntaxException {
+
+		return _bundleContext.createFilter(
+			StringBundler.concat(
+				"(&(objectClass=", ServletContext.class.getName(), ")",
+				"(service.bundleid=", String.valueOf(bundle.getBundleId()),
+				"))"));
+	}
+
+	private final BundleContext _bundleContext;
+	private final String _npmResolvedPackageName;
+	private final ServiceTracker<ServletContext, ServletContext>
+		_serviceTracker;
+
+}

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/NPMResolverJSBundleTracker.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/NPMResolverJSBundleTracker.java
@@ -58,8 +58,8 @@ public class NPMResolverJSBundleTracker implements JSBundleTracker {
 				new NPMResolvedPackageNameRegistrar(
 					_bundleContext, bundle, npmResolvedPackageName);
 
-			_npmResolvedPackageNameRegistrarMap.put(bundle,
-				npmResolvedPackageNameRegistrar);
+			_npmResolvedPackageNameRegistrarMap.put(
+				bundle, npmResolvedPackageNameRegistrar);
 
 			npmResolvedPackageNameRegistrar.open();
 		}

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/NPMResolverJSBundleTracker.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/NPMResolverJSBundleTracker.java
@@ -47,7 +47,9 @@ import org.osgi.service.component.annotations.Reference;
 public class NPMResolverJSBundleTracker implements JSBundleTracker {
 
 	@Override
-	public void addedBundle(Bundle bundle, JSBundle jsBundle) {
+	public void addedJSBundle(
+		JSBundle jsBundle, Bundle bundle, NPMRegistry npmRegistry) {
+
 		ServiceReference<ServletContext> serviceReference =
 			_getServletContextReference(bundle);
 
@@ -60,7 +62,8 @@ public class NPMResolverJSBundleTracker implements JSBundleTracker {
 
 		try {
 			NPMResolvedPackageNameUtil.set(
-				servletContext, _getNpmResolvedPackageName(bundle));
+				servletContext,
+				_getNpmResolvedPackageName(bundle, npmRegistry));
 		}
 		finally {
 			_bundleContext.ungetService(serviceReference);
@@ -68,7 +71,8 @@ public class NPMResolverJSBundleTracker implements JSBundleTracker {
 	}
 
 	@Override
-	public void removedBundle(Bundle bundle, JSBundle jsBundle) {
+	public void removedJSBundle(
+		JSBundle jsBundle, Bundle bundle, NPMRegistry npmRegistry) {
 	}
 
 	@Activate
@@ -76,10 +80,12 @@ public class NPMResolverJSBundleTracker implements JSBundleTracker {
 		_bundleContext = bundleContext;
 	}
 
-	private String _getNpmResolvedPackageName(Bundle bundle) {
+	private String _getNpmResolvedPackageName(
+		Bundle bundle, NPMRegistry npmRegistry) {
+
 		try {
 			NPMResolver npmResolver = new NPMResolverImpl(
-				bundle, _jsonFactory, _npmRegistry);
+				bundle, _jsonFactory, npmRegistry);
 
 			URL url = bundle.getResource("META-INF/resources/package.json");
 
@@ -134,8 +140,5 @@ public class NPMResolverJSBundleTracker implements JSBundleTracker {
 
 	@Reference
 	private JSONFactory _jsonFactory;
-
-	@Reference
-	private NPMRegistry _npmRegistry;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-soy/build.gradle
+++ b/modules/apps/frontend-taglib/frontend-taglib-soy/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":apps:portal-template:portal-template-soy-api")
 	compileOnly project(":apps:portal-template:portal-template-soy-renderer-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/frontend-taglib/frontend-taglib-soy/src/main/java/com/liferay/frontend/taglib/soy/servlet/taglib/TemplateRendererTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-soy/src/main/java/com/liferay/frontend/taglib/soy/servlet/taglib/TemplateRendererTag.java
@@ -14,6 +14,7 @@
 
 package com.liferay.frontend.taglib.soy.servlet.taglib;
 
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolvedPackageNameUtil;
 import com.liferay.frontend.taglib.soy.internal.util.SoyComponentRendererProvider;
 import com.liferay.frontend.taglib.soy.internal.util.SoyContextFactoryUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
@@ -30,6 +31,7 @@ import com.liferay.taglib.util.ParamAndPropertyAncestorTagImpl;
 import java.util.Map;
 import java.util.Set;
 
+import javax.servlet.ServletRequest;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
 
@@ -94,11 +96,24 @@ public class TemplateRendererTag extends ParamAndPropertyAncestorTagImpl {
 	}
 
 	public String getModule() {
-		return _module;
+		if (!_useNamespace) {
+			return _module;
+		}
+
+		ServletRequest servletRequest = pageContext.getRequest();
+
+		String namespace = NPMResolvedPackageNameUtil.get(
+			servletRequest.getServletContext());
+
+		return namespace + "/" + _module;
 	}
 
 	public String getTemplateNamespace() {
 		return _templateNamespace;
+	}
+
+	public boolean getUseNamespace() {
+		return _useNamespace;
 	}
 
 	public void putHTMLValue(String key, String value) {
@@ -147,6 +162,10 @@ public class TemplateRendererTag extends ParamAndPropertyAncestorTagImpl {
 		_templateNamespace = namespace;
 	}
 
+	public void setUseNamespace(boolean useNamespace) {
+		_useNamespace = useNamespace;
+	}
+
 	public void setWrapper(boolean wrapper) {
 		_wrapper = wrapper;
 	}
@@ -159,6 +178,7 @@ public class TemplateRendererTag extends ParamAndPropertyAncestorTagImpl {
 			_hydrate = null;
 			_module = null;
 			_templateNamespace = null;
+			_useNamespace = true;
 			_wrapper = null;
 		}
 	}
@@ -236,6 +256,7 @@ public class TemplateRendererTag extends ParamAndPropertyAncestorTagImpl {
 	private Boolean _hydrate;
 	private String _module;
 	private String _templateNamespace;
+	private Boolean _useNamespace = true;
 	private Boolean _wrapper;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-soy/src/main/resources/META-INF/resources/soy.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-soy/src/main/resources/META-INF/resources/soy.tld
@@ -44,6 +44,13 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description><![CDATA[Whether to use the resolved npm portlet namespace, to avoid name conflicts. The default value is <code>true</code>.]]></description>
+			<name>useNamespace</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>boolean</type>
+		</attribute>
+		<attribute>
 			<description></description>
 			<name>wrapper</name>
 			<required>false</required>
@@ -89,6 +96,13 @@
 			<name>templateNamespace</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description><![CDATA[Whether to use the resolved npm portlet namespace, to avoid name conflicts. The default value is <code>true</code>.]]></description>
+			<name>useNamespace</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>boolean</type>
 		</attribute>
 		<attribute>
 			<description></description>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/DefineObjectsTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/DefineObjectsTag.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.taglib.util.TagResourceBundleUtil;
 
 import java.util.Locale;
@@ -71,9 +72,13 @@ public class DefineObjectsTag extends TagSupport {
 				"windowState", liferayPortletRequest.getWindowState());
 		}
 
-		pageContext.setAttribute(
-			"npmResolvedPackageName",
-			NPMResolvedPackageNameUtil.get(request.getServletContext()));
+		String npmResolvedPackageName = NPMResolvedPackageNameUtil.get(
+			request.getServletContext());
+
+		if (Validator.isNotNull(npmResolvedPackageName)) {
+			pageContext.setAttribute(
+				"npmResolvedPackageName", npmResolvedPackageName);
+		}
 
 		if (_overrideResourceBundle != null) {
 			pageContext.setAttribute("resourceBundle", _overrideResourceBundle);

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -124,7 +124,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 		<c:if test="<%= journalWebConfiguration.changeableDefaultLanguage() %>">
 			<soy:component-renderer
 				context="<%= journalEditArticleDisplayContext.getChangeDefaultLanguageSoyContext() %>"
-				module='<%= npmResolvedPackageName + "/js/ChangeDefaultLanguage.es" %>'
+				module="js/ChangeDefaultLanguage.es"
 				templateNamespace="com.liferay.journal.web.ChangeDefaultLanguage.render"
 			/>
 		</c:if>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_folder.jsp
@@ -29,6 +29,6 @@ context.put("pathThemeImages", themeDisplay.getPathThemeImages());
 
 <soy:component-renderer
 	context="<%= context %>"
-	module='<%= npmResolvedPackageName + "/js/SelectFolder.es" %>'
+	module="js/SelectFolder.es"
 	templateNamespace="com.liferay.journal.web.SelectFolder.render"
 />

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/edit_layout_page_template_entry.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/edit_layout_page_template_entry.jsp
@@ -36,7 +36,7 @@ renderResponse.setTitle(layoutPageTemplateDisplayContext.getLayoutPageTemplateEn
 <soy:component-renderer
 	componentId='<%= renderResponse.getNamespace() + "fragmentsEditor" %>'
 	context="<%= fragmentsEditorDisplayContext.getEditorContext() %>"
-	module='<%= npmResolvedPackageName + "/js/fragments_editor/FragmentsEditor.es" %>'
+	module="js/fragments_editor/FragmentsEditor.es"
 	templateNamespace="com.liferay.layout.admin.web.FragmentsEditor.render"
 />
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/view_layouts.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/view_layouts.jsp
@@ -68,7 +68,7 @@
 
 					<soy:component-renderer
 						context="<%= context %>"
-						module='<%= npmResolvedPackageName + "/js/miller_columns/Layout.es" %>'
+						module="js/miller_columns/Layout.es"
 						templateNamespace="com.liferay.layout.admin.web.Layout.render"
 					/>
 				</c:otherwise>

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/resources/META-INF/resources/view.jsp
@@ -33,6 +33,7 @@ FragmentsEditorDisplayContext fragmentsEditorDisplayContext = (FragmentsEditorDi
 	context="<%= fragmentsEditorDisplayContext.getFragmentsEditorSidebarContext() %>"
 	module="layout-admin-web/js/fragments_editor/components/sidebar/FragmentsEditorSidebar.es"
 	templateNamespace="com.liferay.layout.admin.web.FragmentsEditorSidebar.render"
+	useNamespace="<%= false %>"
 />
 
 <soy:component-renderer
@@ -40,6 +41,7 @@ FragmentsEditorDisplayContext fragmentsEditorDisplayContext = (FragmentsEditorDi
 	context="<%= fragmentsEditorDisplayContext.getFragmentEntryLinkListContext() %>"
 	module="layout-admin-web/js/fragments_editor/components/fragment_entry_link/FragmentEntryLinkList.es"
 	templateNamespace="com.liferay.layout.admin.web.FragmentEntryLinkList.render"
+	useNamespace="<%= false %>"
 />
 
 <%

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/resources/META-INF/resources/view_toolbar.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/resources/META-INF/resources/view_toolbar.jsp
@@ -25,4 +25,5 @@ FragmentsEditorDisplayContext fragmentsEditorDisplayContext = (FragmentsEditorDi
 	context="<%= fragmentsEditorDisplayContext.getFragmentsEditorToolbarContext() %>"
 	module="layout-admin-web/js/fragments_editor/components/toolbar/FragmentsEditorToolbar.es"
 	templateNamespace="com.liferay.layout.admin.web.FragmentsEditorToolbar.render"
+	useNamespace="<%= false %>"
 />

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/background_styles.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/background_styles.jsp
@@ -27,6 +27,6 @@ context.put("name", renderResponse.getNamespace() + "backgroundColor");
 
 <soy:component-renderer
 	context="<%= context %>"
-	module='<%= npmResolvedPackageName + "/js/ColorPickerInput.es" %>'
+	module="js/ColorPickerInput.es"
 	templateNamespace="com.liferay.portlet.configuration.css.web.ColorPickerInput.render"
 />

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/border_styles.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/border_styles.jsp
@@ -31,7 +31,7 @@
 
 			<soy:component-renderer
 				context="<%= contextUseForAllWidth %>"
-				module='<%= npmResolvedPackageName + "/js/ToggleDisableInputs.es" %>'
+				module="js/ToggleDisableInputs.es"
 				templateNamespace="com.liferay.portlet.configuration.css.web.ToggleDisableInputs.render"
 			/>
 
@@ -88,7 +88,7 @@
 
 			<soy:component-renderer
 				context="<%= contextUseForAllStyle %>"
-				module='<%= npmResolvedPackageName + "/js/ToggleDisableInputs.es" %>'
+				module="js/ToggleDisableInputs.es"
 				templateNamespace="com.liferay.portlet.configuration.css.web.ToggleDisableInputs.render"
 			/>
 
@@ -156,7 +156,7 @@
 
 			<soy:component-renderer
 				context="<%= contextUseForAllColor %>"
-				module='<%= npmResolvedPackageName + "/js/ToggleDisableInputs.es" %>'
+				module="js/ToggleDisableInputs.es"
 				templateNamespace="com.liferay.portlet.configuration.css.web.ToggleDisableInputs.render"
 			/>
 
@@ -172,7 +172,7 @@
 
 			<soy:component-renderer
 				context="<%= contextBorderTop %>"
-				module='<%= npmResolvedPackageName + "/js/ColorPickerInput.es" %>'
+				module="js/ColorPickerInput.es"
 				templateNamespace="com.liferay.portlet.configuration.css.web.ColorPickerInput.render"
 			/>
 
@@ -190,7 +190,7 @@
 
 			<soy:component-renderer
 				context="<%= contextBorderRight %>"
-				module='<%= npmResolvedPackageName + "/js/ColorPickerInput.es" %>'
+				module="js/ColorPickerInput.es"
 				templateNamespace="com.liferay.portlet.configuration.css.web.ColorPickerInput.render"
 			/>
 
@@ -208,7 +208,7 @@
 
 			<soy:component-renderer
 				context="<%= contextBorderBottom %>"
-				module='<%= npmResolvedPackageName + "/js/ColorPickerInput.es" %>'
+				module="js/ColorPickerInput.es"
 				templateNamespace="com.liferay.portlet.configuration.css.web.ColorPickerInput.render"
 			/>
 
@@ -226,7 +226,7 @@
 
 			<soy:component-renderer
 				context="<%= contextBorderLeft %>"
-				module='<%= npmResolvedPackageName + "/js/ColorPickerInput.es" %>'
+				module="js/ColorPickerInput.es"
 				templateNamespace="com.liferay.portlet.configuration.css.web.ColorPickerInput.render"
 			/>
 		</aui:fieldset>

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/general.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/general.jsp
@@ -28,7 +28,7 @@ contextUseForAllTitle.put("inputSelector", ".custom-title input");
 
 <soy:component-renderer
 	context="<%= contextUseForAllTitle %>"
-	module='<%= npmResolvedPackageName + "/js/ToggleDisableInputs.es" %>'
+	module="js/ToggleDisableInputs.es"
 	templateNamespace="com.liferay.portlet.configuration.css.web.ToggleDisableInputs.render"
 />
 

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/margin_and_padding.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/margin_and_padding.jsp
@@ -31,7 +31,7 @@
 
 			<soy:component-renderer
 				context="<%= contextUseForAllPadding %>"
-				module='<%= npmResolvedPackageName + "/js/ToggleDisableInputs.es" %>'
+				module="js/ToggleDisableInputs.es"
 				templateNamespace="com.liferay.portlet.configuration.css.web.ToggleDisableInputs.render"
 			/>
 
@@ -88,7 +88,7 @@
 
 			<soy:component-renderer
 				context="<%= contextUseForAllMargin %>"
-				module='<%= npmResolvedPackageName + "/js/ToggleDisableInputs.es" %>'
+				module="js/ToggleDisableInputs.es"
 				templateNamespace="com.liferay.portlet.configuration.css.web.ToggleDisableInputs.render"
 			/>
 

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/text_styles.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/text_styles.jsp
@@ -61,7 +61,7 @@ DecimalFormat decimalFormat = portletConfigurationCSSPortletDisplayContext.getDe
 
 		<soy:component-renderer
 			context="<%= context %>"
-			module='<%= npmResolvedPackageName + "/js/ColorPickerInput.es" %>'
+			module="js/ColorPickerInput.es"
 			templateNamespace="com.liferay.portlet.configuration.css.web.ColorPickerInput.render"
 		/>
 

--- a/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/view_site_navigation_menu_items.jsp
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/view_site_navigation_menu_items.jsp
@@ -42,7 +42,7 @@ SiteNavigationMenuItemItemSelectorViewDisplayContext siteNavigationMenuItemItemS
 
 		<soy:component-renderer
 			context="<%= context %>"
-			module='<%= npmResolvedPackageName + "/js/SelectSiteNavigationMenuItem.es" %>'
+			module="js/SelectSiteNavigationMenuItem.es"
 			templateNamespace="com.liferay.site.navigation.item.selector.web.SelectSiteNavigationMenuItem.render"
 		/>
 	</c:when>


### PR DESCRIPTION
Hey @brianchandotcom, we're continuing with the cleanup around this feature for simplicity. This PR includes:
-  Improved bundle lifecycle management (we have many race conditions that cause weird servletContexts or bundles to be registered). @adolfopa proposed an improvement that we'll explore tomorrow about using a `ServiceTrackerList`
- Implicit `npmResolvedPackageName`, so it's no longer necessary to pass it to the `soy:component-renderer` tag if you're using a module from the same bundle.
- Tag attribute `useNamespace` in `soy:component-renderer` so we can opt out of this. We considered a more implicit approach (if path starts with `/`, for example), but we're still not sure how we'll end up supporting this, so I'd rather wait a little bit for it to clarify.

We ran the full set of tests at https://github.com/jbalsas/liferay-portal/pull/1592#issuecomment-454434715 and things look good.

Some teams are having troubles developing right now, because running `gw deploy` will bring up the race conditions, so unless there's anything big, could you push this and let us know if you'd like to change some things so we can iterate tomorrow over it?

Thanks!!

/cc @liferay-continuous-integration 