### PR TITLE
LPS-90985 Remove other iframe selections that were missed before

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContentNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContentNavigator.macro
@@ -114,8 +114,6 @@ definition {
 
 		MenuItem.click(menuItem = "${menuItem}");
 
-		IFrame.selectEditAssetFrame();
-
 		AssertVisible(locator1 = "TextInput#TITLE");
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-90985

For master only. LPS-90985 removed the iframe when adding assets in web content display and asset publisher. I missed one of the instances in the tests.