### PR TITLE
LPS-92335 Disable testSearchCommentsByKeywords for MBMessage

### DIFF
--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageSearchTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageSearchTest.java
@@ -92,6 +92,12 @@ public class MBMessageSearchTest extends BaseSearchTestCase {
 	@Ignore
 	@Override
 	@Test
+	public void testSearchCommentsByKeywords() throws Exception {
+	}
+
+	@Ignore
+	@Override
+	@Test
 	public void testSearchExpireAllVersions() throws Exception {
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-92335

:heavy_check_mark: `ci:test:search` result: https://github.com/lipusz/liferay-portal/pull/255#issuecomment-475166951 - :information_source: BlogsEntrySearchTest failure is expected until https://issues.liferay.com/browse/LPS-92385 is not resolved.

Regards,
Tibor