### PR TITLE
LPS-92338 TestExecutorUtil is swallowing exception cause in case it d…

### DIFF
--- a/modules/test/arquillian-extension-junit-bridge/src/main/java/com/liferay/arquillian/extension/junit/bridge/server/TestExecutorUtil.java
+++ b/modules/test/arquillian-extension-junit-bridge/src/main/java/com/liferay/arquillian/extension/junit/bridge/server/TestExecutorUtil.java
@@ -183,7 +183,7 @@ public class TestExecutorUtil {
 				"Unexpected exception, expected<" + expected.getName() +
 					"> but was<" + clazz.getName() + ">";
 
-			throw new Exception(message);
+			throw new Exception(message, throwable);
 		}
 	}
 


### PR DESCRIPTION
…oes not match the expected exception type.