### PR TITLE
LPS-89989 Add format int64 to headless-workflow

### DIFF
--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/rest-openapi.yaml
@@ -12,6 +12,7 @@ components:
           type: string
         id:
           type: integer
+          format: int64
         person:
           format: uri
           type: string
@@ -47,6 +48,7 @@ components:
           type: string
         id:
           type: integer
+          format: int64
         logs:
           $ref: "#/components/schemas/WorkflowLog"
         name:
@@ -56,6 +58,7 @@ components:
           properties:
             id:
               type: integer
+              format: int64
             identifier:
               format: uri
               type: string
@@ -113,6 +116,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: int64
       responses:
         200:
           content:
@@ -153,6 +157,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: int64
       responses:
         200:
           content:
@@ -168,6 +173,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: int64
       requestBody:
         content:
           "*/*":
@@ -188,6 +194,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: int64
       requestBody:
         content:
           "*/*":
@@ -208,6 +215,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: int64
       requestBody:
         content:
           "*/*":
@@ -228,6 +236,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: int64
       requestBody:
         content:
           "*/*":


### PR DESCRIPTION
Add `format: int64` to generate Long type in headless-workflow module.