### PR TITLE
LPS-91071 Log message in UserEmailAddressException.MustNotBeDuplicate is confusing and incomplete

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/exception/UserEmailAddressException.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/exception/UserEmailAddressException.java
@@ -85,8 +85,8 @@ public class UserEmailAddressException extends PortalException {
 
 			super(
 				String.format(
-					"User %s with company %s and email address %s is already " +
-						"in use",
+					"User %s cannot be created because a user with company " +
+						"%s and email address %s is already in use",
 					userId, emailAddress, companyId));
 
 			this.companyId = companyId;


### PR DESCRIPTION
This is an update for [LPS-91071](https://issues.liferay.com/browse/LPS-91071).