### PR TITLE
LPS-92335 Disable testSearchCommentsByKeywords for more entities which also don't support comments

### DIFF
--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksEntrySearchTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksEntrySearchTest.java
@@ -87,6 +87,12 @@ public class BookmarksEntrySearchTest extends BaseSearchTestCase {
 	@Ignore
 	@Override
 	@Test
+	public void testSearchCommentsByKeywords() throws Exception {
+	}
+
+	@Ignore
+	@Override
+	@Test
 	public void testSearchExpireAllVersions() {
 	}
 

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksFolderSearchTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksFolderSearchTest.java
@@ -101,6 +101,12 @@ public class BookmarksFolderSearchTest extends BaseSearchTestCase {
 	@Ignore
 	@Override
 	@Test
+	public void testSearchCommentsByKeywords() throws Exception {
+	}
+
+	@Ignore
+	@Override
+	@Test
 	public void testSearchExpireAllVersions() {
 	}
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderSearchTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderSearchTest.java
@@ -94,6 +94,12 @@ public class DLFolderSearchTest extends BaseSearchTestCase {
 	@Ignore
 	@Override
 	@Test
+	public void testSearchCommentsByKeywords() throws Exception {
+	}
+
+	@Ignore
+	@Override
+	@Test
 	public void testSearchExpireAllVersions() throws Exception {
 	}
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalFolderSearchTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalFolderSearchTest.java
@@ -100,6 +100,12 @@ public class JournalFolderSearchTest extends BaseSearchTestCase {
 	@Ignore
 	@Override
 	@Test
+	public void testSearchCommentsByKeywords() throws Exception {
+	}
+
+	@Ignore
+	@Override
+	@Test
 	public void testSearchExpireAllVersions() throws Exception {
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-92335

Follow-up- on https://github.com/brianchandotcom/liferay-portal/pull/69794#issuecomment-474993023.

Sorry about the additional changes. I should have run CI twice maybe to catch these earlier.

Regards,
Tibor