### PR TITLE
LPS-92582 Prevent ambiguous reference in test

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultContentDisplayBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultContentDisplayBuilderTest.java
@@ -225,7 +225,7 @@ public class SearchResultContentDisplayBuilderTest {
 			_assetRenderer
 		).getURLEdit(
 			Mockito.anyObject(), Mockito.anyObject(), Mockito.anyObject(),
-			Mockito.anyObject()
+			Mockito.any(PortletURL.class)
 		);
 
 		Mockito.doReturn(


### PR DESCRIPTION
Caused by https://issues.liferay.com/browse/LPS-92461

Author: @BryanEngler

[Regresstion Bug] SearchResultContentDisplayBuilderTest fails to compile
https://issues.liferay.com/browse/LPS-92582