### PR TITLE
LPS-92384 tree

### DIFF
--- a/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/KnowledgeBaseArticleResource.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/KnowledgeBaseArticleResource.java
@@ -40,6 +40,15 @@ public interface KnowledgeBaseArticleResource {
 			Long contentSpaceId, KnowledgeBaseArticle knowledgeBaseArticle)
 		throws Exception;
 
+	public Page<KnowledgeBaseArticle>
+			getContentSpaceTreeKnowledgeBaseArticlesPage(
+				Long contentSpaceId, Pagination pagination)
+		throws Exception;
+
+	public KnowledgeBaseArticle postContentSpaceTreeKnowledgeBaseArticle(
+			Long contentSpaceId, KnowledgeBaseArticle knowledgeBaseArticle)
+		throws Exception;
+
 	public boolean deleteKnowledgeBaseArticle(Long knowledgeBaseArticleId)
 		throws Exception;
 

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/KnowledgeBaseFolderResource.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/KnowledgeBaseFolderResource.java
@@ -32,11 +32,12 @@ import javax.annotation.Generated;
 @Generated("")
 public interface KnowledgeBaseFolderResource {
 
-	public Page<KnowledgeBaseFolder> getContentSpaceKnowledgeBaseFoldersPage(
-			Long contentSpaceId, Pagination pagination)
+	public Page<KnowledgeBaseFolder>
+			getContentSpaceTreeKnowledgeBaseFoldersPage(
+				Long contentSpaceId, Pagination pagination)
 		throws Exception;
 
-	public KnowledgeBaseFolder postContentSpaceKnowledgeBaseFolder(
+	public KnowledgeBaseFolder postContentSpaceTreeKnowledgeBaseFolder(
 			Long contentSpaceId, KnowledgeBaseFolder knowledgeBaseFolder)
 		throws Exception;
 

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/rest-openapi.yaml
@@ -1005,7 +1005,55 @@ paths:
                                 $ref: "#/components/schemas/KnowledgeBaseArticle"
                     description: ""
             tags: ["KnowledgeBaseArticle"]
-    "/content-spaces/{content-space-id}/knowledge-base-folders":
+    "/content-spaces/{content-space-id}/tree/knowledge-base-articles":
+        get:
+            parameters:
+                - in: path
+                  name: content-space-id
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: query
+                  name: page
+                  schema:
+                      type: integer
+                - in: query
+                  name: pageSize
+                  schema:
+                      type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/KnowledgeBaseArticle"
+                                type: array
+                    description: ""
+            tags: ["KnowledgeBaseArticle"]
+        post:
+            parameters:
+                - in: path
+                  name: content-space-id
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/KnowledgeBaseArticle"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/KnowledgeBaseArticle"
+                    description: ""
+            tags: ["KnowledgeBaseArticle"]
+    "/content-spaces/{content-space-id}/tree/knowledge-base-folders":
         get:
             parameters:
                 - in: path

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/graphql/mutation/v1_0/Mutation.java
@@ -574,6 +574,23 @@ public class Mutation {
 						contentSpaceId, knowledgeBaseArticle));
 	}
 
+	@GraphQLField
+	@GraphQLInvokeDetached
+	public KnowledgeBaseArticle postContentSpaceTreeKnowledgeBaseArticle(
+			@GraphQLName("content-space-id") Long contentSpaceId,
+			@GraphQLName("KnowledgeBaseArticle") KnowledgeBaseArticle
+				knowledgeBaseArticle)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_knowledgeBaseArticleResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			knowledgeBaseArticleResource ->
+				knowledgeBaseArticleResource.
+					postContentSpaceTreeKnowledgeBaseArticle(
+						contentSpaceId, knowledgeBaseArticle));
+	}
+
 	@GraphQLInvokeDetached
 	public boolean deleteKnowledgeBaseArticle(
 			@GraphQLName("knowledge-base-article-id") Long
@@ -689,7 +706,7 @@ public class Mutation {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public KnowledgeBaseFolder postContentSpaceKnowledgeBaseFolder(
+	public KnowledgeBaseFolder postContentSpaceTreeKnowledgeBaseFolder(
 			@GraphQLName("content-space-id") Long contentSpaceId,
 			@GraphQLName("KnowledgeBaseFolder") KnowledgeBaseFolder
 				knowledgeBaseFolder)
@@ -699,8 +716,9 @@ public class Mutation {
 			_knowledgeBaseFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			knowledgeBaseFolderResource ->
-				knowledgeBaseFolderResource.postContentSpaceKnowledgeBaseFolder(
-					contentSpaceId, knowledgeBaseFolder));
+				knowledgeBaseFolderResource.
+					postContentSpaceTreeKnowledgeBaseFolder(
+						contentSpaceId, knowledgeBaseFolder));
 	}
 
 	@GraphQLInvokeDetached

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/graphql/query/v1_0/Query.java
@@ -536,6 +536,28 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
+	public Collection<KnowledgeBaseArticle>
+			getContentSpaceTreeKnowledgeBaseArticlesPage(
+				@GraphQLName("content-space-id") Long contentSpaceId,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_knowledgeBaseArticleResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> {
+				Page paginationPage =
+					knowledgeBaseArticleResource.
+						getContentSpaceTreeKnowledgeBaseArticlesPage(
+							contentSpaceId, Pagination.of(pageSize, page));
+
+				return paginationPage.getItems();
+			});
+	}
+
+	@GraphQLField
+	@GraphQLInvokeDetached
 	public KnowledgeBaseArticle getKnowledgeBaseArticle(
 			@GraphQLName("knowledge-base-article-id") Long
 				knowledgeBaseArticleId)
@@ -636,7 +658,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<KnowledgeBaseFolder>
-			getContentSpaceKnowledgeBaseFoldersPage(
+			getContentSpaceTreeKnowledgeBaseFoldersPage(
 				@GraphQLName("content-space-id") Long contentSpaceId,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page)
@@ -648,7 +670,7 @@ public class Query {
 			knowledgeBaseFolderResource -> {
 				Page paginationPage =
 					knowledgeBaseFolderResource.
-						getContentSpaceKnowledgeBaseFoldersPage(
+						getContentSpaceTreeKnowledgeBaseFoldersPage(
 							contentSpaceId, Pagination.of(pageSize, page));
 
 				return paginationPage.getItems();

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -97,6 +97,40 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	}
 
 	@Override
+	@GET
+	@Parameters(
+		value = {
+			@Parameter(in = ParameterIn.QUERY, name = "page"),
+			@Parameter(in = ParameterIn.QUERY, name = "pageSize")
+		}
+	)
+	@Path("/content-spaces/{content-space-id}/tree/knowledge-base-articles")
+	@Produces("application/json")
+	@Tags(value = {@Tag(name = "KnowledgeBaseArticle")})
+	public Page<KnowledgeBaseArticle>
+			getContentSpaceTreeKnowledgeBaseArticlesPage(
+				@NotNull @PathParam("content-space-id") Long contentSpaceId,
+				@Context Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@Override
+	@Consumes("application/json")
+	@POST
+	@Path("/content-spaces/{content-space-id}/tree/knowledge-base-articles")
+	@Produces("application/json")
+	@Tags(value = {@Tag(name = "KnowledgeBaseArticle")})
+	public KnowledgeBaseArticle postContentSpaceTreeKnowledgeBaseArticle(
+			@NotNull @PathParam("content-space-id") Long contentSpaceId,
+			KnowledgeBaseArticle knowledgeBaseArticle)
+		throws Exception {
+
+		return new KnowledgeBaseArticle();
+	}
+
+	@Override
 	@DELETE
 	@Path("/knowledge-base-articles/{knowledge-base-article-id}")
 	@Produces("application/json")

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -71,12 +71,13 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 			@Parameter(in = ParameterIn.QUERY, name = "pageSize")
 		}
 	)
-	@Path("/content-spaces/{content-space-id}/knowledge-base-folders")
+	@Path("/content-spaces/{content-space-id}/tree/knowledge-base-folders")
 	@Produces("application/json")
 	@Tags(value = {@Tag(name = "KnowledgeBaseFolder")})
-	public Page<KnowledgeBaseFolder> getContentSpaceKnowledgeBaseFoldersPage(
-			@NotNull @PathParam("content-space-id") Long contentSpaceId,
-			@Context Pagination pagination)
+	public Page<KnowledgeBaseFolder>
+			getContentSpaceTreeKnowledgeBaseFoldersPage(
+				@NotNull @PathParam("content-space-id") Long contentSpaceId,
+				@Context Pagination pagination)
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
@@ -85,10 +86,10 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	@Override
 	@Consumes("application/json")
 	@POST
-	@Path("/content-spaces/{content-space-id}/knowledge-base-folders")
+	@Path("/content-spaces/{content-space-id}/tree/knowledge-base-folders")
 	@Produces("application/json")
 	@Tags(value = {@Tag(name = "KnowledgeBaseFolder")})
-	public KnowledgeBaseFolder postContentSpaceKnowledgeBaseFolder(
+	public KnowledgeBaseFolder postContentSpaceTreeKnowledgeBaseFolder(
 			@NotNull @PathParam("content-space-id") Long contentSpaceId,
 			KnowledgeBaseFolder knowledgeBaseFolder)
 		throws Exception {

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/KnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/KnowledgeBaseArticleResourceImpl.java
@@ -74,6 +74,24 @@ public class KnowledgeBaseArticleResourceImpl
 
 		return Page.of(
 			transform(
+				_kbArticleService.getGroupKBArticles(
+					contentSpaceId, WorkflowConstants.STATUS_APPROVED,
+					pagination.getStartPosition(), pagination.getEndPosition(),
+					null),
+				this::_toKBArticle),
+			pagination,
+			_kbArticleService.getKBArticlesCount(
+				contentSpaceId, 0, WorkflowConstants.STATUS_APPROVED));
+	}
+
+	@Override
+	public Page<KnowledgeBaseArticle>
+			getContentSpaceTreeKnowledgeBaseArticlesPage(
+				Long contentSpaceId, Pagination pagination)
+		throws Exception {
+
+		return Page.of(
+			transform(
 				_kbArticleService.getKBArticles(
 					contentSpaceId, 0, WorkflowConstants.STATUS_APPROVED,
 					pagination.getStartPosition(), pagination.getEndPosition(),
@@ -141,6 +159,17 @@ public class KnowledgeBaseArticleResourceImpl
 
 	@Override
 	public KnowledgeBaseArticle postContentSpaceKnowledgeBaseArticle(
+			Long contentSpaceId, KnowledgeBaseArticle knowledgeBaseArticle)
+		throws Exception {
+
+		return _getKnowledgeBaseArticle(
+			contentSpaceId, 0L,
+			_classNameLocalService.fetchClassName(KBFolder.class.getName()),
+			knowledgeBaseArticle);
+	}
+
+	@Override
+	public KnowledgeBaseArticle postContentSpaceTreeKnowledgeBaseArticle(
 			Long contentSpaceId, KnowledgeBaseArticle knowledgeBaseArticle)
 		throws Exception {
 

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/KnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/KnowledgeBaseFolderResourceImpl.java
@@ -51,8 +51,9 @@ public class KnowledgeBaseFolderResourceImpl
 	}
 
 	@Override
-	public Page<KnowledgeBaseFolder> getContentSpaceKnowledgeBaseFoldersPage(
-			Long contentSpaceId, Pagination pagination)
+	public Page<KnowledgeBaseFolder>
+			getContentSpaceTreeKnowledgeBaseFoldersPage(
+				Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
 		return Page.of(
@@ -93,7 +94,7 @@ public class KnowledgeBaseFolderResourceImpl
 	}
 
 	@Override
-	public KnowledgeBaseFolder postContentSpaceKnowledgeBaseFolder(
+	public KnowledgeBaseFolder postContentSpaceTreeKnowledgeBaseFolder(
 			Long contentSpaceId, KnowledgeBaseFolder knowledgeBaseFolder)
 		throws Exception {
 

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -367,6 +367,268 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	}
 
 	@Test
+	public void testGetContentSpaceTreeKnowledgeBaseArticlesPage()
+		throws Exception {
+
+		Long contentSpaceId =
+			testGetContentSpaceTreeKnowledgeBaseArticlesPage_getContentSpaceId();
+		Long irrelevantContentSpaceId =
+			testGetContentSpaceTreeKnowledgeBaseArticlesPage_getIrrelevantContentSpaceId();
+
+		if ((irrelevantContentSpaceId != null)) {
+			KnowledgeBaseArticle irrelevantKnowledgeBaseArticle =
+				testGetContentSpaceTreeKnowledgeBaseArticlesPage_addKnowledgeBaseArticle(
+					irrelevantContentSpaceId,
+					randomIrrelevantKnowledgeBaseArticle());
+
+			Page<KnowledgeBaseArticle> page =
+				invokeGetContentSpaceTreeKnowledgeBaseArticlesPage(
+					irrelevantContentSpaceId, Pagination.of(1, 2));
+
+			Assert.assertEquals(1, page.getTotalCount());
+
+			assertEquals(
+				Arrays.asList(irrelevantKnowledgeBaseArticle),
+				(List<KnowledgeBaseArticle>)page.getItems());
+			assertValid(page);
+		}
+
+		KnowledgeBaseArticle knowledgeBaseArticle1 =
+			testGetContentSpaceTreeKnowledgeBaseArticlesPage_addKnowledgeBaseArticle(
+				contentSpaceId, randomKnowledgeBaseArticle());
+
+		KnowledgeBaseArticle knowledgeBaseArticle2 =
+			testGetContentSpaceTreeKnowledgeBaseArticlesPage_addKnowledgeBaseArticle(
+				contentSpaceId, randomKnowledgeBaseArticle());
+
+		Page<KnowledgeBaseArticle> page =
+			invokeGetContentSpaceTreeKnowledgeBaseArticlesPage(
+				contentSpaceId, Pagination.of(1, 2));
+
+		Assert.assertEquals(2, page.getTotalCount());
+
+		assertEqualsIgnoringOrder(
+			Arrays.asList(knowledgeBaseArticle1, knowledgeBaseArticle2),
+			(List<KnowledgeBaseArticle>)page.getItems());
+		assertValid(page);
+	}
+
+	@Test
+	public void testGetContentSpaceTreeKnowledgeBaseArticlesPageWithPagination()
+		throws Exception {
+
+		Long contentSpaceId =
+			testGetContentSpaceTreeKnowledgeBaseArticlesPage_getContentSpaceId();
+
+		KnowledgeBaseArticle knowledgeBaseArticle1 =
+			testGetContentSpaceTreeKnowledgeBaseArticlesPage_addKnowledgeBaseArticle(
+				contentSpaceId, randomKnowledgeBaseArticle());
+
+		KnowledgeBaseArticle knowledgeBaseArticle2 =
+			testGetContentSpaceTreeKnowledgeBaseArticlesPage_addKnowledgeBaseArticle(
+				contentSpaceId, randomKnowledgeBaseArticle());
+
+		KnowledgeBaseArticle knowledgeBaseArticle3 =
+			testGetContentSpaceTreeKnowledgeBaseArticlesPage_addKnowledgeBaseArticle(
+				contentSpaceId, randomKnowledgeBaseArticle());
+
+		Page<KnowledgeBaseArticle> page1 =
+			invokeGetContentSpaceTreeKnowledgeBaseArticlesPage(
+				contentSpaceId, Pagination.of(1, 2));
+
+		List<KnowledgeBaseArticle> knowledgeBaseArticles1 =
+			(List<KnowledgeBaseArticle>)page1.getItems();
+
+		Assert.assertEquals(
+			knowledgeBaseArticles1.toString(), 2,
+			knowledgeBaseArticles1.size());
+
+		Page<KnowledgeBaseArticle> page2 =
+			invokeGetContentSpaceTreeKnowledgeBaseArticlesPage(
+				contentSpaceId, Pagination.of(2, 2));
+
+		Assert.assertEquals(3, page2.getTotalCount());
+
+		List<KnowledgeBaseArticle> knowledgeBaseArticles2 =
+			(List<KnowledgeBaseArticle>)page2.getItems();
+
+		Assert.assertEquals(
+			knowledgeBaseArticles2.toString(), 1,
+			knowledgeBaseArticles2.size());
+
+		assertEqualsIgnoringOrder(
+			Arrays.asList(
+				knowledgeBaseArticle1, knowledgeBaseArticle2,
+				knowledgeBaseArticle3),
+			new ArrayList<KnowledgeBaseArticle>() {
+				{
+					addAll(knowledgeBaseArticles1);
+					addAll(knowledgeBaseArticles2);
+				}
+			});
+	}
+
+	protected KnowledgeBaseArticle
+			testGetContentSpaceTreeKnowledgeBaseArticlesPage_addKnowledgeBaseArticle(
+				Long contentSpaceId, KnowledgeBaseArticle knowledgeBaseArticle)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Long
+			testGetContentSpaceTreeKnowledgeBaseArticlesPage_getContentSpaceId()
+		throws Exception {
+
+		return testGroup.getGroupId();
+	}
+
+	protected Long
+			testGetContentSpaceTreeKnowledgeBaseArticlesPage_getIrrelevantContentSpaceId()
+		throws Exception {
+
+		return irrelevantGroup.getGroupId();
+	}
+
+	protected Page<KnowledgeBaseArticle>
+			invokeGetContentSpaceTreeKnowledgeBaseArticlesPage(
+				Long contentSpaceId, Pagination pagination)
+		throws Exception {
+
+		Http.Options options = _createHttpOptions();
+
+		String location =
+			_resourceURL +
+				_toPath(
+					"/content-spaces/{content-space-id}/tree/knowledge-base-articles",
+					contentSpaceId);
+
+		location = HttpUtil.addParameter(
+			location, "page", pagination.getPage());
+		location = HttpUtil.addParameter(
+			location, "pageSize", pagination.getPageSize());
+
+		options.setLocation(location);
+
+		String string = HttpUtil.URLtoString(options);
+
+		return _outputObjectMapper.readValue(
+			string,
+			new TypeReference<Page<KnowledgeBaseArticle>>() {
+			});
+	}
+
+	protected Http.Response
+			invokeGetContentSpaceTreeKnowledgeBaseArticlesPageResponse(
+				Long contentSpaceId, Pagination pagination)
+		throws Exception {
+
+		Http.Options options = _createHttpOptions();
+
+		String location =
+			_resourceURL +
+				_toPath(
+					"/content-spaces/{content-space-id}/tree/knowledge-base-articles",
+					contentSpaceId);
+
+		location = HttpUtil.addParameter(
+			location, "page", pagination.getPage());
+		location = HttpUtil.addParameter(
+			location, "pageSize", pagination.getPageSize());
+
+		options.setLocation(location);
+
+		HttpUtil.URLtoString(options);
+
+		return options.getResponse();
+	}
+
+	@Test
+	public void testPostContentSpaceTreeKnowledgeBaseArticle()
+		throws Exception {
+
+		KnowledgeBaseArticle randomKnowledgeBaseArticle =
+			randomKnowledgeBaseArticle();
+
+		KnowledgeBaseArticle postKnowledgeBaseArticle =
+			testPostContentSpaceTreeKnowledgeBaseArticle_addKnowledgeBaseArticle(
+				randomKnowledgeBaseArticle);
+
+		assertEquals(randomKnowledgeBaseArticle, postKnowledgeBaseArticle);
+		assertValid(postKnowledgeBaseArticle);
+	}
+
+	protected KnowledgeBaseArticle
+			testPostContentSpaceTreeKnowledgeBaseArticle_addKnowledgeBaseArticle(
+				KnowledgeBaseArticle knowledgeBaseArticle)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected KnowledgeBaseArticle
+			invokePostContentSpaceTreeKnowledgeBaseArticle(
+				Long contentSpaceId, KnowledgeBaseArticle knowledgeBaseArticle)
+		throws Exception {
+
+		Http.Options options = _createHttpOptions();
+
+		options.setBody(
+			_inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
+			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+
+		String location =
+			_resourceURL +
+				_toPath(
+					"/content-spaces/{content-space-id}/tree/knowledge-base-articles",
+					contentSpaceId);
+
+		options.setLocation(location);
+
+		options.setPost(true);
+
+		String string = HttpUtil.URLtoString(options);
+
+		try {
+			return _outputObjectMapper.readValue(
+				string, KnowledgeBaseArticle.class);
+		}
+		catch (Exception e) {
+			_log.error("Unable to process HTTP response: " + string, e);
+
+			throw e;
+		}
+	}
+
+	protected Http.Response
+			invokePostContentSpaceTreeKnowledgeBaseArticleResponse(
+				Long contentSpaceId, KnowledgeBaseArticle knowledgeBaseArticle)
+		throws Exception {
+
+		Http.Options options = _createHttpOptions();
+
+		options.setBody(
+			_inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
+			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+
+		String location =
+			_resourceURL +
+				_toPath(
+					"/content-spaces/{content-space-id}/tree/knowledge-base-articles",
+					contentSpaceId);
+
+		options.setLocation(location);
+
+		options.setPost(true);
+
+		HttpUtil.URLtoString(options);
+
+		return options.getResponse();
+	}
+
+	@Test
 	public void testDeleteKnowledgeBaseArticle() throws Exception {
 		KnowledgeBaseArticle knowledgeBaseArticle =
 			testDeleteKnowledgeBaseArticle_addKnowledgeBaseArticle();

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -109,20 +109,22 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpaceKnowledgeBaseFoldersPage() throws Exception {
+	public void testGetContentSpaceTreeKnowledgeBaseFoldersPage()
+		throws Exception {
+
 		Long contentSpaceId =
-			testGetContentSpaceKnowledgeBaseFoldersPage_getContentSpaceId();
+			testGetContentSpaceTreeKnowledgeBaseFoldersPage_getContentSpaceId();
 		Long irrelevantContentSpaceId =
-			testGetContentSpaceKnowledgeBaseFoldersPage_getIrrelevantContentSpaceId();
+			testGetContentSpaceTreeKnowledgeBaseFoldersPage_getIrrelevantContentSpaceId();
 
 		if ((irrelevantContentSpaceId != null)) {
 			KnowledgeBaseFolder irrelevantKnowledgeBaseFolder =
-				testGetContentSpaceKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
+				testGetContentSpaceTreeKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
 					irrelevantContentSpaceId,
 					randomIrrelevantKnowledgeBaseFolder());
 
 			Page<KnowledgeBaseFolder> page =
-				invokeGetContentSpaceKnowledgeBaseFoldersPage(
+				invokeGetContentSpaceTreeKnowledgeBaseFoldersPage(
 					irrelevantContentSpaceId, Pagination.of(1, 2));
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -134,15 +136,15 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		}
 
 		KnowledgeBaseFolder knowledgeBaseFolder1 =
-			testGetContentSpaceKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
+			testGetContentSpaceTreeKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
 				contentSpaceId, randomKnowledgeBaseFolder());
 
 		KnowledgeBaseFolder knowledgeBaseFolder2 =
-			testGetContentSpaceKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
+			testGetContentSpaceTreeKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
 				contentSpaceId, randomKnowledgeBaseFolder());
 
 		Page<KnowledgeBaseFolder> page =
-			invokeGetContentSpaceKnowledgeBaseFoldersPage(
+			invokeGetContentSpaceTreeKnowledgeBaseFoldersPage(
 				contentSpaceId, Pagination.of(1, 2));
 
 		Assert.assertEquals(2, page.getTotalCount());
@@ -154,26 +156,26 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpaceKnowledgeBaseFoldersPageWithPagination()
+	public void testGetContentSpaceTreeKnowledgeBaseFoldersPageWithPagination()
 		throws Exception {
 
 		Long contentSpaceId =
-			testGetContentSpaceKnowledgeBaseFoldersPage_getContentSpaceId();
+			testGetContentSpaceTreeKnowledgeBaseFoldersPage_getContentSpaceId();
 
 		KnowledgeBaseFolder knowledgeBaseFolder1 =
-			testGetContentSpaceKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
+			testGetContentSpaceTreeKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
 				contentSpaceId, randomKnowledgeBaseFolder());
 
 		KnowledgeBaseFolder knowledgeBaseFolder2 =
-			testGetContentSpaceKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
+			testGetContentSpaceTreeKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
 				contentSpaceId, randomKnowledgeBaseFolder());
 
 		KnowledgeBaseFolder knowledgeBaseFolder3 =
-			testGetContentSpaceKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
+			testGetContentSpaceTreeKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
 				contentSpaceId, randomKnowledgeBaseFolder());
 
 		Page<KnowledgeBaseFolder> page1 =
-			invokeGetContentSpaceKnowledgeBaseFoldersPage(
+			invokeGetContentSpaceTreeKnowledgeBaseFoldersPage(
 				contentSpaceId, Pagination.of(1, 2));
 
 		List<KnowledgeBaseFolder> knowledgeBaseFolders1 =
@@ -183,7 +185,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			knowledgeBaseFolders1.toString(), 2, knowledgeBaseFolders1.size());
 
 		Page<KnowledgeBaseFolder> page2 =
-			invokeGetContentSpaceKnowledgeBaseFoldersPage(
+			invokeGetContentSpaceTreeKnowledgeBaseFoldersPage(
 				contentSpaceId, Pagination.of(2, 2));
 
 		Assert.assertEquals(3, page2.getTotalCount());
@@ -207,7 +209,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	}
 
 	protected KnowledgeBaseFolder
-			testGetContentSpaceKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
+			testGetContentSpaceTreeKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
 				Long contentSpaceId, KnowledgeBaseFolder knowledgeBaseFolder)
 		throws Exception {
 
@@ -216,21 +218,21 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	}
 
 	protected Long
-			testGetContentSpaceKnowledgeBaseFoldersPage_getContentSpaceId()
+			testGetContentSpaceTreeKnowledgeBaseFoldersPage_getContentSpaceId()
 		throws Exception {
 
 		return testGroup.getGroupId();
 	}
 
 	protected Long
-			testGetContentSpaceKnowledgeBaseFoldersPage_getIrrelevantContentSpaceId()
+			testGetContentSpaceTreeKnowledgeBaseFoldersPage_getIrrelevantContentSpaceId()
 		throws Exception {
 
 		return irrelevantGroup.getGroupId();
 	}
 
 	protected Page<KnowledgeBaseFolder>
-			invokeGetContentSpaceKnowledgeBaseFoldersPage(
+			invokeGetContentSpaceTreeKnowledgeBaseFoldersPage(
 				Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -239,7 +241,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		String location =
 			_resourceURL +
 				_toPath(
-					"/content-spaces/{content-space-id}/knowledge-base-folders",
+					"/content-spaces/{content-space-id}/tree/knowledge-base-folders",
 					contentSpaceId);
 
 		location = HttpUtil.addParameter(
@@ -258,7 +260,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	}
 
 	protected Http.Response
-			invokeGetContentSpaceKnowledgeBaseFoldersPageResponse(
+			invokeGetContentSpaceTreeKnowledgeBaseFoldersPageResponse(
 				Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
@@ -267,7 +269,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		String location =
 			_resourceURL +
 				_toPath(
-					"/content-spaces/{content-space-id}/knowledge-base-folders",
+					"/content-spaces/{content-space-id}/tree/knowledge-base-folders",
 					contentSpaceId);
 
 		location = HttpUtil.addParameter(
@@ -283,12 +285,12 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	}
 
 	@Test
-	public void testPostContentSpaceKnowledgeBaseFolder() throws Exception {
+	public void testPostContentSpaceTreeKnowledgeBaseFolder() throws Exception {
 		KnowledgeBaseFolder randomKnowledgeBaseFolder =
 			randomKnowledgeBaseFolder();
 
 		KnowledgeBaseFolder postKnowledgeBaseFolder =
-			testPostContentSpaceKnowledgeBaseFolder_addKnowledgeBaseFolder(
+			testPostContentSpaceTreeKnowledgeBaseFolder_addKnowledgeBaseFolder(
 				randomKnowledgeBaseFolder);
 
 		assertEquals(randomKnowledgeBaseFolder, postKnowledgeBaseFolder);
@@ -296,7 +298,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	}
 
 	protected KnowledgeBaseFolder
-			testPostContentSpaceKnowledgeBaseFolder_addKnowledgeBaseFolder(
+			testPostContentSpaceTreeKnowledgeBaseFolder_addKnowledgeBaseFolder(
 				KnowledgeBaseFolder knowledgeBaseFolder)
 		throws Exception {
 
@@ -304,7 +306,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			"This method needs to be implemented");
 	}
 
-	protected KnowledgeBaseFolder invokePostContentSpaceKnowledgeBaseFolder(
+	protected KnowledgeBaseFolder invokePostContentSpaceTreeKnowledgeBaseFolder(
 			Long contentSpaceId, KnowledgeBaseFolder knowledgeBaseFolder)
 		throws Exception {
 
@@ -317,7 +319,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		String location =
 			_resourceURL +
 				_toPath(
-					"/content-spaces/{content-space-id}/knowledge-base-folders",
+					"/content-spaces/{content-space-id}/tree/knowledge-base-folders",
 					contentSpaceId);
 
 		options.setLocation(location);
@@ -337,8 +339,9 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		}
 	}
 
-	protected Http.Response invokePostContentSpaceKnowledgeBaseFolderResponse(
-			Long contentSpaceId, KnowledgeBaseFolder knowledgeBaseFolder)
+	protected Http.Response
+			invokePostContentSpaceTreeKnowledgeBaseFolderResponse(
+				Long contentSpaceId, KnowledgeBaseFolder knowledgeBaseFolder)
 		throws Exception {
 
 		Http.Options options = _createHttpOptions();
@@ -350,7 +353,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		String location =
 			_resourceURL +
 				_toPath(
-					"/content-spaces/{content-space-id}/knowledge-base-folders",
+					"/content-spaces/{content-space-id}/tree/knowledge-base-folders",
 					contentSpaceId);
 
 		options.setLocation(location);

--- a/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/DocumentResource.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/DocumentResource.java
@@ -35,12 +35,12 @@ import javax.annotation.Generated;
 @Generated("")
 public interface DocumentResource {
 
-	public Page<Document> getContentSpaceDocumentsPage(
+	public Page<Document> getContentSpaceTreeDocumentsPage(
 			Long contentSpaceId, Filter filter, Pagination pagination,
 			Sort[] sorts)
 		throws Exception;
 
-	public Document postContentSpaceDocument(
+	public Document postContentSpaceTreeDocument(
 			Long contentSpaceId, MultipartBody multipartBody)
 		throws Exception;
 

--- a/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/FolderResource.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/FolderResource.java
@@ -34,12 +34,12 @@ import javax.annotation.Generated;
 @Generated("")
 public interface FolderResource {
 
-	public Page<Folder> getContentSpaceFoldersPage(
+	public Page<Folder> getContentSpaceTreeFoldersPage(
 			Long contentSpaceId, Filter filter, Pagination pagination,
 			Sort[] sorts)
 		throws Exception;
 
-	public Folder postContentSpaceFolder(Long contentSpaceId, Folder folder)
+	public Folder postContentSpaceTreeFolder(Long contentSpaceId, Folder folder)
 		throws Exception;
 
 	public boolean deleteFolder(Long folderId) throws Exception;

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
@@ -273,7 +273,7 @@ paths:
                                 $ref: "#/components/schemas/Comment"
                     description: ""
             tags: ["Comment"]
-    "/content-spaces/{content-space-id}/documents":
+    "/content-spaces/{content-space-id}/tree/documents":
         get:
             parameters:
                 - in: path
@@ -335,7 +335,7 @@ paths:
                                 $ref: "#/components/schemas/Document"
                     description: ""
             tags: ["Document"]
-    "/content-spaces/{content-space-id}/folders":
+    "/content-spaces/{content-space-id}/tree/folders":
         get:
             parameters:
                 - in: path

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/graphql/mutation/v1_0/Mutation.java
@@ -117,7 +117,7 @@ public class Mutation {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Document postContentSpaceDocument(
+	public Document postContentSpaceTreeDocument(
 			@GraphQLName("content-space-id") Long contentSpaceId,
 			@GraphQLName("MultipartBody") MultipartBody multipartBody)
 		throws Exception {
@@ -125,7 +125,7 @@ public class Mutation {
 		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			documentResource -> documentResource.postContentSpaceDocument(
+			documentResource -> documentResource.postContentSpaceTreeDocument(
 				contentSpaceId, multipartBody));
 	}
 
@@ -181,7 +181,7 @@ public class Mutation {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Folder postContentSpaceFolder(
+	public Folder postContentSpaceTreeFolder(
 			@GraphQLName("content-space-id") Long contentSpaceId,
 			@GraphQLName("Folder") Folder folder)
 		throws Exception {
@@ -189,7 +189,7 @@ public class Mutation {
 		return _applyComponentServiceObjects(
 			_folderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			folderResource -> folderResource.postContentSpaceFolder(
+			folderResource -> folderResource.postContentSpaceTreeFolder(
 				contentSpaceId, folder));
 	}
 

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/graphql/query/v1_0/Query.java
@@ -123,7 +123,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Document> getContentSpaceDocumentsPage(
+	public Collection<Document> getContentSpaceTreeDocumentsPage(
 			@GraphQLName("content-space-id") Long contentSpaceId,
 			@GraphQLName("filter") Filter filter,
 			@GraphQLName("pageSize") int pageSize,
@@ -135,7 +135,7 @@ public class Query {
 			this::_populateResourceContext,
 			documentResource -> {
 				Page paginationPage =
-					documentResource.getContentSpaceDocumentsPage(
+					documentResource.getContentSpaceTreeDocumentsPage(
 						contentSpaceId, filter, Pagination.of(pageSize, page),
 						sorts);
 
@@ -176,7 +176,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Folder> getContentSpaceFoldersPage(
+	public Collection<Folder> getContentSpaceTreeFoldersPage(
 			@GraphQLName("content-space-id") Long contentSpaceId,
 			@GraphQLName("filter") Filter filter,
 			@GraphQLName("pageSize") int pageSize,
@@ -187,9 +187,10 @@ public class Query {
 			_folderResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			folderResource -> {
-				Page paginationPage = folderResource.getContentSpaceFoldersPage(
-					contentSpaceId, filter, Pagination.of(pageSize, page),
-					sorts);
+				Page paginationPage =
+					folderResource.getContentSpaceTreeFoldersPage(
+						contentSpaceId, filter, Pagination.of(pageSize, page),
+						sorts);
 
 				return paginationPage.getItems();
 			});

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -74,10 +74,10 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 			@Parameter(in = ParameterIn.QUERY, name = "sorts")
 		}
 	)
-	@Path("/content-spaces/{content-space-id}/documents")
+	@Path("/content-spaces/{content-space-id}/tree/documents")
 	@Produces("application/json")
 	@Tags(value = {@Tag(name = "Document")})
-	public Page<Document> getContentSpaceDocumentsPage(
+	public Page<Document> getContentSpaceTreeDocumentsPage(
 			@NotNull @PathParam("content-space-id") Long contentSpaceId,
 			@Context Filter filter, @Context Pagination pagination,
 			@Context Sort[] sorts)
@@ -89,10 +89,10 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 	@Override
 	@Consumes("multipart/form-data")
 	@POST
-	@Path("/content-spaces/{content-space-id}/documents")
+	@Path("/content-spaces/{content-space-id}/tree/documents")
 	@Produces("application/json")
 	@Tags(value = {@Tag(name = "Document")})
-	public Document postContentSpaceDocument(
+	public Document postContentSpaceTreeDocument(
 			@NotNull @PathParam("content-space-id") Long contentSpaceId,
 			MultipartBody multipartBody)
 		throws Exception {

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseFolderResourceImpl.java
@@ -74,10 +74,10 @@ public abstract class BaseFolderResourceImpl implements FolderResource {
 			@Parameter(in = ParameterIn.QUERY, name = "sorts")
 		}
 	)
-	@Path("/content-spaces/{content-space-id}/folders")
+	@Path("/content-spaces/{content-space-id}/tree/folders")
 	@Produces("application/json")
 	@Tags(value = {@Tag(name = "Folder")})
-	public Page<Folder> getContentSpaceFoldersPage(
+	public Page<Folder> getContentSpaceTreeFoldersPage(
 			@NotNull @PathParam("content-space-id") Long contentSpaceId,
 			@Context Filter filter, @Context Pagination pagination,
 			@Context Sort[] sorts)
@@ -89,10 +89,10 @@ public abstract class BaseFolderResourceImpl implements FolderResource {
 	@Override
 	@Consumes("application/json")
 	@POST
-	@Path("/content-spaces/{content-space-id}/folders")
+	@Path("/content-spaces/{content-space-id}/tree/folders")
 	@Produces("application/json")
 	@Tags(value = {@Tag(name = "Folder")})
-	public Folder postContentSpaceFolder(
+	public Folder postContentSpaceTreeFolder(
 			@NotNull @PathParam("content-space-id") Long contentSpaceId,
 			Folder folder)
 		throws Exception {

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/DocumentResourceImpl.java
@@ -92,7 +92,7 @@ public class DocumentResourceImpl
 	}
 
 	@Override
-	public Page<Document> getContentSpaceDocumentsPage(
+	public Page<Document> getContentSpaceTreeDocumentsPage(
 			Long contentSpaceId, Filter filter, Pagination pagination,
 			Sort[] sorts)
 		throws Exception {
@@ -216,7 +216,7 @@ public class DocumentResourceImpl
 	}
 
 	@Override
-	public Document postContentSpaceDocument(
+	public Document postContentSpaceTreeDocument(
 			Long contentSpaceId, MultipartBody multipartBody)
 		throws Exception {
 

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/FolderResourceImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/FolderResourceImpl.java
@@ -64,7 +64,7 @@ public class FolderResourceImpl
 	}
 
 	@Override
-	public Page<Folder> getContentSpaceFoldersPage(
+	public Page<Folder> getContentSpaceTreeFoldersPage(
 			Long contentSpaceId, Filter filter, Pagination pagination,
 			Sort[] sorts)
 		throws Exception {
@@ -116,7 +116,7 @@ public class FolderResourceImpl
 	}
 
 	@Override
-	public Folder postContentSpaceFolder(Long contentSpaceId, Folder folder)
+	public Folder postContentSpaceTreeFolder(Long contentSpaceId, Folder folder)
 		throws Exception {
 
 		return _addFolder(contentSpaceId, 0L, folder);

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -111,18 +111,18 @@ public abstract class BaseDocumentResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpaceDocumentsPage() throws Exception {
+	public void testGetContentSpaceTreeDocumentsPage() throws Exception {
 		Long contentSpaceId =
-			testGetContentSpaceDocumentsPage_getContentSpaceId();
+			testGetContentSpaceTreeDocumentsPage_getContentSpaceId();
 		Long irrelevantContentSpaceId =
-			testGetContentSpaceDocumentsPage_getIrrelevantContentSpaceId();
+			testGetContentSpaceTreeDocumentsPage_getIrrelevantContentSpaceId();
 
 		if ((irrelevantContentSpaceId != null)) {
 			Document irrelevantDocument =
-				testGetContentSpaceDocumentsPage_addDocument(
+				testGetContentSpaceTreeDocumentsPage_addDocument(
 					irrelevantContentSpaceId, randomIrrelevantDocument());
 
-			Page<Document> page = invokeGetContentSpaceDocumentsPage(
+			Page<Document> page = invokeGetContentSpaceTreeDocumentsPage(
 				irrelevantContentSpaceId, null, Pagination.of(1, 2), null);
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -133,13 +133,13 @@ public abstract class BaseDocumentResourceTestCase {
 			assertValid(page);
 		}
 
-		Document document1 = testGetContentSpaceDocumentsPage_addDocument(
+		Document document1 = testGetContentSpaceTreeDocumentsPage_addDocument(
 			contentSpaceId, randomDocument());
 
-		Document document2 = testGetContentSpaceDocumentsPage_addDocument(
+		Document document2 = testGetContentSpaceTreeDocumentsPage_addDocument(
 			contentSpaceId, randomDocument());
 
-		Page<Document> page = invokeGetContentSpaceDocumentsPage(
+		Page<Document> page = invokeGetContentSpaceTreeDocumentsPage(
 			contentSpaceId, null, Pagination.of(1, 2), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
@@ -151,7 +151,7 @@ public abstract class BaseDocumentResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpaceDocumentsPageWithFilterDateTimeEquals()
+	public void testGetContentSpaceTreeDocumentsPageWithFilterDateTimeEquals()
 		throws Exception {
 
 		List<EntityField> entityFields = getEntityFields(
@@ -162,7 +162,7 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 
 		Long contentSpaceId =
-			testGetContentSpaceDocumentsPage_getContentSpaceId();
+			testGetContentSpaceTreeDocumentsPage_getContentSpaceId();
 
 		Document document1 = randomDocument();
 		Document document2 = randomDocument();
@@ -173,16 +173,16 @@ public abstract class BaseDocumentResourceTestCase {
 				DateUtils.addMinutes(new Date(), -2));
 		}
 
-		document1 = testGetContentSpaceDocumentsPage_addDocument(
+		document1 = testGetContentSpaceTreeDocumentsPage_addDocument(
 			contentSpaceId, document1);
 
 		Thread.sleep(1000);
 
-		document2 = testGetContentSpaceDocumentsPage_addDocument(
+		document2 = testGetContentSpaceTreeDocumentsPage_addDocument(
 			contentSpaceId, document2);
 
 		for (EntityField entityField : entityFields) {
-			Page<Document> page = invokeGetContentSpaceDocumentsPage(
+			Page<Document> page = invokeGetContentSpaceTreeDocumentsPage(
 				contentSpaceId, getFilterString(entityField, "eq", document1),
 				Pagination.of(1, 2), null);
 
@@ -193,7 +193,7 @@ public abstract class BaseDocumentResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpaceDocumentsPageWithFilterStringEquals()
+	public void testGetContentSpaceTreeDocumentsPageWithFilterStringEquals()
 		throws Exception {
 
 		List<EntityField> entityFields = getEntityFields(
@@ -204,17 +204,17 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 
 		Long contentSpaceId =
-			testGetContentSpaceDocumentsPage_getContentSpaceId();
+			testGetContentSpaceTreeDocumentsPage_getContentSpaceId();
 
-		Document document1 = testGetContentSpaceDocumentsPage_addDocument(
+		Document document1 = testGetContentSpaceTreeDocumentsPage_addDocument(
 			contentSpaceId, randomDocument());
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
-		Document document2 = testGetContentSpaceDocumentsPage_addDocument(
+		Document document2 = testGetContentSpaceTreeDocumentsPage_addDocument(
 			contentSpaceId, randomDocument());
 
 		for (EntityField entityField : entityFields) {
-			Page<Document> page = invokeGetContentSpaceDocumentsPage(
+			Page<Document> page = invokeGetContentSpaceTreeDocumentsPage(
 				contentSpaceId, getFilterString(entityField, "eq", document1),
 				Pagination.of(1, 2), null);
 
@@ -225,29 +225,29 @@ public abstract class BaseDocumentResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpaceDocumentsPageWithPagination()
+	public void testGetContentSpaceTreeDocumentsPageWithPagination()
 		throws Exception {
 
 		Long contentSpaceId =
-			testGetContentSpaceDocumentsPage_getContentSpaceId();
+			testGetContentSpaceTreeDocumentsPage_getContentSpaceId();
 
-		Document document1 = testGetContentSpaceDocumentsPage_addDocument(
+		Document document1 = testGetContentSpaceTreeDocumentsPage_addDocument(
 			contentSpaceId, randomDocument());
 
-		Document document2 = testGetContentSpaceDocumentsPage_addDocument(
+		Document document2 = testGetContentSpaceTreeDocumentsPage_addDocument(
 			contentSpaceId, randomDocument());
 
-		Document document3 = testGetContentSpaceDocumentsPage_addDocument(
+		Document document3 = testGetContentSpaceTreeDocumentsPage_addDocument(
 			contentSpaceId, randomDocument());
 
-		Page<Document> page1 = invokeGetContentSpaceDocumentsPage(
+		Page<Document> page1 = invokeGetContentSpaceTreeDocumentsPage(
 			contentSpaceId, null, Pagination.of(1, 2), null);
 
 		List<Document> documents1 = (List<Document>)page1.getItems();
 
 		Assert.assertEquals(documents1.toString(), 2, documents1.size());
 
-		Page<Document> page2 = invokeGetContentSpaceDocumentsPage(
+		Page<Document> page2 = invokeGetContentSpaceTreeDocumentsPage(
 			contentSpaceId, null, Pagination.of(2, 2), null);
 
 		Assert.assertEquals(3, page2.getTotalCount());
@@ -267,7 +267,7 @@ public abstract class BaseDocumentResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpaceDocumentsPageWithSortDateTime()
+	public void testGetContentSpaceTreeDocumentsPageWithSortDateTime()
 		throws Exception {
 
 		List<EntityField> entityFields = getEntityFields(
@@ -278,7 +278,7 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 
 		Long contentSpaceId =
-			testGetContentSpaceDocumentsPage_getContentSpaceId();
+			testGetContentSpaceTreeDocumentsPage_getContentSpaceId();
 
 		Document document1 = randomDocument();
 		Document document2 = randomDocument();
@@ -289,16 +289,16 @@ public abstract class BaseDocumentResourceTestCase {
 				DateUtils.addMinutes(new Date(), -2));
 		}
 
-		document1 = testGetContentSpaceDocumentsPage_addDocument(
+		document1 = testGetContentSpaceTreeDocumentsPage_addDocument(
 			contentSpaceId, document1);
 
 		Thread.sleep(1000);
 
-		document2 = testGetContentSpaceDocumentsPage_addDocument(
+		document2 = testGetContentSpaceTreeDocumentsPage_addDocument(
 			contentSpaceId, document2);
 
 		for (EntityField entityField : entityFields) {
-			Page<Document> ascPage = invokeGetContentSpaceDocumentsPage(
+			Page<Document> ascPage = invokeGetContentSpaceTreeDocumentsPage(
 				contentSpaceId, null, Pagination.of(1, 2),
 				entityField.getName() + ":asc");
 
@@ -306,7 +306,7 @@ public abstract class BaseDocumentResourceTestCase {
 				Arrays.asList(document1, document2),
 				(List<Document>)ascPage.getItems());
 
-			Page<Document> descPage = invokeGetContentSpaceDocumentsPage(
+			Page<Document> descPage = invokeGetContentSpaceTreeDocumentsPage(
 				contentSpaceId, null, Pagination.of(1, 2),
 				entityField.getName() + ":desc");
 
@@ -317,7 +317,7 @@ public abstract class BaseDocumentResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpaceDocumentsPageWithSortString()
+	public void testGetContentSpaceTreeDocumentsPageWithSortString()
 		throws Exception {
 
 		List<EntityField> entityFields = getEntityFields(
@@ -328,7 +328,7 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 
 		Long contentSpaceId =
-			testGetContentSpaceDocumentsPage_getContentSpaceId();
+			testGetContentSpaceTreeDocumentsPage_getContentSpaceId();
 
 		Document document1 = randomDocument();
 		Document document2 = randomDocument();
@@ -338,14 +338,14 @@ public abstract class BaseDocumentResourceTestCase {
 			BeanUtils.setProperty(document2, entityField.getName(), "Bbb");
 		}
 
-		document1 = testGetContentSpaceDocumentsPage_addDocument(
+		document1 = testGetContentSpaceTreeDocumentsPage_addDocument(
 			contentSpaceId, document1);
 
-		document2 = testGetContentSpaceDocumentsPage_addDocument(
+		document2 = testGetContentSpaceTreeDocumentsPage_addDocument(
 			contentSpaceId, document2);
 
 		for (EntityField entityField : entityFields) {
-			Page<Document> ascPage = invokeGetContentSpaceDocumentsPage(
+			Page<Document> ascPage = invokeGetContentSpaceTreeDocumentsPage(
 				contentSpaceId, null, Pagination.of(1, 2),
 				entityField.getName() + ":asc");
 
@@ -353,7 +353,7 @@ public abstract class BaseDocumentResourceTestCase {
 				Arrays.asList(document1, document2),
 				(List<Document>)ascPage.getItems());
 
-			Page<Document> descPage = invokeGetContentSpaceDocumentsPage(
+			Page<Document> descPage = invokeGetContentSpaceTreeDocumentsPage(
 				contentSpaceId, null, Pagination.of(1, 2),
 				entityField.getName() + ":desc");
 
@@ -363,7 +363,7 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 	}
 
-	protected Document testGetContentSpaceDocumentsPage_addDocument(
+	protected Document testGetContentSpaceTreeDocumentsPage_addDocument(
 			Long contentSpaceId, Document document)
 		throws Exception {
 
@@ -371,20 +371,20 @@ public abstract class BaseDocumentResourceTestCase {
 			"This method needs to be implemented");
 	}
 
-	protected Long testGetContentSpaceDocumentsPage_getContentSpaceId()
+	protected Long testGetContentSpaceTreeDocumentsPage_getContentSpaceId()
 		throws Exception {
 
 		return testGroup.getGroupId();
 	}
 
 	protected Long
-			testGetContentSpaceDocumentsPage_getIrrelevantContentSpaceId()
+			testGetContentSpaceTreeDocumentsPage_getIrrelevantContentSpaceId()
 		throws Exception {
 
 		return irrelevantGroup.getGroupId();
 	}
 
-	protected Page<Document> invokeGetContentSpaceDocumentsPage(
+	protected Page<Document> invokeGetContentSpaceTreeDocumentsPage(
 			Long contentSpaceId, String filterString, Pagination pagination,
 			String sortString)
 		throws Exception {
@@ -394,7 +394,7 @@ public abstract class BaseDocumentResourceTestCase {
 		String location =
 			_resourceURL +
 				_toPath(
-					"/content-spaces/{content-space-id}/documents",
+					"/content-spaces/{content-space-id}/tree/documents",
 					contentSpaceId);
 
 		location = HttpUtil.addParameter(location, "filter", filterString);
@@ -416,7 +416,7 @@ public abstract class BaseDocumentResourceTestCase {
 			});
 	}
 
-	protected Http.Response invokeGetContentSpaceDocumentsPageResponse(
+	protected Http.Response invokeGetContentSpaceTreeDocumentsPageResponse(
 			Long contentSpaceId, String filterString, Pagination pagination,
 			String sortString)
 		throws Exception {
@@ -426,7 +426,7 @@ public abstract class BaseDocumentResourceTestCase {
 		String location =
 			_resourceURL +
 				_toPath(
-					"/content-spaces/{content-space-id}/documents",
+					"/content-spaces/{content-space-id}/tree/documents",
 					contentSpaceId);
 
 		location = HttpUtil.addParameter(location, "filter", filterString);
@@ -446,11 +446,11 @@ public abstract class BaseDocumentResourceTestCase {
 	}
 
 	@Test
-	public void testPostContentSpaceDocument() throws Exception {
+	public void testPostContentSpaceTreeDocument() throws Exception {
 		Assert.assertTrue(true);
 	}
 
-	protected Document testPostContentSpaceDocument_addDocument(
+	protected Document testPostContentSpaceTreeDocument_addDocument(
 			Document document)
 		throws Exception {
 
@@ -458,7 +458,7 @@ public abstract class BaseDocumentResourceTestCase {
 			"This method needs to be implemented");
 	}
 
-	protected Document invokePostContentSpaceDocument(
+	protected Document invokePostContentSpaceTreeDocument(
 			Long contentSpaceId, MultipartBody multipartBody)
 		throws Exception {
 
@@ -467,7 +467,7 @@ public abstract class BaseDocumentResourceTestCase {
 		String location =
 			_resourceURL +
 				_toPath(
-					"/content-spaces/{content-space-id}/documents",
+					"/content-spaces/{content-space-id}/tree/documents",
 					contentSpaceId);
 
 		options.setLocation(location);
@@ -486,7 +486,7 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 	}
 
-	protected Http.Response invokePostContentSpaceDocumentResponse(
+	protected Http.Response invokePostContentSpaceTreeDocumentResponse(
 			Long contentSpaceId, MultipartBody multipartBody)
 		throws Exception {
 
@@ -495,7 +495,7 @@ public abstract class BaseDocumentResourceTestCase {
 		String location =
 			_resourceURL +
 				_toPath(
-					"/content-spaces/{content-space-id}/documents",
+					"/content-spaces/{content-space-id}/tree/documents",
 					contentSpaceId);
 
 		options.setLocation(location);

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseFolderResourceTestCase.java
@@ -112,17 +112,18 @@ public abstract class BaseFolderResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpaceFoldersPage() throws Exception {
+	public void testGetContentSpaceTreeFoldersPage() throws Exception {
 		Long contentSpaceId =
-			testGetContentSpaceFoldersPage_getContentSpaceId();
+			testGetContentSpaceTreeFoldersPage_getContentSpaceId();
 		Long irrelevantContentSpaceId =
-			testGetContentSpaceFoldersPage_getIrrelevantContentSpaceId();
+			testGetContentSpaceTreeFoldersPage_getIrrelevantContentSpaceId();
 
 		if ((irrelevantContentSpaceId != null)) {
-			Folder irrelevantFolder = testGetContentSpaceFoldersPage_addFolder(
-				irrelevantContentSpaceId, randomIrrelevantFolder());
+			Folder irrelevantFolder =
+				testGetContentSpaceTreeFoldersPage_addFolder(
+					irrelevantContentSpaceId, randomIrrelevantFolder());
 
-			Page<Folder> page = invokeGetContentSpaceFoldersPage(
+			Page<Folder> page = invokeGetContentSpaceTreeFoldersPage(
 				irrelevantContentSpaceId, null, Pagination.of(1, 2), null);
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -132,13 +133,13 @@ public abstract class BaseFolderResourceTestCase {
 			assertValid(page);
 		}
 
-		Folder folder1 = testGetContentSpaceFoldersPage_addFolder(
+		Folder folder1 = testGetContentSpaceTreeFoldersPage_addFolder(
 			contentSpaceId, randomFolder());
 
-		Folder folder2 = testGetContentSpaceFoldersPage_addFolder(
+		Folder folder2 = testGetContentSpaceTreeFoldersPage_addFolder(
 			contentSpaceId, randomFolder());
 
-		Page<Folder> page = invokeGetContentSpaceFoldersPage(
+		Page<Folder> page = invokeGetContentSpaceTreeFoldersPage(
 			contentSpaceId, null, Pagination.of(1, 2), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
@@ -149,7 +150,7 @@ public abstract class BaseFolderResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpaceFoldersPageWithFilterDateTimeEquals()
+	public void testGetContentSpaceTreeFoldersPageWithFilterDateTimeEquals()
 		throws Exception {
 
 		List<EntityField> entityFields = getEntityFields(
@@ -160,7 +161,7 @@ public abstract class BaseFolderResourceTestCase {
 		}
 
 		Long contentSpaceId =
-			testGetContentSpaceFoldersPage_getContentSpaceId();
+			testGetContentSpaceTreeFoldersPage_getContentSpaceId();
 
 		Folder folder1 = randomFolder();
 		Folder folder2 = randomFolder();
@@ -171,16 +172,16 @@ public abstract class BaseFolderResourceTestCase {
 				DateUtils.addMinutes(new Date(), -2));
 		}
 
-		folder1 = testGetContentSpaceFoldersPage_addFolder(
+		folder1 = testGetContentSpaceTreeFoldersPage_addFolder(
 			contentSpaceId, folder1);
 
 		Thread.sleep(1000);
 
-		folder2 = testGetContentSpaceFoldersPage_addFolder(
+		folder2 = testGetContentSpaceTreeFoldersPage_addFolder(
 			contentSpaceId, folder2);
 
 		for (EntityField entityField : entityFields) {
-			Page<Folder> page = invokeGetContentSpaceFoldersPage(
+			Page<Folder> page = invokeGetContentSpaceTreeFoldersPage(
 				contentSpaceId, getFilterString(entityField, "eq", folder1),
 				Pagination.of(1, 2), null);
 
@@ -191,7 +192,7 @@ public abstract class BaseFolderResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpaceFoldersPageWithFilterStringEquals()
+	public void testGetContentSpaceTreeFoldersPageWithFilterStringEquals()
 		throws Exception {
 
 		List<EntityField> entityFields = getEntityFields(
@@ -202,17 +203,17 @@ public abstract class BaseFolderResourceTestCase {
 		}
 
 		Long contentSpaceId =
-			testGetContentSpaceFoldersPage_getContentSpaceId();
+			testGetContentSpaceTreeFoldersPage_getContentSpaceId();
 
-		Folder folder1 = testGetContentSpaceFoldersPage_addFolder(
+		Folder folder1 = testGetContentSpaceTreeFoldersPage_addFolder(
 			contentSpaceId, randomFolder());
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
-		Folder folder2 = testGetContentSpaceFoldersPage_addFolder(
+		Folder folder2 = testGetContentSpaceTreeFoldersPage_addFolder(
 			contentSpaceId, randomFolder());
 
 		for (EntityField entityField : entityFields) {
-			Page<Folder> page = invokeGetContentSpaceFoldersPage(
+			Page<Folder> page = invokeGetContentSpaceTreeFoldersPage(
 				contentSpaceId, getFilterString(entityField, "eq", folder1),
 				Pagination.of(1, 2), null);
 
@@ -223,29 +224,29 @@ public abstract class BaseFolderResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpaceFoldersPageWithPagination()
+	public void testGetContentSpaceTreeFoldersPageWithPagination()
 		throws Exception {
 
 		Long contentSpaceId =
-			testGetContentSpaceFoldersPage_getContentSpaceId();
+			testGetContentSpaceTreeFoldersPage_getContentSpaceId();
 
-		Folder folder1 = testGetContentSpaceFoldersPage_addFolder(
+		Folder folder1 = testGetContentSpaceTreeFoldersPage_addFolder(
 			contentSpaceId, randomFolder());
 
-		Folder folder2 = testGetContentSpaceFoldersPage_addFolder(
+		Folder folder2 = testGetContentSpaceTreeFoldersPage_addFolder(
 			contentSpaceId, randomFolder());
 
-		Folder folder3 = testGetContentSpaceFoldersPage_addFolder(
+		Folder folder3 = testGetContentSpaceTreeFoldersPage_addFolder(
 			contentSpaceId, randomFolder());
 
-		Page<Folder> page1 = invokeGetContentSpaceFoldersPage(
+		Page<Folder> page1 = invokeGetContentSpaceTreeFoldersPage(
 			contentSpaceId, null, Pagination.of(1, 2), null);
 
 		List<Folder> folders1 = (List<Folder>)page1.getItems();
 
 		Assert.assertEquals(folders1.toString(), 2, folders1.size());
 
-		Page<Folder> page2 = invokeGetContentSpaceFoldersPage(
+		Page<Folder> page2 = invokeGetContentSpaceTreeFoldersPage(
 			contentSpaceId, null, Pagination.of(2, 2), null);
 
 		Assert.assertEquals(3, page2.getTotalCount());
@@ -265,7 +266,7 @@ public abstract class BaseFolderResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpaceFoldersPageWithSortDateTime()
+	public void testGetContentSpaceTreeFoldersPageWithSortDateTime()
 		throws Exception {
 
 		List<EntityField> entityFields = getEntityFields(
@@ -276,7 +277,7 @@ public abstract class BaseFolderResourceTestCase {
 		}
 
 		Long contentSpaceId =
-			testGetContentSpaceFoldersPage_getContentSpaceId();
+			testGetContentSpaceTreeFoldersPage_getContentSpaceId();
 
 		Folder folder1 = randomFolder();
 		Folder folder2 = randomFolder();
@@ -287,16 +288,16 @@ public abstract class BaseFolderResourceTestCase {
 				DateUtils.addMinutes(new Date(), -2));
 		}
 
-		folder1 = testGetContentSpaceFoldersPage_addFolder(
+		folder1 = testGetContentSpaceTreeFoldersPage_addFolder(
 			contentSpaceId, folder1);
 
 		Thread.sleep(1000);
 
-		folder2 = testGetContentSpaceFoldersPage_addFolder(
+		folder2 = testGetContentSpaceTreeFoldersPage_addFolder(
 			contentSpaceId, folder2);
 
 		for (EntityField entityField : entityFields) {
-			Page<Folder> ascPage = invokeGetContentSpaceFoldersPage(
+			Page<Folder> ascPage = invokeGetContentSpaceTreeFoldersPage(
 				contentSpaceId, null, Pagination.of(1, 2),
 				entityField.getName() + ":asc");
 
@@ -304,7 +305,7 @@ public abstract class BaseFolderResourceTestCase {
 				Arrays.asList(folder1, folder2),
 				(List<Folder>)ascPage.getItems());
 
-			Page<Folder> descPage = invokeGetContentSpaceFoldersPage(
+			Page<Folder> descPage = invokeGetContentSpaceTreeFoldersPage(
 				contentSpaceId, null, Pagination.of(1, 2),
 				entityField.getName() + ":desc");
 
@@ -315,7 +316,7 @@ public abstract class BaseFolderResourceTestCase {
 	}
 
 	@Test
-	public void testGetContentSpaceFoldersPageWithSortString()
+	public void testGetContentSpaceTreeFoldersPageWithSortString()
 		throws Exception {
 
 		List<EntityField> entityFields = getEntityFields(
@@ -326,7 +327,7 @@ public abstract class BaseFolderResourceTestCase {
 		}
 
 		Long contentSpaceId =
-			testGetContentSpaceFoldersPage_getContentSpaceId();
+			testGetContentSpaceTreeFoldersPage_getContentSpaceId();
 
 		Folder folder1 = randomFolder();
 		Folder folder2 = randomFolder();
@@ -336,14 +337,14 @@ public abstract class BaseFolderResourceTestCase {
 			BeanUtils.setProperty(folder2, entityField.getName(), "Bbb");
 		}
 
-		folder1 = testGetContentSpaceFoldersPage_addFolder(
+		folder1 = testGetContentSpaceTreeFoldersPage_addFolder(
 			contentSpaceId, folder1);
 
-		folder2 = testGetContentSpaceFoldersPage_addFolder(
+		folder2 = testGetContentSpaceTreeFoldersPage_addFolder(
 			contentSpaceId, folder2);
 
 		for (EntityField entityField : entityFields) {
-			Page<Folder> ascPage = invokeGetContentSpaceFoldersPage(
+			Page<Folder> ascPage = invokeGetContentSpaceTreeFoldersPage(
 				contentSpaceId, null, Pagination.of(1, 2),
 				entityField.getName() + ":asc");
 
@@ -351,7 +352,7 @@ public abstract class BaseFolderResourceTestCase {
 				Arrays.asList(folder1, folder2),
 				(List<Folder>)ascPage.getItems());
 
-			Page<Folder> descPage = invokeGetContentSpaceFoldersPage(
+			Page<Folder> descPage = invokeGetContentSpaceTreeFoldersPage(
 				contentSpaceId, null, Pagination.of(1, 2),
 				entityField.getName() + ":desc");
 
@@ -361,7 +362,7 @@ public abstract class BaseFolderResourceTestCase {
 		}
 	}
 
-	protected Folder testGetContentSpaceFoldersPage_addFolder(
+	protected Folder testGetContentSpaceTreeFoldersPage_addFolder(
 			Long contentSpaceId, Folder folder)
 		throws Exception {
 
@@ -369,19 +370,20 @@ public abstract class BaseFolderResourceTestCase {
 			"This method needs to be implemented");
 	}
 
-	protected Long testGetContentSpaceFoldersPage_getContentSpaceId()
+	protected Long testGetContentSpaceTreeFoldersPage_getContentSpaceId()
 		throws Exception {
 
 		return testGroup.getGroupId();
 	}
 
-	protected Long testGetContentSpaceFoldersPage_getIrrelevantContentSpaceId()
+	protected Long
+			testGetContentSpaceTreeFoldersPage_getIrrelevantContentSpaceId()
 		throws Exception {
 
 		return irrelevantGroup.getGroupId();
 	}
 
-	protected Page<Folder> invokeGetContentSpaceFoldersPage(
+	protected Page<Folder> invokeGetContentSpaceTreeFoldersPage(
 			Long contentSpaceId, String filterString, Pagination pagination,
 			String sortString)
 		throws Exception {
@@ -391,7 +393,7 @@ public abstract class BaseFolderResourceTestCase {
 		String location =
 			_resourceURL +
 				_toPath(
-					"/content-spaces/{content-space-id}/folders",
+					"/content-spaces/{content-space-id}/tree/folders",
 					contentSpaceId);
 
 		location = HttpUtil.addParameter(location, "filter", filterString);
@@ -413,7 +415,7 @@ public abstract class BaseFolderResourceTestCase {
 			});
 	}
 
-	protected Http.Response invokeGetContentSpaceFoldersPageResponse(
+	protected Http.Response invokeGetContentSpaceTreeFoldersPageResponse(
 			Long contentSpaceId, String filterString, Pagination pagination,
 			String sortString)
 		throws Exception {
@@ -423,7 +425,7 @@ public abstract class BaseFolderResourceTestCase {
 		String location =
 			_resourceURL +
 				_toPath(
-					"/content-spaces/{content-space-id}/folders",
+					"/content-spaces/{content-space-id}/tree/folders",
 					contentSpaceId);
 
 		location = HttpUtil.addParameter(location, "filter", filterString);
@@ -443,23 +445,24 @@ public abstract class BaseFolderResourceTestCase {
 	}
 
 	@Test
-	public void testPostContentSpaceFolder() throws Exception {
+	public void testPostContentSpaceTreeFolder() throws Exception {
 		Folder randomFolder = randomFolder();
 
-		Folder postFolder = testPostContentSpaceFolder_addFolder(randomFolder);
+		Folder postFolder = testPostContentSpaceTreeFolder_addFolder(
+			randomFolder);
 
 		assertEquals(randomFolder, postFolder);
 		assertValid(postFolder);
 	}
 
-	protected Folder testPostContentSpaceFolder_addFolder(Folder folder)
+	protected Folder testPostContentSpaceTreeFolder_addFolder(Folder folder)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
 	}
 
-	protected Folder invokePostContentSpaceFolder(
+	protected Folder invokePostContentSpaceTreeFolder(
 			Long contentSpaceId, Folder folder)
 		throws Exception {
 
@@ -472,7 +475,7 @@ public abstract class BaseFolderResourceTestCase {
 		String location =
 			_resourceURL +
 				_toPath(
-					"/content-spaces/{content-space-id}/folders",
+					"/content-spaces/{content-space-id}/tree/folders",
 					contentSpaceId);
 
 		options.setLocation(location);
@@ -491,7 +494,7 @@ public abstract class BaseFolderResourceTestCase {
 		}
 	}
 
-	protected Http.Response invokePostContentSpaceFolderResponse(
+	protected Http.Response invokePostContentSpaceTreeFolderResponse(
 			Long contentSpaceId, Folder folder)
 		throws Exception {
 
@@ -504,7 +507,7 @@ public abstract class BaseFolderResourceTestCase {
 		String location =
 			_resourceURL +
 				_toPath(
-					"/content-spaces/{content-space-id}/folders",
+					"/content-spaces/{content-space-id}/tree/folders",
 					contentSpaceId);
 
 		options.setLocation(location);


### PR DESCRIPTION
Hi Brian!

We want to use the path 'tree' to indicate that we are not listing all documents/articles, just the ones that are under the the root folder of that group. With that path we want to indicate that these APIs can be navigated like a folder, a tree structure.

We'll implement also the paths without it (content-spaces/_id_/documents) that will return all the elements in the group. 

If you are Ok with the pattern we'll send a PR later implementing it in all the APIs (structured content also has to have folders).