### PR TITLE
LPS-92454 expose uuids

### DIFF
--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/StructuredContent.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/StructuredContent.java
@@ -341,6 +341,28 @@ public class StructuredContent {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	@JsonIgnore
+	public void setKey(UnsafeSupplier<String, Exception> keyUnsafeSupplier) {
+		try {
+			key = keyUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String key;
+
 	public String[] getKeywords() {
 		return keywords;
 	}
@@ -512,6 +534,28 @@ public class StructuredContent {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String title;
 
+	public String getUuid() {
+		return uuid;
+	}
+
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+	}
+
+	@JsonIgnore
+	public void setUuid(UnsafeSupplier<String, Exception> uuidUnsafeSupplier) {
+		try {
+			uuid = uuidUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String uuid;
+
 	public ViewableBy getViewableBy() {
 		return viewableBy;
 	}
@@ -647,6 +691,13 @@ public class StructuredContent {
 		sb.append(id);
 		sb.append(", ");
 
+		sb.append("\"key\": ");
+
+		sb.append("\"");
+		sb.append(key);
+		sb.append("\"");
+		sb.append(", ");
+
 		sb.append("\"keywords\": ");
 
 		if (keywords == null) {
@@ -749,6 +800,13 @@ public class StructuredContent {
 
 		sb.append("\"");
 		sb.append(title);
+		sb.append("\"");
+		sb.append(", ");
+
+		sb.append("\"uuid\": ");
+
+		sb.append("\"");
+		sb.append(uuid);
 		sb.append("\"");
 		sb.append(", ");
 

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/StructuredContentResource.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/StructuredContentResource.java
@@ -48,6 +48,14 @@ public interface StructuredContentResource {
 			Sort[] sorts)
 		throws Exception;
 
+	public StructuredContent getContentSpaceStructuredContentKey(
+			Long contentSpaceId, String key)
+		throws Exception;
+
+	public StructuredContent getContentSpaceStructuredContentUuid(
+			Long contentSpaceId, String uuid)
+		throws Exception;
+
 	public boolean deleteStructuredContent(Long structuredContentId)
 		throws Exception;
 

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-client/src/main/java/com/liferay/headless/web/experience/client/dto/v1_0/StructuredContent.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-client/src/main/java/com/liferay/headless/web/experience/client/dto/v1_0/StructuredContent.java
@@ -289,6 +289,25 @@ public class StructuredContent {
 
 	protected Long id;
 
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	public void setKey(UnsafeSupplier<String, Exception> keyUnsafeSupplier) {
+		try {
+			key = keyUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String key;
+
 	public String[] getKeywords() {
 		return keywords;
 	}
@@ -437,6 +456,25 @@ public class StructuredContent {
 	}
 
 	protected String title;
+
+	public String getUuid() {
+		return uuid;
+	}
+
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+	}
+
+	public void setUuid(UnsafeSupplier<String, Exception> uuidUnsafeSupplier) {
+		try {
+			uuid = uuidUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String uuid;
 
 	public ViewableBy getViewableBy() {
 		return viewableBy;

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
@@ -232,6 +232,8 @@ components:
                 id:
                     format: int64
                     type: integer
+                key:
+                    type: string
                 keywords:
                     items:
                         type: string
@@ -269,6 +271,8 @@ components:
                     type: array
                     writeOnly: true
                 title:
+                    type: string
+                uuid:
                     type: string
                 viewableBy:
                     enum: [Anyone, Members, Owner]
@@ -573,6 +577,58 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/StructuredContent"
                                 type: array
+                    description: ""
+            tags: ["StructuredContent"]
+    "/content-spaces/{content-space-id}/structured-contents/key/{key}":
+        get:
+            parameters:
+                - in: header
+                  name: Accept-Language
+                  schema:
+                      type: string
+                - in: path
+                  name: content-space-id
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: key
+                  required: true
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/StructuredContent"
+                    description: ""
+            tags: ["StructuredContent"]
+    "/content-spaces/{content-space-id}/structured-contents/uuid/{uuid}":
+        get:
+            parameters:
+                - in: header
+                  name: Accept-Language
+                  schema:
+                      type: string
+                - in: path
+                  name: content-space-id
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: uuid
+                  required: true
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/StructuredContent"
                     description: ""
             tags: ["StructuredContent"]
     "/structured-contents/{structured-content-id}":

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/graphql/query/v1_0/Query.java
@@ -210,6 +210,36 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
+	public StructuredContent getContentSpaceStructuredContentKey(
+			@GraphQLName("content-space-id") Long contentSpaceId,
+			@GraphQLName("key") String key)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_structuredContentResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			structuredContentResource ->
+				structuredContentResource.getContentSpaceStructuredContentKey(
+					contentSpaceId, key));
+	}
+
+	@GraphQLField
+	@GraphQLInvokeDetached
+	public StructuredContent getContentSpaceStructuredContentUuid(
+			@GraphQLName("content-space-id") Long contentSpaceId,
+			@GraphQLName("uuid") String uuid)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_structuredContentResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			structuredContentResource ->
+				structuredContentResource.getContentSpaceStructuredContentUuid(
+					contentSpaceId, uuid));
+	}
+
+	@GraphQLField
+	@GraphQLInvokeDetached
 	public StructuredContent getStructuredContent(
 			@GraphQLName("structured-content-id") Long structuredContentId)
 		throws Exception {

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -124,6 +124,32 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	@Override
+	@GET
+	@Path("/content-spaces/{content-space-id}/structured-contents/key/{key}")
+	@Produces("application/json")
+	@Tags(value = {@Tag(name = "StructuredContent")})
+	public StructuredContent getContentSpaceStructuredContentKey(
+			@NotNull @PathParam("content-space-id") Long contentSpaceId,
+			@NotNull @PathParam("key") String key)
+		throws Exception {
+
+		return new StructuredContent();
+	}
+
+	@Override
+	@GET
+	@Path("/content-spaces/{content-space-id}/structured-contents/uuid/{uuid}")
+	@Produces("application/json")
+	@Tags(value = {@Tag(name = "StructuredContent")})
+	public StructuredContent getContentSpaceStructuredContentUuid(
+			@NotNull @PathParam("content-space-id") Long contentSpaceId,
+			@NotNull @PathParam("uuid") String uuid)
+		throws Exception {
+
+		return new StructuredContent();
+	}
+
+	@Override
 	@DELETE
 	@Path("/structured-contents/{structured-content-id}")
 	@Produces("application/json")
@@ -201,6 +227,10 @@ public abstract class BaseStructuredContentResourceImpl
 				structuredContent.getDescription());
 		}
 
+		if (Validator.isNotNull(structuredContent.getKey())) {
+			existingStructuredContent.setKey(structuredContent.getKey());
+		}
+
 		if (Validator.isNotNull(structuredContent.getKeywords())) {
 			existingStructuredContent.setKeywords(
 				structuredContent.getKeywords());
@@ -223,6 +253,10 @@ public abstract class BaseStructuredContentResourceImpl
 
 		if (Validator.isNotNull(structuredContent.getTitle())) {
 			existingStructuredContent.setTitle(structuredContent.getTitle());
+		}
+
+		if (Validator.isNotNull(structuredContent.getUuid())) {
+			existingStructuredContent.setUuid(structuredContent.getUuid());
 		}
 
 		if (Validator.isNotNull(structuredContent.getViewableBy())) {

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -60,6 +60,7 @@ import com.liferay.headless.web.experience.internal.odata.entity.v1_0.Structured
 import com.liferay.headless.web.experience.resource.v1_0.StructuredContentResource;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleDisplay;
+import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.service.JournalArticleService;
 import com.liferay.journal.util.JournalContent;
 import com.liferay.journal.util.JournalConverter;
@@ -79,6 +80,9 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.TermFilter;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -156,6 +160,17 @@ public class StructuredContentResourceImpl
 	}
 
 	@Override
+	public StructuredContent getContentSpaceStructuredContentKey(
+			Long contentSpaceId, String key)
+		throws Exception {
+
+		JournalArticle journalArticle = _journalArticleService.getArticle(
+			contentSpaceId, key);
+
+		return _getStructuredContent(journalArticle);
+	}
+
+	@Override
 	public Page<StructuredContent> getContentSpaceStructuredContentsPage(
 			Long contentSpaceId, Filter filter, Pagination pagination,
 			Sort[] sorts)
@@ -163,6 +178,22 @@ public class StructuredContentResourceImpl
 
 		return _getStructuredContentsPage(
 			contentSpaceId, null, filter, pagination, sorts);
+	}
+
+	@Override
+	public StructuredContent getContentSpaceStructuredContentUuid(
+			Long contentSpaceId, String uuid)
+		throws Exception {
+
+		JournalArticle journalArticle =
+			_journalArticleLocalService.fetchJournalArticleByUuidAndGroupId(
+				uuid, contentSpaceId);
+
+		_journalArticleModelResourcePermission.check(
+			PermissionThreadLocal.getPermissionChecker(),
+			journalArticle.getResourcePrimKey(), ActionKeys.VIEW);
+
+		return _getStructuredContent(journalArticle);
 	}
 
 	@Override
@@ -204,12 +235,7 @@ public class StructuredContentResourceImpl
 		JournalArticle journalArticle = _journalArticleService.getLatestArticle(
 			structuredContentId);
 
-		ContentLanguageUtil.addContentLanguageHeader(
-			journalArticle.getAvailableLanguageIds(),
-			journalArticle.getDefaultLanguageId(), _contextHttpServletResponse,
-			contextAcceptLanguage.getPreferredLocale());
-
-		return _toStructuredContent(journalArticle);
+		return _getStructuredContent(journalArticle);
 	}
 
 	@Override
@@ -520,6 +546,18 @@ public class StructuredContentResourceImpl
 		DDMTemplate ddmTemplate = ddmTemplates.get(0);
 
 		return ddmTemplate.getTemplateKey();
+	}
+
+	private StructuredContent _getStructuredContent(
+			JournalArticle journalArticle)
+		throws Exception {
+
+		ContentLanguageUtil.addContentLanguageHeader(
+			journalArticle.getAvailableLanguageIds(),
+			journalArticle.getDefaultLanguageId(), _contextHttpServletResponse,
+			contextAcceptLanguage.getPreferredLocale());
+
+		return _toStructuredContent(journalArticle);
 	}
 
 	private Page<StructuredContent> _getStructuredContentsPage(
@@ -860,6 +898,7 @@ public class StructuredContentResourceImpl
 				description = journalArticle.getDescription(
 					contextAcceptLanguage.getPreferredLocale());
 				id = journalArticle.getResourcePrimKey();
+				key = journalArticle.getArticleId();
 				keywords = ListUtil.toArray(
 					_assetTagLocalService.getTags(
 						JournalArticle.class.getName(),
@@ -895,6 +934,7 @@ public class StructuredContentResourceImpl
 					TaxonomyCategory.class);
 				title = journalArticle.getTitle(
 					contextAcceptLanguage.getPreferredLocale());
+				uuid = journalArticle.getUuid();
 			}
 		};
 	}
@@ -1094,6 +1134,15 @@ public class StructuredContentResourceImpl
 
 	@Reference
 	private FieldsToDDMFormValuesConverter _fieldsToDDMFormValuesConverter;
+
+	@Reference
+	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.journal.model.JournalArticle)"
+	)
+	private ModelResourcePermission<JournalArticle>
+		_journalArticleModelResourcePermission;
 
 	@Reference
 	private JournalArticleService _journalArticleService;

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -937,6 +937,140 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	@Test
+	public void testGetContentSpaceStructuredContentKey() throws Exception {
+		StructuredContent postStructuredContent =
+			testGetContentSpaceStructuredContentKey_addStructuredContent();
+
+		StructuredContent getStructuredContent =
+			invokeGetContentSpaceStructuredContentKey(
+				postStructuredContent.getId());
+
+		assertEquals(postStructuredContent, getStructuredContent);
+		assertValid(getStructuredContent);
+	}
+
+	protected StructuredContent
+			testGetContentSpaceStructuredContentKey_addStructuredContent()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected StructuredContent invokeGetContentSpaceStructuredContentKey(
+			Long contentSpaceId, String key)
+		throws Exception {
+
+		Http.Options options = _createHttpOptions();
+
+		String location =
+			_resourceURL +
+				_toPath(
+					"/content-spaces/{content-space-id}/structured-contents/key/{key}",
+					contentSpaceId, key);
+
+		options.setLocation(location);
+
+		String string = HttpUtil.URLtoString(options);
+
+		try {
+			return _outputObjectMapper.readValue(
+				string, StructuredContent.class);
+		}
+		catch (Exception e) {
+			_log.error("Unable to process HTTP response: " + string, e);
+
+			throw e;
+		}
+	}
+
+	protected Http.Response invokeGetContentSpaceStructuredContentKeyResponse(
+			Long contentSpaceId, String key)
+		throws Exception {
+
+		Http.Options options = _createHttpOptions();
+
+		String location =
+			_resourceURL +
+				_toPath(
+					"/content-spaces/{content-space-id}/structured-contents/key/{key}",
+					contentSpaceId, key);
+
+		options.setLocation(location);
+
+		HttpUtil.URLtoString(options);
+
+		return options.getResponse();
+	}
+
+	@Test
+	public void testGetContentSpaceStructuredContentUuid() throws Exception {
+		StructuredContent postStructuredContent =
+			testGetContentSpaceStructuredContentUuid_addStructuredContent();
+
+		StructuredContent getStructuredContent =
+			invokeGetContentSpaceStructuredContentUuid(
+				postStructuredContent.getId());
+
+		assertEquals(postStructuredContent, getStructuredContent);
+		assertValid(getStructuredContent);
+	}
+
+	protected StructuredContent
+			testGetContentSpaceStructuredContentUuid_addStructuredContent()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected StructuredContent invokeGetContentSpaceStructuredContentUuid(
+			Long contentSpaceId, String uuid)
+		throws Exception {
+
+		Http.Options options = _createHttpOptions();
+
+		String location =
+			_resourceURL +
+				_toPath(
+					"/content-spaces/{content-space-id}/structured-contents/uuid/{uuid}",
+					contentSpaceId, uuid);
+
+		options.setLocation(location);
+
+		String string = HttpUtil.URLtoString(options);
+
+		try {
+			return _outputObjectMapper.readValue(
+				string, StructuredContent.class);
+		}
+		catch (Exception e) {
+			_log.error("Unable to process HTTP response: " + string, e);
+
+			throw e;
+		}
+	}
+
+	protected Http.Response invokeGetContentSpaceStructuredContentUuidResponse(
+			Long contentSpaceId, String uuid)
+		throws Exception {
+
+		Http.Options options = _createHttpOptions();
+
+		String location =
+			_resourceURL +
+				_toPath(
+					"/content-spaces/{content-space-id}/structured-contents/uuid/{uuid}",
+					contentSpaceId, uuid);
+
+		options.setLocation(location);
+
+		HttpUtil.URLtoString(options);
+
+		return options.getResponse();
+	}
+
+	@Test
 	public void testDeleteStructuredContent() throws Exception {
 		StructuredContent structuredContent =
 			testDeleteStructuredContent_addStructuredContent();
@@ -1488,6 +1622,14 @@ public abstract class BaseStructuredContentResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("key")) {
+			sb.append("'");
+			sb.append(String.valueOf(structuredContent.getKey()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("keywords")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -1527,6 +1669,14 @@ public abstract class BaseStructuredContentResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("uuid")) {
+			sb.append("'");
+			sb.append(String.valueOf(structuredContent.getUuid()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("viewableBy")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -1546,8 +1696,10 @@ public abstract class BaseStructuredContentResourceTestCase {
 				datePublished = RandomTestUtil.nextDate();
 				description = RandomTestUtil.randomString();
 				id = RandomTestUtil.randomLong();
+				key = RandomTestUtil.randomString();
 				lastReviewed = RandomTestUtil.nextDate();
 				title = RandomTestUtil.randomString();
+				uuid = RandomTestUtil.randomString();
 			}
 		};
 	}

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -943,7 +943,8 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 		StructuredContent getStructuredContent =
 			invokeGetContentSpaceStructuredContentKey(
-				postStructuredContent.getId());
+				postStructuredContent.getContentSpaceId(),
+					postStructuredContent.getKey());
 
 		assertEquals(postStructuredContent, getStructuredContent);
 		assertValid(getStructuredContent);
@@ -1010,7 +1011,8 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 		StructuredContent getStructuredContent =
 			invokeGetContentSpaceStructuredContentUuid(
-				postStructuredContent.getId());
+				postStructuredContent.getContentSpaceId(),
+				postStructuredContent.getUuid());
 
 		assertEquals(postStructuredContent, getStructuredContent);
 		assertValid(getStructuredContent);


### PR DESCRIPTION
There is a problem with the tests (they assume one single id in GET operations).

I haven't exposed the uuid method in the remote service (given we are the only ones that seems that are going to use it) but I can do it if you think it's better than checking permissions in the API.