### PR TITLE
LPS-87976 Do not require UID field in document

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslator.java
@@ -16,6 +16,8 @@ package com.liferay.portal.search.elasticsearch6.internal.search.engine.adapter.
 
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchClientResolver;
 import com.liferay.portal.search.elasticsearch6.internal.document.DefaultElasticsearchDocumentFactory;
 import com.liferay.portal.search.elasticsearch6.internal.document.ElasticsearchDocumentFactory;
@@ -90,9 +92,7 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 			IndexRequestBuilder indexRequestBuilder =
 				IndexAction.INSTANCE.newRequestBuilder(client);
 
-			Document document = indexDocumentRequest.getDocument();
-
-			indexRequestBuilder.setId(document.getUID());
+			setIndexRequestBuilderId(indexRequestBuilder, indexDocumentRequest);
 
 			indexRequestBuilder.setIndex(indexDocumentRequest.getIndexName());
 
@@ -105,6 +105,8 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 
 			ElasticsearchDocumentFactory elasticsearchDocumentFactory =
 				new DefaultElasticsearchDocumentFactory();
+
+			Document document = indexDocumentRequest.getDocument();
 
 			String elasticsearchDocument =
 				elasticsearchDocumentFactory.getElasticsearchDocument(document);
@@ -134,9 +136,8 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 			UpdateRequestBuilder updateRequestBuilder =
 				UpdateAction.INSTANCE.newRequestBuilder(client);
 
-			Document document = updateDocumentRequest.getDocument();
-
-			updateRequestBuilder.setId(document.getUID());
+			setUpdateRequestBuilderId(
+				updateRequestBuilder, updateDocumentRequest);
 
 			updateRequestBuilder.setIndex(updateDocumentRequest.getIndexName());
 
@@ -149,6 +150,8 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 
 			ElasticsearchDocumentFactory elasticsearchDocumentFactory =
 				new DefaultElasticsearchDocumentFactory();
+
+			Document document = updateDocumentRequest.getDocument();
 
 			String elasticsearchDocument =
 				elasticsearchDocumentFactory.getElasticsearchDocument(document);
@@ -165,6 +168,44 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 		catch (IOException ioe) {
 			throw new SystemException(ioe);
 		}
+	}
+
+	protected void setIndexRequestBuilderId(
+		IndexRequestBuilder indexRequestBuilder,
+		IndexDocumentRequest indexDocumentRequest) {
+
+		String uid = indexDocumentRequest.getUid();
+
+		if (Validator.isBlank(uid)) {
+			Document document = indexDocumentRequest.getDocument();
+
+			Field field = document.getField(Field.UID);
+
+			if (field != null) {
+				uid = field.getValue();
+			}
+		}
+
+		indexRequestBuilder.setId(uid);
+	}
+
+	protected void setUpdateRequestBuilderId(
+		UpdateRequestBuilder updateRequestBuilder,
+		UpdateDocumentRequest updateDocumentRequest) {
+
+		String uid = updateDocumentRequest.getUid();
+
+		if (Validator.isBlank(uid)) {
+			Document document = updateDocumentRequest.getDocument();
+
+			Field field = document.getField(Field.UID);
+
+			if (field != null) {
+				uid = field.getValue();
+			}
+		}
+
+		updateRequestBuilder.setId(uid);
 	}
 
 	@Reference

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/IndexDocumentRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/IndexDocumentRequestExecutorImpl.java
@@ -48,7 +48,7 @@ public class IndexDocumentRequestExecutorImpl
 		RestStatus restStatus = indexResponse.status();
 
 		IndexDocumentResponse indexDocumentResponse = new IndexDocumentResponse(
-			restStatus.getStatus());
+			restStatus.getStatus(), indexResponse.getId());
 
 		return indexDocumentResponse;
 	}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchClientResolver;
 import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch6.internal.search.engine.adapter.document.DocumentRequestExecutorFixture;
@@ -196,6 +197,119 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		Assert.assertEquals(Boolean.TRUE.toString(), map2.get(_FIELD_NAME));
 	}
 
+	@Test
+	public void testExecuteBulkDocumentRequestNoUid() {
+		Document document1 = new DocumentImpl();
+
+		document1.addKeyword(_FIELD_NAME, Boolean.TRUE.toString());
+
+		IndexDocumentRequest indexDocumentRequest = new IndexDocumentRequest(
+			_INDEX_NAME, document1);
+
+		indexDocumentRequest.setType(_MAPPING_NAME);
+
+		BulkDocumentRequest bulkDocumentRequest = new BulkDocumentRequest();
+
+		bulkDocumentRequest.addBulkableDocumentRequest(indexDocumentRequest);
+
+		Document document2 = new DocumentImpl();
+
+		document2.addKeyword(_FIELD_NAME, Boolean.FALSE.toString());
+
+		IndexDocumentRequest indexDocumentRequest2 = new IndexDocumentRequest(
+			_INDEX_NAME, document2);
+
+		indexDocumentRequest2.setType(_MAPPING_NAME);
+
+		bulkDocumentRequest.addBulkableDocumentRequest(indexDocumentRequest2);
+
+		BulkDocumentResponse bulkDocumentResponse =
+			_searchEngineAdapter.execute(bulkDocumentRequest);
+
+		Assert.assertFalse(bulkDocumentResponse.hasErrors());
+
+		List<BulkDocumentItemResponse> bulkDocumentItemResponses =
+			bulkDocumentResponse.getBulkDocumentItemResponses();
+
+		Assert.assertEquals(
+			bulkDocumentItemResponses.toString(), 2,
+			bulkDocumentItemResponses.size());
+
+		BulkDocumentItemResponse bulkDocumentItemResponse1 =
+			bulkDocumentItemResponses.get(0);
+
+		Assert.assertFalse(
+			Validator.isBlank(bulkDocumentItemResponse1.getId()));
+
+		BulkDocumentItemResponse bulkDocumentItemResponse2 =
+			bulkDocumentItemResponses.get(1);
+
+		Assert.assertFalse(
+			Validator.isBlank(bulkDocumentItemResponse2.getId()));
+
+		DeleteDocumentRequest deleteDocumentRequest = new DeleteDocumentRequest(
+			_INDEX_NAME, bulkDocumentItemResponse1.getId());
+
+		deleteDocumentRequest.setType(_MAPPING_NAME);
+
+		BulkDocumentRequest bulkDocumentRequest2 = new BulkDocumentRequest();
+
+		bulkDocumentRequest2.addBulkableDocumentRequest(deleteDocumentRequest);
+
+		Document document2Update = new DocumentImpl();
+
+		document2Update.addKeyword(
+			Field.UID, bulkDocumentItemResponse2.getId());
+		document2Update.addKeyword(_FIELD_NAME, Boolean.TRUE.toString());
+
+		UpdateDocumentRequest updateDocumentRequest = new UpdateDocumentRequest(
+			_INDEX_NAME, bulkDocumentItemResponse2.getId(), document2Update);
+
+		updateDocumentRequest.setType(_MAPPING_NAME);
+
+		bulkDocumentRequest2.addBulkableDocumentRequest(updateDocumentRequest);
+
+		BulkDocumentResponse bulkDocumentResponse2 =
+			_searchEngineAdapter.execute(bulkDocumentRequest2);
+
+		Assert.assertFalse(bulkDocumentResponse2.hasErrors());
+
+		List<BulkDocumentItemResponse> bulkDocumentItemResponses2 =
+			bulkDocumentResponse2.getBulkDocumentItemResponses();
+
+		Assert.assertEquals(
+			bulkDocumentItemResponses2.toString(), 2,
+			bulkDocumentItemResponses2.size());
+
+		BulkDocumentItemResponse bulkDocumentItemResponse3 =
+			bulkDocumentItemResponses2.get(0);
+
+		Assert.assertEquals(
+			bulkDocumentItemResponse1.getId(),
+			bulkDocumentItemResponse3.getId());
+
+		BulkDocumentItemResponse bulkDocumentItemResponse4 =
+			bulkDocumentItemResponses2.get(1);
+
+		Assert.assertEquals(
+			bulkDocumentItemResponse2.getId(),
+			bulkDocumentItemResponse4.getId());
+
+		GetResponse getResponse1 = _getDocument(
+			bulkDocumentItemResponse1.getId());
+
+		Assert.assertFalse(getResponse1.isExists());
+
+		GetResponse getResponse2 = _getDocument(
+			bulkDocumentItemResponse2.getId());
+
+		Assert.assertTrue(getResponse2.isExists());
+
+		Map<String, Object> map2 = getResponse2.getSource();
+
+		Assert.assertEquals(Boolean.TRUE.toString(), map2.get(_FIELD_NAME));
+	}
+
 	@Ignore
 	@Test
 	public void testExecuteDeleteByQueryDocumentRequest() {
@@ -246,21 +360,62 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 	}
 
 	@Test
-	public void testExecuteIndexDocumentRequest() {
+	public void testExecuteIndexDocumentRequestNoUid() {
+		Document document = new DocumentImpl();
+
+		IndexDocumentResponse indexDocumentResponse = _indexDocumentWithAdapter(
+			null, document);
+
+		Assert.assertEquals(
+			RestStatus.CREATED.getStatus(), indexDocumentResponse.getStatus());
+
+		Assert.assertNotNull(indexDocumentResponse.getUid());
+	}
+
+	@Test
+	public void testExecuteIndexDocumentRequestNoUidWithUpdate() {
+		Document document = new DocumentImpl();
+
+		IndexDocumentResponse indexDocumentResponse = _indexDocumentWithAdapter(
+			null, document);
+
+		document.addKeyword(_FIELD_NAME, true);
+
+		_updateDocumentWithAdapter(indexDocumentResponse.getUid(), document);
+
+		GetResponse getResponse = _getDocument(indexDocumentResponse.getUid());
+
+		Map<String, Object> map = getResponse.getSource();
+
+		Assert.assertEquals(Boolean.TRUE.toString(), map.get(_FIELD_NAME));
+	}
+
+	@Test
+	public void testExecuteIndexDocumentRequestUidInDocument() {
 		Document document = new DocumentImpl();
 
 		document.addKeyword(Field.UID, "1");
 
-		IndexDocumentRequest indexDocumentRequest = new IndexDocumentRequest(
-			_INDEX_NAME, document);
-
-		indexDocumentRequest.setType(_MAPPING_NAME);
-
-		IndexDocumentResponse indexDocumentResponse =
-			_searchEngineAdapter.execute(indexDocumentRequest);
+		IndexDocumentResponse indexDocumentResponse = _indexDocumentWithAdapter(
+			null, document);
 
 		Assert.assertEquals(
 			RestStatus.CREATED.getStatus(), indexDocumentResponse.getStatus());
+
+		Assert.assertEquals("1", indexDocumentResponse.getUid());
+	}
+
+	@Test
+	public void testExecuteIndexDocumentRequestUidInRequest() {
+		Document document = new DocumentImpl();
+
+		IndexDocumentResponse indexDocumentResponse = _indexDocumentWithAdapter(
+			"1", document);
+
+		Assert.assertEquals(
+			RestStatus.CREATED.getStatus(), indexDocumentResponse.getStatus());
+
+		Assert.assertEquals("1", indexDocumentResponse.getUid());
 	}
 
 	@Ignore
@@ -302,13 +457,69 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		document.addKeyword(Field.UID, id);
 		document.addKeyword(_FIELD_NAME, false);
 
-		UpdateDocumentRequest updateDocumentRequest = new UpdateDocumentRequest(
-			_INDEX_NAME, id, document);
+		UpdateDocumentResponse updateDocumentResponse =
+			_updateDocumentWithAdapter(id, document);
 
-		updateDocumentRequest.setType(_MAPPING_NAME);
+		Assert.assertEquals(
+			RestStatus.OK.getStatus(), updateDocumentResponse.getStatus());
+
+		GetResponse getResponse2 = _getDocument(id);
+
+		Map<String, Object> map2 = getResponse2.getSource();
+
+		Assert.assertEquals(Boolean.FALSE.toString(), map2.get(_FIELD_NAME));
+	}
+
+	@Test
+	public void testExecuteUpdateDocumentRequestNoDocumentUid() {
+		String documentSource = "{\"" + _FIELD_NAME + "\":\"true\"}";
+		String id = "1";
+
+		_indexDocument(documentSource, id);
+
+		GetResponse getResponse1 = _getDocument(id);
+
+		Map<String, Object> map1 = getResponse1.getSource();
+
+		Assert.assertEquals(Boolean.TRUE.toString(), map1.get(_FIELD_NAME));
+
+		Document document = new DocumentImpl();
+
+		document.addKeyword(_FIELD_NAME, false);
 
 		UpdateDocumentResponse updateDocumentResponse =
-			_searchEngineAdapter.execute(updateDocumentRequest);
+			_updateDocumentWithAdapter(id, document);
+
+		Assert.assertEquals(
+			RestStatus.OK.getStatus(), updateDocumentResponse.getStatus());
+
+		GetResponse getResponse2 = _getDocument(id);
+
+		Map<String, Object> map2 = getResponse2.getSource();
+
+		Assert.assertEquals(Boolean.FALSE.toString(), map2.get(_FIELD_NAME));
+	}
+
+	@Test
+	public void testExecuteUpdateDocumentRequestNoRequestId() {
+		String documentSource = "{\"" + _FIELD_NAME + "\":\"true\"}";
+		String id = "1";
+
+		_indexDocument(documentSource, id);
+
+		GetResponse getResponse1 = _getDocument(id);
+
+		Map<String, Object> map1 = getResponse1.getSource();
+
+		Assert.assertEquals(Boolean.TRUE.toString(), map1.get(_FIELD_NAME));
+
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.UID, id);
+		document.addKeyword(_FIELD_NAME, false);
+
+		UpdateDocumentResponse updateDocumentResponse =
+			_updateDocumentWithAdapter(null, document);
 
 		Assert.assertEquals(
 			RestStatus.OK.getStatus(), updateDocumentResponse.getStatus());
@@ -383,6 +594,34 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		indexRequestBuilder.setSource(documentSource, XContentType.JSON);
 
 		indexRequestBuilder.get();
+	}
+
+	private IndexDocumentResponse _indexDocumentWithAdapter(
+		String uid, Document document) {
+
+		IndexDocumentRequest indexDocumentRequest = new IndexDocumentRequest(
+			_INDEX_NAME, uid, document);
+
+		indexDocumentRequest.setType(_MAPPING_NAME);
+
+		IndexDocumentResponse indexDocumentResponse =
+			_searchEngineAdapter.execute(indexDocumentRequest);
+
+		return indexDocumentResponse;
+	}
+
+	private UpdateDocumentResponse _updateDocumentWithAdapter(
+		String uid, Document document) {
+
+		UpdateDocumentRequest updateDocumentRequest = new UpdateDocumentRequest(
+			_INDEX_NAME, uid, document);
+
+		updateDocumentRequest.setType(_MAPPING_NAME);
+
+		UpdateDocumentResponse updateDocumentResponse =
+			_searchEngineAdapter.execute(updateDocumentRequest);
+
+		return updateDocumentResponse;
 	}
 
 	private static final String _FIELD_NAME = "matchDocument";

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslatorTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslatorTest.java
@@ -17,6 +17,7 @@ package com.liferay.portal.search.elasticsearch6.internal.search.engine.adapter.
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch6.internal.document.DefaultElasticsearchDocumentFactory;
 import com.liferay.portal.search.elasticsearch6.internal.document.ElasticsearchDocumentFactory;
@@ -92,7 +93,15 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 		throws IOException {
 
 		doTestIndexDocumentRequestTranslation(
-			false, WriteRequest.RefreshPolicy.NONE);
+			"1", false, WriteRequest.RefreshPolicy.NONE);
+	}
+
+	@Test
+	public void testIndexDocumentRequestTranslationWithNoRefreshNoId()
+		throws IOException {
+
+		doTestIndexDocumentRequestTranslation(
+			null, false, WriteRequest.RefreshPolicy.NONE);
 	}
 
 	@Test
@@ -100,7 +109,15 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 		throws IOException {
 
 		doTestIndexDocumentRequestTranslation(
-			true, WriteRequest.RefreshPolicy.IMMEDIATE);
+			"1", true, WriteRequest.RefreshPolicy.IMMEDIATE);
+	}
+
+	@Test
+	public void testIndexDocumentRequestTranslationWithRefreshNoId()
+		throws IOException {
+
+		doTestIndexDocumentRequestTranslation(
+			null, true, WriteRequest.RefreshPolicy.IMMEDIATE);
 	}
 
 	@Test
@@ -108,7 +125,15 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 		throws IOException {
 
 		doTestUpdateDocumentRequestTranslation(
-			false, WriteRequest.RefreshPolicy.NONE);
+			"1", false, WriteRequest.RefreshPolicy.NONE);
+	}
+
+	@Test
+	public void testUpdateDocumentRequestTranslationWithNoRefreshNoId()
+		throws IOException {
+
+		doTestUpdateDocumentRequestTranslation(
+			null, false, WriteRequest.RefreshPolicy.NONE);
 	}
 
 	@Test
@@ -116,7 +141,15 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 		throws IOException {
 
 		doTestUpdateDocumentRequestTranslation(
-			true, WriteRequest.RefreshPolicy.IMMEDIATE);
+			"1", true, WriteRequest.RefreshPolicy.IMMEDIATE);
+	}
+
+	@Test
+	public void testUpdateDocumentRequestTranslationWithRefreshNoId()
+		throws IOException {
+
+		doTestUpdateDocumentRequestTranslation(
+			null, true, WriteRequest.RefreshPolicy.IMMEDIATE);
 	}
 
 	protected void doTestDeleteDocumentRequestTranslation(
@@ -155,15 +188,13 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 	}
 
 	protected void doTestIndexDocumentRequestTranslation(
-			boolean refreshPolicy,
+			String id, boolean refreshPolicy,
 			WriteRequest.RefreshPolicy expectedRefreshPolicy)
 		throws IOException {
 
-		String id = "1";
-
 		Document document = new DocumentImpl();
 
-		document.addKeyword(Field.UID, id);
+		_setUid(document, id);
 
 		IndexDocumentRequest indexDocumentRequest = new IndexDocumentRequest(
 			_INDEX_NAME, document);
@@ -205,15 +236,13 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 	}
 
 	protected void doTestUpdateDocumentRequestTranslation(
-			boolean refreshPolicy,
+			String id, boolean refreshPolicy,
 			WriteRequest.RefreshPolicy expectedRefreshPolicy)
 		throws IOException {
 
-		String id = "1";
-
 		Document document = new DocumentImpl();
 
-		document.addKeyword(Field.UID, id);
+		_setUid(document, id);
 
 		UpdateDocumentRequest updateDocumentRequest = new UpdateDocumentRequest(
 			_INDEX_NAME, id, document);
@@ -253,6 +282,12 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 			updateDocumentRequest, bulkRequestBuilder);
 
 		Assert.assertEquals(1, bulkRequestBuilder.numberOfActions());
+	}
+
+	private void _setUid(Document document, String uid) {
+		if (!Validator.isBlank(uid)) {
+			document.addKeyword(Field.UID, uid);
+		}
 	}
 
 	private static final String _INDEX_NAME = "test_request_index";

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/IndexDocumentRequest.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/IndexDocumentRequest.java
@@ -29,7 +29,14 @@ public class IndexDocumentRequest
 			   DocumentRequest<IndexDocumentResponse> {
 
 	public IndexDocumentRequest(String indexName, Document document) {
+		this(indexName, null, document);
+	}
+
+	public IndexDocumentRequest(
+		String indexName, String uid, Document document) {
+
 		_indexName = indexName;
+		_uid = uid;
 		_document = document;
 	}
 
@@ -57,6 +64,10 @@ public class IndexDocumentRequest
 		return _type;
 	}
 
+	public String getUid() {
+		return _uid;
+	}
+
 	public boolean isRefresh() {
 		return _refresh;
 	}
@@ -73,5 +84,6 @@ public class IndexDocumentRequest
 	private final String _indexName;
 	private boolean _refresh;
 	private String _type;
+	private final String _uid;
 
 }

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/IndexDocumentResponse.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/IndexDocumentResponse.java
@@ -22,14 +22,20 @@ import aQute.bnd.annotation.ProviderType;
 @ProviderType
 public class IndexDocumentResponse implements DocumentResponse {
 
-	public IndexDocumentResponse(int status) {
+	public IndexDocumentResponse(int status, String uid) {
 		_status = status;
+		_uid = uid;
 	}
 
 	public int getStatus() {
 		return _status;
 	}
 
+	public String getUid() {
+		return _uid;
+	}
+
 	private final int _status;
+	private final String _uid;
 
 }

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/resources/com/liferay/portal/search/engine/adapter/document/packageinfo
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/resources/com/liferay/portal/search/engine/adapter/document/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 2.0.0


### PR DESCRIPTION
✔️ **ci:test:relevant - 26 out of 26 jobs passed in 1 hour 8 minutes 43 seconds** https://github.com/BryanEngler/liferay-portal/pull/303#issuecomment-454591660

Authors: @wcao20170619 @BryanEngler
Reviewer: @BryanEngler
CC: @arboliveira

[Bug] ElasticsearchBulkableDocumentRequestTranslator should not require the Document to have an UID field
https://issues.liferay.com/browse/LPS-87976