### PR TITLE
Lps 89242 Mock in portal-workflow-kaleo-runtime-integration-impl

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/util/KaleoRuntimeTestUtil.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/util/KaleoRuntimeTestUtil.java
@@ -16,13 +16,14 @@ package com.liferay.portal.workflow.kaleo.runtime.integration.internal.util;
 
 import com.liferay.portal.kernel.workflow.WorkflowTaskAssignee;
 import com.liferay.portal.workflow.kaleo.model.KaleoTaskAssignmentInstance;
+import com.liferay.portal.workflow.kaleo.model.KaleoTaskAssignmentInstanceWrapper;
 import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
+import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceTokenWrapper;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Assert;
-
-import org.mockito.Mockito;
 
 /**
  * @author Marcellus Tavares
@@ -45,20 +46,20 @@ public class KaleoRuntimeTestUtil {
 	public static KaleoTaskAssignmentInstance mockKaleoTaskAssignmentInstance(
 		String returnAssigneeClassName, long returnAssigneeClassPK) {
 
-		KaleoTaskAssignmentInstance kaleoTaskAssignmentInstance = Mockito.mock(
-			KaleoTaskAssignmentInstance.class);
+		KaleoTaskAssignmentInstance kaleoTaskAssignmentInstance =
+			new KaleoTaskAssignmentInstanceWrapper(null) {
 
-		Mockito.when(
-			kaleoTaskAssignmentInstance.getAssigneeClassName()
-		).thenReturn(
-			returnAssigneeClassName
-		);
+				@Override
+				public String getAssigneeClassName() {
+					return returnAssigneeClassName;
+				}
 
-		Mockito.when(
-			kaleoTaskAssignmentInstance.getAssigneeClassPK()
-		).thenReturn(
-			returnAssigneeClassPK
-		);
+				@Override
+				public long getAssigneeClassPK() {
+					return returnAssigneeClassPK;
+				}
+
+			};
 
 		return kaleoTaskAssignmentInstance;
 	}
@@ -66,26 +67,30 @@ public class KaleoRuntimeTestUtil {
 	public static KaleoTaskInstanceToken mockKaleoTaskInstanceToken(
 		KaleoTaskAssignmentInstance... returnKaleoTaskAssignmentInstances) {
 
-		KaleoTaskInstanceToken kaleoTaskInstanceToken = Mockito.mock(
-			KaleoTaskInstanceToken.class);
+		KaleoTaskInstanceToken kaleoTaskInstanceToken =
+			new KaleoTaskInstanceTokenWrapper(null) {
 
-		Mockito.when(
-			kaleoTaskInstanceToken.getKaleoTaskAssignmentInstances()
-		).thenReturn(
-			Arrays.asList(returnKaleoTaskAssignmentInstances)
-		);
+				@Override
+				public KaleoTaskAssignmentInstance
+					getFirstKaleoTaskAssignmentInstance() {
 
-		if ((returnKaleoTaskAssignmentInstances.length == 0) ||
-			(returnKaleoTaskAssignmentInstances.length > 1)) {
+					if ((returnKaleoTaskAssignmentInstances.length == 0) ||
+						(returnKaleoTaskAssignmentInstances.length > 1)) {
 
-			return kaleoTaskInstanceToken;
-		}
+						return null;
+					}
 
-		Mockito.when(
-			kaleoTaskInstanceToken.getFirstKaleoTaskAssignmentInstance()
-		).thenReturn(
-			returnKaleoTaskAssignmentInstances[0]
-		);
+					return returnKaleoTaskAssignmentInstances[0];
+				}
+
+				@Override
+				public List<KaleoTaskAssignmentInstance>
+					getKaleoTaskAssignmentInstances() {
+
+					return Arrays.asList(returnKaleoTaskAssignmentInstances);
+				}
+
+			};
 
 		return kaleoTaskInstanceToken;
 	}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/util/LazyWorkflowTaskAssigneeListTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/util/LazyWorkflowTaskAssigneeListTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowTaskAssignee;
 import com.liferay.portal.workflow.kaleo.model.KaleoTaskAssignmentInstance;
 import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
+import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceTokenWrapper;
 import com.liferay.portal.workflow.kaleo.service.KaleoTaskAssignmentInstanceLocalService;
 
 import org.junit.Assert;
@@ -74,11 +75,15 @@ public class LazyWorkflowTaskAssigneeListTest {
 
 		long kaleoTaskInstanceTokenId = RandomTestUtil.randomLong();
 
-		Mockito.when(
-			kaleoTaskInstanceToken.getKaleoTaskInstanceTokenId()
-		).thenReturn(
-			kaleoTaskInstanceTokenId
-		);
+		kaleoTaskInstanceToken =
+			new KaleoTaskInstanceTokenWrapper(kaleoTaskInstanceToken) {
+
+				@Override
+				public long getKaleoTaskInstanceTokenId() {
+					return kaleoTaskInstanceTokenId;
+				}
+
+			};
 
 		KaleoTaskAssignmentInstanceLocalService
 			kaleoTaskAssignmentInstanceLocalService = Mockito.mock(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/util/LazyWorkflowTaskAssigneeListTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/util/LazyWorkflowTaskAssigneeListTest.java
@@ -125,14 +125,8 @@ public class LazyWorkflowTaskAssigneeListTest {
 			KaleoRuntimeTestUtil.mockKaleoTaskInstanceToken(
 				kaleoTaskAssignmentInstances);
 
-		KaleoTaskAssignmentInstanceLocalService
-			kaleoTaskAssignmentInstanceLocalService = Mockito.mock(
-				KaleoTaskAssignmentInstanceLocalService.class);
-
 		LazyWorkflowTaskAssigneeList lazyWorkflowTaskAssigneeList =
-			new LazyWorkflowTaskAssigneeList(
-				kaleoTaskInstanceToken,
-				kaleoTaskAssignmentInstanceLocalService);
+			new LazyWorkflowTaskAssigneeList(kaleoTaskInstanceToken, null);
 
 		WorkflowTaskAssignee workflowTaskAssignee =
 			lazyWorkflowTaskAssigneeList.get(1);
@@ -161,14 +155,8 @@ public class LazyWorkflowTaskAssigneeListTest {
 			KaleoRuntimeTestUtil.mockKaleoTaskInstanceToken(
 				kaleoTaskAssignmentInstance);
 
-		KaleoTaskAssignmentInstanceLocalService
-			kaleoTaskAssignmentInstanceLocalService = Mockito.mock(
-				KaleoTaskAssignmentInstanceLocalService.class);
-
 		LazyWorkflowTaskAssigneeList lazyWorkflowTaskAssigneeList =
-			new LazyWorkflowTaskAssigneeList(
-				kaleoTaskInstanceToken,
-				kaleoTaskAssignmentInstanceLocalService);
+			new LazyWorkflowTaskAssigneeList(kaleoTaskInstanceToken, null);
 
 		WorkflowTaskAssignee workflowTaskAssignee =
 			lazyWorkflowTaskAssigneeList.get(0);
@@ -189,14 +177,8 @@ public class LazyWorkflowTaskAssigneeListTest {
 		KaleoTaskInstanceToken kaleoTaskInstanceToken =
 			KaleoRuntimeTestUtil.mockKaleoTaskInstanceToken();
 
-		KaleoTaskAssignmentInstanceLocalService
-			kaleoTaskAssignmentInstanceLocalService = Mockito.mock(
-				KaleoTaskAssignmentInstanceLocalService.class);
-
 		LazyWorkflowTaskAssigneeList lazyWorkflowTaskAssigneeList =
-			new LazyWorkflowTaskAssigneeList(
-				kaleoTaskInstanceToken,
-				kaleoTaskAssignmentInstanceLocalService);
+			new LazyWorkflowTaskAssigneeList(kaleoTaskInstanceToken, null);
 
 		lazyWorkflowTaskAssigneeList.get(0);
 	}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/util/LazyWorkflowTaskAssigneeListTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/util/LazyWorkflowTaskAssigneeListTest.java
@@ -25,11 +25,10 @@ import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceTokenWrapper;
 import com.liferay.portal.workflow.kaleo.service.KaleoTaskAssignmentInstanceLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoTaskAssignmentInstanceLocalServiceWrapper;
 
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Test;
-
-import org.mockito.Mockito;
-import org.mockito.verification.VerificationMode;
 
 /**
  * @author Marcellus Tavares
@@ -149,9 +148,32 @@ public class LazyWorkflowTaskAssigneeListTest {
 				User.class.getName(), 2)
 		};
 
+		boolean[] executed = {false, false};
+
 		KaleoTaskInstanceToken kaleoTaskInstanceToken =
-			KaleoRuntimeTestUtil.mockKaleoTaskInstanceToken(
-				kaleoTaskAssignmentInstances);
+			new KaleoTaskInstanceTokenWrapper(
+				KaleoRuntimeTestUtil.mockKaleoTaskInstanceToken(
+					kaleoTaskAssignmentInstances)) {
+
+				@Override
+				public KaleoTaskAssignmentInstance
+					getFirstKaleoTaskAssignmentInstance() {
+
+					executed[0] = true;
+
+					return super.getFirstKaleoTaskAssignmentInstance();
+				}
+
+				@Override
+				public List<KaleoTaskAssignmentInstance>
+					getKaleoTaskAssignmentInstances() {
+
+					executed[1] = true;
+
+					return super.getKaleoTaskAssignmentInstances();
+				}
+
+			};
 
 		LazyWorkflowTaskAssigneeList lazyWorkflowTaskAssigneeList =
 			new LazyWorkflowTaskAssigneeList(kaleoTaskInstanceToken, null);
@@ -159,11 +181,15 @@ public class LazyWorkflowTaskAssigneeListTest {
 		WorkflowTaskAssignee workflowTaskAssignee =
 			lazyWorkflowTaskAssigneeList.get(1);
 
-		verifyGetKaleoTaskAssignmentInstancesCall(
-			kaleoTaskInstanceToken, Mockito.atLeastOnce());
+		Assert.assertTrue(
+			"Method getKaleoTaskAssignmentInstances should be invoked on " +
+				"kaleoTaskInstanceToken",
+			executed[1]);
 
-		verifyGetFirstKaleoTaskAssignmentInstanceCall(
-			kaleoTaskInstanceToken, Mockito.never());
+		Assert.assertFalse(
+			"Method getFirstKaleoTaskAssignmentInstance should not be " +
+				"invoked on kaleoTaskInstanceToken",
+			executed[0]);
 
 		KaleoRuntimeTestUtil.assertWorkflowTaskAssignee(
 			User.class.getName(), 2, workflowTaskAssignee);
@@ -179,9 +205,32 @@ public class LazyWorkflowTaskAssigneeListTest {
 			KaleoRuntimeTestUtil.mockKaleoTaskAssignmentInstance(
 				expectedAssigneeClassName, expectedAssigneeClassPK);
 
+		boolean[] executed = {false, false};
+
 		KaleoTaskInstanceToken kaleoTaskInstanceToken =
-			KaleoRuntimeTestUtil.mockKaleoTaskInstanceToken(
-				kaleoTaskAssignmentInstance);
+			new KaleoTaskInstanceTokenWrapper(
+				KaleoRuntimeTestUtil.mockKaleoTaskInstanceToken(
+					kaleoTaskAssignmentInstance)) {
+
+				@Override
+				public KaleoTaskAssignmentInstance
+					getFirstKaleoTaskAssignmentInstance() {
+
+					executed[0] = true;
+
+					return super.getFirstKaleoTaskAssignmentInstance();
+				}
+
+				@Override
+				public List<KaleoTaskAssignmentInstance>
+					getKaleoTaskAssignmentInstances() {
+
+					executed[1] = true;
+
+					return super.getKaleoTaskAssignmentInstances();
+				}
+
+			};
 
 		LazyWorkflowTaskAssigneeList lazyWorkflowTaskAssigneeList =
 			new LazyWorkflowTaskAssigneeList(kaleoTaskInstanceToken, null);
@@ -189,11 +238,15 @@ public class LazyWorkflowTaskAssigneeListTest {
 		WorkflowTaskAssignee workflowTaskAssignee =
 			lazyWorkflowTaskAssigneeList.get(0);
 
-		verifyGetKaleoTaskAssignmentInstancesCall(
-			kaleoTaskInstanceToken, Mockito.never());
+		Assert.assertFalse(
+			"Method getKaleoTaskAssignmentInstances should not be invoked on " +
+				"kaleoTaskInstanceToken",
+			executed[1]);
 
-		verifyGetFirstKaleoTaskAssignmentInstanceCall(
-			kaleoTaskInstanceToken, Mockito.atLeastOnce());
+		Assert.assertTrue(
+			"Method getFirstKaleoTaskAssignmentInstance should be invoked on " +
+				"kaleoTaskInstanceToken",
+			executed[0]);
 
 		KaleoRuntimeTestUtil.assertWorkflowTaskAssignee(
 			expectedAssigneeClassName, expectedAssigneeClassPK,
@@ -209,24 +262,6 @@ public class LazyWorkflowTaskAssigneeListTest {
 			new LazyWorkflowTaskAssigneeList(kaleoTaskInstanceToken, null);
 
 		lazyWorkflowTaskAssigneeList.get(0);
-	}
-
-	protected void verifyGetFirstKaleoTaskAssignmentInstanceCall(
-		KaleoTaskInstanceToken kaleoTaskInstanceToken,
-		VerificationMode verificationMode) {
-
-		Mockito.verify(
-			kaleoTaskInstanceToken, verificationMode
-		).getFirstKaleoTaskAssignmentInstance();
-	}
-
-	protected void verifyGetKaleoTaskAssignmentInstancesCall(
-		KaleoTaskInstanceToken kaleoTaskInstanceToken,
-		VerificationMode verificationMode) {
-
-		Mockito.verify(
-			kaleoTaskInstanceToken, verificationMode
-		).getKaleoTaskAssignmentInstances();
 	}
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/util/LazyWorkflowTaskAssigneeListTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/util/LazyWorkflowTaskAssigneeListTest.java
@@ -151,29 +151,7 @@ public class LazyWorkflowTaskAssigneeListTest {
 		boolean[] executed = {false, false};
 
 		KaleoTaskInstanceToken kaleoTaskInstanceToken =
-			new KaleoTaskInstanceTokenWrapper(
-				KaleoRuntimeTestUtil.mockKaleoTaskInstanceToken(
-					kaleoTaskAssignmentInstances)) {
-
-				@Override
-				public KaleoTaskAssignmentInstance
-					getFirstKaleoTaskAssignmentInstance() {
-
-					executed[0] = true;
-
-					return super.getFirstKaleoTaskAssignmentInstance();
-				}
-
-				@Override
-				public List<KaleoTaskAssignmentInstance>
-					getKaleoTaskAssignmentInstances() {
-
-					executed[1] = true;
-
-					return super.getKaleoTaskAssignmentInstances();
-				}
-
-			};
+			_getkaleoTaskInstanceToken(executed, kaleoTaskAssignmentInstances);
 
 		LazyWorkflowTaskAssigneeList lazyWorkflowTaskAssigneeList =
 			new LazyWorkflowTaskAssigneeList(kaleoTaskInstanceToken, null);
@@ -208,29 +186,7 @@ public class LazyWorkflowTaskAssigneeListTest {
 		boolean[] executed = {false, false};
 
 		KaleoTaskInstanceToken kaleoTaskInstanceToken =
-			new KaleoTaskInstanceTokenWrapper(
-				KaleoRuntimeTestUtil.mockKaleoTaskInstanceToken(
-					kaleoTaskAssignmentInstance)) {
-
-				@Override
-				public KaleoTaskAssignmentInstance
-					getFirstKaleoTaskAssignmentInstance() {
-
-					executed[0] = true;
-
-					return super.getFirstKaleoTaskAssignmentInstance();
-				}
-
-				@Override
-				public List<KaleoTaskAssignmentInstance>
-					getKaleoTaskAssignmentInstances() {
-
-					executed[1] = true;
-
-					return super.getKaleoTaskAssignmentInstances();
-				}
-
-			};
+			_getkaleoTaskInstanceToken(executed, kaleoTaskAssignmentInstance);
 
 		LazyWorkflowTaskAssigneeList lazyWorkflowTaskAssigneeList =
 			new LazyWorkflowTaskAssigneeList(kaleoTaskInstanceToken, null);
@@ -262,6 +218,35 @@ public class LazyWorkflowTaskAssigneeListTest {
 			new LazyWorkflowTaskAssigneeList(kaleoTaskInstanceToken, null);
 
 		lazyWorkflowTaskAssigneeList.get(0);
+	}
+
+	private KaleoTaskInstanceToken _getkaleoTaskInstanceToken(
+		boolean[] executed,
+		KaleoTaskAssignmentInstance... kaleoTaskAssignmentInstances) {
+
+		return new KaleoTaskInstanceTokenWrapper(
+			KaleoRuntimeTestUtil.mockKaleoTaskInstanceToken(
+				kaleoTaskAssignmentInstances)) {
+
+			@Override
+			public KaleoTaskAssignmentInstance
+				getFirstKaleoTaskAssignmentInstance() {
+
+				executed[0] = true;
+
+				return super.getFirstKaleoTaskAssignmentInstance();
+			}
+
+			@Override
+			public List<KaleoTaskAssignmentInstance>
+				getKaleoTaskAssignmentInstances() {
+
+				executed[1] = true;
+
+				return super.getKaleoTaskAssignmentInstances();
+			}
+
+		};
 	}
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/util/LazyWorkflowTaskAssigneeListTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/util/LazyWorkflowTaskAssigneeListTest.java
@@ -151,7 +151,7 @@ public class LazyWorkflowTaskAssigneeListTest {
 		boolean[] executed = {false, false};
 
 		KaleoTaskInstanceToken kaleoTaskInstanceToken =
-			_getkaleoTaskInstanceToken(executed, kaleoTaskAssignmentInstances);
+			_getKaleoTaskInstanceToken(executed, kaleoTaskAssignmentInstances);
 
 		LazyWorkflowTaskAssigneeList lazyWorkflowTaskAssigneeList =
 			new LazyWorkflowTaskAssigneeList(kaleoTaskInstanceToken, null);
@@ -186,7 +186,7 @@ public class LazyWorkflowTaskAssigneeListTest {
 		boolean[] executed = {false, false};
 
 		KaleoTaskInstanceToken kaleoTaskInstanceToken =
-			_getkaleoTaskInstanceToken(executed, kaleoTaskAssignmentInstance);
+			_getKaleoTaskInstanceToken(executed, kaleoTaskAssignmentInstance);
 
 		LazyWorkflowTaskAssigneeList lazyWorkflowTaskAssigneeList =
 			new LazyWorkflowTaskAssigneeList(kaleoTaskInstanceToken, null);
@@ -220,7 +220,7 @@ public class LazyWorkflowTaskAssigneeListTest {
 		lazyWorkflowTaskAssigneeList.get(0);
 	}
 
-	private KaleoTaskInstanceToken _getkaleoTaskInstanceToken(
+	private KaleoTaskInstanceToken _getKaleoTaskInstanceToken(
 		boolean[] executed,
 		KaleoTaskAssignmentInstance... kaleoTaskAssignmentInstances) {
 


### PR DESCRIPTION
Hi Brian,

I didn't change the var declaration flow in the test since it's actually right.

Invocations of methods getKaleoTaskAssignmentInstances and getFirstKaleoTaskAssignmentInstance are actually inside the logic of method LazyWorkflowTaskAssigneeList.get(int index).  Method _getKaleoTaskInstanceToken(executed, kaleoTaskAssignmentInstances) is just initiating a wrapper. So the tests are asserting right after the behavior.

As a result of that, I just SF the method name.

Thanks.
Lance