### PR TITLE
LPS-90958 Indexer tests with viewCount field

### DIFF
--- a/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/service/impl/AssetEntryAssetCategoryRelLocalServiceImpl.java
+++ b/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/service/impl/AssetEntryAssetCategoryRelLocalServiceImpl.java
@@ -157,6 +157,10 @@ public class AssetEntryAssetCategoryRelLocalServiceImpl
 
 			AssetRenderer assetRenderer = assetEntry.getAssetRenderer();
 
+			if (assetRenderer == null) {
+				return;
+			}
+
 			indexer.reindex(assetRenderer.getAssetObject());
 		}
 		catch (SearchException se) {

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/search/test/BlogsEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/search/test/BlogsEntryIndexerIndexedFieldsTest.java
@@ -158,6 +158,8 @@ public class BlogsEntryIndexerIndexedFieldsTest {
 		indexedFieldsFixture.populateUID(
 			BlogsEntry.class.getName(), blogsEntry.getEntryId(), map);
 		indexedFieldsFixture.populatePriority("0.0", map);
+		indexedFieldsFixture.populateViewCount(
+			BlogsEntry.class, blogsEntry.getEntryId(), map);
 
 		_populateDates(blogsEntry, map);
 		_populateRoles(blogsEntry, map);

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksEntryIndexerIndexedFieldsTest.java
@@ -170,6 +170,8 @@ public class BookmarksEntryIndexerIndexedFieldsTest {
 		indexedFieldsFixture.populatePriority("0.0", map);
 		indexedFieldsFixture.populateUID(
 			BookmarksEntry.class.getName(), bookmarksEntry.getEntryId(), map);
+		indexedFieldsFixture.populateViewCount(
+			BookmarksEntry.class, bookmarksEntry.getEntryId(), map);
 
 		_populateDates(bookmarksEntry, map);
 		_populateRoles(bookmarksEntry, map);

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksFolderIndexerIndexedFieldsTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksFolderIndexerIndexedFieldsTest.java
@@ -173,6 +173,8 @@ public class BookmarksFolderIndexerIndexedFieldsTest {
 		indexedFieldsFixture.populateUID(
 			BookmarksFolder.class.getName(), bookmarksFolder.getFolderId(),
 			map);
+		indexedFieldsFixture.populateViewCount(
+			BookmarksFolder.class, bookmarksFolder.getFolderId(), map);
 
 		_populateDates(bookmarksFolder, map);
 		_populateRoles(bookmarksFolder, map);

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/CalendarBookingIndexerIndexedFieldsTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/CalendarBookingIndexerIndexedFieldsTest.java
@@ -177,7 +177,8 @@ public class CalendarBookingIndexerIndexedFieldsTest
 	}
 
 	protected void populateCalendarBooking(
-		CalendarBooking calendarBooking, Map<String, String> map) {
+			CalendarBooking calendarBooking, Map<String, String> map)
+		throws Exception {
 
 		map.put(
 			Field.CLASS_PK, String.valueOf(calendarBooking.getCalendarId()));
@@ -195,6 +196,9 @@ public class CalendarBookingIndexerIndexedFieldsTest
 		map.put(
 			"startTime_sortable",
 			String.valueOf(calendarBooking.getStartTime()));
+
+		indexedFieldsFixture.populateViewCount(
+			CalendarBooking.class, calendarBooking.getCalendarBookingId(), map);
 
 		populateDates(calendarBooking, map);
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
@@ -218,6 +218,7 @@ public class DLFileEntryIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 		populateDates(fileEntry, map);
 		populateHttpHeaders(fileEntry, map);
 		populateLocalizedTitles(fileEntry, map);
+		populateViewCount(fileEntry, map);
 
 		indexedFieldsFixture.populatePriority("0.0", map);
 		indexedFieldsFixture.populateRoleIdFields(
@@ -271,6 +272,13 @@ public class DLFileEntryIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 			map.put(key, title);
 			map.put(key.concat("_sortable"), title);
 		}
+	}
+
+	protected void populateViewCount(
+		FileEntry fileEntry, Map<String, String> map) {
+
+		map.put("viewCount", String.valueOf(fileEntry.getReadCount()));
+		map.put("viewCount_sortable", String.valueOf(fileEntry.getReadCount()));
 	}
 
 	protected FileEntrySearchFixture fileEntrySearchFixture;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderIndexerIndexedFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderIndexerIndexedFieldsTest.java
@@ -167,6 +167,8 @@ public class DLFolderIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 			dlFolder.getPrimaryKey(), dlFolder.getGroupId(), null, map);
 		indexedFieldsFixture.populateUID(
 			dlFolder.getModelClassName(), dlFolder.getFolderId(), map);
+		indexedFieldsFixture.populateViewCount(
+			DLFolder.class, dlFolder.getFolderId(), map);
 
 		return map;
 	}

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageIndexerIndexedFieldsTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageIndexerIndexedFieldsTest.java
@@ -175,6 +175,8 @@ public class MBMessageIndexerIndexedFieldsTest {
 		indexedFieldsFixture.populatePriority("0.0", map);
 		indexedFieldsFixture.populateUID(
 			MBMessage.class.getName(), mbMessage.getMessageId(), map);
+		indexedFieldsFixture.populateViewCount(
+			MBMessage.class, mbMessage.getMessageId(), map);
 
 		_populateDates(mbMessage, map);
 		_populateRoles(mbMessage, map);

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/AssertUtils.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/AssertUtils.java
@@ -29,8 +29,10 @@ public class AssertUtils {
 	public static void assertEquals(
 		String message, Map<?, ?> expectedMap, Map<?, ?> actualMap) {
 
+		String actual = _toString(actualMap);
+
 		Assert.assertEquals(
-			message, _toString(expectedMap), _toString(actualMap));
+			message + "->" + actual, _toString(expectedMap), actual);
 	}
 
 	private static String _toString(Map<?, ?> map) {

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/IndexedFieldsFixture.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/IndexedFieldsFixture.java
@@ -14,6 +14,9 @@
 
 package com.liferay.portal.search.test.util;
 
+import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
@@ -108,6 +111,22 @@ public class IndexedFieldsFixture {
 		String modelClassName, long id, Map<String, String> map) {
 
 		map.put(Field.UID, modelClassName + "_PORTLET_" + id);
+	}
+
+	public void populateViewCount(
+			Class<?> clazz, long classPK, Map<String, String> map)
+		throws Exception {
+
+		AssetRendererFactory assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClass(
+				clazz);
+
+		AssetEntry assetEntry = assetRendererFactory.getAssetEntry(
+			clazz.getName(), classPK);
+
+		map.put("viewCount", String.valueOf(assetEntry.getViewCount()));
+		map.put(
+			"viewCount_sortable", String.valueOf(assetEntry.getViewCount()));
 	}
 
 	public void postProcessDocument(Document document) {


### PR DESCRIPTION
**❌ ci:test:search - 13 out of 17 jobs passed in 1 hour 30 minutes 51 seconds 276 ms**
https://github.com/arboliveira/liferay-portal/pull/681#issuecomment-470797206


`Execution failed for task ':apps:export-import:export-import-test:compileTestIntegrationJava'`
Contamination in branch `master`. Proper team notified.
https://github.com/liferay/liferay-portal/commit/4e27dda9d7527779ac59b9d81d946efd9901bd48#diff-882005b8a5ffc3d5a7f9c98b8b26a0f0


`Type to 'SEARCH_BAR_WIDGET' the value '*' --> FAILED`
Likely contamination in branch `master`. Reached out to possibly related team.
A certain portlet configuration, when saved, used to get a blank string as its default value. Since yesterday, it's getting the string "null" instead. https://issues.liferay.com/browse/LPS-91767
Although reported as "unique to this pull", failure was spotted in other pull requests. 


`Click on 'CATEGORY_AUTOCOMPLETE_SPECIFIC' --> FAILED`
Causes uncertain. Resembles a contamination found and addressed in January.
https://issues.liferay.com/browse/LRQA-46488
Unlikely this pull request could have caused it, as only integration test code has been changed.

----

Authors: @pavel-savinov @vagnerbc
Reviewer: @arboliveira

_[Bug] Dynamic Asset List does not order by view count_
https://issues.liferay.com/browse/LPS-90958