### PR TITLE
[DO NOT MERGE THIS] Opening just for feedback

### DIFF
--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/ContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/ContentStructureResourceImpl.java
@@ -24,7 +24,10 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchResultPermissionFilterFactory;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
@@ -65,20 +68,23 @@ public class ContentStructureResourceImpl
 
 		List<DDMStructure> ddmStructures = new ArrayList<>();
 
-		Hits hits = SearchUtil.getHits(
-			filter, _indexerRegistry.nullSafeGetIndexer(DDMStructure.class),
-			pagination,
+		Indexer<DDMStructure> indexer = IndexerRegistryUtil.getIndexer(
+			DDMStructure.class);
+
+		SearchContext searchContext = SearchUtil.buildSearchContext(
+			filter, pagination,
 			booleanQuery -> {
 			},
-			queryConfig -> queryConfig.setSelectedFieldNames(
-				Field.ENTRY_CLASS_PK),
-			searchContext -> {
-				searchContext.setAttribute(
-					"searchPermissionContext", StringPool.BLANK);
-				searchContext.setCompanyId(contextCompany.getCompanyId());
-				searchContext.setGroupIds(new long[] {contentSpaceId});
+			queryConfig -> {
+				queryConfig.setSelectedFieldNames(Field.ENTRY_CLASS_PK);
 			},
-			_searchResultPermissionFilterFactory, sorts);
+			sorts);
+
+		searchContext.setGroupIds(new long[] {contentSpaceId});
+		searchContext.setAttribute("searchPermissionContext", StringPool.BLANK);
+		searchContext.setCompanyId(contextCompany.getCompanyId());
+
+		Hits hits = indexer.search(searchContext);
 
 		for (Document document : hits.getDocs()) {
 			DDMStructure ddmStructure = _ddmStructureService.getStructure(
@@ -89,7 +95,7 @@ public class ContentStructureResourceImpl
 
 		return Page.of(
 			transform(ddmStructures, this::_toContentStructure), pagination,
-			ddmStructures.size());
+			Math.toIntExact(indexer.searchCount(searchContext)));
 	}
 
 	@Override

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/SearchUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/SearchUtil.java
@@ -14,21 +14,17 @@
 
 package com.liferay.portal.vulcan.util;
 
+import com.liferay.portal.kernel.search.BooleanClause;
+import com.liferay.portal.kernel.search.BooleanClauseFactoryUtil;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
-import com.liferay.portal.kernel.search.Hits;
-import com.liferay.portal.kernel.search.IndexSearcherHelperUtil;
-import com.liferay.portal.kernel.search.Indexer;
-import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.search.SearchException;
-import com.liferay.portal.kernel.search.SearchResultPermissionFilter;
-import com.liferay.portal.kernel.search.SearchResultPermissionFilterFactory;
-import com.liferay.portal.kernel.search.SearchResultPermissionFilterSearcher;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.search.generic.MatchAllQuery;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -40,56 +36,35 @@ import java.util.function.Consumer;
  */
 public class SearchUtil {
 
-	public static Hits getHits(
-			Filter filter, Indexer<?> indexer, Pagination pagination,
+	public static SearchContext buildSearchContext(
+			Filter filter, Pagination pagination,
 			Consumer<BooleanQuery> booleanQueryConsumer,
-			Consumer<QueryConfig> queryConfigConsumer,
-			Consumer<SearchContext> searchContextConsumer,
-			SearchResultPermissionFilterFactory
-				searchResultPermissionFilterFactory,
-			Sort[] sorts)
-		throws SearchException {
+			Consumer<QueryConfig> queryConfigConsumer, Sort[] sorts)
+		throws Exception {
 
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
-		SearchContext searchContext = _createSearchContext(
-			pagination, permissionChecker, queryConfigConsumer,
-			searchContextConsumer, sorts);
+		BooleanClause<?> booleanClause = _getBooleanClause(
+			filter, booleanQueryConsumer);
 
-		Query query = _getQuery(
-			filter, indexer, booleanQueryConsumer, searchContext);
-
-		SearchResultPermissionFilter searchResultPermissionFilter =
-			searchResultPermissionFilterFactory.create(
-				new SearchResultPermissionFilterSearcher() {
-
-					public Hits search(SearchContext searchContext)
-						throws SearchException {
-
-						return IndexSearcherHelperUtil.search(
-							searchContext, query);
-					}
-
-				},
-				permissionChecker);
-
-		return searchResultPermissionFilter.search(searchContext);
+		return _createSearchContext(
+			booleanClause, pagination, permissionChecker, queryConfigConsumer,
+			sorts);
 	}
 
 	private static SearchContext _createSearchContext(
-		Pagination pagination, PermissionChecker permissionChecker,
-		Consumer<QueryConfig> queryConfigConsumer,
-		Consumer<SearchContext> searchContextConsumer, Sort[] sorts) {
+		BooleanClause<?> booleanClause, Pagination pagination,
+		PermissionChecker permissionChecker,
+		Consumer<QueryConfig> queryConfigConsumer, Sort[] sorts) {
 
 		SearchContext searchContext = new SearchContext();
 
+		searchContext.setBooleanClauses(new BooleanClause[] {booleanClause});
 		searchContext.setEnd(pagination.getEndPosition());
 		searchContext.setSorts(sorts);
 		searchContext.setStart(pagination.getStartPosition());
 		searchContext.setUserId(permissionChecker.getUserId());
-
-		searchContextConsumer.accept(searchContext);
 
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 
@@ -101,23 +76,26 @@ public class SearchUtil {
 		return searchContext;
 	}
 
-	private static Query _getQuery(
-			Filter filter, Indexer<?> indexer,
-			Consumer<BooleanQuery> booleanQueryConsumer,
-			SearchContext searchContext)
-		throws SearchException {
+	private static BooleanClause<?> _getBooleanClause(
+			Filter filter, Consumer<BooleanQuery> booleanQueryConsumer)
+		throws Exception {
 
-		BooleanQuery booleanQuery = indexer.getFullQuery(searchContext);
+		BooleanQuery booleanQuery = new BooleanQueryImpl();
+
+		booleanQuery.add(new MatchAllQuery(), BooleanClauseOccur.MUST);
 
 		if (filter != null) {
-			BooleanFilter booleanFilter = booleanQuery.getPreBooleanFilter();
+			BooleanFilter booleanFilter = new BooleanFilter();
 
 			booleanFilter.add(filter, BooleanClauseOccur.MUST);
+
+			booleanQuery.setPreBooleanFilter(booleanFilter);
 		}
 
 		booleanQueryConsumer.accept(booleanQuery);
 
-		return booleanQuery;
+		return BooleanClauseFactoryUtil.create(
+			booleanQuery, BooleanClauseOccur.MUST.getName());
 	}
 
 }


### PR DESCRIPTION
Hey Brian,

We had to do a workaround for a bug in the search framework that is now resolved. This code is extracted in SearchUtil.

Now, I've to change this code to use the search framework in the "normal" way. Instead of returning the Hits, I've created a method that returns the searchContext, because right now, we have to make two calls using this searchContext `indexer.search(searchContext)` and ìndexer.searchCount(searchContext)`. 

I've to apply the change across all APIs so I wanted to obtain your feedback about this approach first, what do you think?

Thanks!