### PR TITLE
LPS-89912 When index type is tableIndexStatistic, the index name can …

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -199,6 +199,10 @@ public abstract class BaseDB implements DB {
 					while (indexRS.next()) {
 						String indexName = indexRS.getString("INDEX_NAME");
 
+						if (indexName == null) {
+							continue;
+						}
+
 						String lowerCaseIndexName = StringUtil.toLowerCase(
 							indexName);
 


### PR DESCRIPTION
…be null, this only happens to Sybase and DB2

@vicnate5 after this, you will still an upgrade failure on DB2 and Sybase. But this time it is a real one, due to we are trying to add a new unique index on table with duplicated values.

For Sybase:
```
     [java] 2019-01-31 04:47:40.354 WARN  [main][BaseDB:116] Create unique index aborted on duplicate key.  Primary key is '<NULL>'
     [java] : create unique index IX_84D30230 on LayoutPageTemplateEntry (plid);
```
For DB2:
```
     [java] WARN - DB2 SQL Error: SQLCODE=-603, SQLSTATE=23515, SQLERRMC=null, DRIVER=4.24.92: create unique index IX_84D30230 on LayoutPageTemplateEntry (plid);
```
This is caused by https://github.com/liferay/liferay-portal/commit/4a1345b889c87c6c3d28a38149fd38b870ac086c

@ealonso the unique can not be added this way. You need to either undo it or provide an upgrade process to scrub the data clean before adding the new index.