### PR TITLE
LPS-89732 | master

### DIFF
--- a/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/packageinfo
+++ b/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.2
+version 1.1.0


### PR DESCRIPTION
@ahdezma fixes semver error caused by https://github.com/brianchandotcom/liferay-portal/pull/68694
```
     [exec] > Task :apps:blogs:blogs-api:baseline FAILED
     [exec]   PACKAGE_NAME                                       DELTA      CUR_VER    BASE_VER   REC_VER    WARNINGS  
     [exec] = ================================================== ========== ========== ========== ========== ==========
     [exec] * com.liferay.blogs.service                          MINOR      1.0.2      1.0.1      1.1.0      VERSION INCREASE REQUIRED
     [exec] 	<   class      com.liferay.blogs.service.BlogsEntryServiceUtil
     [exec] 		+   method     addAttachmentsFolder(long)
     [exec] 			+   access     static
     [exec] 			+   return     com.liferay.portal.kernel.repository.model.Folder
     [exec] 	<   class      com.liferay.blogs.service.BlogsEntryServiceWrapper
     [exec] 		+   method     addAttachmentsFolder(long)
     [exec] 			+   return     com.liferay.portal.kernel.repository.model.Folder
     [exec] 	<   interface  com.liferay.blogs.service.BlogsEntryService
     [exec] 		+   method     addAttachmentsFolder(long)
     [exec] 			+   access     abstract
     [exec] 			+   return     com.liferay.portal.kernel.repository.model.Folder
     [exec] 		-   annotated  com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties
     [exec] 			-   property   property.0='json.web.service.context.name=blogs'
     [exec] 			-   property   property.1='json.web.service.context.path=BlogsEntry'
     [exec] 			-   property   service.0=com.liferay.blogs.service.BlogsEntryService
     [exec] 	-   version    1.0.1
     [exec] 	+   version    1.0.2
```