### PR TITLE
LPS-85855 trash-service: Integrate Trash into new indexer model. Integrate Trash into new permission model. Deprecate Trash legacy indexer. Rename class to the right pattern.

### DIFF
--- a/modules/apps/trash/trash-service/build.gradle
+++ b/modules/apps/trash/trash-service/build.gradle
@@ -9,10 +9,12 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	compileOnly group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:petra:petra-model-adapter")
 	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal:portal-spring-extender-api")
 	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":apps:trash:trash-api")

--- a/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashIndexer.java
+++ b/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashIndexer.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
@@ -41,13 +40,12 @@ import java.util.Locale;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
-import org.osgi.service.component.annotations.Component;
-
 /**
  * @author Julio Camarero
  * @author Zsolt Berentey
+ * @deprecated As of Judson (7.1.x), since 7.1.0
  */
-@Component(immediate = true, service = Indexer.class)
+@Deprecated
 public class TrashIndexer extends BaseIndexer<TrashEntry> {
 
 	public static final String CLASS_NAME = TrashEntry.class.getName();

--- a/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashIndexerPostProcessor.java
+++ b/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashIndexerPostProcessor.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.trash.internal.search;
+
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.IndexerPostProcessor;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.search.filter.QueryFilter;
+import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.trash.TrashHandler;
+import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Luan Maoski
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.trash.model.TrashEntry",
+	service = IndexerPostProcessor.class
+)
+public class TrashIndexerPostProcessor implements IndexerPostProcessor {
+
+	@Override
+	public void postProcessContextBooleanFilter(
+			BooleanFilter booleanFilter, SearchContext searchContext)
+		throws Exception {
+	}
+
+	@Override
+	public void postProcessContextQuery(
+			BooleanQuery contextQuery, SearchContext searchContext)
+		throws Exception {
+	}
+
+	@Override
+	public void postProcessDocument(Document document, Object obj)
+		throws Exception {
+	}
+
+	@Override
+	public void postProcessFullQuery(
+			BooleanQuery fullQuery, SearchContext searchContext)
+		throws Exception {
+
+		BooleanFilter booleanFilter = new BooleanFilter();
+
+		fullQuery.setPreBooleanFilter(booleanFilter);
+
+		booleanFilter.addRequiredTerm(
+			Field.COMPANY_ID, searchContext.getCompanyId());
+
+		List<TrashHandler> trashHandlers =
+			TrashHandlerRegistryUtil.getTrashHandlers();
+
+		for (TrashHandler trashHandler : trashHandlers) {
+			Filter excludeFilter = trashHandler.getExcludeFilter(searchContext);
+
+			if (excludeFilter != null) {
+				booleanFilter.add(excludeFilter, BooleanClauseOccur.MUST_NOT);
+			}
+
+			processTrashHandlerExcludeQuery(
+				searchContext, booleanFilter, trashHandler);
+		}
+
+		long[] groupIds = searchContext.getGroupIds();
+
+		if (ArrayUtil.isNotEmpty(groupIds)) {
+			TermsFilter termsFilter = new TermsFilter(Field.GROUP_ID);
+
+			termsFilter.addValues(ArrayUtil.toStringArray(groupIds));
+
+			booleanFilter.add(termsFilter, BooleanClauseOccur.MUST);
+		}
+
+		booleanFilter.addRequiredTerm(
+			Field.STATUS, WorkflowConstants.STATUS_IN_TRASH);
+	}
+
+	@Override
+	public void postProcessSearchQuery(
+			BooleanQuery searchQuery, BooleanFilter booleanFilter,
+			SearchContext searchContext)
+		throws Exception {
+	}
+
+	@Override
+	public void postProcessSearchQuery(
+			BooleanQuery searchQuery, SearchContext searchContext)
+		throws Exception {
+	}
+
+	@Override
+	public void postProcessSummary(
+		Summary summary, Document document, Locale locale, String snippet) {
+	}
+
+	protected void processTrashHandlerExcludeQuery(
+		SearchContext searchContext, BooleanFilter fullQueryBooleanFilter,
+		TrashHandler trashHandler) {
+
+		Query excludeQuery = trashHandler.getExcludeQuery(searchContext);
+
+		if (excludeQuery != null) {
+			fullQueryBooleanFilter.add(
+				new QueryFilter(excludeQuery), BooleanClauseOccur.MUST_NOT);
+		}
+	}
+
+}

--- a/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashSearchRegistrar.java
+++ b/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashSearchRegistrar.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.trash.internal.search;
+
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchRegistrarHelper;
+import com.liferay.trash.model.TrashEntry;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Luan Maoski
+ */
+@Component(immediate = true, service = {})
+public class TrashSearchRegistrar {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceRegistration = modelSearchRegistrarHelper.register(
+			TrashEntry.class, bundleContext,
+			modelSearchDefinition -> {
+				modelSearchDefinition.setDefaultSelectedFieldNames(
+					Field.ENTRY_CLASS_NAME, Field.ENTRY_CLASS_PK,
+					Field.REMOVED_BY_USER_NAME, Field.REMOVED_DATE,
+					Field.ROOT_ENTRY_CLASS_NAME, Field.ROOT_ENTRY_CLASS_PK,
+					Field.UID);
+			});
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceRegistration.unregister();
+	}
+
+	@Reference
+	protected ModelSearchRegistrarHelper modelSearchRegistrarHelper;
+
+	private ServiceRegistration<?> _serviceRegistration;
+
+}

--- a/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashSearcher.java
+++ b/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashSearcher.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.trash.internal.search;
+
+import com.liferay.portal.kernel.search.BaseSearcher;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.trash.model.TrashEntry;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Luan Maoski
+ */
+@Component(
+	immediate = true,
+	property = "model.class.name=com.liferay.trash.model.TrashEntry",
+	service = BaseSearcher.class
+)
+public class TrashSearcher extends BaseSearcher {
+
+	public static final String CLASS_NAME = TrashEntry.class.getName();
+
+	public TrashSearcher() {
+		setDefaultSelectedFieldNames(
+			Field.ENTRY_CLASS_NAME, Field.ENTRY_CLASS_PK,
+			Field.REMOVED_BY_USER_NAME, Field.REMOVED_DATE,
+			Field.ROOT_ENTRY_CLASS_NAME, Field.ROOT_ENTRY_CLASS_PK, Field.UID);
+		setFilterSearch(true);
+		setPermissionAware(true);
+	}
+
+	@Override
+	public String getClassName() {
+		return CLASS_NAME;
+	}
+
+}

--- a/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashedDocumentContributor.java
+++ b/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashedDocumentContributor.java
@@ -39,7 +39,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(immediate = true, service = DocumentContributor.class)
-public class TrashedModelDocumentContributor implements DocumentContributor {
+public class TrashedDocumentContributor implements DocumentContributor {
 
 	@Override
 	public void contribute(Document document, BaseModel baseModel) {
@@ -133,7 +133,7 @@ public class TrashedModelDocumentContributor implements DocumentContributor {
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
-		TrashedModelDocumentContributor.class);
+		TrashedDocumentContributor.class);
 
 	private UserLocalService _userLocalService;
 

--- a/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/search/spi/query/contributor/TrashKeywordQueryContributor.java
+++ b/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/search/spi/query/contributor/TrashKeywordQueryContributor.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.trash.internal.search.spi.query.contributor;
+
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.search.query.QueryHelper;
+import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
+import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Luan Maoski
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.trash.model.TrashEntry",
+	service = KeywordQueryContributor.class
+)
+public class TrashKeywordQueryContributor implements KeywordQueryContributor {
+
+	@Override
+	public void contribute(
+		String keywords, BooleanQuery booleanQuery,
+		KeywordQueryContributorHelper keywordQueryContributorHelper) {
+
+		SearchContext searchContext =
+			keywordQueryContributorHelper.getSearchContext();
+
+		if (searchContext.getAttributes() == null) {
+			return;
+		}
+
+		queryHelper.addSearchLocalizedTerm(
+			booleanQuery, searchContext, Field.CONTENT, true);
+
+		queryHelper.addSearchLocalizedTerm(
+			booleanQuery, searchContext, Field.DESCRIPTION, true);
+
+		queryHelper.addSearchTerm(
+			booleanQuery, searchContext, Field.REMOVED_BY_USER_NAME, true);
+
+		queryHelper.addSearchLocalizedTerm(
+			booleanQuery, searchContext, Field.TITLE, true);
+		queryHelper.addSearchTerm(
+			booleanQuery, searchContext, Field.TYPE, false);
+		queryHelper.addSearchTerm(
+			booleanQuery, searchContext, Field.USER_NAME, true);
+	}
+
+	@Reference
+	protected QueryHelper queryHelper;
+
+}

--- a/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/security/permission/resource/TrashModelResourcePermission.java
+++ b/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/security/permission/resource/TrashModelResourcePermission.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.trash.internal.security.permission.resource;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+import com.liferay.trash.model.TrashEntry;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Luan Maoski
+ */
+@Component(
+	immediate = true,
+	property = "model.class.name=com.liferay.trash.model.TrashEntry",
+	service = ModelResourcePermission.class
+)
+public class TrashModelResourcePermission
+	implements ModelResourcePermission<TrashEntry> {
+
+	@Override
+	public void check(
+			PermissionChecker permissionChecker, long entryId, String actionId)
+		throws PortalException {
+
+		trashPermission.check(permissionChecker, entryId, actionId);
+	}
+
+	@Override
+	public void check(
+			PermissionChecker permissionChecker, TrashEntry model,
+			String actionId)
+		throws PortalException {
+
+		trashPermission.check(permissionChecker, model.getEntryId(), actionId);
+	}
+
+	@Override
+	public boolean contains(
+			PermissionChecker permissionChecker, long entryId, String actionId)
+		throws PortalException {
+
+		return trashPermission.contains(permissionChecker, entryId, actionId);
+	}
+
+	@Override
+	public boolean contains(
+			PermissionChecker permissionChecker, TrashEntry model,
+			String actionId)
+		throws PortalException {
+
+		return trashPermission.contains(
+			permissionChecker, model.getEntryId(), actionId);
+	}
+
+	@Override
+	public String getModelName() {
+		return TrashEntry.class.getName();
+	}
+
+	@Override
+	public PortletResourcePermission getPortletResourcePermission() {
+		return null;
+	}
+
+	@Reference
+	protected TrashPermission trashPermission;
+
+}

--- a/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/security/permission/resource/TrashPermission.java
+++ b/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/security/permission/resource/TrashPermission.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.trash.internal.security.permission.resource;
+
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+
+/**
+ * @author Luan Maoski
+ */
+public interface TrashPermission {
+
+	public void check(
+			PermissionChecker permissionChecker, long entryId, String actionId)
+		throws PrincipalException;
+
+	public boolean contains(
+		PermissionChecker permissionChecker, long entryId, String actionId);
+
+}

--- a/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/security/permission/resource/TrashPermissionImpl.java
+++ b/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/security/permission/resource/TrashPermissionImpl.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.trash.internal.security.permission.resource;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.trash.TrashHandler;
+import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
+import com.liferay.trash.model.TrashEntry;
+
+/**
+ * @author Luan Maoski
+ */
+public class TrashPermissionImpl implements TrashPermission {
+
+	@Override
+	public void check(
+			PermissionChecker permissionChecker, long entryId, String actionId)
+		throws PrincipalException {
+
+		if (!contains(permissionChecker, entryId, actionId)) {
+			throw new PrincipalException.MustHavePermission(
+				permissionChecker, TrashEntry.class.getName(), entryId,
+				actionId);
+		}
+	}
+
+	@Override
+	public boolean contains(
+		PermissionChecker permissionChecker, long entryId, String actionId) {
+
+		TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(
+			TrashEntry.class.getName());
+
+		try {
+			return trashHandler.hasTrashPermission(
+				permissionChecker, 0, entryId, actionId);
+		}
+		catch (PortalException pe) {
+			throw new SystemException(pe);
+		}
+	}
+
+}

--- a/modules/apps/trash/trash-test/build.gradle
+++ b/modules/apps/trash/trash-test/build.gradle
@@ -1,7 +1,10 @@
 dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile project(":apps:document-library:document-library-test-util")
+	testIntegrationCompile project(":apps:portal-search:portal-search-test-util")
 	testIntegrationCompile project(":apps:trash:trash-api")
 	testIntegrationCompile project(":apps:trash:trash-test-util")
+	testIntegrationCompile project(":apps:users-admin:users-admin-test-util")
 	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/search/test/TrashEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/search/test/TrashEntryIndexerIndexedFieldsTest.java
@@ -1,0 +1,286 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.trash.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
+import com.liferay.document.library.kernel.model.DLFileVersion;
+import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryMetadataLocalService;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.test.util.FieldValuesAssert;
+import com.liferay.portal.search.test.util.IndexedFieldsFixture;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+import com.liferay.trash.model.TrashEntry;
+import com.liferay.trash.service.TrashEntryLocalServiceUtil;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luan Maoski
+ */
+@RunWith(Arquillian.class)
+public class TrashEntryIndexerIndexedFieldsTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		setUpUserSearchFixture();
+		setUpTrashEntryFixture();
+		setUpTrashEntryIndexerFixture();
+		setUpIndexedFieldsFixture();
+
+		_fileEntry = trashFixture.createFileEntry();
+	}
+
+	@Test
+	public void testIndexedFields() throws Exception {
+		String searchTerm = _fileEntry.getTitle();
+
+		Document document = trashEntryIndexerFixture.searchOnlyOne(searchTerm);
+
+		indexedFieldsFixture.postProcessDocument(document);
+
+		Map<String, String> map = new HashMap<>();
+
+		FieldValuesAssert.assertFieldValues(
+			populateExpectedFieldValues(_fileEntry, map), document, searchTerm);
+	}
+
+	protected long getDDMStructureId(FileEntry fileEntry) throws Exception {
+		long ddmStructureId = 0;
+
+		DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
+
+		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
+
+		List<DLFileEntryMetadata> dlFileEntryMetadatas =
+			dlFileEntryMetadataLocalService.getFileVersionFileEntryMetadatas(
+				dlFileVersion.getFileVersionId());
+
+		for (DLFileEntryMetadata dlFileEntryMetadata : dlFileEntryMetadatas) {
+			if (dlFileEntryMetadata != null) {
+				ddmStructureId = dlFileEntryMetadata.getDDMStructureId();
+			}
+		}
+
+		return ddmStructureId;
+	}
+
+	protected Map<String, String> populateExpectedFieldValues(
+			FileEntry fileEntry, Map<String, String> map)
+		throws Exception {
+
+		map.put(Field.COMPANY_ID, String.valueOf(fileEntry.getCompanyId()));
+		map.put(Field.CLASS_NAME_ID, "0");
+		map.put(Field.CLASS_PK, "0");
+		map.put(Field.ENTRY_CLASS_NAME, DLFileEntry.class.getName());
+		map.put(
+			Field.ENTRY_CLASS_PK, String.valueOf(fileEntry.getFileEntryId()));
+		map.put(Field.FOLDER_ID, String.valueOf(fileEntry.getFolderId()));
+		map.put(Field.GROUP_ID, String.valueOf(fileEntry.getGroupId()));
+		map.put(Field.SCOPE_GROUP_ID, String.valueOf(fileEntry.getGroupId()));
+		map.put(Field.STAGING_GROUP, "false");
+		map.put(Field.STATUS, "8");
+		map.put(Field.TITLE, fileEntry.getTitle());
+		map.put(
+			Field.TITLE + "_sortable",
+			StringUtil.lowerCase(fileEntry.getTitle()));
+		map.put(Field.TREE_PATH, "");
+		map.put(Field.USER_ID, String.valueOf(fileEntry.getUserId()));
+		map.put(
+			Field.USER_NAME, StringUtil.toLowerCase(fileEntry.getUserName()));
+
+		map.put("classTypeId", "0");
+		map.put(
+			"dataRepositoryId", String.valueOf(fileEntry.getRepositoryId()));
+		map.put("extension", fileEntry.getExtension());
+		map.put("fileEntryTypeId", "0");
+		map.put("hidden", "false");
+		map.put("mimeType", fileEntry.getMimeType().replaceAll("/", "_"));
+		map.put("path", fileEntry.getTitle());
+		map.put("readCount", String.valueOf(fileEntry.getReadCount()));
+		map.put("size", String.valueOf(fileEntry.getSize()));
+		map.put("size_sortable", String.valueOf(fileEntry.getSize()));
+		map.put("visible", "false");
+
+		_populateDates(fileEntry, map);
+		_populateLocalizedTitles(fileEntry, map);
+		_populateTrashEntryFields(fileEntry, map);
+
+		indexedFieldsFixture.populatePriority("0.0", map);
+		indexedFieldsFixture.populateRoleIdFields(
+			fileEntry.getCompanyId(), DLFileEntry.class.getName(),
+			fileEntry.getPrimaryKey(), fileEntry.getGroupId(), null, map);
+		indexedFieldsFixture.populateUID(
+			DLFileEntry.class.getName(), fileEntry.getFileEntryId(), map);
+
+		return map;
+	}
+
+	protected void setUpIndexedFieldsFixture() {
+		indexedFieldsFixture = new IndexedFieldsFixture(
+			resourcePermissionLocalService, searchEngineHelper);
+	}
+
+	protected void setUpTrashEntryFixture() throws Exception {
+		trashFixture = new TrashFixture();
+
+		trashFixture.setUp();
+
+		trashFixture.setGroup(_group);
+
+		_trashEntries = trashFixture.getTrashEntries();
+	}
+
+	protected void setUpTrashEntryIndexerFixture() {
+		trashEntryIndexerFixture = new IndexerFixture<>(TrashEntry.class);
+	}
+
+	protected void setUpUserSearchFixture() throws Exception {
+		userSearchFixture = new UserSearchFixture();
+
+		userSearchFixture.setUp();
+
+		_group = userSearchFixture.addGroup();
+
+		_groups = userSearchFixture.getGroups();
+
+		_user = userSearchFixture.addUser(
+			RandomTestUtil.randomString(), _group);
+
+		_users = userSearchFixture.getUsers();
+	}
+
+	@Inject
+	protected DLFileEntryMetadataLocalService dlFileEntryMetadataLocalService;
+
+	protected IndexedFieldsFixture indexedFieldsFixture;
+
+	@Inject
+	protected IndexerRegistry indexerRegistry;
+
+	@Inject
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+
+	@Inject
+	protected SearchEngineHelper searchEngineHelper;
+
+	protected IndexerFixture<TrashEntry> trashEntryIndexerFixture;
+	protected TrashFixture trashFixture;
+	protected UserSearchFixture userSearchFixture;
+
+	private void _populateDates(FileEntry fileEntry, Map<String, String> map) {
+		indexedFieldsFixture.populateDate(
+			Field.CREATE_DATE, fileEntry.getCreateDate(), map);
+		indexedFieldsFixture.populateDate(
+			Field.PUBLISH_DATE, fileEntry.getCreateDate(), map);
+		indexedFieldsFixture.populateExpirationDateWithForever(map);
+
+		indexedFieldsFixture.populateExpirationDateWithForever(map);
+	}
+
+	private void _populateLocalizedTitles(
+		FileEntry fileEntry, Map<String, String> map) {
+
+		String title = StringUtil.lowerCase(fileEntry.getTitle());
+
+		map.put("localized_title", title);
+
+		for (Locale locale : LanguageUtil.getAvailableLocales()) {
+			String languageId = LocaleUtil.toLanguageId(locale);
+
+			String key = "localized_title_" + languageId;
+
+			map.put(key, title);
+			map.put(key.concat("_sortable"), title);
+		}
+	}
+
+	private void _populateTrashEntryFields(
+			FileEntry fileEntry, Map<String, String> map)
+		throws Exception {
+
+		fileEntry = DLAppLocalServiceUtil.getFileEntry(
+			fileEntry.getFileEntryId());
+
+		TrashEntry trashEntry = TrashEntryLocalServiceUtil.getEntry(
+			DLFileEntry.class.getName(), fileEntry.getFileEntryId());
+
+		map.put(Field.PROPERTIES, fileEntry.getTitle());
+
+		map.put(
+			Field.REMOVED_BY_USER_NAME,
+			StringUtil.lowerCase(trashEntry.getUserName()));
+		map.put(Field.TYPE, "document");
+
+		map.put("path", fileEntry.getTitle());
+
+		indexedFieldsFixture.populateDate(
+			Field.MODIFIED_DATE, fileEntry.getModifiedDate(), map);
+		indexedFieldsFixture.populateDate(
+			Field.REMOVED_DATE, trashEntry.getCreateDate(), map);
+	}
+
+	private FileEntry _fileEntry;
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	@DeleteAfterTestRun
+	private List<TrashEntry> _trashEntries;
+
+	private User _user;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+}

--- a/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/search/test/TrashFixture.java
+++ b/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/search/test/TrashFixture.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.trash.search.test;
+
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLTrashLocalServiceUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.service.test.ServiceTestUtil;
+import com.liferay.trash.model.TrashEntry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Luan Maoski
+ */
+public class TrashFixture {
+
+	public FileEntry createFileEntry() throws Exception {
+		FileEntry fileEntry = DLAppLocalServiceUtil.addFileEntry(
+			getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN, null,
+			getServiceContext());
+
+		DLTrashLocalServiceUtil.moveFileEntryToTrash(
+			getUserId(), fileEntry.getRepositoryId(),
+			fileEntry.getFileEntryId());
+
+		return fileEntry;
+	}
+
+	public ServiceContext getServiceContext() throws Exception {
+		return ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId(), getUserId());
+	}
+
+	public List<TrashEntry> getTrashEntries() {
+		return _trashEntries;
+	}
+
+	public void setGroup(Group group) {
+		_group = group;
+	}
+
+	public void setUp() throws Exception {
+		ServiceTestUtil.setUser(TestPropsValues.getUser());
+
+		CompanyThreadLocal.setCompanyId(TestPropsValues.getCompanyId());
+	}
+
+	protected long getUserId() throws Exception {
+		return TestPropsValues.getUserId();
+	}
+
+	private Group _group;
+	private final List<TrashEntry> _trashEntries = new ArrayList<>();
+
+}

--- a/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/search/test/TrashIndexerSearchTest.java
+++ b/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/search/test/TrashIndexerSearchTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.trash.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.search.test.util.IndexedFieldsFixture;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+import com.liferay.trash.model.TrashEntry;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luan Maoski
+ */
+@RunWith(Arquillian.class)
+public class TrashIndexerSearchTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		setUpUserSearchFixture();
+		setUpIndexedFieldsFixture();
+		setUpTrashEntryIndexerFixture();
+		setUpTrashEntryFixture();
+
+		_fileEntry = trashFixture.createFileEntry();
+
+		_fileEntry = DLAppLocalServiceUtil.getFileEntry(
+			_fileEntry.getFileEntryId());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		DLAppLocalServiceUtil.deleteFileEntry(_fileEntry.getFileEntryId());
+	}
+
+	@Test
+	public void testSearch() throws Exception {
+		String searchTerm = _fileEntry.getTitle();
+
+		Document document = trashIndexerFixture.searchOnlyOne(searchTerm);
+
+		indexedFieldsFixture.postProcessDocument(document);
+
+		Assert.assertEquals(searchTerm, document.get("path"));
+	}
+
+	protected void setUpIndexedFieldsFixture() {
+		indexedFieldsFixture = new IndexedFieldsFixture(
+			resourcePermissionLocalService, searchEngineHelper);
+	}
+
+	protected void setUpTrashEntryFixture() throws Exception {
+		trashFixture = new TrashFixture();
+
+		trashFixture.setUp();
+
+		trashFixture.setGroup(group);
+
+		_trashEntries = trashFixture.getTrashEntries();
+	}
+
+	protected void setUpTrashEntryIndexerFixture() {
+		trashIndexerFixture = new IndexerFixture<>(TrashEntry.class);
+	}
+
+	protected void setUpUserSearchFixture() throws Exception {
+		userSearchFixture = new UserSearchFixture();
+
+		userSearchFixture.setUp();
+
+		_users = userSearchFixture.getUsers();
+
+		group = userSearchFixture.addGroup();
+
+		_groups = userSearchFixture.getGroups();
+	}
+
+	protected Group group;
+	protected IndexedFieldsFixture indexedFieldsFixture;
+
+	@Inject
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+
+	@Inject
+	protected SearchEngineHelper searchEngineHelper;
+
+	protected TrashFixture trashFixture;
+	protected IndexerFixture<TrashEntry> trashIndexerFixture;
+	protected UserSearchFixture userSearchFixture;
+
+	private FileEntry _fileEntry;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	@DeleteAfterTestRun
+	private List<TrashEntry> _trashEntries;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+}


### PR DESCRIPTION
<h3>:x: ci:test:search - 13 out of 17 jobs passed in 1 hour 25 minutes 23 seconds 745 ms</h3>

https://github.com/brandizzi/liferay-portal/pull/633#issuecomment-471002314

The test failures are not related, they are working for some time now with all pull requests:

* [LocalFile.Search#ViewFacetPersistence](https://testray.liferay.com/home/-/testray/case_results/492529019/history?tab=result&hideFilterPin=true)
* [LocalFile.Search#NavigateToSearchResultsViaURL](https://testray.liferay.com/home/-/testray/case_results/492529792/history?tab=result&hideFilterPin=true)
* [LocalFile.Search#SearchBlogsEntryCategory]( ttps://testray.liferay.com/home/-/testray/case_results/492529918/history?tab=result&hideFilterPin=true)

Authors: @luanmaoski
Reviewer: @brandizzi

[Task] New Indexer: TrashEntry
https://issues.liferay.com/browse/LPS-85855