### PR TITLE
LPS-92462 add child information

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
@@ -44,13 +44,20 @@ import javax.xml.bind.annotation.XmlRootElement;
 			</#list>
 		}
 	)
-	@JsonTypeInfo(include = JsonTypeInfo.As.PROPERTY, property = "type", use = JsonTypeInfo.Id.NAME)
+	@JsonTypeInfo(include = JsonTypeInfo.As.PROPERTY, property = "childType", use = JsonTypeInfo.Id.NAME)
+</#if>
+<#assign dtoParentClassName = freeMarkerTool.getDTOParentClassName(openAPIYAML, schemaName)!/>
+<#if dtoParentClassName?has_content>
+	@JsonTypeInfo(
+		use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "childType",
+		defaultImpl = ${schemaName}.class
+	)
 </#if>
 @Generated("")
 @GraphQLName("${schemaName}")
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "${schemaName}")
-public class ${schemaName} <#if freeMarkerTool.getDTOParentClassName(openAPIYAML, schemaName)??>extends ${freeMarkerTool.getDTOParentClassName(openAPIYAML, schemaName)}</#if> {
+public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoParentClassName}</#if> {
 	<#assign enumSchemas = freeMarkerTool.getDTOEnumSchemas(schema) />
 
 	<#list enumSchemas?keys as enumName>


### PR DESCRIPTION
This is needed for @ruben-pulido PR. The inheritance we have right now allows to send a PUT/POST to a ContentElement endpoint (for example) and needs a discriminator property to be able to know which class to instantiate.

But if you do a POST to a StructuredContent endpoint (that inherits ContentElement) jackson should know already which class to use and shouldn't need the extra property. This allows that behaviour :)

Should fix https://github.com/brianchandotcom/liferay-portal/pull/69860/commits/d5b1b338acdcc94618be5dfcddca47320fc55f7a