### PR TITLE
LPS-88599 Upgrade zookeeper version

### DIFF
--- a/modules/apps/portal-search-solr/portal-search-solr/build.gradle
+++ b/modules/apps/portal-search-solr/portal-search-solr/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 	compileInclude group: "org.apache.lucene", name: "lucene-queryparser", version: "5.2.1"
 	compileInclude group: "org.apache.lucene", name: "lucene-suggest", version: "5.2.1"
 	compileInclude group: "org.apache.solr", name: "solr-solrj", version: "5.2.1"
-	compileInclude group: "org.apache.zookeeper", name: "zookeeper", version: "3.4.7"
+	compileInclude group: "org.apache.zookeeper", name: "zookeeper", version: "3.4.10"
 	compileInclude group: "org.codehaus.woodstox", name: "stax2-api", version: "3.1.4"
 	compileInclude group: "org.codehaus.woodstox", name: "woodstox-core-asl", version: "4.4.1"
 	compileInclude group: "org.noggit", name: "noggit", version: "0.6"

--- a/modules/apps/portal-search-solr7/portal-search-solr7-impl/build.gradle
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-impl/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 	compileInclude group: "org.apache.lucene", name: "lucene-queryparser", version: luceneVersion
 	compileInclude group: "org.apache.lucene", name: "lucene-suggest", version: luceneVersion
 	compileInclude group: "org.apache.solr", name: "solr-solrj", version: luceneVersion
-	compileInclude group: "org.apache.zookeeper", name: "zookeeper", version: "3.4.7"
+	compileInclude group: "org.apache.zookeeper", name: "zookeeper", version: "3.4.10"
 	compileInclude group: "org.codehaus.woodstox", name: "stax2-api", version: "3.1.4"
 	compileInclude group: "org.codehaus.woodstox", name: "woodstox-core-asl", version: "4.4.1"
 	compileInclude group: "org.noggit", name: "noggit", version: "0.6"


### PR DESCRIPTION
This fix is needed for the Solr 5 release, Tibor requested that you **backport to 7.1.x and 7.0.x** if possible, otherwise we will do it.
https://issues.liferay.com/browse/RELEASE-1129

❌ **ci:test:solr - 93 out of 178 jobs passed in 5 hours 21 minutes 42 seconds** https://github.com/BryanEngler/liferay-portal/pull/305#issuecomment-457778115

Failures are unrelated to changes in this pr, confirmed by @xbrianlee

Authors: @lipusz
Reviewers: @BryanEngler

[Bug] Solr: Known vulnerabilities in zookeeper-3.4.7
https://issues.liferay.com/browse/LPS-88599