### PR TITLE
LPS-89658 If ExpressionVisitException extends from BadRequestException, we don't need to rethrow this exception either.

### DIFF
--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/filter/expression/ExpressionVisitException.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/filter/expression/ExpressionVisitException.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.odata.filter.expression;
 
+import javax.ws.rs.BadRequestException;
+
 /**
  * Defines an exception for {@link ExpressionVisitor} to throw if an error
  * occurs while traversing the expression tree.
@@ -21,7 +23,7 @@ package com.liferay.portal.odata.filter.expression;
  * @author Cristina González
  * @review
  */
-public class ExpressionVisitException extends Exception {
+public class ExpressionVisitException extends BadRequestException {
 
 	/**
 	 * Creates a new {@code ExpressionVisitException} with a message.

--- a/modules/apps/portal-odata/portal-odata-api/src/main/resources/com/liferay/portal/odata/filter/expression/packageinfo
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/resources/com/liferay/portal/odata/filter/expression/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 2.0.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/FilterContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/FilterContextProvider.java
@@ -24,6 +24,7 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
 import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.filter.InvalidFilterException;
 import com.liferay.portal.odata.filter.expression.ExpressionVisitException;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.internal.accept.language.AcceptLanguageImpl;
@@ -63,6 +64,9 @@ public class FilterContextProvider implements ContextProvider<Filter> {
 		}
 		catch (ExpressionVisitException eve) {
 			throw new BadRequestException(eve.getMessage(), eve);
+		}
+		catch (InvalidFilterException ife) {
+			throw new BadRequestException(ife.getMessage(), ife);
 		}
 		catch (Exception e) {
 			throw new ServerErrorException(500, e);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/FilterContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/FilterContextProvider.java
@@ -24,7 +24,6 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
 import com.liferay.portal.odata.filter.FilterParserProvider;
-import com.liferay.portal.odata.filter.InvalidFilterException;
 import com.liferay.portal.odata.filter.expression.ExpressionVisitException;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.internal.accept.language.AcceptLanguageImpl;
@@ -64,9 +63,6 @@ public class FilterContextProvider implements ContextProvider<Filter> {
 		}
 		catch (ExpressionVisitException eve) {
 			throw new BadRequestException(eve.getMessage(), eve);
-		}
-		catch (InvalidFilterException ife) {
-			throw new BadRequestException(ife.getMessage(), ife);
 		}
 		catch (Exception e) {
 			throw new ServerErrorException(500, e);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/FilterContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/FilterContextProvider.java
@@ -24,13 +24,11 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParser;
 import com.liferay.portal.odata.filter.FilterParserProvider;
-import com.liferay.portal.odata.filter.expression.ExpressionVisitException;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.internal.accept.language.AcceptLanguageImpl;
 
 import javax.servlet.http.HttpServletRequest;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.ext.Provider;
 
@@ -60,9 +58,6 @@ public class FilterContextProvider implements ContextProvider<Filter> {
 	public Filter createContext(Message message) {
 		try {
 			return _createContext(message);
-		}
-		catch (ExpressionVisitException eve) {
-			throw new BadRequestException(eve.getMessage(), eve);
 		}
 		catch (Exception e) {
 			throw new ServerErrorException(500, e);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/SortContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/SortContextProvider.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.sort.InvalidSortException;
 import com.liferay.portal.odata.sort.SortField;
 import com.liferay.portal.odata.sort.SortParser;
 import com.liferay.portal.odata.sort.SortParserProvider;
@@ -31,6 +32,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.ext.Provider;
 
@@ -58,6 +60,9 @@ public class SortContextProvider implements ContextProvider<Sort[]> {
 	public Sort[] createContext(Message message) {
 		try {
 			return _createContext(message);
+		}
+		catch (InvalidSortException ise) {
+			throw new BadRequestException(ise.getMessage(), ise);
 		}
 		catch (Exception e) {
 			throw new ServerErrorException(500, e);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/SortContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/SortContextProvider.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
-import com.liferay.portal.odata.sort.InvalidSortException;
 import com.liferay.portal.odata.sort.SortField;
 import com.liferay.portal.odata.sort.SortParser;
 import com.liferay.portal.odata.sort.SortParserProvider;
@@ -32,7 +31,6 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.ext.Provider;
 
@@ -60,9 +58,6 @@ public class SortContextProvider implements ContextProvider<Sort[]> {
 	public Sort[] createContext(Message message) {
 		try {
 			return _createContext(message);
-		}
-		catch (InvalidSortException ise) {
-			throw new BadRequestException(ise.getMessage(), ise);
 		}
 		catch (Exception e) {
 			throw new ServerErrorException(500, e);


### PR DESCRIPTION
Hey @brianchandotcom,

About comments in https://github.com/brianchandotcom/liferay-portal/pull/67882.

The ExpressionVisitException is the only exception in the portal-odata module that doesn't inherit form BadRequestException, that is the reason we need to rethrow that.

So we have 2 options in order to be more consistent:

1. Make InvalidSortException and InvalidFilterException extend Exception instead BadRequestException, so we need to catch it and rethrow a BadRequestException (this change need an increment in the portal-odata version).

2. Make ExpressionVisitException extends BadRequestException instead Exception, so we don't need to catch it and rethrow it anymore (this change need an increment in the portal-odata version).

If this pull I have send you a few commits with the second solution.

Thanks!