### PR TITLE
Revert "LPS-92292 DropdownItems shouldn't have an href (or a blank href) by default"

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownItem.java
@@ -21,8 +21,6 @@ public class DropdownItem extends NavigationItem {
 
 	public DropdownItem() {
 		put("type", "item");
-
-		setHref(null);
 	}
 
 	public void setIcon(String icon) {


### PR DESCRIPTION
@brianchandotcom 
This causes [LPS-92435](https://issues.liferay.com/browse/LPS-92435) and [LPS-92436](https://issues.liferay.com/browse/LPS-92436) where Display Pages and Nav Menus are broken.

@jbalsas - unfortunately, it seems like your fix for [LPS-92292](https://issues.liferay.com/browse/LPS-92292) caused it.

Could you take a look at this?

cc @kyle-miho @jkappler @pavel-savinov @ealonso