### PR TITLE
LPS-90014 add explicit id for parent relationships

### DIFF
--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/rest-openapi.yaml
@@ -135,11 +135,11 @@ info:
   version: 1.0.0
 openapi: 3.0.1
 paths:
-  "/aggregate-rating/{id}":
+  "/aggregate-rating/{aggregate-rating-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: aggregate-rating-id
           required: true
           schema:
             format: int64
@@ -151,11 +151,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/AggregateRating"
           description: ""
-  "/blog-posting/{id}":
+  "/blog-posting/{blog-posting-id}":
     delete:
       parameters:
         - in: path
-          name: id
+          name: blog-posting-id
           required: true
           schema:
             format: int64
@@ -168,7 +168,7 @@ paths:
     get:
       parameters:
         - in: path
-          name: id
+          name: blog-posting-id
           required: true
           schema:
             format: int64
@@ -183,7 +183,7 @@ paths:
     put:
       parameters:
         - in: path
-          name: id
+          name: blog-posting-id
           required: true
           schema:
             format: int64
@@ -200,7 +200,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/BlogPosting"
           description: ""
-  "/blog-posting/{parent-id}/comment":
+  "/blog-posting/{blog-posting-id}/comment":
     get:
       parameters:
         - in: query
@@ -212,7 +212,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: blog-posting-id
           required: true
           schema:
             format: int64
@@ -226,11 +226,11 @@ paths:
                   $ref: "#/components/schemas/Comment"
                 type: array
           description: ""
-  "/comment/{id}":
+  "/comment/{comment-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: comment-id
           required: true
           schema:
             format: int64
@@ -242,7 +242,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Comment"
           description: ""
-  "/comment/{parent-id}/comment":
+  "/comment/{comment-id}/comment":
     get:
       parameters:
         - in: query
@@ -254,7 +254,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: comment-id
           required: true
           schema:
             format: int64
@@ -268,7 +268,7 @@ paths:
                   $ref: "#/components/schemas/Comment"
                 type: array
           description: ""
-  "/content-space/{parent-id}/blog-posting":
+  "/content-space/{content-space-id}/blog-posting":
     get:
       parameters:
         - in: query
@@ -280,7 +280,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -297,7 +297,7 @@ paths:
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -314,11 +314,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/BlogPosting"
           description: ""
-  "/content-space/{parent-id}/blog-posting/batch-create":
+  "/content-space/{content-space-id}/blog-posting/batch-create":
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -335,11 +335,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/BlogPosting"
           description: ""
-  "/image-object-repository/{id}":
+  "/image-object-repository/{image-object-repository-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: image-object-repository-id
           required: true
           schema:
             format: int64
@@ -351,7 +351,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ImageObjectRepository"
           description: ""
-  "/image-object-repository/{parent-id}/image-object":
+  "/image-object-repository/{image-object-repository-id}/image-object":
     get:
       parameters:
         - in: query
@@ -363,7 +363,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: image-object-repository-id
           required: true
           schema:
             format: int64
@@ -380,7 +380,7 @@ paths:
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: image-object-repository-id
           required: true
           schema:
             format: int64
@@ -397,11 +397,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ImageObject"
           description: ""
-  "/image-object-repository/{parent-id}/image-object/batch-create":
+  "/image-object-repository/{image-object-repository-id}/image-object/batch-create":
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: image-object-repository-id
           required: true
           schema:
             format: int64
@@ -418,11 +418,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ImageObject"
           description: ""
-  "/image-object/{id}":
+  "/image-object/{image-object-id}":
     delete:
       parameters:
         - in: path
-          name: id
+          name: image-object-id
           required: true
           schema:
             format: int64
@@ -435,7 +435,7 @@ paths:
     get:
       parameters:
         - in: path
-          name: id
+          name: image-object-id
           required: true
           schema:
             format: int64

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
@@ -111,11 +111,11 @@ info:
   version: 1.0.0
 openapi: 3.0.1
 paths:
-  "/document/{id}":
+  "/document/{document-id}":
     delete:
       parameters:
         - in: path
-          name: id
+          name: document-id
           required: true
           schema:
             format: int64
@@ -128,7 +128,7 @@ paths:
     get:
       parameters:
         - in: path
-          name: id
+          name: document-id
           required: true
           schema:
             format: int64
@@ -140,7 +140,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Document"
           description: ""
-  "/document/{parent-id}/comment":
+  "/document/{document-id}/comment":
     get:
       parameters:
         - in: query
@@ -152,7 +152,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: document-id
           required: true
           schema:
             format: int64
@@ -182,7 +182,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Folder"
           description: ""
-  "/documents-repository/{parent-id}/document":
+  "/documents-repository/{documents-repository-id}/document":
     get:
       parameters:
         - in: query
@@ -194,7 +194,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: documents-repository-id
           required: true
           schema:
             format: int64
@@ -211,7 +211,7 @@ paths:
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: documents-repository-id
           required: true
           schema:
             format: int64
@@ -228,11 +228,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Document"
           description: ""
-  "/documents-repository/{parent-id}/document/batch-create":
+  "/documents-repository/{documents-repository-id}/document/batch-create":
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: documents-repository-id
           required: true
           schema:
             format: int64
@@ -249,7 +249,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Document"
           description: ""
-  "/documents-repository/{parent-id}/folder":
+  "/documents-repository/{documents-repository-id}/folder":
     get:
       parameters:
         - in: query
@@ -261,7 +261,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: documents-repository-id
           required: true
           schema:
             format: int64
@@ -278,7 +278,7 @@ paths:
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: documents-repository-id
           required: true
           schema:
             format: int64
@@ -295,11 +295,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Folder"
           description: ""
-  "/documents-repository/{parent-id}/folder/batch-create":
+  "/documents-repository/{documents-repository-id}/folder/batch-create":
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: documents-repository-id
           required: true
           schema:
             format: int64
@@ -316,11 +316,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Folder"
           description: ""
-  "/folder/{id}":
+  "/folder/{folder-id}":
     delete:
       parameters:
         - in: path
-          name: id
+          name: folder-id
           required: true
           schema:
             format: int64
@@ -333,7 +333,7 @@ paths:
     get:
       parameters:
         - in: path
-          name: id
+          name: folder-id
           required: true
           schema:
             format: int64
@@ -348,7 +348,7 @@ paths:
     put:
       parameters:
         - in: path
-          name: id
+          name: folder-id
           required: true
           schema:
             format: int64
@@ -365,7 +365,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Folder"
           description: ""
-  "/folder/{parent-id}/document":
+  "/folder/{folder-id}/document":
     get:
       parameters:
         - in: query
@@ -377,7 +377,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: folder-id
           required: true
           schema:
             format: int64
@@ -394,7 +394,7 @@ paths:
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: folder-id
           required: true
           schema:
             format: int64
@@ -411,11 +411,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Document"
           description: ""
-  "/folder/{parent-id}/document/batch-create":
+  "/folder/{folder-id}/document/batch-create":
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: folder-id
           required: true
           schema:
             format: int64
@@ -432,7 +432,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Document"
           description: ""
-  "/folder/{parent-id}/folder":
+  "/folder/{folder-id}/folder":
     get:
       parameters:
         - in: query
@@ -444,7 +444,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: folder-id
           required: true
           schema:
             format: int64
@@ -461,7 +461,7 @@ paths:
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: folder-id
           required: true
           schema:
             format: int64
@@ -478,11 +478,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Folder"
           description: ""
-  "/folder/{parent-id}/folder/batch-create":
+  "/folder/{folder-id}/folder/batch-create":
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: folder-id
           required: true
           schema:
             format: int64

--- a/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
@@ -285,7 +285,7 @@ info:
   version: 1.0.0
 openapi: 3.0.1
 paths:
-  "/content-space/{parent-id}/form":
+  "/content-space/{content-space-id}/form":
     get:
       parameters:
         - in: query
@@ -297,7 +297,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -311,7 +311,7 @@ paths:
                   $ref: "#/components/schemas/Form"
                 type: array
           description: ""
-  "/content-space/{parent-id}/form-structures":
+  "/content-space/{content-space-id}/form-structures":
     get:
       parameters:
         - in: query
@@ -323,7 +323,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -337,11 +337,11 @@ paths:
                   $ref: "#/components/schemas/FormStructure"
                 type: array
           description: ""
-  "/form-document/{id}":
+  "/form-document/{form-document-id}":
     delete:
       parameters:
         - in: path
-          name: id
+          name: form-document-id
           required: true
           schema:
             format: int64
@@ -354,7 +354,7 @@ paths:
     get:
       parameters:
         - in: path
-          name: id
+          name: form-document-id
           required: true
           schema:
             format: int64
@@ -366,11 +366,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/FormDocument"
           description: ""
-  "/form-record/{id}":
+  "/form-record/{form-record-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: form-record-id
           required: true
           schema:
             format: int64
@@ -385,7 +385,7 @@ paths:
     put:
       parameters:
         - in: path
-          name: id
+          name: form-record-id
           required: true
           schema:
             format: int64
@@ -406,11 +406,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/FormRecord"
           description: ""
-  "/form-structures/{id}":
+  "/form-structures/{form-structures-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: form-structures-id
           required: true
           schema:
             format: int64
@@ -422,11 +422,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/FormStructure"
           description: ""
-  "/form/{id}":
+  "/form/{form-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: form-id
           required: true
           schema:
             format: int64
@@ -438,11 +438,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Form"
           description: ""
-  "/form/{id}/evaluate-context":
+  "/form/{form-id}/evaluate-context":
     post:
       parameters:
         - in: path
-          name: id
+          name: form-id
           required: true
           schema:
             format: int64
@@ -463,11 +463,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Form"
           description: ""
-  "/form/{id}/fetch-latest-draft":
+  "/form/{form-id}/fetch-latest-draft":
     get:
       parameters:
         - in: path
-          name: id
+          name: form-id
           required: true
           schema:
             format: int64
@@ -479,28 +479,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Form"
           description: ""
-  "/form/{id}/upload-file":
-    post:
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            format: int64
-            type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Form"
-      responses:
-        200:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Form"
-          description: ""
-  "/form/{parent-id}/form-record":
+  "/form/{form-id}/form-record":
     get:
       parameters:
         - in: query
@@ -512,7 +491,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: form-id
           required: true
           schema:
             format: int64
@@ -529,7 +508,7 @@ paths:
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: form-id
           required: true
           schema:
             format: int64
@@ -550,11 +529,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/FormRecord"
           description: ""
-  "/form/{parent-id}/form-record/batch-create":
+  "/form/{form-id}/form-record/batch-create":
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: form-id
           required: true
           schema:
             format: int64
@@ -574,4 +553,25 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/FormRecord"
+          description: ""
+  "/form/{form-id}/upload-file":
+    post:
+      parameters:
+        - in: path
+          name: form-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Form"
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Form"
           description: ""

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/rest-openapi.yaml
@@ -456,11 +456,11 @@ paths:
                   $ref: "#/components/schemas/PostalAddress"
                 type: array
           description: ""
-  "/addresses/{id}":
+  "/addresses/{addresses-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: addresses-id
           required: true
           schema:
             format: int64
@@ -472,11 +472,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/PostalAddress"
           description: ""
-  "/categories/{id}":
+  "/categories/{categories-id}":
     delete:
       parameters:
         - in: path
-          name: id
+          name: categories-id
           required: true
           schema:
             format: int64
@@ -489,7 +489,7 @@ paths:
     get:
       parameters:
         - in: path
-          name: id
+          name: categories-id
           required: true
           schema:
             format: int64
@@ -504,7 +504,7 @@ paths:
     put:
       parameters:
         - in: path
-          name: id
+          name: categories-id
           required: true
           schema:
             format: int64
@@ -521,7 +521,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Category"
           description: ""
-  "/categories/{parent-id}/categories":
+  "/categories/{categories-id}/categories":
     get:
       parameters:
         - in: query
@@ -533,7 +533,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: categories-id
           required: true
           schema:
             format: int64
@@ -550,7 +550,7 @@ paths:
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: categories-id
           required: true
           schema:
             format: int64
@@ -567,11 +567,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Category"
           description: ""
-  "/categories/{parent-id}/categories/batch-create":
+  "/categories/{categories-id}/categories/batch-create":
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: categories-id
           required: true
           schema:
             format: int64
@@ -588,11 +588,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Category"
           description: ""
-  "/content-space/{id}":
+  "/content-space/{content-space-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -604,7 +604,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ContentSpace"
           description: ""
-  "/content-space/{parent-id}/keywords":
+  "/content-space/{content-space-id}/keywords":
     get:
       parameters:
         - in: query
@@ -616,7 +616,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -633,7 +633,7 @@ paths:
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -650,11 +650,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Keyword"
           description: ""
-  "/content-space/{parent-id}/keywords/batch-create":
+  "/content-space/{content-space-id}/keywords/batch-create":
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -671,7 +671,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Keyword"
           description: ""
-  "/content-space/{parent-id}/vocabularies":
+  "/content-space/{content-space-id}/vocabularies":
     get:
       parameters:
         - in: query
@@ -683,7 +683,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -700,7 +700,7 @@ paths:
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -717,11 +717,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Vocabulary"
           description: ""
-  "/content-space/{parent-id}/vocabularies/batch-create":
+  "/content-space/{content-space-id}/vocabularies/batch-create":
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -763,11 +763,11 @@ paths:
                   $ref: "#/components/schemas/Email"
                 type: array
           description: ""
-  "/emails/{id}":
+  "/emails/{emails-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: emails-id
           required: true
           schema:
             format: int64
@@ -779,11 +779,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Email"
           description: ""
-  "/keywords/{id}":
+  "/keywords/{keywords-id}":
     delete:
       parameters:
         - in: path
-          name: id
+          name: keywords-id
           required: true
           schema:
             format: int64
@@ -796,7 +796,7 @@ paths:
     get:
       parameters:
         - in: path
-          name: id
+          name: keywords-id
           required: true
           schema:
             format: int64
@@ -811,7 +811,7 @@ paths:
     put:
       parameters:
         - in: path
-          name: id
+          name: keywords-id
           required: true
           schema:
             format: int64
@@ -848,11 +848,11 @@ paths:
                   $ref: "#/components/schemas/UserAccount"
                 type: array
           description: ""
-  "/my-user-account/{id}":
+  "/my-user-account/{my-user-account-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: my-user-account-id
           required: true
           schema:
             format: int64
@@ -864,7 +864,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/UserAccount"
           description: ""
-  "/my-user-account/{parent-id}/organization":
+  "/my-user-account/{my-user-account-id}/organization":
     get:
       parameters:
         - in: query
@@ -876,7 +876,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: my-user-account-id
           required: true
           schema:
             format: int64
@@ -890,7 +890,7 @@ paths:
                   $ref: "#/components/schemas/Organization"
                 type: array
           description: ""
-  "/my-user-account/{parent-id}/roles":
+  "/my-user-account/{my-user-account-id}/roles":
     get:
       parameters:
         - in: query
@@ -902,7 +902,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: my-user-account-id
           required: true
           schema:
             format: int64
@@ -916,7 +916,7 @@ paths:
                   $ref: "#/components/schemas/Role"
                 type: array
           description: ""
-  "/my-user-account/{parent-id}/web-site":
+  "/my-user-account/{my-user-account-id}/web-site":
     get:
       parameters:
         - in: query
@@ -928,7 +928,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: my-user-account-id
           required: true
           schema:
             format: int64
@@ -962,11 +962,11 @@ paths:
                   $ref: "#/components/schemas/Organization"
                 type: array
           description: ""
-  "/organization/{id}":
+  "/organization/{organization-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: organization-id
           required: true
           schema:
             format: int64
@@ -978,7 +978,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
           description: ""
-  "/organization/{parent-id}/organization":
+  "/organization/{organization-id}/organization":
     get:
       parameters:
         - in: query
@@ -990,7 +990,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: organization-id
           required: true
           schema:
             format: int64
@@ -1004,7 +1004,7 @@ paths:
                   $ref: "#/components/schemas/Organization"
                 type: array
           description: ""
-  "/organization/{parent-id}/user-account":
+  "/organization/{organization-id}/user-account":
     get:
       parameters:
         - in: query
@@ -1016,7 +1016,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: organization-id
           required: true
           schema:
             format: int64
@@ -1055,11 +1055,11 @@ paths:
                   $ref: "#/components/schemas/Phone"
                 type: array
           description: ""
-  "/phones/{id}":
+  "/phones/{phones-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: phones-id
           required: true
           schema:
             format: int64
@@ -1091,11 +1091,11 @@ paths:
                   $ref: "#/components/schemas/Role"
                 type: array
           description: ""
-  "/roles/{id}":
+  "/roles/{roles-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: roles-id
           required: true
           schema:
             format: int64
@@ -1160,11 +1160,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/UserAccount"
           description: ""
-  "/user-account/{id}":
+  "/user-account/{user-account-id}":
     delete:
       parameters:
         - in: path
-          name: id
+          name: user-account-id
           required: true
           schema:
             format: int64
@@ -1177,7 +1177,7 @@ paths:
     get:
       parameters:
         - in: path
-          name: id
+          name: user-account-id
           required: true
           schema:
             format: int64
@@ -1192,7 +1192,7 @@ paths:
     put:
       parameters:
         - in: path
-          name: id
+          name: user-account-id
           required: true
           schema:
             format: int64
@@ -1209,7 +1209,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/UserAccount"
           description: ""
-  "/user-account/{parent-id}/organization":
+  "/user-account/{user-account-id}/organization":
     get:
       parameters:
         - in: query
@@ -1221,7 +1221,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: user-account-id
           required: true
           schema:
             format: int64
@@ -1235,7 +1235,7 @@ paths:
                   $ref: "#/components/schemas/Organization"
                 type: array
           description: ""
-  "/user-account/{parent-id}/roles":
+  "/user-account/{user-account-id}/roles":
     get:
       parameters:
         - in: query
@@ -1247,7 +1247,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: user-account-id
           required: true
           schema:
             format: int64
@@ -1261,7 +1261,7 @@ paths:
                   $ref: "#/components/schemas/Role"
                 type: array
           description: ""
-  "/user-account/{parent-id}/web-site":
+  "/user-account/{user-account-id}/web-site":
     get:
       parameters:
         - in: query
@@ -1273,7 +1273,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: user-account-id
           required: true
           schema:
             format: int64
@@ -1287,11 +1287,11 @@ paths:
                   $ref: "#/components/schemas/WebSite"
                 type: array
           description: ""
-  "/vocabularies/{id}":
+  "/vocabularies/{vocabularies-id}":
     delete:
       parameters:
         - in: path
-          name: id
+          name: vocabularies-id
           required: true
           schema:
             format: int64
@@ -1304,7 +1304,7 @@ paths:
     get:
       parameters:
         - in: path
-          name: id
+          name: vocabularies-id
           required: true
           schema:
             format: int64
@@ -1319,7 +1319,7 @@ paths:
     put:
       parameters:
         - in: path
-          name: id
+          name: vocabularies-id
           required: true
           schema:
             format: int64
@@ -1336,7 +1336,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Vocabulary"
           description: ""
-  "/vocabularies/{parent-id}/categories":
+  "/vocabularies/{vocabularies-id}/categories":
     get:
       parameters:
         - in: query
@@ -1348,7 +1348,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: vocabularies-id
           required: true
           schema:
             format: int64
@@ -1365,7 +1365,7 @@ paths:
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: vocabularies-id
           required: true
           schema:
             format: int64
@@ -1382,11 +1382,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Category"
           description: ""
-  "/vocabularies/{parent-id}/categories/batch-create":
+  "/vocabularies/{vocabularies-id}/categories/batch-create":
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: vocabularies-id
           required: true
           schema:
             format: int64
@@ -1403,11 +1403,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Category"
           description: ""
-  "/web-site/{id}":
+  "/web-site/{web-site-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: web-site-id
           required: true
           schema:
             format: int64
@@ -1419,7 +1419,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/WebSite"
           description: ""
-  "/web-site/{parent-id}/user-account":
+  "/web-site/{web-site-id}/user-account":
     get:
       parameters:
         - in: query
@@ -1431,7 +1431,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: web-site-id
           required: true
           schema:
             format: int64
@@ -1445,7 +1445,7 @@ paths:
                   $ref: "#/components/schemas/UserAccount"
                 type: array
           description: ""
-  "/web-site/{parent-id}/web-site":
+  "/web-site/{web-site-id}/web-site":
     get:
       parameters:
         - in: query
@@ -1457,7 +1457,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: web-site-id
           required: true
           schema:
             format: int64
@@ -1496,11 +1496,11 @@ paths:
                   $ref: "#/components/schemas/WebUrl"
                 type: array
           description: ""
-  "/web-urls/{id}":
+  "/web-urls/{web-urls-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: web-urls-id
           required: true
           schema:
             format: int64

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
@@ -205,11 +205,11 @@ info:
   version: 1.0.0
 openapi: 3.0.1
 paths:
-  "/aggregate-rating/{id}":
+  "/aggregate-rating/{aggregate-rating-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: aggregate-rating-id
           required: true
           schema:
             format: int64
@@ -221,11 +221,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/AggregateRating"
           description: ""
-  "/comment/{id}":
+  "/comment/{comment-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: comment-id
           required: true
           schema:
             format: int64
@@ -237,7 +237,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Comment"
           description: ""
-  "/comment/{parent-id}/comment":
+  "/comment/{comment-id}/comment":
     get:
       parameters:
         - in: query
@@ -249,7 +249,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: comment-id
           required: true
           schema:
             format: int64
@@ -263,11 +263,11 @@ paths:
                   $ref: "#/components/schemas/Comment"
                 type: array
           description: ""
-  "/content-document/{id}":
+  "/content-document/{content-document-id}":
     delete:
       parameters:
         - in: path
-          name: id
+          name: content-document-id
           required: true
           schema:
             format: int64
@@ -280,7 +280,7 @@ paths:
     get:
       parameters:
         - in: path
-          name: id
+          name: content-document-id
           required: true
           schema:
             format: int64
@@ -292,7 +292,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ContentDocument"
           description: ""
-  "/content-space/{parent-id}/content-structures":
+  "/content-space/{content-space-id}/content-structures":
     get:
       parameters:
         - in: query
@@ -304,7 +304,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -318,7 +318,7 @@ paths:
                   $ref: "#/components/schemas/ContentStructure"
                 type: array
           description: ""
-  "/content-space/{parent-id}/structured-contents":
+  "/content-space/{content-space-id}/structured-contents":
     get:
       parameters:
         - in: query
@@ -330,7 +330,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -359,7 +359,7 @@ paths:
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -380,11 +380,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/StructuredContent"
           description: ""
-  "/content-space/{parent-id}/structured-contents/batch-create":
+  "/content-space/{content-space-id}/structured-contents/batch-create":
     post:
       parameters:
         - in: path
-          name: parent-id
+          name: content-space-id
           required: true
           schema:
             format: int64
@@ -405,11 +405,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/StructuredContent"
           description: ""
-  "/content-structures/{id}":
+  "/content-structures/{content-structures-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: content-structures-id
           required: true
           schema:
             format: int64
@@ -421,37 +421,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ContentStructure"
           description: ""
-  "/content-document/{parent-id}/comment":
-    get:
-      parameters:
-        - in: query
-          name: page
-          schema:
-            type: integer
-        - in: query
-          name: per_page
-          schema:
-            type: integer
-        - in: path
-          name: parent-id
-          required: true
-          schema:
-            format: int64
-            type: integer
-      responses:
-        200:
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: "#/components/schemas/Comment"
-                type: array
-          description: ""
-  "/structured-contents/{id}":
+  "/structured-contents/{structured-contents-id}":
     delete:
       parameters:
         - in: path
-          name: id
+          name: structured-contents-id
           required: true
           schema:
             format: int64
@@ -464,7 +438,7 @@ paths:
     get:
       parameters:
         - in: path
-          name: id
+          name: structured-contents-id
           required: true
           schema:
             format: int64
@@ -483,7 +457,7 @@ paths:
     put:
       parameters:
         - in: path
-          name: id
+          name: structured-contents-id
           required: true
           schema:
             format: int64
@@ -504,7 +478,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StructuredContent"
           description: ""
-  "/structured-contents/{parent-id}/comment":
+  "/structured-contents/{structured-contents-id}/comment":
     get:
       parameters:
         - in: query
@@ -516,7 +490,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: structured-contents-id
           required: true
           schema:
             format: int64

--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/rest-openapi.yaml
@@ -86,7 +86,7 @@ info:
   version: 1.0.0
 openapi: 3.0.1
 paths:
-  "/roles/{parent-id}/workflow-tasks":
+  "/roles/{roles-id}/workflow-tasks":
     get:
       parameters:
         - in: query
@@ -98,7 +98,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: roles-id
           required: true
           schema:
             format: int64
@@ -112,11 +112,11 @@ paths:
                   $ref: "#/components/schemas/WorkflowTask"
                 type: array
           description: ""
-  "/workflow-logs/{id}":
+  "/workflow-logs/{workflow-logs-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: workflow-logs-id
           required: true
           schema:
             format: int64
@@ -153,11 +153,11 @@ paths:
                   $ref: "#/components/schemas/WorkflowTask"
                 type: array
           description: ""
-  "/workflow-tasks/{id}":
+  "/workflow-tasks/{workflow-tasks-id}":
     get:
       parameters:
         - in: path
-          name: id
+          name: workflow-tasks-id
           required: true
           schema:
             format: int64
@@ -169,11 +169,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowTask"
           description: ""
-  "/workflow-tasks/{id}/assign-to-me":
+  "/workflow-tasks/{workflow-tasks-id}/assign-to-me":
     post:
       parameters:
         - in: path
-          name: id
+          name: workflow-tasks-id
           required: true
           schema:
             format: int64
@@ -190,11 +190,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowTask"
           description: ""
-  "/workflow-tasks/{id}/assign-to-user":
+  "/workflow-tasks/{workflow-tasks-id}/assign-to-user":
     post:
       parameters:
         - in: path
-          name: id
+          name: workflow-tasks-id
           required: true
           schema:
             format: int64
@@ -211,11 +211,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowTask"
           description: ""
-  "/workflow-tasks/{id}/change-transition":
+  "/workflow-tasks/{workflow-tasks-id}/change-transition":
     post:
       parameters:
         - in: path
-          name: id
+          name: workflow-tasks-id
           required: true
           schema:
             format: int64
@@ -232,11 +232,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowTask"
           description: ""
-  "/workflow-tasks/{id}/update-due-date":
+  "/workflow-tasks/{workflow-tasks-id}/update-due-date":
     post:
       parameters:
         - in: path
-          name: id
+          name: workflow-tasks-id
           required: true
           schema:
             format: int64
@@ -253,7 +253,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowTask"
           description: ""
-  "/workflow-tasks/{parent-id}/workflow-logs":
+  "/workflow-tasks/{workflow-tasks-id}/workflow-logs":
     get:
       parameters:
         - in: query
@@ -265,7 +265,7 @@ paths:
           schema:
             type: integer
         - in: path
-          name: parent-id
+          name: workflow-tasks-id
           required: true
           schema:
             format: int64


### PR DESCRIPTION
Hi Brian!

We need this to receive a `long commentId` as the parentId of a resource instead of a `long parentId` without information of the parent resource.