### PR TITLE
LPS-88922 UAD data exports file shows 0kb

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/TextFormatter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TextFormatter.java
@@ -198,9 +198,13 @@ public class TextFormatter {
 	}
 
 	public static String formatStorageSize(double size, Locale locale) {
-		String suffix = _STORAGE_SIZE_SUFFIX_KB;
+		String suffix = _STORAGE_SIZE_SUFFIX_B;
 
-		size = size / _STORAGE_SIZE_DENOMINATOR;
+		if (size >= _STORAGE_SIZE_DENOMINATOR) {
+			suffix = _STORAGE_SIZE_SUFFIX_KB;
+
+			size = size / _STORAGE_SIZE_DENOMINATOR;
+		}
 
 		if (size >= _STORAGE_SIZE_DENOMINATOR) {
 			suffix = _STORAGE_SIZE_SUFFIX_MB;
@@ -216,7 +220,9 @@ public class TextFormatter {
 
 		NumberFormat numberFormat = NumberFormat.getInstance(locale);
 
-		if (suffix.equals(_STORAGE_SIZE_SUFFIX_KB)) {
+		if (suffix.equals(_STORAGE_SIZE_SUFFIX_B) ||
+			suffix.equals(_STORAGE_SIZE_SUFFIX_KB)) {
+
 			numberFormat.setMaximumFractionDigits(0);
 		}
 		else {
@@ -420,6 +426,8 @@ public class TextFormatter {
 	}
 
 	private static final double _STORAGE_SIZE_DENOMINATOR = 1024.0;
+
+	private static final String _STORAGE_SIZE_SUFFIX_B = "B";
 
 	private static final String _STORAGE_SIZE_SUFFIX_GB = "GB";
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/TextFormatterTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/TextFormatterTest.java
@@ -119,6 +119,16 @@ public class TextFormatterTest {
 	}
 
 	@Test
+	public void testformatStorageSizeOneB() throws Exception {
+		long bytes = 1;
+
+		Assert.assertEquals(
+			"1B", TextFormatter.formatStorageSize(bytes, LocaleUtil.SPAIN));
+		Assert.assertEquals(
+			"1B", TextFormatter.formatStorageSize(bytes, LocaleUtil.US));
+	}
+
+	@Test
 	public void testformatStorageSizeOneGB() throws Exception {
 		long bytes = 1024 * 1024 * 1024;
 


### PR DESCRIPTION
This is an update for [LPS-88922](https://issues.liferay.com/browse/LPS-88922).

Hey Brian, this adds a new display for file size. When the size is less than one kilobyte, it will display as "2B", similarly to the Unix pattern of what is displayed when you run `ls -la`.

Relevant test results [here](https://github.com/drewbrokke/liferay-portal/pull/719#issuecomment-454243693) 
TextFormatterTest results [here](https://test-1-21.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/212676/AXIS_VARIABLE=0,label_exp=!master/testReport/com.liferay.portal.kernel.util/TextFormatterTest/)
New test case results [here](https://test-1-21.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/212676/AXIS_VARIABLE=0,label_exp=!master/testReport/com.liferay.portal.kernel.util/TextFormatterTest/testformatStorageSizeOneB/)

/cc @pei-jung @stsquared99 @alee8888 @ChrisKian