### PR TITLE
LPS-89955 Remove batch-create with empty parameters

### DIFF
--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/rest-openapi.yaml
@@ -1084,21 +1084,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/UserAccount"
           description: ""
-  "/user-account/batch-create":
-    post:
-      parameters: []
-      requestBody:
-        content:
-          "*/*":
-            schema:
-              $ref: "#/components/schemas/UserAccount"
-      responses:
-        200:
-          content:
-            "*/*":
-              schema:
-                $ref: "#/components/schemas/UserAccount"
-          description: ""
   "/user-account/{id}":
     delete:
       parameters:


### PR DESCRIPTION
Gradle task `buildREST` failes if the operation has empty parameters: `parameters: []`
/cc @petershin