### PR TITLE
LPS-90435 singular in method names

### DIFF
--- a/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/AggregateRatingResource.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/AggregateRatingResource.java
@@ -63,6 +63,6 @@ public interface AggregateRatingResource {
 	@Path("/aggregate-ratings/{aggregate-rating-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public AggregateRating getAggregateRatings( @PathParam("aggregate-rating-id") Long aggregateRatingId ) throws Exception;
+	public AggregateRating getAggregateRating( @PathParam("aggregate-rating-id") Long aggregateRatingId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/BlogPostingResource.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/BlogPostingResource.java
@@ -63,59 +63,59 @@ public interface BlogPostingResource {
 	@Path("/blog-postings/{blog-posting-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Response deleteBlogPostings( @PathParam("blog-posting-id") Long blogPostingId ) throws Exception;
+	public Response deleteBlogPosting( @PathParam("blog-posting-id") Long blogPostingId ) throws Exception;
 
 	@GET
 	@Path("/blog-postings/{blog-posting-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public BlogPosting getBlogPostings( @PathParam("blog-posting-id") Long blogPostingId ) throws Exception;
+	public BlogPosting getBlogPosting( @PathParam("blog-posting-id") Long blogPostingId ) throws Exception;
 
 	@Consumes("application/json")
 	@PUT
 	@Path("/blog-postings/{blog-posting-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public BlogPosting putBlogPostings( @PathParam("blog-posting-id") Long blogPostingId , BlogPosting blogPosting ) throws Exception;
+	public BlogPosting putBlogPosting( @PathParam("blog-posting-id") Long blogPostingId , BlogPosting blogPosting ) throws Exception;
 
 	@GET
 	@Path("/blog-postings/{blog-posting-id}/categories")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Long> getBlogPostingsCategoriesPage( @PathParam("blog-posting-id") Long blogPostingId , @Context Pagination pagination ) throws Exception;
+	public Page<Long> getBlogPostingCategoriesPage( @PathParam("blog-posting-id") Long blogPostingId , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/blog-postings/{blog-posting-id}/categories")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Response postBlogPostingsCategories( @PathParam("blog-posting-id") Long blogPostingId , Long referenceId ) throws Exception;
+	public Response postBlogPostingCategories( @PathParam("blog-posting-id") Long blogPostingId , Long referenceId ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/blog-postings/{blog-posting-id}/categories/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public Response postBlogPostingsCategoriesBatchCreate( @PathParam("blog-posting-id") Long blogPostingId , Long referenceId ) throws Exception;
+	public Response postBlogPostingCategoriesBatchCreate( @PathParam("blog-posting-id") Long blogPostingId , Long referenceId ) throws Exception;
 
 	@GET
 	@Path("/content-spaces/{content-space-id}/blog-postings")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<BlogPosting> getContentSpacesBlogPostingsPage( @PathParam("content-space-id") Long contentSpaceId , @Context Pagination pagination ) throws Exception;
+	public Page<BlogPosting> getContentSpaceBlogPostingPage( @PathParam("content-space-id") Long contentSpaceId , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/content-spaces/{content-space-id}/blog-postings")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public BlogPosting postContentSpacesBlogPostings( @PathParam("content-space-id") Long contentSpaceId , BlogPosting blogPosting ) throws Exception;
+	public BlogPosting postContentSpaceBlogPosting( @PathParam("content-space-id") Long contentSpaceId , BlogPosting blogPosting ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/content-spaces/{content-space-id}/blog-postings/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public BlogPosting postContentSpacesBlogPostingsBatchCreate( @PathParam("content-space-id") Long contentSpaceId , BlogPosting blogPosting ) throws Exception;
+	public BlogPosting postContentSpaceBlogPostingBatchCreate( @PathParam("content-space-id") Long contentSpaceId , BlogPosting blogPosting ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/CommentResource.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/CommentResource.java
@@ -63,18 +63,18 @@ public interface CommentResource {
 	@Path("/blog-postings/{blog-posting-id}/comments")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Comment> getBlogPostingsCommentsPage( @PathParam("blog-posting-id") Long blogPostingId , @Context Pagination pagination ) throws Exception;
+	public Page<Comment> getBlogPostingCommentPage( @PathParam("blog-posting-id") Long blogPostingId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/comments/{comment-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Comment getComments( @PathParam("comment-id") Long commentId ) throws Exception;
+	public Comment getComment( @PathParam("comment-id") Long commentId ) throws Exception;
 
 	@GET
 	@Path("/comments/{comment-id}/comments")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Comment> getCommentsCommentsPage( @PathParam("comment-id") Long commentId , @Context Pagination pagination ) throws Exception;
+	public Page<Comment> getCommentCommentPage( @PathParam("comment-id") Long commentId , @Context Pagination pagination ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/CreatorResource.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/CreatorResource.java
@@ -63,6 +63,6 @@ public interface CreatorResource {
 	@Path("/creators/{creator-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Creator getCreators( @PathParam("creator-id") Long creatorId ) throws Exception;
+	public Creator getCreator( @PathParam("creator-id") Long creatorId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/ImageObjectRepositoryResource.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/ImageObjectRepositoryResource.java
@@ -63,6 +63,6 @@ public interface ImageObjectRepositoryResource {
 	@Path("/image-object-repositories/{image-object-repository-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public ImageObjectRepository getImageObjectRepositories( @PathParam("image-object-repository-id") Long imageObjectRepositoryId ) throws Exception;
+	public ImageObjectRepository getImageObjectRepository( @PathParam("image-object-repository-id") Long imageObjectRepositoryId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/ImageObjectResource.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/ImageObjectResource.java
@@ -63,32 +63,32 @@ public interface ImageObjectResource {
 	@Path("/image-object-repositories/{image-object-repository-id}/image-objects")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<ImageObject> getImageObjectRepositoriesImageObjectsPage( @PathParam("image-object-repository-id") Long imageObjectRepositoryId , @Context Pagination pagination ) throws Exception;
+	public Page<ImageObject> getImageObjectRepositoryImageObjectPage( @PathParam("image-object-repository-id") Long imageObjectRepositoryId , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/image-object-repositories/{image-object-repository-id}/image-objects")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public ImageObject postImageObjectRepositoriesImageObjects( @PathParam("image-object-repository-id") Long imageObjectRepositoryId , ImageObject imageObject ) throws Exception;
+	public ImageObject postImageObjectRepositoryImageObject( @PathParam("image-object-repository-id") Long imageObjectRepositoryId , ImageObject imageObject ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/image-object-repositories/{image-object-repository-id}/image-objects/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public ImageObject postImageObjectRepositoriesImageObjectsBatchCreate( @PathParam("image-object-repository-id") Long imageObjectRepositoryId , ImageObject imageObject ) throws Exception;
+	public ImageObject postImageObjectRepositoryImageObjectBatchCreate( @PathParam("image-object-repository-id") Long imageObjectRepositoryId , ImageObject imageObject ) throws Exception;
 
 	@DELETE
 	@Path("/image-objects/{image-object-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Response deleteImageObjects( @PathParam("image-object-id") Long imageObjectId ) throws Exception;
+	public Response deleteImageObject( @PathParam("image-object-id") Long imageObjectId ) throws Exception;
 
 	@GET
 	@Path("/image-objects/{image-object-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public ImageObject getImageObjects( @PathParam("image-object-id") Long imageObjectId ) throws Exception;
+	public ImageObject getImageObject( @PathParam("image-object-id") Long imageObjectId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseAggregateRatingResourceImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseAggregateRatingResourceImpl.java
@@ -37,7 +37,7 @@ public abstract class BaseAggregateRatingResourceImpl
 	implements AggregateRatingResource {
 
 	@Override
-	public AggregateRating getAggregateRatings(Long aggregateRatingId)
+	public AggregateRating getAggregateRating(Long aggregateRatingId)
 		throws Exception {
 
 		return new AggregateRating();

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -40,19 +40,19 @@ public abstract class BaseBlogPostingResourceImpl
 	implements BlogPostingResource {
 
 	@Override
-	public Response deleteBlogPostings(Long blogPostingId) throws Exception {
+	public Response deleteBlogPosting(Long blogPostingId) throws Exception {
 		Response.ResponseBuilder responseBuilder = Response.ok();
 
 		return responseBuilder.build();
 	}
 
 	@Override
-	public BlogPosting getBlogPostings(Long blogPostingId) throws Exception {
+	public BlogPosting getBlogPosting(Long blogPostingId) throws Exception {
 		return new BlogPosting();
 	}
 
 	@Override
-	public Page<Long> getBlogPostingsCategoriesPage(
+	public Page<Long> getBlogPostingCategoriesPage(
 			Long blogPostingId, Pagination pagination)
 		throws Exception {
 
@@ -60,7 +60,7 @@ public abstract class BaseBlogPostingResourceImpl
 	}
 
 	@Override
-	public Page<BlogPosting> getContentSpacesBlogPostingsPage(
+	public Page<BlogPosting> getContentSpaceBlogPostingPage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -68,7 +68,7 @@ public abstract class BaseBlogPostingResourceImpl
 	}
 
 	@Override
-	public Response postBlogPostingsCategories(
+	public Response postBlogPostingCategories(
 			Long blogPostingId, Long referenceId)
 		throws Exception {
 
@@ -78,7 +78,7 @@ public abstract class BaseBlogPostingResourceImpl
 	}
 
 	@Override
-	public Response postBlogPostingsCategoriesBatchCreate(
+	public Response postBlogPostingCategoriesBatchCreate(
 			Long blogPostingId, Long referenceId)
 		throws Exception {
 
@@ -88,7 +88,7 @@ public abstract class BaseBlogPostingResourceImpl
 	}
 
 	@Override
-	public BlogPosting postContentSpacesBlogPostings(
+	public BlogPosting postContentSpaceBlogPosting(
 			Long contentSpaceId, BlogPosting blogPosting)
 		throws Exception {
 
@@ -96,7 +96,7 @@ public abstract class BaseBlogPostingResourceImpl
 	}
 
 	@Override
-	public BlogPosting postContentSpacesBlogPostingsBatchCreate(
+	public BlogPosting postContentSpaceBlogPostingBatchCreate(
 			Long contentSpaceId, BlogPosting blogPosting)
 		throws Exception {
 
@@ -104,7 +104,7 @@ public abstract class BaseBlogPostingResourceImpl
 	}
 
 	@Override
-	public BlogPosting putBlogPostings(
+	public BlogPosting putBlogPosting(
 			Long blogPostingId, BlogPosting blogPosting)
 		throws Exception {
 

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -39,7 +39,7 @@ import javax.ws.rs.core.Response;
 public abstract class BaseCommentResourceImpl implements CommentResource {
 
 	@Override
-	public Page<Comment> getBlogPostingsCommentsPage(
+	public Page<Comment> getBlogPostingCommentPage(
 			Long blogPostingId, Pagination pagination)
 		throws Exception {
 
@@ -47,12 +47,12 @@ public abstract class BaseCommentResourceImpl implements CommentResource {
 	}
 
 	@Override
-	public Comment getComments(Long commentId) throws Exception {
+	public Comment getComment(Long commentId) throws Exception {
 		return new Comment();
 	}
 
 	@Override
-	public Page<Comment> getCommentsCommentsPage(
+	public Page<Comment> getCommentCommentPage(
 			Long commentId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseCreatorResourceImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseCreatorResourceImpl.java
@@ -36,7 +36,7 @@ import javax.ws.rs.core.Response;
 public abstract class BaseCreatorResourceImpl implements CreatorResource {
 
 	@Override
-	public Creator getCreators(Long creatorId) throws Exception {
+	public Creator getCreator(Long creatorId) throws Exception {
 		return new Creator();
 	}
 

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseImageObjectRepositoryResourceImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseImageObjectRepositoryResourceImpl.java
@@ -37,7 +37,7 @@ public abstract class BaseImageObjectRepositoryResourceImpl
 	implements ImageObjectRepositoryResource {
 
 	@Override
-	public ImageObjectRepository getImageObjectRepositories(
+	public ImageObjectRepository getImageObjectRepository(
 			Long imageObjectRepositoryId)
 		throws Exception {
 

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseImageObjectResourceImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseImageObjectResourceImpl.java
@@ -40,14 +40,19 @@ public abstract class BaseImageObjectResourceImpl
 	implements ImageObjectResource {
 
 	@Override
-	public Response deleteImageObjects(Long imageObjectId) throws Exception {
+	public Response deleteImageObject(Long imageObjectId) throws Exception {
 		Response.ResponseBuilder responseBuilder = Response.ok();
 
 		return responseBuilder.build();
 	}
 
 	@Override
-	public Page<ImageObject> getImageObjectRepositoriesImageObjectsPage(
+	public ImageObject getImageObject(Long imageObjectId) throws Exception {
+		return new ImageObject();
+	}
+
+	@Override
+	public Page<ImageObject> getImageObjectRepositoryImageObjectPage(
 			Long imageObjectRepositoryId, Pagination pagination)
 		throws Exception {
 
@@ -55,12 +60,7 @@ public abstract class BaseImageObjectResourceImpl
 	}
 
 	@Override
-	public ImageObject getImageObjects(Long imageObjectId) throws Exception {
-		return new ImageObject();
-	}
-
-	@Override
-	public ImageObject postImageObjectRepositoriesImageObjects(
+	public ImageObject postImageObjectRepositoryImageObject(
 			Long imageObjectRepositoryId, ImageObject imageObject)
 		throws Exception {
 
@@ -68,7 +68,7 @@ public abstract class BaseImageObjectResourceImpl
 	}
 
 	@Override
-	public ImageObject postImageObjectRepositoriesImageObjectsBatchCreate(
+	public ImageObject postImageObjectRepositoryImageObjectBatchCreate(
 			Long imageObjectRepositoryId, ImageObject imageObject)
 		throws Exception {
 

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BlogPostingResourceImpl.java
@@ -54,21 +54,21 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 
 	@Override
-	public Response deleteBlogPostings(Long blogPostingId) throws Exception {
+	public Response deleteBlogPosting(Long blogPostingId) throws Exception {
 		_blogsEntryService.deleteEntry(blogPostingId);
 
 		return buildNoContentResponse();
 	}
 
 	@Override
-	public BlogPosting getBlogPostings(Long blogPostingId) throws Exception {
+	public BlogPosting getBlogPosting(Long blogPostingId) throws Exception {
 		BlogsEntry blogsEntry = _blogsEntryService.getEntry(blogPostingId);
 
 		return _toBlogPosting(blogsEntry);
 	}
 
 	@Override
-	public Page<BlogPosting> getContentSpacesBlogPostingsPage(
+	public Page<BlogPosting> getContentSpaceBlogPostingPage(
 		Long parentId, Pagination pagination) {
 
 		return Page.of(
@@ -83,7 +83,7 @@ public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 	}
 
 	@Override
-	public BlogPosting postContentSpacesBlogPostings(
+	public BlogPosting postContentSpaceBlogPosting(
 			Long contentSpaceId, BlogPosting blogPosting)
 		throws Exception {
 
@@ -103,7 +103,7 @@ public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 	}
 
 	@Override
-	public BlogPosting putBlogPostings(
+	public BlogPosting putBlogPosting(
 			Long blogPostingId, BlogPosting blogPosting)
 		throws Exception {
 

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseAggregateRatingResourceTestCase.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseAggregateRatingResourceTestCase.java
@@ -51,11 +51,11 @@ public abstract class BaseAggregateRatingResourceTestCase {
 	}
 
 	@Test
-	public void testGetAggregateRatings() throws Exception {
+	public void testGetAggregateRating() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetAggregateRatings(Long aggregateRatingId)
+	protected void invokeGetAggregateRating(Long aggregateRatingId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -54,53 +54,51 @@ public abstract class BaseBlogPostingResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteBlogPostings() throws Exception {
+	public void testDeleteBlogPosting() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetBlogPostings() throws Exception {
+	public void testGetBlogPosting() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetBlogPostingsCategoriesPage() throws Exception {
+	public void testGetBlogPostingCategoriesPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetContentSpacesBlogPostingsPage() throws Exception {
+	public void testGetContentSpaceBlogPostingPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostBlogPostingsCategories() throws Exception {
+	public void testPostBlogPostingCategories() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostBlogPostingsCategoriesBatchCreate() throws Exception {
+	public void testPostBlogPostingCategoriesBatchCreate() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostContentSpacesBlogPostings() throws Exception {
+	public void testPostContentSpaceBlogPosting() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostContentSpacesBlogPostingsBatchCreate()
-		throws Exception {
-
-			Assert.assertTrue(true);
-	}
-
-	@Test
-	public void testPutBlogPostings() throws Exception {
+	public void testPostContentSpaceBlogPostingBatchCreate() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeDeleteBlogPostings(Long blogPostingId)
+	@Test
+	public void testPutBlogPosting() throws Exception {
+		Assert.assertTrue(true);
+	}
+
+	protected void invokeDeleteBlogPosting(Long blogPostingId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -108,13 +106,13 @@ public abstract class BaseBlogPostingResourceTestCase {
 			requestSender.post("/blog-postings/{blog-posting-id}");
 	}
 
-	protected void invokeGetBlogPostings(Long blogPostingId) throws Exception {
+	protected void invokeGetBlogPosting(Long blogPostingId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/blog-postings/{blog-posting-id}");
 	}
 
-	protected void invokeGetBlogPostingsCategoriesPage(
+	protected void invokeGetBlogPostingCategoriesPage(
 			Long blogPostingId, Pagination pagination)
 		throws Exception {
 
@@ -123,7 +121,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 			requestSender.post("/blog-postings/{blog-posting-id}/categories");
 	}
 
-	protected void invokeGetContentSpacesBlogPostingsPage(
+	protected void invokeGetContentSpaceBlogPostingPage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -133,7 +131,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 				"/content-spaces/{content-space-id}/blog-postings");
 	}
 
-	protected void invokePostBlogPostingsCategories(
+	protected void invokePostBlogPostingCategories(
 			Long blogPostingId, Long referenceId)
 		throws Exception {
 
@@ -142,7 +140,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 			requestSender.post("/blog-postings/{blog-posting-id}/categories");
 	}
 
-	protected void invokePostBlogPostingsCategoriesBatchCreate(
+	protected void invokePostBlogPostingCategoriesBatchCreate(
 			Long blogPostingId, Long referenceId)
 		throws Exception {
 
@@ -152,7 +150,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 				"/blog-postings/{blog-posting-id}/categories/batch-create");
 	}
 
-	protected void invokePostContentSpacesBlogPostings(
+	protected void invokePostContentSpaceBlogPosting(
 			Long contentSpaceId, BlogPosting blogPosting)
 		throws Exception {
 
@@ -162,7 +160,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 				"/content-spaces/{content-space-id}/blog-postings");
 	}
 
-	protected void invokePostContentSpacesBlogPostingsBatchCreate(
+	protected void invokePostContentSpaceBlogPostingBatchCreate(
 			Long contentSpaceId, BlogPosting blogPosting)
 		throws Exception {
 
@@ -172,7 +170,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 				"/content-spaces/{content-space-id}/blog-postings/batch-create");
 	}
 
-	protected void invokePutBlogPostings(
+	protected void invokePutBlogPosting(
 			Long blogPostingId, BlogPosting blogPosting)
 		throws Exception {
 

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -53,21 +53,21 @@ public abstract class BaseCommentResourceTestCase {
 	}
 
 	@Test
-	public void testGetBlogPostingsCommentsPage() throws Exception {
+	public void testGetBlogPostingCommentPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetComments() throws Exception {
+	public void testGetComment() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetCommentsCommentsPage() throws Exception {
+	public void testGetCommentCommentPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetBlogPostingsCommentsPage(
+	protected void invokeGetBlogPostingCommentPage(
 			Long blogPostingId, Pagination pagination)
 		throws Exception {
 
@@ -76,13 +76,13 @@ public abstract class BaseCommentResourceTestCase {
 			requestSender.post("/blog-postings/{blog-posting-id}/comments");
 	}
 
-	protected void invokeGetComments(Long commentId) throws Exception {
+	protected void invokeGetComment(Long commentId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/comments/{comment-id}");
 	}
 
-	protected void invokeGetCommentsCommentsPage(
+	protected void invokeGetCommentCommentPage(
 			Long commentId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseCreatorResourceTestCase.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseCreatorResourceTestCase.java
@@ -51,11 +51,11 @@ public abstract class BaseCreatorResourceTestCase {
 	}
 
 	@Test
-	public void testGetCreators() throws Exception {
+	public void testGetCreator() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetCreators(Long creatorId) throws Exception {
+	protected void invokeGetCreator(Long creatorId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/creators/{creator-id}");

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseImageObjectRepositoryResourceTestCase.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseImageObjectRepositoryResourceTestCase.java
@@ -51,12 +51,11 @@ public abstract class BaseImageObjectRepositoryResourceTestCase {
 	}
 
 	@Test
-	public void testGetImageObjectRepositories() throws Exception {
+	public void testGetImageObjectRepository() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetImageObjectRepositories(
-			Long imageObjectRepositoryId)
+	protected void invokeGetImageObjectRepository(Long imageObjectRepositoryId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseImageObjectResourceTestCase.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseImageObjectResourceTestCase.java
@@ -54,35 +54,33 @@ public abstract class BaseImageObjectResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteImageObjects() throws Exception {
+	public void testDeleteImageObject() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetImageObjectRepositoriesImageObjectsPage()
+	public void testGetImageObject() throws Exception {
+		Assert.assertTrue(true);
+	}
+
+	@Test
+	public void testGetImageObjectRepositoryImageObjectPage() throws Exception {
+		Assert.assertTrue(true);
+	}
+
+	@Test
+	public void testPostImageObjectRepositoryImageObject() throws Exception {
+		Assert.assertTrue(true);
+	}
+
+	@Test
+	public void testPostImageObjectRepositoryImageObjectBatchCreate()
 		throws Exception {
 
 			Assert.assertTrue(true);
 	}
 
-	@Test
-	public void testGetImageObjects() throws Exception {
-		Assert.assertTrue(true);
-	}
-
-	@Test
-	public void testPostImageObjectRepositoriesImageObjects() throws Exception {
-		Assert.assertTrue(true);
-	}
-
-	@Test
-	public void testPostImageObjectRepositoriesImageObjectsBatchCreate()
-		throws Exception {
-
-			Assert.assertTrue(true);
-	}
-
-	protected void invokeDeleteImageObjects(Long imageObjectId)
+	protected void invokeDeleteImageObject(Long imageObjectId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -90,7 +88,13 @@ public abstract class BaseImageObjectResourceTestCase {
 			requestSender.post("/image-objects/{image-object-id}");
 	}
 
-	protected void invokeGetImageObjectRepositoriesImageObjectsPage(
+	protected void invokeGetImageObject(Long imageObjectId) throws Exception {
+		RequestSender requestSender = _createRequestSender();
+
+			requestSender.post("/image-objects/{image-object-id}");
+	}
+
+	protected void invokeGetImageObjectRepositoryImageObjectPage(
 			Long imageObjectRepositoryId, Pagination pagination)
 		throws Exception {
 
@@ -100,13 +104,7 @@ public abstract class BaseImageObjectResourceTestCase {
 				"/image-object-repositories/{image-object-repository-id}/image-objects");
 	}
 
-	protected void invokeGetImageObjects(Long imageObjectId) throws Exception {
-		RequestSender requestSender = _createRequestSender();
-
-			requestSender.post("/image-objects/{image-object-id}");
-	}
-
-	protected void invokePostImageObjectRepositoriesImageObjects(
+	protected void invokePostImageObjectRepositoryImageObject(
 			Long imageObjectRepositoryId, ImageObject imageObject)
 		throws Exception {
 
@@ -116,7 +114,7 @@ public abstract class BaseImageObjectResourceTestCase {
 				"/image-object-repositories/{image-object-repository-id}/image-objects");
 	}
 
-	protected void invokePostImageObjectRepositoriesImageObjectsBatchCreate(
+	protected void invokePostImageObjectRepositoryImageObjectBatchCreate(
 			Long imageObjectRepositoryId, ImageObject imageObject)
 		throws Exception {
 

--- a/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/CommentResource.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/CommentResource.java
@@ -61,6 +61,6 @@ public interface CommentResource {
 	@Path("/documents/{document-id}/comments")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Comment> getDocumentsCommentsPage( @PathParam("document-id") Long documentId , @Context Pagination pagination ) throws Exception;
+	public Page<Comment> getDocumentCommentPage( @PathParam("document-id") Long documentId , @Context Pagination pagination ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/CreatorResource.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/CreatorResource.java
@@ -61,6 +61,6 @@ public interface CreatorResource {
 	@Path("/creators/{creator-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Creator getCreators( @PathParam("creator-id") Long creatorId ) throws Exception;
+	public Creator getCreator( @PathParam("creator-id") Long creatorId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/DocumentResource.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/DocumentResource.java
@@ -61,72 +61,72 @@ public interface DocumentResource {
 	@Path("/documents/{document-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Response deleteDocuments( @PathParam("document-id") Long documentId ) throws Exception;
+	public Response deleteDocument( @PathParam("document-id") Long documentId ) throws Exception;
 
 	@GET
 	@Path("/documents/{document-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Document getDocuments( @PathParam("document-id") Long documentId ) throws Exception;
+	public Document getDocument( @PathParam("document-id") Long documentId ) throws Exception;
 
 	@GET
 	@Path("/documents/{document-id}/categories")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Long> getDocumentsCategoriesPage( @PathParam("document-id") Long documentId , @Context Pagination pagination ) throws Exception;
+	public Page<Long> getDocumentCategoriesPage( @PathParam("document-id") Long documentId , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/documents/{document-id}/categories")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Response postDocumentsCategories( @PathParam("document-id") Long documentId , Long referenceId ) throws Exception;
+	public Response postDocumentCategories( @PathParam("document-id") Long documentId , Long referenceId ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/documents/{document-id}/categories/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public Response postDocumentsCategoriesBatchCreate( @PathParam("document-id") Long documentId , Long referenceId ) throws Exception;
+	public Response postDocumentCategoriesBatchCreate( @PathParam("document-id") Long documentId , Long referenceId ) throws Exception;
 
 	@GET
 	@Path("/documents-repositories/{documents-repository-id}/documents")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Document> getDocumentsRepositoriesDocumentsPage( @PathParam("documents-repository-id") Long documentsRepositoryId , @Context Pagination pagination ) throws Exception;
+	public Page<Document> getDocumentsRepositoryDocumentPage( @PathParam("documents-repository-id") Long documentsRepositoryId , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/documents-repositories/{documents-repository-id}/documents")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Document postDocumentsRepositoriesDocuments( @PathParam("documents-repository-id") Long documentsRepositoryId , Document document ) throws Exception;
+	public Document postDocumentsRepositoryDocument( @PathParam("documents-repository-id") Long documentsRepositoryId , Document document ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/documents-repositories/{documents-repository-id}/documents/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public Document postDocumentsRepositoriesDocumentsBatchCreate( @PathParam("documents-repository-id") Long documentsRepositoryId , Document document ) throws Exception;
+	public Document postDocumentsRepositoryDocumentBatchCreate( @PathParam("documents-repository-id") Long documentsRepositoryId , Document document ) throws Exception;
 
 	@GET
 	@Path("/folders/{folder-id}/documents")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Document> getFoldersDocumentsPage( @PathParam("folder-id") Long folderId , @Context Pagination pagination ) throws Exception;
+	public Page<Document> getFolderDocumentPage( @PathParam("folder-id") Long folderId , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("multipart/form-data")
 	@POST
 	@Path("/folders/{folder-id}/documents")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Document postFoldersDocuments( @PathParam("folder-id") Long folderId , MultipartBody multipartBody ) throws Exception;
+	public Document postFolderDocument( @PathParam("folder-id") Long folderId , MultipartBody multipartBody ) throws Exception;
 
 	@Consumes("multipart/form-data")
 	@POST
 	@Path("/folders/{folder-id}/documents/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public Document postFoldersDocumentsBatchCreate( @PathParam("folder-id") Long folderId , MultipartBody multipartBody ) throws Exception;
+	public Document postFolderDocumentBatchCreate( @PathParam("folder-id") Long folderId , MultipartBody multipartBody ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/FolderResource.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/FolderResource.java
@@ -61,65 +61,65 @@ public interface FolderResource {
 	@Path("/documents-repositories/{documents-repository-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Folder getDocumentsRepositories( @PathParam("documents-repository-id") Long documentsRepositoryId ) throws Exception;
+	public Folder getDocumentsRepository( @PathParam("documents-repository-id") Long documentsRepositoryId ) throws Exception;
 
 	@GET
 	@Path("/documents-repositories/{documents-repository-id}/folders")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Folder> getDocumentsRepositoriesFoldersPage( @PathParam("documents-repository-id") Long documentsRepositoryId , @Context Pagination pagination ) throws Exception;
+	public Page<Folder> getDocumentsRepositoryFolderPage( @PathParam("documents-repository-id") Long documentsRepositoryId , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/documents-repositories/{documents-repository-id}/folders")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Folder postDocumentsRepositoriesFolders( @PathParam("documents-repository-id") Long documentsRepositoryId , Folder folder ) throws Exception;
+	public Folder postDocumentsRepositoryFolder( @PathParam("documents-repository-id") Long documentsRepositoryId , Folder folder ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/documents-repositories/{documents-repository-id}/folders/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public Folder postDocumentsRepositoriesFoldersBatchCreate( @PathParam("documents-repository-id") Long documentsRepositoryId , Folder folder ) throws Exception;
+	public Folder postDocumentsRepositoryFolderBatchCreate( @PathParam("documents-repository-id") Long documentsRepositoryId , Folder folder ) throws Exception;
 
 	@DELETE
 	@Path("/folders/{folder-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Response deleteFolders( @PathParam("folder-id") Long folderId ) throws Exception;
+	public Response deleteFolder( @PathParam("folder-id") Long folderId ) throws Exception;
 
 	@GET
 	@Path("/folders/{folder-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Folder getFolders( @PathParam("folder-id") Long folderId ) throws Exception;
+	public Folder getFolder( @PathParam("folder-id") Long folderId ) throws Exception;
 
 	@Consumes("application/json")
 	@PUT
 	@Path("/folders/{folder-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Folder putFolders( @PathParam("folder-id") Long folderId , Folder folder ) throws Exception;
+	public Folder putFolder( @PathParam("folder-id") Long folderId , Folder folder ) throws Exception;
 
 	@GET
 	@Path("/folders/{folder-id}/folders")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Folder> getFoldersFoldersPage( @PathParam("folder-id") Long folderId , @Context Pagination pagination ) throws Exception;
+	public Page<Folder> getFolderFolderPage( @PathParam("folder-id") Long folderId , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/folders/{folder-id}/folders")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Folder postFoldersFolders( @PathParam("folder-id") Long folderId , Folder folder ) throws Exception;
+	public Folder postFolderFolder( @PathParam("folder-id") Long folderId , Folder folder ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/folders/{folder-id}/folders/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public Folder postFoldersFoldersBatchCreate( @PathParam("folder-id") Long folderId , Folder folder ) throws Exception;
+	public Folder postFolderFolderBatchCreate( @PathParam("folder-id") Long folderId , Folder folder ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -39,7 +39,7 @@ import javax.ws.rs.core.Response;
 public abstract class BaseCommentResourceImpl implements CommentResource {
 
 	@Override
-	public Page<Comment> getDocumentsCommentsPage(
+	public Page<Comment> getDocumentCommentPage(
 			Long documentId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseCreatorResourceImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseCreatorResourceImpl.java
@@ -36,7 +36,7 @@ import javax.ws.rs.core.Response;
 public abstract class BaseCreatorResourceImpl implements CreatorResource {
 
 	@Override
-	public Creator getCreators(Long creatorId) throws Exception {
+	public Creator getCreator(Long creatorId) throws Exception {
 		return new Creator();
 	}
 

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -40,19 +40,19 @@ import javax.ws.rs.core.Response;
 public abstract class BaseDocumentResourceImpl implements DocumentResource {
 
 	@Override
-	public Response deleteDocuments(Long documentId) throws Exception {
+	public Response deleteDocument(Long documentId) throws Exception {
 		Response.ResponseBuilder responseBuilder = Response.ok();
 
 		return responseBuilder.build();
 	}
 
 	@Override
-	public Document getDocuments(Long documentId) throws Exception {
+	public Document getDocument(Long documentId) throws Exception {
 		return new Document();
 	}
 
 	@Override
-	public Page<Long> getDocumentsCategoriesPage(
+	public Page<Long> getDocumentCategoriesPage(
 			Long documentId, Pagination pagination)
 		throws Exception {
 
@@ -60,7 +60,7 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 	}
 
 	@Override
-	public Page<Document> getDocumentsRepositoriesDocumentsPage(
+	public Page<Document> getDocumentsRepositoryDocumentPage(
 			Long documentsRepositoryId, Pagination pagination)
 		throws Exception {
 
@@ -68,7 +68,7 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 	}
 
 	@Override
-	public Page<Document> getFoldersDocumentsPage(
+	public Page<Document> getFolderDocumentPage(
 			Long folderId, Pagination pagination)
 		throws Exception {
 
@@ -76,7 +76,7 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 	}
 
 	@Override
-	public Response postDocumentsCategories(Long documentId, Long referenceId)
+	public Response postDocumentCategories(Long documentId, Long referenceId)
 		throws Exception {
 
 		Response.ResponseBuilder responseBuilder = Response.ok();
@@ -85,7 +85,7 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 	}
 
 	@Override
-	public Response postDocumentsCategoriesBatchCreate(
+	public Response postDocumentCategoriesBatchCreate(
 			Long documentId, Long referenceId)
 		throws Exception {
 
@@ -95,7 +95,7 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 	}
 
 	@Override
-	public Document postDocumentsRepositoriesDocuments(
+	public Document postDocumentsRepositoryDocument(
 			Long documentsRepositoryId, Document document)
 		throws Exception {
 
@@ -103,7 +103,7 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 	}
 
 	@Override
-	public Document postDocumentsRepositoriesDocumentsBatchCreate(
+	public Document postDocumentsRepositoryDocumentBatchCreate(
 			Long documentsRepositoryId, Document document)
 		throws Exception {
 
@@ -111,7 +111,7 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 	}
 
 	@Override
-	public Document postFoldersDocuments(
+	public Document postFolderDocument(
 			Long folderId, MultipartBody multipartBody)
 		throws Exception {
 
@@ -119,7 +119,7 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 	}
 
 	@Override
-	public Document postFoldersDocumentsBatchCreate(
+	public Document postFolderDocumentBatchCreate(
 			Long folderId, MultipartBody multipartBody)
 		throws Exception {
 

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseFolderResourceImpl.java
@@ -39,21 +39,21 @@ import javax.ws.rs.core.Response;
 public abstract class BaseFolderResourceImpl implements FolderResource {
 
 	@Override
-	public Response deleteFolders(Long folderId) throws Exception {
+	public Response deleteFolder(Long folderId) throws Exception {
 		Response.ResponseBuilder responseBuilder = Response.ok();
 
 		return responseBuilder.build();
 	}
 
 	@Override
-	public Folder getDocumentsRepositories(Long documentsRepositoryId)
+	public Folder getDocumentsRepository(Long documentsRepositoryId)
 		throws Exception {
 
 		return new Folder();
 	}
 
 	@Override
-	public Page<Folder> getDocumentsRepositoriesFoldersPage(
+	public Page<Folder> getDocumentsRepositoryFolderPage(
 			Long documentsRepositoryId, Pagination pagination)
 		throws Exception {
 
@@ -61,12 +61,12 @@ public abstract class BaseFolderResourceImpl implements FolderResource {
 	}
 
 	@Override
-	public Folder getFolders(Long folderId) throws Exception {
+	public Folder getFolder(Long folderId) throws Exception {
 		return new Folder();
 	}
 
 	@Override
-	public Page<Folder> getFoldersFoldersPage(
+	public Page<Folder> getFolderFolderPage(
 			Long folderId, Pagination pagination)
 		throws Exception {
 
@@ -74,7 +74,7 @@ public abstract class BaseFolderResourceImpl implements FolderResource {
 	}
 
 	@Override
-	public Folder postDocumentsRepositoriesFolders(
+	public Folder postDocumentsRepositoryFolder(
 			Long documentsRepositoryId, Folder folder)
 		throws Exception {
 
@@ -82,7 +82,7 @@ public abstract class BaseFolderResourceImpl implements FolderResource {
 	}
 
 	@Override
-	public Folder postDocumentsRepositoriesFoldersBatchCreate(
+	public Folder postDocumentsRepositoryFolderBatchCreate(
 			Long documentsRepositoryId, Folder folder)
 		throws Exception {
 
@@ -90,21 +90,21 @@ public abstract class BaseFolderResourceImpl implements FolderResource {
 	}
 
 	@Override
-	public Folder postFoldersFolders(Long folderId, Folder folder)
+	public Folder postFolderFolder(Long folderId, Folder folder)
 		throws Exception {
 
 		return new Folder();
 	}
 
 	@Override
-	public Folder postFoldersFoldersBatchCreate(Long folderId, Folder folder)
+	public Folder postFolderFolderBatchCreate(Long folderId, Folder folder)
 		throws Exception {
 
 		return new Folder();
 	}
 
 	@Override
-	public Folder putFolders(Long folderId, Folder folder) throws Exception {
+	public Folder putFolder(Long folderId, Folder folder) throws Exception {
 		return new Folder();
 	}
 

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/FolderResourceImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/FolderResourceImpl.java
@@ -38,14 +38,14 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class FolderResourceImpl extends BaseFolderResourceImpl {
 
 	@Override
-	public Response deleteFolders(Long folderId) throws Exception {
+	public Response deleteFolder(Long folderId) throws Exception {
 		_dlAppService.deleteFolder(folderId);
 
 		return buildNoContentResponse();
 	}
 
 	@Override
-	public Page<Folder> getDocumentsRepositoriesFoldersPage(
+	public Page<Folder> getDocumentsRepositoryFolderPage(
 			Long documentsRepositoryId, Pagination pagination)
 		throws Exception {
 
@@ -55,12 +55,12 @@ public class FolderResourceImpl extends BaseFolderResourceImpl {
 	}
 
 	@Override
-	public Folder getFolders(Long folderId) throws Exception {
+	public Folder getFolder(Long folderId) throws Exception {
 		return _toFolder(_dlAppService.getFolder(folderId));
 	}
 
 	@Override
-	public Page<Folder> getFoldersFoldersPage(
+	public Page<Folder> getFolderFolderPage(
 			Long folderId, Pagination pagination)
 		throws Exception {
 
@@ -72,7 +72,7 @@ public class FolderResourceImpl extends BaseFolderResourceImpl {
 	}
 
 	@Override
-	public Folder postDocumentsRepositoriesFolders(
+	public Folder postDocumentsRepositoryFolder(
 			Long documentsRepositoryId, Folder folder)
 		throws Exception {
 
@@ -80,7 +80,7 @@ public class FolderResourceImpl extends BaseFolderResourceImpl {
 	}
 
 	@Override
-	public Folder postFoldersFolders(Long folderId, Folder folder)
+	public Folder postFolderFolder(Long folderId, Folder folder)
 		throws Exception {
 
 		Folder parentFolder = _toFolder(_dlAppService.getFolder(folderId));
@@ -91,7 +91,7 @@ public class FolderResourceImpl extends BaseFolderResourceImpl {
 	}
 
 	@Override
-	public Folder putFolders(Long folderId, Folder folder) throws Exception {
+	public Folder putFolder(Long folderId, Folder folder) throws Exception {
 		return _toFolder(
 			_dlAppService.updateFolder(
 				folderId, folder.getName(), folder.getDescription(),

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -53,11 +53,11 @@ public abstract class BaseCommentResourceTestCase {
 	}
 
 	@Test
-	public void testGetDocumentsCommentsPage() throws Exception {
+	public void testGetDocumentCommentPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetDocumentsCommentsPage(
+	protected void invokeGetDocumentCommentPage(
 			Long documentId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseCreatorResourceTestCase.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseCreatorResourceTestCase.java
@@ -51,11 +51,11 @@ public abstract class BaseCreatorResourceTestCase {
 	}
 
 	@Test
-	public void testGetCreators() throws Exception {
+	public void testGetCreator() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetCreators(Long creatorId) throws Exception {
+	protected void invokeGetCreator(Long creatorId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/creators/{creator-id}");

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -55,75 +55,75 @@ public abstract class BaseDocumentResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteDocuments() throws Exception {
+	public void testDeleteDocument() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetDocuments() throws Exception {
+	public void testGetDocument() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetDocumentsCategoriesPage() throws Exception {
+	public void testGetDocumentCategoriesPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetDocumentsRepositoriesDocumentsPage() throws Exception {
+	public void testGetDocumentsRepositoryDocumentPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetFoldersDocumentsPage() throws Exception {
+	public void testGetFolderDocumentPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostDocumentsCategories() throws Exception {
+	public void testPostDocumentCategories() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostDocumentsCategoriesBatchCreate() throws Exception {
+	public void testPostDocumentCategoriesBatchCreate() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostDocumentsRepositoriesDocuments() throws Exception {
+	public void testPostDocumentsRepositoryDocument() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostDocumentsRepositoriesDocumentsBatchCreate()
+	public void testPostDocumentsRepositoryDocumentBatchCreate()
 		throws Exception {
 
 			Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostFoldersDocuments() throws Exception {
+	public void testPostFolderDocument() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostFoldersDocumentsBatchCreate() throws Exception {
+	public void testPostFolderDocumentBatchCreate() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeDeleteDocuments(Long documentId) throws Exception {
+	protected void invokeDeleteDocument(Long documentId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/documents/{document-id}");
 	}
 
-	protected void invokeGetDocuments(Long documentId) throws Exception {
+	protected void invokeGetDocument(Long documentId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/documents/{document-id}");
 	}
 
-	protected void invokeGetDocumentsCategoriesPage(
+	protected void invokeGetDocumentCategoriesPage(
 			Long documentId, Pagination pagination)
 		throws Exception {
 
@@ -132,7 +132,7 @@ public abstract class BaseDocumentResourceTestCase {
 			requestSender.post("/documents/{document-id}/categories");
 	}
 
-	protected void invokeGetDocumentsRepositoriesDocumentsPage(
+	protected void invokeGetDocumentsRepositoryDocumentPage(
 			Long documentsRepositoryId, Pagination pagination)
 		throws Exception {
 
@@ -142,7 +142,7 @@ public abstract class BaseDocumentResourceTestCase {
 				"/documents-repositories/{documents-repository-id}/documents");
 	}
 
-	protected void invokeGetFoldersDocumentsPage(
+	protected void invokeGetFolderDocumentPage(
 			Long folderId, Pagination pagination)
 		throws Exception {
 
@@ -151,7 +151,7 @@ public abstract class BaseDocumentResourceTestCase {
 			requestSender.post("/folders/{folder-id}/documents");
 	}
 
-	protected void invokePostDocumentsCategories(
+	protected void invokePostDocumentCategories(
 			Long documentId, Long referenceId)
 		throws Exception {
 
@@ -160,7 +160,7 @@ public abstract class BaseDocumentResourceTestCase {
 			requestSender.post("/documents/{document-id}/categories");
 	}
 
-	protected void invokePostDocumentsCategoriesBatchCreate(
+	protected void invokePostDocumentCategoriesBatchCreate(
 			Long documentId, Long referenceId)
 		throws Exception {
 
@@ -170,7 +170,7 @@ public abstract class BaseDocumentResourceTestCase {
 				"/documents/{document-id}/categories/batch-create");
 	}
 
-	protected void invokePostDocumentsRepositoriesDocuments(
+	protected void invokePostDocumentsRepositoryDocument(
 			Long documentsRepositoryId, Document document)
 		throws Exception {
 
@@ -180,7 +180,7 @@ public abstract class BaseDocumentResourceTestCase {
 				"/documents-repositories/{documents-repository-id}/documents");
 	}
 
-	protected void invokePostDocumentsRepositoriesDocumentsBatchCreate(
+	protected void invokePostDocumentsRepositoryDocumentBatchCreate(
 			Long documentsRepositoryId, Document document)
 		throws Exception {
 
@@ -190,7 +190,7 @@ public abstract class BaseDocumentResourceTestCase {
 				"/documents-repositories/{documents-repository-id}/documents/batch-create");
 	}
 
-	protected void invokePostFoldersDocuments(
+	protected void invokePostFolderDocument(
 			Long folderId, MultipartBody multipartBody)
 		throws Exception {
 
@@ -199,7 +199,7 @@ public abstract class BaseDocumentResourceTestCase {
 			requestSender.post("/folders/{folder-id}/documents");
 	}
 
-	protected void invokePostFoldersDocumentsBatchCreate(
+	protected void invokePostFolderDocumentBatchCreate(
 			Long folderId, MultipartBody multipartBody)
 		throws Exception {
 

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseFolderResourceTestCase.java
@@ -54,64 +54,64 @@ public abstract class BaseFolderResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteFolders() throws Exception {
+	public void testDeleteFolder() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetDocumentsRepositories() throws Exception {
+	public void testGetDocumentsRepository() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetDocumentsRepositoriesFoldersPage() throws Exception {
+	public void testGetDocumentsRepositoryFolderPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetFolders() throws Exception {
+	public void testGetFolder() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetFoldersFoldersPage() throws Exception {
+	public void testGetFolderFolderPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostDocumentsRepositoriesFolders() throws Exception {
+	public void testPostDocumentsRepositoryFolder() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostDocumentsRepositoriesFoldersBatchCreate()
+	public void testPostDocumentsRepositoryFolderBatchCreate()
 		throws Exception {
 
 			Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostFoldersFolders() throws Exception {
+	public void testPostFolderFolder() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostFoldersFoldersBatchCreate() throws Exception {
+	public void testPostFolderFolderBatchCreate() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPutFolders() throws Exception {
+	public void testPutFolder() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeDeleteFolders(Long folderId) throws Exception {
+	protected void invokeDeleteFolder(Long folderId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/folders/{folder-id}");
 	}
 
-	protected void invokeGetDocumentsRepositories(Long documentsRepositoryId)
+	protected void invokeGetDocumentsRepository(Long documentsRepositoryId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -120,7 +120,7 @@ public abstract class BaseFolderResourceTestCase {
 				"/documents-repositories/{documents-repository-id}");
 	}
 
-	protected void invokeGetDocumentsRepositoriesFoldersPage(
+	protected void invokeGetDocumentsRepositoryFolderPage(
 			Long documentsRepositoryId, Pagination pagination)
 		throws Exception {
 
@@ -130,13 +130,13 @@ public abstract class BaseFolderResourceTestCase {
 				"/documents-repositories/{documents-repository-id}/folders");
 	}
 
-	protected void invokeGetFolders(Long folderId) throws Exception {
+	protected void invokeGetFolder(Long folderId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/folders/{folder-id}");
 	}
 
-	protected void invokeGetFoldersFoldersPage(
+	protected void invokeGetFolderFolderPage(
 			Long folderId, Pagination pagination)
 		throws Exception {
 
@@ -145,7 +145,7 @@ public abstract class BaseFolderResourceTestCase {
 			requestSender.post("/folders/{folder-id}/folders");
 	}
 
-	protected void invokePostDocumentsRepositoriesFolders(
+	protected void invokePostDocumentsRepositoryFolder(
 			Long documentsRepositoryId, Folder folder)
 		throws Exception {
 
@@ -155,7 +155,7 @@ public abstract class BaseFolderResourceTestCase {
 				"/documents-repositories/{documents-repository-id}/folders");
 	}
 
-	protected void invokePostDocumentsRepositoriesFoldersBatchCreate(
+	protected void invokePostDocumentsRepositoryFolderBatchCreate(
 			Long documentsRepositoryId, Folder folder)
 		throws Exception {
 
@@ -165,7 +165,7 @@ public abstract class BaseFolderResourceTestCase {
 				"/documents-repositories/{documents-repository-id}/folders/batch-create");
 	}
 
-	protected void invokePostFoldersFolders(Long folderId, Folder folder)
+	protected void invokePostFolderFolder(Long folderId, Folder folder)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -173,7 +173,7 @@ public abstract class BaseFolderResourceTestCase {
 			requestSender.post("/folders/{folder-id}/folders");
 	}
 
-	protected void invokePostFoldersFoldersBatchCreate(
+	protected void invokePostFolderFolderBatchCreate(
 			Long folderId, Folder folder)
 		throws Exception {
 
@@ -182,7 +182,7 @@ public abstract class BaseFolderResourceTestCase {
 			requestSender.post("/folders/{folder-id}/folders/batch-create");
 	}
 
-	protected void invokePutFolders(Long folderId, Folder folder)
+	protected void invokePutFolder(Long folderId, Folder folder)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/CreatorResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/CreatorResource.java
@@ -62,6 +62,6 @@ public interface CreatorResource {
 	@Path("/creators/{creator-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Creator getCreators( @PathParam("creator-id") Long creatorId ) throws Exception;
+	public Creator getCreator( @PathParam("creator-id") Long creatorId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormDocumentResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormDocumentResource.java
@@ -62,12 +62,12 @@ public interface FormDocumentResource {
 	@Path("/form-documents/{form-document-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Response deleteFormDocuments( @PathParam("form-document-id") Long formDocumentId ) throws Exception;
+	public Response deleteFormDocument( @PathParam("form-document-id") Long formDocumentId ) throws Exception;
 
 	@GET
 	@Path("/form-documents/{form-document-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public FormDocument getFormDocuments( @PathParam("form-document-id") Long formDocumentId ) throws Exception;
+	public FormDocument getFormDocument( @PathParam("form-document-id") Long formDocumentId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormRecordResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormRecordResource.java
@@ -62,33 +62,33 @@ public interface FormRecordResource {
 	@Path("/form-records/{form-record-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public FormRecord getFormRecords( @PathParam("form-record-id") Long formRecordId ) throws Exception;
+	public FormRecord getFormRecord( @PathParam("form-record-id") Long formRecordId ) throws Exception;
 
 	@Consumes("application/json")
 	@PUT
 	@Path("/form-records/{form-record-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public FormRecord putFormRecords( @PathParam("form-record-id") Long formRecordId , FormRecord formRecord ) throws Exception;
+	public FormRecord putFormRecord( @PathParam("form-record-id") Long formRecordId , FormRecord formRecord ) throws Exception;
 
 	@GET
 	@Path("/forms/{form-id}/form-records")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<FormRecord> getFormsFormRecordsPage( @PathParam("form-id") Long formId , @Context Pagination pagination ) throws Exception;
+	public Page<FormRecord> getFormFormRecordPage( @PathParam("form-id") Long formId , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/forms/{form-id}/form-records")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public FormRecord postFormsFormRecords( @PathParam("form-id") Long formId , FormRecord formRecord ) throws Exception;
+	public FormRecord postFormFormRecord( @PathParam("form-id") Long formId , FormRecord formRecord ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/forms/{form-id}/form-records/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public FormRecord postFormsFormRecordsBatchCreate( @PathParam("form-id") Long formId , FormRecord formRecord ) throws Exception;
+	public FormRecord postFormFormRecordBatchCreate( @PathParam("form-id") Long formId , FormRecord formRecord ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormResource.java
@@ -62,32 +62,32 @@ public interface FormResource {
 	@Path("/content-spaces/{content-space-id}/form")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Form> getContentSpacesFormPage( @PathParam("content-space-id") Long contentSpaceId , @Context Pagination pagination ) throws Exception;
+	public Page<Form> getContentSpaceFormPage( @PathParam("content-space-id") Long contentSpaceId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/forms/{form-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Form getForms( @PathParam("form-id") Long formId ) throws Exception;
+	public Form getForm( @PathParam("form-id") Long formId ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/forms/{form-id}/evaluate-context")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public Form postFormsEvaluateContext( @PathParam("form-id") Long formId , Form form ) throws Exception;
+	public Form postFormEvaluateContext( @PathParam("form-id") Long formId , Form form ) throws Exception;
 
 	@GET
 	@Path("/forms/{form-id}/fetch-latest-draft")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Form getFormsFetchLatestDraft( @PathParam("form-id") Long formId ) throws Exception;
+	public Form getFormFetchLatestDraft( @PathParam("form-id") Long formId ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/forms/{form-id}/upload-file")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public Form postFormsUploadFile( @PathParam("form-id") Long formId , Form form ) throws Exception;
+	public Form postFormUploadFile( @PathParam("form-id") Long formId , Form form ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormStructureResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormStructureResource.java
@@ -62,12 +62,12 @@ public interface FormStructureResource {
 	@Path("/content-spaces/{content-space-id}/form-structures")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<FormStructure> getContentSpacesFormStructuresPage( @PathParam("content-space-id") Long contentSpaceId , @Context Pagination pagination ) throws Exception;
+	public Page<FormStructure> getContentSpaceFormStructurePage( @PathParam("content-space-id") Long contentSpaceId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/form-structures/{form-structure-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public FormStructure getFormStructures( @PathParam("form-structure-id") Long formStructureId ) throws Exception;
+	public FormStructure getFormStructure( @PathParam("form-structure-id") Long formStructureId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseCreatorResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseCreatorResourceImpl.java
@@ -36,7 +36,7 @@ import javax.ws.rs.core.Response;
 public abstract class BaseCreatorResourceImpl implements CreatorResource {
 
 	@Override
-	public Creator getCreators(Long creatorId) throws Exception {
+	public Creator getCreator(Long creatorId) throws Exception {
 		return new Creator();
 	}
 

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
@@ -37,14 +37,14 @@ public abstract class BaseFormDocumentResourceImpl
 	implements FormDocumentResource {
 
 	@Override
-	public Response deleteFormDocuments(Long formDocumentId) throws Exception {
+	public Response deleteFormDocument(Long formDocumentId) throws Exception {
 		Response.ResponseBuilder responseBuilder = Response.ok();
 
 		return responseBuilder.build();
 	}
 
 	@Override
-	public FormDocument getFormDocuments(Long formDocumentId) throws Exception {
+	public FormDocument getFormDocument(Long formDocumentId) throws Exception {
 		return new FormDocument();
 	}
 

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
@@ -39,12 +39,7 @@ import javax.ws.rs.core.Response;
 public abstract class BaseFormRecordResourceImpl implements FormRecordResource {
 
 	@Override
-	public FormRecord getFormRecords(Long formRecordId) throws Exception {
-		return new FormRecord();
-	}
-
-	@Override
-	public Page<FormRecord> getFormsFormRecordsPage(
+	public Page<FormRecord> getFormFormRecordPage(
 			Long formId, Pagination pagination)
 		throws Exception {
 
@@ -52,14 +47,19 @@ public abstract class BaseFormRecordResourceImpl implements FormRecordResource {
 	}
 
 	@Override
-	public FormRecord postFormsFormRecords(Long formId, FormRecord formRecord)
+	public FormRecord getFormRecord(Long formRecordId) throws Exception {
+		return new FormRecord();
+	}
+
+	@Override
+	public FormRecord postFormFormRecord(Long formId, FormRecord formRecord)
 		throws Exception {
 
 		return new FormRecord();
 	}
 
 	@Override
-	public FormRecord postFormsFormRecordsBatchCreate(
+	public FormRecord postFormFormRecordBatchCreate(
 			Long formId, FormRecord formRecord)
 		throws Exception {
 
@@ -67,7 +67,7 @@ public abstract class BaseFormRecordResourceImpl implements FormRecordResource {
 	}
 
 	@Override
-	public FormRecord putFormRecords(Long formRecordId, FormRecord formRecord)
+	public FormRecord putFormRecord(Long formRecordId, FormRecord formRecord)
 		throws Exception {
 
 		return new FormRecord();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
@@ -39,7 +39,7 @@ import javax.ws.rs.core.Response;
 public abstract class BaseFormResourceImpl implements FormResource {
 
 	@Override
-	public Page<Form> getContentSpacesFormPage(
+	public Page<Form> getContentSpaceFormPage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -47,24 +47,24 @@ public abstract class BaseFormResourceImpl implements FormResource {
 	}
 
 	@Override
-	public Form getForms(Long formId) throws Exception {
+	public Form getForm(Long formId) throws Exception {
 		return new Form();
 	}
 
 	@Override
-	public Form getFormsFetchLatestDraft(Long formId) throws Exception {
+	public Form getFormFetchLatestDraft(Long formId) throws Exception {
 		return new Form();
 	}
 
 	@Override
-	public Form postFormsEvaluateContext(Long formId, Form form)
+	public Form postFormEvaluateContext(Long formId, Form form)
 		throws Exception {
 
 		return new Form();
 	}
 
 	@Override
-	public Form postFormsUploadFile(Long formId, Form form) throws Exception {
+	public Form postFormUploadFile(Long formId, Form form) throws Exception {
 		return new Form();
 	}
 

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
@@ -40,7 +40,7 @@ public abstract class BaseFormStructureResourceImpl
 	implements FormStructureResource {
 
 	@Override
-	public Page<FormStructure> getContentSpacesFormStructuresPage(
+	public Page<FormStructure> getContentSpaceFormStructurePage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -48,7 +48,7 @@ public abstract class BaseFormStructureResourceImpl
 	}
 
 	@Override
-	public FormStructure getFormStructures(Long formStructureId)
+	public FormStructure getFormStructure(Long formStructureId)
 		throws Exception {
 
 		return new FormStructure();

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseCreatorResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseCreatorResourceTestCase.java
@@ -50,11 +50,11 @@ public abstract class BaseCreatorResourceTestCase {
 	}
 
 	@Test
-	public void testGetCreators() throws Exception {
+	public void testGetCreator() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetCreators(Long creatorId) throws Exception {
+	protected void invokeGetCreator(Long creatorId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/creators/{creator-id}");

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
@@ -50,16 +50,16 @@ public abstract class BaseFormDocumentResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteFormDocuments() throws Exception {
+	public void testDeleteFormDocument() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetFormDocuments() throws Exception {
+	public void testGetFormDocument() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeDeleteFormDocuments(Long formDocumentId)
+	protected void invokeDeleteFormDocument(Long formDocumentId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -67,10 +67,8 @@ public abstract class BaseFormDocumentResourceTestCase {
 			requestSender.post("/form-documents/{form-document-id}");
 	}
 
-	protected void invokeGetFormDocuments(Long formDocumentId)
-		throws Exception {
-
-			RequestSender requestSender = _createRequestSender();
+	protected void invokeGetFormDocument(Long formDocumentId) throws Exception {
+		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/form-documents/{form-document-id}");
 	}

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
@@ -53,37 +53,31 @@ public abstract class BaseFormRecordResourceTestCase {
 	}
 
 	@Test
-	public void testGetFormRecords() throws Exception {
+	public void testGetFormFormRecordPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetFormsFormRecordsPage() throws Exception {
+	public void testGetFormRecord() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostFormsFormRecords() throws Exception {
+	public void testPostFormFormRecord() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostFormsFormRecordsBatchCreate() throws Exception {
+	public void testPostFormFormRecordBatchCreate() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPutFormRecords() throws Exception {
+	public void testPutFormRecord() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetFormRecords(Long formRecordId) throws Exception {
-		RequestSender requestSender = _createRequestSender();
-
-			requestSender.post("/form-records/{form-record-id}");
-	}
-
-	protected void invokeGetFormsFormRecordsPage(
+	protected void invokeGetFormFormRecordPage(
 			Long formId, Pagination pagination)
 		throws Exception {
 
@@ -92,8 +86,13 @@ public abstract class BaseFormRecordResourceTestCase {
 			requestSender.post("/forms/{form-id}/form-records");
 	}
 
-	protected void invokePostFormsFormRecords(
-			Long formId, FormRecord formRecord)
+	protected void invokeGetFormRecord(Long formRecordId) throws Exception {
+		RequestSender requestSender = _createRequestSender();
+
+			requestSender.post("/form-records/{form-record-id}");
+	}
+
+	protected void invokePostFormFormRecord(Long formId, FormRecord formRecord)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -101,7 +100,7 @@ public abstract class BaseFormRecordResourceTestCase {
 			requestSender.post("/forms/{form-id}/form-records");
 	}
 
-	protected void invokePostFormsFormRecordsBatchCreate(
+	protected void invokePostFormFormRecordBatchCreate(
 			Long formId, FormRecord formRecord)
 		throws Exception {
 
@@ -110,8 +109,7 @@ public abstract class BaseFormRecordResourceTestCase {
 			requestSender.post("/forms/{form-id}/form-records/batch-create");
 	}
 
-	protected void invokePutFormRecords(
-			Long formRecordId, FormRecord formRecord)
+	protected void invokePutFormRecord(Long formRecordId, FormRecord formRecord)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
@@ -53,31 +53,31 @@ public abstract class BaseFormResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpacesFormPage() throws Exception {
+	public void testGetContentSpaceFormPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetForms() throws Exception {
+	public void testGetForm() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetFormsFetchLatestDraft() throws Exception {
+	public void testGetFormFetchLatestDraft() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostFormsEvaluateContext() throws Exception {
+	public void testPostFormEvaluateContext() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostFormsUploadFile() throws Exception {
+	public void testPostFormUploadFile() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetContentSpacesFormPage(
+	protected void invokeGetContentSpaceFormPage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -86,21 +86,19 @@ public abstract class BaseFormResourceTestCase {
 			requestSender.post("/content-spaces/{content-space-id}/form");
 	}
 
-	protected void invokeGetForms(Long formId) throws Exception {
+	protected void invokeGetForm(Long formId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/forms/{form-id}");
 	}
 
-	protected void invokeGetFormsFetchLatestDraft(Long formId)
-		throws Exception {
-
-			RequestSender requestSender = _createRequestSender();
+	protected void invokeGetFormFetchLatestDraft(Long formId) throws Exception {
+		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/forms/{form-id}/fetch-latest-draft");
 	}
 
-	protected void invokePostFormsEvaluateContext(Long formId, Form form)
+	protected void invokePostFormEvaluateContext(Long formId, Form form)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -108,7 +106,7 @@ public abstract class BaseFormResourceTestCase {
 			requestSender.post("/forms/{form-id}/evaluate-context");
 	}
 
-	protected void invokePostFormsUploadFile(Long formId, Form form)
+	protected void invokePostFormUploadFile(Long formId, Form form)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
@@ -52,16 +52,16 @@ public abstract class BaseFormStructureResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpacesFormStructuresPage() throws Exception {
+	public void testGetContentSpaceFormStructurePage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetFormStructures() throws Exception {
+	public void testGetFormStructure() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetContentSpacesFormStructuresPage(
+	protected void invokeGetContentSpaceFormStructurePage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -71,7 +71,7 @@ public abstract class BaseFormStructureResourceTestCase {
 				"/content-spaces/{content-space-id}/form-structures");
 	}
 
-	protected void invokeGetFormStructures(Long formStructureId)
+	protected void invokeGetFormStructure(Long formStructureId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();

--- a/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/CategoryResource.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/CategoryResource.java
@@ -67,59 +67,59 @@ public interface CategoryResource {
 	@Path("/categories/{category-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Response deleteCategories( @PathParam("category-id") Long categoryId ) throws Exception;
+	public Response deleteCategory( @PathParam("category-id") Long categoryId ) throws Exception;
 
 	@GET
 	@Path("/categories/{category-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Category getCategories( @PathParam("category-id") Long categoryId ) throws Exception;
+	public Category getCategory( @PathParam("category-id") Long categoryId ) throws Exception;
 
 	@Consumes("application/json")
 	@PUT
 	@Path("/categories/{category-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Category putCategories( @PathParam("category-id") Long categoryId , Category category ) throws Exception;
+	public Category putCategory( @PathParam("category-id") Long categoryId , Category category ) throws Exception;
 
 	@GET
 	@Path("/categories/{category-id}/categories")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Category> getCategoriesCategoriesPage( @PathParam("category-id") Long categoryId , @Context Pagination pagination ) throws Exception;
+	public Page<Category> getCategoryCategoryPage( @PathParam("category-id") Long categoryId , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/categories/{category-id}/categories")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Category postCategoriesCategories( @PathParam("category-id") Long categoryId , Category category ) throws Exception;
+	public Category postCategoryCategory( @PathParam("category-id") Long categoryId , Category category ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/categories/{category-id}/categories/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public Category postCategoriesCategoriesBatchCreate( @PathParam("category-id") Long categoryId , Category category ) throws Exception;
+	public Category postCategoryCategoryBatchCreate( @PathParam("category-id") Long categoryId , Category category ) throws Exception;
 
 	@GET
 	@Path("/vocabularies/{vocabulary-id}/categories")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Category> getVocabulariesCategoriesPage( @PathParam("vocabulary-id") Long vocabularyId , @Context Pagination pagination ) throws Exception;
+	public Page<Category> getVocabularyCategoryPage( @PathParam("vocabulary-id") Long vocabularyId , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/vocabularies/{vocabulary-id}/categories")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Category postVocabulariesCategories( @PathParam("vocabulary-id") Long vocabularyId , Category category ) throws Exception;
+	public Category postVocabularyCategory( @PathParam("vocabulary-id") Long vocabularyId , Category category ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/vocabularies/{vocabulary-id}/categories/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public Category postVocabulariesCategoriesBatchCreate( @PathParam("vocabulary-id") Long vocabularyId , Category category ) throws Exception;
+	public Category postVocabularyCategoryBatchCreate( @PathParam("vocabulary-id") Long vocabularyId , Category category ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/EmailResource.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/EmailResource.java
@@ -67,12 +67,12 @@ public interface EmailResource {
 	@Path("/emails")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Email> getEmailsPage( @PathParam("generic-parent-id") Object genericParentId , @Context Pagination pagination ) throws Exception;
+	public Page<Email> getGenericParentEmailPage( @PathParam("generic-parent-id") Object genericParentId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/emails/{email-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Email getEmails( @PathParam("email-id") Long emailId ) throws Exception;
+	public Email getEmail( @PathParam("email-id") Long emailId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/KeywordResource.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/KeywordResource.java
@@ -67,39 +67,39 @@ public interface KeywordResource {
 	@Path("/content-spaces/{content-space-id}/keywords")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Keyword> getContentSpacesKeywordsPage( @PathParam("content-space-id") Long contentSpaceId , @Context Pagination pagination ) throws Exception;
+	public Page<Keyword> getContentSpaceKeywordPage( @PathParam("content-space-id") Long contentSpaceId , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/content-spaces/{content-space-id}/keywords")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Keyword postContentSpacesKeywords( @PathParam("content-space-id") Long contentSpaceId , Keyword keyword ) throws Exception;
+	public Keyword postContentSpaceKeyword( @PathParam("content-space-id") Long contentSpaceId , Keyword keyword ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/content-spaces/{content-space-id}/keywords/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public Keyword postContentSpacesKeywordsBatchCreate( @PathParam("content-space-id") Long contentSpaceId , Keyword keyword ) throws Exception;
+	public Keyword postContentSpaceKeywordBatchCreate( @PathParam("content-space-id") Long contentSpaceId , Keyword keyword ) throws Exception;
 
 	@DELETE
 	@Path("/keywords/{keyword-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Response deleteKeywords( @PathParam("keyword-id") Long keywordId ) throws Exception;
+	public Response deleteKeyword( @PathParam("keyword-id") Long keywordId ) throws Exception;
 
 	@GET
 	@Path("/keywords/{keyword-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Keyword getKeywords( @PathParam("keyword-id") Long keywordId ) throws Exception;
+	public Keyword getKeyword( @PathParam("keyword-id") Long keywordId ) throws Exception;
 
 	@Consumes("application/json")
 	@PUT
 	@Path("/keywords/{keyword-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Keyword putKeywords( @PathParam("keyword-id") Long keywordId , Keyword keyword ) throws Exception;
+	public Keyword putKeyword( @PathParam("keyword-id") Long keywordId , Keyword keyword ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/OrganizationResource.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/OrganizationResource.java
@@ -67,30 +67,30 @@ public interface OrganizationResource {
 	@Path("/my-user-accounts/{my-user-account-id}/organizations")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Organization> getMyUserAccountsOrganizationsPage( @PathParam("my-user-account-id") Long myUserAccountId , @Context Pagination pagination ) throws Exception;
+	public Page<Organization> getMyUserAccountOrganizationPage( @PathParam("my-user-account-id") Long myUserAccountId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/organizations")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Organization> getOrganizationsPage( @Context Pagination pagination ) throws Exception;
+	public Page<Organization> getOrganizationPage( @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/organizations/{organization-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Organization getOrganizations( @PathParam("organization-id") Long organizationId ) throws Exception;
+	public Organization getOrganization( @PathParam("organization-id") Long organizationId ) throws Exception;
 
 	@GET
 	@Path("/organizations/{organization-id}/organizations")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Organization> getOrganizationsOrganizationsPage( @PathParam("organization-id") Long organizationId , @Context Pagination pagination ) throws Exception;
+	public Page<Organization> getOrganizationOrganizationPage( @PathParam("organization-id") Long organizationId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/user-accounts/{user-account-id}/organizations")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Organization> getUserAccountsOrganizationsPage( @PathParam("user-account-id") Long userAccountId , @Context Pagination pagination ) throws Exception;
+	public Page<Organization> getUserAccountOrganizationPage( @PathParam("user-account-id") Long userAccountId , @Context Pagination pagination ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/PhoneResource.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/PhoneResource.java
@@ -67,12 +67,12 @@ public interface PhoneResource {
 	@Path("/phones")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Phone> getPhonesPage( @PathParam("generic-parent-id") Object genericParentId , @Context Pagination pagination ) throws Exception;
+	public Page<Phone> getGenericParentPhonePage( @PathParam("generic-parent-id") Object genericParentId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/phones/{phone-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Phone getPhones( @PathParam("phone-id") Long phoneId ) throws Exception;
+	public Phone getPhone( @PathParam("phone-id") Long phoneId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/PostalAddressResource.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/PostalAddressResource.java
@@ -67,12 +67,12 @@ public interface PostalAddressResource {
 	@Path("/addresses")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<PostalAddress> getAddressesPage( @PathParam("generic-parent-id") Object genericParentId , @Context Pagination pagination ) throws Exception;
+	public Page<PostalAddress> getGenericParentPostalAddressPage( @PathParam("generic-parent-id") Object genericParentId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/addresses/{address-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public PostalAddress getAddresses( @PathParam("address-id") Long addressId ) throws Exception;
+	public PostalAddress getAddress( @PathParam("address-id") Long addressId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/RoleResource.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/RoleResource.java
@@ -67,24 +67,24 @@ public interface RoleResource {
 	@Path("/my-user-accounts/{my-user-account-id}/roles")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Role> getMyUserAccountsRolesPage( @PathParam("my-user-account-id") Long myUserAccountId , @Context Pagination pagination ) throws Exception;
+	public Page<Role> getMyUserAccountRolePage( @PathParam("my-user-account-id") Long myUserAccountId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/roles")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Role> getRolesPage( @Context Pagination pagination ) throws Exception;
+	public Page<Role> getRolePage( @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/roles/{role-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Role getRoles( @PathParam("role-id") Long roleId ) throws Exception;
+	public Role getRole( @PathParam("role-id") Long roleId ) throws Exception;
 
 	@GET
 	@Path("/user-accounts/{user-account-id}/roles")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Role> getUserAccountsRolesPage( @PathParam("user-account-id") Long userAccountId , @Context Pagination pagination ) throws Exception;
+	public Page<Role> getUserAccountRolePage( @PathParam("user-account-id") Long userAccountId , @Context Pagination pagination ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/UserAccountResource.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/UserAccountResource.java
@@ -64,12 +64,6 @@ import javax.ws.rs.core.Response;
 public interface UserAccountResource {
 
 	@GET
-	@Path("/my-user-accounts")
-	@Produces("application/json")
-	@RequiresScope("everything.read")
-	public Page<UserAccount> getUserAccountPage( @Context Pagination pagination ) throws Exception;
-
-	@GET
 	@Path("/my-user-accounts/{my-user-account-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")

--- a/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/UserAccountResource.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/UserAccountResource.java
@@ -67,63 +67,63 @@ public interface UserAccountResource {
 	@Path("/my-user-accounts")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<UserAccount> getMyUserAccountsPage( @Context Pagination pagination ) throws Exception;
+	public Page<UserAccount> getUserAccountPage( @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/my-user-accounts/{my-user-account-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public UserAccount getMyUserAccounts( @PathParam("my-user-account-id") Long myUserAccountId ) throws Exception;
+	public UserAccount getMyUserAccount( @PathParam("my-user-account-id") Long myUserAccountId ) throws Exception;
 
 	@GET
 	@Path("/organizations/{organization-id}/user-accounts")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<UserAccount> getOrganizationsUserAccountsPage( @PathParam("organization-id") Long organizationId , @Context Pagination pagination ) throws Exception;
+	public Page<UserAccount> getOrganizationUserAccountPage( @PathParam("organization-id") Long organizationId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/user-accounts")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<UserAccount> getUserAccountsPage( @QueryParam("fullnamequery") String fullnamequery , @Context Pagination pagination ) throws Exception;
+	public Page<UserAccount> getUserAccountPage( @QueryParam("fullnamequery") String fullnamequery , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/user-accounts")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public UserAccount postUserAccounts( UserAccount userAccount ) throws Exception;
+	public UserAccount postUserAccount( UserAccount userAccount ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/user-accounts/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public UserAccount postUserAccountsBatchCreate( UserAccount userAccount ) throws Exception;
+	public UserAccount postUserAccountBatchCreate( UserAccount userAccount ) throws Exception;
 
 	@DELETE
 	@Path("/user-accounts/{user-account-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Response deleteUserAccounts( @PathParam("user-account-id") Long userAccountId ) throws Exception;
+	public Response deleteUserAccount( @PathParam("user-account-id") Long userAccountId ) throws Exception;
 
 	@GET
 	@Path("/user-accounts/{user-account-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public UserAccount getUserAccounts( @PathParam("user-account-id") Long userAccountId ) throws Exception;
+	public UserAccount getUserAccount( @PathParam("user-account-id") Long userAccountId ) throws Exception;
 
 	@Consumes("application/json")
 	@PUT
 	@Path("/user-accounts/{user-account-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public UserAccount putUserAccounts( @PathParam("user-account-id") Long userAccountId , UserAccount userAccount ) throws Exception;
+	public UserAccount putUserAccount( @PathParam("user-account-id") Long userAccountId , UserAccount userAccount ) throws Exception;
 
 	@GET
 	@Path("/web-sites/{web-site-id}/user-accounts")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<UserAccount> getWebSitesUserAccountsPage( @PathParam("web-site-id") Long webSiteId , @Context Pagination pagination ) throws Exception;
+	public Page<UserAccount> getWebSiteUserAccountPage( @PathParam("web-site-id") Long webSiteId , @Context Pagination pagination ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/VocabularyResource.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/VocabularyResource.java
@@ -67,39 +67,39 @@ public interface VocabularyResource {
 	@Path("/content-spaces/{content-space-id}/vocabularies")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Vocabulary> getContentSpacesVocabulariesPage( @PathParam("content-space-id") Long contentSpaceId , @Context Pagination pagination ) throws Exception;
+	public Page<Vocabulary> getContentSpaceVocabularyPage( @PathParam("content-space-id") Long contentSpaceId , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/content-spaces/{content-space-id}/vocabularies")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Vocabulary postContentSpacesVocabularies( @PathParam("content-space-id") Long contentSpaceId , Vocabulary vocabulary ) throws Exception;
+	public Vocabulary postContentSpaceVocabulary( @PathParam("content-space-id") Long contentSpaceId , Vocabulary vocabulary ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/content-spaces/{content-space-id}/vocabularies/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public Vocabulary postContentSpacesVocabulariesBatchCreate( @PathParam("content-space-id") Long contentSpaceId , Vocabulary vocabulary ) throws Exception;
+	public Vocabulary postContentSpaceVocabularyBatchCreate( @PathParam("content-space-id") Long contentSpaceId , Vocabulary vocabulary ) throws Exception;
 
 	@DELETE
 	@Path("/vocabularies/{vocabulary-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Response deleteVocabularies( @PathParam("vocabulary-id") Long vocabularyId ) throws Exception;
+	public Response deleteVocabulary( @PathParam("vocabulary-id") Long vocabularyId ) throws Exception;
 
 	@GET
 	@Path("/vocabularies/{vocabulary-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Vocabulary getVocabularies( @PathParam("vocabulary-id") Long vocabularyId ) throws Exception;
+	public Vocabulary getVocabulary( @PathParam("vocabulary-id") Long vocabularyId ) throws Exception;
 
 	@Consumes("application/json")
 	@PUT
 	@Path("/vocabularies/{vocabulary-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Vocabulary putVocabularies( @PathParam("vocabulary-id") Long vocabularyId , Vocabulary vocabulary ) throws Exception;
+	public Vocabulary putVocabulary( @PathParam("vocabulary-id") Long vocabularyId , Vocabulary vocabulary ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/WebUrlResource.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/WebUrlResource.java
@@ -67,12 +67,12 @@ public interface WebUrlResource {
 	@Path("/web-urls")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<WebUrl> getWebUrlsPage( @PathParam("generic-parent-id") Object genericParentId , @Context Pagination pagination ) throws Exception;
+	public Page<WebUrl> getGenericParentWebUrlPage( @PathParam("generic-parent-id") Object genericParentId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/web-urls/{web-url-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public WebUrl getWebUrls( @PathParam("web-url-id") Long webUrlId ) throws Exception;
+	public WebUrl getWebUrl( @PathParam("web-url-id") Long webUrlId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/rest-openapi.yaml
@@ -857,27 +857,6 @@ paths:
                 $ref: "#/components/schemas/Keyword"
           description: ""
       tags: ["Keyword"]
-  "/my-user-accounts":
-    get:
-      parameters:
-        - in: query
-          name: page
-          schema:
-            type: integer
-        - in: query
-          name: per_page
-          schema:
-            type: integer
-      responses:
-        200:
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: "#/components/schemas/UserAccount"
-                type: array
-          description: ""
-      tags: ["UserAccount"]
   "/my-user-accounts/{my-user-account-id}":
     get:
       parameters:

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseCategoryResourceImpl.java
@@ -39,19 +39,19 @@ import javax.ws.rs.core.Response;
 public abstract class BaseCategoryResourceImpl implements CategoryResource {
 
 	@Override
-	public Response deleteCategories(Long categoryId) throws Exception {
+	public Response deleteCategory(Long categoryId) throws Exception {
 		Response.ResponseBuilder responseBuilder = Response.ok();
 
 		return responseBuilder.build();
 	}
 
 	@Override
-	public Category getCategories(Long categoryId) throws Exception {
+	public Category getCategory(Long categoryId) throws Exception {
 		return new Category();
 	}
 
 	@Override
-	public Page<Category> getCategoriesCategoriesPage(
+	public Page<Category> getCategoryCategoryPage(
 			Long categoryId, Pagination pagination)
 		throws Exception {
 
@@ -59,7 +59,7 @@ public abstract class BaseCategoryResourceImpl implements CategoryResource {
 	}
 
 	@Override
-	public Page<Category> getVocabulariesCategoriesPage(
+	public Page<Category> getVocabularyCategoryPage(
 			Long vocabularyId, Pagination pagination)
 		throws Exception {
 
@@ -67,14 +67,14 @@ public abstract class BaseCategoryResourceImpl implements CategoryResource {
 	}
 
 	@Override
-	public Category postCategoriesCategories(Long categoryId, Category category)
+	public Category postCategoryCategory(Long categoryId, Category category)
 		throws Exception {
 
 		return new Category();
 	}
 
 	@Override
-	public Category postCategoriesCategoriesBatchCreate(
+	public Category postCategoryCategoryBatchCreate(
 			Long categoryId, Category category)
 		throws Exception {
 
@@ -82,7 +82,14 @@ public abstract class BaseCategoryResourceImpl implements CategoryResource {
 	}
 
 	@Override
-	public Category postVocabulariesCategories(
+	public Category postVocabularyCategory(Long vocabularyId, Category category)
+		throws Exception {
+
+		return new Category();
+	}
+
+	@Override
+	public Category postVocabularyCategoryBatchCreate(
 			Long vocabularyId, Category category)
 		throws Exception {
 
@@ -90,15 +97,7 @@ public abstract class BaseCategoryResourceImpl implements CategoryResource {
 	}
 
 	@Override
-	public Category postVocabulariesCategoriesBatchCreate(
-			Long vocabularyId, Category category)
-		throws Exception {
-
-		return new Category();
-	}
-
-	@Override
-	public Category putCategories(Long categoryId, Category category)
+	public Category putCategory(Long categoryId, Category category)
 		throws Exception {
 
 		return new Category();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseEmailResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseEmailResourceImpl.java
@@ -39,12 +39,12 @@ import javax.ws.rs.core.Response;
 public abstract class BaseEmailResourceImpl implements EmailResource {
 
 	@Override
-	public Email getEmails(Long emailId) throws Exception {
+	public Email getEmail(Long emailId) throws Exception {
 		return new Email();
 	}
 
 	@Override
-	public Page<Email> getEmailsPage(
+	public Page<Email> getGenericParentEmailPage(
 			Object genericParentId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -39,14 +39,14 @@ import javax.ws.rs.core.Response;
 public abstract class BaseKeywordResourceImpl implements KeywordResource {
 
 	@Override
-	public Response deleteKeywords(Long keywordId) throws Exception {
+	public Response deleteKeyword(Long keywordId) throws Exception {
 		Response.ResponseBuilder responseBuilder = Response.ok();
 
 		return responseBuilder.build();
 	}
 
 	@Override
-	public Page<Keyword> getContentSpacesKeywordsPage(
+	public Page<Keyword> getContentSpaceKeywordPage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -54,12 +54,19 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	}
 
 	@Override
-	public Keyword getKeywords(Long keywordId) throws Exception {
+	public Keyword getKeyword(Long keywordId) throws Exception {
 		return new Keyword();
 	}
 
 	@Override
-	public Keyword postContentSpacesKeywords(
+	public Keyword postContentSpaceKeyword(Long contentSpaceId, Keyword keyword)
+		throws Exception {
+
+		return new Keyword();
+	}
+
+	@Override
+	public Keyword postContentSpaceKeywordBatchCreate(
 			Long contentSpaceId, Keyword keyword)
 		throws Exception {
 
@@ -67,15 +74,7 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	}
 
 	@Override
-	public Keyword postContentSpacesKeywordsBatchCreate(
-			Long contentSpaceId, Keyword keyword)
-		throws Exception {
-
-		return new Keyword();
-	}
-
-	@Override
-	public Keyword putKeywords(Long keywordId, Keyword keyword)
+	public Keyword putKeyword(Long keywordId, Keyword keyword)
 		throws Exception {
 
 		return new Keyword();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -40,7 +40,7 @@ public abstract class BaseOrganizationResourceImpl
 	implements OrganizationResource {
 
 	@Override
-	public Page<Organization> getMyUserAccountsOrganizationsPage(
+	public Page<Organization> getMyUserAccountOrganizationPage(
 			Long myUserAccountId, Pagination pagination)
 		throws Exception {
 
@@ -48,12 +48,12 @@ public abstract class BaseOrganizationResourceImpl
 	}
 
 	@Override
-	public Organization getOrganizations(Long organizationId) throws Exception {
+	public Organization getOrganization(Long organizationId) throws Exception {
 		return new Organization();
 	}
 
 	@Override
-	public Page<Organization> getOrganizationsOrganizationsPage(
+	public Page<Organization> getOrganizationOrganizationPage(
 			Long organizationId, Pagination pagination)
 		throws Exception {
 
@@ -61,14 +61,14 @@ public abstract class BaseOrganizationResourceImpl
 	}
 
 	@Override
-	public Page<Organization> getOrganizationsPage(Pagination pagination)
+	public Page<Organization> getOrganizationPage(Pagination pagination)
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
 	}
 
 	@Override
-	public Page<Organization> getUserAccountsOrganizationsPage(
+	public Page<Organization> getUserAccountOrganizationPage(
 			Long userAccountId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BasePhoneResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BasePhoneResourceImpl.java
@@ -39,16 +39,16 @@ import javax.ws.rs.core.Response;
 public abstract class BasePhoneResourceImpl implements PhoneResource {
 
 	@Override
-	public Phone getPhones(Long phoneId) throws Exception {
-		return new Phone();
-	}
-
-	@Override
-	public Page<Phone> getPhonesPage(
+	public Page<Phone> getGenericParentPhonePage(
 			Object genericParentId, Pagination pagination)
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
+	}
+
+	@Override
+	public Phone getPhone(Long phoneId) throws Exception {
+		return new Phone();
 	}
 
 	protected Response buildNoContentResponse() {

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BasePostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BasePostalAddressResourceImpl.java
@@ -40,12 +40,12 @@ public abstract class BasePostalAddressResourceImpl
 	implements PostalAddressResource {
 
 	@Override
-	public PostalAddress getAddresses(Long addressId) throws Exception {
+	public PostalAddress getAddress(Long addressId) throws Exception {
 		return new PostalAddress();
 	}
 
 	@Override
-	public Page<PostalAddress> getAddressesPage(
+	public Page<PostalAddress> getGenericParentPostalAddressPage(
 			Object genericParentId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -39,7 +39,7 @@ import javax.ws.rs.core.Response;
 public abstract class BaseRoleResourceImpl implements RoleResource {
 
 	@Override
-	public Page<Role> getMyUserAccountsRolesPage(
+	public Page<Role> getMyUserAccountRolePage(
 			Long myUserAccountId, Pagination pagination)
 		throws Exception {
 
@@ -47,17 +47,17 @@ public abstract class BaseRoleResourceImpl implements RoleResource {
 	}
 
 	@Override
-	public Role getRoles(Long roleId) throws Exception {
+	public Role getRole(Long roleId) throws Exception {
 		return new Role();
 	}
 
 	@Override
-	public Page<Role> getRolesPage(Pagination pagination) throws Exception {
+	public Page<Role> getRolePage(Pagination pagination) throws Exception {
 		return Page.of(Collections.emptyList());
 	}
 
 	@Override
-	public Page<Role> getUserAccountsRolesPage(
+	public Page<Role> getUserAccountRolePage(
 			Long userAccountId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -65,13 +65,6 @@ public abstract class BaseUserAccountResourceImpl
 	}
 
 	@Override
-	public Page<UserAccount> getUserAccountPage(Pagination pagination)
-		throws Exception {
-
-		return Page.of(Collections.emptyList());
-	}
-
-	@Override
 	public Page<UserAccount> getUserAccountPage(
 			String fullnamequery, Pagination pagination)
 		throws Exception {

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -40,28 +40,19 @@ public abstract class BaseUserAccountResourceImpl
 	implements UserAccountResource {
 
 	@Override
-	public Response deleteUserAccounts(Long userAccountId) throws Exception {
+	public Response deleteUserAccount(Long userAccountId) throws Exception {
 		Response.ResponseBuilder responseBuilder = Response.ok();
 
 		return responseBuilder.build();
 	}
 
 	@Override
-	public UserAccount getMyUserAccounts(Long myUserAccountId)
-		throws Exception {
-
+	public UserAccount getMyUserAccount(Long myUserAccountId) throws Exception {
 		return new UserAccount();
 	}
 
 	@Override
-	public Page<UserAccount> getMyUserAccountsPage(Pagination pagination)
-		throws Exception {
-
-		return Page.of(Collections.emptyList());
-	}
-
-	@Override
-	public Page<UserAccount> getOrganizationsUserAccountsPage(
+	public Page<UserAccount> getOrganizationUserAccountPage(
 			Long organizationId, Pagination pagination)
 		throws Exception {
 
@@ -69,12 +60,19 @@ public abstract class BaseUserAccountResourceImpl
 	}
 
 	@Override
-	public UserAccount getUserAccounts(Long userAccountId) throws Exception {
+	public UserAccount getUserAccount(Long userAccountId) throws Exception {
 		return new UserAccount();
 	}
 
 	@Override
-	public Page<UserAccount> getUserAccountsPage(
+	public Page<UserAccount> getUserAccountPage(Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@Override
+	public Page<UserAccount> getUserAccountPage(
 			String fullnamequery, Pagination pagination)
 		throws Exception {
 
@@ -82,7 +80,7 @@ public abstract class BaseUserAccountResourceImpl
 	}
 
 	@Override
-	public Page<UserAccount> getWebSitesUserAccountsPage(
+	public Page<UserAccount> getWebSiteUserAccountPage(
 			Long webSiteId, Pagination pagination)
 		throws Exception {
 
@@ -90,21 +88,21 @@ public abstract class BaseUserAccountResourceImpl
 	}
 
 	@Override
-	public UserAccount postUserAccounts(UserAccount userAccount)
+	public UserAccount postUserAccount(UserAccount userAccount)
 		throws Exception {
 
 		return new UserAccount();
 	}
 
 	@Override
-	public UserAccount postUserAccountsBatchCreate(UserAccount userAccount)
+	public UserAccount postUserAccountBatchCreate(UserAccount userAccount)
 		throws Exception {
 
 		return new UserAccount();
 	}
 
 	@Override
-	public UserAccount putUserAccounts(
+	public UserAccount putUserAccount(
 			Long userAccountId, UserAccount userAccount)
 		throws Exception {
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseVocabularyResourceImpl.java
@@ -39,14 +39,14 @@ import javax.ws.rs.core.Response;
 public abstract class BaseVocabularyResourceImpl implements VocabularyResource {
 
 	@Override
-	public Response deleteVocabularies(Long vocabularyId) throws Exception {
+	public Response deleteVocabulary(Long vocabularyId) throws Exception {
 		Response.ResponseBuilder responseBuilder = Response.ok();
 
 		return responseBuilder.build();
 	}
 
 	@Override
-	public Page<Vocabulary> getContentSpacesVocabulariesPage(
+	public Page<Vocabulary> getContentSpaceVocabularyPage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -54,12 +54,12 @@ public abstract class BaseVocabularyResourceImpl implements VocabularyResource {
 	}
 
 	@Override
-	public Vocabulary getVocabularies(Long vocabularyId) throws Exception {
+	public Vocabulary getVocabulary(Long vocabularyId) throws Exception {
 		return new Vocabulary();
 	}
 
 	@Override
-	public Vocabulary postContentSpacesVocabularies(
+	public Vocabulary postContentSpaceVocabulary(
 			Long contentSpaceId, Vocabulary vocabulary)
 		throws Exception {
 
@@ -67,7 +67,7 @@ public abstract class BaseVocabularyResourceImpl implements VocabularyResource {
 	}
 
 	@Override
-	public Vocabulary postContentSpacesVocabulariesBatchCreate(
+	public Vocabulary postContentSpaceVocabularyBatchCreate(
 			Long contentSpaceId, Vocabulary vocabulary)
 		throws Exception {
 
@@ -75,7 +75,7 @@ public abstract class BaseVocabularyResourceImpl implements VocabularyResource {
 	}
 
 	@Override
-	public Vocabulary putVocabularies(Long vocabularyId, Vocabulary vocabulary)
+	public Vocabulary putVocabulary(Long vocabularyId, Vocabulary vocabulary)
 		throws Exception {
 
 		return new Vocabulary();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseWebUrlResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseWebUrlResourceImpl.java
@@ -39,16 +39,16 @@ import javax.ws.rs.core.Response;
 public abstract class BaseWebUrlResourceImpl implements WebUrlResource {
 
 	@Override
-	public WebUrl getWebUrls(Long webUrlId) throws Exception {
-		return new WebUrl();
-	}
-
-	@Override
-	public Page<WebUrl> getWebUrlsPage(
+	public Page<WebUrl> getGenericParentWebUrlPage(
 			Object genericParentId, Pagination pagination)
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
+	}
+
+	@Override
+	public WebUrl getWebUrl(Long webUrlId) throws Exception {
+		return new WebUrl();
 	}
 
 	protected Response buildNoContentResponse() {

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/CategoryResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/CategoryResourceImpl.java
@@ -47,12 +47,12 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class CategoryResourceImpl extends BaseCategoryResourceImpl {
 
 	@Override
-	public Category getCategories(Long categoryId) throws Exception {
+	public Category getCategory(Long categoryId) throws Exception {
 		return _toCategory(_assetCategoryService.getCategory(categoryId));
 	}
 
 	@Override
-	public Page<Category> getCategoriesCategoriesPage(
+	public Page<Category> getCategoryCategoryPage(
 			Long categoryId, Pagination pagination)
 		throws Exception {
 
@@ -67,7 +67,7 @@ public class CategoryResourceImpl extends BaseCategoryResourceImpl {
 	}
 
 	@Override
-	public Page<Category> getVocabulariesCategoriesPage(
+	public Page<Category> getVocabularyCategoryPage(
 			Long vocabularyId, Pagination pagination)
 		throws Exception {
 
@@ -87,7 +87,7 @@ public class CategoryResourceImpl extends BaseCategoryResourceImpl {
 	}
 
 	@Override
-	public Category postCategoriesCategories(Long categoryId, Category category)
+	public Category postCategoryCategory(Long categoryId, Category category)
 		throws Exception {
 
 		AssetCategory assetCategory = _assetCategoryService.getCategory(
@@ -106,7 +106,7 @@ public class CategoryResourceImpl extends BaseCategoryResourceImpl {
 	}
 
 	@Override
-	public Category postVocabulariesCategories(
+	public Category postVocabularyCategory(
 			Long vocabularyId, Category category)
 		throws Exception {
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/KeywordResourceImpl.java
@@ -39,19 +39,19 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 
 	@Override
-	public Response deleteKeywords(Long keywordId) throws Exception {
+	public Response deleteKeyword(Long keywordId) throws Exception {
 		_assetTagService.deleteTag(keywordId);
 
 		return buildNoContentResponse();
 	}
 
 	@Override
-	public Keyword getKeywords(Long keywordId) throws Exception {
+	public Keyword getKeyword(Long keywordId) throws Exception {
 		return _toKeyword(_assetTagService.getTag(keywordId));
 	}
 
 	@Override
-	public Keyword postContentSpacesKeywords(
+	public Keyword postContentSpaceKeyword(
 			Long contentSpaceId, Keyword keyword)
 		throws Exception {
 
@@ -78,7 +78,7 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 	}
 
 	@Override
-	public Keyword putKeywords(Long keywordId, Keyword keyword)
+	public Keyword putKeyword(Long keywordId, Keyword keyword)
 		throws Exception {
 
 		try {

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseCategoryResourceTestCase.java
@@ -54,63 +54,63 @@ public abstract class BaseCategoryResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteCategories() throws Exception {
+	public void testDeleteCategory() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetCategories() throws Exception {
+	public void testGetCategory() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetCategoriesCategoriesPage() throws Exception {
+	public void testGetCategoryCategoryPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetVocabulariesCategoriesPage() throws Exception {
+	public void testGetVocabularyCategoryPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostCategoriesCategories() throws Exception {
+	public void testPostCategoryCategory() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostCategoriesCategoriesBatchCreate() throws Exception {
+	public void testPostCategoryCategoryBatchCreate() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostVocabulariesCategories() throws Exception {
+	public void testPostVocabularyCategory() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostVocabulariesCategoriesBatchCreate() throws Exception {
+	public void testPostVocabularyCategoryBatchCreate() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPutCategories() throws Exception {
+	public void testPutCategory() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeDeleteCategories(Long categoryId) throws Exception {
+	protected void invokeDeleteCategory(Long categoryId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/categories/{category-id}");
 	}
 
-	protected void invokeGetCategories(Long categoryId) throws Exception {
+	protected void invokeGetCategory(Long categoryId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/categories/{category-id}");
 	}
 
-	protected void invokeGetCategoriesCategoriesPage(
+	protected void invokeGetCategoryCategoryPage(
 			Long categoryId, Pagination pagination)
 		throws Exception {
 
@@ -119,7 +119,7 @@ public abstract class BaseCategoryResourceTestCase {
 			requestSender.post("/categories/{category-id}/categories");
 	}
 
-	protected void invokeGetVocabulariesCategoriesPage(
+	protected void invokeGetVocabularyCategoryPage(
 			Long vocabularyId, Pagination pagination)
 		throws Exception {
 
@@ -128,7 +128,7 @@ public abstract class BaseCategoryResourceTestCase {
 			requestSender.post("/vocabularies/{vocabulary-id}/categories");
 	}
 
-	protected void invokePostCategoriesCategories(
+	protected void invokePostCategoryCategory(
 			Long categoryId, Category category)
 		throws Exception {
 
@@ -137,7 +137,7 @@ public abstract class BaseCategoryResourceTestCase {
 			requestSender.post("/categories/{category-id}/categories");
 	}
 
-	protected void invokePostCategoriesCategoriesBatchCreate(
+	protected void invokePostCategoryCategoryBatchCreate(
 			Long categoryId, Category category)
 		throws Exception {
 
@@ -147,7 +147,7 @@ public abstract class BaseCategoryResourceTestCase {
 				"/categories/{category-id}/categories/batch-create");
 	}
 
-	protected void invokePostVocabulariesCategories(
+	protected void invokePostVocabularyCategory(
 			Long vocabularyId, Category category)
 		throws Exception {
 
@@ -156,7 +156,7 @@ public abstract class BaseCategoryResourceTestCase {
 			requestSender.post("/vocabularies/{vocabulary-id}/categories");
 	}
 
-	protected void invokePostVocabulariesCategoriesBatchCreate(
+	protected void invokePostVocabularyCategoryBatchCreate(
 			Long vocabularyId, Category category)
 		throws Exception {
 
@@ -166,7 +166,7 @@ public abstract class BaseCategoryResourceTestCase {
 				"/vocabularies/{vocabulary-id}/categories/batch-create");
 	}
 
-	protected void invokePutCategories(Long categoryId, Category category)
+	protected void invokePutCategory(Long categoryId, Category category)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseEmailResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseEmailResourceTestCase.java
@@ -53,22 +53,22 @@ public abstract class BaseEmailResourceTestCase {
 	}
 
 	@Test
-	public void testGetEmails() throws Exception {
+	public void testGetEmail() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetEmailsPage() throws Exception {
+	public void testGetGenericParentEmailPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetEmails(Long emailId) throws Exception {
+	protected void invokeGetEmail(Long emailId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/emails/{email-id}");
 	}
 
-	protected void invokeGetEmailsPage(
+	protected void invokeGetGenericParentEmailPage(
 			Object genericParentId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -54,42 +54,42 @@ public abstract class BaseKeywordResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteKeywords() throws Exception {
+	public void testDeleteKeyword() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetContentSpacesKeywordsPage() throws Exception {
+	public void testGetContentSpaceKeywordPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetKeywords() throws Exception {
+	public void testGetKeyword() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostContentSpacesKeywords() throws Exception {
+	public void testPostContentSpaceKeyword() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostContentSpacesKeywordsBatchCreate() throws Exception {
+	public void testPostContentSpaceKeywordBatchCreate() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPutKeywords() throws Exception {
+	public void testPutKeyword() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeDeleteKeywords(Long keywordId) throws Exception {
+	protected void invokeDeleteKeyword(Long keywordId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/keywords/{keyword-id}");
 	}
 
-	protected void invokeGetContentSpacesKeywordsPage(
+	protected void invokeGetContentSpaceKeywordPage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -98,13 +98,13 @@ public abstract class BaseKeywordResourceTestCase {
 			requestSender.post("/content-spaces/{content-space-id}/keywords");
 	}
 
-	protected void invokeGetKeywords(Long keywordId) throws Exception {
+	protected void invokeGetKeyword(Long keywordId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/keywords/{keyword-id}");
 	}
 
-	protected void invokePostContentSpacesKeywords(
+	protected void invokePostContentSpaceKeyword(
 			Long contentSpaceId, Keyword keyword)
 		throws Exception {
 
@@ -113,7 +113,7 @@ public abstract class BaseKeywordResourceTestCase {
 			requestSender.post("/content-spaces/{content-space-id}/keywords");
 	}
 
-	protected void invokePostContentSpacesKeywordsBatchCreate(
+	protected void invokePostContentSpaceKeywordBatchCreate(
 			Long contentSpaceId, Keyword keyword)
 		throws Exception {
 
@@ -123,7 +123,7 @@ public abstract class BaseKeywordResourceTestCase {
 				"/content-spaces/{content-space-id}/keywords/batch-create");
 	}
 
-	protected void invokePutKeywords(Long keywordId, Keyword keyword)
+	protected void invokePutKeyword(Long keywordId, Keyword keyword)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -53,31 +53,31 @@ public abstract class BaseOrganizationResourceTestCase {
 	}
 
 	@Test
-	public void testGetMyUserAccountsOrganizationsPage() throws Exception {
+	public void testGetMyUserAccountOrganizationPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetOrganizations() throws Exception {
+	public void testGetOrganization() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetOrganizationsOrganizationsPage() throws Exception {
+	public void testGetOrganizationOrganizationPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetOrganizationsPage() throws Exception {
+	public void testGetOrganizationPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetUserAccountsOrganizationsPage() throws Exception {
+	public void testGetUserAccountOrganizationPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetMyUserAccountsOrganizationsPage(
+	protected void invokeGetMyUserAccountOrganizationPage(
 			Long myUserAccountId, Pagination pagination)
 		throws Exception {
 
@@ -87,15 +87,13 @@ public abstract class BaseOrganizationResourceTestCase {
 				"/my-user-accounts/{my-user-account-id}/organizations");
 	}
 
-	protected void invokeGetOrganizations(Long organizationId)
-		throws Exception {
-
-			RequestSender requestSender = _createRequestSender();
+	protected void invokeGetOrganization(Long organizationId) throws Exception {
+		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/organizations/{organization-id}");
 	}
 
-	protected void invokeGetOrganizationsOrganizationsPage(
+	protected void invokeGetOrganizationOrganizationPage(
 			Long organizationId, Pagination pagination)
 		throws Exception {
 
@@ -105,7 +103,7 @@ public abstract class BaseOrganizationResourceTestCase {
 				"/organizations/{organization-id}/organizations");
 	}
 
-	protected void invokeGetOrganizationsPage(Pagination pagination)
+	protected void invokeGetOrganizationPage(Pagination pagination)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -113,7 +111,7 @@ public abstract class BaseOrganizationResourceTestCase {
 			requestSender.post("/organizations");
 	}
 
-	protected void invokeGetUserAccountsOrganizationsPage(
+	protected void invokeGetUserAccountOrganizationPage(
 			Long userAccountId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BasePhoneResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BasePhoneResourceTestCase.java
@@ -53,28 +53,28 @@ public abstract class BasePhoneResourceTestCase {
 	}
 
 	@Test
-	public void testGetPhones() throws Exception {
+	public void testGetGenericParentPhonePage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetPhonesPage() throws Exception {
+	public void testGetPhone() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetPhones(Long phoneId) throws Exception {
-		RequestSender requestSender = _createRequestSender();
-
-			requestSender.post("/phones/{phone-id}");
-	}
-
-	protected void invokeGetPhonesPage(
+	protected void invokeGetGenericParentPhonePage(
 			Object genericParentId, Pagination pagination)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/phones");
+	}
+
+	protected void invokeGetPhone(Long phoneId) throws Exception {
+		RequestSender requestSender = _createRequestSender();
+
+			requestSender.post("/phones/{phone-id}");
 	}
 
 	private RequestSender _createRequestSender() {

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BasePostalAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BasePostalAddressResourceTestCase.java
@@ -53,22 +53,22 @@ public abstract class BasePostalAddressResourceTestCase {
 	}
 
 	@Test
-	public void testGetAddresses() throws Exception {
+	public void testGetAddress() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetAddressesPage() throws Exception {
+	public void testGetGenericParentPostalAddressPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetAddresses(Long addressId) throws Exception {
+	protected void invokeGetAddress(Long addressId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/addresses/{address-id}");
 	}
 
-	protected void invokeGetAddressesPage(
+	protected void invokeGetGenericParentPostalAddressPage(
 			Object genericParentId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -53,26 +53,26 @@ public abstract class BaseRoleResourceTestCase {
 	}
 
 	@Test
-	public void testGetMyUserAccountsRolesPage() throws Exception {
+	public void testGetMyUserAccountRolePage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetRoles() throws Exception {
+	public void testGetRole() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetRolesPage() throws Exception {
+	public void testGetRolePage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetUserAccountsRolesPage() throws Exception {
+	public void testGetUserAccountRolePage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetMyUserAccountsRolesPage(
+	protected void invokeGetMyUserAccountRolePage(
 			Long myUserAccountId, Pagination pagination)
 		throws Exception {
 
@@ -81,19 +81,19 @@ public abstract class BaseRoleResourceTestCase {
 			requestSender.post("/my-user-accounts/{my-user-account-id}/roles");
 	}
 
-	protected void invokeGetRoles(Long roleId) throws Exception {
+	protected void invokeGetRole(Long roleId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/roles/{role-id}");
 	}
 
-	protected void invokeGetRolesPage(Pagination pagination) throws Exception {
+	protected void invokeGetRolePage(Pagination pagination) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/roles");
 	}
 
-	protected void invokeGetUserAccountsRolesPage(
+	protected void invokeGetUserAccountRolePage(
 			Long userAccountId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -54,56 +54,51 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteUserAccounts() throws Exception {
+	public void testDeleteUserAccount() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetMyUserAccounts() throws Exception {
+	public void testGetMyUserAccount() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetMyUserAccountsPage() throws Exception {
+	public void testGetOrganizationUserAccountPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetOrganizationsUserAccountsPage() throws Exception {
+	public void testGetUserAccount() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetUserAccounts() throws Exception {
+	public void testGetUserAccountPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetUserAccountsPage() throws Exception {
+	public void testGetWebSiteUserAccountPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetWebSitesUserAccountsPage() throws Exception {
+	public void testPostUserAccount() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostUserAccounts() throws Exception {
+	public void testPostUserAccountBatchCreate() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostUserAccountsBatchCreate() throws Exception {
+	public void testPutUserAccount() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	@Test
-	public void testPutUserAccounts() throws Exception {
-		Assert.assertTrue(true);
-	}
-
-	protected void invokeDeleteUserAccounts(Long userAccountId)
+	protected void invokeDeleteUserAccount(Long userAccountId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -111,7 +106,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			requestSender.post("/user-accounts/{user-account-id}");
 	}
 
-	protected void invokeGetMyUserAccounts(Long myUserAccountId)
+	protected void invokeGetMyUserAccount(Long myUserAccountId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -119,15 +114,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			requestSender.post("/my-user-accounts/{my-user-account-id}");
 	}
 
-	protected void invokeGetMyUserAccountsPage(Pagination pagination)
-		throws Exception {
-
-			RequestSender requestSender = _createRequestSender();
-
-			requestSender.post("/my-user-accounts");
-	}
-
-	protected void invokeGetOrganizationsUserAccountsPage(
+	protected void invokeGetOrganizationUserAccountPage(
 			Long organizationId, Pagination pagination)
 		throws Exception {
 
@@ -137,13 +124,21 @@ public abstract class BaseUserAccountResourceTestCase {
 				"/organizations/{organization-id}/user-accounts");
 	}
 
-	protected void invokeGetUserAccounts(Long userAccountId) throws Exception {
+	protected void invokeGetUserAccount(Long userAccountId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/user-accounts/{user-account-id}");
 	}
 
-	protected void invokeGetUserAccountsPage(
+	protected void invokeGetUserAccountPage(Pagination pagination)
+		throws Exception {
+
+			RequestSender requestSender = _createRequestSender();
+
+			requestSender.post("/my-user-accounts");
+	}
+
+	protected void invokeGetUserAccountPage(
 			String fullnamequery, Pagination pagination)
 		throws Exception {
 
@@ -152,7 +147,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			requestSender.post("/user-accounts");
 	}
 
-	protected void invokeGetWebSitesUserAccountsPage(
+	protected void invokeGetWebSiteUserAccountPage(
 			Long webSiteId, Pagination pagination)
 		throws Exception {
 
@@ -161,7 +156,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			requestSender.post("/web-sites/{web-site-id}/user-accounts");
 	}
 
-	protected void invokePostUserAccounts(UserAccount userAccount)
+	protected void invokePostUserAccount(UserAccount userAccount)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -169,7 +164,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			requestSender.post("/user-accounts");
 	}
 
-	protected void invokePostUserAccountsBatchCreate(UserAccount userAccount)
+	protected void invokePostUserAccountBatchCreate(UserAccount userAccount)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -177,7 +172,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			requestSender.post("/user-accounts/batch-create");
 	}
 
-	protected void invokePutUserAccounts(
+	protected void invokePutUserAccount(
 			Long userAccountId, UserAccount userAccount)
 		throws Exception {
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -130,14 +130,6 @@ public abstract class BaseUserAccountResourceTestCase {
 			requestSender.post("/user-accounts/{user-account-id}");
 	}
 
-	protected void invokeGetUserAccountPage(Pagination pagination)
-		throws Exception {
-
-			RequestSender requestSender = _createRequestSender();
-
-			requestSender.post("/my-user-accounts");
-	}
-
 	protected void invokeGetUserAccountPage(
 			String fullnamequery, Pagination pagination)
 		throws Exception {

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseVocabularyResourceTestCase.java
@@ -54,46 +54,42 @@ public abstract class BaseVocabularyResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteVocabularies() throws Exception {
+	public void testDeleteVocabulary() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetContentSpacesVocabulariesPage() throws Exception {
+	public void testGetContentSpaceVocabularyPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetVocabularies() throws Exception {
+	public void testGetVocabulary() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostContentSpacesVocabularies() throws Exception {
+	public void testPostContentSpaceVocabulary() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostContentSpacesVocabulariesBatchCreate()
-		throws Exception {
-
-			Assert.assertTrue(true);
-	}
-
-	@Test
-	public void testPutVocabularies() throws Exception {
+	public void testPostContentSpaceVocabularyBatchCreate() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeDeleteVocabularies(Long vocabularyId)
-		throws Exception {
+	@Test
+	public void testPutVocabulary() throws Exception {
+		Assert.assertTrue(true);
+	}
 
-			RequestSender requestSender = _createRequestSender();
+	protected void invokeDeleteVocabulary(Long vocabularyId) throws Exception {
+		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/vocabularies/{vocabulary-id}");
 	}
 
-	protected void invokeGetContentSpacesVocabulariesPage(
+	protected void invokeGetContentSpaceVocabularyPage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -103,13 +99,13 @@ public abstract class BaseVocabularyResourceTestCase {
 				"/content-spaces/{content-space-id}/vocabularies");
 	}
 
-	protected void invokeGetVocabularies(Long vocabularyId) throws Exception {
+	protected void invokeGetVocabulary(Long vocabularyId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/vocabularies/{vocabulary-id}");
 	}
 
-	protected void invokePostContentSpacesVocabularies(
+	protected void invokePostContentSpaceVocabulary(
 			Long contentSpaceId, Vocabulary vocabulary)
 		throws Exception {
 
@@ -119,7 +115,7 @@ public abstract class BaseVocabularyResourceTestCase {
 				"/content-spaces/{content-space-id}/vocabularies");
 	}
 
-	protected void invokePostContentSpacesVocabulariesBatchCreate(
+	protected void invokePostContentSpaceVocabularyBatchCreate(
 			Long contentSpaceId, Vocabulary vocabulary)
 		throws Exception {
 
@@ -129,8 +125,7 @@ public abstract class BaseVocabularyResourceTestCase {
 				"/content-spaces/{content-space-id}/vocabularies/batch-create");
 	}
 
-	protected void invokePutVocabularies(
-			Long vocabularyId, Vocabulary vocabulary)
+	protected void invokePutVocabulary(Long vocabularyId, Vocabulary vocabulary)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseWebUrlResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseWebUrlResourceTestCase.java
@@ -53,28 +53,28 @@ public abstract class BaseWebUrlResourceTestCase {
 	}
 
 	@Test
-	public void testGetWebUrls() throws Exception {
+	public void testGetGenericParentWebUrlPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetWebUrlsPage() throws Exception {
+	public void testGetWebUrl() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetWebUrls(Long webUrlId) throws Exception {
-		RequestSender requestSender = _createRequestSender();
-
-			requestSender.post("/web-urls/{web-url-id}");
-	}
-
-	protected void invokeGetWebUrlsPage(
+	protected void invokeGetGenericParentWebUrlPage(
 			Object genericParentId, Pagination pagination)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/web-urls");
+	}
+
+	protected void invokeGetWebUrl(Long webUrlId) throws Exception {
+		RequestSender requestSender = _createRequestSender();
+
+			requestSender.post("/web-urls/{web-url-id}");
 	}
 
 	private RequestSender _createRequestSender() {

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/AggregateRatingResource.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/AggregateRatingResource.java
@@ -63,6 +63,6 @@ public interface AggregateRatingResource {
 	@Path("/aggregate-ratings/{aggregate-rating-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public AggregateRating getAggregateRatings( @PathParam("aggregate-rating-id") Long aggregateRatingId ) throws Exception;
+	public AggregateRating getAggregateRating( @PathParam("aggregate-rating-id") Long aggregateRatingId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/CommentResource.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/CommentResource.java
@@ -63,18 +63,18 @@ public interface CommentResource {
 	@Path("/comments/{comment-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Comment getComments( @PathParam("comment-id") Long commentId ) throws Exception;
+	public Comment getComment( @PathParam("comment-id") Long commentId ) throws Exception;
 
 	@GET
 	@Path("/comments/{comment-id}/comments")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Comment> getCommentsCommentsPage( @PathParam("comment-id") Long commentId , @Context Pagination pagination ) throws Exception;
+	public Page<Comment> getCommentCommentPage( @PathParam("comment-id") Long commentId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/structured-contents/{structured-content-id}/comments")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Comment> getStructuredContentsCommentsPage( @PathParam("structured-content-id") Long structuredContentId , @Context Pagination pagination ) throws Exception;
+	public Page<Comment> getStructuredContentCommentPage( @PathParam("structured-content-id") Long structuredContentId , @Context Pagination pagination ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/ContentDocumentResource.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/ContentDocumentResource.java
@@ -63,12 +63,12 @@ public interface ContentDocumentResource {
 	@Path("/content-documents/{content-document-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Response deleteContentDocuments( @PathParam("content-document-id") Long contentDocumentId ) throws Exception;
+	public Response deleteContentDocument( @PathParam("content-document-id") Long contentDocumentId ) throws Exception;
 
 	@GET
 	@Path("/content-documents/{content-document-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public ContentDocument getContentDocuments( @PathParam("content-document-id") Long contentDocumentId ) throws Exception;
+	public ContentDocument getContentDocument( @PathParam("content-document-id") Long contentDocumentId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/ContentStructureResource.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/ContentStructureResource.java
@@ -63,12 +63,12 @@ public interface ContentStructureResource {
 	@Path("/content-spaces/{content-space-id}/content-structures")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<ContentStructure> getContentSpacesContentStructuresPage( @PathParam("content-space-id") Long contentSpaceId , @Context Pagination pagination ) throws Exception;
+	public Page<ContentStructure> getContentSpaceContentStructurePage( @PathParam("content-space-id") Long contentSpaceId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/content-structures/{content-structure-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public ContentStructure getContentStructures( @PathParam("content-structure-id") Long contentStructureId ) throws Exception;
+	public ContentStructure getContentStructure( @PathParam("content-structure-id") Long contentStructureId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/CreatorResource.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/CreatorResource.java
@@ -63,6 +63,6 @@ public interface CreatorResource {
 	@Path("/creators/{creator-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Creator getCreators( @PathParam("creator-id") Long creatorId ) throws Exception;
+	public Creator getCreator( @PathParam("creator-id") Long creatorId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/StructuredContentResource.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/StructuredContentResource.java
@@ -63,78 +63,78 @@ public interface StructuredContentResource {
 	@Path("/content-spaces/{content-space-id}/content-structures/{content-structure-id}/structured-contents")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<StructuredContent> getContentSpacesContentStructuresStructuredContentsPage( @PathParam("content-space-id") Long contentSpaceId , @PathParam("content-structure-id") Long contentStructureId , @Context Filter filter , @Context Pagination pagination , @Context Sort[] sorts ) throws Exception;
+	public Page<StructuredContent> getContentSpaceContentStructureStructuredContentPage( @PathParam("content-space-id") Long contentSpaceId , @PathParam("content-structure-id") Long contentStructureId , @Context Filter filter , @Context Pagination pagination , @Context Sort[] sorts ) throws Exception;
 
 	@GET
 	@Path("/content-spaces/{content-space-id}/structured-contents")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<StructuredContent> getContentSpacesStructuredContentsPage( @PathParam("content-space-id") Long contentSpaceId , @Context Filter filter , @Context Pagination pagination , @Context Sort[] sorts ) throws Exception;
+	public Page<StructuredContent> getContentSpaceStructuredContentPage( @PathParam("content-space-id") Long contentSpaceId , @Context Filter filter , @Context Pagination pagination , @Context Sort[] sorts ) throws Exception;
 
 	@Consumes("application/json")
 	@PATCH
 	@Path("/content-spaces/{content-space-id}/structured-contents")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public StructuredContent patchContentSpacesStructuredContents( @PathParam("content-space-id") Long contentSpaceId , StructuredContent structuredContent ) throws Exception;
+	public StructuredContent patchContentSpaceStructuredContents( @PathParam("content-space-id") Long contentSpaceId , StructuredContent structuredContent ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/content-spaces/{content-space-id}/structured-contents")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public StructuredContent postContentSpacesStructuredContents( @PathParam("content-space-id") Long contentSpaceId , StructuredContent structuredContent ) throws Exception;
+	public StructuredContent postContentSpaceStructuredContent( @PathParam("content-space-id") Long contentSpaceId , StructuredContent structuredContent ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/content-spaces/{content-space-id}/structured-contents/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public StructuredContent postContentSpacesStructuredContentsBatchCreate( @PathParam("content-space-id") Long contentSpaceId , StructuredContent structuredContent ) throws Exception;
+	public StructuredContent postContentSpaceStructuredContentBatchCreate( @PathParam("content-space-id") Long contentSpaceId , StructuredContent structuredContent ) throws Exception;
 
 	@GET
 	@Path("/content-structures/{content-structure-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public ContentStructure getContentStructures( @PathParam("content-structure-id") Long contentStructureId ) throws Exception;
+	public ContentStructure getContentStructure( @PathParam("content-structure-id") Long contentStructureId ) throws Exception;
 
 	@DELETE
 	@Path("/structured-contents/{structured-content-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Response deleteStructuredContents( @PathParam("structured-content-id") Long structuredContentId ) throws Exception;
+	public Response deleteStructuredContent( @PathParam("structured-content-id") Long structuredContentId ) throws Exception;
 
 	@GET
 	@Path("/structured-contents/{structured-content-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public StructuredContent getStructuredContents( @PathParam("structured-content-id") Long structuredContentId ) throws Exception;
+	public StructuredContent getStructuredContent( @PathParam("structured-content-id") Long structuredContentId ) throws Exception;
 
 	@Consumes("application/json")
 	@PUT
 	@Path("/structured-contents/{structured-content-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public StructuredContent putStructuredContents( @PathParam("structured-content-id") Long structuredContentId , StructuredContent structuredContent ) throws Exception;
+	public StructuredContent putStructuredContent( @PathParam("structured-content-id") Long structuredContentId , StructuredContent structuredContent ) throws Exception;
 
 	@GET
 	@Path("/structured-contents/{structured-content-id}/categories")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<Long> getStructuredContentsCategoriesPage( @PathParam("structured-content-id") Long structuredContentId , @Context Pagination pagination ) throws Exception;
+	public Page<Long> getStructuredContentCategoriesPage( @PathParam("structured-content-id") Long structuredContentId , @Context Pagination pagination ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/structured-contents/{structured-content-id}/categories")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Response postStructuredContentsCategories( @PathParam("structured-content-id") Long structuredContentId , Long referenceId ) throws Exception;
+	public Response postStructuredContentCategories( @PathParam("structured-content-id") Long structuredContentId , Long referenceId ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/structured-contents/{structured-content-id}/categories/batch-create")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public Response postStructuredContentsCategoriesBatchCreate( @PathParam("structured-content-id") Long structuredContentId , Long referenceId ) throws Exception;
+	public Response postStructuredContentCategoriesBatchCreate( @PathParam("structured-content-id") Long structuredContentId , Long referenceId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseAggregateRatingResourceImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseAggregateRatingResourceImpl.java
@@ -37,7 +37,7 @@ public abstract class BaseAggregateRatingResourceImpl
 	implements AggregateRatingResource {
 
 	@Override
-	public AggregateRating getAggregateRatings(Long aggregateRatingId)
+	public AggregateRating getAggregateRating(Long aggregateRatingId)
 		throws Exception {
 
 		return new AggregateRating();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -39,12 +39,12 @@ import javax.ws.rs.core.Response;
 public abstract class BaseCommentResourceImpl implements CommentResource {
 
 	@Override
-	public Comment getComments(Long commentId) throws Exception {
+	public Comment getComment(Long commentId) throws Exception {
 		return new Comment();
 	}
 
 	@Override
-	public Page<Comment> getCommentsCommentsPage(
+	public Page<Comment> getCommentCommentPage(
 			Long commentId, Pagination pagination)
 		throws Exception {
 
@@ -52,7 +52,7 @@ public abstract class BaseCommentResourceImpl implements CommentResource {
 	}
 
 	@Override
-	public Page<Comment> getStructuredContentsCommentsPage(
+	public Page<Comment> getStructuredContentCommentPage(
 			Long structuredContentId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseContentDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseContentDocumentResourceImpl.java
@@ -37,7 +37,7 @@ public abstract class BaseContentDocumentResourceImpl
 	implements ContentDocumentResource {
 
 	@Override
-	public Response deleteContentDocuments(Long contentDocumentId)
+	public Response deleteContentDocument(Long contentDocumentId)
 		throws Exception {
 
 		Response.ResponseBuilder responseBuilder = Response.ok();
@@ -46,7 +46,7 @@ public abstract class BaseContentDocumentResourceImpl
 	}
 
 	@Override
-	public ContentDocument getContentDocuments(Long contentDocumentId)
+	public ContentDocument getContentDocument(Long contentDocumentId)
 		throws Exception {
 
 		return new ContentDocument();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -40,7 +40,7 @@ public abstract class BaseContentStructureResourceImpl
 	implements ContentStructureResource {
 
 	@Override
-	public Page<ContentStructure> getContentSpacesContentStructuresPage(
+	public Page<ContentStructure> getContentSpaceContentStructurePage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -48,7 +48,7 @@ public abstract class BaseContentStructureResourceImpl
 	}
 
 	@Override
-	public ContentStructure getContentStructures(Long contentStructureId)
+	public ContentStructure getContentStructure(Long contentStructureId)
 		throws Exception {
 
 		return new ContentStructure();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseCreatorResourceImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseCreatorResourceImpl.java
@@ -36,7 +36,7 @@ import javax.ws.rs.core.Response;
 public abstract class BaseCreatorResourceImpl implements CreatorResource {
 
 	@Override
-	public Creator getCreators(Long creatorId) throws Exception {
+	public Creator getCreator(Long creatorId) throws Exception {
 		return new Creator();
 	}
 

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -43,7 +43,7 @@ public abstract class BaseStructuredContentResourceImpl
 	implements StructuredContentResource {
 
 	@Override
-	public Response deleteStructuredContents(Long structuredContentId)
+	public Response deleteStructuredContent(Long structuredContentId)
 		throws Exception {
 
 		Response.ResponseBuilder responseBuilder = Response.ok();
@@ -52,7 +52,7 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	@Override
-	public Page<StructuredContent> getContentSpacesContentStructuresStructuredContentsPage(
+	public Page<StructuredContent> getContentSpaceContentStructureStructuredContentPage(
 			Long contentSpaceId, Long contentStructureId, Filter filter,
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
@@ -61,7 +61,7 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	@Override
-	public Page<StructuredContent> getContentSpacesStructuredContentsPage(
+	public Page<StructuredContent> getContentSpaceStructuredContentPage(
 			Long contentSpaceId, Filter filter, Pagination pagination,
 			Sort[] sorts)
 		throws Exception {
@@ -70,21 +70,21 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	@Override
-	public ContentStructure getContentStructures(Long contentStructureId)
+	public ContentStructure getContentStructure(Long contentStructureId)
 		throws Exception {
 
 		return new ContentStructure();
 	}
 
 	@Override
-	public StructuredContent getStructuredContents(Long structuredContentId)
+	public StructuredContent getStructuredContent(Long structuredContentId)
 		throws Exception {
 
 		return new StructuredContent();
 	}
 
 	@Override
-	public Page<Long> getStructuredContentsCategoriesPage(
+	public Page<Long> getStructuredContentCategoriesPage(
 			Long structuredContentId, Pagination pagination)
 		throws Exception {
 
@@ -92,7 +92,7 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	@Override
-	public StructuredContent patchContentSpacesStructuredContents(
+	public StructuredContent patchContentSpaceStructuredContents(
 			Long contentSpaceId, StructuredContent structuredContent)
 		throws Exception {
 
@@ -100,7 +100,7 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	@Override
-	public StructuredContent postContentSpacesStructuredContents(
+	public StructuredContent postContentSpaceStructuredContent(
 			Long contentSpaceId, StructuredContent structuredContent)
 		throws Exception {
 
@@ -108,7 +108,7 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	@Override
-	public StructuredContent postContentSpacesStructuredContentsBatchCreate(
+	public StructuredContent postContentSpaceStructuredContentBatchCreate(
 			Long contentSpaceId, StructuredContent structuredContent)
 		throws Exception {
 
@@ -116,7 +116,7 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	@Override
-	public Response postStructuredContentsCategories(
+	public Response postStructuredContentCategories(
 			Long structuredContentId, Long referenceId)
 		throws Exception {
 
@@ -126,7 +126,7 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	@Override
-	public Response postStructuredContentsCategoriesBatchCreate(
+	public Response postStructuredContentCategoriesBatchCreate(
 			Long structuredContentId, Long referenceId)
 		throws Exception {
 
@@ -136,7 +136,7 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	@Override
-	public StructuredContent putStructuredContents(
+	public StructuredContent putStructuredContent(
 			Long structuredContentId, StructuredContent structuredContent)
 		throws Exception {
 

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/ContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/ContentStructureResourceImpl.java
@@ -45,7 +45,7 @@ public class ContentStructureResourceImpl
 	extends BaseContentStructureResourceImpl {
 
 	@Override
-	public Page<ContentStructure> getContentSpacesContentStructuresPage(
+	public Page<ContentStructure> getContentSpaceContentStructurePage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -67,7 +67,7 @@ public class ContentStructureResourceImpl
 	}
 
 	@Override
-	public ContentStructure getContentStructures(Long contentStructuresId)
+	public ContentStructure getContentStructure(Long contentStructuresId)
 		throws Exception {
 
 		return _toContentStructure(

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -97,7 +97,7 @@ public class StructuredContentResourceImpl
 	extends BaseStructuredContentResourceImpl implements EntityModelResource {
 
 	@Override
-	public Response deleteStructuredContents(Long structuredContentId)
+	public Response deleteStructuredContent(Long structuredContentId)
 		throws Exception {
 
 		JournalArticle journalArticle = _journalArticleService.getLatestArticle(
@@ -112,17 +112,17 @@ public class StructuredContentResourceImpl
 
 	@Override
 	public Page<StructuredContent>
-			getContentSpacesContentStructuresStructuredContentsPage(
+			getContentSpaceContentStructureStructuredContentPage(
 				Long contentSpaceId, Long contentStructureId, Filter filter,
 				Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		return getContentSpacesStructuredContentsPage(
+		return getContentSpaceStructuredContentPage(
 			contentSpaceId, filter, pagination, sorts);
 	}
 
 	@Override
-	public Page<StructuredContent> getContentSpacesStructuredContentsPage(
+	public Page<StructuredContent> getContentSpaceStructuredContentPage(
 			Long contentSpaceId, Filter filter, Pagination pagination,
 			Sort[] sorts)
 		throws Exception {
@@ -158,7 +158,7 @@ public class StructuredContentResourceImpl
 	}
 
 	@Override
-	public StructuredContent getStructuredContents(Long structuredContentId)
+	public StructuredContent getStructuredContent(Long structuredContentId)
 		throws Exception {
 
 		return _toStructuredContent(
@@ -166,7 +166,7 @@ public class StructuredContentResourceImpl
 	}
 
 	@Override
-	public StructuredContent postContentSpacesStructuredContents(
+	public StructuredContent postContentSpaceStructuredContent(
 			Long contentSpaceId, StructuredContent structuredContent)
 		throws Exception {
 
@@ -203,7 +203,7 @@ public class StructuredContentResourceImpl
 	}
 
 	@Override
-	public StructuredContent putStructuredContents(
+	public StructuredContent putStructuredContent(
 			Long structuredContentId, StructuredContent structuredContent)
 		throws Exception {
 

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseAggregateRatingResourceTestCase.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseAggregateRatingResourceTestCase.java
@@ -51,11 +51,11 @@ public abstract class BaseAggregateRatingResourceTestCase {
 	}
 
 	@Test
-	public void testGetAggregateRatings() throws Exception {
+	public void testGetAggregateRating() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetAggregateRatings(Long aggregateRatingId)
+	protected void invokeGetAggregateRating(Long aggregateRatingId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -53,27 +53,27 @@ public abstract class BaseCommentResourceTestCase {
 	}
 
 	@Test
-	public void testGetComments() throws Exception {
+	public void testGetComment() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetCommentsCommentsPage() throws Exception {
+	public void testGetCommentCommentPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetStructuredContentsCommentsPage() throws Exception {
+	public void testGetStructuredContentCommentPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetComments(Long commentId) throws Exception {
+	protected void invokeGetComment(Long commentId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/comments/{comment-id}");
 	}
 
-	protected void invokeGetCommentsCommentsPage(
+	protected void invokeGetCommentCommentPage(
 			Long commentId, Pagination pagination)
 		throws Exception {
 
@@ -82,7 +82,7 @@ public abstract class BaseCommentResourceTestCase {
 			requestSender.post("/comments/{comment-id}/comments");
 	}
 
-	protected void invokeGetStructuredContentsCommentsPage(
+	protected void invokeGetStructuredContentCommentPage(
 			Long structuredContentId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseContentDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseContentDocumentResourceTestCase.java
@@ -51,16 +51,16 @@ public abstract class BaseContentDocumentResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteContentDocuments() throws Exception {
+	public void testDeleteContentDocument() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetContentDocuments() throws Exception {
+	public void testGetContentDocument() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeDeleteContentDocuments(Long contentDocumentId)
+	protected void invokeDeleteContentDocument(Long contentDocumentId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -68,7 +68,7 @@ public abstract class BaseContentDocumentResourceTestCase {
 			requestSender.post("/content-documents/{content-document-id}");
 	}
 
-	protected void invokeGetContentDocuments(Long contentDocumentId)
+	protected void invokeGetContentDocument(Long contentDocumentId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -53,16 +53,16 @@ public abstract class BaseContentStructureResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpacesContentStructuresPage() throws Exception {
+	public void testGetContentSpaceContentStructurePage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetContentStructures() throws Exception {
+	public void testGetContentStructure() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetContentSpacesContentStructuresPage(
+	protected void invokeGetContentSpaceContentStructurePage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -72,7 +72,7 @@ public abstract class BaseContentStructureResourceTestCase {
 				"/content-spaces/{content-space-id}/content-structures");
 	}
 
-	protected void invokeGetContentStructures(Long contentStructureId)
+	protected void invokeGetContentStructure(Long contentStructureId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseCreatorResourceTestCase.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseCreatorResourceTestCase.java
@@ -51,11 +51,11 @@ public abstract class BaseCreatorResourceTestCase {
 	}
 
 	@Test
-	public void testGetCreators() throws Exception {
+	public void testGetCreator() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetCreators(Long creatorId) throws Exception {
+	protected void invokeGetCreator(Long creatorId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/creators/{creator-id}");

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -56,72 +56,72 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteStructuredContents() throws Exception {
+	public void testDeleteStructuredContent() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetContentSpacesContentStructuresStructuredContentsPage()
+	public void testGetContentSpaceContentStructureStructuredContentPage()
 		throws Exception {
 
 			Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetContentSpacesStructuredContentsPage() throws Exception {
+	public void testGetContentSpaceStructuredContentPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetContentStructures() throws Exception {
+	public void testGetContentStructure() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetStructuredContents() throws Exception {
+	public void testGetStructuredContent() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetStructuredContentsCategoriesPage() throws Exception {
+	public void testGetStructuredContentCategoriesPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPatchContentSpacesStructuredContents() throws Exception {
+	public void testPatchContentSpaceStructuredContents() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostContentSpacesStructuredContents() throws Exception {
+	public void testPostContentSpaceStructuredContent() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostContentSpacesStructuredContentsBatchCreate()
+	public void testPostContentSpaceStructuredContentBatchCreate()
 		throws Exception {
 
 			Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostStructuredContentsCategories() throws Exception {
+	public void testPostStructuredContentCategories() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostStructuredContentsCategoriesBatchCreate()
+	public void testPostStructuredContentCategoriesBatchCreate()
 		throws Exception {
 
 			Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPutStructuredContents() throws Exception {
+	public void testPutStructuredContent() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeDeleteStructuredContents(Long structuredContentId)
+	protected void invokeDeleteStructuredContent(Long structuredContentId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -129,7 +129,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 			requestSender.post("/structured-contents/{structured-content-id}");
 	}
 
-	protected void invokeGetContentSpacesContentStructuresStructuredContentsPage(
+	protected void invokeGetContentSpaceContentStructureStructuredContentPage(
 			Long contentSpaceId, Long contentStructureId, Filter filter,
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
@@ -140,7 +140,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 				"/content-spaces/{content-space-id}/content-structures/{content-structure-id}/structured-contents");
 	}
 
-	protected void invokeGetContentSpacesStructuredContentsPage(
+	protected void invokeGetContentSpaceStructuredContentPage(
 			Long contentSpaceId, Filter filter, Pagination pagination,
 			Sort[] sorts)
 		throws Exception {
@@ -151,7 +151,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 				"/content-spaces/{content-space-id}/structured-contents");
 	}
 
-	protected void invokeGetContentStructures(Long contentStructureId)
+	protected void invokeGetContentStructure(Long contentStructureId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -159,7 +159,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 			requestSender.post("/content-structures/{content-structure-id}");
 	}
 
-	protected void invokeGetStructuredContents(Long structuredContentId)
+	protected void invokeGetStructuredContent(Long structuredContentId)
 		throws Exception {
 
 			RequestSender requestSender = _createRequestSender();
@@ -167,7 +167,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 			requestSender.post("/structured-contents/{structured-content-id}");
 	}
 
-	protected void invokeGetStructuredContentsCategoriesPage(
+	protected void invokeGetStructuredContentCategoriesPage(
 			Long structuredContentId, Pagination pagination)
 		throws Exception {
 
@@ -177,7 +177,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 				"/structured-contents/{structured-content-id}/categories");
 	}
 
-	protected void invokePatchContentSpacesStructuredContents(
+	protected void invokePatchContentSpaceStructuredContents(
 			Long contentSpaceId, StructuredContent structuredContent)
 		throws Exception {
 
@@ -187,7 +187,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 				"/content-spaces/{content-space-id}/structured-contents");
 	}
 
-	protected void invokePostContentSpacesStructuredContents(
+	protected void invokePostContentSpaceStructuredContent(
 			Long contentSpaceId, StructuredContent structuredContent)
 		throws Exception {
 
@@ -197,7 +197,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 				"/content-spaces/{content-space-id}/structured-contents");
 	}
 
-	protected void invokePostContentSpacesStructuredContentsBatchCreate(
+	protected void invokePostContentSpaceStructuredContentBatchCreate(
 			Long contentSpaceId, StructuredContent structuredContent)
 		throws Exception {
 
@@ -207,7 +207,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 				"/content-spaces/{content-space-id}/structured-contents/batch-create");
 	}
 
-	protected void invokePostStructuredContentsCategories(
+	protected void invokePostStructuredContentCategories(
 			Long structuredContentId, Long referenceId)
 		throws Exception {
 
@@ -217,7 +217,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 				"/structured-contents/{structured-content-id}/categories");
 	}
 
-	protected void invokePostStructuredContentsCategoriesBatchCreate(
+	protected void invokePostStructuredContentCategoriesBatchCreate(
 			Long structuredContentId, Long referenceId)
 		throws Exception {
 
@@ -227,7 +227,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 				"/structured-contents/{structured-content-id}/categories/batch-create");
 	}
 
-	protected void invokePutStructuredContents(
+	protected void invokePutStructuredContent(
 			Long structuredContentId, StructuredContent structuredContent)
 		throws Exception {
 

--- a/modules/apps/headless/headless-workflow/headless-workflow-api/src/main/java/com/liferay/headless/workflow/resource/v1_0/WorkflowLogResource.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-api/src/main/java/com/liferay/headless/workflow/resource/v1_0/WorkflowLogResource.java
@@ -59,12 +59,12 @@ public interface WorkflowLogResource {
 	@Path("/workflow-logs/{workflow-log-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public WorkflowLog getWorkflowLogs( @PathParam("workflow-log-id") Long workflowLogId ) throws Exception;
+	public WorkflowLog getWorkflowLog( @PathParam("workflow-log-id") Long workflowLogId ) throws Exception;
 
 	@GET
 	@Path("/workflow-tasks/{workflow-task-id}/workflow-logs")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<WorkflowLog> getWorkflowTasksWorkflowLogsPage( @PathParam("workflow-task-id") Long workflowTaskId , @Context Pagination pagination ) throws Exception;
+	public Page<WorkflowLog> getWorkflowTaskWorkflowLogPage( @PathParam("workflow-task-id") Long workflowTaskId , @Context Pagination pagination ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-workflow/headless-workflow-api/src/main/java/com/liferay/headless/workflow/resource/v1_0/WorkflowTaskResource.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-api/src/main/java/com/liferay/headless/workflow/resource/v1_0/WorkflowTaskResource.java
@@ -59,46 +59,46 @@ public interface WorkflowTaskResource {
 	@Path("/roles/{role-id}/workflow-tasks")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<WorkflowTask> getRolesWorkflowTasksPage( @PathParam("role-id") Long roleId , @Context Pagination pagination ) throws Exception;
+	public Page<WorkflowTask> getRoleWorkflowTaskPage( @PathParam("role-id") Long roleId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/workflow-tasks")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public Page<WorkflowTask> getWorkflowTasksPage( @PathParam("generic-parent-id") Object genericParentId , @Context Pagination pagination ) throws Exception;
+	public Page<WorkflowTask> getGenericParentWorkflowTaskPage( @PathParam("generic-parent-id") Object genericParentId , @Context Pagination pagination ) throws Exception;
 
 	@GET
 	@Path("/workflow-tasks/{workflow-task-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
-	public WorkflowTask getWorkflowTasks( @PathParam("workflow-task-id") Long workflowTaskId ) throws Exception;
+	public WorkflowTask getWorkflowTask( @PathParam("workflow-task-id") Long workflowTaskId ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/workflow-tasks/{workflow-task-id}/assign-to-me")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public WorkflowTask postWorkflowTasksAssignToMe( @PathParam("workflow-task-id") Long workflowTaskId , WorkflowTask workflowTask ) throws Exception;
+	public WorkflowTask postWorkflowTaskAssignToMe( @PathParam("workflow-task-id") Long workflowTaskId , WorkflowTask workflowTask ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/workflow-tasks/{workflow-task-id}/assign-to-user")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public WorkflowTask postWorkflowTasksAssignToUser( @PathParam("workflow-task-id") Long workflowTaskId , WorkflowTask workflowTask ) throws Exception;
+	public WorkflowTask postWorkflowTaskAssignToUser( @PathParam("workflow-task-id") Long workflowTaskId , WorkflowTask workflowTask ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/workflow-tasks/{workflow-task-id}/change-transition")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public WorkflowTask postWorkflowTasksChangeTransition( @PathParam("workflow-task-id") Long workflowTaskId , WorkflowTask workflowTask ) throws Exception;
+	public WorkflowTask postWorkflowTaskChangeTransition( @PathParam("workflow-task-id") Long workflowTaskId , WorkflowTask workflowTask ) throws Exception;
 
 	@Consumes("application/json")
 	@POST
 	@Path("/workflow-tasks/{workflow-task-id}/update-due-date")
 	@Produces("application/json")
 	@RequiresScope("everything.write")
-	public WorkflowTask postWorkflowTasksUpdateDueDate( @PathParam("workflow-task-id") Long workflowTaskId , WorkflowTask workflowTask ) throws Exception;
+	public WorkflowTask postWorkflowTaskUpdateDueDate( @PathParam("workflow-task-id") Long workflowTaskId , WorkflowTask workflowTask ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
@@ -40,12 +40,12 @@ public abstract class BaseWorkflowLogResourceImpl
 	implements WorkflowLogResource {
 
 	@Override
-	public WorkflowLog getWorkflowLogs(Long workflowLogId) throws Exception {
+	public WorkflowLog getWorkflowLog(Long workflowLogId) throws Exception {
 		return new WorkflowLog();
 	}
 
 	@Override
-	public Page<WorkflowLog> getWorkflowTasksWorkflowLogsPage(
+	public Page<WorkflowLog> getWorkflowTaskWorkflowLogPage(
 			Long workflowTaskId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/resource/v1_0/BaseWorkflowTaskResourceImpl.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/resource/v1_0/BaseWorkflowTaskResourceImpl.java
@@ -40,20 +40,7 @@ public abstract class BaseWorkflowTaskResourceImpl
 	implements WorkflowTaskResource {
 
 	@Override
-	public Page<WorkflowTask> getRolesWorkflowTasksPage(
-			Long roleId, Pagination pagination)
-		throws Exception {
-
-		return Page.of(Collections.emptyList());
-	}
-
-	@Override
-	public WorkflowTask getWorkflowTasks(Long workflowTaskId) throws Exception {
-		return new WorkflowTask();
-	}
-
-	@Override
-	public Page<WorkflowTask> getWorkflowTasksPage(
+	public Page<WorkflowTask> getGenericParentWorkflowTaskPage(
 			Object genericParentId, Pagination pagination)
 		throws Exception {
 
@@ -61,7 +48,20 @@ public abstract class BaseWorkflowTaskResourceImpl
 	}
 
 	@Override
-	public WorkflowTask postWorkflowTasksAssignToMe(
+	public Page<WorkflowTask> getRoleWorkflowTaskPage(
+			Long roleId, Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@Override
+	public WorkflowTask getWorkflowTask(Long workflowTaskId) throws Exception {
+		return new WorkflowTask();
+	}
+
+	@Override
+	public WorkflowTask postWorkflowTaskAssignToMe(
 			Long workflowTaskId, WorkflowTask workflowTask)
 		throws Exception {
 
@@ -69,7 +69,7 @@ public abstract class BaseWorkflowTaskResourceImpl
 	}
 
 	@Override
-	public WorkflowTask postWorkflowTasksAssignToUser(
+	public WorkflowTask postWorkflowTaskAssignToUser(
 			Long workflowTaskId, WorkflowTask workflowTask)
 		throws Exception {
 
@@ -77,7 +77,7 @@ public abstract class BaseWorkflowTaskResourceImpl
 	}
 
 	@Override
-	public WorkflowTask postWorkflowTasksChangeTransition(
+	public WorkflowTask postWorkflowTaskChangeTransition(
 			Long workflowTaskId, WorkflowTask workflowTask)
 		throws Exception {
 
@@ -85,7 +85,7 @@ public abstract class BaseWorkflowTaskResourceImpl
 	}
 
 	@Override
-	public WorkflowTask postWorkflowTasksUpdateDueDate(
+	public WorkflowTask postWorkflowTaskUpdateDueDate(
 			Long workflowTaskId, WorkflowTask workflowTask)
 		throws Exception {
 

--- a/modules/apps/headless/headless-workflow/headless-workflow-test/src/testIntegration/java/com/liferay/headless/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-test/src/testIntegration/java/com/liferay/headless/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
@@ -53,22 +53,22 @@ public abstract class BaseWorkflowLogResourceTestCase {
 	}
 
 	@Test
-	public void testGetWorkflowLogs() throws Exception {
+	public void testGetWorkflowLog() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetWorkflowTasksWorkflowLogsPage() throws Exception {
+	public void testGetWorkflowTaskWorkflowLogPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetWorkflowLogs(Long workflowLogId) throws Exception {
+	protected void invokeGetWorkflowLog(Long workflowLogId) throws Exception {
 		RequestSender requestSender = _createRequestSender();
 
 			requestSender.post("/workflow-logs/{workflow-log-id}");
 	}
 
-	protected void invokeGetWorkflowTasksWorkflowLogsPage(
+	protected void invokeGetWorkflowTaskWorkflowLogPage(
 			Long workflowTaskId, Pagination pagination)
 		throws Exception {
 

--- a/modules/apps/headless/headless-workflow/headless-workflow-test/src/testIntegration/java/com/liferay/headless/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-test/src/testIntegration/java/com/liferay/headless/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
@@ -54,58 +54,41 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 	}
 
 	@Test
-	public void testGetRolesWorkflowTasksPage() throws Exception {
+	public void testGetGenericParentWorkflowTaskPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetWorkflowTasks() throws Exception {
+	public void testGetRoleWorkflowTaskPage() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testGetWorkflowTasksPage() throws Exception {
+	public void testGetWorkflowTask() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostWorkflowTasksAssignToMe() throws Exception {
+	public void testPostWorkflowTaskAssignToMe() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostWorkflowTasksAssignToUser() throws Exception {
+	public void testPostWorkflowTaskAssignToUser() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostWorkflowTasksChangeTransition() throws Exception {
+	public void testPostWorkflowTaskChangeTransition() throws Exception {
 		Assert.assertTrue(true);
 	}
 
 	@Test
-	public void testPostWorkflowTasksUpdateDueDate() throws Exception {
+	public void testPostWorkflowTaskUpdateDueDate() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected void invokeGetRolesWorkflowTasksPage(
-			Long roleId, Pagination pagination)
-		throws Exception {
-
-			RequestSender requestSender = _createRequestSender();
-
-			requestSender.post("/roles/{role-id}/workflow-tasks");
-	}
-
-	protected void invokeGetWorkflowTasks(Long workflowTaskId)
-		throws Exception {
-
-			RequestSender requestSender = _createRequestSender();
-
-			requestSender.post("/workflow-tasks/{workflow-task-id}");
-	}
-
-	protected void invokeGetWorkflowTasksPage(
+	protected void invokeGetGenericParentWorkflowTaskPage(
 			Object genericParentId, Pagination pagination)
 		throws Exception {
 
@@ -114,7 +97,22 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 			requestSender.post("/workflow-tasks");
 	}
 
-	protected void invokePostWorkflowTasksAssignToMe(
+	protected void invokeGetRoleWorkflowTaskPage(
+			Long roleId, Pagination pagination)
+		throws Exception {
+
+			RequestSender requestSender = _createRequestSender();
+
+			requestSender.post("/roles/{role-id}/workflow-tasks");
+	}
+
+	protected void invokeGetWorkflowTask(Long workflowTaskId) throws Exception {
+		RequestSender requestSender = _createRequestSender();
+
+			requestSender.post("/workflow-tasks/{workflow-task-id}");
+	}
+
+	protected void invokePostWorkflowTaskAssignToMe(
 			Long workflowTaskId, WorkflowTask workflowTask)
 		throws Exception {
 
@@ -124,7 +122,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 				"/workflow-tasks/{workflow-task-id}/assign-to-me");
 	}
 
-	protected void invokePostWorkflowTasksAssignToUser(
+	protected void invokePostWorkflowTaskAssignToUser(
 			Long workflowTaskId, WorkflowTask workflowTask)
 		throws Exception {
 
@@ -134,7 +132,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 				"/workflow-tasks/{workflow-task-id}/assign-to-user");
 	}
 
-	protected void invokePostWorkflowTasksChangeTransition(
+	protected void invokePostWorkflowTaskChangeTransition(
 			Long workflowTaskId, WorkflowTask workflowTask)
 		throws Exception {
 
@@ -144,7 +142,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 				"/workflow-tasks/{workflow-task-id}/change-transition");
 	}
 
-	protected void invokePostWorkflowTasksUpdateDueDate(
+	protected void invokePostWorkflowTaskUpdateDueDate(
 			Long workflowTaskId, WorkflowTask workflowTask)
 		throws Exception {
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/JavaTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/JavaTool.java
@@ -491,6 +491,12 @@ public class JavaTool {
 			return name + "Page";
 		}
 
+		if (StringUtil.equals(returnType, schemaName) &&
+			StringUtil.endsWith(name, schemaName + "s")) {
+
+			return name.substring(0, name.length() - 1);
+		}
+
 		return name;
 	}
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/util/PathUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/util/PathUtil.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.rest.builder.internal.util;
+
+/**
+ * @author Javier Gamarra
+ */
+public class PathUtil {
+
+	public static String getLastSegmentFromPath(String path, int number) {
+		int index = _nthIndexOf(path, "/", number);
+
+		if (index == -1) {
+			return "";
+		}
+
+		String pattern = path.substring(index);
+
+		return CamelCaseUtil.toCamelCase(pattern, true);
+	}
+
+	private static int _nthIndexOf(String source, String search, int n) {
+		int index = source.indexOf(search);
+
+		if (index == -1) {
+			return -1;
+		}
+
+		for (int i = 1; i < n; i++) {
+			index = source.indexOf(search, index + 1);
+
+			if (index == -1) {
+				return -1;
+			}
+		}
+
+		return index;
+	}
+
+}


### PR DESCRIPTION
Ok... it's not as easy as I thought at the beginning because irregular plurals (like categories or vocabularies)... but we can construct it from the combination of parameters, httpMethod, returnType, comparing names and extracting the segments from the URL. 

It's not very pretty at it is, maybe we can extract the segment part to a regex. If you want me to change something I'll be around all day.

/cc @petershin