### PR TITLE
LPS-90813 Not required

### DIFF
--- a/modules/apps/segments/segments-content-targeting-upgrade-test/bnd.bnd
+++ b/modules/apps/segments/segments-content-targeting-upgrade-test/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: Liferay Segments Content Targeting Upgrade Test
+Bundle-SymbolicName: com.liferay.segments.content.targeting.upgrade.test
+Bundle-Version: 1.0.0
+Import-Package: *
+-includeresource: test-classes/integration

--- a/modules/apps/segments/segments-content-targeting-upgrade-test/build.gradle
+++ b/modules/apps/segments/segments-content-targeting-upgrade-test/build.gradle
@@ -1,0 +1,12 @@
+copyLibs {
+	enabled = true
+}
+
+dependencies {
+	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.0"
+	testIntegrationCompile project(":apps:portal:portal-upgrade-api")
+	testIntegrationCompile project(":apps:segments:segments-api")
+	testIntegrationCompile project(":core:registry-api")
+	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/segments/segments-content-targeting-upgrade-test/src/testIntegration/java/com/liferay/segments/content/targeting/upgrade/test/UpgradeContentTargetingTest.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade-test/src/testIntegration/java/com/liferay/segments/content/targeting/upgrade/test/UpgradeContentTargetingTest.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.segments.upgrade.v_0_0_1.test;
+package com.liferay.segments.content.targeting.upgrade.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.counter.kernel.service.CounterLocalService;
@@ -652,7 +652,8 @@ public class UpgradeContentTargetingTest {
 		Registry registry = RegistryUtil.getRegistry();
 
 		UpgradeStepRegistrator upgradeStepRegistror = registry.getService(
-			"com.liferay.segments.internal.upgrade.SegmentsServiceUpgrade");
+			"com.liferay.segments.content.targeting.upgrade.internal." +
+				"SegmentsContentTargetingUpgrade");
 
 		upgradeStepRegistror.register(
 			new UpgradeStepRegistrator.Registry() {
@@ -740,7 +741,8 @@ public class UpgradeContentTargetingTest {
 	}
 
 	private static final String _CLASS_NAME =
-		"com.liferay.segments.internal.upgrade.v0_0_1.UpgradeContentTargeting";
+		"com.liferay.segments.content.targeting.upgrade.internal.v1_0_0." +
+			"UpgradeContentTargeting";
 
 	private static DB _db;
 

--- a/modules/apps/segments/segments-content-targeting-upgrade/bnd.bnd
+++ b/modules/apps/segments/segments-content-targeting-upgrade/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Segments Content Targeting Upgrade
+Bundle-SymbolicName: com.liferay.segments.content.targeting.upgrade
+Bundle-Version: 1.0.0

--- a/modules/apps/segments/segments-content-targeting-upgrade/build.gradle
+++ b/modules/apps/segments/segments-content-targeting-upgrade/build.gradle
@@ -1,0 +1,21 @@
+dependencies {
+	compileInclude group: "org.apache.commons", name: "commons-lang3", version: "3.8"
+
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
+	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
+	compileOnly group: "org.apache.cxf", name: "cxf-rt-rs-client", version: "3.2.5"
+	compileOnly group: "org.apache.cxf", name: "cxf-rt-rs-extension-providers", version: "3.2.5"
+	compileOnly group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	compileOnly group: "org.osgi", name: "org.osgi.enterprise", version: "5.0.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:portal:portal-upgrade-api")
+	compileOnly project(":apps:segments:segments-api")
+	compileOnly project(":core:osgi-service-tracker-collections")
+	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":core:registry-api")
+}

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/SegmentsContentTargetingUpgrade.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/SegmentsContentTargetingUpgrade.java
@@ -14,10 +14,10 @@
 
 package com.liferay.segments.content.targeting.upgrade.internal;
 
-import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.UpgradeContentTargeting;
 import com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util.RuleConverterRegistry;
+import com.liferay.segments.service.SegmentsEntryLocalService;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -38,13 +38,13 @@ public class SegmentsContentTargetingUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"0.0.0", "1.0.0",
 			new UpgradeContentTargeting(
-				_counterLocalService, _ruleConverterRegistry));
+				_ruleConverterRegistry, _segmentsEntryLocalService));
 	}
 
 	@Reference
-	private CounterLocalService _counterLocalService;
+	private RuleConverterRegistry _ruleConverterRegistry;
 
 	@Reference
-	private RuleConverterRegistry _ruleConverterRegistry;
+	private SegmentsEntryLocalService _segmentsEntryLocalService;
 
 }

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/SegmentsContentTargetingUpgrade.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/SegmentsContentTargetingUpgrade.java
@@ -36,7 +36,7 @@ public class SegmentsContentTargetingUpgrade implements UpgradeStepRegistrator {
 	@Override
 	public void register(Registry registry) {
 		registry.register(
-			"0.0.1", "1.0.0",
+			"0.0.0", "1.0.0",
 			new UpgradeContentTargeting(
 				_counterLocalService, _ruleConverterRegistry));
 	}

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/SegmentsContentTargetingUpgrade.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/SegmentsContentTargetingUpgrade.java
@@ -12,12 +12,12 @@
  * details.
  */
 
-package com.liferay.segments.internal.upgrade;
+package com.liferay.segments.content.targeting.upgrade.internal;
 
 import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-import com.liferay.segments.internal.upgrade.v0_0_1.UpgradeContentTargeting;
-import com.liferay.segments.internal.upgrade.v0_0_1.util.RuleConverterRegistry;
+import com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.UpgradeContentTargeting;
+import com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util.RuleConverterRegistry;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -27,9 +27,11 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	immediate = true,
-	service = {SegmentsServiceUpgrade.class, UpgradeStepRegistrator.class}
+	service = {
+		SegmentsContentTargetingUpgrade.class, UpgradeStepRegistrator.class
+	}
 )
-public class SegmentsServiceUpgrade implements UpgradeStepRegistrator {
+public class SegmentsContentTargetingUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/UpgradeContentTargeting.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/UpgradeContentTargeting.java
@@ -110,12 +110,22 @@ public class UpgradeContentTargeting extends UpgradeProcess {
 			try (ResultSet rs = ps.executeQuery()) {
 				while (rs.next()) {
 					String ruleKey = rs.getString("ruleKey");
-					String typeSettings = rs.getString("typeSettings");
 
 					RuleConverter ruleConverter =
 						_ruleConverterRegistry.getRuleConverter(ruleKey);
 
+					if (ruleConverter == null) {
+						if (_log.isWarnEnabled()) {
+							_log.warn(
+								"Unable to perform automated update of rule " +
+									ruleKey);
+						}
+
+						continue;
+					}
+
 					long companyId = rs.getLong("companyId");
+					String typeSettings = rs.getString("typeSettings");
 
 					ruleConverter.convert(companyId, criteria, typeSettings);
 				}

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/UpgradeContentTargeting.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/UpgradeContentTargeting.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.segments.internal.upgrade.v0_0_1;
+package com.liferay.segments.content.targeting.upgrade.internal.v1_0_0;
 
 import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.petra.string.StringBundler;
@@ -22,10 +22,10 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util.RuleConverter;
+import com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util.RuleConverterRegistry;
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.CriteriaSerializer;
-import com.liferay.segments.internal.upgrade.v0_0_1.util.RuleConverter;
-import com.liferay.segments.internal.upgrade.v0_0_1.util.RuleConverterRegistry;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/BrowseRuleConverter.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/BrowseRuleConverter.java
@@ -12,11 +12,10 @@
  * details.
  */
 
-package com.liferay.segments.internal.upgrade.v0_0_1.util;
+package com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util;
 
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
-import com.liferay.segments.internal.criteria.contributor.ContextSegmentsCriteriaContributor;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -25,23 +24,21 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eduardo García
  */
 @Component(
-	immediate = true, property = "rule.converter.key=LanguageRule",
+	immediate = true, property = "rule.converter.key=BrowserRule",
 	service = RuleConverter.class
 )
-public class LanguageRuleConverter implements RuleConverter {
+public class BrowseRuleConverter implements RuleConverter {
 
 	@Override
 	public void convert(
 		long companyId, Criteria criteria, String typeSettings) {
 
 		_contextSegmentsCriteriaContributor.contribute(
-			criteria, "(languageId eq '" + typeSettings + "')",
+			criteria, "(browser eq '" + typeSettings + "')",
 			Criteria.Conjunction.AND);
 	}
 
-	@Reference(
-		target = "(segments.criteria.contributor.key=" + ContextSegmentsCriteriaContributor.KEY + ")"
-	)
+	@Reference(target = "(segments.criteria.contributor.key=context)")
 	private SegmentsCriteriaContributor _contextSegmentsCriteriaContributor;
 
 }

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/CustomFieldRuleConverter.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/CustomFieldRuleConverter.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.segments.internal.upgrade.v0_0_1.util;
+package com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util;
 
 import com.liferay.expando.kernel.model.ExpandoColumn;
 import com.liferay.expando.kernel.model.ExpandoTable;
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
-import com.liferay.segments.internal.criteria.contributor.UserSegmentsCriteriaContributor;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -101,9 +100,7 @@ public class CustomFieldRuleConverter implements RuleConverter {
 	@Reference
 	private ExpandoTableLocalService _expandoTableLocalService;
 
-	@Reference(
-		target = "(segments.criteria.contributor.key=" + UserSegmentsCriteriaContributor.KEY + ")"
-	)
+	@Reference(target = "(segments.criteria.contributor.key=user)")
 	private SegmentsCriteriaContributor _userSegmentsCriteriaContributor;
 
 }

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/LanguageRuleConverter.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/LanguageRuleConverter.java
@@ -12,11 +12,10 @@
  * details.
  */
 
-package com.liferay.segments.internal.upgrade.v0_0_1.util;
+package com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util;
 
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
-import com.liferay.segments.internal.criteria.contributor.ContextSegmentsCriteriaContributor;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -25,23 +24,21 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eduardo García
  */
 @Component(
-	immediate = true, property = "rule.converter.key=BrowserRule",
+	immediate = true, property = "rule.converter.key=LanguageRule",
 	service = RuleConverter.class
 )
-public class BrowseRuleConverter implements RuleConverter {
+public class LanguageRuleConverter implements RuleConverter {
 
 	@Override
 	public void convert(
 		long companyId, Criteria criteria, String typeSettings) {
 
 		_contextSegmentsCriteriaContributor.contribute(
-			criteria, "(browser eq '" + typeSettings + "')",
+			criteria, "(languageId eq '" + typeSettings + "')",
 			Criteria.Conjunction.AND);
 	}
 
-	@Reference(
-		target = "(segments.criteria.contributor.key=" + ContextSegmentsCriteriaContributor.KEY + ")"
-	)
+	@Reference(target = "(segments.criteria.contributor.key=context)")
 	private SegmentsCriteriaContributor _contextSegmentsCriteriaContributor;
 
 }

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/LastLoginDateRuleConverter.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/LastLoginDateRuleConverter.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.segments.internal.upgrade.v0_0_1.util;
+package com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.util.TimeZoneUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
-import com.liferay.segments.internal.criteria.contributor.ContextSegmentsCriteriaContributor;
 
 import java.text.DateFormat;
 
@@ -130,9 +129,7 @@ public class LastLoginDateRuleConverter implements RuleConverter {
 	private static final Log _log = LogFactoryUtil.getLog(
 		LastLoginDateRuleConverter.class);
 
-	@Reference(
-		target = "(segments.criteria.contributor.key=" + ContextSegmentsCriteriaContributor.KEY + ")"
-	)
+	@Reference(target = "(segments.criteria.contributor.key=context)")
 	private SegmentsCriteriaContributor _contextSegmentsCriteriaContributor;
 
 }

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/OSRuleConverter.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/OSRuleConverter.java
@@ -12,11 +12,10 @@
  * details.
  */
 
-package com.liferay.segments.internal.upgrade.v0_0_1.util;
+package com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util;
 
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
-import com.liferay.segments.internal.criteria.contributor.UserOrganizationSegmentsCriteriaContributor;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -25,24 +24,21 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eduardo García
  */
 @Component(
-	immediate = true, property = "rule.converter.key=OrganizationMemberRule",
+	immediate = true, property = "rule.converter.key=OSRule",
 	service = RuleConverter.class
 )
-public class OrganizationMemberRuleConverter implements RuleConverter {
+public class OSRuleConverter implements RuleConverter {
 
 	@Override
 	public void convert(
 		long companyId, Criteria criteria, String typeSettings) {
 
-		_userOrganizationSegmentsCriteriaContributor.contribute(
-			criteria, "(organizationId eq '" + typeSettings + "')",
+		_contextSegmentsCriteriaContributor.contribute(
+			criteria, "contains(userAgent, '" + typeSettings + "')",
 			Criteria.Conjunction.AND);
 	}
 
-	@Reference(
-		target = "(segments.criteria.contributor.key=" + UserOrganizationSegmentsCriteriaContributor.KEY + ")"
-	)
-	private SegmentsCriteriaContributor
-		_userOrganizationSegmentsCriteriaContributor;
+	@Reference(target = "(segments.criteria.contributor.key=context)")
+	private SegmentsCriteriaContributor _contextSegmentsCriteriaContributor;
 
 }

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/OrganizationMemberRuleConverter.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/OrganizationMemberRuleConverter.java
@@ -12,11 +12,10 @@
  * details.
  */
 
-package com.liferay.segments.internal.upgrade.v0_0_1.util;
+package com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util;
 
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
-import com.liferay.segments.internal.criteria.contributor.UserSegmentsCriteriaContributor;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -25,23 +24,22 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eduardo García
  */
 @Component(
-	immediate = true, property = "rule.converter.key=UserGroupMemberRule",
+	immediate = true, property = "rule.converter.key=OrganizationMemberRule",
 	service = RuleConverter.class
 )
-public class UserGroupMemberRuleConverter implements RuleConverter {
+public class OrganizationMemberRuleConverter implements RuleConverter {
 
 	@Override
 	public void convert(
 		long companyId, Criteria criteria, String typeSettings) {
 
-		_userSegmentsCriteriaContributor.contribute(
-			criteria, "(userGroupIds eq '" + typeSettings + "')",
+		_userOrganizationSegmentsCriteriaContributor.contribute(
+			criteria, "(organizationId eq '" + typeSettings + "')",
 			Criteria.Conjunction.AND);
 	}
 
-	@Reference(
-		target = "(segments.criteria.contributor.key=" + UserSegmentsCriteriaContributor.KEY + ")"
-	)
-	private SegmentsCriteriaContributor _userSegmentsCriteriaContributor;
+	@Reference(target = "(segments.criteria.contributor.key=user-organization)")
+	private SegmentsCriteriaContributor
+		_userOrganizationSegmentsCriteriaContributor;
 
 }

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/RegularRoleRuleConverter.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/RegularRoleRuleConverter.java
@@ -12,11 +12,10 @@
  * details.
  */
 
-package com.liferay.segments.internal.upgrade.v0_0_1.util;
+package com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util;
 
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
-import com.liferay.segments.internal.criteria.contributor.ContextSegmentsCriteriaContributor;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -25,23 +24,21 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eduardo García
  */
 @Component(
-	immediate = true, property = "rule.converter.key=UserLoggedRule",
+	immediate = true, property = "rule.converter.key=RegularRoleRule",
 	service = RuleConverter.class
 )
-public class UserLoggedRuleConverter implements RuleConverter {
+public class RegularRoleRuleConverter implements RuleConverter {
 
 	@Override
 	public void convert(
 		long companyId, Criteria criteria, String typeSettings) {
 
-		_contextSegmentsCriteriaContributor.contribute(
-			criteria, "(signedIn eq " + Boolean.TRUE + ")",
+		_userSegmentsCriteriaContributor.contribute(
+			criteria, "(roleIds eq '" + typeSettings + "')",
 			Criteria.Conjunction.AND);
 	}
 
-	@Reference(
-		target = "(segments.criteria.contributor.key=" + ContextSegmentsCriteriaContributor.KEY + ")"
-	)
-	private SegmentsCriteriaContributor _contextSegmentsCriteriaContributor;
+	@Reference(target = "(segments.criteria.contributor.key=user)")
+	private SegmentsCriteriaContributor _userSegmentsCriteriaContributor;
 
 }

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/RuleConverter.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/RuleConverter.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.segments.internal.upgrade.v0_0_1.util;
+package com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util;
 
 import com.liferay.segments.criteria.Criteria;
 

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/RuleConverterRegistry.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/RuleConverterRegistry.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.segments.internal.upgrade.v0_0_1.util;
+package com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util;
 
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/SiteMemberRuleConverter.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/SiteMemberRuleConverter.java
@@ -12,11 +12,10 @@
  * details.
  */
 
-package com.liferay.segments.internal.upgrade.v0_0_1.util;
+package com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util;
 
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
-import com.liferay.segments.internal.criteria.contributor.UserSegmentsCriteriaContributor;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -39,9 +38,7 @@ public class SiteMemberRuleConverter implements RuleConverter {
 			Criteria.Conjunction.AND);
 	}
 
-	@Reference(
-		target = "(segments.criteria.contributor.key=" + UserSegmentsCriteriaContributor.KEY + ")"
-	)
+	@Reference(target = "(segments.criteria.contributor.key=user)")
 	private SegmentsCriteriaContributor _userSegmentsCriteriaContributor;
 
 }

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/UserGroupMemberRuleConverter.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/UserGroupMemberRuleConverter.java
@@ -12,11 +12,10 @@
  * details.
  */
 
-package com.liferay.segments.internal.upgrade.v0_0_1.util;
+package com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util;
 
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
-import com.liferay.segments.internal.criteria.contributor.UserSegmentsCriteriaContributor;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -25,23 +24,21 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eduardo García
  */
 @Component(
-	immediate = true, property = "rule.converter.key=RegularRoleRule",
+	immediate = true, property = "rule.converter.key=UserGroupMemberRule",
 	service = RuleConverter.class
 )
-public class RegularRoleRuleConverter implements RuleConverter {
+public class UserGroupMemberRuleConverter implements RuleConverter {
 
 	@Override
 	public void convert(
 		long companyId, Criteria criteria, String typeSettings) {
 
 		_userSegmentsCriteriaContributor.contribute(
-			criteria, "(roleIds eq '" + typeSettings + "')",
+			criteria, "(userGroupIds eq '" + typeSettings + "')",
 			Criteria.Conjunction.AND);
 	}
 
-	@Reference(
-		target = "(segments.criteria.contributor.key=" + UserSegmentsCriteriaContributor.KEY + ")"
-	)
+	@Reference(target = "(segments.criteria.contributor.key=user)")
 	private SegmentsCriteriaContributor _userSegmentsCriteriaContributor;
 
 }

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/UserLoggedRuleConverter.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/v1_0_0/util/UserLoggedRuleConverter.java
@@ -12,11 +12,10 @@
  * details.
  */
 
-package com.liferay.segments.internal.upgrade.v0_0_1.util;
+package com.liferay.segments.content.targeting.upgrade.internal.v1_0_0.util;
 
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
-import com.liferay.segments.internal.criteria.contributor.ContextSegmentsCriteriaContributor;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -25,23 +24,21 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eduardo García
  */
 @Component(
-	immediate = true, property = "rule.converter.key=OSRule",
+	immediate = true, property = "rule.converter.key=UserLoggedRule",
 	service = RuleConverter.class
 )
-public class OSRuleConverter implements RuleConverter {
+public class UserLoggedRuleConverter implements RuleConverter {
 
 	@Override
 	public void convert(
 		long companyId, Criteria criteria, String typeSettings) {
 
 		_contextSegmentsCriteriaContributor.contribute(
-			criteria, "contains(userAgent, '" + typeSettings + "')",
+			criteria, "(signedIn eq " + Boolean.TRUE + ")",
 			Criteria.Conjunction.AND);
 	}
 
-	@Reference(
-		target = "(segments.criteria.contributor.key=" + ContextSegmentsCriteriaContributor.KEY + ")"
-	)
+	@Reference(target = "(segments.criteria.contributor.key=context)")
 	private SegmentsCriteriaContributor _contextSegmentsCriteriaContributor;
 
 }

--- a/modules/apps/segments/segments-test/bnd.bnd
+++ b/modules/apps/segments/segments-test/bnd.bnd
@@ -1,7 +1,6 @@
 Bundle-Name: Liferay Segments Test
 Bundle-SymbolicName: com.liferay.segments.test
 Bundle-Version: 1.0.0
-Import-Package: *
 -includeresource:\
 	test-classes/integration,\
 	@lib/jackson-databind.jar


### PR DESCRIPTION
@brianchandotcom this are the last changes for the upgrade of Audience Targeting segments to 7.2. During the manual testing, we found that it's more convenient to decouple the upgrade from the segments services and keep the logic on the separate module. Thx

@darquesdev