### PR TITLE
LPS-89975 Have change tracking it's own suite

### DIFF
--- a/modules/apps/change-tracking/app.bnd
+++ b/modules/apps/change-tracking/app.bnd
@@ -10,6 +10,6 @@ Liferay-Releng-Marketplace: true
 Liferay-Releng-Portal-Required: true
 Liferay-Releng-Public: ${liferay.releng.public}
 Liferay-Releng-Restart-Required: true
-Liferay-Releng-Suite: foundation
+Liferay-Releng-Suite: change-tracking
 Liferay-Releng-Support-Url: http://www.liferay.com
 Liferay-Releng-Supported: ${liferay.releng.supported}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/orphan_portlets.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/orphan_portlets.jsp
@@ -18,7 +18,7 @@
 
 <%
 OrphanPortletsDisplayContext orphanPortletsDisplayContext = new OrphanPortletsDisplayContext(request, liferayPortletRequest, liferayPortletResponse);
-OrphanPortletsManagementToolbarDisplayContext = new OrphanPortletsManagementToolbarDisplayContext(liferayPortletRequest, liferayPortletResponse, request, orphanPortletsDisplayContext);
+OrphanPortletsManagementToolbarDisplayContext orphanPortletsManagementToolbarDisplayContext = new OrphanPortletsManagementToolbarDisplayContext(liferayPortletRequest, liferayPortletResponse, request, orphanPortletsDisplayContext);
 
 Layout selLayout = orphanPortletsDisplayContext.getSelLayout();
 

--- a/modules/suites/change-tracking/suite.bnd
+++ b/modules/suites/change-tracking/suite.bnd
@@ -1,0 +1,2 @@
+Liferay-Releng-Suite-Description: The Liferay Change Tracking suite provides features for users to track and publish their changes, manage change lists and publish history.
+Liferay-Releng-Suite-Title: ${liferay.releng.app.title.prefix} Change Tracking


### PR DESCRIPTION
@brianchandotcom I was asked to review the app.bnd-s and I wanted change tracking to have it's own suite, to be not dependent on other bundles. This would make delivering fixes and potentially new features more smoothly in the future