### PR TITLE
LPS-90643 SF

### DIFF
--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/CommentResourceImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/CommentResourceImpl.java
@@ -22,6 +22,7 @@ import com.liferay.headless.collaboration.resource.v1_0.CommentResource;
 import com.liferay.message.boards.exception.DiscussionMaxCommentsException;
 import com.liferay.message.boards.exception.MessageSubjectException;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.comment.CommentManager;
 import com.liferay.portal.kernel.comment.DiscussionPermission;
@@ -128,11 +129,12 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 		BlogsEntry blogsEntry = _blogsEntryService.getEntry(blogPostingId);
 
 		return _postComment(
-			blogsEntry.getGroupId(), blogsEntry.getEntryId(),
+			blogsEntry.getGroupId(), blogPostingId,
 			() -> _commentManager.addComment(
 				_getUserId(), blogsEntry.getGroupId(),
-				blogsEntry.getModelClassName(), blogsEntry.getEntryId(),
-				StringPool.BLANK, StringPool.BLANK, comment.getText(),
+				blogsEntry.getModelClassName(), blogPostingId, StringPool.BLANK,
+				StringPool.BLANK,
+				StringBundler.concat("<p>", comment.getText(), "</p>"),
 				_createServiceContextFunction()));
 	}
 
@@ -152,7 +154,8 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			() -> _commentManager.addComment(
 				_getUserId(), BlogsEntry.class.getName(),
 				parentComment.getClassPK(), StringPool.BLANK, parentCommentId,
-				StringPool.BLANK, comment.getText(),
+				StringPool.BLANK,
+				StringBundler.concat("<p>", comment.getText(), "</p>"),
 				_createServiceContextFunction()));
 	}
 
@@ -171,7 +174,8 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			_commentManager.updateComment(
 				existingComment.getUserId(), existingComment.getClassName(),
 				existingComment.getClassPK(), commentId, StringPool.BLANK,
-				comment.getText(), _createServiceContextFunction());
+				StringBundler.concat("<p>", comment.getText(), "</p>"),
+				_createServiceContextFunction());
 
 			return CommentUtil.toComment(
 				_commentManager.fetchComment(commentId), _portal);

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/CommentResourceImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/CommentResourceImpl.java
@@ -132,8 +132,8 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			() -> _commentManager.addComment(
 				_getUserId(), blogsEntry.getGroupId(),
 				blogsEntry.getModelClassName(), blogsEntry.getEntryId(),
-				StringPool.BLANK, StringPool.BLANK,
-				comment.getText(), _createServiceContextFunction()));
+				StringPool.BLANK, StringPool.BLANK, comment.getText(),
+				_createServiceContextFunction()));
 	}
 
 	@Override
@@ -148,7 +148,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 		}
 
 		return _postComment(
-			parentComment.getGroupId(), parentComment.getGroupId(),
+			parentComment.getGroupId(), parentComment.getClassPK(),
 			() -> _commentManager.addComment(
 				_getUserId(), BlogsEntry.class.getName(),
 				parentComment.getClassPK(), StringPool.BLANK, parentCommentId,
@@ -170,8 +170,8 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 		try {
 			_commentManager.updateComment(
 				existingComment.getUserId(), existingComment.getClassName(),
-				existingComment.getClassPK(), commentId, "", comment.getText(),
-				_createServiceContextFunction());
+				existingComment.getClassPK(), commentId, StringPool.BLANK,
+				comment.getText(), _createServiceContextFunction());
 
 			return CommentUtil.toComment(
 				_commentManager.fetchComment(commentId), _portal);

--- a/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/CommentResource.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/CommentResource.java
@@ -32,14 +32,26 @@ import javax.annotation.Generated;
 @Generated("")
 public interface CommentResource {
 
+	public boolean deleteComment(
+				Long commentId)
+			throws Exception;
 	public Comment getComment(
 				Long commentId)
+			throws Exception;
+	public Comment putComment(
+				Long commentId,Comment comment)
 			throws Exception;
 	public Page<Comment> getCommentCommentsPage(
 				Long commentId,Pagination pagination)
 			throws Exception;
+	public Comment postCommentComment(
+				Long commentId,Comment comment)
+			throws Exception;
 	public Page<Comment> getDocumentCommentsPage(
 				Long documentId,Pagination pagination)
+			throws Exception;
+	public Comment postDocumentComment(
+				Long documentId,Comment comment)
 			throws Exception;
 
 	public void setContextCompany(Company contextCompany);

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/build.gradle
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly project(":apps:adaptive-media:adaptive-media-image-api")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:headless:headless-document-library:headless-document-library-api")
+	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
@@ -161,6 +161,20 @@ info:
 openapi: 3.0.1
 paths:
   "/comments/{comment-id}":
+    delete:
+      parameters:
+        - in: path
+          name: comment-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        204:
+          content:
+            application/json: {}
+          description: ""
+      tags: ["Comment"]
     get:
       parameters:
         - in: path
@@ -169,6 +183,27 @@ paths:
           schema:
             format: int64
             type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Comment"
+          description: ""
+      tags: ["Comment"]
+    put:
+      parameters:
+        - in: path
+          name: comment-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Comment"
       responses:
         200:
           content:
@@ -202,6 +237,27 @@ paths:
                 items:
                   $ref: "#/components/schemas/Comment"
                 type: array
+          description: ""
+      tags: ["Comment"]
+    post:
+      parameters:
+        - in: path
+          name: comment-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Comment"
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Comment"
           description: ""
       tags: ["Comment"]
   "/content-spaces/{content-space-id}/documents":
@@ -370,6 +426,27 @@ paths:
                 items:
                   $ref: "#/components/schemas/Comment"
                 type: array
+          description: ""
+      tags: ["Comment"]
+    post:
+      parameters:
+        - in: path
+          name: document-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Comment"
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Comment"
           description: ""
       tags: ["Comment"]
   "/folders/{folder-id}":

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/graphql/mutation/v1_0/Mutation.java
@@ -14,8 +14,10 @@
 
 package com.liferay.headless.document.library.internal.graphql.mutation.v1_0;
 
+import com.liferay.headless.document.library.dto.v1_0.Comment;
 import com.liferay.headless.document.library.dto.v1_0.Document;
 import com.liferay.headless.document.library.dto.v1_0.Folder;
+import com.liferay.headless.document.library.resource.v1_0.CommentResource;
 import com.liferay.headless.document.library.resource.v1_0.DocumentResource;
 import com.liferay.headless.document.library.resource.v1_0.FolderResource;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
@@ -37,6 +39,40 @@ import org.osgi.util.tracker.ServiceTracker;
 @Generated("")
 public class Mutation {
 
+	@GraphQLInvokeDetached
+	public boolean deleteComment(
+	@GraphQLName("comment-id") Long commentId)
+			throws Exception {
+
+				return _getCommentResource().deleteComment(
+					commentId);
+	}
+	@GraphQLInvokeDetached
+	public Comment putComment(
+	@GraphQLName("comment-id") Long commentId,@GraphQLName("Comment") Comment comment)
+			throws Exception {
+
+				return _getCommentResource().putComment(
+					commentId,comment);
+	}
+	@GraphQLField
+	@GraphQLInvokeDetached
+	public Comment postCommentComment(
+	@GraphQLName("comment-id") Long commentId,@GraphQLName("Comment") Comment comment)
+			throws Exception {
+
+				return _getCommentResource().postCommentComment(
+					commentId,comment);
+	}
+	@GraphQLField
+	@GraphQLInvokeDetached
+	public Comment postDocumentComment(
+	@GraphQLName("document-id") Long documentId,@GraphQLName("Comment") Comment comment)
+			throws Exception {
+
+				return _getCommentResource().postDocumentComment(
+					documentId,comment);
+	}
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Document postContentSpaceDocument(
@@ -98,6 +134,12 @@ public class Mutation {
 					folderId,folder);
 	}
 
+	private static CommentResource _getCommentResource() {
+			return _commentResourceServiceTracker.getService();
+	}
+
+	private static final ServiceTracker<CommentResource, CommentResource>
+			_commentResourceServiceTracker;
 	private static DocumentResource _getDocumentResource() {
 			return _documentResourceServiceTracker.getService();
 	}
@@ -114,6 +156,16 @@ public class Mutation {
 		static {
 			Bundle bundle = FrameworkUtil.getBundle(Mutation.class);
 
+				ServiceTracker<CommentResource, CommentResource>
+					commentResourceServiceTracker =
+						new ServiceTracker<>(
+							bundle.getBundleContext(),
+							CommentResource.class, null);
+
+				commentResourceServiceTracker.open();
+
+				_commentResourceServiceTracker =
+					commentResourceServiceTracker;
 				ServiceTracker<DocumentResource, DocumentResource>
 					documentResourceServiceTracker =
 						new ServiceTracker<>(

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -32,7 +32,11 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -49,12 +53,35 @@ import javax.ws.rs.core.UriInfo;
 public abstract class BaseCommentResourceImpl implements CommentResource {
 
 	@Override
+	@DELETE
+	@Path("/comments/{comment-id}")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public boolean deleteComment(
+	@PathParam("comment-id") Long commentId)
+			throws Exception {
+
+				return false;
+	}
+	@Override
 	@GET
 	@Path("/comments/{comment-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
 	public Comment getComment(
 	@PathParam("comment-id") Long commentId)
+			throws Exception {
+
+				return new CommentImpl();
+	}
+	@Override
+	@Consumes("application/json")
+	@PUT
+	@Path("/comments/{comment-id}")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Comment putComment(
+	@PathParam("comment-id") Long commentId,Comment comment)
 			throws Exception {
 
 				return new CommentImpl();
@@ -71,6 +98,18 @@ public abstract class BaseCommentResourceImpl implements CommentResource {
 				return Page.of(Collections.emptyList());
 	}
 	@Override
+	@Consumes("application/json")
+	@POST
+	@Path("/comments/{comment-id}/comments")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Comment postCommentComment(
+	@PathParam("comment-id") Long commentId,Comment comment)
+			throws Exception {
+
+				return new CommentImpl();
+	}
+	@Override
 	@GET
 	@Path("/documents/{document-id}/comments")
 	@Produces("application/json")
@@ -80,6 +119,18 @@ public abstract class BaseCommentResourceImpl implements CommentResource {
 			throws Exception {
 
 				return Page.of(Collections.emptyList());
+	}
+	@Override
+	@Consumes("application/json")
+	@POST
+	@Path("/documents/{document-id}/comments")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Comment postDocumentComment(
+	@PathParam("document-id") Long documentId,Comment comment)
+			throws Exception {
+
+				return new CommentImpl();
 	}
 
 	public void setContextCompany(Company contextCompany) {

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/CommentResourceImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/CommentResourceImpl.java
@@ -19,16 +19,27 @@ import com.liferay.document.library.kernel.service.DLFileEntryService;
 import com.liferay.headless.document.library.dto.v1_0.Comment;
 import com.liferay.headless.document.library.internal.dto.v1_0.util.CommentUtil;
 import com.liferay.headless.document.library.resource.v1_0.CommentResource;
+import com.liferay.message.boards.exception.DiscussionMaxCommentsException;
+import com.liferay.message.boards.exception.MessageSubjectException;
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.comment.CommentManager;
 import com.liferay.portal.kernel.comment.DiscussionPermission;
+import com.liferay.portal.kernel.comment.DuplicateCommentException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.Collections;
+import java.util.function.Function;
+
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.NotFoundException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -42,6 +53,45 @@ import org.osgi.service.component.annotations.ServiceScope;
 	scope = ServiceScope.PROTOTYPE, service = CommentResource.class
 )
 public class CommentResourceImpl extends BaseCommentResourceImpl {
+
+	@Override
+	public boolean deleteComment(Long commentId) throws Exception {
+		DiscussionPermission discussionPermission = _getDiscussionPermission();
+
+		discussionPermission.checkDeletePermission(commentId);
+
+		_commentManager.deleteComment(commentId);
+
+		return true;
+	}
+
+	@Override
+	public Comment getComment(Long commentId) throws Exception {
+		com.liferay.portal.kernel.comment.Comment comment =
+			_commentManager.fetchComment(commentId);
+
+		_checkViewPermission(comment);
+
+		return CommentUtil.toComment(comment, _portal);
+	}
+
+	@Override
+	public Page<Comment> getCommentCommentsPage(
+			Long commentId, Pagination pagination)
+		throws Exception {
+
+		_checkViewPermission(_commentManager.fetchComment(commentId));
+
+		return Page.of(
+			transform(
+				_commentManager.getChildComments(
+					commentId, WorkflowConstants.STATUS_APPROVED,
+					pagination.getStartPosition(), pagination.getEndPosition()),
+				comment -> CommentUtil.toComment(comment, _portal)),
+			pagination,
+			_commentManager.getChildCommentsCount(
+				commentId, WorkflowConstants.STATUS_APPROVED));
+	}
 
 	@Override
 	public Page<Comment> getDocumentCommentsPage(
@@ -72,18 +122,144 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			pagination, count);
 	}
 
+	@Override
+	public Comment postCommentComment(Long parentCommentId, Comment comment)
+		throws Exception {
+
+		com.liferay.portal.kernel.comment.Comment parentComment =
+			_commentManager.fetchComment(parentCommentId);
+
+		if (parentComment == null) {
+			throw new NotFoundException();
+		}
+
+		return _postComment(
+			parentComment.getGroupId(), parentComment.getClassPK(),
+			() -> _commentManager.addComment(
+				_getUserId(), DLFileEntry.class.getName(),
+				parentComment.getClassPK(), StringPool.BLANK, parentCommentId,
+				StringPool.BLANK,
+				StringBundler.concat("<p>", comment.getText(), "</p>"),
+				_createServiceContextFunction()));
+	}
+
+	@Override
+	public Comment postDocumentComment(Long documentId, Comment comment)
+		throws Exception {
+
+		DLFileEntry fileEntry = _dlFileEntryService.getFileEntry(documentId);
+
+		return _postComment(
+			fileEntry.getGroupId(), documentId,
+			() -> _commentManager.addComment(
+				_getUserId(), fileEntry.getGroupId(),
+				fileEntry.getModelClassName(), documentId, StringPool.BLANK,
+				StringPool.BLANK,
+				StringBundler.concat("<p>", comment.getText(), "</p>"),
+				_createServiceContextFunction()));
+	}
+
+	@Override
+	public Comment putComment(Long commentId, Comment comment)
+		throws Exception {
+
+		DiscussionPermission discussionPermission = _getDiscussionPermission();
+
+		discussionPermission.checkUpdatePermission(commentId);
+
+		com.liferay.portal.kernel.comment.Comment existingComment =
+			_commentManager.fetchComment(commentId);
+
+		try {
+			_commentManager.updateComment(
+				existingComment.getUserId(), existingComment.getClassName(),
+				existingComment.getClassPK(), commentId, StringPool.BLANK,
+				StringBundler.concat("<p>", comment.getText(), "</p>"),
+				_createServiceContextFunction());
+
+			return CommentUtil.toComment(
+				_commentManager.fetchComment(commentId), _portal);
+		}
+		catch (MessageSubjectException mse) {
+			throw new ClientErrorException("Comment text is null", 422, mse);
+		}
+	}
+
+	private void _checkViewPermission(
+			com.liferay.portal.kernel.comment.Comment comment)
+		throws Exception {
+
+		if (comment == null) {
+			throw new NotFoundException();
+		}
+
+		DiscussionPermission discussionPermission = _getDiscussionPermission();
+
+		discussionPermission.checkViewPermission(
+			contextCompany.getCompanyId(), comment.getGroupId(),
+			DLFileEntry.class.getName(), comment.getClassPK());
+	}
+
 	private void _checkViewPermission(
 			long groupId, String className, long classPK)
 		throws Exception {
 
+		DiscussionPermission discussionPermission = _getDiscussionPermission();
+
+		discussionPermission.checkViewPermission(
+			contextCompany.getCompanyId(), groupId, className, classPK);
+	}
+
+	private Function<String, ServiceContext> _createServiceContextFunction() {
+		return className -> {
+			ServiceContext serviceContext = new ServiceContext();
+
+			serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
+
+			return serviceContext;
+		};
+	}
+
+	private DiscussionPermission _getDiscussionPermission() {
+		return _commentManager.getDiscussionPermission(
+			PermissionThreadLocal.getPermissionChecker());
+	}
+
+	private long _getUserId() {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
-		DiscussionPermission discussionPermission =
-			_commentManager.getDiscussionPermission(permissionChecker);
+		return permissionChecker.getUserId();
+	}
 
-		discussionPermission.checkViewPermission(
-			permissionChecker.getCompanyId(), groupId, className, classPK);
+	private Comment _postComment(
+			long groupId, long classPK,
+			UnsafeSupplier<Long, ? extends Exception> addCommentUnsafeSupplier)
+		throws Exception {
+
+		DiscussionPermission discussionPermission = _getDiscussionPermission();
+
+		discussionPermission.checkAddPermission(
+			contextCompany.getCompanyId(), groupId, DLFileEntry.class.getName(),
+			classPK);
+
+		try {
+			long commentId = addCommentUnsafeSupplier.get();
+
+			return CommentUtil.toComment(
+				_commentManager.fetchComment(commentId), _portal);
+		}
+		catch (DiscussionMaxCommentsException dmce) {
+			throw new ClientErrorException(
+				"Maximum number of comments has been reached", 422, dmce);
+		}
+		catch (DuplicateCommentException dce) {
+			throw new ClientErrorException(
+				"A comment with the same text already exists", 409, dce);
+		}
+		catch (MessageSubjectException mse) {
+			throw new ClientErrorException("Comment text is null", 422, mse);
+		}
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -26,8 +26,10 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -63,7 +65,15 @@ public abstract class BaseCommentResourceTestCase {
 	}
 
 	@Test
+	public void testDeleteComment() throws Exception {
+			Assert.assertTrue(true);
+	}
+	@Test
 	public void testGetComment() throws Exception {
+			Assert.assertTrue(true);
+	}
+	@Test
+	public void testPutComment() throws Exception {
 			Assert.assertTrue(true);
 	}
 	@Test
@@ -71,7 +81,15 @@ public abstract class BaseCommentResourceTestCase {
 			Assert.assertTrue(true);
 	}
 	@Test
+	public void testPostCommentComment() throws Exception {
+			Assert.assertTrue(true);
+	}
+	@Test
 	public void testGetDocumentCommentsPage() throws Exception {
+			Assert.assertTrue(true);
+	}
+	@Test
+	public void testPostDocumentComment() throws Exception {
 			Assert.assertTrue(true);
 	}
 
@@ -79,6 +97,33 @@ public abstract class BaseCommentResourceTestCase {
 		Assert.assertEquals(expectedResponseCode, actualResponse.getResponseCode());
 	}
 
+	protected boolean invokeDeleteComment(
+				Long commentId)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setDelete(true);
+
+			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}", commentId));
+
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Boolean.class);
+	}
+
+	protected Http.Response invokeDeleteCommentResponse(
+				Long commentId)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setDelete(true);
+
+			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}", commentId));
+
+			HttpUtil.URLtoString(options);
+
+			return options.getResponse();
+	}
 	protected Comment invokeGetComment(
 				Long commentId)
 			throws Exception {
@@ -97,6 +142,37 @@ public abstract class BaseCommentResourceTestCase {
 			Http.Options options = _createHttpOptions();
 
 			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}", commentId));
+
+			HttpUtil.URLtoString(options);
+
+			return options.getResponse();
+	}
+	protected Comment invokePutComment(
+				Long commentId,Comment comment)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setBody(_inputObjectMapper.writeValueAsString(comment), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+
+			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}", commentId,comment));
+
+				options.setPut(true);
+
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), CommentImpl.class);
+	}
+
+	protected Http.Response invokePutCommentResponse(
+				Long commentId,Comment comment)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setBody(_inputObjectMapper.writeValueAsString(comment), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+
+			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}", commentId,comment));
+
+				options.setPut(true);
 
 			HttpUtil.URLtoString(options);
 
@@ -125,6 +201,37 @@ public abstract class BaseCommentResourceTestCase {
 
 			return options.getResponse();
 	}
+	protected Comment invokePostCommentComment(
+				Long commentId,Comment comment)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setBody(_inputObjectMapper.writeValueAsString(comment), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+
+			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}/comments", commentId,comment));
+
+				options.setPost(true);
+
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), CommentImpl.class);
+	}
+
+	protected Http.Response invokePostCommentCommentResponse(
+				Long commentId,Comment comment)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setBody(_inputObjectMapper.writeValueAsString(comment), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+
+			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}/comments", commentId,comment));
+
+				options.setPost(true);
+
+			HttpUtil.URLtoString(options);
+
+			return options.getResponse();
+	}
 	protected Page<Comment> invokeGetDocumentCommentsPage(
 				Long documentId,Pagination pagination)
 			throws Exception {
@@ -143,6 +250,37 @@ public abstract class BaseCommentResourceTestCase {
 			Http.Options options = _createHttpOptions();
 
 			options.setLocation(_resourceURL + _toPath("/documents/{document-id}/comments", documentId));
+
+			HttpUtil.URLtoString(options);
+
+			return options.getResponse();
+	}
+	protected Comment invokePostDocumentComment(
+				Long documentId,Comment comment)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setBody(_inputObjectMapper.writeValueAsString(comment), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+
+			options.setLocation(_resourceURL + _toPath("/documents/{document-id}/comments", documentId,comment));
+
+				options.setPost(true);
+
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), CommentImpl.class);
+	}
+
+	protected Http.Response invokePostDocumentCommentResponse(
+				Long documentId,Comment comment)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setBody(_inputObjectMapper.writeValueAsString(comment), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+
+			options.setLocation(_resourceURL + _toPath("/documents/{document-id}/comments", documentId,comment));
+
+				options.setPost(true);
 
 			HttpUtil.URLtoString(options);
 

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/FolderResourceTest.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/FolderResourceTest.java
@@ -40,8 +40,7 @@ public class FolderResourceTest extends BaseFolderResourceTestCase {
 		assertResponseCode(
 			202, invokeDeleteFolderResponse(randomFolder.getId()));
 
-		assertResponseCode(
-			404, invokeGetFolderResponse(randomFolder.getId()));
+		assertResponseCode(404, invokeGetFolderResponse(randomFolder.getId()));
 	}
 
 	@Test

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/CommentResource.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/CommentResource.java
@@ -32,14 +32,26 @@ import javax.annotation.Generated;
 @Generated("")
 public interface CommentResource {
 
+	public boolean deleteComment(
+				Long commentId)
+			throws Exception;
 	public Comment getComment(
 				Long commentId)
+			throws Exception;
+	public Comment putComment(
+				Long commentId,Comment comment)
 			throws Exception;
 	public Page<Comment> getCommentCommentsPage(
 				Long commentId,Pagination pagination)
 			throws Exception;
+	public Comment postCommentComment(
+				Long commentId,Comment comment)
+			throws Exception;
 	public Page<Comment> getStructuredContentCommentsPage(
 				Long structuredContentId,Pagination pagination)
+			throws Exception;
+	public Comment postStructuredContentComment(
+				Long structuredContentId,Comment comment)
 			throws Exception;
 
 	public void setContextCompany(Company contextCompany);

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/build.gradle
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:headless:headless-web-experience:headless-web-experience-api")
 	compileOnly project(":apps:journal:journal-api")
+	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
@@ -292,6 +292,20 @@ info:
 openapi: 3.0.1
 paths:
   "/comments/{comment-id}":
+    delete:
+      parameters:
+        - in: path
+          name: comment-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        204:
+          content:
+            application/json: {}
+          description: ""
+      tags: ["Comment"]
     get:
       parameters:
         - in: path
@@ -300,6 +314,27 @@ paths:
           schema:
             format: int64
             type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Comment"
+          description: ""
+      tags: ["Comment"]
+    put:
+      parameters:
+        - in: path
+          name: comment-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Comment"
       responses:
         200:
           content:
@@ -333,6 +368,27 @@ paths:
                 items:
                   $ref: "#/components/schemas/Comment"
                 type: array
+          description: ""
+      tags: ["Comment"]
+    post:
+      parameters:
+        - in: path
+          name: comment-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Comment"
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Comment"
           description: ""
       tags: ["Comment"]
   "/content-spaces/{content-space-id}/content-structures":
@@ -606,6 +662,27 @@ paths:
                 items:
                   $ref: "#/components/schemas/Comment"
                 type: array
+          description: ""
+      tags: ["Comment"]
+    post:
+      parameters:
+        - in: path
+          name: structured-content-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Comment"
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Comment"
           description: ""
       tags: ["Comment"]
   "/structured-contents/{structured-content-id}/rendered-content/{template-id}":

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/graphql/mutation/v1_0/Mutation.java
@@ -14,7 +14,9 @@
 
 package com.liferay.headless.web.experience.internal.graphql.mutation.v1_0;
 
+import com.liferay.headless.web.experience.dto.v1_0.Comment;
 import com.liferay.headless.web.experience.dto.v1_0.StructuredContent;
+import com.liferay.headless.web.experience.resource.v1_0.CommentResource;
 import com.liferay.headless.web.experience.resource.v1_0.StructuredContentImageResource;
 import com.liferay.headless.web.experience.resource.v1_0.StructuredContentResource;
 
@@ -35,6 +37,40 @@ import org.osgi.util.tracker.ServiceTracker;
 @Generated("")
 public class Mutation {
 
+	@GraphQLInvokeDetached
+	public boolean deleteComment(
+	@GraphQLName("comment-id") Long commentId)
+			throws Exception {
+
+				return _getCommentResource().deleteComment(
+					commentId);
+	}
+	@GraphQLInvokeDetached
+	public Comment putComment(
+	@GraphQLName("comment-id") Long commentId,@GraphQLName("Comment") Comment comment)
+			throws Exception {
+
+				return _getCommentResource().putComment(
+					commentId,comment);
+	}
+	@GraphQLField
+	@GraphQLInvokeDetached
+	public Comment postCommentComment(
+	@GraphQLName("comment-id") Long commentId,@GraphQLName("Comment") Comment comment)
+			throws Exception {
+
+				return _getCommentResource().postCommentComment(
+					commentId,comment);
+	}
+	@GraphQLField
+	@GraphQLInvokeDetached
+	public Comment postStructuredContentComment(
+	@GraphQLName("structured-content-id") Long structuredContentId,@GraphQLName("Comment") Comment comment)
+			throws Exception {
+
+				return _getCommentResource().postStructuredContentComment(
+					structuredContentId,comment);
+	}
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public StructuredContent postContentSpaceStructuredContent(
@@ -77,6 +113,12 @@ public class Mutation {
 					structuredContentId,contentDocumentId);
 	}
 
+	private static CommentResource _getCommentResource() {
+			return _commentResourceServiceTracker.getService();
+	}
+
+	private static final ServiceTracker<CommentResource, CommentResource>
+			_commentResourceServiceTracker;
 	private static StructuredContentResource _getStructuredContentResource() {
 			return _structuredContentResourceServiceTracker.getService();
 	}
@@ -93,6 +135,16 @@ public class Mutation {
 		static {
 			Bundle bundle = FrameworkUtil.getBundle(Mutation.class);
 
+				ServiceTracker<CommentResource, CommentResource>
+					commentResourceServiceTracker =
+						new ServiceTracker<>(
+							bundle.getBundleContext(),
+							CommentResource.class, null);
+
+				commentResourceServiceTracker.open();
+
+				_commentResourceServiceTracker =
+					commentResourceServiceTracker;
 				ServiceTracker<StructuredContentResource, StructuredContentResource>
 					structuredContentResourceServiceTracker =
 						new ServiceTracker<>(

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -32,7 +32,11 @@ import java.util.List;
 
 import javax.annotation.Generated;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -49,12 +53,35 @@ import javax.ws.rs.core.UriInfo;
 public abstract class BaseCommentResourceImpl implements CommentResource {
 
 	@Override
+	@DELETE
+	@Path("/comments/{comment-id}")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public boolean deleteComment(
+	@PathParam("comment-id") Long commentId)
+			throws Exception {
+
+				return false;
+	}
+	@Override
 	@GET
 	@Path("/comments/{comment-id}")
 	@Produces("application/json")
 	@RequiresScope("everything.read")
 	public Comment getComment(
 	@PathParam("comment-id") Long commentId)
+			throws Exception {
+
+				return new CommentImpl();
+	}
+	@Override
+	@Consumes("application/json")
+	@PUT
+	@Path("/comments/{comment-id}")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Comment putComment(
+	@PathParam("comment-id") Long commentId,Comment comment)
 			throws Exception {
 
 				return new CommentImpl();
@@ -71,6 +98,18 @@ public abstract class BaseCommentResourceImpl implements CommentResource {
 				return Page.of(Collections.emptyList());
 	}
 	@Override
+	@Consumes("application/json")
+	@POST
+	@Path("/comments/{comment-id}/comments")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Comment postCommentComment(
+	@PathParam("comment-id") Long commentId,Comment comment)
+			throws Exception {
+
+				return new CommentImpl();
+	}
+	@Override
 	@GET
 	@Path("/structured-contents/{structured-content-id}/comments")
 	@Produces("application/json")
@@ -80,6 +119,18 @@ public abstract class BaseCommentResourceImpl implements CommentResource {
 			throws Exception {
 
 				return Page.of(Collections.emptyList());
+	}
+	@Override
+	@Consumes("application/json")
+	@POST
+	@Path("/structured-contents/{structured-content-id}/comments")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Comment postStructuredContentComment(
+	@PathParam("structured-content-id") Long structuredContentId,Comment comment)
+			throws Exception {
+
+				return new CommentImpl();
 	}
 
 	public void setContextCompany(Company contextCompany) {

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -27,8 +27,10 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -64,7 +66,15 @@ public abstract class BaseCommentResourceTestCase {
 	}
 
 	@Test
+	public void testDeleteComment() throws Exception {
+			Assert.assertTrue(true);
+	}
+	@Test
 	public void testGetComment() throws Exception {
+			Assert.assertTrue(true);
+	}
+	@Test
+	public void testPutComment() throws Exception {
 			Assert.assertTrue(true);
 	}
 	@Test
@@ -72,7 +82,15 @@ public abstract class BaseCommentResourceTestCase {
 			Assert.assertTrue(true);
 	}
 	@Test
+	public void testPostCommentComment() throws Exception {
+			Assert.assertTrue(true);
+	}
+	@Test
 	public void testGetStructuredContentCommentsPage() throws Exception {
+			Assert.assertTrue(true);
+	}
+	@Test
+	public void testPostStructuredContentComment() throws Exception {
 			Assert.assertTrue(true);
 	}
 
@@ -80,6 +98,33 @@ public abstract class BaseCommentResourceTestCase {
 		Assert.assertEquals(expectedResponseCode, actualResponse.getResponseCode());
 	}
 
+	protected boolean invokeDeleteComment(
+				Long commentId)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setDelete(true);
+
+			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}", commentId));
+
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Boolean.class);
+	}
+
+	protected Http.Response invokeDeleteCommentResponse(
+				Long commentId)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setDelete(true);
+
+			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}", commentId));
+
+			HttpUtil.URLtoString(options);
+
+			return options.getResponse();
+	}
 	protected Comment invokeGetComment(
 				Long commentId)
 			throws Exception {
@@ -98,6 +143,37 @@ public abstract class BaseCommentResourceTestCase {
 			Http.Options options = _createHttpOptions();
 
 			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}", commentId));
+
+			HttpUtil.URLtoString(options);
+
+			return options.getResponse();
+	}
+	protected Comment invokePutComment(
+				Long commentId,Comment comment)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setBody(_inputObjectMapper.writeValueAsString(comment), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+
+			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}", commentId,comment));
+
+				options.setPut(true);
+
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), CommentImpl.class);
+	}
+
+	protected Http.Response invokePutCommentResponse(
+				Long commentId,Comment comment)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setBody(_inputObjectMapper.writeValueAsString(comment), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+
+			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}", commentId,comment));
+
+				options.setPut(true);
 
 			HttpUtil.URLtoString(options);
 
@@ -126,6 +202,37 @@ public abstract class BaseCommentResourceTestCase {
 
 			return options.getResponse();
 	}
+	protected Comment invokePostCommentComment(
+				Long commentId,Comment comment)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setBody(_inputObjectMapper.writeValueAsString(comment), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+
+			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}/comments", commentId,comment));
+
+				options.setPost(true);
+
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), CommentImpl.class);
+	}
+
+	protected Http.Response invokePostCommentCommentResponse(
+				Long commentId,Comment comment)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setBody(_inputObjectMapper.writeValueAsString(comment), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+
+			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}/comments", commentId,comment));
+
+				options.setPost(true);
+
+			HttpUtil.URLtoString(options);
+
+			return options.getResponse();
+	}
 	protected Page<Comment> invokeGetStructuredContentCommentsPage(
 				Long structuredContentId,Pagination pagination)
 			throws Exception {
@@ -144,6 +251,37 @@ public abstract class BaseCommentResourceTestCase {
 			Http.Options options = _createHttpOptions();
 
 			options.setLocation(_resourceURL + _toPath("/structured-contents/{structured-content-id}/comments", structuredContentId));
+
+			HttpUtil.URLtoString(options);
+
+			return options.getResponse();
+	}
+	protected Comment invokePostStructuredContentComment(
+				Long structuredContentId,Comment comment)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setBody(_inputObjectMapper.writeValueAsString(comment), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+
+			options.setLocation(_resourceURL + _toPath("/structured-contents/{structured-content-id}/comments", structuredContentId,comment));
+
+				options.setPost(true);
+
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), CommentImpl.class);
+	}
+
+	protected Http.Response invokePostStructuredContentCommentResponse(
+				Long structuredContentId,Comment comment)
+			throws Exception {
+
+			Http.Options options = _createHttpOptions();
+
+				options.setBody(_inputObjectMapper.writeValueAsString(comment), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+
+			options.setLocation(_resourceURL + _toPath("/structured-contents/{structured-content-id}/comments", structuredContentId,comment));
+
+				options.setPost(true);
 
 			HttpUtil.URLtoString(options);
 


### PR DESCRIPTION
Hey brian,

We can make ExceptionMappers for this exception but it would require to copy those exception mappers to all bounded context, so I decide to keep the try-catch, is that ok?

The alternative would be to put those exception mappers in portal-vulcan, but this will require portal-vulcan to depend on message-boards-api, which I think it is a scenario we want to avoid.

Thanks!