### PR TITLE
LPS-91970 Fix bad column name policy for columns with db-name

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/persistence/impl/AssetListEntrySegmentsEntryRelPersistenceImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/persistence/impl/AssetListEntrySegmentsEntryRelPersistenceImpl.java
@@ -3850,6 +3850,6 @@ public class AssetListEntrySegmentsEntryRelPersistenceImpl
 		AssetListEntrySegmentsEntryRelPersistenceImpl.class);
 
 	private static final Set<String> _badColumnNames = SetUtil.fromArray(
-		new String[] {"uuid", "assetListEntrySegmentsEntryRelId"});
+		new String[] {"uuid"});
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ApplicationPersistenceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ApplicationPersistenceImpl.java
@@ -44,7 +44,6 @@ import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ProxyUtil;
-import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.Serializable;
@@ -56,7 +55,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import javax.sql.DataSource;
 
@@ -1863,11 +1861,6 @@ public class OAuth2ApplicationPersistenceImpl
 	}
 
 	@Override
-	public Set<String> getBadColumnNames() {
-		return _badColumnNames;
-	}
-
-	@Override
 	protected EntityCache getEntityCache() {
 		return entityCache;
 	}
@@ -2037,8 +2030,5 @@ public class OAuth2ApplicationPersistenceImpl
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		OAuth2ApplicationPersistenceImpl.class);
-
-	private static final Set<String> _badColumnNames = SetUtil.fromArray(
-		new String[] {"oAuth2ApplicationScopeAliasesId"});
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ApplicationScopeAliasesPersistenceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ApplicationScopeAliasesPersistenceImpl.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ProxyUtil;
-import com.liferay.portal.kernel.util.SetUtil;
 
 import java.io.Serializable;
 
@@ -49,7 +48,6 @@ import java.lang.reflect.InvocationHandler;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.sql.DataSource;
 
@@ -2373,11 +2371,6 @@ public class OAuth2ApplicationScopeAliasesPersistenceImpl
 	}
 
 	@Override
-	public Set<String> getBadColumnNames() {
-		return _badColumnNames;
-	}
-
-	@Override
 	protected EntityCache getEntityCache() {
 		return entityCache;
 	}
@@ -2568,8 +2561,5 @@ public class OAuth2ApplicationScopeAliasesPersistenceImpl
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		OAuth2ApplicationScopeAliasesPersistenceImpl.class);
-
-	private static final Set<String> _badColumnNames = SetUtil.fromArray(
-		new String[] {"oAuth2ApplicationScopeAliasesId"});
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2AuthorizationPersistenceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2AuthorizationPersistenceImpl.java
@@ -3178,11 +3178,6 @@ public class OAuth2AuthorizationPersistenceImpl
 	}
 
 	@Override
-	public Set<String> getBadColumnNames() {
-		return _badColumnNames;
-	}
-
-	@Override
 	protected EntityCache getEntityCache() {
 		return entityCache;
 	}
@@ -3406,8 +3401,5 @@ public class OAuth2AuthorizationPersistenceImpl
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		OAuth2AuthorizationPersistenceImpl.class);
-
-	private static final Set<String> _badColumnNames = SetUtil.fromArray(
-		new String[] {"oAuth2ApplicationScopeAliasesId"});
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ScopeGrantFinderBaseImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ScopeGrantFinderBaseImpl.java
@@ -19,11 +19,7 @@ import com.liferay.oauth2.provider.service.persistence.OAuth2ScopeGrantPersisten
 import com.liferay.oauth2.provider.service.persistence.impl.constants.OAuthTwoPersistenceConstants;
 import com.liferay.portal.kernel.configuration.Configuration;
 import com.liferay.portal.kernel.dao.orm.SessionFactory;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
-
-import java.util.Set;
 
 import javax.sql.DataSource;
 
@@ -38,11 +34,6 @@ public abstract class OAuth2ScopeGrantFinderBaseImpl
 
 	public OAuth2ScopeGrantFinderBaseImpl() {
 		setModelClass(OAuth2ScopeGrant.class);
-	}
-
-	@Override
-	public Set<String> getBadColumnNames() {
-		return oAuth2ScopeGrantPersistence.getBadColumnNames();
 	}
 
 	@Override
@@ -74,8 +65,5 @@ public abstract class OAuth2ScopeGrantFinderBaseImpl
 
 	@Reference
 	protected OAuth2ScopeGrantPersistence oAuth2ScopeGrantPersistence;
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		OAuth2ScopeGrantFinderBaseImpl.class);
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ScopeGrantPersistenceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/persistence/impl/OAuth2ScopeGrantPersistenceImpl.java
@@ -2002,11 +2002,6 @@ public class OAuth2ScopeGrantPersistenceImpl
 	}
 
 	@Override
-	public Set<String> getBadColumnNames() {
-		return _badColumnNames;
-	}
-
-	@Override
 	protected EntityCache getEntityCache() {
 		return entityCache;
 	}
@@ -2185,8 +2180,5 @@ public class OAuth2ScopeGrantPersistenceImpl
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		OAuth2ScopeGrantPersistenceImpl.class);
-
-	private static final Set<String> _badColumnNames = SetUtil.fromArray(
-		new String[] {"oAuth2ApplicationScopeAliasesId"});
 
 }

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/Entity.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/Entity.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.tools.service.builder;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -260,9 +261,10 @@ public class Entity implements Comparable<Entity> {
 		while (iterator.hasNext()) {
 			EntityColumn entityColumn = iterator.next();
 
+			String dbName = entityColumn.getDBName();
 			String name = entityColumn.getName();
 
-			if (name.equals(entityColumn.getDBName())) {
+			if (name.equals(dbName) || !dbName.endsWith(StringPool.UNDERLINE)) {
 				iterator.remove();
 			}
 		}


### PR DESCRIPTION
This solves the errors in the CI, with the AssetListEntrySegmentsEntryRelPersistenceTest > testFindAll test.

As explained in the commit comment, I think we could change the condition to `!dbName.endsWith(StringPool.UNDERLINE)` only, as all the badColumnNames are suffixed with "_" in their dbNames. 

**Update:** this PR **only fixes adding the column with the db-name option as a badColumnName** (which laters fails as our logic is assuming that the dbColumnName = columnName + "_" (valid only for actual "bad column" names).

As suggested in a mail, for this case the PersistenceImpl subclass should return a dbColumNames map with the actual "translation" of columnNames into dbColumnNames. We had something similiar in persistence_impl.ftl#223, but only for legacy services and using reflection.  

@ealonso
@jpince 
@shuyangzhou
