### PR TITLE
LRCI-36 Change stopWatch back to stopwatch in stopWatchPattern

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -2918,7 +2918,7 @@ public abstract class BaseBuild implements Build {
 		"(?<baseJob>[^\\(]+)\\((?<branchName>[^\\)]+)\\)");
 	protected static final Pattern stopWatchPattern = Pattern.compile(
 		JenkinsResultsParserUtil.combine(
-			"\\s*\\[stopWatch\\]\\s*\\[(?<name>[^:]+): ",
+			"\\s*\\[stopwatch\\]\\s*\\[(?<name>[^:]+): ",
 			"((?<minutes>\\d+):)?((?<seconds>\\d+))?\\.",
 			"(?<milliseconds>\\d+) sec\\]"));
 	protected static final Pattern stopWatchStartTimestampPattern =


### PR DESCRIPTION
@brianchandotcom I can't control the stopwatch text that appears in the console log because I am using the ant-commons task, stopwatch and it doesn't allow you to override the prefix text that is printed when it prints the total time.