### PR TITLE
Revert "LPS-92149 Check if field belongs to the tabs"

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
@@ -240,9 +240,8 @@ AUI.add(
 						var formNode = instance.formNode;
 
 						var field = formNode.one('.' + instance.formValidator.get('errorClass'));
-						var fieldWrapper = field.ancestor('form > div');
 
-						if (field && fieldWrapper) {
+						if (field && field.ancestor('.lfr-nav')) {
 							var formTabs = formNode.one('.lfr-nav');
 
 							if (formTabs) {
@@ -255,6 +254,8 @@ AUI.add(
 										return tab.getAttribute('data-tab-name');
 									}
 								)
+
+								var fieldWrapper = field.ancestor('form > div');
 
 								var fieldWrapperId = fieldWrapper.getAttribute('id').slice(0, -TABS_SECTION_STR.length);
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
@@ -241,7 +241,7 @@ AUI.add(
 
 						var field = formNode.one('.' + instance.formValidator.get('errorClass'));
 
-						if (field && field.ancestor('.lfr-nav')) {
+						if (field) {
 							var formTabs = formNode.one('.lfr-nav');
 
 							if (formTabs) {


### PR DESCRIPTION
@brianchandotcom 
We're reverting this because it causes [LPS-92360](https://issues.liferay.com/browse/LPS-92360) where we cannot add web content articles. We believe it had also caused issues adding documents and bookmarks.

Original pull: https://github.com/brianchandotcom/liferay-portal/pull/69737

cc @pavel-savinov @jbalsas