### PR TITLE
LPS-90782

### DIFF
--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/AggregateRatingImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/AggregateRatingImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.collaboration.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.collaboration.dto.v1_0.AggregateRating;
@@ -43,6 +44,7 @@ public class AggregateRatingImpl implements AggregateRating {
 			this.bestRating = bestRating;
 	}
 
+	@JsonIgnore
 	public void setBestRating(UnsafeSupplier<Number, Throwable> bestRatingUnsafeSupplier) {
 			try {
 				bestRating = bestRatingUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class AggregateRatingImpl implements AggregateRating {
 			this.ratingCount = ratingCount;
 	}
 
+	@JsonIgnore
 	public void setRatingCount(UnsafeSupplier<Number, Throwable> ratingCountUnsafeSupplier) {
 			try {
 				ratingCount = ratingCountUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class AggregateRatingImpl implements AggregateRating {
 			this.ratingValue = ratingValue;
 	}
 
+	@JsonIgnore
 	public void setRatingValue(UnsafeSupplier<Number, Throwable> ratingValueUnsafeSupplier) {
 			try {
 				ratingValue = ratingValueUnsafeSupplier.get();
@@ -103,6 +107,7 @@ public class AggregateRatingImpl implements AggregateRating {
 			this.worstRating = worstRating;
 	}
 
+	@JsonIgnore
 	public void setWorstRating(UnsafeSupplier<Number, Throwable> worstRatingUnsafeSupplier) {
 			try {
 				worstRating = worstRatingUnsafeSupplier.get();

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/BlogPostingImageImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/BlogPostingImageImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.collaboration.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.collaboration.dto.v1_0.BlogPostingImage;
@@ -43,6 +44,7 @@ public class BlogPostingImageImpl implements BlogPostingImage {
 			this.contentUrl = contentUrl;
 	}
 
+	@JsonIgnore
 	public void setContentUrl(UnsafeSupplier<String, Throwable> contentUrlUnsafeSupplier) {
 			try {
 				contentUrl = contentUrlUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class BlogPostingImageImpl implements BlogPostingImage {
 			this.encodingFormat = encodingFormat;
 	}
 
+	@JsonIgnore
 	public void setEncodingFormat(UnsafeSupplier<String, Throwable> encodingFormatUnsafeSupplier) {
 			try {
 				encodingFormat = encodingFormatUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class BlogPostingImageImpl implements BlogPostingImage {
 			this.fileExtension = fileExtension;
 	}
 
+	@JsonIgnore
 	public void setFileExtension(UnsafeSupplier<String, Throwable> fileExtensionUnsafeSupplier) {
 			try {
 				fileExtension = fileExtensionUnsafeSupplier.get();
@@ -103,6 +107,7 @@ public class BlogPostingImageImpl implements BlogPostingImage {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -123,6 +128,7 @@ public class BlogPostingImageImpl implements BlogPostingImage {
 			this.sizeInBytes = sizeInBytes;
 	}
 
+	@JsonIgnore
 	public void setSizeInBytes(UnsafeSupplier<Number, Throwable> sizeInBytesUnsafeSupplier) {
 			try {
 				sizeInBytes = sizeInBytesUnsafeSupplier.get();
@@ -143,6 +149,7 @@ public class BlogPostingImageImpl implements BlogPostingImage {
 			this.title = title;
 	}
 
+	@JsonIgnore
 	public void setTitle(UnsafeSupplier<String, Throwable> titleUnsafeSupplier) {
 			try {
 				title = titleUnsafeSupplier.get();

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/BlogPostingImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/BlogPostingImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.collaboration.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.collaboration.dto.v1_0.AggregateRating;
@@ -51,6 +52,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.aggregateRating = aggregateRating;
 	}
 
+	@JsonIgnore
 	public void setAggregateRating(UnsafeSupplier<AggregateRating, Throwable> aggregateRatingUnsafeSupplier) {
 			try {
 				aggregateRating = aggregateRatingUnsafeSupplier.get();
@@ -71,6 +73,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.alternativeHeadline = alternativeHeadline;
 	}
 
+	@JsonIgnore
 	public void setAlternativeHeadline(UnsafeSupplier<String, Throwable> alternativeHeadlineUnsafeSupplier) {
 			try {
 				alternativeHeadline = alternativeHeadlineUnsafeSupplier.get();
@@ -91,6 +94,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.articleBody = articleBody;
 	}
 
+	@JsonIgnore
 	public void setArticleBody(UnsafeSupplier<String, Throwable> articleBodyUnsafeSupplier) {
 			try {
 				articleBody = articleBodyUnsafeSupplier.get();
@@ -111,6 +115,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.caption = caption;
 	}
 
+	@JsonIgnore
 	public void setCaption(UnsafeSupplier<String, Throwable> captionUnsafeSupplier) {
 			try {
 				caption = captionUnsafeSupplier.get();
@@ -131,6 +136,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.category = category;
 	}
 
+	@JsonIgnore
 	public void setCategory(UnsafeSupplier<Category[], Throwable> categoryUnsafeSupplier) {
 			try {
 				category = categoryUnsafeSupplier.get();
@@ -151,6 +157,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.comment = comment;
 	}
 
+	@JsonIgnore
 	public void setComment(UnsafeSupplier<Comment[], Throwable> commentUnsafeSupplier) {
 			try {
 				comment = commentUnsafeSupplier.get();
@@ -171,6 +178,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.contentSpace = contentSpace;
 	}
 
+	@JsonIgnore
 	public void setContentSpace(UnsafeSupplier<Long, Throwable> contentSpaceUnsafeSupplier) {
 			try {
 				contentSpace = contentSpaceUnsafeSupplier.get();
@@ -191,6 +199,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -211,6 +220,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -231,6 +241,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.dateModified = dateModified;
 	}
 
+	@JsonIgnore
 	public void setDateModified(UnsafeSupplier<Date, Throwable> dateModifiedUnsafeSupplier) {
 			try {
 				dateModified = dateModifiedUnsafeSupplier.get();
@@ -251,6 +262,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.datePublished = datePublished;
 	}
 
+	@JsonIgnore
 	public void setDatePublished(UnsafeSupplier<Date, Throwable> datePublishedUnsafeSupplier) {
 			try {
 				datePublished = datePublishedUnsafeSupplier.get();
@@ -271,6 +283,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.description = description;
 	}
 
+	@JsonIgnore
 	public void setDescription(UnsafeSupplier<String, Throwable> descriptionUnsafeSupplier) {
 			try {
 				description = descriptionUnsafeSupplier.get();
@@ -291,6 +304,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.encodingFormat = encodingFormat;
 	}
 
+	@JsonIgnore
 	public void setEncodingFormat(UnsafeSupplier<String, Throwable> encodingFormatUnsafeSupplier) {
 			try {
 				encodingFormat = encodingFormatUnsafeSupplier.get();
@@ -311,6 +325,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.friendlyUrlPath = friendlyUrlPath;
 	}
 
+	@JsonIgnore
 	public void setFriendlyUrlPath(UnsafeSupplier<String, Throwable> friendlyUrlPathUnsafeSupplier) {
 			try {
 				friendlyUrlPath = friendlyUrlPathUnsafeSupplier.get();
@@ -331,6 +346,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.headline = headline;
 	}
 
+	@JsonIgnore
 	public void setHeadline(UnsafeSupplier<String, Throwable> headlineUnsafeSupplier) {
 			try {
 				headline = headlineUnsafeSupplier.get();
@@ -351,6 +367,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -371,6 +388,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.image = image;
 	}
 
+	@JsonIgnore
 	public void setImage(UnsafeSupplier<Image, Throwable> imageUnsafeSupplier) {
 			try {
 				image = imageUnsafeSupplier.get();
@@ -391,6 +409,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.imageId = imageId;
 	}
 
+	@JsonIgnore
 	public void setImageId(UnsafeSupplier<Long, Throwable> imageIdUnsafeSupplier) {
 			try {
 				imageId = imageIdUnsafeSupplier.get();
@@ -411,6 +430,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.keywords = keywords;
 	}
 
+	@JsonIgnore
 	public void setKeywords(UnsafeSupplier<String[], Throwable> keywordsUnsafeSupplier) {
 			try {
 				keywords = keywordsUnsafeSupplier.get();
@@ -431,6 +451,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.repository = repository;
 	}
 
+	@JsonIgnore
 	public void setRepository(UnsafeSupplier<ImageObjectRepository, Throwable> repositoryUnsafeSupplier) {
 			try {
 				repository = repositoryUnsafeSupplier.get();
@@ -451,6 +472,7 @@ public class BlogPostingImpl implements BlogPosting {
 			this.repositoryId = repositoryId;
 	}
 
+	@JsonIgnore
 	public void setRepositoryId(UnsafeSupplier<Long, Throwable> repositoryIdUnsafeSupplier) {
 			try {
 				repositoryId = repositoryIdUnsafeSupplier.get();

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/CategoryImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/CategoryImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.collaboration.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.collaboration.dto.v1_0.Category;
@@ -43,6 +44,7 @@ public class CategoryImpl implements Category {
 			this.categoryId = categoryId;
 	}
 
+	@JsonIgnore
 	public void setCategoryId(UnsafeSupplier<Long, Throwable> categoryIdUnsafeSupplier) {
 			try {
 				categoryId = categoryIdUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class CategoryImpl implements Category {
 			this.categoryName = categoryName;
 	}
 
+	@JsonIgnore
 	public void setCategoryName(UnsafeSupplier<String, Throwable> categoryNameUnsafeSupplier) {
 			try {
 				categoryName = categoryNameUnsafeSupplier.get();

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/CommentImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/CommentImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.collaboration.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.collaboration.dto.v1_0.Comment;
@@ -44,6 +45,7 @@ public class CommentImpl implements Comment {
 			this.comments = comments;
 	}
 
+	@JsonIgnore
 	public void setComments(UnsafeSupplier<Comment[], Throwable> commentsUnsafeSupplier) {
 			try {
 				comments = commentsUnsafeSupplier.get();
@@ -64,6 +66,7 @@ public class CommentImpl implements Comment {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -84,6 +87,7 @@ public class CommentImpl implements Comment {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -104,6 +108,7 @@ public class CommentImpl implements Comment {
 			this.text = text;
 	}
 
+	@JsonIgnore
 	public void setText(UnsafeSupplier<String, Throwable> textUnsafeSupplier) {
 			try {
 				text = textUnsafeSupplier.get();

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/CreatorImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/CreatorImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.collaboration.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.collaboration.dto.v1_0.Creator;
@@ -43,6 +44,7 @@ public class CreatorImpl implements Creator {
 			this.additionalName = additionalName;
 	}
 
+	@JsonIgnore
 	public void setAdditionalName(UnsafeSupplier<String, Throwable> additionalNameUnsafeSupplier) {
 			try {
 				additionalName = additionalNameUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class CreatorImpl implements Creator {
 			this.familyName = familyName;
 	}
 
+	@JsonIgnore
 	public void setFamilyName(UnsafeSupplier<String, Throwable> familyNameUnsafeSupplier) {
 			try {
 				familyName = familyNameUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class CreatorImpl implements Creator {
 			this.givenName = givenName;
 	}
 
+	@JsonIgnore
 	public void setGivenName(UnsafeSupplier<String, Throwable> givenNameUnsafeSupplier) {
 			try {
 				givenName = givenNameUnsafeSupplier.get();
@@ -103,6 +107,7 @@ public class CreatorImpl implements Creator {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -123,6 +128,7 @@ public class CreatorImpl implements Creator {
 			this.image = image;
 	}
 
+	@JsonIgnore
 	public void setImage(UnsafeSupplier<String, Throwable> imageUnsafeSupplier) {
 			try {
 				image = imageUnsafeSupplier.get();
@@ -143,6 +149,7 @@ public class CreatorImpl implements Creator {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -163,6 +170,7 @@ public class CreatorImpl implements Creator {
 			this.profileURL = profileURL;
 	}
 
+	@JsonIgnore
 	public void setProfileURL(UnsafeSupplier<String, Throwable> profileURLUnsafeSupplier) {
 			try {
 				profileURL = profileURLUnsafeSupplier.get();

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/ImageImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/ImageImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.collaboration.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.collaboration.dto.v1_0.Image;
@@ -43,6 +44,7 @@ public class ImageImpl implements Image {
 			this.contentUrl = contentUrl;
 	}
 
+	@JsonIgnore
 	public void setContentUrl(UnsafeSupplier<String, Throwable> contentUrlUnsafeSupplier) {
 			try {
 				contentUrl = contentUrlUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class ImageImpl implements Image {
 			this.imageId = imageId;
 	}
 
+	@JsonIgnore
 	public void setImageId(UnsafeSupplier<Long, Throwable> imageIdUnsafeSupplier) {
 			try {
 				imageId = imageIdUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class ImageImpl implements Image {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/ImageObjectRepositoryImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/dto/v1_0/ImageObjectRepositoryImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.collaboration.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.collaboration.dto.v1_0.BlogPostingImage;
@@ -46,6 +47,7 @@ public class ImageObjectRepositoryImpl implements ImageObjectRepository {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -66,6 +68,7 @@ public class ImageObjectRepositoryImpl implements ImageObjectRepository {
 			this.dateModified = dateModified;
 	}
 
+	@JsonIgnore
 	public void setDateModified(UnsafeSupplier<Date, Throwable> dateModifiedUnsafeSupplier) {
 			try {
 				dateModified = dateModifiedUnsafeSupplier.get();
@@ -86,6 +89,7 @@ public class ImageObjectRepositoryImpl implements ImageObjectRepository {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -106,6 +110,7 @@ public class ImageObjectRepositoryImpl implements ImageObjectRepository {
 			this.images = images;
 	}
 
+	@JsonIgnore
 	public void setImages(UnsafeSupplier<BlogPostingImage[], Throwable> imagesUnsafeSupplier) {
 			try {
 				images = imagesUnsafeSupplier.get();
@@ -126,6 +131,7 @@ public class ImageObjectRepositoryImpl implements ImageObjectRepository {
 			this.imagesIds = imagesIds;
 	}
 
+	@JsonIgnore
 	public void setImagesIds(UnsafeSupplier<Long[], Throwable> imagesIdsUnsafeSupplier) {
 			try {
 				imagesIds = imagesIdsUnsafeSupplier.get();
@@ -146,6 +152,7 @@ public class ImageObjectRepositoryImpl implements ImageObjectRepository {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/jaxrs/message/body/v1_0/JSONMessageBodyReader.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/jaxrs/message/body/v1_0/JSONMessageBodyReader.java
@@ -14,7 +14,10 @@
 
 package com.liferay.headless.collaboration.internal.jaxrs.message.body.v1_0;
 
+import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
 import com.liferay.headless.collaboration.dto.v1_0.AggregateRating;
@@ -108,36 +111,31 @@ public class JSONMessageBodyReader implements MessageBodyReader<Object> {
 			InputStream inputStream)
 		throws IOException, WebApplicationException {
 
-			if (clazz.equals(AggregateRating.class)) {
-				return _objectMapper.readValue(inputStream, AggregateRatingImpl.class);
-	}
-			if (clazz.equals(BlogPosting.class)) {
-				return _objectMapper.readValue(inputStream, BlogPostingImpl.class);
-	}
-			if (clazz.equals(BlogPostingImage.class)) {
-				return _objectMapper.readValue(inputStream, BlogPostingImageImpl.class);
-	}
-			if (clazz.equals(Category.class)) {
-				return _objectMapper.readValue(inputStream, CategoryImpl.class);
-	}
-			if (clazz.equals(Comment.class)) {
-				return _objectMapper.readValue(inputStream, CommentImpl.class);
-	}
-			if (clazz.equals(Creator.class)) {
-				return _objectMapper.readValue(inputStream, CreatorImpl.class);
-	}
-			if (clazz.equals(Image.class)) {
-				return _objectMapper.readValue(inputStream, ImageImpl.class);
-	}
-			if (clazz.equals(ImageObjectRepository.class)) {
-				return _objectMapper.readValue(inputStream, ImageObjectRepositoryImpl.class);
-	}
-
-		return null;
+		return _objectMapper.readValue(inputStream, clazz);
 	}
 
 	private static final ObjectMapper _objectMapper = new ObjectMapper() {
 		{
+			SimpleModule module =
+				new SimpleModule("Liferay.Headless.Collaboration",
+					Version.unknownVersion());
+
+			SimpleAbstractTypeResolver resolver =
+				new SimpleAbstractTypeResolver();
+
+			resolver.addMapping(AggregateRating.class, AggregateRatingImpl.class);
+			resolver.addMapping(BlogPosting.class, BlogPostingImpl.class);
+			resolver.addMapping(BlogPostingImage.class, BlogPostingImageImpl.class);
+			resolver.addMapping(Category.class, CategoryImpl.class);
+			resolver.addMapping(Comment.class, CommentImpl.class);
+			resolver.addMapping(Creator.class, CreatorImpl.class);
+			resolver.addMapping(Image.class, ImageImpl.class);
+			resolver.addMapping(ImageObjectRepository.class, ImageObjectRepositoryImpl.class);
+
+			module.setAbstractTypes(resolver);
+
+			registerModule(module);
+
 			setDateFormat(new ISO8601DateFormat());
 	}
 	};

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/dto/v1_0/AdaptedMediaImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/dto/v1_0/AdaptedMediaImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.document.library.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.document.library.dto.v1_0.AdaptedMedia;
@@ -43,6 +44,7 @@ public class AdaptedMediaImpl implements AdaptedMedia {
 			this.contentUrl = contentUrl;
 	}
 
+	@JsonIgnore
 	public void setContentUrl(UnsafeSupplier<String, Throwable> contentUrlUnsafeSupplier) {
 			try {
 				contentUrl = contentUrlUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class AdaptedMediaImpl implements AdaptedMedia {
 			this.height = height;
 	}
 
+	@JsonIgnore
 	public void setHeight(UnsafeSupplier<Number, Throwable> heightUnsafeSupplier) {
 			try {
 				height = heightUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class AdaptedMediaImpl implements AdaptedMedia {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -103,6 +107,7 @@ public class AdaptedMediaImpl implements AdaptedMedia {
 			this.resolutionName = resolutionName;
 	}
 
+	@JsonIgnore
 	public void setResolutionName(UnsafeSupplier<String, Throwable> resolutionNameUnsafeSupplier) {
 			try {
 				resolutionName = resolutionNameUnsafeSupplier.get();
@@ -123,6 +128,7 @@ public class AdaptedMediaImpl implements AdaptedMedia {
 			this.sizeInBytes = sizeInBytes;
 	}
 
+	@JsonIgnore
 	public void setSizeInBytes(UnsafeSupplier<Number, Throwable> sizeInBytesUnsafeSupplier) {
 			try {
 				sizeInBytes = sizeInBytesUnsafeSupplier.get();
@@ -143,6 +149,7 @@ public class AdaptedMediaImpl implements AdaptedMedia {
 			this.width = width;
 	}
 
+	@JsonIgnore
 	public void setWidth(UnsafeSupplier<Number, Throwable> widthUnsafeSupplier) {
 			try {
 				width = widthUnsafeSupplier.get();

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/dto/v1_0/CommentImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/dto/v1_0/CommentImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.document.library.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.document.library.dto.v1_0.Comment;
@@ -44,6 +45,7 @@ public class CommentImpl implements Comment {
 			this.comments = comments;
 	}
 
+	@JsonIgnore
 	public void setComments(UnsafeSupplier<Comment[], Throwable> commentsUnsafeSupplier) {
 			try {
 				comments = commentsUnsafeSupplier.get();
@@ -64,6 +66,7 @@ public class CommentImpl implements Comment {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -84,6 +87,7 @@ public class CommentImpl implements Comment {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -104,6 +108,7 @@ public class CommentImpl implements Comment {
 			this.text = text;
 	}
 
+	@JsonIgnore
 	public void setText(UnsafeSupplier<String, Throwable> textUnsafeSupplier) {
 			try {
 				text = textUnsafeSupplier.get();

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/dto/v1_0/CreatorImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/dto/v1_0/CreatorImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.document.library.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.document.library.dto.v1_0.Creator;
@@ -43,6 +44,7 @@ public class CreatorImpl implements Creator {
 			this.additionalName = additionalName;
 	}
 
+	@JsonIgnore
 	public void setAdditionalName(UnsafeSupplier<String, Throwable> additionalNameUnsafeSupplier) {
 			try {
 				additionalName = additionalNameUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class CreatorImpl implements Creator {
 			this.familyName = familyName;
 	}
 
+	@JsonIgnore
 	public void setFamilyName(UnsafeSupplier<String, Throwable> familyNameUnsafeSupplier) {
 			try {
 				familyName = familyNameUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class CreatorImpl implements Creator {
 			this.givenName = givenName;
 	}
 
+	@JsonIgnore
 	public void setGivenName(UnsafeSupplier<String, Throwable> givenNameUnsafeSupplier) {
 			try {
 				givenName = givenNameUnsafeSupplier.get();
@@ -103,6 +107,7 @@ public class CreatorImpl implements Creator {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -123,6 +128,7 @@ public class CreatorImpl implements Creator {
 			this.image = image;
 	}
 
+	@JsonIgnore
 	public void setImage(UnsafeSupplier<String, Throwable> imageUnsafeSupplier) {
 			try {
 				image = imageUnsafeSupplier.get();
@@ -143,6 +149,7 @@ public class CreatorImpl implements Creator {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -163,6 +170,7 @@ public class CreatorImpl implements Creator {
 			this.profileURL = profileURL;
 	}
 
+	@JsonIgnore
 	public void setProfileURL(UnsafeSupplier<String, Throwable> profileURLUnsafeSupplier) {
 			try {
 				profileURL = profileURLUnsafeSupplier.get();

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/dto/v1_0/DocumentImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/dto/v1_0/DocumentImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.document.library.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.document.library.dto.v1_0.AdaptedMedia;
@@ -47,6 +48,7 @@ public class DocumentImpl implements Document {
 			this.adaptedMedia = adaptedMedia;
 	}
 
+	@JsonIgnore
 	public void setAdaptedMedia(UnsafeSupplier<AdaptedMedia[], Throwable> adaptedMediaUnsafeSupplier) {
 			try {
 				adaptedMedia = adaptedMediaUnsafeSupplier.get();
@@ -67,6 +69,7 @@ public class DocumentImpl implements Document {
 			this.category = category;
 	}
 
+	@JsonIgnore
 	public void setCategory(UnsafeSupplier<Long[], Throwable> categoryUnsafeSupplier) {
 			try {
 				category = categoryUnsafeSupplier.get();
@@ -87,6 +90,7 @@ public class DocumentImpl implements Document {
 			this.contentUrl = contentUrl;
 	}
 
+	@JsonIgnore
 	public void setContentUrl(UnsafeSupplier<String, Throwable> contentUrlUnsafeSupplier) {
 			try {
 				contentUrl = contentUrlUnsafeSupplier.get();
@@ -107,6 +111,7 @@ public class DocumentImpl implements Document {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -127,6 +132,7 @@ public class DocumentImpl implements Document {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -147,6 +153,7 @@ public class DocumentImpl implements Document {
 			this.dateModified = dateModified;
 	}
 
+	@JsonIgnore
 	public void setDateModified(UnsafeSupplier<Date, Throwable> dateModifiedUnsafeSupplier) {
 			try {
 				dateModified = dateModifiedUnsafeSupplier.get();
@@ -167,6 +174,7 @@ public class DocumentImpl implements Document {
 			this.description = description;
 	}
 
+	@JsonIgnore
 	public void setDescription(UnsafeSupplier<String, Throwable> descriptionUnsafeSupplier) {
 			try {
 				description = descriptionUnsafeSupplier.get();
@@ -187,6 +195,7 @@ public class DocumentImpl implements Document {
 			this.encodingFormat = encodingFormat;
 	}
 
+	@JsonIgnore
 	public void setEncodingFormat(UnsafeSupplier<String, Throwable> encodingFormatUnsafeSupplier) {
 			try {
 				encodingFormat = encodingFormatUnsafeSupplier.get();
@@ -207,6 +216,7 @@ public class DocumentImpl implements Document {
 			this.fileExtension = fileExtension;
 	}
 
+	@JsonIgnore
 	public void setFileExtension(UnsafeSupplier<String, Throwable> fileExtensionUnsafeSupplier) {
 			try {
 				fileExtension = fileExtensionUnsafeSupplier.get();
@@ -227,6 +237,7 @@ public class DocumentImpl implements Document {
 			this.folderId = folderId;
 	}
 
+	@JsonIgnore
 	public void setFolderId(UnsafeSupplier<Long, Throwable> folderIdUnsafeSupplier) {
 			try {
 				folderId = folderIdUnsafeSupplier.get();
@@ -247,6 +258,7 @@ public class DocumentImpl implements Document {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -267,6 +279,7 @@ public class DocumentImpl implements Document {
 			this.keywords = keywords;
 	}
 
+	@JsonIgnore
 	public void setKeywords(UnsafeSupplier<String[], Throwable> keywordsUnsafeSupplier) {
 			try {
 				keywords = keywordsUnsafeSupplier.get();
@@ -287,6 +300,7 @@ public class DocumentImpl implements Document {
 			this.sizeInBytes = sizeInBytes;
 	}
 
+	@JsonIgnore
 	public void setSizeInBytes(UnsafeSupplier<Number, Throwable> sizeInBytesUnsafeSupplier) {
 			try {
 				sizeInBytes = sizeInBytesUnsafeSupplier.get();
@@ -307,6 +321,7 @@ public class DocumentImpl implements Document {
 			this.title = title;
 	}
 
+	@JsonIgnore
 	public void setTitle(UnsafeSupplier<String, Throwable> titleUnsafeSupplier) {
 			try {
 				title = titleUnsafeSupplier.get();

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/dto/v1_0/FolderImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/dto/v1_0/FolderImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.document.library.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.document.library.dto.v1_0.Document;
@@ -46,6 +47,7 @@ public class FolderImpl implements Folder {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -66,6 +68,7 @@ public class FolderImpl implements Folder {
 			this.dateModified = dateModified;
 	}
 
+	@JsonIgnore
 	public void setDateModified(UnsafeSupplier<Date, Throwable> dateModifiedUnsafeSupplier) {
 			try {
 				dateModified = dateModifiedUnsafeSupplier.get();
@@ -86,6 +89,7 @@ public class FolderImpl implements Folder {
 			this.description = description;
 	}
 
+	@JsonIgnore
 	public void setDescription(UnsafeSupplier<String, Throwable> descriptionUnsafeSupplier) {
 			try {
 				description = descriptionUnsafeSupplier.get();
@@ -106,6 +110,7 @@ public class FolderImpl implements Folder {
 			this.documents = documents;
 	}
 
+	@JsonIgnore
 	public void setDocuments(UnsafeSupplier<Document[], Throwable> documentsUnsafeSupplier) {
 			try {
 				documents = documentsUnsafeSupplier.get();
@@ -126,6 +131,7 @@ public class FolderImpl implements Folder {
 			this.documentsIds = documentsIds;
 	}
 
+	@JsonIgnore
 	public void setDocumentsIds(UnsafeSupplier<Long[], Throwable> documentsIdsUnsafeSupplier) {
 			try {
 				documentsIds = documentsIdsUnsafeSupplier.get();
@@ -146,6 +152,7 @@ public class FolderImpl implements Folder {
 			this.documentsRepository = documentsRepository;
 	}
 
+	@JsonIgnore
 	public void setDocumentsRepository(UnsafeSupplier<Folder, Throwable> documentsRepositoryUnsafeSupplier) {
 			try {
 				documentsRepository = documentsRepositoryUnsafeSupplier.get();
@@ -166,6 +173,7 @@ public class FolderImpl implements Folder {
 			this.documentsRepositoryId = documentsRepositoryId;
 	}
 
+	@JsonIgnore
 	public void setDocumentsRepositoryId(UnsafeSupplier<Long, Throwable> documentsRepositoryIdUnsafeSupplier) {
 			try {
 				documentsRepositoryId = documentsRepositoryIdUnsafeSupplier.get();
@@ -186,6 +194,7 @@ public class FolderImpl implements Folder {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -206,6 +215,7 @@ public class FolderImpl implements Folder {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -226,6 +236,7 @@ public class FolderImpl implements Folder {
 			this.subFolders = subFolders;
 	}
 
+	@JsonIgnore
 	public void setSubFolders(UnsafeSupplier<Folder[], Throwable> subFoldersUnsafeSupplier) {
 			try {
 				subFolders = subFoldersUnsafeSupplier.get();

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/jaxrs/message/body/v1_0/JSONMessageBodyReader.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/jaxrs/message/body/v1_0/JSONMessageBodyReader.java
@@ -14,7 +14,10 @@
 
 package com.liferay.headless.document.library.internal.jaxrs.message.body.v1_0;
 
+import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
 import com.liferay.headless.document.library.dto.v1_0.AdaptedMedia;
@@ -93,27 +96,28 @@ public class JSONMessageBodyReader implements MessageBodyReader<Object> {
 			InputStream inputStream)
 		throws IOException, WebApplicationException {
 
-			if (clazz.equals(AdaptedMedia.class)) {
-				return _objectMapper.readValue(inputStream, AdaptedMediaImpl.class);
-	}
-			if (clazz.equals(Comment.class)) {
-				return _objectMapper.readValue(inputStream, CommentImpl.class);
-	}
-			if (clazz.equals(Creator.class)) {
-				return _objectMapper.readValue(inputStream, CreatorImpl.class);
-	}
-			if (clazz.equals(Document.class)) {
-				return _objectMapper.readValue(inputStream, DocumentImpl.class);
-	}
-			if (clazz.equals(Folder.class)) {
-				return _objectMapper.readValue(inputStream, FolderImpl.class);
-	}
-
-		return null;
+		return _objectMapper.readValue(inputStream, clazz);
 	}
 
 	private static final ObjectMapper _objectMapper = new ObjectMapper() {
 		{
+			SimpleModule module =
+				new SimpleModule("Liferay.Headless.Document.Library",
+					Version.unknownVersion());
+
+			SimpleAbstractTypeResolver resolver =
+				new SimpleAbstractTypeResolver();
+
+			resolver.addMapping(AdaptedMedia.class, AdaptedMediaImpl.class);
+			resolver.addMapping(Comment.class, CommentImpl.class);
+			resolver.addMapping(Creator.class, CreatorImpl.class);
+			resolver.addMapping(Document.class, DocumentImpl.class);
+			resolver.addMapping(Folder.class, FolderImpl.class);
+
+			module.setAbstractTypes(resolver);
+
+			registerModule(module);
+
 			setDateFormat(new ISO8601DateFormat());
 	}
 	};

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/ColumnsImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/ColumnsImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.form.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.form.dto.v1_0.Columns;
@@ -43,6 +44,7 @@ public class ColumnsImpl implements Columns {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class ColumnsImpl implements Columns {
 			this.label = label;
 	}
 
+	@JsonIgnore
 	public void setLabel(UnsafeSupplier<String, Throwable> labelUnsafeSupplier) {
 			try {
 				label = labelUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class ColumnsImpl implements Columns {
 			this.value = value;
 	}
 
+	@JsonIgnore
 	public void setValue(UnsafeSupplier<String, Throwable> valueUnsafeSupplier) {
 			try {
 				value = valueUnsafeSupplier.get();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/CreatorImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/CreatorImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.form.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.form.dto.v1_0.Creator;
@@ -43,6 +44,7 @@ public class CreatorImpl implements Creator {
 			this.additionalName = additionalName;
 	}
 
+	@JsonIgnore
 	public void setAdditionalName(UnsafeSupplier<String, Throwable> additionalNameUnsafeSupplier) {
 			try {
 				additionalName = additionalNameUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class CreatorImpl implements Creator {
 			this.familyName = familyName;
 	}
 
+	@JsonIgnore
 	public void setFamilyName(UnsafeSupplier<String, Throwable> familyNameUnsafeSupplier) {
 			try {
 				familyName = familyNameUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class CreatorImpl implements Creator {
 			this.givenName = givenName;
 	}
 
+	@JsonIgnore
 	public void setGivenName(UnsafeSupplier<String, Throwable> givenNameUnsafeSupplier) {
 			try {
 				givenName = givenNameUnsafeSupplier.get();
@@ -103,6 +107,7 @@ public class CreatorImpl implements Creator {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -123,6 +128,7 @@ public class CreatorImpl implements Creator {
 			this.image = image;
 	}
 
+	@JsonIgnore
 	public void setImage(UnsafeSupplier<String, Throwable> imageUnsafeSupplier) {
 			try {
 				image = imageUnsafeSupplier.get();
@@ -143,6 +149,7 @@ public class CreatorImpl implements Creator {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -163,6 +170,7 @@ public class CreatorImpl implements Creator {
 			this.profileURL = profileURL;
 	}
 
+	@JsonIgnore
 	public void setProfileURL(UnsafeSupplier<String, Throwable> profileURLUnsafeSupplier) {
 			try {
 				profileURL = profileURLUnsafeSupplier.get();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/FieldValuesImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/FieldValuesImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.form.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.form.dto.v1_0.FieldValues;
@@ -44,6 +45,7 @@ public class FieldValuesImpl implements FieldValues {
 			this.document = document;
 	}
 
+	@JsonIgnore
 	public void setDocument(UnsafeSupplier<FormDocument, Throwable> documentUnsafeSupplier) {
 			try {
 				document = documentUnsafeSupplier.get();
@@ -64,6 +66,7 @@ public class FieldValuesImpl implements FieldValues {
 			this.documentId = documentId;
 	}
 
+	@JsonIgnore
 	public void setDocumentId(UnsafeSupplier<Long, Throwable> documentIdUnsafeSupplier) {
 			try {
 				documentId = documentIdUnsafeSupplier.get();
@@ -84,6 +87,7 @@ public class FieldValuesImpl implements FieldValues {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -104,6 +108,7 @@ public class FieldValuesImpl implements FieldValues {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -124,6 +129,7 @@ public class FieldValuesImpl implements FieldValues {
 			this.value = value;
 	}
 
+	@JsonIgnore
 	public void setValue(UnsafeSupplier<String, Throwable> valueUnsafeSupplier) {
 			try {
 				value = valueUnsafeSupplier.get();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/FieldsImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/FieldsImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.form.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.form.dto.v1_0.Fields;
@@ -46,6 +47,7 @@ public class FieldsImpl implements Fields {
 			this.autocomplete = autocomplete;
 	}
 
+	@JsonIgnore
 	public void setAutocomplete(UnsafeSupplier<Boolean, Throwable> autocompleteUnsafeSupplier) {
 			try {
 				autocomplete = autocompleteUnsafeSupplier.get();
@@ -66,6 +68,7 @@ public class FieldsImpl implements Fields {
 			this.dataSourceType = dataSourceType;
 	}
 
+	@JsonIgnore
 	public void setDataSourceType(UnsafeSupplier<String, Throwable> dataSourceTypeUnsafeSupplier) {
 			try {
 				dataSourceType = dataSourceTypeUnsafeSupplier.get();
@@ -86,6 +89,7 @@ public class FieldsImpl implements Fields {
 			this.dataType = dataType;
 	}
 
+	@JsonIgnore
 	public void setDataType(UnsafeSupplier<String, Throwable> dataTypeUnsafeSupplier) {
 			try {
 				dataType = dataTypeUnsafeSupplier.get();
@@ -106,6 +110,7 @@ public class FieldsImpl implements Fields {
 			this.displayStyle = displayStyle;
 	}
 
+	@JsonIgnore
 	public void setDisplayStyle(UnsafeSupplier<String, Throwable> displayStyleUnsafeSupplier) {
 			try {
 				displayStyle = displayStyleUnsafeSupplier.get();
@@ -126,6 +131,7 @@ public class FieldsImpl implements Fields {
 			this.grid = grid;
 	}
 
+	@JsonIgnore
 	public void setGrid(UnsafeSupplier<Grid, Throwable> gridUnsafeSupplier) {
 			try {
 				grid = gridUnsafeSupplier.get();
@@ -146,6 +152,7 @@ public class FieldsImpl implements Fields {
 			this.hasFormRules = hasFormRules;
 	}
 
+	@JsonIgnore
 	public void setHasFormRules(UnsafeSupplier<Boolean, Throwable> hasFormRulesUnsafeSupplier) {
 			try {
 				hasFormRules = hasFormRulesUnsafeSupplier.get();
@@ -166,6 +173,7 @@ public class FieldsImpl implements Fields {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -186,6 +194,7 @@ public class FieldsImpl implements Fields {
 			this.immutable = immutable;
 	}
 
+	@JsonIgnore
 	public void setImmutable(UnsafeSupplier<Boolean, Throwable> immutableUnsafeSupplier) {
 			try {
 				immutable = immutableUnsafeSupplier.get();
@@ -206,6 +215,7 @@ public class FieldsImpl implements Fields {
 			this.inline = inline;
 	}
 
+	@JsonIgnore
 	public void setInline(UnsafeSupplier<Boolean, Throwable> inlineUnsafeSupplier) {
 			try {
 				inline = inlineUnsafeSupplier.get();
@@ -226,6 +236,7 @@ public class FieldsImpl implements Fields {
 			this.inputControl = inputControl;
 	}
 
+	@JsonIgnore
 	public void setInputControl(UnsafeSupplier<String, Throwable> inputControlUnsafeSupplier) {
 			try {
 				inputControl = inputControlUnsafeSupplier.get();
@@ -246,6 +257,7 @@ public class FieldsImpl implements Fields {
 			this.label = label;
 	}
 
+	@JsonIgnore
 	public void setLabel(UnsafeSupplier<String, Throwable> labelUnsafeSupplier) {
 			try {
 				label = labelUnsafeSupplier.get();
@@ -266,6 +278,7 @@ public class FieldsImpl implements Fields {
 			this.localizable = localizable;
 	}
 
+	@JsonIgnore
 	public void setLocalizable(UnsafeSupplier<Boolean, Throwable> localizableUnsafeSupplier) {
 			try {
 				localizable = localizableUnsafeSupplier.get();
@@ -286,6 +299,7 @@ public class FieldsImpl implements Fields {
 			this.multiple = multiple;
 	}
 
+	@JsonIgnore
 	public void setMultiple(UnsafeSupplier<Boolean, Throwable> multipleUnsafeSupplier) {
 			try {
 				multiple = multipleUnsafeSupplier.get();
@@ -306,6 +320,7 @@ public class FieldsImpl implements Fields {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -326,6 +341,7 @@ public class FieldsImpl implements Fields {
 			this.options = options;
 	}
 
+	@JsonIgnore
 	public void setOptions(UnsafeSupplier<Options, Throwable> optionsUnsafeSupplier) {
 			try {
 				options = optionsUnsafeSupplier.get();
@@ -346,6 +362,7 @@ public class FieldsImpl implements Fields {
 			this.placeholder = placeholder;
 	}
 
+	@JsonIgnore
 	public void setPlaceholder(UnsafeSupplier<String, Throwable> placeholderUnsafeSupplier) {
 			try {
 				placeholder = placeholderUnsafeSupplier.get();
@@ -366,6 +383,7 @@ public class FieldsImpl implements Fields {
 			this.predefinedValue = predefinedValue;
 	}
 
+	@JsonIgnore
 	public void setPredefinedValue(UnsafeSupplier<String, Throwable> predefinedValueUnsafeSupplier) {
 			try {
 				predefinedValue = predefinedValueUnsafeSupplier.get();
@@ -386,6 +404,7 @@ public class FieldsImpl implements Fields {
 			this.readOnly = readOnly;
 	}
 
+	@JsonIgnore
 	public void setReadOnly(UnsafeSupplier<Boolean, Throwable> readOnlyUnsafeSupplier) {
 			try {
 				readOnly = readOnlyUnsafeSupplier.get();
@@ -406,6 +425,7 @@ public class FieldsImpl implements Fields {
 			this.repeatable = repeatable;
 	}
 
+	@JsonIgnore
 	public void setRepeatable(UnsafeSupplier<Boolean, Throwable> repeatableUnsafeSupplier) {
 			try {
 				repeatable = repeatableUnsafeSupplier.get();
@@ -426,6 +446,7 @@ public class FieldsImpl implements Fields {
 			this.required = required;
 	}
 
+	@JsonIgnore
 	public void setRequired(UnsafeSupplier<Boolean, Throwable> requiredUnsafeSupplier) {
 			try {
 				required = requiredUnsafeSupplier.get();
@@ -446,6 +467,7 @@ public class FieldsImpl implements Fields {
 			this.showAsSwitcher = showAsSwitcher;
 	}
 
+	@JsonIgnore
 	public void setShowAsSwitcher(UnsafeSupplier<Boolean, Throwable> showAsSwitcherUnsafeSupplier) {
 			try {
 				showAsSwitcher = showAsSwitcherUnsafeSupplier.get();
@@ -466,6 +488,7 @@ public class FieldsImpl implements Fields {
 			this.showLabel = showLabel;
 	}
 
+	@JsonIgnore
 	public void setShowLabel(UnsafeSupplier<Boolean, Throwable> showLabelUnsafeSupplier) {
 			try {
 				showLabel = showLabelUnsafeSupplier.get();
@@ -486,6 +509,7 @@ public class FieldsImpl implements Fields {
 			this.style = style;
 	}
 
+	@JsonIgnore
 	public void setStyle(UnsafeSupplier<String, Throwable> styleUnsafeSupplier) {
 			try {
 				style = styleUnsafeSupplier.get();
@@ -506,6 +530,7 @@ public class FieldsImpl implements Fields {
 			this.text = text;
 	}
 
+	@JsonIgnore
 	public void setText(UnsafeSupplier<String, Throwable> textUnsafeSupplier) {
 			try {
 				text = textUnsafeSupplier.get();
@@ -526,6 +551,7 @@ public class FieldsImpl implements Fields {
 			this.tooltip = tooltip;
 	}
 
+	@JsonIgnore
 	public void setTooltip(UnsafeSupplier<String, Throwable> tooltipUnsafeSupplier) {
 			try {
 				tooltip = tooltipUnsafeSupplier.get();
@@ -546,6 +572,7 @@ public class FieldsImpl implements Fields {
 			this.validation = validation;
 	}
 
+	@JsonIgnore
 	public void setValidation(UnsafeSupplier<Validation, Throwable> validationUnsafeSupplier) {
 			try {
 				validation = validationUnsafeSupplier.get();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/FormDocumentImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/FormDocumentImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.form.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.form.dto.v1_0.FormDocument;
@@ -43,6 +44,7 @@ public class FormDocumentImpl implements FormDocument {
 			this.contentUrl = contentUrl;
 	}
 
+	@JsonIgnore
 	public void setContentUrl(UnsafeSupplier<String, Throwable> contentUrlUnsafeSupplier) {
 			try {
 				contentUrl = contentUrlUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class FormDocumentImpl implements FormDocument {
 			this.encodingFormat = encodingFormat;
 	}
 
+	@JsonIgnore
 	public void setEncodingFormat(UnsafeSupplier<String, Throwable> encodingFormatUnsafeSupplier) {
 			try {
 				encodingFormat = encodingFormatUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class FormDocumentImpl implements FormDocument {
 			this.fileExtension = fileExtension;
 	}
 
+	@JsonIgnore
 	public void setFileExtension(UnsafeSupplier<String, Throwable> fileExtensionUnsafeSupplier) {
 			try {
 				fileExtension = fileExtensionUnsafeSupplier.get();
@@ -103,6 +107,7 @@ public class FormDocumentImpl implements FormDocument {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -123,6 +128,7 @@ public class FormDocumentImpl implements FormDocument {
 			this.sizeInBytes = sizeInBytes;
 	}
 
+	@JsonIgnore
 	public void setSizeInBytes(UnsafeSupplier<Number, Throwable> sizeInBytesUnsafeSupplier) {
 			try {
 				sizeInBytes = sizeInBytesUnsafeSupplier.get();
@@ -143,6 +149,7 @@ public class FormDocumentImpl implements FormDocument {
 			this.title = title;
 	}
 
+	@JsonIgnore
 	public void setTitle(UnsafeSupplier<String, Throwable> titleUnsafeSupplier) {
 			try {
 				title = titleUnsafeSupplier.get();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/FormImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/FormImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.form.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.form.dto.v1_0.Creator;
@@ -48,6 +49,7 @@ public class FormImpl implements Form {
 			this.availableLanguages = availableLanguages;
 	}
 
+	@JsonIgnore
 	public void setAvailableLanguages(UnsafeSupplier<String[], Throwable> availableLanguagesUnsafeSupplier) {
 			try {
 				availableLanguages = availableLanguagesUnsafeSupplier.get();
@@ -68,6 +70,7 @@ public class FormImpl implements Form {
 			this.contentSpace = contentSpace;
 	}
 
+	@JsonIgnore
 	public void setContentSpace(UnsafeSupplier<Long, Throwable> contentSpaceUnsafeSupplier) {
 			try {
 				contentSpace = contentSpaceUnsafeSupplier.get();
@@ -88,6 +91,7 @@ public class FormImpl implements Form {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -108,6 +112,7 @@ public class FormImpl implements Form {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -128,6 +133,7 @@ public class FormImpl implements Form {
 			this.dateModified = dateModified;
 	}
 
+	@JsonIgnore
 	public void setDateModified(UnsafeSupplier<Date, Throwable> dateModifiedUnsafeSupplier) {
 			try {
 				dateModified = dateModifiedUnsafeSupplier.get();
@@ -148,6 +154,7 @@ public class FormImpl implements Form {
 			this.datePublished = datePublished;
 	}
 
+	@JsonIgnore
 	public void setDatePublished(UnsafeSupplier<Date, Throwable> datePublishedUnsafeSupplier) {
 			try {
 				datePublished = datePublishedUnsafeSupplier.get();
@@ -168,6 +175,7 @@ public class FormImpl implements Form {
 			this.defaultLanguage = defaultLanguage;
 	}
 
+	@JsonIgnore
 	public void setDefaultLanguage(UnsafeSupplier<String, Throwable> defaultLanguageUnsafeSupplier) {
 			try {
 				defaultLanguage = defaultLanguageUnsafeSupplier.get();
@@ -188,6 +196,7 @@ public class FormImpl implements Form {
 			this.description = description;
 	}
 
+	@JsonIgnore
 	public void setDescription(UnsafeSupplier<String, Throwable> descriptionUnsafeSupplier) {
 			try {
 				description = descriptionUnsafeSupplier.get();
@@ -208,6 +217,7 @@ public class FormImpl implements Form {
 			this.formRecords = formRecords;
 	}
 
+	@JsonIgnore
 	public void setFormRecords(UnsafeSupplier<FormRecord[], Throwable> formRecordsUnsafeSupplier) {
 			try {
 				formRecords = formRecordsUnsafeSupplier.get();
@@ -228,6 +238,7 @@ public class FormImpl implements Form {
 			this.formRecordsIds = formRecordsIds;
 	}
 
+	@JsonIgnore
 	public void setFormRecordsIds(UnsafeSupplier<Long[], Throwable> formRecordsIdsUnsafeSupplier) {
 			try {
 				formRecordsIds = formRecordsIdsUnsafeSupplier.get();
@@ -248,6 +259,7 @@ public class FormImpl implements Form {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -268,6 +280,7 @@ public class FormImpl implements Form {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -288,6 +301,7 @@ public class FormImpl implements Form {
 			this.structure = structure;
 	}
 
+	@JsonIgnore
 	public void setStructure(UnsafeSupplier<FormStructure, Throwable> structureUnsafeSupplier) {
 			try {
 				structure = structureUnsafeSupplier.get();
@@ -308,6 +322,7 @@ public class FormImpl implements Form {
 			this.structureId = structureId;
 	}
 
+	@JsonIgnore
 	public void setStructureId(UnsafeSupplier<Long, Throwable> structureIdUnsafeSupplier) {
 			try {
 				structureId = structureIdUnsafeSupplier.get();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/FormPagesImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/FormPagesImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.form.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.form.dto.v1_0.Fields;
@@ -44,6 +45,7 @@ public class FormPagesImpl implements FormPages {
 			this.fields = fields;
 	}
 
+	@JsonIgnore
 	public void setFields(UnsafeSupplier<Fields[], Throwable> fieldsUnsafeSupplier) {
 			try {
 				fields = fieldsUnsafeSupplier.get();
@@ -64,6 +66,7 @@ public class FormPagesImpl implements FormPages {
 			this.headline = headline;
 	}
 
+	@JsonIgnore
 	public void setHeadline(UnsafeSupplier<String, Throwable> headlineUnsafeSupplier) {
 			try {
 				headline = headlineUnsafeSupplier.get();
@@ -84,6 +87,7 @@ public class FormPagesImpl implements FormPages {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -104,6 +108,7 @@ public class FormPagesImpl implements FormPages {
 			this.text = text;
 	}
 
+	@JsonIgnore
 	public void setText(UnsafeSupplier<String, Throwable> textUnsafeSupplier) {
 			try {
 				text = textUnsafeSupplier.get();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/FormRecordImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/FormRecordImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.form.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.form.dto.v1_0.Creator;
@@ -48,6 +49,7 @@ public class FormRecordImpl implements FormRecord {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -68,6 +70,7 @@ public class FormRecordImpl implements FormRecord {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -88,6 +91,7 @@ public class FormRecordImpl implements FormRecord {
 			this.dateModified = dateModified;
 	}
 
+	@JsonIgnore
 	public void setDateModified(UnsafeSupplier<Date, Throwable> dateModifiedUnsafeSupplier) {
 			try {
 				dateModified = dateModifiedUnsafeSupplier.get();
@@ -108,6 +112,7 @@ public class FormRecordImpl implements FormRecord {
 			this.datePublished = datePublished;
 	}
 
+	@JsonIgnore
 	public void setDatePublished(UnsafeSupplier<Date, Throwable> datePublishedUnsafeSupplier) {
 			try {
 				datePublished = datePublishedUnsafeSupplier.get();
@@ -128,6 +133,7 @@ public class FormRecordImpl implements FormRecord {
 			this.draft = draft;
 	}
 
+	@JsonIgnore
 	public void setDraft(UnsafeSupplier<Boolean, Throwable> draftUnsafeSupplier) {
 			try {
 				draft = draftUnsafeSupplier.get();
@@ -148,6 +154,7 @@ public class FormRecordImpl implements FormRecord {
 			this.fieldValues = fieldValues;
 	}
 
+	@JsonIgnore
 	public void setFieldValues(UnsafeSupplier<FieldValues[], Throwable> fieldValuesUnsafeSupplier) {
 			try {
 				fieldValues = fieldValuesUnsafeSupplier.get();
@@ -168,6 +175,7 @@ public class FormRecordImpl implements FormRecord {
 			this.form = form;
 	}
 
+	@JsonIgnore
 	public void setForm(UnsafeSupplier<Form, Throwable> formUnsafeSupplier) {
 			try {
 				form = formUnsafeSupplier.get();
@@ -188,6 +196,7 @@ public class FormRecordImpl implements FormRecord {
 			this.formId = formId;
 	}
 
+	@JsonIgnore
 	public void setFormId(UnsafeSupplier<Long, Throwable> formIdUnsafeSupplier) {
 			try {
 				formId = formIdUnsafeSupplier.get();
@@ -208,6 +217,7 @@ public class FormRecordImpl implements FormRecord {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/FormStructureImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/FormStructureImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.form.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.form.dto.v1_0.Creator;
@@ -48,6 +49,7 @@ public class FormStructureImpl implements FormStructure {
 			this.availableLanguages = availableLanguages;
 	}
 
+	@JsonIgnore
 	public void setAvailableLanguages(UnsafeSupplier<String[], Throwable> availableLanguagesUnsafeSupplier) {
 			try {
 				availableLanguages = availableLanguagesUnsafeSupplier.get();
@@ -68,6 +70,7 @@ public class FormStructureImpl implements FormStructure {
 			this.contentSpace = contentSpace;
 	}
 
+	@JsonIgnore
 	public void setContentSpace(UnsafeSupplier<Long, Throwable> contentSpaceUnsafeSupplier) {
 			try {
 				contentSpace = contentSpaceUnsafeSupplier.get();
@@ -88,6 +91,7 @@ public class FormStructureImpl implements FormStructure {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -108,6 +112,7 @@ public class FormStructureImpl implements FormStructure {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -128,6 +133,7 @@ public class FormStructureImpl implements FormStructure {
 			this.dateModified = dateModified;
 	}
 
+	@JsonIgnore
 	public void setDateModified(UnsafeSupplier<Date, Throwable> dateModifiedUnsafeSupplier) {
 			try {
 				dateModified = dateModifiedUnsafeSupplier.get();
@@ -148,6 +154,7 @@ public class FormStructureImpl implements FormStructure {
 			this.description = description;
 	}
 
+	@JsonIgnore
 	public void setDescription(UnsafeSupplier<String, Throwable> descriptionUnsafeSupplier) {
 			try {
 				description = descriptionUnsafeSupplier.get();
@@ -168,6 +175,7 @@ public class FormStructureImpl implements FormStructure {
 			this.formPages = formPages;
 	}
 
+	@JsonIgnore
 	public void setFormPages(UnsafeSupplier<FormPages[], Throwable> formPagesUnsafeSupplier) {
 			try {
 				formPages = formPagesUnsafeSupplier.get();
@@ -188,6 +196,7 @@ public class FormStructureImpl implements FormStructure {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -208,6 +217,7 @@ public class FormStructureImpl implements FormStructure {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -228,6 +238,7 @@ public class FormStructureImpl implements FormStructure {
 			this.successPage = successPage;
 	}
 
+	@JsonIgnore
 	public void setSuccessPage(UnsafeSupplier<SuccessPage, Throwable> successPageUnsafeSupplier) {
 			try {
 				successPage = successPageUnsafeSupplier.get();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/GridImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/GridImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.form.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.form.dto.v1_0.Columns;
@@ -45,6 +46,7 @@ public class GridImpl implements Grid {
 			this.columns = columns;
 	}
 
+	@JsonIgnore
 	public void setColumns(UnsafeSupplier<Columns[], Throwable> columnsUnsafeSupplier) {
 			try {
 				columns = columnsUnsafeSupplier.get();
@@ -65,6 +67,7 @@ public class GridImpl implements Grid {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -85,6 +88,7 @@ public class GridImpl implements Grid {
 			this.rows = rows;
 	}
 
+	@JsonIgnore
 	public void setRows(UnsafeSupplier<Rows[], Throwable> rowsUnsafeSupplier) {
 			try {
 				rows = rowsUnsafeSupplier.get();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/OptionsImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/OptionsImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.form.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.form.dto.v1_0.Options;
@@ -43,6 +44,7 @@ public class OptionsImpl implements Options {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class OptionsImpl implements Options {
 			this.label = label;
 	}
 
+	@JsonIgnore
 	public void setLabel(UnsafeSupplier<String, Throwable> labelUnsafeSupplier) {
 			try {
 				label = labelUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class OptionsImpl implements Options {
 			this.value = value;
 	}
 
+	@JsonIgnore
 	public void setValue(UnsafeSupplier<String, Throwable> valueUnsafeSupplier) {
 			try {
 				value = valueUnsafeSupplier.get();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/RowsImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/RowsImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.form.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.form.dto.v1_0.Rows;
@@ -43,6 +44,7 @@ public class RowsImpl implements Rows {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class RowsImpl implements Rows {
 			this.label = label;
 	}
 
+	@JsonIgnore
 	public void setLabel(UnsafeSupplier<String, Throwable> labelUnsafeSupplier) {
 			try {
 				label = labelUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class RowsImpl implements Rows {
 			this.value = value;
 	}
 
+	@JsonIgnore
 	public void setValue(UnsafeSupplier<String, Throwable> valueUnsafeSupplier) {
 			try {
 				value = valueUnsafeSupplier.get();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/SuccessPageImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/SuccessPageImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.form.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.form.dto.v1_0.SuccessPage;
@@ -43,6 +44,7 @@ public class SuccessPageImpl implements SuccessPage {
 			this.description = description;
 	}
 
+	@JsonIgnore
 	public void setDescription(UnsafeSupplier<String, Throwable> descriptionUnsafeSupplier) {
 			try {
 				description = descriptionUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class SuccessPageImpl implements SuccessPage {
 			this.headline = headline;
 	}
 
+	@JsonIgnore
 	public void setHeadline(UnsafeSupplier<String, Throwable> headlineUnsafeSupplier) {
 			try {
 				headline = headlineUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class SuccessPageImpl implements SuccessPage {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/ValidationImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/dto/v1_0/ValidationImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.form.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.form.dto.v1_0.Validation;
@@ -43,6 +44,7 @@ public class ValidationImpl implements Validation {
 			this.errorMessage = errorMessage;
 	}
 
+	@JsonIgnore
 	public void setErrorMessage(UnsafeSupplier<String, Throwable> errorMessageUnsafeSupplier) {
 			try {
 				errorMessage = errorMessageUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class ValidationImpl implements Validation {
 			this.expression = expression;
 	}
 
+	@JsonIgnore
 	public void setExpression(UnsafeSupplier<String, Throwable> expressionUnsafeSupplier) {
 			try {
 				expression = expressionUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class ValidationImpl implements Validation {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/jaxrs/message/body/v1_0/JSONMessageBodyReader.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/jaxrs/message/body/v1_0/JSONMessageBodyReader.java
@@ -14,7 +14,10 @@
 
 package com.liferay.headless.form.internal.jaxrs.message.body.v1_0;
 
+import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
 import com.liferay.headless.form.dto.v1_0.Columns;
@@ -138,54 +141,37 @@ public class JSONMessageBodyReader implements MessageBodyReader<Object> {
 			InputStream inputStream)
 		throws IOException, WebApplicationException {
 
-			if (clazz.equals(Columns.class)) {
-				return _objectMapper.readValue(inputStream, ColumnsImpl.class);
-	}
-			if (clazz.equals(Creator.class)) {
-				return _objectMapper.readValue(inputStream, CreatorImpl.class);
-	}
-			if (clazz.equals(FieldValues.class)) {
-				return _objectMapper.readValue(inputStream, FieldValuesImpl.class);
-	}
-			if (clazz.equals(Fields.class)) {
-				return _objectMapper.readValue(inputStream, FieldsImpl.class);
-	}
-			if (clazz.equals(Form.class)) {
-				return _objectMapper.readValue(inputStream, FormImpl.class);
-	}
-			if (clazz.equals(FormDocument.class)) {
-				return _objectMapper.readValue(inputStream, FormDocumentImpl.class);
-	}
-			if (clazz.equals(FormPages.class)) {
-				return _objectMapper.readValue(inputStream, FormPagesImpl.class);
-	}
-			if (clazz.equals(FormRecord.class)) {
-				return _objectMapper.readValue(inputStream, FormRecordImpl.class);
-	}
-			if (clazz.equals(FormStructure.class)) {
-				return _objectMapper.readValue(inputStream, FormStructureImpl.class);
-	}
-			if (clazz.equals(Grid.class)) {
-				return _objectMapper.readValue(inputStream, GridImpl.class);
-	}
-			if (clazz.equals(Options.class)) {
-				return _objectMapper.readValue(inputStream, OptionsImpl.class);
-	}
-			if (clazz.equals(Rows.class)) {
-				return _objectMapper.readValue(inputStream, RowsImpl.class);
-	}
-			if (clazz.equals(SuccessPage.class)) {
-				return _objectMapper.readValue(inputStream, SuccessPageImpl.class);
-	}
-			if (clazz.equals(Validation.class)) {
-				return _objectMapper.readValue(inputStream, ValidationImpl.class);
-	}
-
-		return null;
+		return _objectMapper.readValue(inputStream, clazz);
 	}
 
 	private static final ObjectMapper _objectMapper = new ObjectMapper() {
 		{
+			SimpleModule module =
+				new SimpleModule("Liferay.Headless.Form",
+					Version.unknownVersion());
+
+			SimpleAbstractTypeResolver resolver =
+				new SimpleAbstractTypeResolver();
+
+			resolver.addMapping(Columns.class, ColumnsImpl.class);
+			resolver.addMapping(Creator.class, CreatorImpl.class);
+			resolver.addMapping(FieldValues.class, FieldValuesImpl.class);
+			resolver.addMapping(Fields.class, FieldsImpl.class);
+			resolver.addMapping(Form.class, FormImpl.class);
+			resolver.addMapping(FormDocument.class, FormDocumentImpl.class);
+			resolver.addMapping(FormPages.class, FormPagesImpl.class);
+			resolver.addMapping(FormRecord.class, FormRecordImpl.class);
+			resolver.addMapping(FormStructure.class, FormStructureImpl.class);
+			resolver.addMapping(Grid.class, GridImpl.class);
+			resolver.addMapping(Options.class, OptionsImpl.class);
+			resolver.addMapping(Rows.class, RowsImpl.class);
+			resolver.addMapping(SuccessPage.class, SuccessPageImpl.class);
+			resolver.addMapping(Validation.class, ValidationImpl.class);
+
+			module.setAbstractTypes(resolver);
+
+			registerModule(module);
+
 			setDateFormat(new ISO8601DateFormat());
 	}
 	};

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/CategoryImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/CategoryImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.Category;
@@ -47,6 +48,7 @@ public class CategoryImpl implements Category {
 			this.availableLanguages = availableLanguages;
 	}
 
+	@JsonIgnore
 	public void setAvailableLanguages(UnsafeSupplier<String[], Throwable> availableLanguagesUnsafeSupplier) {
 			try {
 				availableLanguages = availableLanguagesUnsafeSupplier.get();
@@ -67,6 +69,7 @@ public class CategoryImpl implements Category {
 			this.category = category;
 	}
 
+	@JsonIgnore
 	public void setCategory(UnsafeSupplier<Category, Throwable> categoryUnsafeSupplier) {
 			try {
 				category = categoryUnsafeSupplier.get();
@@ -87,6 +90,7 @@ public class CategoryImpl implements Category {
 			this.categoryId = categoryId;
 	}
 
+	@JsonIgnore
 	public void setCategoryId(UnsafeSupplier<Long, Throwable> categoryIdUnsafeSupplier) {
 			try {
 				categoryId = categoryIdUnsafeSupplier.get();
@@ -107,6 +111,7 @@ public class CategoryImpl implements Category {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -127,6 +132,7 @@ public class CategoryImpl implements Category {
 			this.creatorId = creatorId;
 	}
 
+	@JsonIgnore
 	public void setCreatorId(UnsafeSupplier<Long, Throwable> creatorIdUnsafeSupplier) {
 			try {
 				creatorId = creatorIdUnsafeSupplier.get();
@@ -147,6 +153,7 @@ public class CategoryImpl implements Category {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -167,6 +174,7 @@ public class CategoryImpl implements Category {
 			this.dateModified = dateModified;
 	}
 
+	@JsonIgnore
 	public void setDateModified(UnsafeSupplier<Date, Throwable> dateModifiedUnsafeSupplier) {
 			try {
 				dateModified = dateModifiedUnsafeSupplier.get();
@@ -187,6 +195,7 @@ public class CategoryImpl implements Category {
 			this.description = description;
 	}
 
+	@JsonIgnore
 	public void setDescription(UnsafeSupplier<String, Throwable> descriptionUnsafeSupplier) {
 			try {
 				description = descriptionUnsafeSupplier.get();
@@ -207,6 +216,7 @@ public class CategoryImpl implements Category {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -227,6 +237,7 @@ public class CategoryImpl implements Category {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -247,6 +258,7 @@ public class CategoryImpl implements Category {
 			this.subcategories = subcategories;
 	}
 
+	@JsonIgnore
 	public void setSubcategories(UnsafeSupplier<Category[], Throwable> subcategoriesUnsafeSupplier) {
 			try {
 				subcategories = subcategoriesUnsafeSupplier.get();
@@ -267,6 +279,7 @@ public class CategoryImpl implements Category {
 			this.vocabulary = vocabulary;
 	}
 
+	@JsonIgnore
 	public void setVocabulary(UnsafeSupplier<Vocabulary, Throwable> vocabularyUnsafeSupplier) {
 			try {
 				vocabulary = vocabularyUnsafeSupplier.get();
@@ -287,6 +300,7 @@ public class CategoryImpl implements Category {
 			this.vocabularyId = vocabularyId;
 	}
 
+	@JsonIgnore
 	public void setVocabularyId(UnsafeSupplier<Long, Throwable> vocabularyIdUnsafeSupplier) {
 			try {
 				vocabularyId = vocabularyIdUnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/ContactInformationImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/ContactInformationImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.ContactInformation;
@@ -47,6 +48,7 @@ public class ContactInformationImpl implements ContactInformation {
 			this.address = address;
 	}
 
+	@JsonIgnore
 	public void setAddress(UnsafeSupplier<PostalAddress[], Throwable> addressUnsafeSupplier) {
 			try {
 				address = addressUnsafeSupplier.get();
@@ -67,6 +69,7 @@ public class ContactInformationImpl implements ContactInformation {
 			this.addressIds = addressIds;
 	}
 
+	@JsonIgnore
 	public void setAddressIds(UnsafeSupplier<Long[], Throwable> addressIdsUnsafeSupplier) {
 			try {
 				addressIds = addressIdsUnsafeSupplier.get();
@@ -87,6 +90,7 @@ public class ContactInformationImpl implements ContactInformation {
 			this.email = email;
 	}
 
+	@JsonIgnore
 	public void setEmail(UnsafeSupplier<Email[], Throwable> emailUnsafeSupplier) {
 			try {
 				email = emailUnsafeSupplier.get();
@@ -107,6 +111,7 @@ public class ContactInformationImpl implements ContactInformation {
 			this.emailIds = emailIds;
 	}
 
+	@JsonIgnore
 	public void setEmailIds(UnsafeSupplier<Long[], Throwable> emailIdsUnsafeSupplier) {
 			try {
 				emailIds = emailIdsUnsafeSupplier.get();
@@ -127,6 +132,7 @@ public class ContactInformationImpl implements ContactInformation {
 			this.facebook = facebook;
 	}
 
+	@JsonIgnore
 	public void setFacebook(UnsafeSupplier<String, Throwable> facebookUnsafeSupplier) {
 			try {
 				facebook = facebookUnsafeSupplier.get();
@@ -147,6 +153,7 @@ public class ContactInformationImpl implements ContactInformation {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -167,6 +174,7 @@ public class ContactInformationImpl implements ContactInformation {
 			this.jabber = jabber;
 	}
 
+	@JsonIgnore
 	public void setJabber(UnsafeSupplier<String, Throwable> jabberUnsafeSupplier) {
 			try {
 				jabber = jabberUnsafeSupplier.get();
@@ -187,6 +195,7 @@ public class ContactInformationImpl implements ContactInformation {
 			this.skype = skype;
 	}
 
+	@JsonIgnore
 	public void setSkype(UnsafeSupplier<String, Throwable> skypeUnsafeSupplier) {
 			try {
 				skype = skypeUnsafeSupplier.get();
@@ -207,6 +216,7 @@ public class ContactInformationImpl implements ContactInformation {
 			this.sms = sms;
 	}
 
+	@JsonIgnore
 	public void setSms(UnsafeSupplier<String, Throwable> smsUnsafeSupplier) {
 			try {
 				sms = smsUnsafeSupplier.get();
@@ -227,6 +237,7 @@ public class ContactInformationImpl implements ContactInformation {
 			this.telephone = telephone;
 	}
 
+	@JsonIgnore
 	public void setTelephone(UnsafeSupplier<Phone[], Throwable> telephoneUnsafeSupplier) {
 			try {
 				telephone = telephoneUnsafeSupplier.get();
@@ -247,6 +258,7 @@ public class ContactInformationImpl implements ContactInformation {
 			this.telephoneIds = telephoneIds;
 	}
 
+	@JsonIgnore
 	public void setTelephoneIds(UnsafeSupplier<Long[], Throwable> telephoneIdsUnsafeSupplier) {
 			try {
 				telephoneIds = telephoneIdsUnsafeSupplier.get();
@@ -267,6 +279,7 @@ public class ContactInformationImpl implements ContactInformation {
 			this.twitter = twitter;
 	}
 
+	@JsonIgnore
 	public void setTwitter(UnsafeSupplier<String, Throwable> twitterUnsafeSupplier) {
 			try {
 				twitter = twitterUnsafeSupplier.get();
@@ -287,6 +300,7 @@ public class ContactInformationImpl implements ContactInformation {
 			this.webUrl = webUrl;
 	}
 
+	@JsonIgnore
 	public void setWebUrl(UnsafeSupplier<WebUrl[], Throwable> webUrlUnsafeSupplier) {
 			try {
 				webUrl = webUrlUnsafeSupplier.get();
@@ -307,6 +321,7 @@ public class ContactInformationImpl implements ContactInformation {
 			this.webUrlIds = webUrlIds;
 	}
 
+	@JsonIgnore
 	public void setWebUrlIds(UnsafeSupplier<Long[], Throwable> webUrlIdsUnsafeSupplier) {
 			try {
 				webUrlIds = webUrlIdsUnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/CreatorImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/CreatorImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.Creator;
@@ -43,6 +44,7 @@ public class CreatorImpl implements Creator {
 			this.additionalName = additionalName;
 	}
 
+	@JsonIgnore
 	public void setAdditionalName(UnsafeSupplier<String, Throwable> additionalNameUnsafeSupplier) {
 			try {
 				additionalName = additionalNameUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class CreatorImpl implements Creator {
 			this.familyName = familyName;
 	}
 
+	@JsonIgnore
 	public void setFamilyName(UnsafeSupplier<String, Throwable> familyNameUnsafeSupplier) {
 			try {
 				familyName = familyNameUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class CreatorImpl implements Creator {
 			this.givenName = givenName;
 	}
 
+	@JsonIgnore
 	public void setGivenName(UnsafeSupplier<String, Throwable> givenNameUnsafeSupplier) {
 			try {
 				givenName = givenNameUnsafeSupplier.get();
@@ -103,6 +107,7 @@ public class CreatorImpl implements Creator {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -123,6 +128,7 @@ public class CreatorImpl implements Creator {
 			this.image = image;
 	}
 
+	@JsonIgnore
 	public void setImage(UnsafeSupplier<String, Throwable> imageUnsafeSupplier) {
 			try {
 				image = imageUnsafeSupplier.get();
@@ -143,6 +149,7 @@ public class CreatorImpl implements Creator {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -163,6 +170,7 @@ public class CreatorImpl implements Creator {
 			this.profileURL = profileURL;
 	}
 
+	@JsonIgnore
 	public void setProfileURL(UnsafeSupplier<String, Throwable> profileURLUnsafeSupplier) {
 			try {
 				profileURL = profileURLUnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/EmailImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/EmailImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.Email;
@@ -43,6 +44,7 @@ public class EmailImpl implements Email {
 			this.email = email;
 	}
 
+	@JsonIgnore
 	public void setEmail(UnsafeSupplier<String, Throwable> emailUnsafeSupplier) {
 			try {
 				email = emailUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class EmailImpl implements Email {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class EmailImpl implements Email {
 			this.type = type;
 	}
 
+	@JsonIgnore
 	public void setType(UnsafeSupplier<String, Throwable> typeUnsafeSupplier) {
 			try {
 				type = typeUnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/HoursAvailableImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/HoursAvailableImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.HoursAvailable;
@@ -43,6 +44,7 @@ public class HoursAvailableImpl implements HoursAvailable {
 			this.closes = closes;
 	}
 
+	@JsonIgnore
 	public void setCloses(UnsafeSupplier<String, Throwable> closesUnsafeSupplier) {
 			try {
 				closes = closesUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class HoursAvailableImpl implements HoursAvailable {
 			this.dayOfWeek = dayOfWeek;
 	}
 
+	@JsonIgnore
 	public void setDayOfWeek(UnsafeSupplier<String, Throwable> dayOfWeekUnsafeSupplier) {
 			try {
 				dayOfWeek = dayOfWeekUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class HoursAvailableImpl implements HoursAvailable {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -103,6 +107,7 @@ public class HoursAvailableImpl implements HoursAvailable {
 			this.opens = opens;
 	}
 
+	@JsonIgnore
 	public void setOpens(UnsafeSupplier<String, Throwable> opensUnsafeSupplier) {
 			try {
 				opens = opensUnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/KeywordImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/KeywordImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.Creator;
@@ -46,6 +47,7 @@ public class KeywordImpl implements Keyword {
 			this.contentSpace = contentSpace;
 	}
 
+	@JsonIgnore
 	public void setContentSpace(UnsafeSupplier<Long, Throwable> contentSpaceUnsafeSupplier) {
 			try {
 				contentSpace = contentSpaceUnsafeSupplier.get();
@@ -66,6 +68,7 @@ public class KeywordImpl implements Keyword {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -86,6 +89,7 @@ public class KeywordImpl implements Keyword {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -106,6 +110,7 @@ public class KeywordImpl implements Keyword {
 			this.dateModified = dateModified;
 	}
 
+	@JsonIgnore
 	public void setDateModified(UnsafeSupplier<Date, Throwable> dateModifiedUnsafeSupplier) {
 			try {
 				dateModified = dateModifiedUnsafeSupplier.get();
@@ -126,6 +131,7 @@ public class KeywordImpl implements Keyword {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -146,6 +152,7 @@ public class KeywordImpl implements Keyword {
 			this.keywordUsageCount = keywordUsageCount;
 	}
 
+	@JsonIgnore
 	public void setKeywordUsageCount(UnsafeSupplier<Number, Throwable> keywordUsageCountUnsafeSupplier) {
 			try {
 				keywordUsageCount = keywordUsageCountUnsafeSupplier.get();
@@ -166,6 +173,7 @@ public class KeywordImpl implements Keyword {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/LocationImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/LocationImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.Location;
@@ -43,6 +44,7 @@ public class LocationImpl implements Location {
 			this.addressCountry = addressCountry;
 	}
 
+	@JsonIgnore
 	public void setAddressCountry(UnsafeSupplier<String, Throwable> addressCountryUnsafeSupplier) {
 			try {
 				addressCountry = addressCountryUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class LocationImpl implements Location {
 			this.addressRegion = addressRegion;
 	}
 
+	@JsonIgnore
 	public void setAddressRegion(UnsafeSupplier<String, Throwable> addressRegionUnsafeSupplier) {
 			try {
 				addressRegion = addressRegionUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class LocationImpl implements Location {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/OrganizationImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/OrganizationImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.ContactInformation;
@@ -47,6 +48,7 @@ public class OrganizationImpl implements Organization {
 			this.comment = comment;
 	}
 
+	@JsonIgnore
 	public void setComment(UnsafeSupplier<String, Throwable> commentUnsafeSupplier) {
 			try {
 				comment = commentUnsafeSupplier.get();
@@ -67,6 +69,7 @@ public class OrganizationImpl implements Organization {
 			this.contactInformation = contactInformation;
 	}
 
+	@JsonIgnore
 	public void setContactInformation(UnsafeSupplier<ContactInformation, Throwable> contactInformationUnsafeSupplier) {
 			try {
 				contactInformation = contactInformationUnsafeSupplier.get();
@@ -87,6 +90,7 @@ public class OrganizationImpl implements Organization {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -107,6 +111,7 @@ public class OrganizationImpl implements Organization {
 			this.location = location;
 	}
 
+	@JsonIgnore
 	public void setLocation(UnsafeSupplier<Location, Throwable> locationUnsafeSupplier) {
 			try {
 				location = locationUnsafeSupplier.get();
@@ -127,6 +132,7 @@ public class OrganizationImpl implements Organization {
 			this.logo = logo;
 	}
 
+	@JsonIgnore
 	public void setLogo(UnsafeSupplier<String, Throwable> logoUnsafeSupplier) {
 			try {
 				logo = logoUnsafeSupplier.get();
@@ -147,6 +153,7 @@ public class OrganizationImpl implements Organization {
 			this.members = members;
 	}
 
+	@JsonIgnore
 	public void setMembers(UnsafeSupplier<UserAccount[], Throwable> membersUnsafeSupplier) {
 			try {
 				members = membersUnsafeSupplier.get();
@@ -167,6 +174,7 @@ public class OrganizationImpl implements Organization {
 			this.membersIds = membersIds;
 	}
 
+	@JsonIgnore
 	public void setMembersIds(UnsafeSupplier<Long[], Throwable> membersIdsUnsafeSupplier) {
 			try {
 				membersIds = membersIdsUnsafeSupplier.get();
@@ -187,6 +195,7 @@ public class OrganizationImpl implements Organization {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -207,6 +216,7 @@ public class OrganizationImpl implements Organization {
 			this.parentOrganization = parentOrganization;
 	}
 
+	@JsonIgnore
 	public void setParentOrganization(UnsafeSupplier<Organization, Throwable> parentOrganizationUnsafeSupplier) {
 			try {
 				parentOrganization = parentOrganizationUnsafeSupplier.get();
@@ -227,6 +237,7 @@ public class OrganizationImpl implements Organization {
 			this.parentOrganizationId = parentOrganizationId;
 	}
 
+	@JsonIgnore
 	public void setParentOrganizationId(UnsafeSupplier<Long, Throwable> parentOrganizationIdUnsafeSupplier) {
 			try {
 				parentOrganizationId = parentOrganizationIdUnsafeSupplier.get();
@@ -247,6 +258,7 @@ public class OrganizationImpl implements Organization {
 			this.services = services;
 	}
 
+	@JsonIgnore
 	public void setServices(UnsafeSupplier<Services[], Throwable> servicesUnsafeSupplier) {
 			try {
 				services = servicesUnsafeSupplier.get();
@@ -267,6 +279,7 @@ public class OrganizationImpl implements Organization {
 			this.subOrganization = subOrganization;
 	}
 
+	@JsonIgnore
 	public void setSubOrganization(UnsafeSupplier<Organization[], Throwable> subOrganizationUnsafeSupplier) {
 			try {
 				subOrganization = subOrganizationUnsafeSupplier.get();
@@ -287,6 +300,7 @@ public class OrganizationImpl implements Organization {
 			this.subOrganizationIds = subOrganizationIds;
 	}
 
+	@JsonIgnore
 	public void setSubOrganizationIds(UnsafeSupplier<Long[], Throwable> subOrganizationIdsUnsafeSupplier) {
 			try {
 				subOrganizationIds = subOrganizationIdsUnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/PhoneImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/PhoneImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.Phone;
@@ -43,6 +44,7 @@ public class PhoneImpl implements Phone {
 			this.extension = extension;
 	}
 
+	@JsonIgnore
 	public void setExtension(UnsafeSupplier<String, Throwable> extensionUnsafeSupplier) {
 			try {
 				extension = extensionUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class PhoneImpl implements Phone {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class PhoneImpl implements Phone {
 			this.phoneNumber = phoneNumber;
 	}
 
+	@JsonIgnore
 	public void setPhoneNumber(UnsafeSupplier<String, Throwable> phoneNumberUnsafeSupplier) {
 			try {
 				phoneNumber = phoneNumberUnsafeSupplier.get();
@@ -103,6 +107,7 @@ public class PhoneImpl implements Phone {
 			this.phoneType = phoneType;
 	}
 
+	@JsonIgnore
 	public void setPhoneType(UnsafeSupplier<String, Throwable> phoneTypeUnsafeSupplier) {
 			try {
 				phoneType = phoneTypeUnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/PostalAddressImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/PostalAddressImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.PostalAddress;
@@ -43,6 +44,7 @@ public class PostalAddressImpl implements PostalAddress {
 			this.addressCountry = addressCountry;
 	}
 
+	@JsonIgnore
 	public void setAddressCountry(UnsafeSupplier<String, Throwable> addressCountryUnsafeSupplier) {
 			try {
 				addressCountry = addressCountryUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class PostalAddressImpl implements PostalAddress {
 			this.addressLocality = addressLocality;
 	}
 
+	@JsonIgnore
 	public void setAddressLocality(UnsafeSupplier<String, Throwable> addressLocalityUnsafeSupplier) {
 			try {
 				addressLocality = addressLocalityUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class PostalAddressImpl implements PostalAddress {
 			this.addressRegion = addressRegion;
 	}
 
+	@JsonIgnore
 	public void setAddressRegion(UnsafeSupplier<String, Throwable> addressRegionUnsafeSupplier) {
 			try {
 				addressRegion = addressRegionUnsafeSupplier.get();
@@ -103,6 +107,7 @@ public class PostalAddressImpl implements PostalAddress {
 			this.addressType = addressType;
 	}
 
+	@JsonIgnore
 	public void setAddressType(UnsafeSupplier<String, Throwable> addressTypeUnsafeSupplier) {
 			try {
 				addressType = addressTypeUnsafeSupplier.get();
@@ -123,6 +128,7 @@ public class PostalAddressImpl implements PostalAddress {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -143,6 +149,7 @@ public class PostalAddressImpl implements PostalAddress {
 			this.postalCode = postalCode;
 	}
 
+	@JsonIgnore
 	public void setPostalCode(UnsafeSupplier<String, Throwable> postalCodeUnsafeSupplier) {
 			try {
 				postalCode = postalCodeUnsafeSupplier.get();
@@ -163,6 +170,7 @@ public class PostalAddressImpl implements PostalAddress {
 			this.streetAddressLine1 = streetAddressLine1;
 	}
 
+	@JsonIgnore
 	public void setStreetAddressLine1(UnsafeSupplier<String, Throwable> streetAddressLine1UnsafeSupplier) {
 			try {
 				streetAddressLine1 = streetAddressLine1UnsafeSupplier.get();
@@ -183,6 +191,7 @@ public class PostalAddressImpl implements PostalAddress {
 			this.streetAddressLine2 = streetAddressLine2;
 	}
 
+	@JsonIgnore
 	public void setStreetAddressLine2(UnsafeSupplier<String, Throwable> streetAddressLine2UnsafeSupplier) {
 			try {
 				streetAddressLine2 = streetAddressLine2UnsafeSupplier.get();
@@ -203,6 +212,7 @@ public class PostalAddressImpl implements PostalAddress {
 			this.streetAddressLine3 = streetAddressLine3;
 	}
 
+	@JsonIgnore
 	public void setStreetAddressLine3(UnsafeSupplier<String, Throwable> streetAddressLine3UnsafeSupplier) {
 			try {
 				streetAddressLine3 = streetAddressLine3UnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/RoleImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/RoleImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.Creator;
@@ -46,6 +47,7 @@ public class RoleImpl implements Role {
 			this.availableLanguages = availableLanguages;
 	}
 
+	@JsonIgnore
 	public void setAvailableLanguages(UnsafeSupplier<String[], Throwable> availableLanguagesUnsafeSupplier) {
 			try {
 				availableLanguages = availableLanguagesUnsafeSupplier.get();
@@ -66,6 +68,7 @@ public class RoleImpl implements Role {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -86,6 +89,7 @@ public class RoleImpl implements Role {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -106,6 +110,7 @@ public class RoleImpl implements Role {
 			this.dateModified = dateModified;
 	}
 
+	@JsonIgnore
 	public void setDateModified(UnsafeSupplier<Date, Throwable> dateModifiedUnsafeSupplier) {
 			try {
 				dateModified = dateModifiedUnsafeSupplier.get();
@@ -126,6 +131,7 @@ public class RoleImpl implements Role {
 			this.description = description;
 	}
 
+	@JsonIgnore
 	public void setDescription(UnsafeSupplier<String, Throwable> descriptionUnsafeSupplier) {
 			try {
 				description = descriptionUnsafeSupplier.get();
@@ -146,6 +152,7 @@ public class RoleImpl implements Role {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -166,6 +173,7 @@ public class RoleImpl implements Role {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -186,6 +194,7 @@ public class RoleImpl implements Role {
 			this.roleType = roleType;
 	}
 
+	@JsonIgnore
 	public void setRoleType(UnsafeSupplier<String, Throwable> roleTypeUnsafeSupplier) {
 			try {
 				roleType = roleTypeUnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/ServicesImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/ServicesImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.HoursAvailable;
@@ -44,6 +45,7 @@ public class ServicesImpl implements Services {
 			this.hoursAvailable = hoursAvailable;
 	}
 
+	@JsonIgnore
 	public void setHoursAvailable(UnsafeSupplier<HoursAvailable[], Throwable> hoursAvailableUnsafeSupplier) {
 			try {
 				hoursAvailable = hoursAvailableUnsafeSupplier.get();
@@ -64,6 +66,7 @@ public class ServicesImpl implements Services {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -84,6 +87,7 @@ public class ServicesImpl implements Services {
 			this.serviceType = serviceType;
 	}
 
+	@JsonIgnore
 	public void setServiceType(UnsafeSupplier<String, Throwable> serviceTypeUnsafeSupplier) {
 			try {
 				serviceType = serviceTypeUnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/UserAccountImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/UserAccountImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.ContactInformation;
@@ -48,6 +49,7 @@ public class UserAccountImpl implements UserAccount {
 			this.additionalName = additionalName;
 	}
 
+	@JsonIgnore
 	public void setAdditionalName(UnsafeSupplier<String, Throwable> additionalNameUnsafeSupplier) {
 			try {
 				additionalName = additionalNameUnsafeSupplier.get();
@@ -68,6 +70,7 @@ public class UserAccountImpl implements UserAccount {
 			this.alternateName = alternateName;
 	}
 
+	@JsonIgnore
 	public void setAlternateName(UnsafeSupplier<String, Throwable> alternateNameUnsafeSupplier) {
 			try {
 				alternateName = alternateNameUnsafeSupplier.get();
@@ -88,6 +91,7 @@ public class UserAccountImpl implements UserAccount {
 			this.birthDate = birthDate;
 	}
 
+	@JsonIgnore
 	public void setBirthDate(UnsafeSupplier<Date, Throwable> birthDateUnsafeSupplier) {
 			try {
 				birthDate = birthDateUnsafeSupplier.get();
@@ -108,6 +112,7 @@ public class UserAccountImpl implements UserAccount {
 			this.contactInformation = contactInformation;
 	}
 
+	@JsonIgnore
 	public void setContactInformation(UnsafeSupplier<ContactInformation, Throwable> contactInformationUnsafeSupplier) {
 			try {
 				contactInformation = contactInformationUnsafeSupplier.get();
@@ -128,6 +133,7 @@ public class UserAccountImpl implements UserAccount {
 			this.dashboardURL = dashboardURL;
 	}
 
+	@JsonIgnore
 	public void setDashboardURL(UnsafeSupplier<String, Throwable> dashboardURLUnsafeSupplier) {
 			try {
 				dashboardURL = dashboardURLUnsafeSupplier.get();
@@ -148,6 +154,7 @@ public class UserAccountImpl implements UserAccount {
 			this.email = email;
 	}
 
+	@JsonIgnore
 	public void setEmail(UnsafeSupplier<String, Throwable> emailUnsafeSupplier) {
 			try {
 				email = emailUnsafeSupplier.get();
@@ -168,6 +175,7 @@ public class UserAccountImpl implements UserAccount {
 			this.familyName = familyName;
 	}
 
+	@JsonIgnore
 	public void setFamilyName(UnsafeSupplier<String, Throwable> familyNameUnsafeSupplier) {
 			try {
 				familyName = familyNameUnsafeSupplier.get();
@@ -188,6 +196,7 @@ public class UserAccountImpl implements UserAccount {
 			this.givenName = givenName;
 	}
 
+	@JsonIgnore
 	public void setGivenName(UnsafeSupplier<String, Throwable> givenNameUnsafeSupplier) {
 			try {
 				givenName = givenNameUnsafeSupplier.get();
@@ -208,6 +217,7 @@ public class UserAccountImpl implements UserAccount {
 			this.honorificPrefix = honorificPrefix;
 	}
 
+	@JsonIgnore
 	public void setHonorificPrefix(UnsafeSupplier<String, Throwable> honorificPrefixUnsafeSupplier) {
 			try {
 				honorificPrefix = honorificPrefixUnsafeSupplier.get();
@@ -228,6 +238,7 @@ public class UserAccountImpl implements UserAccount {
 			this.honorificSuffix = honorificSuffix;
 	}
 
+	@JsonIgnore
 	public void setHonorificSuffix(UnsafeSupplier<String, Throwable> honorificSuffixUnsafeSupplier) {
 			try {
 				honorificSuffix = honorificSuffixUnsafeSupplier.get();
@@ -248,6 +259,7 @@ public class UserAccountImpl implements UserAccount {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -268,6 +280,7 @@ public class UserAccountImpl implements UserAccount {
 			this.image = image;
 	}
 
+	@JsonIgnore
 	public void setImage(UnsafeSupplier<String, Throwable> imageUnsafeSupplier) {
 			try {
 				image = imageUnsafeSupplier.get();
@@ -288,6 +301,7 @@ public class UserAccountImpl implements UserAccount {
 			this.jobTitle = jobTitle;
 	}
 
+	@JsonIgnore
 	public void setJobTitle(UnsafeSupplier<String, Throwable> jobTitleUnsafeSupplier) {
 			try {
 				jobTitle = jobTitleUnsafeSupplier.get();
@@ -308,6 +322,7 @@ public class UserAccountImpl implements UserAccount {
 			this.myOrganizations = myOrganizations;
 	}
 
+	@JsonIgnore
 	public void setMyOrganizations(UnsafeSupplier<Organization[], Throwable> myOrganizationsUnsafeSupplier) {
 			try {
 				myOrganizations = myOrganizationsUnsafeSupplier.get();
@@ -328,6 +343,7 @@ public class UserAccountImpl implements UserAccount {
 			this.myOrganizationsIds = myOrganizationsIds;
 	}
 
+	@JsonIgnore
 	public void setMyOrganizationsIds(UnsafeSupplier<Long[], Throwable> myOrganizationsIdsUnsafeSupplier) {
 			try {
 				myOrganizationsIds = myOrganizationsIdsUnsafeSupplier.get();
@@ -348,6 +364,7 @@ public class UserAccountImpl implements UserAccount {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -368,6 +385,7 @@ public class UserAccountImpl implements UserAccount {
 			this.profileURL = profileURL;
 	}
 
+	@JsonIgnore
 	public void setProfileURL(UnsafeSupplier<String, Throwable> profileURLUnsafeSupplier) {
 			try {
 				profileURL = profileURLUnsafeSupplier.get();
@@ -388,6 +406,7 @@ public class UserAccountImpl implements UserAccount {
 			this.roles = roles;
 	}
 
+	@JsonIgnore
 	public void setRoles(UnsafeSupplier<Role[], Throwable> rolesUnsafeSupplier) {
 			try {
 				roles = rolesUnsafeSupplier.get();
@@ -408,6 +427,7 @@ public class UserAccountImpl implements UserAccount {
 			this.rolesIds = rolesIds;
 	}
 
+	@JsonIgnore
 	public void setRolesIds(UnsafeSupplier<Long[], Throwable> rolesIdsUnsafeSupplier) {
 			try {
 				rolesIds = rolesIdsUnsafeSupplier.get();
@@ -428,6 +448,7 @@ public class UserAccountImpl implements UserAccount {
 			this.tasksAssignedToMe = tasksAssignedToMe;
 	}
 
+	@JsonIgnore
 	public void setTasksAssignedToMe(UnsafeSupplier<String[], Throwable> tasksAssignedToMeUnsafeSupplier) {
 			try {
 				tasksAssignedToMe = tasksAssignedToMeUnsafeSupplier.get();
@@ -448,6 +469,7 @@ public class UserAccountImpl implements UserAccount {
 			this.tasksAssignedToMyRoles = tasksAssignedToMyRoles;
 	}
 
+	@JsonIgnore
 	public void setTasksAssignedToMyRoles(UnsafeSupplier<String[], Throwable> tasksAssignedToMyRolesUnsafeSupplier) {
 			try {
 				tasksAssignedToMyRoles = tasksAssignedToMyRolesUnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/VocabularyImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/VocabularyImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.Category;
@@ -47,6 +48,7 @@ public class VocabularyImpl implements Vocabulary {
 			this.availableLanguages = availableLanguages;
 	}
 
+	@JsonIgnore
 	public void setAvailableLanguages(UnsafeSupplier<String[], Throwable> availableLanguagesUnsafeSupplier) {
 			try {
 				availableLanguages = availableLanguagesUnsafeSupplier.get();
@@ -67,6 +69,7 @@ public class VocabularyImpl implements Vocabulary {
 			this.contentSpace = contentSpace;
 	}
 
+	@JsonIgnore
 	public void setContentSpace(UnsafeSupplier<Long, Throwable> contentSpaceUnsafeSupplier) {
 			try {
 				contentSpace = contentSpaceUnsafeSupplier.get();
@@ -87,6 +90,7 @@ public class VocabularyImpl implements Vocabulary {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -107,6 +111,7 @@ public class VocabularyImpl implements Vocabulary {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -127,6 +132,7 @@ public class VocabularyImpl implements Vocabulary {
 			this.dateModified = dateModified;
 	}
 
+	@JsonIgnore
 	public void setDateModified(UnsafeSupplier<Date, Throwable> dateModifiedUnsafeSupplier) {
 			try {
 				dateModified = dateModifiedUnsafeSupplier.get();
@@ -147,6 +153,7 @@ public class VocabularyImpl implements Vocabulary {
 			this.description = description;
 	}
 
+	@JsonIgnore
 	public void setDescription(UnsafeSupplier<String, Throwable> descriptionUnsafeSupplier) {
 			try {
 				description = descriptionUnsafeSupplier.get();
@@ -167,6 +174,7 @@ public class VocabularyImpl implements Vocabulary {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -187,6 +195,7 @@ public class VocabularyImpl implements Vocabulary {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -207,6 +216,7 @@ public class VocabularyImpl implements Vocabulary {
 			this.vocabularyCategories = vocabularyCategories;
 	}
 
+	@JsonIgnore
 	public void setVocabularyCategories(UnsafeSupplier<Category[], Throwable> vocabularyCategoriesUnsafeSupplier) {
 			try {
 				vocabularyCategories = vocabularyCategoriesUnsafeSupplier.get();
@@ -227,6 +237,7 @@ public class VocabularyImpl implements Vocabulary {
 			this.vocabularyCategoriesIds = vocabularyCategoriesIds;
 	}
 
+	@JsonIgnore
 	public void setVocabularyCategoriesIds(UnsafeSupplier<Long[], Throwable> vocabularyCategoriesIdsUnsafeSupplier) {
 			try {
 				vocabularyCategoriesIds = vocabularyCategoriesIdsUnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/WebUrlImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/dto/v1_0/WebUrlImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.foundation.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.foundation.dto.v1_0.WebUrl;
@@ -43,6 +44,7 @@ public class WebUrlImpl implements WebUrl {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class WebUrlImpl implements WebUrl {
 			this.url = url;
 	}
 
+	@JsonIgnore
 	public void setUrl(UnsafeSupplier<String, Throwable> urlUnsafeSupplier) {
 			try {
 				url = urlUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class WebUrlImpl implements WebUrl {
 			this.urlType = urlType;
 	}
 
+	@JsonIgnore
 	public void setUrlType(UnsafeSupplier<String, Throwable> urlTypeUnsafeSupplier) {
 			try {
 				urlType = urlTypeUnsafeSupplier.get();

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/jaxrs/message/body/v1_0/JSONMessageBodyReader.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/jaxrs/message/body/v1_0/JSONMessageBodyReader.java
@@ -14,7 +14,10 @@
 
 package com.liferay.headless.foundation.internal.jaxrs.message.body.v1_0;
 
+import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
 import com.liferay.headless.foundation.dto.v1_0.Category;
@@ -143,57 +146,38 @@ public class JSONMessageBodyReader implements MessageBodyReader<Object> {
 			InputStream inputStream)
 		throws IOException, WebApplicationException {
 
-			if (clazz.equals(Category.class)) {
-				return _objectMapper.readValue(inputStream, CategoryImpl.class);
-	}
-			if (clazz.equals(ContactInformation.class)) {
-				return _objectMapper.readValue(inputStream, ContactInformationImpl.class);
-	}
-			if (clazz.equals(Creator.class)) {
-				return _objectMapper.readValue(inputStream, CreatorImpl.class);
-	}
-			if (clazz.equals(Email.class)) {
-				return _objectMapper.readValue(inputStream, EmailImpl.class);
-	}
-			if (clazz.equals(HoursAvailable.class)) {
-				return _objectMapper.readValue(inputStream, HoursAvailableImpl.class);
-	}
-			if (clazz.equals(Keyword.class)) {
-				return _objectMapper.readValue(inputStream, KeywordImpl.class);
-	}
-			if (clazz.equals(Location.class)) {
-				return _objectMapper.readValue(inputStream, LocationImpl.class);
-	}
-			if (clazz.equals(Organization.class)) {
-				return _objectMapper.readValue(inputStream, OrganizationImpl.class);
-	}
-			if (clazz.equals(Phone.class)) {
-				return _objectMapper.readValue(inputStream, PhoneImpl.class);
-	}
-			if (clazz.equals(PostalAddress.class)) {
-				return _objectMapper.readValue(inputStream, PostalAddressImpl.class);
-	}
-			if (clazz.equals(Role.class)) {
-				return _objectMapper.readValue(inputStream, RoleImpl.class);
-	}
-			if (clazz.equals(Services.class)) {
-				return _objectMapper.readValue(inputStream, ServicesImpl.class);
-	}
-			if (clazz.equals(UserAccount.class)) {
-				return _objectMapper.readValue(inputStream, UserAccountImpl.class);
-	}
-			if (clazz.equals(Vocabulary.class)) {
-				return _objectMapper.readValue(inputStream, VocabularyImpl.class);
-	}
-			if (clazz.equals(WebUrl.class)) {
-				return _objectMapper.readValue(inputStream, WebUrlImpl.class);
-	}
-
-		return null;
+		return _objectMapper.readValue(inputStream, clazz);
 	}
 
 	private static final ObjectMapper _objectMapper = new ObjectMapper() {
 		{
+			SimpleModule module =
+				new SimpleModule("Liferay.Headless.Foundation",
+					Version.unknownVersion());
+
+			SimpleAbstractTypeResolver resolver =
+				new SimpleAbstractTypeResolver();
+
+			resolver.addMapping(Category.class, CategoryImpl.class);
+			resolver.addMapping(ContactInformation.class, ContactInformationImpl.class);
+			resolver.addMapping(Creator.class, CreatorImpl.class);
+			resolver.addMapping(Email.class, EmailImpl.class);
+			resolver.addMapping(HoursAvailable.class, HoursAvailableImpl.class);
+			resolver.addMapping(Keyword.class, KeywordImpl.class);
+			resolver.addMapping(Location.class, LocationImpl.class);
+			resolver.addMapping(Organization.class, OrganizationImpl.class);
+			resolver.addMapping(Phone.class, PhoneImpl.class);
+			resolver.addMapping(PostalAddress.class, PostalAddressImpl.class);
+			resolver.addMapping(Role.class, RoleImpl.class);
+			resolver.addMapping(Services.class, ServicesImpl.class);
+			resolver.addMapping(UserAccount.class, UserAccountImpl.class);
+			resolver.addMapping(Vocabulary.class, VocabularyImpl.class);
+			resolver.addMapping(WebUrl.class, WebUrlImpl.class);
+
+			module.setAbstractTypes(resolver);
+
+			registerModule(module);
+
 			setDateFormat(new ISO8601DateFormat());
 	}
 	};

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/AggregateRatingImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/AggregateRatingImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.web.experience.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.web.experience.dto.v1_0.AggregateRating;
@@ -43,6 +44,7 @@ public class AggregateRatingImpl implements AggregateRating {
 			this.bestRating = bestRating;
 	}
 
+	@JsonIgnore
 	public void setBestRating(UnsafeSupplier<Number, Throwable> bestRatingUnsafeSupplier) {
 			try {
 				bestRating = bestRatingUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class AggregateRatingImpl implements AggregateRating {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class AggregateRatingImpl implements AggregateRating {
 			this.ratingCount = ratingCount;
 	}
 
+	@JsonIgnore
 	public void setRatingCount(UnsafeSupplier<Number, Throwable> ratingCountUnsafeSupplier) {
 			try {
 				ratingCount = ratingCountUnsafeSupplier.get();
@@ -103,6 +107,7 @@ public class AggregateRatingImpl implements AggregateRating {
 			this.ratingValue = ratingValue;
 	}
 
+	@JsonIgnore
 	public void setRatingValue(UnsafeSupplier<Number, Throwable> ratingValueUnsafeSupplier) {
 			try {
 				ratingValue = ratingValueUnsafeSupplier.get();
@@ -123,6 +128,7 @@ public class AggregateRatingImpl implements AggregateRating {
 			this.worstRating = worstRating;
 	}
 
+	@JsonIgnore
 	public void setWorstRating(UnsafeSupplier<Number, Throwable> worstRatingUnsafeSupplier) {
 			try {
 				worstRating = worstRatingUnsafeSupplier.get();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/CommentImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/CommentImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.web.experience.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.web.experience.dto.v1_0.Comment;
@@ -44,6 +45,7 @@ public class CommentImpl implements Comment {
 			this.comments = comments;
 	}
 
+	@JsonIgnore
 	public void setComments(UnsafeSupplier<Comment[], Throwable> commentsUnsafeSupplier) {
 			try {
 				comments = commentsUnsafeSupplier.get();
@@ -64,6 +66,7 @@ public class CommentImpl implements Comment {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -84,6 +87,7 @@ public class CommentImpl implements Comment {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -104,6 +108,7 @@ public class CommentImpl implements Comment {
 			this.text = text;
 	}
 
+	@JsonIgnore
 	public void setText(UnsafeSupplier<String, Throwable> textUnsafeSupplier) {
 			try {
 				text = textUnsafeSupplier.get();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/ContentDocumentImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/ContentDocumentImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.web.experience.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.web.experience.dto.v1_0.ContentDocument;
@@ -46,6 +47,7 @@ public class ContentDocumentImpl implements ContentDocument {
 			this.contentUrl = contentUrl;
 	}
 
+	@JsonIgnore
 	public void setContentUrl(UnsafeSupplier<String, Throwable> contentUrlUnsafeSupplier) {
 			try {
 				contentUrl = contentUrlUnsafeSupplier.get();
@@ -66,6 +68,7 @@ public class ContentDocumentImpl implements ContentDocument {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -86,6 +89,7 @@ public class ContentDocumentImpl implements ContentDocument {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -106,6 +110,7 @@ public class ContentDocumentImpl implements ContentDocument {
 			this.dateModified = dateModified;
 	}
 
+	@JsonIgnore
 	public void setDateModified(UnsafeSupplier<Date, Throwable> dateModifiedUnsafeSupplier) {
 			try {
 				dateModified = dateModifiedUnsafeSupplier.get();
@@ -126,6 +131,7 @@ public class ContentDocumentImpl implements ContentDocument {
 			this.encodingFormat = encodingFormat;
 	}
 
+	@JsonIgnore
 	public void setEncodingFormat(UnsafeSupplier<String, Throwable> encodingFormatUnsafeSupplier) {
 			try {
 				encodingFormat = encodingFormatUnsafeSupplier.get();
@@ -146,6 +152,7 @@ public class ContentDocumentImpl implements ContentDocument {
 			this.fileExtension = fileExtension;
 	}
 
+	@JsonIgnore
 	public void setFileExtension(UnsafeSupplier<String, Throwable> fileExtensionUnsafeSupplier) {
 			try {
 				fileExtension = fileExtensionUnsafeSupplier.get();
@@ -166,6 +173,7 @@ public class ContentDocumentImpl implements ContentDocument {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -186,6 +194,7 @@ public class ContentDocumentImpl implements ContentDocument {
 			this.sizeInBytes = sizeInBytes;
 	}
 
+	@JsonIgnore
 	public void setSizeInBytes(UnsafeSupplier<Number, Throwable> sizeInBytesUnsafeSupplier) {
 			try {
 				sizeInBytes = sizeInBytesUnsafeSupplier.get();
@@ -206,6 +215,7 @@ public class ContentDocumentImpl implements ContentDocument {
 			this.title = title;
 	}
 
+	@JsonIgnore
 	public void setTitle(UnsafeSupplier<String, Throwable> titleUnsafeSupplier) {
 			try {
 				title = titleUnsafeSupplier.get();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/ContentStructureImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/ContentStructureImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.web.experience.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.web.experience.dto.v1_0.ContentStructure;
@@ -47,6 +48,7 @@ public class ContentStructureImpl implements ContentStructure {
 			this.availableLanguages = availableLanguages;
 	}
 
+	@JsonIgnore
 	public void setAvailableLanguages(UnsafeSupplier<String[], Throwable> availableLanguagesUnsafeSupplier) {
 			try {
 				availableLanguages = availableLanguagesUnsafeSupplier.get();
@@ -67,6 +69,7 @@ public class ContentStructureImpl implements ContentStructure {
 			this.contentSpace = contentSpace;
 	}
 
+	@JsonIgnore
 	public void setContentSpace(UnsafeSupplier<Long, Throwable> contentSpaceUnsafeSupplier) {
 			try {
 				contentSpace = contentSpaceUnsafeSupplier.get();
@@ -87,6 +90,7 @@ public class ContentStructureImpl implements ContentStructure {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -107,6 +111,7 @@ public class ContentStructureImpl implements ContentStructure {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -127,6 +132,7 @@ public class ContentStructureImpl implements ContentStructure {
 			this.dateModified = dateModified;
 	}
 
+	@JsonIgnore
 	public void setDateModified(UnsafeSupplier<Date, Throwable> dateModifiedUnsafeSupplier) {
 			try {
 				dateModified = dateModifiedUnsafeSupplier.get();
@@ -147,6 +153,7 @@ public class ContentStructureImpl implements ContentStructure {
 			this.description = description;
 	}
 
+	@JsonIgnore
 	public void setDescription(UnsafeSupplier<String, Throwable> descriptionUnsafeSupplier) {
 			try {
 				description = descriptionUnsafeSupplier.get();
@@ -167,6 +174,7 @@ public class ContentStructureImpl implements ContentStructure {
 			this.fields = fields;
 	}
 
+	@JsonIgnore
 	public void setFields(UnsafeSupplier<Fields[], Throwable> fieldsUnsafeSupplier) {
 			try {
 				fields = fieldsUnsafeSupplier.get();
@@ -187,6 +195,7 @@ public class ContentStructureImpl implements ContentStructure {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -207,6 +216,7 @@ public class ContentStructureImpl implements ContentStructure {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/CreatorImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/CreatorImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.web.experience.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.web.experience.dto.v1_0.Creator;
@@ -43,6 +44,7 @@ public class CreatorImpl implements Creator {
 			this.additionalName = additionalName;
 	}
 
+	@JsonIgnore
 	public void setAdditionalName(UnsafeSupplier<String, Throwable> additionalNameUnsafeSupplier) {
 			try {
 				additionalName = additionalNameUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class CreatorImpl implements Creator {
 			this.familyName = familyName;
 	}
 
+	@JsonIgnore
 	public void setFamilyName(UnsafeSupplier<String, Throwable> familyNameUnsafeSupplier) {
 			try {
 				familyName = familyNameUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class CreatorImpl implements Creator {
 			this.givenName = givenName;
 	}
 
+	@JsonIgnore
 	public void setGivenName(UnsafeSupplier<String, Throwable> givenNameUnsafeSupplier) {
 			try {
 				givenName = givenNameUnsafeSupplier.get();
@@ -103,6 +107,7 @@ public class CreatorImpl implements Creator {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -123,6 +128,7 @@ public class CreatorImpl implements Creator {
 			this.image = image;
 	}
 
+	@JsonIgnore
 	public void setImage(UnsafeSupplier<String, Throwable> imageUnsafeSupplier) {
 			try {
 				image = imageUnsafeSupplier.get();
@@ -143,6 +149,7 @@ public class CreatorImpl implements Creator {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -163,6 +170,7 @@ public class CreatorImpl implements Creator {
 			this.profileURL = profileURL;
 	}
 
+	@JsonIgnore
 	public void setProfileURL(UnsafeSupplier<String, Throwable> profileURLUnsafeSupplier) {
 			try {
 				profileURL = profileURLUnsafeSupplier.get();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/FieldsImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/FieldsImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.web.experience.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.web.experience.dto.v1_0.Fields;
@@ -44,6 +45,7 @@ public class FieldsImpl implements Fields {
 			this.dataType = dataType;
 	}
 
+	@JsonIgnore
 	public void setDataType(UnsafeSupplier<String, Throwable> dataTypeUnsafeSupplier) {
 			try {
 				dataType = dataTypeUnsafeSupplier.get();
@@ -64,6 +66,7 @@ public class FieldsImpl implements Fields {
 			this.label = label;
 	}
 
+	@JsonIgnore
 	public void setLabel(UnsafeSupplier<String, Throwable> labelUnsafeSupplier) {
 			try {
 				label = labelUnsafeSupplier.get();
@@ -84,6 +87,7 @@ public class FieldsImpl implements Fields {
 			this.localizable = localizable;
 	}
 
+	@JsonIgnore
 	public void setLocalizable(UnsafeSupplier<Boolean, Throwable> localizableUnsafeSupplier) {
 			try {
 				localizable = localizableUnsafeSupplier.get();
@@ -104,6 +108,7 @@ public class FieldsImpl implements Fields {
 			this.multiple = multiple;
 	}
 
+	@JsonIgnore
 	public void setMultiple(UnsafeSupplier<Boolean, Throwable> multipleUnsafeSupplier) {
 			try {
 				multiple = multipleUnsafeSupplier.get();
@@ -124,6 +129,7 @@ public class FieldsImpl implements Fields {
 			this.inputControl = inputControl;
 	}
 
+	@JsonIgnore
 	public void setInputControl(UnsafeSupplier<String, Throwable> inputControlUnsafeSupplier) {
 			try {
 				inputControl = inputControlUnsafeSupplier.get();
@@ -144,6 +150,7 @@ public class FieldsImpl implements Fields {
 			this.predefinedValue = predefinedValue;
 	}
 
+	@JsonIgnore
 	public void setPredefinedValue(UnsafeSupplier<String, Throwable> predefinedValueUnsafeSupplier) {
 			try {
 				predefinedValue = predefinedValueUnsafeSupplier.get();
@@ -164,6 +171,7 @@ public class FieldsImpl implements Fields {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -184,6 +192,7 @@ public class FieldsImpl implements Fields {
 			this.repeatable = repeatable;
 	}
 
+	@JsonIgnore
 	public void setRepeatable(UnsafeSupplier<Boolean, Throwable> repeatableUnsafeSupplier) {
 			try {
 				repeatable = repeatableUnsafeSupplier.get();
@@ -204,6 +213,7 @@ public class FieldsImpl implements Fields {
 			this.required = required;
 	}
 
+	@JsonIgnore
 	public void setRequired(UnsafeSupplier<Boolean, Throwable> requiredUnsafeSupplier) {
 			try {
 				required = requiredUnsafeSupplier.get();
@@ -224,6 +234,7 @@ public class FieldsImpl implements Fields {
 			this.showLabel = showLabel;
 	}
 
+	@JsonIgnore
 	public void setShowLabel(UnsafeSupplier<Boolean, Throwable> showLabelUnsafeSupplier) {
 			try {
 				showLabel = showLabelUnsafeSupplier.get();
@@ -244,6 +255,7 @@ public class FieldsImpl implements Fields {
 			this.options = options;
 	}
 
+	@JsonIgnore
 	public void setOptions(UnsafeSupplier<Options[], Throwable> optionsUnsafeSupplier) {
 			try {
 				options = optionsUnsafeSupplier.get();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/OptionsImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/OptionsImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.web.experience.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.web.experience.dto.v1_0.Options;
@@ -43,6 +44,7 @@ public class OptionsImpl implements Options {
 			this.label = label;
 	}
 
+	@JsonIgnore
 	public void setLabel(UnsafeSupplier<String, Throwable> labelUnsafeSupplier) {
 			try {
 				label = labelUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class OptionsImpl implements Options {
 			this.value = value;
 	}
 
+	@JsonIgnore
 	public void setValue(UnsafeSupplier<String, Throwable> valueUnsafeSupplier) {
 			try {
 				value = valueUnsafeSupplier.get();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/RenderedContentsByTemplateImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/RenderedContentsByTemplateImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.web.experience.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.web.experience.dto.v1_0.RenderedContentsByTemplate;
@@ -43,6 +44,7 @@ public class RenderedContentsByTemplateImpl implements RenderedContentsByTemplat
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class RenderedContentsByTemplateImpl implements RenderedContentsByTemplat
 			this.renderedContent = renderedContent;
 	}
 
+	@JsonIgnore
 	public void setRenderedContent(UnsafeSupplier<String, Throwable> renderedContentUnsafeSupplier) {
 			try {
 				renderedContent = renderedContentUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class RenderedContentsByTemplateImpl implements RenderedContentsByTemplat
 			this.template = template;
 	}
 
+	@JsonIgnore
 	public void setTemplate(UnsafeSupplier<String, Throwable> templateUnsafeSupplier) {
 			try {
 				template = templateUnsafeSupplier.get();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/StructuredContentImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/StructuredContentImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.web.experience.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.web.experience.dto.v1_0.AggregateRating;
@@ -51,6 +52,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.aggregateRating = aggregateRating;
 	}
 
+	@JsonIgnore
 	public void setAggregateRating(UnsafeSupplier<AggregateRating, Throwable> aggregateRatingUnsafeSupplier) {
 			try {
 				aggregateRating = aggregateRatingUnsafeSupplier.get();
@@ -71,6 +73,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.availableLanguages = availableLanguages;
 	}
 
+	@JsonIgnore
 	public void setAvailableLanguages(UnsafeSupplier<String[], Throwable> availableLanguagesUnsafeSupplier) {
 			try {
 				availableLanguages = availableLanguagesUnsafeSupplier.get();
@@ -91,6 +94,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.category = category;
 	}
 
+	@JsonIgnore
 	public void setCategory(UnsafeSupplier<Long[], Throwable> categoryUnsafeSupplier) {
 			try {
 				category = categoryUnsafeSupplier.get();
@@ -111,6 +115,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.comment = comment;
 	}
 
+	@JsonIgnore
 	public void setComment(UnsafeSupplier<Comment[], Throwable> commentUnsafeSupplier) {
 			try {
 				comment = commentUnsafeSupplier.get();
@@ -131,6 +136,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.contentSpace = contentSpace;
 	}
 
+	@JsonIgnore
 	public void setContentSpace(UnsafeSupplier<Long, Throwable> contentSpaceUnsafeSupplier) {
 			try {
 				contentSpace = contentSpaceUnsafeSupplier.get();
@@ -151,6 +157,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.contentStructure = contentStructure;
 	}
 
+	@JsonIgnore
 	public void setContentStructure(UnsafeSupplier<ContentStructure, Throwable> contentStructureUnsafeSupplier) {
 			try {
 				contentStructure = contentStructureUnsafeSupplier.get();
@@ -171,6 +178,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.contentStructureId = contentStructureId;
 	}
 
+	@JsonIgnore
 	public void setContentStructureId(UnsafeSupplier<Long, Throwable> contentStructureIdUnsafeSupplier) {
 			try {
 				contentStructureId = contentStructureIdUnsafeSupplier.get();
@@ -191,6 +199,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.creator = creator;
 	}
 
+	@JsonIgnore
 	public void setCreator(UnsafeSupplier<Creator, Throwable> creatorUnsafeSupplier) {
 			try {
 				creator = creatorUnsafeSupplier.get();
@@ -211,6 +220,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -231,6 +241,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.dateModified = dateModified;
 	}
 
+	@JsonIgnore
 	public void setDateModified(UnsafeSupplier<Date, Throwable> dateModifiedUnsafeSupplier) {
 			try {
 				dateModified = dateModifiedUnsafeSupplier.get();
@@ -251,6 +262,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.datePublished = datePublished;
 	}
 
+	@JsonIgnore
 	public void setDatePublished(UnsafeSupplier<Date, Throwable> datePublishedUnsafeSupplier) {
 			try {
 				datePublished = datePublishedUnsafeSupplier.get();
@@ -271,6 +283,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.description = description;
 	}
 
+	@JsonIgnore
 	public void setDescription(UnsafeSupplier<String, Throwable> descriptionUnsafeSupplier) {
 			try {
 				description = descriptionUnsafeSupplier.get();
@@ -291,6 +304,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -311,6 +325,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.keywords = keywords;
 	}
 
+	@JsonIgnore
 	public void setKeywords(UnsafeSupplier<String[], Throwable> keywordsUnsafeSupplier) {
 			try {
 				keywords = keywordsUnsafeSupplier.get();
@@ -331,6 +346,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.lastReviewed = lastReviewed;
 	}
 
+	@JsonIgnore
 	public void setLastReviewed(UnsafeSupplier<Date, Throwable> lastReviewedUnsafeSupplier) {
 			try {
 				lastReviewed = lastReviewedUnsafeSupplier.get();
@@ -351,6 +367,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.renderedContentsByTemplate = renderedContentsByTemplate;
 	}
 
+	@JsonIgnore
 	public void setRenderedContentsByTemplate(UnsafeSupplier<RenderedContentsByTemplate[], Throwable> renderedContentsByTemplateUnsafeSupplier) {
 			try {
 				renderedContentsByTemplate = renderedContentsByTemplateUnsafeSupplier.get();
@@ -371,6 +388,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.title = title;
 	}
 
+	@JsonIgnore
 	public void setTitle(UnsafeSupplier<String, Throwable> titleUnsafeSupplier) {
 			try {
 				title = titleUnsafeSupplier.get();
@@ -391,6 +409,7 @@ public class StructuredContentImpl implements StructuredContent {
 			this.values = values;
 	}
 
+	@JsonIgnore
 	public void setValues(UnsafeSupplier<Values[], Throwable> valuesUnsafeSupplier) {
 			try {
 				values = valuesUnsafeSupplier.get();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/ValuesImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/dto/v1_0/ValuesImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.web.experience.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.web.experience.dto.v1_0.Values;
@@ -43,6 +44,7 @@ public class ValuesImpl implements Values {
 			this.dataType = dataType;
 	}
 
+	@JsonIgnore
 	public void setDataType(UnsafeSupplier<String, Throwable> dataTypeUnsafeSupplier) {
 			try {
 				dataType = dataTypeUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class ValuesImpl implements Values {
 			this.filterAndSortIdentifier = filterAndSortIdentifier;
 	}
 
+	@JsonIgnore
 	public void setFilterAndSortIdentifier(UnsafeSupplier<String, Throwable> filterAndSortIdentifierUnsafeSupplier) {
 			try {
 				filterAndSortIdentifier = filterAndSortIdentifierUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class ValuesImpl implements Values {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -103,6 +107,7 @@ public class ValuesImpl implements Values {
 			this.inputControl = inputControl;
 	}
 
+	@JsonIgnore
 	public void setInputControl(UnsafeSupplier<String, Throwable> inputControlUnsafeSupplier) {
 			try {
 				inputControl = inputControlUnsafeSupplier.get();
@@ -123,6 +128,7 @@ public class ValuesImpl implements Values {
 			this.label = label;
 	}
 
+	@JsonIgnore
 	public void setLabel(UnsafeSupplier<String, Throwable> labelUnsafeSupplier) {
 			try {
 				label = labelUnsafeSupplier.get();
@@ -143,6 +149,7 @@ public class ValuesImpl implements Values {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -163,6 +170,7 @@ public class ValuesImpl implements Values {
 			this.value = value;
 	}
 
+	@JsonIgnore
 	public void setValue(UnsafeSupplier<Object, Throwable> valueUnsafeSupplier) {
 			try {
 				value = valueUnsafeSupplier.get();

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/jaxrs/message/body/v1_0/JSONMessageBodyReader.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/jaxrs/message/body/v1_0/JSONMessageBodyReader.java
@@ -14,7 +14,10 @@
 
 package com.liferay.headless.web.experience.internal.jaxrs.message.body.v1_0;
 
+import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
 import com.liferay.headless.web.experience.dto.v1_0.AggregateRating;
@@ -118,42 +121,33 @@ public class JSONMessageBodyReader implements MessageBodyReader<Object> {
 			InputStream inputStream)
 		throws IOException, WebApplicationException {
 
-			if (clazz.equals(AggregateRating.class)) {
-				return _objectMapper.readValue(inputStream, AggregateRatingImpl.class);
-	}
-			if (clazz.equals(Comment.class)) {
-				return _objectMapper.readValue(inputStream, CommentImpl.class);
-	}
-			if (clazz.equals(ContentDocument.class)) {
-				return _objectMapper.readValue(inputStream, ContentDocumentImpl.class);
-	}
-			if (clazz.equals(ContentStructure.class)) {
-				return _objectMapper.readValue(inputStream, ContentStructureImpl.class);
-	}
-			if (clazz.equals(Creator.class)) {
-				return _objectMapper.readValue(inputStream, CreatorImpl.class);
-	}
-			if (clazz.equals(Fields.class)) {
-				return _objectMapper.readValue(inputStream, FieldsImpl.class);
-	}
-			if (clazz.equals(Options.class)) {
-				return _objectMapper.readValue(inputStream, OptionsImpl.class);
-	}
-			if (clazz.equals(RenderedContentsByTemplate.class)) {
-				return _objectMapper.readValue(inputStream, RenderedContentsByTemplateImpl.class);
-	}
-			if (clazz.equals(StructuredContent.class)) {
-				return _objectMapper.readValue(inputStream, StructuredContentImpl.class);
-	}
-			if (clazz.equals(Values.class)) {
-				return _objectMapper.readValue(inputStream, ValuesImpl.class);
-	}
-
-		return null;
+		return _objectMapper.readValue(inputStream, clazz);
 	}
 
 	private static final ObjectMapper _objectMapper = new ObjectMapper() {
 		{
+			SimpleModule module =
+				new SimpleModule("Liferay.Headless.Web.Experience",
+					Version.unknownVersion());
+
+			SimpleAbstractTypeResolver resolver =
+				new SimpleAbstractTypeResolver();
+
+			resolver.addMapping(AggregateRating.class, AggregateRatingImpl.class);
+			resolver.addMapping(Comment.class, CommentImpl.class);
+			resolver.addMapping(ContentDocument.class, ContentDocumentImpl.class);
+			resolver.addMapping(ContentStructure.class, ContentStructureImpl.class);
+			resolver.addMapping(Creator.class, CreatorImpl.class);
+			resolver.addMapping(Fields.class, FieldsImpl.class);
+			resolver.addMapping(Options.class, OptionsImpl.class);
+			resolver.addMapping(RenderedContentsByTemplate.class, RenderedContentsByTemplateImpl.class);
+			resolver.addMapping(StructuredContent.class, StructuredContentImpl.class);
+			resolver.addMapping(Values.class, ValuesImpl.class);
+
+			module.setAbstractTypes(resolver);
+
+			registerModule(module);
+
 			setDateFormat(new ISO8601DateFormat());
 	}
 	};

--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/dto/v1_0/ObjectReviewedImpl.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/dto/v1_0/ObjectReviewedImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.workflow.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.workflow.dto.v1_0.ObjectReviewed;
@@ -43,6 +44,7 @@ public class ObjectReviewedImpl implements ObjectReviewed {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -63,6 +65,7 @@ public class ObjectReviewedImpl implements ObjectReviewed {
 			this.identifier = identifier;
 	}
 
+	@JsonIgnore
 	public void setIdentifier(UnsafeSupplier<String, Throwable> identifierUnsafeSupplier) {
 			try {
 				identifier = identifierUnsafeSupplier.get();
@@ -83,6 +86,7 @@ public class ObjectReviewedImpl implements ObjectReviewed {
 			this.resourceType = resourceType;
 	}
 
+	@JsonIgnore
 	public void setResourceType(UnsafeSupplier<String, Throwable> resourceTypeUnsafeSupplier) {
 			try {
 				resourceType = resourceTypeUnsafeSupplier.get();

--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/dto/v1_0/WorkflowLogImpl.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/dto/v1_0/WorkflowLogImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.workflow.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.workflow.dto.v1_0.WorkflowLog;
@@ -46,6 +47,7 @@ public class WorkflowLogImpl implements WorkflowLog {
 			this.auditPerson = auditPerson;
 	}
 
+	@JsonIgnore
 	public void setAuditPerson(UnsafeSupplier<String, Throwable> auditPersonUnsafeSupplier) {
 			try {
 				auditPerson = auditPersonUnsafeSupplier.get();
@@ -66,6 +68,7 @@ public class WorkflowLogImpl implements WorkflowLog {
 			this.commentLog = commentLog;
 	}
 
+	@JsonIgnore
 	public void setCommentLog(UnsafeSupplier<String, Throwable> commentLogUnsafeSupplier) {
 			try {
 				commentLog = commentLogUnsafeSupplier.get();
@@ -86,6 +89,7 @@ public class WorkflowLogImpl implements WorkflowLog {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -106,6 +110,7 @@ public class WorkflowLogImpl implements WorkflowLog {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -126,6 +131,7 @@ public class WorkflowLogImpl implements WorkflowLog {
 			this.person = person;
 	}
 
+	@JsonIgnore
 	public void setPerson(UnsafeSupplier<String, Throwable> personUnsafeSupplier) {
 			try {
 				person = personUnsafeSupplier.get();
@@ -146,6 +152,7 @@ public class WorkflowLogImpl implements WorkflowLog {
 			this.previousPerson = previousPerson;
 	}
 
+	@JsonIgnore
 	public void setPreviousPerson(UnsafeSupplier<String, Throwable> previousPersonUnsafeSupplier) {
 			try {
 				previousPerson = previousPersonUnsafeSupplier.get();
@@ -166,6 +173,7 @@ public class WorkflowLogImpl implements WorkflowLog {
 			this.previousState = previousState;
 	}
 
+	@JsonIgnore
 	public void setPreviousState(UnsafeSupplier<String, Throwable> previousStateUnsafeSupplier) {
 			try {
 				previousState = previousStateUnsafeSupplier.get();
@@ -186,6 +194,7 @@ public class WorkflowLogImpl implements WorkflowLog {
 			this.state = state;
 	}
 
+	@JsonIgnore
 	public void setState(UnsafeSupplier<String, Throwable> stateUnsafeSupplier) {
 			try {
 				state = stateUnsafeSupplier.get();
@@ -206,6 +215,7 @@ public class WorkflowLogImpl implements WorkflowLog {
 			this.task = task;
 	}
 
+	@JsonIgnore
 	public void setTask(UnsafeSupplier<WorkflowTask, Throwable> taskUnsafeSupplier) {
 			try {
 				task = taskUnsafeSupplier.get();
@@ -226,6 +236,7 @@ public class WorkflowLogImpl implements WorkflowLog {
 			this.taskId = taskId;
 	}
 
+	@JsonIgnore
 	public void setTaskId(UnsafeSupplier<Long, Throwable> taskIdUnsafeSupplier) {
 			try {
 				taskId = taskIdUnsafeSupplier.get();
@@ -246,6 +257,7 @@ public class WorkflowLogImpl implements WorkflowLog {
 			this.type = type;
 	}
 
+	@JsonIgnore
 	public void setType(UnsafeSupplier<String, Throwable> typeUnsafeSupplier) {
 			try {
 				type = typeUnsafeSupplier.get();

--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/dto/v1_0/WorkflowTaskImpl.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/dto/v1_0/WorkflowTaskImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.workflow.internal.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.headless.workflow.dto.v1_0.ObjectReviewed;
@@ -47,6 +48,7 @@ public class WorkflowTaskImpl implements WorkflowTask {
 			this.completed = completed;
 	}
 
+	@JsonIgnore
 	public void setCompleted(UnsafeSupplier<Boolean, Throwable> completedUnsafeSupplier) {
 			try {
 				completed = completedUnsafeSupplier.get();
@@ -67,6 +69,7 @@ public class WorkflowTaskImpl implements WorkflowTask {
 			this.dateCompleted = dateCompleted;
 	}
 
+	@JsonIgnore
 	public void setDateCompleted(UnsafeSupplier<Date, Throwable> dateCompletedUnsafeSupplier) {
 			try {
 				dateCompleted = dateCompletedUnsafeSupplier.get();
@@ -87,6 +90,7 @@ public class WorkflowTaskImpl implements WorkflowTask {
 			this.dateCreated = dateCreated;
 	}
 
+	@JsonIgnore
 	public void setDateCreated(UnsafeSupplier<Date, Throwable> dateCreatedUnsafeSupplier) {
 			try {
 				dateCreated = dateCreatedUnsafeSupplier.get();
@@ -107,6 +111,7 @@ public class WorkflowTaskImpl implements WorkflowTask {
 			this.definitionName = definitionName;
 	}
 
+	@JsonIgnore
 	public void setDefinitionName(UnsafeSupplier<String, Throwable> definitionNameUnsafeSupplier) {
 			try {
 				definitionName = definitionNameUnsafeSupplier.get();
@@ -127,6 +132,7 @@ public class WorkflowTaskImpl implements WorkflowTask {
 			this.description = description;
 	}
 
+	@JsonIgnore
 	public void setDescription(UnsafeSupplier<String, Throwable> descriptionUnsafeSupplier) {
 			try {
 				description = descriptionUnsafeSupplier.get();
@@ -147,6 +153,7 @@ public class WorkflowTaskImpl implements WorkflowTask {
 			this.dueDate = dueDate;
 	}
 
+	@JsonIgnore
 	public void setDueDate(UnsafeSupplier<Date, Throwable> dueDateUnsafeSupplier) {
 			try {
 				dueDate = dueDateUnsafeSupplier.get();
@@ -167,6 +174,7 @@ public class WorkflowTaskImpl implements WorkflowTask {
 			this.id = id;
 	}
 
+	@JsonIgnore
 	public void setId(UnsafeSupplier<Long, Throwable> idUnsafeSupplier) {
 			try {
 				id = idUnsafeSupplier.get();
@@ -187,6 +195,7 @@ public class WorkflowTaskImpl implements WorkflowTask {
 			this.logs = logs;
 	}
 
+	@JsonIgnore
 	public void setLogs(UnsafeSupplier<WorkflowLog[], Throwable> logsUnsafeSupplier) {
 			try {
 				logs = logsUnsafeSupplier.get();
@@ -207,6 +216,7 @@ public class WorkflowTaskImpl implements WorkflowTask {
 			this.logsIds = logsIds;
 	}
 
+	@JsonIgnore
 	public void setLogsIds(UnsafeSupplier<Long[], Throwable> logsIdsUnsafeSupplier) {
 			try {
 				logsIds = logsIdsUnsafeSupplier.get();
@@ -227,6 +237,7 @@ public class WorkflowTaskImpl implements WorkflowTask {
 			this.name = name;
 	}
 
+	@JsonIgnore
 	public void setName(UnsafeSupplier<String, Throwable> nameUnsafeSupplier) {
 			try {
 				name = nameUnsafeSupplier.get();
@@ -247,6 +258,7 @@ public class WorkflowTaskImpl implements WorkflowTask {
 			this.objectReviewed = objectReviewed;
 	}
 
+	@JsonIgnore
 	public void setObjectReviewed(UnsafeSupplier<ObjectReviewed, Throwable> objectReviewedUnsafeSupplier) {
 			try {
 				objectReviewed = objectReviewedUnsafeSupplier.get();
@@ -267,6 +279,7 @@ public class WorkflowTaskImpl implements WorkflowTask {
 			this.transitions = transitions;
 	}
 
+	@JsonIgnore
 	public void setTransitions(UnsafeSupplier<String[], Throwable> transitionsUnsafeSupplier) {
 			try {
 				transitions = transitionsUnsafeSupplier.get();

--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/jaxrs/message/body/v1_0/JSONMessageBodyReader.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/jaxrs/message/body/v1_0/JSONMessageBodyReader.java
@@ -14,7 +14,10 @@
 
 package com.liferay.headless.workflow.internal.jaxrs.message.body.v1_0;
 
+import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
 import com.liferay.headless.workflow.dto.v1_0.ObjectReviewed;
@@ -83,21 +86,26 @@ public class JSONMessageBodyReader implements MessageBodyReader<Object> {
 			InputStream inputStream)
 		throws IOException, WebApplicationException {
 
-			if (clazz.equals(ObjectReviewed.class)) {
-				return _objectMapper.readValue(inputStream, ObjectReviewedImpl.class);
-	}
-			if (clazz.equals(WorkflowLog.class)) {
-				return _objectMapper.readValue(inputStream, WorkflowLogImpl.class);
-	}
-			if (clazz.equals(WorkflowTask.class)) {
-				return _objectMapper.readValue(inputStream, WorkflowTaskImpl.class);
-	}
-
-		return null;
+		return _objectMapper.readValue(inputStream, clazz);
 	}
 
 	private static final ObjectMapper _objectMapper = new ObjectMapper() {
 		{
+			SimpleModule module =
+				new SimpleModule("Liferay.Headless.Workflow",
+					Version.unknownVersion());
+
+			SimpleAbstractTypeResolver resolver =
+				new SimpleAbstractTypeResolver();
+
+			resolver.addMapping(ObjectReviewed.class, ObjectReviewedImpl.class);
+			resolver.addMapping(WorkflowLog.class, WorkflowLogImpl.class);
+			resolver.addMapping(WorkflowTask.class, WorkflowTaskImpl.class);
+
+			module.setAbstractTypes(resolver);
+
+			registerModule(module);
+
 			setDateFormat(new ISO8601DateFormat());
 	}
 	};

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto_impl.ftl
@@ -6,6 +6,7 @@ package ${configYAML.apiPackagePath}.internal.dto.${versionDirName};
 	</#list>
 </#compress>
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.petra.function.UnsafeSupplier;
@@ -37,6 +38,7 @@ public class ${schemaName}Impl implements ${schemaName} {
 			this.${javaParameter.parameterName} = ${javaParameter.parameterName};
 		}
 
+		@JsonIgnore
 		public void set${javaParameter.parameterName?cap_first}(UnsafeSupplier<${javaParameter.parameterType}, Throwable> ${javaParameter.parameterName}UnsafeSupplier) {
 			try {
 				${javaParameter.parameterName} = ${javaParameter.parameterName}UnsafeSupplier.get();

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/json_message_body_reader.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/json_message_body_reader.ftl
@@ -7,7 +7,10 @@ package ${configYAML.apiPackagePath}.internal.jaxrs.message.body.${versionDirNam
 	</#list>
 </#compress>
 
+import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
 import java.io.IOException;
@@ -65,17 +68,26 @@ public class JSONMessageBodyReader implements MessageBodyReader<Object> {
 			InputStream inputStream)
 		throws IOException, WebApplicationException {
 
-		<#list allSchemas?keys as schemaName>
-			if (clazz.equals(${schemaName}.class)) {
-				return _objectMapper.readValue(inputStream, ${schemaName}Impl.class);
-			}
-		</#list>
-
-		return null;
+		return _objectMapper.readValue(inputStream, clazz);
 	}
 
 	private static final ObjectMapper _objectMapper = new ObjectMapper() {
 		{
+			SimpleModule module =
+				new SimpleModule("${configYAML.application.name}",
+					Version.unknownVersion());
+
+			SimpleAbstractTypeResolver resolver =
+				new SimpleAbstractTypeResolver();
+
+			<#list allSchemas?keys as schemaName>
+			resolver.addMapping(${schemaName}.class, ${schemaName}Impl.class);
+			</#list>
+
+			module.setAbstractTypes(resolver);
+
+			registerModule(module);
+
 			setDateFormat(new ISO8601DateFormat());
 		}
 	};


### PR DESCRIPTION
Hi Brian!

Right now we are creating 2 setters per json property and that is preventing POST/PUT calls, jackson can't serialize the json request, can't decide between 2 ambiguous methods.

If we use @JsonIgnore Jackson will ignore those methods but, because of the dto/impl separation, it's going to try to use the interface in the relations (like CategoryImpl having a Vocabulary). To allow serializing VocabularyImpl instead of Vocabulary jackson has to know the relation between the interface and the implementation. Creating the mapping in the ObjectMapper is enough to be able to do it :)

/cc @petershin