### PR TITLE
LPS-91698 Autogenerated

### DIFF
--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/model/CTEntryModel.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/model/CTEntryModel.java
@@ -17,10 +17,8 @@ package com.liferay.change.tracking.model;
 import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
-import com.liferay.portal.kernel.model.AttachedModel;
 import com.liferay.portal.kernel.model.AuditedModel;
 import com.liferay.portal.kernel.model.BaseModel;
-import com.liferay.portal.kernel.model.ResourcedModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 
 import java.util.Date;
@@ -38,8 +36,7 @@ import java.util.Date;
  */
 @ProviderType
 public interface CTEntryModel
-	extends AttachedModel, AuditedModel, BaseModel<CTEntry>, ResourcedModel,
-			ShardedModel {
+	extends AuditedModel, BaseModel<CTEntry>, ShardedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -173,65 +170,46 @@ public interface CTEntryModel
 	public void setModifiedDate(Date modifiedDate);
 
 	/**
-	 * Returns the fully qualified class name of this ct entry.
+	 * Returns the model class name ID of this ct entry.
 	 *
-	 * @return the fully qualified class name of this ct entry
+	 * @return the model class name ID of this ct entry
 	 */
-	@Override
-	public String getClassName();
-
-	public void setClassName(String className);
+	public long getModelClassNameId();
 
 	/**
-	 * Returns the class name ID of this ct entry.
+	 * Sets the model class name ID of this ct entry.
 	 *
-	 * @return the class name ID of this ct entry
+	 * @param modelClassNameId the model class name ID of this ct entry
 	 */
-	@Override
-	public long getClassNameId();
+	public void setModelClassNameId(long modelClassNameId);
 
 	/**
-	 * Sets the class name ID of this ct entry.
+	 * Returns the model class pk of this ct entry.
 	 *
-	 * @param classNameId the class name ID of this ct entry
+	 * @return the model class pk of this ct entry
 	 */
-	@Override
-	public void setClassNameId(long classNameId);
+	public long getModelClassPK();
 
 	/**
-	 * Returns the class pk of this ct entry.
+	 * Sets the model class pk of this ct entry.
 	 *
-	 * @return the class pk of this ct entry
+	 * @param modelClassPK the model class pk of this ct entry
 	 */
-	@Override
-	public long getClassPK();
+	public void setModelClassPK(long modelClassPK);
 
 	/**
-	 * Sets the class pk of this ct entry.
+	 * Returns the model resource prim key of this ct entry.
 	 *
-	 * @param classPK the class pk of this ct entry
+	 * @return the model resource prim key of this ct entry
 	 */
-	@Override
-	public void setClassPK(long classPK);
+	public long getModelResourcePrimKey();
 
 	/**
-	 * Returns the resource prim key of this ct entry.
+	 * Sets the model resource prim key of this ct entry.
 	 *
-	 * @return the resource prim key of this ct entry
+	 * @param modelResourcePrimKey the model resource prim key of this ct entry
 	 */
-	@Override
-	public long getResourcePrimKey();
-
-	/**
-	 * Sets the resource prim key of this ct entry.
-	 *
-	 * @param resourcePrimKey the resource prim key of this ct entry
-	 */
-	@Override
-	public void setResourcePrimKey(long resourcePrimKey);
-
-	@Override
-	public boolean isResourceMain();
+	public void setModelResourcePrimKey(long modelResourcePrimKey);
 
 	/**
 	 * Returns the change type of this ct entry.

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/model/CTEntrySoap.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/model/CTEntrySoap.java
@@ -40,9 +40,9 @@ public class CTEntrySoap implements Serializable {
 		soapModel.setUserName(model.getUserName());
 		soapModel.setCreateDate(model.getCreateDate());
 		soapModel.setModifiedDate(model.getModifiedDate());
-		soapModel.setClassNameId(model.getClassNameId());
-		soapModel.setClassPK(model.getClassPK());
-		soapModel.setResourcePrimKey(model.getResourcePrimKey());
+		soapModel.setModelClassNameId(model.getModelClassNameId());
+		soapModel.setModelClassPK(model.getModelClassPK());
+		soapModel.setModelResourcePrimKey(model.getModelResourcePrimKey());
 		soapModel.setChangeType(model.getChangeType());
 		soapModel.setStatus(model.getStatus());
 
@@ -146,28 +146,28 @@ public class CTEntrySoap implements Serializable {
 		_modifiedDate = modifiedDate;
 	}
 
-	public long getClassNameId() {
-		return _classNameId;
+	public long getModelClassNameId() {
+		return _modelClassNameId;
 	}
 
-	public void setClassNameId(long classNameId) {
-		_classNameId = classNameId;
+	public void setModelClassNameId(long modelClassNameId) {
+		_modelClassNameId = modelClassNameId;
 	}
 
-	public long getClassPK() {
-		return _classPK;
+	public long getModelClassPK() {
+		return _modelClassPK;
 	}
 
-	public void setClassPK(long classPK) {
-		_classPK = classPK;
+	public void setModelClassPK(long modelClassPK) {
+		_modelClassPK = modelClassPK;
 	}
 
-	public long getResourcePrimKey() {
-		return _resourcePrimKey;
+	public long getModelResourcePrimKey() {
+		return _modelResourcePrimKey;
 	}
 
-	public void setResourcePrimKey(long resourcePrimKey) {
-		_resourcePrimKey = resourcePrimKey;
+	public void setModelResourcePrimKey(long modelResourcePrimKey) {
+		_modelResourcePrimKey = modelResourcePrimKey;
 	}
 
 	public int getChangeType() {
@@ -192,9 +192,9 @@ public class CTEntrySoap implements Serializable {
 	private String _userName;
 	private Date _createDate;
 	private Date _modifiedDate;
-	private long _classNameId;
-	private long _classPK;
-	private long _resourcePrimKey;
+	private long _modelClassNameId;
+	private long _modelClassPK;
+	private long _modelResourcePrimKey;
 	private int _changeType;
 	private int _status;
 

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/model/CTEntryWrapper.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/model/CTEntryWrapper.java
@@ -51,9 +51,9 @@ public class CTEntryWrapper
 		attributes.put("userName", getUserName());
 		attributes.put("createDate", getCreateDate());
 		attributes.put("modifiedDate", getModifiedDate());
-		attributes.put("classNameId", getClassNameId());
-		attributes.put("classPK", getClassPK());
-		attributes.put("resourcePrimKey", getResourcePrimKey());
+		attributes.put("modelClassNameId", getModelClassNameId());
+		attributes.put("modelClassPK", getModelClassPK());
+		attributes.put("modelResourcePrimKey", getModelResourcePrimKey());
 		attributes.put("changeType", getChangeType());
 		attributes.put("status", getStatus());
 
@@ -98,22 +98,23 @@ public class CTEntryWrapper
 			setModifiedDate(modifiedDate);
 		}
 
-		Long classNameId = (Long)attributes.get("classNameId");
+		Long modelClassNameId = (Long)attributes.get("modelClassNameId");
 
-		if (classNameId != null) {
-			setClassNameId(classNameId);
+		if (modelClassNameId != null) {
+			setModelClassNameId(modelClassNameId);
 		}
 
-		Long classPK = (Long)attributes.get("classPK");
+		Long modelClassPK = (Long)attributes.get("modelClassPK");
 
-		if (classPK != null) {
-			setClassPK(classPK);
+		if (modelClassPK != null) {
+			setModelClassPK(modelClassPK);
 		}
 
-		Long resourcePrimKey = (Long)attributes.get("resourcePrimKey");
+		Long modelResourcePrimKey = (Long)attributes.get(
+			"modelResourcePrimKey");
 
-		if (resourcePrimKey != null) {
-			setResourcePrimKey(resourcePrimKey);
+		if (modelResourcePrimKey != null) {
+			setModelResourcePrimKey(modelResourcePrimKey);
 		}
 
 		Integer changeType = (Integer)attributes.get("changeType");
@@ -137,36 +138,6 @@ public class CTEntryWrapper
 	@Override
 	public int getChangeType() {
 		return model.getChangeType();
-	}
-
-	/**
-	 * Returns the fully qualified class name of this ct entry.
-	 *
-	 * @return the fully qualified class name of this ct entry
-	 */
-	@Override
-	public String getClassName() {
-		return model.getClassName();
-	}
-
-	/**
-	 * Returns the class name ID of this ct entry.
-	 *
-	 * @return the class name ID of this ct entry
-	 */
-	@Override
-	public long getClassNameId() {
-		return model.getClassNameId();
-	}
-
-	/**
-	 * Returns the class pk of this ct entry.
-	 *
-	 * @return the class pk of this ct entry
-	 */
-	@Override
-	public long getClassPK() {
-		return model.getClassPK();
 	}
 
 	/**
@@ -205,6 +176,36 @@ public class CTEntryWrapper
 	}
 
 	/**
+	 * Returns the model class name ID of this ct entry.
+	 *
+	 * @return the model class name ID of this ct entry
+	 */
+	@Override
+	public long getModelClassNameId() {
+		return model.getModelClassNameId();
+	}
+
+	/**
+	 * Returns the model class pk of this ct entry.
+	 *
+	 * @return the model class pk of this ct entry
+	 */
+	@Override
+	public long getModelClassPK() {
+		return model.getModelClassPK();
+	}
+
+	/**
+	 * Returns the model resource prim key of this ct entry.
+	 *
+	 * @return the model resource prim key of this ct entry
+	 */
+	@Override
+	public long getModelResourcePrimKey() {
+		return model.getModelResourcePrimKey();
+	}
+
+	/**
 	 * Returns the modified date of this ct entry.
 	 *
 	 * @return the modified date of this ct entry
@@ -222,16 +223,6 @@ public class CTEntryWrapper
 	@Override
 	public long getPrimaryKey() {
 		return model.getPrimaryKey();
-	}
-
-	/**
-	 * Returns the resource prim key of this ct entry.
-	 *
-	 * @return the resource prim key of this ct entry
-	 */
-	@Override
-	public long getResourcePrimKey() {
-		return model.getResourcePrimKey();
 	}
 
 	/**
@@ -280,11 +271,6 @@ public class CTEntryWrapper
 	}
 
 	@Override
-	public boolean isResourceMain() {
-		return model.isResourceMain();
-	}
-
-	@Override
 	public void persist() {
 		model.persist();
 	}
@@ -297,31 +283,6 @@ public class CTEntryWrapper
 	@Override
 	public void setChangeType(int changeType) {
 		model.setChangeType(changeType);
-	}
-
-	@Override
-	public void setClassName(String className) {
-		model.setClassName(className);
-	}
-
-	/**
-	 * Sets the class name ID of this ct entry.
-	 *
-	 * @param classNameId the class name ID of this ct entry
-	 */
-	@Override
-	public void setClassNameId(long classNameId) {
-		model.setClassNameId(classNameId);
-	}
-
-	/**
-	 * Sets the class pk of this ct entry.
-	 *
-	 * @param classPK the class pk of this ct entry
-	 */
-	@Override
-	public void setClassPK(long classPK) {
-		model.setClassPK(classPK);
 	}
 
 	/**
@@ -355,6 +316,36 @@ public class CTEntryWrapper
 	}
 
 	/**
+	 * Sets the model class name ID of this ct entry.
+	 *
+	 * @param modelClassNameId the model class name ID of this ct entry
+	 */
+	@Override
+	public void setModelClassNameId(long modelClassNameId) {
+		model.setModelClassNameId(modelClassNameId);
+	}
+
+	/**
+	 * Sets the model class pk of this ct entry.
+	 *
+	 * @param modelClassPK the model class pk of this ct entry
+	 */
+	@Override
+	public void setModelClassPK(long modelClassPK) {
+		model.setModelClassPK(modelClassPK);
+	}
+
+	/**
+	 * Sets the model resource prim key of this ct entry.
+	 *
+	 * @param modelResourcePrimKey the model resource prim key of this ct entry
+	 */
+	@Override
+	public void setModelResourcePrimKey(long modelResourcePrimKey) {
+		model.setModelResourcePrimKey(modelResourcePrimKey);
+	}
+
+	/**
 	 * Sets the modified date of this ct entry.
 	 *
 	 * @param modifiedDate the modified date of this ct entry
@@ -372,16 +363,6 @@ public class CTEntryWrapper
 	@Override
 	public void setPrimaryKey(long primaryKey) {
 		model.setPrimaryKey(primaryKey);
-	}
-
-	/**
-	 * Sets the resource prim key of this ct entry.
-	 *
-	 * @param resourcePrimKey the resource prim key of this ct entry
-	 */
-	@Override
-	public void setResourcePrimKey(long resourcePrimKey) {
-		model.setResourcePrimKey(resourcePrimKey);
 	}
 
 	/**

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalService.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalService.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.BaseLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
-import com.liferay.portal.kernel.service.PersistedResourcedModelLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
@@ -56,8 +55,7 @@ import java.util.List;
 	rollbackFor = {PortalException.class, SystemException.class}
 )
 public interface CTEntryLocalService
-	extends BaseLocalService, PersistedModelLocalService,
-			PersistedResourcedModelLocalService {
+	extends BaseLocalService, PersistedModelLocalService {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -84,8 +82,9 @@ public interface CTEntryLocalService
 	public CTEntry addCTEntry(CTEntry ctEntry);
 
 	public CTEntry addCTEntry(
-			long userId, long classNameId, long classPK, long resourcePrimKey,
-			int changeType, long ctCollectionId, ServiceContext serviceContext)
+			long userId, long modelClassNameId, long modelClassPK,
+			long resourcePrimKey, int changeType, long ctCollectionId,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	public void addCTEntryAggregateCTEntries(
@@ -240,11 +239,11 @@ public interface CTEntryLocalService
 	public CTEntry fetchCTEntry(long ctEntryId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CTEntry fetchCTEntry(long classNameId, long classPK);
+	public CTEntry fetchCTEntry(long modelClassNameId, long modelClassPK);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CTEntry fetchCTEntry(
-		long ctCollectionId, long classNameId, long classPK);
+		long ctCollectionId, long modelClassNameId, long modelClassPK);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();
@@ -341,12 +340,6 @@ public interface CTEntryLocalService
 	 * @return the OSGi service identifier
 	 */
 	public String getOSGiServiceIdentifier();
-
-	@Override
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public List<? extends PersistedModel> getPersistedModel(
-			long resourcePrimKey)
-		throws PortalException;
 
 	@Override
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalServiceUtil.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalServiceUtil.java
@@ -79,13 +79,13 @@ public class CTEntryLocalServiceUtil {
 	}
 
 	public static com.liferay.change.tracking.model.CTEntry addCTEntry(
-			long userId, long classNameId, long classPK, long resourcePrimKey,
-			int changeType, long ctCollectionId,
+			long userId, long modelClassNameId, long modelClassPK,
+			long resourcePrimKey, int changeType, long ctCollectionId,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return getService().addCTEntry(
-			userId, classNameId, classPK, resourcePrimKey, changeType,
+			userId, modelClassNameId, modelClassPK, resourcePrimKey, changeType,
 			ctCollectionId, serviceContext);
 	}
 
@@ -340,15 +340,16 @@ public class CTEntryLocalServiceUtil {
 	}
 
 	public static com.liferay.change.tracking.model.CTEntry fetchCTEntry(
-		long classNameId, long classPK) {
+		long modelClassNameId, long modelClassPK) {
 
-		return getService().fetchCTEntry(classNameId, classPK);
+		return getService().fetchCTEntry(modelClassNameId, modelClassPK);
 	}
 
 	public static com.liferay.change.tracking.model.CTEntry fetchCTEntry(
-		long ctCollectionId, long classNameId, long classPK) {
+		long ctCollectionId, long modelClassNameId, long modelClassPK) {
 
-		return getService().fetchCTEntry(ctCollectionId, classNameId, classPK);
+		return getService().fetchCTEntry(
+			ctCollectionId, modelClassNameId, modelClassPK);
 	}
 
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
@@ -493,14 +494,6 @@ public class CTEntryLocalServiceUtil {
 	 */
 	public static String getOSGiServiceIdentifier() {
 		return getService().getOSGiServiceIdentifier();
-	}
-
-	public static java.util.List
-		<? extends com.liferay.portal.kernel.model.PersistedModel>
-				getPersistedModel(long resourcePrimKey)
-			throws com.liferay.portal.kernel.exception.PortalException {
-
-		return getService().getPersistedModel(resourcePrimKey);
 	}
 
 	public static com.liferay.portal.kernel.model.PersistedModel

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalServiceWrapper.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/CTEntryLocalServiceWrapper.java
@@ -78,13 +78,13 @@ public class CTEntryLocalServiceWrapper
 
 	@Override
 	public com.liferay.change.tracking.model.CTEntry addCTEntry(
-			long userId, long classNameId, long classPK, long resourcePrimKey,
-			int changeType, long ctCollectionId,
+			long userId, long modelClassNameId, long modelClassPK,
+			long resourcePrimKey, int changeType, long ctCollectionId,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _ctEntryLocalService.addCTEntry(
-			userId, classNameId, classPK, resourcePrimKey, changeType,
+			userId, modelClassNameId, modelClassPK, resourcePrimKey, changeType,
 			ctCollectionId, serviceContext);
 	}
 
@@ -369,17 +369,18 @@ public class CTEntryLocalServiceWrapper
 
 	@Override
 	public com.liferay.change.tracking.model.CTEntry fetchCTEntry(
-		long classNameId, long classPK) {
+		long modelClassNameId, long modelClassPK) {
 
-		return _ctEntryLocalService.fetchCTEntry(classNameId, classPK);
+		return _ctEntryLocalService.fetchCTEntry(
+			modelClassNameId, modelClassPK);
 	}
 
 	@Override
 	public com.liferay.change.tracking.model.CTEntry fetchCTEntry(
-		long ctCollectionId, long classNameId, long classPK) {
+		long ctCollectionId, long modelClassNameId, long modelClassPK) {
 
 		return _ctEntryLocalService.fetchCTEntry(
-			ctCollectionId, classNameId, classPK);
+			ctCollectionId, modelClassNameId, modelClassPK);
 	}
 
 	@Override
@@ -539,15 +540,6 @@ public class CTEntryLocalServiceWrapper
 	@Override
 	public String getOSGiServiceIdentifier() {
 		return _ctEntryLocalService.getOSGiServiceIdentifier();
-	}
-
-	@Override
-	public java.util.List
-		<? extends com.liferay.portal.kernel.model.PersistedModel>
-				getPersistedModel(long resourcePrimKey)
-			throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _ctEntryLocalService.getPersistedModel(resourcePrimKey);
 	}
 
 	@Override

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/persistence/CTEntryFinder.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/persistence/CTEntryFinder.java
@@ -34,18 +34,18 @@ public interface CTEntryFinder {
 			com.liferay.portal.kernel.dao.orm.QueryDefinition
 				<com.liferay.change.tracking.model.CTEntry> queryDefinition);
 
-	public java.util.List<com.liferay.change.tracking.model.CTEntry> findByC_R(
-		long ctCollectionId, long resourcePrimKey,
-		com.liferay.portal.kernel.dao.orm.QueryDefinition
-			<com.liferay.change.tracking.model.CTEntry> queryDefinition);
-
-	public com.liferay.change.tracking.model.CTEntry findByC_C_C(
-		long ctCollectionId, long classNameId, long classPK);
-
 	public java.util.List<com.liferay.change.tracking.model.CTEntry>
 		findByRelatedCTEntries(
 			long ctEntryId,
 			com.liferay.portal.kernel.dao.orm.QueryDefinition
 				<com.liferay.change.tracking.model.CTEntry> queryDefinition);
+
+	public java.util.List<com.liferay.change.tracking.model.CTEntry> findByC_R(
+		long ctCollectionId, long modelResourcePrimKey,
+		com.liferay.portal.kernel.dao.orm.QueryDefinition
+			<com.liferay.change.tracking.model.CTEntry> queryDefinition);
+
+	public com.liferay.change.tracking.model.CTEntry findByC_C_C(
+		long ctCollectionId, long modelClassNameId, long modelClassPK);
 
 }

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/persistence/CTEntryPersistence.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/persistence/CTEntryPersistence.java
@@ -41,197 +41,54 @@ public interface CTEntryPersistence extends BasePersistence<CTEntry> {
 	 */
 
 	/**
-	 * Returns all the ct entries where resourcePrimKey = &#63;.
+	 * Returns the ct entry where modelClassNameId = &#63; and modelClassPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @return the matching ct entries
-	 */
-	public java.util.List<CTEntry> findByResourcePrimKey(long resourcePrimKey);
-
-	/**
-	 * Returns a range of all the ct entries where resourcePrimKey = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>CTEntryModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
-	 * </p>
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param start the lower bound of the range of ct entries
-	 * @param end the upper bound of the range of ct entries (not inclusive)
-	 * @return the range of matching ct entries
-	 */
-	public java.util.List<CTEntry> findByResourcePrimKey(
-		long resourcePrimKey, int start, int end);
-
-	/**
-	 * Returns an ordered range of all the ct entries where resourcePrimKey = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>CTEntryModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
-	 * </p>
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param start the lower bound of the range of ct entries
-	 * @param end the upper bound of the range of ct entries (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @return the ordered range of matching ct entries
-	 */
-	public java.util.List<CTEntry> findByResourcePrimKey(
-		long resourcePrimKey, int start, int end,
-		com.liferay.portal.kernel.util.OrderByComparator<CTEntry>
-			orderByComparator);
-
-	/**
-	 * Returns an ordered range of all the ct entries where resourcePrimKey = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>CTEntryModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
-	 * </p>
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param start the lower bound of the range of ct entries
-	 * @param end the upper bound of the range of ct entries (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @param retrieveFromCache whether to retrieve from the finder cache
-	 * @return the ordered range of matching ct entries
-	 */
-	public java.util.List<CTEntry> findByResourcePrimKey(
-		long resourcePrimKey, int start, int end,
-		com.liferay.portal.kernel.util.OrderByComparator<CTEntry>
-			orderByComparator,
-		boolean retrieveFromCache);
-
-	/**
-	 * Returns the first ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching ct entry
-	 * @throws NoSuchEntryException if a matching ct entry could not be found
-	 */
-	public CTEntry findByResourcePrimKey_First(
-			long resourcePrimKey,
-			com.liferay.portal.kernel.util.OrderByComparator<CTEntry>
-				orderByComparator)
-		throws NoSuchEntryException;
-
-	/**
-	 * Returns the first ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching ct entry, or <code>null</code> if a matching ct entry could not be found
-	 */
-	public CTEntry fetchByResourcePrimKey_First(
-		long resourcePrimKey,
-		com.liferay.portal.kernel.util.OrderByComparator<CTEntry>
-			orderByComparator);
-
-	/**
-	 * Returns the last ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the last matching ct entry
-	 * @throws NoSuchEntryException if a matching ct entry could not be found
-	 */
-	public CTEntry findByResourcePrimKey_Last(
-			long resourcePrimKey,
-			com.liferay.portal.kernel.util.OrderByComparator<CTEntry>
-				orderByComparator)
-		throws NoSuchEntryException;
-
-	/**
-	 * Returns the last ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the last matching ct entry, or <code>null</code> if a matching ct entry could not be found
-	 */
-	public CTEntry fetchByResourcePrimKey_Last(
-		long resourcePrimKey,
-		com.liferay.portal.kernel.util.OrderByComparator<CTEntry>
-			orderByComparator);
-
-	/**
-	 * Returns the ct entries before and after the current ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param ctEntryId the primary key of the current ct entry
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the previous, current, and next ct entry
-	 * @throws NoSuchEntryException if a ct entry with the primary key could not be found
-	 */
-	public CTEntry[] findByResourcePrimKey_PrevAndNext(
-			long ctEntryId, long resourcePrimKey,
-			com.liferay.portal.kernel.util.OrderByComparator<CTEntry>
-				orderByComparator)
-		throws NoSuchEntryException;
-
-	/**
-	 * Removes all the ct entries where resourcePrimKey = &#63; from the database.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 */
-	public void removeByResourcePrimKey(long resourcePrimKey);
-
-	/**
-	 * Returns the number of ct entries where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @return the number of matching ct entries
-	 */
-	public int countByResourcePrimKey(long resourcePrimKey);
-
-	/**
-	 * Returns the ct entry where classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
-	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @return the matching ct entry
 	 * @throws NoSuchEntryException if a matching ct entry could not be found
 	 */
-	public CTEntry findByC_C(long classNameId, long classPK)
+	public CTEntry findByC_C(long modelClassNameId, long modelClassPK)
 		throws NoSuchEntryException;
 
 	/**
-	 * Returns the ct entry where classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the ct entry where modelClassNameId = &#63; and modelClassPK = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @return the matching ct entry, or <code>null</code> if a matching ct entry could not be found
 	 */
-	public CTEntry fetchByC_C(long classNameId, long classPK);
+	public CTEntry fetchByC_C(long modelClassNameId, long modelClassPK);
 
 	/**
-	 * Returns the ct entry where classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the ct entry where modelClassNameId = &#63; and modelClassPK = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @param retrieveFromCache whether to retrieve from the finder cache
 	 * @return the matching ct entry, or <code>null</code> if a matching ct entry could not be found
 	 */
 	public CTEntry fetchByC_C(
-		long classNameId, long classPK, boolean retrieveFromCache);
+		long modelClassNameId, long modelClassPK, boolean retrieveFromCache);
 
 	/**
-	 * Removes the ct entry where classNameId = &#63; and classPK = &#63; from the database.
+	 * Removes the ct entry where modelClassNameId = &#63; and modelClassPK = &#63; from the database.
 	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @return the ct entry that was removed
 	 */
-	public CTEntry removeByC_C(long classNameId, long classPK)
+	public CTEntry removeByC_C(long modelClassNameId, long modelClassPK)
 		throws NoSuchEntryException;
 
 	/**
-	 * Returns the number of ct entries where classNameId = &#63; and classPK = &#63;.
+	 * Returns the number of ct entries where modelClassNameId = &#63; and modelClassPK = &#63;.
 	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @return the number of matching ct entries
 	 */
-	public int countByC_C(long classNameId, long classPK);
+	public int countByC_C(long modelClassNameId, long modelClassPK);
 
 	/**
 	 * Caches the ct entry in the entity cache if it is enabled.

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/persistence/CTEntryUtil.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/service/persistence/CTEntryUtil.java
@@ -127,237 +127,67 @@ public class CTEntryUtil {
 	}
 
 	/**
-	 * Returns all the ct entries where resourcePrimKey = &#63;.
+	 * Returns the ct entry where modelClassNameId = &#63; and modelClassPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @return the matching ct entries
-	 */
-	public static List<CTEntry> findByResourcePrimKey(long resourcePrimKey) {
-		return getPersistence().findByResourcePrimKey(resourcePrimKey);
-	}
-
-	/**
-	 * Returns a range of all the ct entries where resourcePrimKey = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>CTEntryModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
-	 * </p>
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param start the lower bound of the range of ct entries
-	 * @param end the upper bound of the range of ct entries (not inclusive)
-	 * @return the range of matching ct entries
-	 */
-	public static List<CTEntry> findByResourcePrimKey(
-		long resourcePrimKey, int start, int end) {
-
-		return getPersistence().findByResourcePrimKey(
-			resourcePrimKey, start, end);
-	}
-
-	/**
-	 * Returns an ordered range of all the ct entries where resourcePrimKey = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>CTEntryModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
-	 * </p>
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param start the lower bound of the range of ct entries
-	 * @param end the upper bound of the range of ct entries (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @return the ordered range of matching ct entries
-	 */
-	public static List<CTEntry> findByResourcePrimKey(
-		long resourcePrimKey, int start, int end,
-		OrderByComparator<CTEntry> orderByComparator) {
-
-		return getPersistence().findByResourcePrimKey(
-			resourcePrimKey, start, end, orderByComparator);
-	}
-
-	/**
-	 * Returns an ordered range of all the ct entries where resourcePrimKey = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>CTEntryModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
-	 * </p>
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param start the lower bound of the range of ct entries
-	 * @param end the upper bound of the range of ct entries (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @param retrieveFromCache whether to retrieve from the finder cache
-	 * @return the ordered range of matching ct entries
-	 */
-	public static List<CTEntry> findByResourcePrimKey(
-		long resourcePrimKey, int start, int end,
-		OrderByComparator<CTEntry> orderByComparator,
-		boolean retrieveFromCache) {
-
-		return getPersistence().findByResourcePrimKey(
-			resourcePrimKey, start, end, orderByComparator, retrieveFromCache);
-	}
-
-	/**
-	 * Returns the first ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching ct entry
-	 * @throws NoSuchEntryException if a matching ct entry could not be found
-	 */
-	public static CTEntry findByResourcePrimKey_First(
-			long resourcePrimKey, OrderByComparator<CTEntry> orderByComparator)
-		throws com.liferay.change.tracking.exception.NoSuchEntryException {
-
-		return getPersistence().findByResourcePrimKey_First(
-			resourcePrimKey, orderByComparator);
-	}
-
-	/**
-	 * Returns the first ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching ct entry, or <code>null</code> if a matching ct entry could not be found
-	 */
-	public static CTEntry fetchByResourcePrimKey_First(
-		long resourcePrimKey, OrderByComparator<CTEntry> orderByComparator) {
-
-		return getPersistence().fetchByResourcePrimKey_First(
-			resourcePrimKey, orderByComparator);
-	}
-
-	/**
-	 * Returns the last ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the last matching ct entry
-	 * @throws NoSuchEntryException if a matching ct entry could not be found
-	 */
-	public static CTEntry findByResourcePrimKey_Last(
-			long resourcePrimKey, OrderByComparator<CTEntry> orderByComparator)
-		throws com.liferay.change.tracking.exception.NoSuchEntryException {
-
-		return getPersistence().findByResourcePrimKey_Last(
-			resourcePrimKey, orderByComparator);
-	}
-
-	/**
-	 * Returns the last ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the last matching ct entry, or <code>null</code> if a matching ct entry could not be found
-	 */
-	public static CTEntry fetchByResourcePrimKey_Last(
-		long resourcePrimKey, OrderByComparator<CTEntry> orderByComparator) {
-
-		return getPersistence().fetchByResourcePrimKey_Last(
-			resourcePrimKey, orderByComparator);
-	}
-
-	/**
-	 * Returns the ct entries before and after the current ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param ctEntryId the primary key of the current ct entry
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the previous, current, and next ct entry
-	 * @throws NoSuchEntryException if a ct entry with the primary key could not be found
-	 */
-	public static CTEntry[] findByResourcePrimKey_PrevAndNext(
-			long ctEntryId, long resourcePrimKey,
-			OrderByComparator<CTEntry> orderByComparator)
-		throws com.liferay.change.tracking.exception.NoSuchEntryException {
-
-		return getPersistence().findByResourcePrimKey_PrevAndNext(
-			ctEntryId, resourcePrimKey, orderByComparator);
-	}
-
-	/**
-	 * Removes all the ct entries where resourcePrimKey = &#63; from the database.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 */
-	public static void removeByResourcePrimKey(long resourcePrimKey) {
-		getPersistence().removeByResourcePrimKey(resourcePrimKey);
-	}
-
-	/**
-	 * Returns the number of ct entries where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @return the number of matching ct entries
-	 */
-	public static int countByResourcePrimKey(long resourcePrimKey) {
-		return getPersistence().countByResourcePrimKey(resourcePrimKey);
-	}
-
-	/**
-	 * Returns the ct entry where classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
-	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @return the matching ct entry
 	 * @throws NoSuchEntryException if a matching ct entry could not be found
 	 */
-	public static CTEntry findByC_C(long classNameId, long classPK)
+	public static CTEntry findByC_C(long modelClassNameId, long modelClassPK)
 		throws com.liferay.change.tracking.exception.NoSuchEntryException {
 
-		return getPersistence().findByC_C(classNameId, classPK);
+		return getPersistence().findByC_C(modelClassNameId, modelClassPK);
 	}
 
 	/**
-	 * Returns the ct entry where classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the ct entry where modelClassNameId = &#63; and modelClassPK = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @return the matching ct entry, or <code>null</code> if a matching ct entry could not be found
 	 */
-	public static CTEntry fetchByC_C(long classNameId, long classPK) {
-		return getPersistence().fetchByC_C(classNameId, classPK);
+	public static CTEntry fetchByC_C(long modelClassNameId, long modelClassPK) {
+		return getPersistence().fetchByC_C(modelClassNameId, modelClassPK);
 	}
 
 	/**
-	 * Returns the ct entry where classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the ct entry where modelClassNameId = &#63; and modelClassPK = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @param retrieveFromCache whether to retrieve from the finder cache
 	 * @return the matching ct entry, or <code>null</code> if a matching ct entry could not be found
 	 */
 	public static CTEntry fetchByC_C(
-		long classNameId, long classPK, boolean retrieveFromCache) {
+		long modelClassNameId, long modelClassPK, boolean retrieveFromCache) {
 
 		return getPersistence().fetchByC_C(
-			classNameId, classPK, retrieveFromCache);
+			modelClassNameId, modelClassPK, retrieveFromCache);
 	}
 
 	/**
-	 * Removes the ct entry where classNameId = &#63; and classPK = &#63; from the database.
+	 * Removes the ct entry where modelClassNameId = &#63; and modelClassPK = &#63; from the database.
 	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @return the ct entry that was removed
 	 */
-	public static CTEntry removeByC_C(long classNameId, long classPK)
+	public static CTEntry removeByC_C(long modelClassNameId, long modelClassPK)
 		throws com.liferay.change.tracking.exception.NoSuchEntryException {
 
-		return getPersistence().removeByC_C(classNameId, classPK);
+		return getPersistence().removeByC_C(modelClassNameId, modelClassPK);
 	}
 
 	/**
-	 * Returns the number of ct entries where classNameId = &#63; and classPK = &#63;.
+	 * Returns the number of ct entries where modelClassNameId = &#63; and modelClassPK = &#63;.
 	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @return the number of matching ct entries
 	 */
-	public static int countByC_C(long classNameId, long classPK) {
-		return getPersistence().countByC_C(classNameId, classPK);
+	public static int countByC_C(long modelClassNameId, long modelClassPK) {
+		return getPersistence().countByC_C(modelClassNameId, modelClassPK);
 	}
 
 	/**

--- a/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/model/entry/CTEntryModel.java
+++ b/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/model/entry/CTEntryModel.java
@@ -36,26 +36,26 @@ public class CTEntryModel {
 		return builder.setChangeType(
 			ctEntry.getChangeType()
 		).setClassNameId(
-			ctEntry.getClassNameId()
+			ctEntry.getModelClassNameId()
 		).setClassPK(
-			ctEntry.getClassPK()
+			ctEntry.getModelClassPK()
 		).setCTEntryId(
 			ctEntry.getCtEntryId()
 		).setModifiedDate(
 			ctEntry.getModifiedDate()
 		).setResourcePrimKey(
-			ctEntry.getResourcePrimKey()
+			ctEntry.getModelResourcePrimKey()
 		).setSiteName(
 			CTConfigurationRegistryUtil.getVersionEntitySiteName(
-				ctEntry.getClassNameId(), ctEntry.getClassPK())
+				ctEntry.getModelClassNameId(), ctEntry.getModelClassPK())
 		).setTitle(
 			CTConfigurationRegistryUtil.getVersionEntityTitle(
-				ctEntry.getClassNameId(), ctEntry.getClassPK())
+				ctEntry.getModelClassNameId(), ctEntry.getModelClassPK())
 		).setUserName(
 			ctEntry.getUserName()
 		).setVersion(
 			CTConfigurationRegistryUtil.getVersionEntityVersion(
-				ctEntry.getClassNameId(), ctEntry.getClassPK())
+				ctEntry.getModelClassNameId(), ctEntry.getModelClassPK())
 		).build();
 	}
 

--- a/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/resource/CTProcessResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/resource/CTProcessResource.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserConstants;
-import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -153,13 +152,8 @@ public class CTProcessResource {
 			portalKernelBackgroundTaskOptional =
 				_fetchPortalKernelBackgroundTaskOptional(backgroundTask);
 
-		if (portalKernelBackgroundTaskOptional.isPresent()) {
-			return Optional.of(
-				backgroundTaskExecutor.getBackgroundTaskDisplay(
-					portalKernelBackgroundTaskOptional.get()));
-		}
-
-		return Optional.empty();
+		return portalKernelBackgroundTaskOptional.map(
+			backgroundTaskExecutor::getBackgroundTaskDisplay);
 	}
 
 	private CTProcessModel _getCTProcessModel(CTProcess ctProcess) {
@@ -337,9 +331,6 @@ public class CTProcessResource {
 
 	@Reference
 	private BackgroundTaskManager _backgroundTaskManager;
-
-	@Reference
-	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private CTCollectionLocalService _ctCollectionLocalService;

--- a/modules/apps/change-tracking/change-tracking-service/service.xml
+++ b/modules/apps/change-tracking/change-tracking-service/service.xml
@@ -67,9 +67,9 @@
 
 		<!-- Other fields -->
 
-		<column name="classNameId" type="long" />
-		<column name="classPK" type="long" />
-		<column name="resourcePrimKey" type="long" />
+		<column name="modelClassNameId" type="long" />
+		<column name="modelClassPK" type="long" />
+		<column name="modelResourcePrimKey" type="long" />
 		<column name="changeType" type="int" />
 		<column name="status" type="int" />
 
@@ -81,8 +81,8 @@
 		<!-- Finder methods -->
 
 		<finder name="C_C" return-type="CTEntry" unique="true">
-			<finder-column name="classNameId" />
-			<finder-column name="classPK" />
+			<finder-column name="modelClassNameId" />
+			<finder-column name="modelClassPK" />
 		</finder>
 
 		<!-- References -->

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/CTEngineManagerImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/CTEngineManagerImpl.java
@@ -254,7 +254,7 @@ public class CTEngineManagerImpl implements CTEngineManager {
 
 		for (CTEntry ctEntry : sourceCTEntries) {
 			Optional<CTEntry> latestTargetCTEntryOptional = _getLatestCTEntry(
-				targetCTCollectionId, ctEntry.getResourcePrimKey());
+				targetCTCollectionId, ctEntry.getModelResourcePrimKey());
 
 			if (!latestTargetCTEntryOptional.isPresent()) {
 				continue;
@@ -670,7 +670,7 @@ public class CTEngineManagerImpl implements CTEngineManager {
 	}
 
 	private boolean _isColliding(CTEntry ctEntry, CTEntry productionCTEntry) {
-		if (ctEntry.getClassPK() < productionCTEntry.getClassPK()) {
+		if (ctEntry.getModelClassPK() < productionCTEntry.getModelClassPK()) {
 			return true;
 		}
 

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/CTManagerImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/CTManagerImpl.java
@@ -522,7 +522,8 @@ public class CTManagerImpl implements CTManager {
 				ctEntryAggregate, relatedCTEntry);
 		}
 		else if (!_containsResource(
-					ctEntryAggregate, relatedCTEntry.getResourcePrimKey())) {
+					ctEntryAggregate,
+					relatedCTEntry.getModelResourcePrimKey())) {
 
 			_ctEntryAggregateLocalService.addCTEntry(
 				ctEntryAggregate, relatedCTEntry);
@@ -544,7 +545,8 @@ public class CTManagerImpl implements CTManager {
 			relatedCTEntries.parallelStream();
 
 		if (relatedCTEntriesStream.anyMatch(
-				ctEntry -> ctEntry.getResourcePrimKey() == resourcePrimKey)) {
+				ctEntry ->
+					ctEntry.getModelResourcePrimKey() == resourcePrimKey)) {
 
 			return true;
 		}
@@ -625,8 +627,8 @@ public class CTManagerImpl implements CTManager {
 		Optional<CTEntry> previousCTEntryOptional =
 			relatedCTEntriesStream.filter(
 				relatedCTEntry ->
-					relatedCTEntry.getResourcePrimKey() ==
-						ctEntry.getResourcePrimKey()
+					relatedCTEntry.getModelResourcePrimKey() ==
+						ctEntry.getModelResourcePrimKey()
 			).findFirst();
 
 		previousCTEntryOptional.ifPresent(

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/process/util/CTProcessMessageSenderUtil.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/process/util/CTProcessMessageSenderUtil.java
@@ -136,9 +136,9 @@ public class CTProcessMessageSenderUtil {
 
 		Map<String, Serializable> messageParameters = new HashMap<>();
 
-		messageParameters.put("className", ctEntry.getClassName());
-		messageParameters.put("classPK", ctEntry.getClassPK());
 		messageParameters.put("ctEntryId", ctEntry.getCtEntryId());
+		messageParameters.put("modelClassName", ctEntry.getModelClassName());
+		messageParameters.put("modelClassPK", ctEntry.getModelClassPK());
 
 		return messageParameters;
 	}

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/model/impl/CTEntryCacheModel.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/model/impl/CTEntryCacheModel.java
@@ -77,12 +77,12 @@ public class CTEntryCacheModel implements CacheModel<CTEntry>, Externalizable {
 		sb.append(createDate);
 		sb.append(", modifiedDate=");
 		sb.append(modifiedDate);
-		sb.append(", classNameId=");
-		sb.append(classNameId);
-		sb.append(", classPK=");
-		sb.append(classPK);
-		sb.append(", resourcePrimKey=");
-		sb.append(resourcePrimKey);
+		sb.append(", modelClassNameId=");
+		sb.append(modelClassNameId);
+		sb.append(", modelClassPK=");
+		sb.append(modelClassPK);
+		sb.append(", modelResourcePrimKey=");
+		sb.append(modelResourcePrimKey);
 		sb.append(", changeType=");
 		sb.append(changeType);
 		sb.append(", status=");
@@ -121,9 +121,9 @@ public class CTEntryCacheModel implements CacheModel<CTEntry>, Externalizable {
 			ctEntryImpl.setModifiedDate(new Date(modifiedDate));
 		}
 
-		ctEntryImpl.setClassNameId(classNameId);
-		ctEntryImpl.setClassPK(classPK);
-		ctEntryImpl.setResourcePrimKey(resourcePrimKey);
+		ctEntryImpl.setModelClassNameId(modelClassNameId);
+		ctEntryImpl.setModelClassPK(modelClassPK);
+		ctEntryImpl.setModelResourcePrimKey(modelResourcePrimKey);
 		ctEntryImpl.setChangeType(changeType);
 		ctEntryImpl.setStatus(status);
 
@@ -143,11 +143,11 @@ public class CTEntryCacheModel implements CacheModel<CTEntry>, Externalizable {
 		createDate = objectInput.readLong();
 		modifiedDate = objectInput.readLong();
 
-		classNameId = objectInput.readLong();
+		modelClassNameId = objectInput.readLong();
 
-		classPK = objectInput.readLong();
+		modelClassPK = objectInput.readLong();
 
-		resourcePrimKey = objectInput.readLong();
+		modelResourcePrimKey = objectInput.readLong();
 
 		changeType = objectInput.readInt();
 
@@ -172,11 +172,11 @@ public class CTEntryCacheModel implements CacheModel<CTEntry>, Externalizable {
 		objectOutput.writeLong(createDate);
 		objectOutput.writeLong(modifiedDate);
 
-		objectOutput.writeLong(classNameId);
+		objectOutput.writeLong(modelClassNameId);
 
-		objectOutput.writeLong(classPK);
+		objectOutput.writeLong(modelClassPK);
 
-		objectOutput.writeLong(resourcePrimKey);
+		objectOutput.writeLong(modelResourcePrimKey);
 
 		objectOutput.writeInt(changeType);
 
@@ -189,9 +189,9 @@ public class CTEntryCacheModel implements CacheModel<CTEntry>, Externalizable {
 	public String userName;
 	public long createDate;
 	public long modifiedDate;
-	public long classNameId;
-	public long classPK;
-	public long resourcePrimKey;
+	public long modelClassNameId;
+	public long modelClassPK;
+	public long modelResourcePrimKey;
 	public int changeType;
 	public int status;
 

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/model/impl/CTEntryModelImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/model/impl/CTEntryModelImpl.java
@@ -30,9 +30,7 @@ import com.liferay.portal.kernel.model.impl.BaseModelImpl;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
-import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
@@ -72,8 +70,8 @@ public class CTEntryModelImpl
 		{"ctEntryId", Types.BIGINT}, {"companyId", Types.BIGINT},
 		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
 		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
-		{"classNameId", Types.BIGINT}, {"classPK", Types.BIGINT},
-		{"resourcePrimKey", Types.BIGINT}, {"changeType", Types.INTEGER},
+		{"modelClassNameId", Types.BIGINT}, {"modelClassPK", Types.BIGINT},
+		{"modelResourcePrimKey", Types.BIGINT}, {"changeType", Types.INTEGER},
 		{"status", Types.INTEGER}
 	};
 
@@ -87,15 +85,15 @@ public class CTEntryModelImpl
 		TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
 		TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
-		TABLE_COLUMNS_MAP.put("classNameId", Types.BIGINT);
-		TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
-		TABLE_COLUMNS_MAP.put("resourcePrimKey", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("modelClassNameId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("modelClassPK", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("modelResourcePrimKey", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("changeType", Types.INTEGER);
 		TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table CTEntry (ctEntryId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,classNameId LONG,classPK LONG,resourcePrimKey LONG,changeType INTEGER,status INTEGER)";
+		"create table CTEntry (ctEntryId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,modelClassNameId LONG,modelClassPK LONG,modelResourcePrimKey LONG,changeType INTEGER,status INTEGER)";
 
 	public static final String TABLE_SQL_DROP = "drop table CTEntry";
 
@@ -125,13 +123,11 @@ public class CTEntryModelImpl
 			"value.object.column.bitmask.enabled.com.liferay.change.tracking.model.CTEntry"),
 		true);
 
-	public static final long CLASSNAMEID_COLUMN_BITMASK = 1L;
+	public static final long MODELCLASSNAMEID_COLUMN_BITMASK = 1L;
 
-	public static final long CLASSPK_COLUMN_BITMASK = 2L;
+	public static final long MODELCLASSPK_COLUMN_BITMASK = 2L;
 
-	public static final long RESOURCEPRIMKEY_COLUMN_BITMASK = 4L;
-
-	public static final long CTENTRYID_COLUMN_BITMASK = 8L;
+	public static final long CTENTRYID_COLUMN_BITMASK = 4L;
 
 	public static final String MAPPING_TABLE_CTENTRYAGGREGATES_CTENTRIES_NAME =
 		"CTEntryAggregates_CTEntries";
@@ -293,17 +289,20 @@ public class CTEntryModelImpl
 		attributeSetterBiConsumers.put(
 			"modifiedDate",
 			(BiConsumer<CTEntry, Date>)CTEntry::setModifiedDate);
-		attributeGetterFunctions.put("classNameId", CTEntry::getClassNameId);
-		attributeSetterBiConsumers.put(
-			"classNameId", (BiConsumer<CTEntry, Long>)CTEntry::setClassNameId);
-		attributeGetterFunctions.put("classPK", CTEntry::getClassPK);
-		attributeSetterBiConsumers.put(
-			"classPK", (BiConsumer<CTEntry, Long>)CTEntry::setClassPK);
 		attributeGetterFunctions.put(
-			"resourcePrimKey", CTEntry::getResourcePrimKey);
+			"modelClassNameId", CTEntry::getModelClassNameId);
 		attributeSetterBiConsumers.put(
-			"resourcePrimKey",
-			(BiConsumer<CTEntry, Long>)CTEntry::setResourcePrimKey);
+			"modelClassNameId",
+			(BiConsumer<CTEntry, Long>)CTEntry::setModelClassNameId);
+		attributeGetterFunctions.put("modelClassPK", CTEntry::getModelClassPK);
+		attributeSetterBiConsumers.put(
+			"modelClassPK",
+			(BiConsumer<CTEntry, Long>)CTEntry::setModelClassPK);
+		attributeGetterFunctions.put(
+			"modelResourcePrimKey", CTEntry::getModelResourcePrimKey);
+		attributeSetterBiConsumers.put(
+			"modelResourcePrimKey",
+			(BiConsumer<CTEntry, Long>)CTEntry::setModelResourcePrimKey);
 		attributeGetterFunctions.put("changeType", CTEntry::getChangeType);
 		attributeSetterBiConsumers.put(
 			"changeType", (BiConsumer<CTEntry, Integer>)CTEntry::setChangeType);
@@ -405,94 +404,57 @@ public class CTEntryModelImpl
 	}
 
 	@Override
-	public String getClassName() {
-		if (getClassNameId() <= 0) {
-			return "";
+	public long getModelClassNameId() {
+		return _modelClassNameId;
+	}
+
+	@Override
+	public void setModelClassNameId(long modelClassNameId) {
+		_columnBitmask |= MODELCLASSNAMEID_COLUMN_BITMASK;
+
+		if (!_setOriginalModelClassNameId) {
+			_setOriginalModelClassNameId = true;
+
+			_originalModelClassNameId = _modelClassNameId;
 		}
 
-		return PortalUtil.getClassName(getClassNameId());
+		_modelClassNameId = modelClassNameId;
+	}
+
+	public long getOriginalModelClassNameId() {
+		return _originalModelClassNameId;
 	}
 
 	@Override
-	public void setClassName(String className) {
-		long classNameId = 0;
+	public long getModelClassPK() {
+		return _modelClassPK;
+	}
 
-		if (Validator.isNotNull(className)) {
-			classNameId = PortalUtil.getClassNameId(className);
+	@Override
+	public void setModelClassPK(long modelClassPK) {
+		_columnBitmask |= MODELCLASSPK_COLUMN_BITMASK;
+
+		if (!_setOriginalModelClassPK) {
+			_setOriginalModelClassPK = true;
+
+			_originalModelClassPK = _modelClassPK;
 		}
 
-		setClassNameId(classNameId);
+		_modelClassPK = modelClassPK;
+	}
+
+	public long getOriginalModelClassPK() {
+		return _originalModelClassPK;
 	}
 
 	@Override
-	public long getClassNameId() {
-		return _classNameId;
+	public long getModelResourcePrimKey() {
+		return _modelResourcePrimKey;
 	}
 
 	@Override
-	public void setClassNameId(long classNameId) {
-		_columnBitmask |= CLASSNAMEID_COLUMN_BITMASK;
-
-		if (!_setOriginalClassNameId) {
-			_setOriginalClassNameId = true;
-
-			_originalClassNameId = _classNameId;
-		}
-
-		_classNameId = classNameId;
-	}
-
-	public long getOriginalClassNameId() {
-		return _originalClassNameId;
-	}
-
-	@Override
-	public long getClassPK() {
-		return _classPK;
-	}
-
-	@Override
-	public void setClassPK(long classPK) {
-		_columnBitmask |= CLASSPK_COLUMN_BITMASK;
-
-		if (!_setOriginalClassPK) {
-			_setOriginalClassPK = true;
-
-			_originalClassPK = _classPK;
-		}
-
-		_classPK = classPK;
-	}
-
-	public long getOriginalClassPK() {
-		return _originalClassPK;
-	}
-
-	@Override
-	public long getResourcePrimKey() {
-		return _resourcePrimKey;
-	}
-
-	@Override
-	public void setResourcePrimKey(long resourcePrimKey) {
-		_columnBitmask |= RESOURCEPRIMKEY_COLUMN_BITMASK;
-
-		if (!_setOriginalResourcePrimKey) {
-			_setOriginalResourcePrimKey = true;
-
-			_originalResourcePrimKey = _resourcePrimKey;
-		}
-
-		_resourcePrimKey = resourcePrimKey;
-	}
-
-	@Override
-	public boolean isResourceMain() {
-		return true;
-	}
-
-	public long getOriginalResourcePrimKey() {
-		return _originalResourcePrimKey;
+	public void setModelResourcePrimKey(long modelResourcePrimKey) {
+		_modelResourcePrimKey = modelResourcePrimKey;
 	}
 
 	@Override
@@ -553,9 +515,9 @@ public class CTEntryModelImpl
 		ctEntryImpl.setUserName(getUserName());
 		ctEntryImpl.setCreateDate(getCreateDate());
 		ctEntryImpl.setModifiedDate(getModifiedDate());
-		ctEntryImpl.setClassNameId(getClassNameId());
-		ctEntryImpl.setClassPK(getClassPK());
-		ctEntryImpl.setResourcePrimKey(getResourcePrimKey());
+		ctEntryImpl.setModelClassNameId(getModelClassNameId());
+		ctEntryImpl.setModelClassPK(getModelClassPK());
+		ctEntryImpl.setModelResourcePrimKey(getModelResourcePrimKey());
 		ctEntryImpl.setChangeType(getChangeType());
 		ctEntryImpl.setStatus(getStatus());
 
@@ -622,18 +584,14 @@ public class CTEntryModelImpl
 
 		ctEntryModelImpl._setModifiedDate = false;
 
-		ctEntryModelImpl._originalClassNameId = ctEntryModelImpl._classNameId;
+		ctEntryModelImpl._originalModelClassNameId =
+			ctEntryModelImpl._modelClassNameId;
 
-		ctEntryModelImpl._setOriginalClassNameId = false;
+		ctEntryModelImpl._setOriginalModelClassNameId = false;
 
-		ctEntryModelImpl._originalClassPK = ctEntryModelImpl._classPK;
+		ctEntryModelImpl._originalModelClassPK = ctEntryModelImpl._modelClassPK;
 
-		ctEntryModelImpl._setOriginalClassPK = false;
-
-		ctEntryModelImpl._originalResourcePrimKey =
-			ctEntryModelImpl._resourcePrimKey;
-
-		ctEntryModelImpl._setOriginalResourcePrimKey = false;
+		ctEntryModelImpl._setOriginalModelClassPK = false;
 
 		ctEntryModelImpl._columnBitmask = 0;
 	}
@@ -674,11 +632,11 @@ public class CTEntryModelImpl
 			ctEntryCacheModel.modifiedDate = Long.MIN_VALUE;
 		}
 
-		ctEntryCacheModel.classNameId = getClassNameId();
+		ctEntryCacheModel.modelClassNameId = getModelClassNameId();
 
-		ctEntryCacheModel.classPK = getClassPK();
+		ctEntryCacheModel.modelClassPK = getModelClassPK();
 
-		ctEntryCacheModel.resourcePrimKey = getResourcePrimKey();
+		ctEntryCacheModel.modelResourcePrimKey = getModelResourcePrimKey();
 
 		ctEntryCacheModel.changeType = getChangeType();
 
@@ -763,15 +721,13 @@ public class CTEntryModelImpl
 	private Date _createDate;
 	private Date _modifiedDate;
 	private boolean _setModifiedDate;
-	private long _classNameId;
-	private long _originalClassNameId;
-	private boolean _setOriginalClassNameId;
-	private long _classPK;
-	private long _originalClassPK;
-	private boolean _setOriginalClassPK;
-	private long _resourcePrimKey;
-	private long _originalResourcePrimKey;
-	private boolean _setOriginalResourcePrimKey;
+	private long _modelClassNameId;
+	private long _originalModelClassNameId;
+	private boolean _setOriginalModelClassNameId;
+	private long _modelClassPK;
+	private long _originalModelClassPK;
+	private boolean _setOriginalModelClassPK;
+	private long _modelResourcePrimKey;
 	private int _changeType;
 	private int _status;
 	private long _columnBitmask;

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/base/CTEntryLocalServiceBaseImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/base/CTEntryLocalServiceBaseImpl.java
@@ -292,14 +292,6 @@ public abstract class CTEntryLocalServiceBaseImpl
 		return ctEntryPersistence.findByPrimaryKey(primaryKeyObj);
 	}
 
-	@Override
-	public List<? extends PersistedModel> getPersistedModel(
-			long resourcePrimKey)
-		throws PortalException {
-
-		return ctEntryPersistence.findByResourcePrimKey(resourcePrimKey);
-	}
-
 	/**
 	 * Returns a range of all the ct entries.
 	 *

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTEntryLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTEntryLocalServiceImpl.java
@@ -39,14 +39,16 @@ public class CTEntryLocalServiceImpl extends CTEntryLocalServiceBaseImpl {
 
 	@Override
 	public CTEntry addCTEntry(
-			long userId, long classNameId, long classPK, long resourcePrimKey,
-			int changeType, long ctCollectionId, ServiceContext serviceContext)
+			long userId, long modelClassNameId, long modelClassPK,
+			long resourcePrimKey, int changeType, long ctCollectionId,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		boolean force = GetterUtil.getBoolean(
 			serviceContext.getAttribute("force"));
 
-		CTEntry ctEntry = ctEntryPersistence.fetchByC_C(classNameId, classPK);
+		CTEntry ctEntry = ctEntryPersistence.fetchByC_C(
+			modelClassNameId, modelClassPK);
 
 		_validate(ctEntry, changeType, ctCollectionId, force);
 
@@ -57,7 +59,7 @@ public class CTEntryLocalServiceImpl extends CTEntryLocalServiceBaseImpl {
 		}
 
 		return _addCTEntry(
-			user, classNameId, classPK, resourcePrimKey, changeType,
+			user, modelClassNameId, modelClassPK, resourcePrimKey, changeType,
 			ctCollectionId, serviceContext);
 	}
 
@@ -78,15 +80,16 @@ public class CTEntryLocalServiceImpl extends CTEntryLocalServiceBaseImpl {
 	}
 
 	@Override
-	public CTEntry fetchCTEntry(long classNameId, long classPK) {
-		return ctEntryPersistence.fetchByC_C(classNameId, classPK);
+	public CTEntry fetchCTEntry(long modelClassNameId, long modelClassPK) {
+		return ctEntryPersistence.fetchByC_C(modelClassNameId, modelClassPK);
 	}
 
 	@Override
 	public CTEntry fetchCTEntry(
-		long ctCollectionId, long classNameId, long classPK) {
+		long ctCollectionId, long modelClassNameId, long modelClassPK) {
 
-		return ctEntryFinder.findByC_C_C(ctCollectionId, classNameId, classPK);
+		return ctEntryFinder.findByC_C_C(
+			ctCollectionId, modelClassNameId, modelClassPK);
 	}
 
 	@Override
@@ -169,8 +172,9 @@ public class CTEntryLocalServiceImpl extends CTEntryLocalServiceBaseImpl {
 	}
 
 	private CTEntry _addCTEntry(
-		User user, long classNameId, long classPK, long resourcePrimKey,
-		int changeType, long ctCollectionId, ServiceContext serviceContext) {
+		User user, long modelClassNameId, long modelClassPK,
+		long resourcePrimKey, int changeType, long ctCollectionId,
+		ServiceContext serviceContext) {
 
 		long ctEntryId = counterLocalService.increment();
 
@@ -185,9 +189,9 @@ public class CTEntryLocalServiceImpl extends CTEntryLocalServiceBaseImpl {
 		ctEntry.setCreateDate(serviceContext.getCreateDate(now));
 		ctEntry.setModifiedDate(serviceContext.getModifiedDate(now));
 
-		ctEntry.setClassNameId(classNameId);
-		ctEntry.setClassPK(classPK);
-		ctEntry.setResourcePrimKey(resourcePrimKey);
+		ctEntry.setModelClassNameId(modelClassNameId);
+		ctEntry.setModelClassPK(modelClassPK);
+		ctEntry.setModelResourcePrimKey(resourcePrimKey);
 		ctEntry.setChangeType(changeType);
 
 		int status = WorkflowConstants.STATUS_DRAFT;

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/persistence/impl/CTEntryFinderImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/persistence/impl/CTEntryFinderImpl.java
@@ -202,7 +202,7 @@ public class CTEntryFinderImpl
 	@Override
 	@SuppressWarnings("unchecked")
 	public List<CTEntry> findByC_R(
-		long ctCollectionId, long resourcePrimKey,
+		long ctCollectionId, long modelResourcePrimKey,
 		QueryDefinition<CTEntry> queryDefinition) {
 
 		Session session = null;
@@ -212,9 +212,9 @@ public class CTEntryFinderImpl
 
 			String sql = _customSQL.get(getClass(), FIND_BY_CT_COLLECTION_ID);
 
-			if (resourcePrimKey > 0) {
+			if (modelResourcePrimKey > 0) {
 				sql = _customSQL.appendCriteria(
-					sql, "AND (CTEntry.resourcePrimKey = ?)");
+					sql, "AND (CTEntry.modelResourcePrimKey = ?)");
 			}
 
 			sql = _customSQL.replaceOrderBy(
@@ -228,8 +228,8 @@ public class CTEntryFinderImpl
 
 			qPos.add(ctCollectionId);
 
-			if (resourcePrimKey > 0) {
-				qPos.add(resourcePrimKey);
+			if (modelResourcePrimKey > 0) {
+				qPos.add(modelResourcePrimKey);
 			}
 
 			return (List<CTEntry>)QueryUtil.list(
@@ -247,7 +247,7 @@ public class CTEntryFinderImpl
 	@Override
 	@SuppressWarnings("unchecked")
 	public CTEntry findByC_C_C(
-		long ctCollectionId, long classNameId, long classPK) {
+		long ctCollectionId, long modelClassNameId, long modelClassPK) {
 
 		Session session = null;
 
@@ -257,9 +257,10 @@ public class CTEntryFinderImpl
 			String sql = _customSQL.get(getClass(), FIND_BY_CT_COLLECTION_ID);
 
 			sql = _customSQL.appendCriteria(
-				sql, "AND (CTEntry.classNameId = ?)");
+				sql, "AND (CTEntry.modelClassNameId = ?)");
 
-			sql = _customSQL.appendCriteria(sql, "AND (CTEntry.classPK = ?)");
+			sql = _customSQL.appendCriteria(
+				sql, "AND (CTEntry.modelClassPK = ?)");
 
 			SQLQuery q = session.createSynchronizedSQLQuery(sql);
 
@@ -269,9 +270,9 @@ public class CTEntryFinderImpl
 
 			qPos.add(ctCollectionId);
 
-			qPos.add(classNameId);
+			qPos.add(modelClassNameId);
 
-			qPos.add(classPK);
+			qPos.add(modelClassPK);
 
 			List<CTEntry> ctEntries = q.list();
 

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/persistence/impl/CTEntryPersistenceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/persistence/impl/CTEntryPersistenceImpl.java
@@ -90,544 +90,33 @@ public class CTEntryPersistenceImpl
 	private FinderPath _finderPathWithPaginationFindAll;
 	private FinderPath _finderPathWithoutPaginationFindAll;
 	private FinderPath _finderPathCountAll;
-	private FinderPath _finderPathWithPaginationFindByResourcePrimKey;
-	private FinderPath _finderPathWithoutPaginationFindByResourcePrimKey;
-	private FinderPath _finderPathCountByResourcePrimKey;
-
-	/**
-	 * Returns all the ct entries where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @return the matching ct entries
-	 */
-	@Override
-	public List<CTEntry> findByResourcePrimKey(long resourcePrimKey) {
-		return findByResourcePrimKey(
-			resourcePrimKey, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
-	}
-
-	/**
-	 * Returns a range of all the ct entries where resourcePrimKey = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>CTEntryModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
-	 * </p>
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param start the lower bound of the range of ct entries
-	 * @param end the upper bound of the range of ct entries (not inclusive)
-	 * @return the range of matching ct entries
-	 */
-	@Override
-	public List<CTEntry> findByResourcePrimKey(
-		long resourcePrimKey, int start, int end) {
-
-		return findByResourcePrimKey(resourcePrimKey, start, end, null);
-	}
-
-	/**
-	 * Returns an ordered range of all the ct entries where resourcePrimKey = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>CTEntryModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
-	 * </p>
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param start the lower bound of the range of ct entries
-	 * @param end the upper bound of the range of ct entries (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @return the ordered range of matching ct entries
-	 */
-	@Override
-	public List<CTEntry> findByResourcePrimKey(
-		long resourcePrimKey, int start, int end,
-		OrderByComparator<CTEntry> orderByComparator) {
-
-		return findByResourcePrimKey(
-			resourcePrimKey, start, end, orderByComparator, true);
-	}
-
-	/**
-	 * Returns an ordered range of all the ct entries where resourcePrimKey = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>CTEntryModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
-	 * </p>
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param start the lower bound of the range of ct entries
-	 * @param end the upper bound of the range of ct entries (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @param retrieveFromCache whether to retrieve from the finder cache
-	 * @return the ordered range of matching ct entries
-	 */
-	@Override
-	public List<CTEntry> findByResourcePrimKey(
-		long resourcePrimKey, int start, int end,
-		OrderByComparator<CTEntry> orderByComparator,
-		boolean retrieveFromCache) {
-
-		boolean pagination = true;
-		FinderPath finderPath = null;
-		Object[] finderArgs = null;
-
-		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
-			(orderByComparator == null)) {
-
-			pagination = false;
-			finderPath = _finderPathWithoutPaginationFindByResourcePrimKey;
-			finderArgs = new Object[] {resourcePrimKey};
-		}
-		else {
-			finderPath = _finderPathWithPaginationFindByResourcePrimKey;
-			finderArgs = new Object[] {
-				resourcePrimKey, start, end, orderByComparator
-			};
-		}
-
-		List<CTEntry> list = null;
-
-		if (retrieveFromCache) {
-			list = (List<CTEntry>)finderCache.getResult(
-				finderPath, finderArgs, this);
-
-			if ((list != null) && !list.isEmpty()) {
-				for (CTEntry ctEntry : list) {
-					if ((resourcePrimKey != ctEntry.getResourcePrimKey())) {
-						list = null;
-
-						break;
-					}
-				}
-			}
-		}
-
-		if (list == null) {
-			StringBundler query = null;
-
-			if (orderByComparator != null) {
-				query = new StringBundler(
-					3 + (orderByComparator.getOrderByFields().length * 2));
-			}
-			else {
-				query = new StringBundler(3);
-			}
-
-			query.append(_SQL_SELECT_CTENTRY_WHERE);
-
-			query.append(_FINDER_COLUMN_RESOURCEPRIMKEY_RESOURCEPRIMKEY_2);
-
-			if (orderByComparator != null) {
-				appendOrderByComparator(
-					query, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
-			}
-			else if (pagination) {
-				query.append(CTEntryModelImpl.ORDER_BY_JPQL);
-			}
-
-			String sql = query.toString();
-
-			Session session = null;
-
-			try {
-				session = openSession();
-
-				Query q = session.createQuery(sql);
-
-				QueryPos qPos = QueryPos.getInstance(q);
-
-				qPos.add(resourcePrimKey);
-
-				if (!pagination) {
-					list = (List<CTEntry>)QueryUtil.list(
-						q, getDialect(), start, end, false);
-
-					Collections.sort(list);
-
-					list = Collections.unmodifiableList(list);
-				}
-				else {
-					list = (List<CTEntry>)QueryUtil.list(
-						q, getDialect(), start, end);
-				}
-
-				cacheResult(list);
-
-				finderCache.putResult(finderPath, finderArgs, list);
-			}
-			catch (Exception e) {
-				finderCache.removeResult(finderPath, finderArgs);
-
-				throw processException(e);
-			}
-			finally {
-				closeSession(session);
-			}
-		}
-
-		return list;
-	}
-
-	/**
-	 * Returns the first ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching ct entry
-	 * @throws NoSuchEntryException if a matching ct entry could not be found
-	 */
-	@Override
-	public CTEntry findByResourcePrimKey_First(
-			long resourcePrimKey, OrderByComparator<CTEntry> orderByComparator)
-		throws NoSuchEntryException {
-
-		CTEntry ctEntry = fetchByResourcePrimKey_First(
-			resourcePrimKey, orderByComparator);
-
-		if (ctEntry != null) {
-			return ctEntry;
-		}
-
-		StringBundler msg = new StringBundler(4);
-
-		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
-
-		msg.append("resourcePrimKey=");
-		msg.append(resourcePrimKey);
-
-		msg.append("}");
-
-		throw new NoSuchEntryException(msg.toString());
-	}
-
-	/**
-	 * Returns the first ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching ct entry, or <code>null</code> if a matching ct entry could not be found
-	 */
-	@Override
-	public CTEntry fetchByResourcePrimKey_First(
-		long resourcePrimKey, OrderByComparator<CTEntry> orderByComparator) {
-
-		List<CTEntry> list = findByResourcePrimKey(
-			resourcePrimKey, 0, 1, orderByComparator);
-
-		if (!list.isEmpty()) {
-			return list.get(0);
-		}
-
-		return null;
-	}
-
-	/**
-	 * Returns the last ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the last matching ct entry
-	 * @throws NoSuchEntryException if a matching ct entry could not be found
-	 */
-	@Override
-	public CTEntry findByResourcePrimKey_Last(
-			long resourcePrimKey, OrderByComparator<CTEntry> orderByComparator)
-		throws NoSuchEntryException {
-
-		CTEntry ctEntry = fetchByResourcePrimKey_Last(
-			resourcePrimKey, orderByComparator);
-
-		if (ctEntry != null) {
-			return ctEntry;
-		}
-
-		StringBundler msg = new StringBundler(4);
-
-		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
-
-		msg.append("resourcePrimKey=");
-		msg.append(resourcePrimKey);
-
-		msg.append("}");
-
-		throw new NoSuchEntryException(msg.toString());
-	}
-
-	/**
-	 * Returns the last ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the last matching ct entry, or <code>null</code> if a matching ct entry could not be found
-	 */
-	@Override
-	public CTEntry fetchByResourcePrimKey_Last(
-		long resourcePrimKey, OrderByComparator<CTEntry> orderByComparator) {
-
-		int count = countByResourcePrimKey(resourcePrimKey);
-
-		if (count == 0) {
-			return null;
-		}
-
-		List<CTEntry> list = findByResourcePrimKey(
-			resourcePrimKey, count - 1, count, orderByComparator);
-
-		if (!list.isEmpty()) {
-			return list.get(0);
-		}
-
-		return null;
-	}
-
-	/**
-	 * Returns the ct entries before and after the current ct entry in the ordered set where resourcePrimKey = &#63;.
-	 *
-	 * @param ctEntryId the primary key of the current ct entry
-	 * @param resourcePrimKey the resource prim key
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the previous, current, and next ct entry
-	 * @throws NoSuchEntryException if a ct entry with the primary key could not be found
-	 */
-	@Override
-	public CTEntry[] findByResourcePrimKey_PrevAndNext(
-			long ctEntryId, long resourcePrimKey,
-			OrderByComparator<CTEntry> orderByComparator)
-		throws NoSuchEntryException {
-
-		CTEntry ctEntry = findByPrimaryKey(ctEntryId);
-
-		Session session = null;
-
-		try {
-			session = openSession();
-
-			CTEntry[] array = new CTEntryImpl[3];
-
-			array[0] = getByResourcePrimKey_PrevAndNext(
-				session, ctEntry, resourcePrimKey, orderByComparator, true);
-
-			array[1] = ctEntry;
-
-			array[2] = getByResourcePrimKey_PrevAndNext(
-				session, ctEntry, resourcePrimKey, orderByComparator, false);
-
-			return array;
-		}
-		catch (Exception e) {
-			throw processException(e);
-		}
-		finally {
-			closeSession(session);
-		}
-	}
-
-	protected CTEntry getByResourcePrimKey_PrevAndNext(
-		Session session, CTEntry ctEntry, long resourcePrimKey,
-		OrderByComparator<CTEntry> orderByComparator, boolean previous) {
-
-		StringBundler query = null;
-
-		if (orderByComparator != null) {
-			query = new StringBundler(
-				4 + (orderByComparator.getOrderByConditionFields().length * 3) +
-					(orderByComparator.getOrderByFields().length * 3));
-		}
-		else {
-			query = new StringBundler(3);
-		}
-
-		query.append(_SQL_SELECT_CTENTRY_WHERE);
-
-		query.append(_FINDER_COLUMN_RESOURCEPRIMKEY_RESOURCEPRIMKEY_2);
-
-		if (orderByComparator != null) {
-			String[] orderByConditionFields =
-				orderByComparator.getOrderByConditionFields();
-
-			if (orderByConditionFields.length > 0) {
-				query.append(WHERE_AND);
-			}
-
-			for (int i = 0; i < orderByConditionFields.length; i++) {
-				query.append(_ORDER_BY_ENTITY_ALIAS);
-				query.append(orderByConditionFields[i]);
-
-				if ((i + 1) < orderByConditionFields.length) {
-					if (orderByComparator.isAscending() ^ previous) {
-						query.append(WHERE_GREATER_THAN_HAS_NEXT);
-					}
-					else {
-						query.append(WHERE_LESSER_THAN_HAS_NEXT);
-					}
-				}
-				else {
-					if (orderByComparator.isAscending() ^ previous) {
-						query.append(WHERE_GREATER_THAN);
-					}
-					else {
-						query.append(WHERE_LESSER_THAN);
-					}
-				}
-			}
-
-			query.append(ORDER_BY_CLAUSE);
-
-			String[] orderByFields = orderByComparator.getOrderByFields();
-
-			for (int i = 0; i < orderByFields.length; i++) {
-				query.append(_ORDER_BY_ENTITY_ALIAS);
-				query.append(orderByFields[i]);
-
-				if ((i + 1) < orderByFields.length) {
-					if (orderByComparator.isAscending() ^ previous) {
-						query.append(ORDER_BY_ASC_HAS_NEXT);
-					}
-					else {
-						query.append(ORDER_BY_DESC_HAS_NEXT);
-					}
-				}
-				else {
-					if (orderByComparator.isAscending() ^ previous) {
-						query.append(ORDER_BY_ASC);
-					}
-					else {
-						query.append(ORDER_BY_DESC);
-					}
-				}
-			}
-		}
-		else {
-			query.append(CTEntryModelImpl.ORDER_BY_JPQL);
-		}
-
-		String sql = query.toString();
-
-		Query q = session.createQuery(sql);
-
-		q.setFirstResult(0);
-		q.setMaxResults(2);
-
-		QueryPos qPos = QueryPos.getInstance(q);
-
-		qPos.add(resourcePrimKey);
-
-		if (orderByComparator != null) {
-			for (Object orderByConditionValue :
-					orderByComparator.getOrderByConditionValues(ctEntry)) {
-
-				qPos.add(orderByConditionValue);
-			}
-		}
-
-		List<CTEntry> list = q.list();
-
-		if (list.size() == 2) {
-			return list.get(1);
-		}
-		else {
-			return null;
-		}
-	}
-
-	/**
-	 * Removes all the ct entries where resourcePrimKey = &#63; from the database.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 */
-	@Override
-	public void removeByResourcePrimKey(long resourcePrimKey) {
-		for (CTEntry ctEntry :
-				findByResourcePrimKey(
-					resourcePrimKey, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-					null)) {
-
-			remove(ctEntry);
-		}
-	}
-
-	/**
-	 * Returns the number of ct entries where resourcePrimKey = &#63;.
-	 *
-	 * @param resourcePrimKey the resource prim key
-	 * @return the number of matching ct entries
-	 */
-	@Override
-	public int countByResourcePrimKey(long resourcePrimKey) {
-		FinderPath finderPath = _finderPathCountByResourcePrimKey;
-
-		Object[] finderArgs = new Object[] {resourcePrimKey};
-
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
-
-		if (count == null) {
-			StringBundler query = new StringBundler(2);
-
-			query.append(_SQL_COUNT_CTENTRY_WHERE);
-
-			query.append(_FINDER_COLUMN_RESOURCEPRIMKEY_RESOURCEPRIMKEY_2);
-
-			String sql = query.toString();
-
-			Session session = null;
-
-			try {
-				session = openSession();
-
-				Query q = session.createQuery(sql);
-
-				QueryPos qPos = QueryPos.getInstance(q);
-
-				qPos.add(resourcePrimKey);
-
-				count = (Long)q.uniqueResult();
-
-				finderCache.putResult(finderPath, finderArgs, count);
-			}
-			catch (Exception e) {
-				finderCache.removeResult(finderPath, finderArgs);
-
-				throw processException(e);
-			}
-			finally {
-				closeSession(session);
-			}
-		}
-
-		return count.intValue();
-	}
-
-	private static final String
-		_FINDER_COLUMN_RESOURCEPRIMKEY_RESOURCEPRIMKEY_2 =
-			"ctEntry.resourcePrimKey = ?";
-
 	private FinderPath _finderPathFetchByC_C;
 	private FinderPath _finderPathCountByC_C;
 
 	/**
-	 * Returns the ct entry where classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
+	 * Returns the ct entry where modelClassNameId = &#63; and modelClassPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @return the matching ct entry
 	 * @throws NoSuchEntryException if a matching ct entry could not be found
 	 */
 	@Override
-	public CTEntry findByC_C(long classNameId, long classPK)
+	public CTEntry findByC_C(long modelClassNameId, long modelClassPK)
 		throws NoSuchEntryException {
 
-		CTEntry ctEntry = fetchByC_C(classNameId, classPK);
+		CTEntry ctEntry = fetchByC_C(modelClassNameId, modelClassPK);
 
 		if (ctEntry == null) {
 			StringBundler msg = new StringBundler(6);
 
 			msg.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			msg.append("classNameId=");
-			msg.append(classNameId);
+			msg.append("modelClassNameId=");
+			msg.append(modelClassNameId);
 
-			msg.append(", classPK=");
-			msg.append(classPK);
+			msg.append(", modelClassPK=");
+			msg.append(modelClassPK);
 
 			msg.append("}");
 
@@ -642,30 +131,30 @@ public class CTEntryPersistenceImpl
 	}
 
 	/**
-	 * Returns the ct entry where classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the ct entry where modelClassNameId = &#63; and modelClassPK = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @return the matching ct entry, or <code>null</code> if a matching ct entry could not be found
 	 */
 	@Override
-	public CTEntry fetchByC_C(long classNameId, long classPK) {
-		return fetchByC_C(classNameId, classPK, true);
+	public CTEntry fetchByC_C(long modelClassNameId, long modelClassPK) {
+		return fetchByC_C(modelClassNameId, modelClassPK, true);
 	}
 
 	/**
-	 * Returns the ct entry where classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the ct entry where modelClassNameId = &#63; and modelClassPK = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @param retrieveFromCache whether to retrieve from the finder cache
 	 * @return the matching ct entry, or <code>null</code> if a matching ct entry could not be found
 	 */
 	@Override
 	public CTEntry fetchByC_C(
-		long classNameId, long classPK, boolean retrieveFromCache) {
+		long modelClassNameId, long modelClassPK, boolean retrieveFromCache) {
 
-		Object[] finderArgs = new Object[] {classNameId, classPK};
+		Object[] finderArgs = new Object[] {modelClassNameId, modelClassPK};
 
 		Object result = null;
 
@@ -677,8 +166,8 @@ public class CTEntryPersistenceImpl
 		if (result instanceof CTEntry) {
 			CTEntry ctEntry = (CTEntry)result;
 
-			if ((classNameId != ctEntry.getClassNameId()) ||
-				(classPK != ctEntry.getClassPK())) {
+			if ((modelClassNameId != ctEntry.getModelClassNameId()) ||
+				(modelClassPK != ctEntry.getModelClassPK())) {
 
 				result = null;
 			}
@@ -689,9 +178,9 @@ public class CTEntryPersistenceImpl
 
 			query.append(_SQL_SELECT_CTENTRY_WHERE);
 
-			query.append(_FINDER_COLUMN_C_C_CLASSNAMEID_2);
+			query.append(_FINDER_COLUMN_C_C_MODELCLASSNAMEID_2);
 
-			query.append(_FINDER_COLUMN_C_C_CLASSPK_2);
+			query.append(_FINDER_COLUMN_C_C_MODELCLASSPK_2);
 
 			String sql = query.toString();
 
@@ -704,9 +193,9 @@ public class CTEntryPersistenceImpl
 
 				QueryPos qPos = QueryPos.getInstance(q);
 
-				qPos.add(classNameId);
+				qPos.add(modelClassNameId);
 
-				qPos.add(classPK);
+				qPos.add(modelClassPK);
 
 				List<CTEntry> list = q.list();
 
@@ -741,33 +230,33 @@ public class CTEntryPersistenceImpl
 	}
 
 	/**
-	 * Removes the ct entry where classNameId = &#63; and classPK = &#63; from the database.
+	 * Removes the ct entry where modelClassNameId = &#63; and modelClassPK = &#63; from the database.
 	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @return the ct entry that was removed
 	 */
 	@Override
-	public CTEntry removeByC_C(long classNameId, long classPK)
+	public CTEntry removeByC_C(long modelClassNameId, long modelClassPK)
 		throws NoSuchEntryException {
 
-		CTEntry ctEntry = findByC_C(classNameId, classPK);
+		CTEntry ctEntry = findByC_C(modelClassNameId, modelClassPK);
 
 		return remove(ctEntry);
 	}
 
 	/**
-	 * Returns the number of ct entries where classNameId = &#63; and classPK = &#63;.
+	 * Returns the number of ct entries where modelClassNameId = &#63; and modelClassPK = &#63;.
 	 *
-	 * @param classNameId the class name ID
-	 * @param classPK the class pk
+	 * @param modelClassNameId the model class name ID
+	 * @param modelClassPK the model class pk
 	 * @return the number of matching ct entries
 	 */
 	@Override
-	public int countByC_C(long classNameId, long classPK) {
+	public int countByC_C(long modelClassNameId, long modelClassPK) {
 		FinderPath finderPath = _finderPathCountByC_C;
 
-		Object[] finderArgs = new Object[] {classNameId, classPK};
+		Object[] finderArgs = new Object[] {modelClassNameId, modelClassPK};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -776,9 +265,9 @@ public class CTEntryPersistenceImpl
 
 			query.append(_SQL_COUNT_CTENTRY_WHERE);
 
-			query.append(_FINDER_COLUMN_C_C_CLASSNAMEID_2);
+			query.append(_FINDER_COLUMN_C_C_MODELCLASSNAMEID_2);
 
-			query.append(_FINDER_COLUMN_C_C_CLASSPK_2);
+			query.append(_FINDER_COLUMN_C_C_MODELCLASSPK_2);
 
 			String sql = query.toString();
 
@@ -791,9 +280,9 @@ public class CTEntryPersistenceImpl
 
 				QueryPos qPos = QueryPos.getInstance(q);
 
-				qPos.add(classNameId);
+				qPos.add(modelClassNameId);
 
-				qPos.add(classPK);
+				qPos.add(modelClassPK);
 
 				count = (Long)q.uniqueResult();
 
@@ -812,11 +301,11 @@ public class CTEntryPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_C_C_CLASSNAMEID_2 =
-		"ctEntry.classNameId = ? AND ";
+	private static final String _FINDER_COLUMN_C_C_MODELCLASSNAMEID_2 =
+		"ctEntry.modelClassNameId = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_C_CLASSPK_2 =
-		"ctEntry.classPK = ?";
+	private static final String _FINDER_COLUMN_C_C_MODELCLASSPK_2 =
+		"ctEntry.modelClassPK = ?";
 
 	public CTEntryPersistenceImpl() {
 		setModelClass(CTEntry.class);
@@ -839,7 +328,9 @@ public class CTEntryPersistenceImpl
 
 		finderCache.putResult(
 			_finderPathFetchByC_C,
-			new Object[] {ctEntry.getClassNameId(), ctEntry.getClassPK()},
+			new Object[] {
+				ctEntry.getModelClassNameId(), ctEntry.getModelClassPK()
+			},
 			ctEntry);
 
 		ctEntry.resetOriginalValues();
@@ -916,7 +407,8 @@ public class CTEntryPersistenceImpl
 
 	protected void cacheUniqueFindersCache(CTEntryModelImpl ctEntryModelImpl) {
 		Object[] args = new Object[] {
-			ctEntryModelImpl.getClassNameId(), ctEntryModelImpl.getClassPK()
+			ctEntryModelImpl.getModelClassNameId(),
+			ctEntryModelImpl.getModelClassPK()
 		};
 
 		finderCache.putResult(
@@ -930,7 +422,8 @@ public class CTEntryPersistenceImpl
 
 		if (clearCurrent) {
 			Object[] args = new Object[] {
-				ctEntryModelImpl.getClassNameId(), ctEntryModelImpl.getClassPK()
+				ctEntryModelImpl.getModelClassNameId(),
+				ctEntryModelImpl.getModelClassPK()
 			};
 
 			finderCache.removeResult(_finderPathCountByC_C, args);
@@ -941,8 +434,8 @@ public class CTEntryPersistenceImpl
 			 _finderPathFetchByC_C.getColumnBitmask()) != 0) {
 
 			Object[] args = new Object[] {
-				ctEntryModelImpl.getOriginalClassNameId(),
-				ctEntryModelImpl.getOriginalClassPK()
+				ctEntryModelImpl.getOriginalModelClassNameId(),
+				ctEntryModelImpl.getOriginalModelClassPK()
 			};
 
 			finderCache.removeResult(_finderPathCountByC_C, args);
@@ -1127,39 +620,9 @@ public class CTEntryPersistenceImpl
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
 		}
 		else if (isNew) {
-			Object[] args = new Object[] {
-				ctEntryModelImpl.getResourcePrimKey()
-			};
-
-			finderCache.removeResult(_finderPathCountByResourcePrimKey, args);
-			finderCache.removeResult(
-				_finderPathWithoutPaginationFindByResourcePrimKey, args);
-
 			finderCache.removeResult(_finderPathCountAll, FINDER_ARGS_EMPTY);
 			finderCache.removeResult(
 				_finderPathWithoutPaginationFindAll, FINDER_ARGS_EMPTY);
-		}
-		else {
-			if ((ctEntryModelImpl.getColumnBitmask() &
-				 _finderPathWithoutPaginationFindByResourcePrimKey.
-					 getColumnBitmask()) != 0) {
-
-				Object[] args = new Object[] {
-					ctEntryModelImpl.getOriginalResourcePrimKey()
-				};
-
-				finderCache.removeResult(
-					_finderPathCountByResourcePrimKey, args);
-				finderCache.removeResult(
-					_finderPathWithoutPaginationFindByResourcePrimKey, args);
-
-				args = new Object[] {ctEntryModelImpl.getResourcePrimKey()};
-
-				finderCache.removeResult(
-					_finderPathCountByResourcePrimKey, args);
-				finderCache.removeResult(
-					_finderPathWithoutPaginationFindByResourcePrimKey, args);
-			}
 		}
 
 		entityCache.putResult(
@@ -2133,35 +1596,13 @@ public class CTEntryPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countAll",
 			new String[0]);
 
-		_finderPathWithPaginationFindByResourcePrimKey = new FinderPath(
-			CTEntryModelImpl.ENTITY_CACHE_ENABLED,
-			CTEntryModelImpl.FINDER_CACHE_ENABLED, CTEntryImpl.class,
-			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByResourcePrimKey",
-			new String[] {
-				Long.class.getName(), Integer.class.getName(),
-				Integer.class.getName(), OrderByComparator.class.getName()
-			});
-
-		_finderPathWithoutPaginationFindByResourcePrimKey = new FinderPath(
-			CTEntryModelImpl.ENTITY_CACHE_ENABLED,
-			CTEntryModelImpl.FINDER_CACHE_ENABLED, CTEntryImpl.class,
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByResourcePrimKey",
-			new String[] {Long.class.getName()},
-			CTEntryModelImpl.RESOURCEPRIMKEY_COLUMN_BITMASK);
-
-		_finderPathCountByResourcePrimKey = new FinderPath(
-			CTEntryModelImpl.ENTITY_CACHE_ENABLED,
-			CTEntryModelImpl.FINDER_CACHE_ENABLED, Long.class,
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByResourcePrimKey",
-			new String[] {Long.class.getName()});
-
 		_finderPathFetchByC_C = new FinderPath(
 			CTEntryModelImpl.ENTITY_CACHE_ENABLED,
 			CTEntryModelImpl.FINDER_CACHE_ENABLED, CTEntryImpl.class,
 			FINDER_CLASS_NAME_ENTITY, "fetchByC_C",
 			new String[] {Long.class.getName(), Long.class.getName()},
-			CTEntryModelImpl.CLASSNAMEID_COLUMN_BITMASK |
-			CTEntryModelImpl.CLASSPK_COLUMN_BITMASK);
+			CTEntryModelImpl.MODELCLASSNAMEID_COLUMN_BITMASK |
+			CTEntryModelImpl.MODELCLASSPK_COLUMN_BITMASK);
 
 		_finderPathCountByC_C = new FinderPath(
 			CTEntryModelImpl.ENTITY_CACHE_ENABLED,

--- a/modules/apps/change-tracking/change-tracking-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/resources/META-INF/module-hbm.xml
@@ -31,9 +31,9 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="userName" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="createDate" type="org.hibernate.type.TimestampType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="modifiedDate" type="org.hibernate.type.TimestampType" />
-		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="classNameId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
-		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="classPK" type="com.liferay.portal.dao.orm.hibernate.LongType" />
-		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="resourcePrimKey" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="modelClassNameId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="modelClassPK" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="modelResourcePrimKey" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="changeType" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="status" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 	</class>

--- a/modules/apps/change-tracking/change-tracking-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -22,9 +22,9 @@
 		<field name="userName" type="String" />
 		<field name="createDate" type="Date" />
 		<field name="modifiedDate" type="Date" />
-		<field name="classNameId" type="long" />
-		<field name="classPK" type="long" />
-		<field name="resourcePrimKey" type="long" />
+		<field name="modelClassNameId" type="long" />
+		<field name="modelClassPK" type="long" />
+		<field name="modelResourcePrimKey" type="long" />
 		<field name="changeType" type="int" />
 		<field name="status" type="int" />
 	</model>

--- a/modules/apps/change-tracking/change-tracking-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/resources/META-INF/sql/indexes.sql
@@ -8,8 +8,7 @@ create index IX_AFC3725E on CTCollections_CTEntries (companyId);
 create index IX_D9FBD9E8 on CTCollections_CTEntries (ctCollectionId);
 create index IX_6EA8BE62 on CTCollections_CTEntries (ctEntryId);
 
-create unique index IX_776391C on CTEntry (classNameId, classPK);
-create index IX_C57DDD34 on CTEntry (resourcePrimKey);
+create unique index IX_88A1512E on CTEntry (modelClassNameId, modelClassPK);
 
 create index IX_49B471E1 on CTEntryAggregate (ownerCTEntryId);
 

--- a/modules/apps/change-tracking/change-tracking-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/resources/META-INF/sql/tables.sql
@@ -34,9 +34,9 @@ create table CTEntry (
 	userName VARCHAR(75) null,
 	createDate DATE null,
 	modifiedDate DATE null,
-	classNameId LONG,
-	classPK LONG,
-	resourcePrimKey LONG,
+	modelClassNameId LONG,
+	modelClassPK LONG,
+	modelResourcePrimKey LONG,
 	changeType INTEGER,
 	status INTEGER
 );

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTEntryPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTEntryPersistenceTest.java
@@ -133,11 +133,11 @@ public class CTEntryPersistenceTest {
 
 		newCTEntry.setModifiedDate(RandomTestUtil.nextDate());
 
-		newCTEntry.setClassNameId(RandomTestUtil.nextLong());
+		newCTEntry.setModelClassNameId(RandomTestUtil.nextLong());
 
-		newCTEntry.setClassPK(RandomTestUtil.nextLong());
+		newCTEntry.setModelClassPK(RandomTestUtil.nextLong());
 
-		newCTEntry.setResourcePrimKey(RandomTestUtil.nextLong());
+		newCTEntry.setModelResourcePrimKey(RandomTestUtil.nextLong());
 
 		newCTEntry.setChangeType(RandomTestUtil.nextInt());
 
@@ -163,23 +163,17 @@ public class CTEntryPersistenceTest {
 			Time.getShortTimestamp(existingCTEntry.getModifiedDate()),
 			Time.getShortTimestamp(newCTEntry.getModifiedDate()));
 		Assert.assertEquals(
-			existingCTEntry.getClassNameId(), newCTEntry.getClassNameId());
+			existingCTEntry.getModelClassNameId(),
+			newCTEntry.getModelClassNameId());
 		Assert.assertEquals(
-			existingCTEntry.getClassPK(), newCTEntry.getClassPK());
+			existingCTEntry.getModelClassPK(), newCTEntry.getModelClassPK());
 		Assert.assertEquals(
-			existingCTEntry.getResourcePrimKey(),
-			newCTEntry.getResourcePrimKey());
+			existingCTEntry.getModelResourcePrimKey(),
+			newCTEntry.getModelResourcePrimKey());
 		Assert.assertEquals(
 			existingCTEntry.getChangeType(), newCTEntry.getChangeType());
 		Assert.assertEquals(
 			existingCTEntry.getStatus(), newCTEntry.getStatus());
-	}
-
-	@Test
-	public void testCountByResourcePrimKey() throws Exception {
-		_persistence.countByResourcePrimKey(RandomTestUtil.nextLong());
-
-		_persistence.countByResourcePrimKey(0L);
 	}
 
 	@Test
@@ -217,8 +211,8 @@ public class CTEntryPersistenceTest {
 		return OrderByComparatorFactoryUtil.create(
 			"CTEntry", "ctEntryId", true, "companyId", true, "userId", true,
 			"userName", true, "createDate", true, "modifiedDate", true,
-			"classNameId", true, "classPK", true, "resourcePrimKey", true,
-			"changeType", true, "status", true);
+			"modelClassNameId", true, "modelClassPK", true,
+			"modelResourcePrimKey", true, "changeType", true, "status", true);
 	}
 
 	@Test
@@ -434,13 +428,14 @@ public class CTEntryPersistenceTest {
 			newCTEntry.getPrimaryKey());
 
 		Assert.assertEquals(
-			Long.valueOf(existingCTEntry.getClassNameId()),
+			Long.valueOf(existingCTEntry.getModelClassNameId()),
 			ReflectionTestUtil.<Long>invoke(
-				existingCTEntry, "getOriginalClassNameId", new Class<?>[0]));
+				existingCTEntry, "getOriginalModelClassNameId",
+				new Class<?>[0]));
 		Assert.assertEquals(
-			Long.valueOf(existingCTEntry.getClassPK()),
+			Long.valueOf(existingCTEntry.getModelClassPK()),
 			ReflectionTestUtil.<Long>invoke(
-				existingCTEntry, "getOriginalClassPK", new Class<?>[0]));
+				existingCTEntry, "getOriginalModelClassPK", new Class<?>[0]));
 	}
 
 	protected CTEntry addCTEntry() throws Exception {
@@ -458,11 +453,11 @@ public class CTEntryPersistenceTest {
 
 		ctEntry.setModifiedDate(RandomTestUtil.nextDate());
 
-		ctEntry.setClassNameId(RandomTestUtil.nextLong());
+		ctEntry.setModelClassNameId(RandomTestUtil.nextLong());
 
-		ctEntry.setClassPK(RandomTestUtil.nextLong());
+		ctEntry.setModelClassPK(RandomTestUtil.nextLong());
 
-		ctEntry.setResourcePrimKey(RandomTestUtil.nextLong());
+		ctEntry.setModelResourcePrimKey(RandomTestUtil.nextLong());
 
 		ctEntry.setChangeType(RandomTestUtil.nextInt());
 

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTManagerTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTManagerTest.java
@@ -541,11 +541,11 @@ public class CTManagerTest {
 
 		Assert.assertEquals(
 			_testVersionClassClassName.getClassNameId(),
-			ctEntry.getClassNameId());
+			ctEntry.getModelClassNameId());
 		Assert.assertEquals(
-			_TEST_VERSION_CLASS_ENTITY_ID, ctEntry.getClassPK());
+			_TEST_VERSION_CLASS_ENTITY_ID, ctEntry.getModelClassPK());
 		Assert.assertEquals(
-			_TEST_RESOURCE_CLASS_ENTITY_ID, ctEntry.getResourcePrimKey());
+			_TEST_RESOURCE_CLASS_ENTITY_ID, ctEntry.getModelResourcePrimKey());
 	}
 
 	@Test

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-change-tracking/src/main/java/com/liferay/dynamic/data/mapping/change/tracking/internal/service/CTDDMStructureLocalServiceWrapper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-change-tracking/src/main/java/com/liferay/dynamic/data/mapping/change/tracking/internal/service/CTDDMStructureLocalServiceWrapper.java
@@ -262,7 +262,7 @@ public class CTDDMStructureLocalServiceWrapper
 
 		Optional<DDMStructureVersion> ddmStructureVersionOptional =
 			ctEntryOptional.map(
-				CTEntry::getClassPK
+				CTEntry::getModelClassPK
 			).map(
 				_ddmStructureVersionLocalService::fetchDDMStructureVersion
 			);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-change-tracking/src/main/java/com/liferay/dynamic/data/mapping/change/tracking/internal/service/CTDDMTemplateLocalServiceWrapper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-change-tracking/src/main/java/com/liferay/dynamic/data/mapping/change/tracking/internal/service/CTDDMTemplateLocalServiceWrapper.java
@@ -181,7 +181,7 @@ public class CTDDMTemplateLocalServiceWrapper
 
 		Optional<DDMTemplateVersion> ddmTemplateVersionOptional =
 			ctEntryOptional.map(
-				CTEntry::getClassPK
+				CTEntry::getModelClassPK
 			).map(
 				_ddmTemplateVersionLocalService::fetchDDMTemplateVersion
 			);

--- a/modules/apps/journal/journal-change-tracking/src/main/java/com/liferay/journal/change/tracking/internal/service/CTJournalArticleLocalServiceWrapper.java
+++ b/modules/apps/journal/journal-change-tracking/src/main/java/com/liferay/journal/change/tracking/internal/service/CTJournalArticleLocalServiceWrapper.java
@@ -1824,10 +1824,10 @@ public class CTJournalArticleLocalServiceWrapper
 
 		List<Long> classPKs = ctEntryStream.filter(
 			ctEntry ->
-				ctEntry.getClassNameId() == _portal.getClassNameId(
+				ctEntry.getModelClassNameId() == _portal.getClassNameId(
 					JournalArticle.class.getName())
 		).map(
-			CTEntry::getClassPK
+			CTEntry::getModelClassPK
 		).collect(
 			Collectors.toList()
 		);


### PR DESCRIPTION
@brianchandotcom we used the standard column names for the entities in the first place because that's the pattern everywhere. however this implies that these entities become ResourcedModels and AttachedModels.

These entities are __not__ valid ResourcedModels, they don't have the same setup as JournalArticle has. JournalArticle is a valid ResourcedModel because it has a JournalArticleResource, but our entities don't have these similarities.

It was only a matter of coincidence that these entities became ResoucedModels. So renaming is actually not introducing a new pattern, merely fixing the problem that these are not behaving properly.

The reason why these generate problems is that for example indexing does not work for our entities because the indexing framework assumes our entities are ResourcedModels however they are not.

cc @danielkocsis 