### PR TITLE
LPS-92341 Exceptions library specific must not cross boundaries of engine neutral Search modules

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/ElasticsearchEngineAdapterFixture.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/ElasticsearchEngineAdapterFixture.java
@@ -109,6 +109,8 @@ public class ElasticsearchEngineAdapterFixture {
 				setSnapshotRequestExecutor(
 					snapshotRequestExecutorFixture.
 						getSnapshotRequestExecutor());
+
+				setThrowOriginalExceptions(true);
 			}
 		};
 	}

--- a/modules/apps/portal-search/portal-search-test/build.gradle
+++ b/modules/apps/portal-search/portal-search-test/build.gradle
@@ -1,14 +1,12 @@
 dependencies {
 	testCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testCompile project(":apps:calendar:calendar-api")
-	testCompile project(":apps:calendar:calendar-service")
 	testCompile project(":apps:portal-search:portal-search-test-util")
 	testCompile project(":core:petra:petra-lang")
 
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	testIntegrationCompile project(":apps:blogs:blogs-api")
-	testIntegrationCompile project(":apps:blogs:blogs-service")
 	testIntegrationCompile project(":apps:document-library:document-library-test-util")
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
 	testIntegrationCompile project(":apps:journal:journal-api")

--- a/modules/apps/portal-search/portal-search-test/build.gradle
+++ b/modules/apps/portal-search/portal-search-test/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	testIntegrationCompile project(":apps:journal:journal-test-util")
 	testIntegrationCompile project(":apps:message-boards:message-boards-api")
 	testIntegrationCompile project(":apps:portal-search:portal-search-api")
+	testIntegrationCompile project(":apps:portal-search:portal-search-engine-adapter-api")
 	testIntegrationCompile project(":apps:static:osgi:osgi-util")
 	testIntegrationCompile project(":apps:users-admin:users-admin-test-util")
 	testIntegrationCompile project(":core:petra:petra-string")

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/engine/adapter/test/SearchEngineAdapterTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/engine/adapter/test/SearchEngineAdapterTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.engine.adapter.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.engine.adapter.document.UpdateDocumentRequest;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author André de Oliveira
+ */
+@RunWith(Arquillian.class)
+public class SearchEngineAdapterTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testExceptionBoundaries() {
+		String index = RandomTestUtil.randomString();
+
+		UpdateDocumentRequest updateDocumentRequest = new UpdateDocumentRequest(
+			index, RandomTestUtil.randomString(), new DocumentImpl());
+
+		updateDocumentRequest.setType(RandomTestUtil.randomString());
+
+		try {
+			_searchEngineAdapter.execute(updateDocumentRequest);
+
+			Assert.fail("exception expected");
+		}
+		catch (RuntimeException re) {
+			assertClientSideSafeToLoad(re);
+
+			String message = re.getMessage();
+
+			Assert.assertTrue(
+				message,
+				message.startsWith(
+					"org.elasticsearch.index.IndexNotFoundException: [" +
+						index + "] IndexNotFoundException[no such index"));
+		}
+	}
+
+	protected void assertClientSideSafeToLoad(Throwable t) {
+		if (t == null) {
+			return;
+		}
+
+		Class<?> clazz = t.getClass();
+
+		String name = clazz.getName();
+
+		if (name.startsWith("org.elasticsearch")) {
+			throw _getTestFrameworkSafeToLoadException(
+				name, t.getMessage(), t.getStackTrace());
+		}
+
+		assertClientSideSafeToLoad(t.getCause());
+	}
+
+	private RuntimeException _getTestFrameworkSafeToLoadException(
+		String name, String message, StackTraceElement[] stackTrace) {
+
+		RuntimeException re = new RuntimeException(name + ": " + message);
+
+		re.setStackTrace(stackTrace);
+
+		return re;
+	}
+
+	@Inject
+	private static SearchEngineAdapter _searchEngineAdapter;
+
+}


### PR DESCRIPTION
@brianchandotcom This is a critical fix to solve pull requests upstream often getting stuck and timing out after 3 hours. cc/ @xbrianlee @joshchong

@rafaprax @inacionery After this fix you'll see a large number of tests breaking with a legitimate problem that was masked by the aforementioned issue. In tests that create a company on the fly and then delete it, apparently the index or related documents are gone before `KaleoTaskModelListener` has a chance to delete them. Possibly the search engine exception can be safely caught and discarded in this case.

```
     [exec]     java.lang.AssertionError: {level=ERROR, loggerName=com.liferay.portal.workflow.metrics.internal.model.listener.KaleoTaskModelListener, message=java.lang.RuntimeException: org.elasticsearch.index.engine.DocumentMissingException: [workflow-metrics-tasks/RoboPANNRL22NoQ4W3B-Ww][[workflow-metrics-tasks][0]] DocumentMissingException[[WorkflowMetricsTaskType][WorkflowMetricsTask_PORTLET_c73fec27d813a665bdcbbbb847c65a3dc9407e090328f7a4e3a6913e0142d891]: document missing]
     [exec]         at com.liferay.portal.workflow.metrics.internal.model.listener.KaleoTaskModelListener.onAfterRemove(KaleoTaskModelListener.java:54)
     [exec]         at com.liferay.portal.workflow.kaleo.service.persistence.impl.KaleoTaskPersistenceImpl.removeByCompanyId(KaleoTaskPersistenceImpl.java:532)
     [exec]         at com.liferay.portal.workflow.kaleo.service.impl.KaleoTaskLocalServiceImpl.deleteCompanyKaleoTasks(KaleoTaskLocalServiceImpl.java:89)
     [exec]         at com.liferay.portal.workflow.kaleo.runtime.internal.manager.DefaultPortalKaleoManager.deleteKaleoData(DefaultPortalKaleoManager.java:61)
     [exec]         at com.liferay.portal.workflow.kaleo.internal.model.listener.CompanyModelListener.onAfterRemove(CompanyModelListener.java:37)
     [exec]         at com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl.remove(BasePersistenceImpl.java:473)
     [exec]         at com.liferay.portal.service.impl.CompanyLocalServiceImpl.doDeleteCompany(CompanyLocalServiceImpl.java:1338)
```


**❌ ci:test:search - 14 out of 17 jobs passed in 1 hour 19 minutes 24 seconds 985 ms**
https://github.com/arboliveira/liferay-portal/pull/691#issuecomment-474733570

Branch `master` is contaminated.

----

```
     [exec] Execution failed for task ':private:apps:portal-workflow:portal-workflow-metrics-web:npmRunTest'.
     [exec] > java.io.IOException: Process '[/opt/dev/projects/github/liferay-portal/build/node/bin/node, /opt/dev/projects/github/liferay-portal/build/node/lib/node_modules/npm/bin/npm-cli.js, --loglevel, warn, --production, false, --progress, true, --registry, http://mirrors.lax.liferay.com:4873, run-script, test]' finished with non-zero exit value 1
```

Reported fixed by https://github.com/brianchandotcom/liferay-portal-ee/pull/23579

----

```
junit.framework.AssertionFailedError: 
Unable to register portal instance {mvccVersion=1, companyId=20100, accountId=20102, webId=liferay.com, key=JixuHt+TvWD3pkH4Al74qQ==, mx=liferay.com, homeURL=, logoId=0, system=false, maxUsers=0, active=true}
com.liferay.portal.kernel.exception.NoSuchResourceActionException: There are no actions associated with the resource com.liferay.dynamic.data.mapping.model.DDMStructure-com.liferay.portal.workflow.kaleo.forms.model.KaleoProcess
```

Startup logs seem to suggest this is unrelated to Search.  @rafaprax @inacionery

---

_[Bug] LPS-92341 Exceptions library specific must not cross boundaries of engine neutral Search modules_
https://issues.liferay.com/browse/LPS-92341
