### PR TITLE
LPS-92253 Rename *Rest* classes to REST for consistency's sake

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/LiferayAccessTokenService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/LiferayAccessTokenService.java
@@ -14,7 +14,7 @@
 
 package com.liferay.oauth2.provider.rest.internal.endpoint.access.token;
 
-import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRestEndpointConstants;
+import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.portal.remote.cors.annotation.CORS;
 
 import java.net.InetAddress;
@@ -77,10 +77,10 @@ public class LiferayAccessTokenService extends AccessTokenService {
 		}
 
 		properties.put(
-			OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_CLIENT_REMOTE_ADDR,
+			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_CLIENT_REMOTE_ADDR,
 			remoteAddr);
 		properties.put(
-			OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_CLIENT_REMOTE_HOST,
+			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_CLIENT_REMOTE_HOST,
 			remoteHost);
 
 		return client;

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/BaseAccessTokenGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/BaseAccessTokenGrantHandler.java
@@ -16,7 +16,7 @@ package com.liferay.oauth2.provider.rest.internal.endpoint.access.token.grant.ha
 
 import com.liferay.oauth2.provider.constants.OAuth2ProviderActionKeys;
 import com.liferay.oauth2.provider.model.OAuth2Application;
-import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRestEndpointConstants;
+import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -81,10 +81,10 @@ public abstract class BaseAccessTokenGrantHandler
 
 		String companyId1 = MapUtil.getString(
 			client1.getProperties(),
-			OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID);
+			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_COMPANY_ID);
 		String companyId2 = MapUtil.getString(
 			client2.getProperties(),
-			OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID);
+			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_COMPANY_ID);
 
 		if (Objects.equals(companyId1, companyId2)) {
 			return true;

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayAuthorizationAccessTokenCodeGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayAuthorizationAccessTokenCodeGrantHandler.java
@@ -16,7 +16,7 @@ package com.liferay.oauth2.provider.rest.internal.endpoint.access.token.grant.ha
 
 import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
 import com.liferay.oauth2.provider.model.OAuth2Application;
-import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRestEndpointConstants;
+import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.oauth2.provider.rest.internal.endpoint.liferay.LiferayOAuthDataProvider;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -152,7 +152,7 @@ public class LiferayAuthorizationAccessTokenCodeGrantHandler
 			List<String> allowedGrantTypes = client.getAllowedGrantTypes();
 
 			if (!allowedGrantTypes.contains(
-					OAuth2ProviderRestEndpointConstants.
+					OAuth2ProviderRESTEndpointConstants.
 						AUTHORIZATION_CODE_PKCE_GRANT)) {
 
 				if (_log.isDebugEnabled()) {

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/constants/OAuth2ProviderRESTEndpointConstants.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/constants/OAuth2ProviderRESTEndpointConstants.java
@@ -17,7 +17,7 @@ package com.liferay.oauth2.provider.rest.internal.endpoint.constants;
 /**
  * @author Tomas Polesovsky
  */
-public class OAuth2ProviderRestEndpointConstants {
+public class OAuth2ProviderRESTEndpointConstants {
 
 	/**
 	 * Embraces CXF OAuthConstants naming + RFC grant_type value formats.

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/introspect/LiferayTokenIntrospectionService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/introspect/LiferayTokenIntrospectionService.java
@@ -15,7 +15,7 @@
 package com.liferay.oauth2.provider.rest.internal.endpoint.introspect;
 
 import com.liferay.oauth2.provider.model.OAuth2Application;
-import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRestEndpointConstants;
+import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.oauth2.provider.rest.internal.endpoint.liferay.LiferayOAuthDataProvider;
 import com.liferay.oauth2.provider.rest.spi.bearer.token.provider.BearerTokenProvider;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -120,10 +120,10 @@ public class LiferayTokenIntrospectionService extends AbstractTokenService {
 
 		String companyId1 = MapUtil.getString(
 			client1.getProperties(),
-			OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID);
+			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_COMPANY_ID);
 		String companyId2 = MapUtil.getString(
 			client2.getProperties(),
-			OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID);
+			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_COMPANY_ID);
 
 		if (Objects.equals(companyId1, companyId2)) {
 			return true;
@@ -270,9 +270,9 @@ public class LiferayTokenIntrospectionService extends AbstractTokenService {
 		Map<String, String> properties = client.getProperties();
 
 		if (!properties.containsKey(
-				OAuth2ProviderRestEndpointConstants.
+				OAuth2ProviderRESTEndpointConstants.
 					PROPERTY_KEY_CLIENT_FEATURE_PREFIX +
-						OAuth2ProviderRestEndpointConstants.
+						OAuth2ProviderRESTEndpointConstants.
 							PROPERTY_KEY_CLIENT_FEATURE_TOKEN_INTROSPECTION)) {
 
 			return false;

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -21,7 +21,7 @@ import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.rest.internal.endpoint.authorize.configuration.OAuth2AuthorizationFlowConfiguration;
-import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRestEndpointConstants;
+import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.oauth2.provider.rest.spi.bearer.token.provider.BearerTokenProvider;
 import com.liferay.oauth2.provider.rest.spi.bearer.token.provider.BearerTokenProviderAccessor;
 import com.liferay.oauth2.provider.scope.liferay.LiferayOAuth2Scope;
@@ -415,7 +415,7 @@ public class LiferayOAuthDataProvider
 				refreshToken.getExtraProperties();
 
 			extraProperties.put(
-				OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID,
+				OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_COMPANY_ID,
 				String.valueOf(oAuth2Authorization.getCompanyId()));
 
 			return refreshToken;
@@ -560,7 +560,7 @@ public class LiferayOAuthDataProvider
 
 		long companyId = GetterUtil.getLong(
 			properties.get(
-				OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID));
+				OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_COMPANY_ID));
 
 		OAuth2Application oAuth2Application =
 			_oAuth2ApplicationLocalService.fetchOAuth2Application(
@@ -810,7 +810,7 @@ public class LiferayOAuthDataProvider
 			serverAccessToken.getExtraProperties();
 
 		extraProperties.put(
-			OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID,
+			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_COMPANY_ID,
 			String.valueOf(oAuth2Authorization.getCompanyId()));
 
 		return serverAccessToken;
@@ -844,7 +844,7 @@ public class LiferayOAuthDataProvider
 
 				clientGrantTypes.add(OAuthConstants.AUTHORIZATION_CODE_GRANT);
 				clientGrantTypes.add(
-					OAuth2ProviderRestEndpointConstants.
+					OAuth2ProviderRESTEndpointConstants.
 						AUTHORIZATION_CODE_PKCE_GRANT);
 			}
 			else if (_oAuth2ProviderConfiguration.
@@ -908,15 +908,15 @@ public class LiferayOAuthDataProvider
 		Map<String, String> properties = client.getProperties();
 
 		properties.put(
-			OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID,
+			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_COMPANY_ID,
 			String.valueOf(oAuth2Application.getCompanyId()));
 		properties.put(
-			OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_CLIENT_FEATURES,
+			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_CLIENT_FEATURES,
 			oAuth2Application.getFeatures());
 
 		for (String feature : oAuth2Application.getFeaturesList()) {
 			properties.put(
-				OAuth2ProviderRestEndpointConstants.
+				OAuth2ProviderRESTEndpointConstants.
 					PROPERTY_KEY_CLIENT_FEATURE_PREFIX + feature,
 				feature);
 		}
@@ -933,7 +933,7 @@ public class LiferayOAuthDataProvider
 		Map<String, String> properties = userSubject.getProperties();
 
 		properties.put(
-			OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID,
+			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_COMPANY_ID,
 			String.valueOf(companyId));
 
 		return userSubject;
@@ -1060,10 +1060,10 @@ public class LiferayOAuthDataProvider
 		Map<String, String> properties = client.getProperties();
 
 		String remoteAddr = properties.get(
-			OAuth2ProviderRestEndpointConstants.
+			OAuth2ProviderRESTEndpointConstants.
 				PROPERTY_KEY_CLIENT_REMOTE_ADDR);
 		String remoteHost = properties.get(
-			OAuth2ProviderRestEndpointConstants.
+			OAuth2ProviderRESTEndpointConstants.
 				PROPERTY_KEY_CLIENT_REMOTE_HOST);
 
 		OAuth2Authorization oAuth2Authorization =

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayResourceOwnerLoginHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayResourceOwnerLoginHandler.java
@@ -14,7 +14,7 @@
 
 package com.liferay.oauth2.provider.rest.internal.endpoint.liferay;
 
-import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRestEndpointConstants;
+import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -63,7 +63,7 @@ public class LiferayResourceOwnerLoginHandler
 			Map<String, String> properties = userSubject.getProperties();
 
 			properties.put(
-				OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID,
+				OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_COMPANY_ID,
 				String.valueOf(user.getCompanyId()));
 
 			return userSubject;

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferaySubjectCreator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferaySubjectCreator.java
@@ -14,7 +14,7 @@
 
 package com.liferay.oauth2.provider.rest.internal.endpoint.liferay;
 
-import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRestEndpointConstants;
+import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -61,7 +61,7 @@ public class LiferaySubjectCreator implements SubjectCreator {
 			Map<String, String> properties = userSubject.getProperties();
 
 			properties.put(
-				OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID,
+				OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_COMPANY_ID,
 				String.valueOf(user.getCompanyId()));
 
 			return userSubject;

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/security/auth/verifier/OAuth2RESTAuthVerifier.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/security/auth/verifier/OAuth2RESTAuthVerifier.java
@@ -57,10 +57,10 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
  */
 @Component(
 	immediate = true,
-	property = "auth.verifier.OAuth2RestAuthVerifier.urls.includes=#N/A#",
+	property = "auth.verifier.OAuth2RESTAuthVerifier.urls.includes=#N/A#",
 	service = AuthVerifier.class
 )
-public class OAuth2RestAuthVerifier implements AuthVerifier {
+public class OAuth2RESTAuthVerifier implements AuthVerifier {
 
 	@Override
 	public String getAuthType() {
@@ -204,7 +204,7 @@ public class OAuth2RestAuthVerifier implements AuthVerifier {
 	private static final String _TOKEN_KEY = "Bearer";
 
 	private static final Log _log = LogFactoryUtil.getLog(
-		OAuth2RestAuthVerifier.class);
+		OAuth2RESTAuthVerifier.class);
 
 	@Reference(
 		policy = ReferencePolicy.DYNAMIC,

--- a/modules/apps/portal-remote/portal-remote-rest-extender-test/bnd.bnd
+++ b/modules/apps/portal-remote/portal-remote-rest-extender-test/bnd.bnd
@@ -1,4 +1,4 @@
-Bundle-Activator: com.liferay.portal.remote.rest.extender.test.internal.activator.configuration.RemoteRestExtenderTestBundleActivator
+Bundle-Activator: com.liferay.portal.remote.rest.extender.test.internal.activator.configuration.RemoteRESTExtenderTestBundleActivator
 Bundle-Name: Liferay Portal Remote REST Extender Test
 Bundle-SymbolicName: com.liferay.portal.remote.rest.extender.test
 Bundle-Version: 4.0.0

--- a/modules/apps/portal-remote/portal-remote-rest-extender-test/src/main/java/com/liferay/portal/remote/rest/extender/test/internal/activator/configuration/RemoteRESTExtenderTestBundleActivator.java
+++ b/modules/apps/portal-remote/portal-remote-rest-extender-test/src/main/java/com/liferay/portal/remote/rest/extender/test/internal/activator/configuration/RemoteRESTExtenderTestBundleActivator.java
@@ -44,7 +44,7 @@ import org.osgi.util.tracker.ServiceTracker;
 /**
  * @author Carlos Sierra Andrés
  */
-public class RemoteRestExtenderTestBundleActivator implements BundleActivator {
+public class RemoteRESTExtenderTestBundleActivator implements BundleActivator {
 
 	@Override
 	public void start(BundleContext bundleContext) throws Exception {

--- a/modules/apps/portal-remote/portal-remote-rest-extender/src/main/java/com/liferay/portal/remote/rest/extender/internal/RESTExtender.java
+++ b/modules/apps/portal-remote/portal-remote-rest-extender/src/main/java/com/liferay/portal/remote/rest/extender/internal/RESTExtender.java
@@ -43,7 +43,7 @@ import org.osgi.service.jaxrs.runtime.JaxrsServiceRuntime;
 	configurationPid = "com.liferay.portal.remote.rest.extender.configuration.RestExtenderConfiguration",
 	configurationPolicy = ConfigurationPolicy.REQUIRE, service = {}
 )
-public class RestExtender {
+public class RESTExtender {
 
 	public RestExtenderConfiguration getRestExtenderConfiguration() {
 		return _restExtenderConfiguration;

--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/tracker/AuthVerifierFilterTracker.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/tracker/AuthVerifierFilterTracker.java
@@ -59,7 +59,7 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 	immediate = true,
 	property = {
 		"default.registration.property=filter.init.auth.verifier.BasicAuthHeaderAuthVerifier.urls.includes=/*",
-		"default.registration.property=filter.init.auth.verifier.OAuth2RestAuthVerifier.urls.includes=*",
+		"default.registration.property=filter.init.auth.verifier.OAuth2RESTAuthVerifier.urls.includes=*",
 		"default.registration.property=filter.init.auth.verifier.PortalSessionAuthVerifier.urls.includes=/*",
 		"default.registration.property=filter.init.guest.allowed=true",
 		"default.remote.access.filter.service.ranking:Integer=-10",

--- a/modules/sdk/project-templates/project-templates-rest/src/main/java/com/liferay/project/templates/rest/internal/RESTProjectTemplateCustomizer.java
+++ b/modules/sdk/project-templates/project-templates-rest/src/main/java/com/liferay/project/templates/rest/internal/RESTProjectTemplateCustomizer.java
@@ -27,7 +27,7 @@ import org.apache.maven.archetype.ArchetypeGenerationResult;
 /**
  * @author Gregory Amerson
  */
-public class RestProjectTemplateCustomizer
+public class RESTProjectTemplateCustomizer
 	implements ProjectTemplateCustomizer {
 
 	@Override

--- a/modules/sdk/project-templates/project-templates-rest/src/main/resources/META-INF/services/com.liferay.project.templates.ProjectTemplateCustomizer
+++ b/modules/sdk/project-templates/project-templates-rest/src/main/resources/META-INF/services/com.liferay.project.templates.ProjectTemplateCustomizer
@@ -1,1 +1,1 @@
-com.liferay.project.templates.rest.internal.RestProjectTemplateCustomizer
+com.liferay.project.templates.rest.internal.RESTProjectTemplateCustomizer


### PR DESCRIPTION
Hi Brian,

renaming the rest of classes except  `modules/apps/portal-remote/portal-remote-rest-extender/src/main/java/com/liferay/portal/remote/rest/extender/configuration/RestExtenderConfiguration.java`

Ref: https://github.com/brianchandotcom/liferay-portal/pull/69521#issuecomment-473442548

https://issues.liferay.com/browse/LPS-92253

Thanks.