### PR TITLE
Example (DO NOT MERGE)

### DIFF
--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/src/configs/com.liferay.oauth2.provider.rest.internal.jaxrs.feature.configuration.ConfigurableScopeCheckerFeatureConfiguration.config
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/src/configs/com.liferay.oauth2.provider.rest.internal.jaxrs.feature.configuration.ConfigurableScopeCheckerFeatureConfiguration.config
@@ -1,0 +1,4 @@
+allow.unmatched=false
+osgi.jaxrs.application.select="(osgi.jaxrs.name=Liferay.Headless.Workflow)"
+osgi.jaxrs.name="Scope.Checker.Headless.Workflow"
+patterns=["GET::/workflow-logs/[\d]+::everything.read"]

--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/jaxrs/application/HeadlessWorkflowApplication.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/jaxrs/application/HeadlessWorkflowApplication.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"oauth2.scope.checker.type=annotations",
+		"oauth2.scope.checker.type=configuration",
 		"osgi.jaxrs.application.base=/headless-workflow",
 		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=Liferay.Vulcan)",
 		"osgi.jaxrs.name=Liferay.Headless.Workflow"

--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
@@ -53,7 +53,6 @@ public abstract class BaseWorkflowLogResourceImpl
 	@Override
 	@Path("/workflow-logs/{workflow-log-id}")
 	@Produces("application/json")
-	@RequiresScope("everything.read")
 	public WorkflowLog getWorkflowLog(
 			@PathParam("workflow-log-id") Long workflowLogId)
 		throws Exception {


### PR DESCRIPTION
Hey @brianchandotcom, 
as discussed here you have an example on how to have OAuth2 scopes in an application using configuration. You can use the regex you need to match the URIs and methods to assign scopes to them. You can add as many `patterns` as you need to replace all the annotated scopes. 

I hope this helps.