### PR TITLE
LPS-90109 FIX: Elasticsearch client dropping documents without reporting server errors

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexSearcher.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexSearcher.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.search.IndexSearcher;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.suggest.QuerySuggester;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -80,9 +79,7 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 	}
 
 	@Override
-	public Hits search(SearchContext searchContext, Query query)
-		throws SearchException {
-
+	public Hits search(SearchContext searchContext, Query query) {
 		StopWatch stopWatch = new StopWatch();
 
 		stopWatch.start();
@@ -151,15 +148,13 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 
 			return hits;
 		}
-		catch (Exception e) {
-			if (!handle(e)) {
+		catch (RuntimeException re) {
+			if (!handle(re)) {
 				if (_logExceptionsOnly) {
-					if (_log.isWarnEnabled()) {
-						_log.warn(e, e);
-					}
+					_log.error(re, re);
 				}
 				else {
-					throw new SearchException(e.getMessage(), e);
+					throw re;
 				}
 			}
 
@@ -178,9 +173,7 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 	}
 
 	@Override
-	public long searchCount(SearchContext searchContext, Query query)
-		throws SearchException {
-
+	public long searchCount(SearchContext searchContext, Query query) {
 		StopWatch stopWatch = new StopWatch();
 
 		stopWatch.start();
@@ -205,15 +198,13 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 
 			return countSearchResponse.getCount();
 		}
-		catch (Exception e) {
-			if (!handle(e)) {
+		catch (RuntimeException re) {
+			if (!handle(re)) {
 				if (_logExceptionsOnly) {
-					if (_log.isWarnEnabled()) {
-						_log.warn(e, e);
-					}
+					_log.error(re, re);
 				}
 				else {
-					throw new SearchException(e.getMessage(), e);
+					throw re;
 				}
 			}
 

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexWriter.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexWriter.java
@@ -14,7 +14,10 @@
 
 package com.liferay.portal.search.elasticsearch6.internal;
 
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.BaseIndexWriter;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
@@ -29,10 +32,12 @@ import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.search.generic.MatchAllQuery;
 import com.liferay.portal.kernel.search.suggest.SpellCheckIndexWriter;
 import com.liferay.portal.kernel.util.PortalRunMode;
+import com.liferay.portal.search.elasticsearch6.configuration.ElasticsearchConfiguration;
 import com.liferay.portal.search.elasticsearch6.internal.index.IndexNameBuilder;
 import com.liferay.portal.search.elasticsearch6.internal.util.DocumentTypes;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.engine.adapter.document.BulkDocumentRequest;
+import com.liferay.portal.search.engine.adapter.document.BulkDocumentResponse;
 import com.liferay.portal.search.engine.adapter.document.DeleteByQueryDocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.DeleteDocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.IndexDocumentRequest;
@@ -40,8 +45,11 @@ import com.liferay.portal.search.engine.adapter.document.UpdateDocumentRequest;
 import com.liferay.portal.search.engine.adapter.index.RefreshIndexRequest;
 
 import java.util.Collection;
+import java.util.Map;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -49,6 +57,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Milen Dyankov
  */
 @Component(
+	configurationPid = "com.liferay.portal.search.elasticsearch6.configuration.ElasticsearchConfiguration",
 	immediate = true, property = "search.engine.impl=Elasticsearch",
 	service = IndexWriter.class
 )
@@ -68,7 +77,17 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 			indexDocumentRequest.setRefresh(true);
 		}
 
-		_searchEngineAdapter.execute(indexDocumentRequest);
+		try {
+			_searchEngineAdapter.execute(indexDocumentRequest);
+		}
+		catch (RuntimeException re) {
+			if (_logExceptionsOnly) {
+				_log.error(re, re);
+			}
+			else {
+				throw re;
+			}
+		}
 	}
 
 	@Override
@@ -95,7 +114,17 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 					indexDocumentRequest);
 			});
 
-		_searchEngineAdapter.execute(bulkDocumentRequest);
+		BulkDocumentResponse bulkDocumentResponse =
+			_searchEngineAdapter.execute(bulkDocumentRequest);
+
+		if (bulkDocumentResponse.hasErrors()) {
+			if (_logExceptionsOnly) {
+				_log.error("Bulk add failed");
+			}
+			else {
+				throw new SystemException("Bulk add failed");
+			}
+		}
 	}
 
 	@Override
@@ -106,7 +135,17 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 		RefreshIndexRequest refreshIndexRequest = new RefreshIndexRequest(
 			indexName);
 
-		_searchEngineAdapter.execute(refreshIndexRequest);
+		try {
+			_searchEngineAdapter.execute(refreshIndexRequest);
+		}
+		catch (RuntimeException re) {
+			if (_logExceptionsOnly) {
+				_log.error(re, re);
+			}
+			else {
+				throw re;
+			}
+		}
 	}
 
 	@Override
@@ -123,7 +162,17 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 
 		deleteDocumentRequest.setType(DocumentTypes.LIFERAY);
 
-		_searchEngineAdapter.execute(deleteDocumentRequest);
+		try {
+			_searchEngineAdapter.execute(deleteDocumentRequest);
+		}
+		catch (RuntimeException re) {
+			if (_logExceptionsOnly) {
+				_log.error(re, re);
+			}
+			else {
+				throw re;
+			}
+		}
 	}
 
 	@Override
@@ -150,7 +199,17 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 					deleteDocumentRequest);
 			});
 
-		_searchEngineAdapter.execute(bulkDocumentRequest);
+		BulkDocumentResponse bulkDocumentResponse =
+			_searchEngineAdapter.execute(bulkDocumentRequest);
+
+		if (bulkDocumentResponse.hasErrors()) {
+			if (_logExceptionsOnly) {
+				_log.error("Bulk delete failed");
+			}
+			else {
+				throw new SystemException("Bulk delete failed");
+			}
+		}
 	}
 
 	@Override
@@ -187,6 +246,14 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 		catch (ParseException pe) {
 			throw new SystemException(pe);
 		}
+		catch (RuntimeException re) {
+			if (_logExceptionsOnly) {
+				_log.error(re, re);
+			}
+			else {
+				throw re;
+			}
+		}
 	}
 
 	@Override
@@ -205,7 +272,17 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 			updateDocumentRequest.setRefresh(true);
 		}
 
-		_searchEngineAdapter.execute(updateDocumentRequest);
+		try {
+			_searchEngineAdapter.execute(updateDocumentRequest);
+		}
+		catch (RuntimeException re) {
+			if (_logExceptionsOnly) {
+				_log.error(re, re);
+			}
+			else {
+				throw re;
+			}
+		}
 	}
 
 	@Override
@@ -233,7 +310,17 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 					updateDocumentRequest);
 			});
 
-		_searchEngineAdapter.execute(bulkDocumentRequest);
+		BulkDocumentResponse bulkDocumentResponse =
+			_searchEngineAdapter.execute(bulkDocumentRequest);
+
+		if (bulkDocumentResponse.hasErrors()) {
+			if (_logExceptionsOnly) {
+				_log.error("Bulk partial update failed");
+			}
+			else {
+				throw new SystemException("Bulk partial update failed");
+			}
+		}
 	}
 
 	@Override
@@ -269,7 +356,17 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 
 		bulkDocumentRequest.addBulkableDocumentRequest(indexDocumentRequest);
 
-		_searchEngineAdapter.execute(bulkDocumentRequest);
+		BulkDocumentResponse bulkDocumentResponse =
+			_searchEngineAdapter.execute(bulkDocumentRequest);
+
+		if (bulkDocumentResponse.hasErrors()) {
+			if (_logExceptionsOnly) {
+				_log.error("Update failed");
+			}
+			else {
+				throw new SystemException("Update failed");
+			}
+		}
 	}
 
 	@Override
@@ -304,7 +401,26 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 					indexDocumentRequest);
 			});
 
-		_searchEngineAdapter.execute(bulkDocumentRequest);
+		BulkDocumentResponse bulkDocumentResponse =
+			_searchEngineAdapter.execute(bulkDocumentRequest);
+
+		if (bulkDocumentResponse.hasErrors()) {
+			if (_logExceptionsOnly) {
+				_log.error("Bulk update failed");
+			}
+			else {
+				throw new SystemException("Bulk update failed");
+			}
+		}
+	}
+
+	@Activate
+	@Modified
+	protected void activate(Map<String, Object> properties) {
+		_elasticsearchConfiguration = ConfigurableUtil.createConfigurable(
+			ElasticsearchConfiguration.class, properties);
+
+		_logExceptionsOnly = _elasticsearchConfiguration.logExceptionsOnly();
 	}
 
 	@Reference(unbind = "-")
@@ -319,7 +435,12 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 		_searchEngineAdapter = searchEngineAdapter;
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		ElasticsearchIndexWriter.class);
+
+	private volatile ElasticsearchConfiguration _elasticsearchConfiguration;
 	private IndexNameBuilder _indexNameBuilder;
+	private boolean _logExceptionsOnly;
 	private SearchEngineAdapter _searchEngineAdapter;
 
 }

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/BulkDocumentRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/BulkDocumentRequestExecutorImpl.java
@@ -14,7 +14,10 @@
 
 package com.liferay.portal.search.elasticsearch6.internal.search.engine.adapter.document;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchClientResolver;
+import com.liferay.portal.search.elasticsearch6.internal.util.LogUtil;
 import com.liferay.portal.search.engine.adapter.document.BulkDocumentItemResponse;
 import com.liferay.portal.search.engine.adapter.document.BulkDocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.BulkDocumentResponse;
@@ -54,6 +57,8 @@ public class BulkDocumentRequestExecutorImpl
 			bulkDocumentRequest);
 
 		BulkResponse bulkResponse = bulkRequestBuilder.get();
+
+		LogUtil.logActionResponse(_log, bulkResponse);
 
 		TimeValue timeValue = bulkResponse.getTook();
 
@@ -150,6 +155,9 @@ public class BulkDocumentRequestExecutorImpl
 
 		_elasticsearchClientResolver = elasticsearchClientResolver;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BulkDocumentRequestExecutorImpl.class);
 
 	private BulkableDocumentRequestTranslator
 		<DeleteRequestBuilder, IndexRequestBuilder, UpdateRequestBuilder,

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/util/LogUtil.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/util/LogUtil.java
@@ -49,8 +49,8 @@ public class LogUtil {
 	}
 
 	public static void logActionResponse(Log log, BulkResponse bulkResponse) {
-		if (bulkResponse.hasFailures()) {
-			log.error(bulkResponse.buildFailureMessage());
+		if (bulkResponse.hasFailures() && log.isWarnEnabled()) {
+			log.warn(bulkResponse.buildFailureMessage());
 		}
 
 		logActionResponse(log, (ActionResponse)bulkResponse);

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexingFixture.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexingFixture.java
@@ -95,7 +95,8 @@ public class ElasticsearchIndexingFixture implements IndexingFixture {
 				localization);
 
 		IndexWriter indexWriter = createIndexWriter(
-			searchEngineAdapter, indexNameBuilder, localization);
+			_elasticsearchFixture, searchEngineAdapter, indexNameBuilder,
+			localization);
 
 		_indexSearcher = elasticsearchIndexSearcher;
 		_indexWriter = indexWriter;
@@ -194,17 +195,21 @@ public class ElasticsearchIndexingFixture implements IndexingFixture {
 	}
 
 	protected static IndexWriter createIndexWriter(
-		final SearchEngineAdapter searchEngineAdapter,
-		final IndexNameBuilder indexNameBuilder, Localization localization) {
+		ElasticsearchFixture elasticsearchFixture,
+		SearchEngineAdapter searchEngineAdapter,
+		IndexNameBuilder indexNameBuilder, Localization localization) {
 
 		return new ElasticsearchIndexWriter() {
 			{
-				setSearchEngineAdapter(searchEngineAdapter);
 				setIndexNameBuilder(indexNameBuilder);
-
+				setSearchEngineAdapter(searchEngineAdapter);
 				setSpellCheckIndexWriter(
 					createElasticsearchSpellCheckIndexWriter(
 						searchEngineAdapter, indexNameBuilder, localization));
+
+				activate(
+					elasticsearchFixture.
+						getElasticsearchConfigurationProperties());
 			}
 		};
 	}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/ElasticsearchFixture.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/ElasticsearchFixture.java
@@ -236,12 +236,13 @@ public class ElasticsearchFixture implements ElasticsearchClientResolver {
 	protected Map<String, Object> createElasticsearchConfigurationProperties(
 		Map<String, Object> elasticsearchConfigurationProperties) {
 
-		Map<String, Object> map = new HashMap<>(
-			elasticsearchConfigurationProperties);
+		Map<String, Object> map = new HashMap<>();
 
 		map.put("configurationPid", ElasticsearchConfiguration.class.getName());
 		map.put("httpCORSAllowOrigin", "*");
 		map.put("logExceptionsOnly", false);
+
+		map.putAll(elasticsearchConfigurationProperties);
 
 		return map;
 	}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/logging/ElasticsearchIndexSearcherExceptionsTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/logging/ElasticsearchIndexSearcherExceptionsTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.logging;
+
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.search.generic.TermQueryImpl;
+import com.liferay.portal.search.elasticsearch6.internal.ElasticsearchIndexingFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Bryan Engler
+ */
+public class ElasticsearchIndexSearcherExceptionsTest
+	extends BaseIndexingTestCase {
+
+	@Test
+	public void testExceptionThrownWhenQueryMalformedSearch() {
+		expectedException.expect(SearchPhaseExecutionException.class);
+		expectedException.expectMessage("all shards failed");
+
+		search(createSearchContext(), getMalformedQuery());
+	}
+
+	@Test
+	public void testExceptionThrownWhenQueryMalformedSearchCount() {
+		expectedException.expect(SearchPhaseExecutionException.class);
+		expectedException.expectMessage("all shards failed");
+
+		searchCount(createSearchContext(), getMalformedQuery());
+	}
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Override
+	protected IndexingFixture createIndexingFixture() {
+		return new ElasticsearchIndexingFixture() {
+			{
+				setCompanyId(BaseIndexingTestCase.COMPANY_ID);
+				setElasticsearchFixture(new ElasticsearchFixture(getClass()));
+				setLiferayMappingsAddedToIndex(true);
+			}
+		};
+	}
+
+	protected Query getMalformedQuery() {
+		BooleanQueryImpl booleanQueryImpl = new BooleanQueryImpl();
+
+		booleanQueryImpl.add(
+			new TermQueryImpl(Field.EXPIRATION_DATE, "text"),
+			BooleanClauseOccur.MUST);
+
+		return booleanQueryImpl;
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/logging/ElasticsearchIndexSearcherLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/logging/ElasticsearchIndexSearcherLogExceptionsOnlyTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.logging;
+
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.search.generic.TermQueryImpl;
+import com.liferay.portal.search.elasticsearch6.internal.ElasticsearchIndexingFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.logging.ExpectedLogTestRule;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Bryan Engler
+ */
+public class ElasticsearchIndexSearcherLogExceptionsOnlyTest
+	extends BaseIndexingTestCase {
+
+	@Test
+	public void testExceptionOnlyLoggedWhenQueryMalformedSearch() {
+		expectedLogTestRule.expectMessage(
+			"Failed to execute phase [query], all shards failed");
+
+		search(createSearchContext(), getMalformedQuery());
+	}
+
+	@Test
+	public void testExceptionOnlyLoggedWhenQueryMalformedSearchCount() {
+		expectedLogTestRule.expectMessage(
+			"Failed to execute phase [query], all shards failed");
+
+		searchCount(createSearchContext(), getMalformedQuery());
+	}
+
+	@Rule
+	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.none();
+
+	protected ElasticsearchFixture createElasticsearchFixture() {
+		Map<String, Object> elasticsearchConfigurationProperties =
+			new HashMap<>();
+
+		elasticsearchConfigurationProperties.put("logExceptionsOnly", true);
+
+		return new ElasticsearchFixture(
+			ElasticsearchIndexWriterLogExceptionsOnlyTest.class.getSimpleName(),
+			elasticsearchConfigurationProperties);
+	}
+
+	@Override
+	protected IndexingFixture createIndexingFixture() {
+		return new ElasticsearchIndexingFixture() {
+			{
+				setCompanyId(BaseIndexingTestCase.COMPANY_ID);
+				setElasticsearchFixture(createElasticsearchFixture());
+				setLiferayMappingsAddedToIndex(true);
+			}
+		};
+	}
+
+	protected Query getMalformedQuery() {
+		BooleanQueryImpl booleanQueryImpl = new BooleanQueryImpl();
+
+		booleanQueryImpl.add(
+			new TermQueryImpl(Field.EXPIRATION_DATE, "text"),
+			BooleanClauseOccur.MUST);
+
+		return booleanQueryImpl;
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
@@ -1,0 +1,253 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.logging;
+
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.IndexWriter;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.search.elasticsearch6.internal.ElasticsearchIndexingFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.engine.DocumentMissingException;
+import org.elasticsearch.index.mapper.MapperParsingException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Bryan Engler
+ */
+public class ElasticsearchIndexWriterExceptionsTest
+	extends BaseIndexingTestCase {
+
+	@Test
+	public void testAddDocument() {
+		expectedException.expect(MapperParsingException.class);
+		expectedException.expectMessage(
+			"failed to parse field [expirationDate] of type [date]");
+
+		addDocument(
+			DocumentCreationHelpers.singleKeyword(
+				Field.EXPIRATION_DATE, "text"));
+	}
+
+	@Test
+	public void testAddDocuments() {
+		expectedException.expect(RuntimeException.class);
+		expectedException.expectMessage("Bulk add failed");
+
+		List<Document> documents = new ArrayList<>();
+
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.EXPIRATION_DATE, "text");
+
+		documents.add(document);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.addDocuments(createSearchContext(), documents);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testCommit() {
+		expectedException.expect(IndexNotFoundException.class);
+		expectedException.expectMessage("no such index");
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(1);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.commit(searchContext);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testDeleteDocument() {
+		expectedException.expect(IndexNotFoundException.class);
+		expectedException.expectMessage("no such index");
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(1);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.deleteDocument(searchContext, "1");
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testDeleteDocuments() {
+		expectedException.expect(RuntimeException.class);
+		expectedException.expectMessage("Bulk delete failed");
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(1);
+
+		List<String> uids = new ArrayList<>();
+
+		uids.add("1");
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.deleteDocuments(searchContext, uids);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testDeleteEntityDocuments() {
+		expectedException.expect(IndexNotFoundException.class);
+		expectedException.expectMessage("no such index");
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(1);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.deleteEntityDocuments(searchContext, "test");
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testPartiallyUpdateDocument() {
+		expectedException.expect(DocumentMissingException.class);
+		expectedException.expectMessage("document missing");
+
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.UID, "1");
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.partiallyUpdateDocument(
+				createSearchContext(), document);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testPartiallyUpdateDocuments() {
+		expectedException.expect(RuntimeException.class);
+		expectedException.expectMessage("Bulk partial update failed");
+
+		Document document = new DocumentImpl();
+
+		List<Document> documents = new ArrayList<>();
+
+		document.addKeyword(Field.UID, "1");
+
+		documents.add(document);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.partiallyUpdateDocuments(
+				createSearchContext(), documents);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testUpdateDocument() {
+		expectedException.expect(RuntimeException.class);
+		expectedException.expectMessage("Update failed");
+
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.UID, "1");
+		document.addKeyword(Field.EXPIRATION_DATE, "text");
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.updateDocument(createSearchContext(), document);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testUpdateDocuments() {
+		expectedException.expect(RuntimeException.class);
+		expectedException.expectMessage("Bulk update failed");
+
+		List<Document> documents = new ArrayList<>();
+
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.UID, "1");
+		document.addKeyword(Field.EXPIRATION_DATE, "text");
+
+		documents.add(document);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.updateDocuments(createSearchContext(), documents);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Override
+	protected IndexingFixture createIndexingFixture() {
+		return new ElasticsearchIndexingFixture() {
+			{
+				setCompanyId(BaseIndexingTestCase.COMPANY_ID);
+				setElasticsearchFixture(new ElasticsearchFixture(getClass()));
+				setLiferayMappingsAddedToIndex(true);
+			}
+		};
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
@@ -1,0 +1,371 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.logging;
+
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.IndexWriter;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.search.elasticsearch6.internal.ElasticsearchIndexingFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch6.internal.search.engine.adapter.document.BulkDocumentRequestExecutorImpl;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.logging.ExpectedLogTestRule;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Bryan Engler
+ */
+public class ElasticsearchIndexWriterLogExceptionsOnlyTest
+	extends BaseIndexingTestCase {
+
+	@Test
+	public void testAddDocument() throws Exception {
+		expectedLogTestRule.expectMessage(
+			"failed to parse field [expirationDate] of type [date]");
+
+		addDocument(
+			DocumentCreationHelpers.singleKeyword(
+				Field.EXPIRATION_DATE, "text"));
+	}
+
+	@Test
+	public void testAddDocuments() {
+		expectedLogTestRule.expectMessage("Bulk add failed");
+
+		List<Document> documents = new ArrayList<>();
+
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.EXPIRATION_DATE, "text");
+
+		documents.add(document);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.addDocuments(createSearchContext(), documents);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testAddDocumentsBulkExecutor() {
+		expectedLogTestRule.configure(
+			BulkDocumentRequestExecutorImpl.class, Level.WARNING);
+		expectedLogTestRule.expectMessage(
+			"failed to parse field [expirationDate] of type [date]");
+
+		List<Document> documents = new ArrayList<>();
+
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.EXPIRATION_DATE, "text");
+
+		documents.add(document);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.addDocuments(createSearchContext(), documents);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testCommit() {
+		expectedLogTestRule.expectMessage("no such index");
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(1);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.commit(searchContext);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testDeleteDocument() {
+		expectedLogTestRule.expectMessage("no such index");
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(1);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.deleteDocument(searchContext, "1");
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testDeleteDocuments() {
+		expectedLogTestRule.expectMessage("Bulk delete failed");
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(1);
+
+		List<String> uids = new ArrayList<>();
+
+		uids.add("1");
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.deleteDocuments(searchContext, uids);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testDeleteDocumentsBulkExecutor() {
+		expectedLogTestRule.configure(
+			BulkDocumentRequestExecutorImpl.class, Level.WARNING);
+		expectedLogTestRule.expectMessage("no such index");
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(1);
+
+		List<String> uids = new ArrayList<>();
+
+		uids.add("1");
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.deleteDocuments(searchContext, uids);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testDeleteEntityDocuments() {
+		expectedLogTestRule.expectMessage("no such index");
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(1);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.deleteEntityDocuments(searchContext, "test");
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testPartiallyUpdateDocument() {
+		expectedLogTestRule.expectMessage("document missing");
+
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.UID, "1");
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.partiallyUpdateDocument(
+				createSearchContext(), document);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testPartiallyUpdateDocuments() {
+		expectedLogTestRule.expectMessage("Bulk partial update failed");
+
+		Document document = new DocumentImpl();
+
+		List<Document> documents = new ArrayList<>();
+
+		document.addKeyword(Field.UID, "1");
+
+		documents.add(document);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.partiallyUpdateDocuments(
+				createSearchContext(), documents);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testPartiallyUpdateDocumentsBulkExecutor() {
+		expectedLogTestRule.configure(
+			BulkDocumentRequestExecutorImpl.class, Level.WARNING);
+		expectedLogTestRule.expectMessage("document missing");
+
+		Document document = new DocumentImpl();
+
+		List<Document> documents = new ArrayList<>();
+
+		document.addKeyword(Field.UID, "1");
+
+		documents.add(document);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.partiallyUpdateDocuments(
+				createSearchContext(), documents);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testUpdateDocument() {
+		expectedLogTestRule.expectMessage("Update failed");
+
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.UID, "1");
+		document.addKeyword(Field.EXPIRATION_DATE, "text");
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.updateDocument(createSearchContext(), document);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testUpdateDocumentBulkExecutor() {
+		expectedLogTestRule.configure(
+			BulkDocumentRequestExecutorImpl.class, Level.WARNING);
+		expectedLogTestRule.expectMessage(
+			"failed to parse field [expirationDate] of type [date]");
+
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.UID, "1");
+		document.addKeyword(Field.EXPIRATION_DATE, "text");
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.updateDocument(createSearchContext(), document);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testUpdateDocuments() {
+		expectedLogTestRule.expectMessage("Bulk update failed");
+
+		List<Document> documents = new ArrayList<>();
+
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.UID, "1");
+		document.addKeyword(Field.EXPIRATION_DATE, "text");
+
+		documents.add(document);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.updateDocuments(createSearchContext(), documents);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Test
+	public void testUpdateDocumentsBulkExecutor() {
+		expectedLogTestRule.configure(
+			BulkDocumentRequestExecutorImpl.class, Level.WARNING);
+		expectedLogTestRule.expectMessage(
+			"failed to parse field [expirationDate] of type [date]");
+
+		List<Document> documents = new ArrayList<>();
+
+		Document document = new DocumentImpl();
+
+		document.addKeyword(Field.UID, "1");
+		document.addKeyword(Field.EXPIRATION_DATE, "text");
+
+		documents.add(document);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.updateDocuments(createSearchContext(), documents);
+		}
+		catch (SearchException se) {
+		}
+	}
+
+	@Rule
+	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.none();
+
+	protected ElasticsearchFixture createElasticsearchFixture() {
+		Map<String, Object> elasticsearchConfigurationProperties =
+			new HashMap<>();
+
+		elasticsearchConfigurationProperties.put("logExceptionsOnly", true);
+
+		return new ElasticsearchFixture(
+			ElasticsearchIndexWriterLogExceptionsOnlyTest.class.getSimpleName(),
+			elasticsearchConfigurationProperties);
+	}
+
+	@Override
+	protected IndexingFixture createIndexingFixture() {
+		return new ElasticsearchIndexingFixture() {
+			{
+				setCompanyId(BaseIndexingTestCase.COMPANY_ID);
+				setElasticsearchFixture(createElasticsearchFixture());
+				setLiferayMappingsAddedToIndex(true);
+			}
+		};
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java
@@ -100,12 +100,8 @@ public abstract class BaseIndexingTestCase {
 			return;
 		}
 
-		try {
-			_indexWriter.deleteEntityDocuments(
-				createSearchContext(), _entryClassName);
-		}
-		catch (SearchException se) {
-		}
+		_indexWriter.deleteEntityDocuments(
+			createSearchContext(), _entryClassName);
 
 		_documentFixture.tearDown();
 
@@ -143,11 +139,7 @@ public abstract class BaseIndexingTestCase {
 			_indexWriter.addDocument(createSearchContext(), document);
 		}
 		catch (SearchException se) {
-			Throwable t = se.getCause();
-
-			if (t instanceof RuntimeException) {
-				throw (RuntimeException)t;
-			}
+			_handle(se);
 
 			throw new RuntimeException(se);
 		}
@@ -232,11 +224,7 @@ public abstract class BaseIndexingTestCase {
 			return _indexSearcher.search(searchContext, query);
 		}
 		catch (SearchException se) {
-			Throwable t = se.getCause();
-
-			if (t instanceof RuntimeException) {
-				throw (RuntimeException)t;
-			}
+			_handle(se);
 
 			throw new RuntimeException(se);
 		}
@@ -247,11 +235,7 @@ public abstract class BaseIndexingTestCase {
 			return _indexSearcher.searchCount(searchContext, query);
 		}
 		catch (SearchException se) {
-			Throwable t = se.getCause();
-
-			if (t instanceof RuntimeException) {
-				throw (RuntimeException)t;
-			}
+			_handle(se);
 
 			throw new RuntimeException(se);
 		}
@@ -443,6 +427,18 @@ public abstract class BaseIndexingTestCase {
 		private final SearchRequestBuilder _searchRequestBuilder;
 		private SearchResponse _searchResponse;
 
+	}
+
+	private void _handle(SearchException se) {
+		Throwable t = se.getCause();
+
+		if (t instanceof RuntimeException) {
+			throw (RuntimeException)t;
+		}
+
+		if (t != null) {
+			throw new RuntimeException(t);
+		}
 	}
 
 	private final DocumentFixture _documentFixture = new DocumentFixture();


### PR DESCRIPTION
This reverts the revert from https://github.com/brianchandotcom/liferay-portal/pull/69678. It was a false alarm. The nature of that change, similar to recent CI timeout symptoms (library exceptions in logs) led me to believe we could have let some overlooked issue sneak in, so I authorized the remedial revert. But further investigation showed the root cause was actually a different bug, https://issues.liferay.com/browse/LPS-92341, now fixed and merged. (https://github.com/brianchandotcom/liferay-portal/pull/69778) cc/ @joshchong @xbrianlee

----

**❌ ci:test:search - 14 out of 17 jobs passed in 1 hour 25 minutes 940 ms**
https://github.com/arboliveira/liferay-portal/pull/692#issuecomment-474759731

All failures are unrelated, with fixes from proper teams already merged into master since then.

----

Author: @BryanEngler
Reviewer: @arboliveira

_[Bug] LPS-90109 Elasticsearch client dropping documents without reporting server errors_
https://issues.liferay.com/browse/LPS-90109