### PR TITLE
LPS-91799 Add post method to manage permissions for data definition objects

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/dto/v1_0/DataDefinitionPermission.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/dto/v1_0/DataDefinitionPermission.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.data.engine.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Jeyvison Nascimento
+ * @generated
+ */
+@Generated("")
+@GraphQLName("DataDefinitionPermission")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "DataDefinitionPermission")
+public class DataDefinitionPermission {
+
+	public Boolean getDelete() {
+		return delete;
+	}
+
+	public void setDelete(Boolean delete) {
+		this.delete = delete;
+	}
+
+	@JsonIgnore
+	public void setDelete(
+		UnsafeSupplier<Boolean, Exception> deleteUnsafeSupplier) {
+
+		try {
+			delete = deleteUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean delete;
+
+	public String[] getRoleNames() {
+		return roleNames;
+	}
+
+	public void setRoleNames(String[] roleNames) {
+		this.roleNames = roleNames;
+	}
+
+	@JsonIgnore
+	public void setRoleNames(
+		UnsafeSupplier<String[], Exception> roleNamesUnsafeSupplier) {
+
+		try {
+			roleNames = roleNamesUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String[] roleNames;
+
+	public Boolean getUpdate() {
+		return update;
+	}
+
+	public void setUpdate(Boolean update) {
+		this.update = update;
+	}
+
+	@JsonIgnore
+	public void setUpdate(
+		UnsafeSupplier<Boolean, Exception> updateUnsafeSupplier) {
+
+		try {
+			update = updateUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean update;
+
+	public Boolean getView() {
+		return view;
+	}
+
+	public void setView(Boolean view) {
+		this.view = view;
+	}
+
+	@JsonIgnore
+	public void setView(UnsafeSupplier<Boolean, Exception> viewUnsafeSupplier) {
+		try {
+			view = viewUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean view;
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		sb.append("\"delete\": ");
+
+		sb.append(delete);
+		sb.append(", ");
+
+		sb.append("\"roleNames\": ");
+
+		if (roleNames == null) {
+			sb.append("null");
+		}
+		else {
+			sb.append("[");
+
+			for (int i = 0; i < roleNames.length; i++) {
+				sb.append("\"");
+				sb.append(roleNames[i]);
+				sb.append("\"");
+
+				if ((i + 1) < roleNames.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		sb.append(", ");
+
+		sb.append("\"update\": ");
+
+		sb.append(update);
+		sb.append(", ");
+
+		sb.append("\"view\": ");
+
+		sb.append(view);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v1_0/DataDefinitionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v1_0/DataDefinitionResource.java
@@ -15,6 +15,7 @@
 package com.liferay.data.engine.rest.resource.v1_0;
 
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinition;
+import com.liferay.data.engine.rest.dto.v1_0.DataDefinitionPermission;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -38,6 +39,11 @@ public interface DataDefinitionResource {
 
 	public DataDefinition postContentSpaceDataDefinition(
 			Long contentSpaceId, DataDefinition dataDefinition)
+		throws Exception;
+
+	public boolean postDataDefinitionPermission(
+			Long dataDefinitionId, String operation,
+			DataDefinitionPermission dataDefinitionPermission)
 		throws Exception;
 
 	public boolean deleteDataDefinition(Long dataDefinitionId) throws Exception;

--- a/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
+++ b/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
@@ -63,6 +63,20 @@ components:
                         $ref: '#/components/schemas/LocalizedValue'
                     type: array
             type: object
+        DataDefinitionPermission:
+            properties:
+                delete:
+                    type: boolean
+                update:
+                    type: boolean
+                view:
+                    type: boolean
+                roleNames:
+                    items:
+                        type: string
+                    type:
+                        array
+            type: object
         DataDefinitionRule:
             properties:
                 dataDefinitionFieldNames:
@@ -320,6 +334,32 @@ paths:
                                 type: array
                     description: ""
             tags: ["DataRecordCollection"]
+    "/data-definitions/{data-definition-id}/permissions":
+        post:
+            parameters:
+                - in: path
+                  name: data-definition-id
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: query
+                  name: operation
+                  required: true
+                  schema:
+                      type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/DataDefinitionPermission"
+                description: ""
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                    description: ""
+            tags: ["DataDefinition"]
     "/data-definitions/{data-definition-id}":
         delete:
             parameters:

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/constants/DataActionKeys.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/constants/DataActionKeys.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.data.engine.rest.internal.constants;
+
+/**
+ * @author Jeyvison Nascimento
+ */
+public class DataActionKeys {
+
+	public static final String ADD_DATA_DEFINITION = "ADD_DATA_DEFINITION";
+
+}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/constants/PermissionConstants.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/constants/PermissionConstants.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.data.engine.rest.internal.constants;
+
+/**
+ * @author Jeyvison Nascimento
+ */
+public class PermissionConstants {
+
+	public static final String RESOURCE_NAME = "com.liferay.data.engine";
+
+}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/constants/PermissionConstants.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/constants/PermissionConstants.java
@@ -19,6 +19,10 @@ package com.liferay.data.engine.rest.internal.constants;
  */
 public class PermissionConstants {
 
+	public static final String DELETE_PERMISSION_OPERATION = "DELETE";
+
 	public static final String RESOURCE_NAME = "com.liferay.data.engine";
+
+	public static final String SAVE_PERMISSION_OPERATION = "SAVE";
 
 }

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -15,6 +15,7 @@
 package com.liferay.data.engine.rest.internal.graphql.mutation.v1_0;
 
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinition;
+import com.liferay.data.engine.rest.dto.v1_0.DataDefinitionPermission;
 import com.liferay.data.engine.rest.dto.v1_0.DataLayout;
 import com.liferay.data.engine.rest.dto.v1_0.DataRecord;
 import com.liferay.data.engine.rest.dto.v1_0.DataRecordCollection;
@@ -87,6 +88,23 @@ public class Mutation {
 			dataDefinitionResource ->
 				dataDefinitionResource.postContentSpaceDataDefinition(
 					contentSpaceId, dataDefinition));
+	}
+
+	@GraphQLField
+	@GraphQLInvokeDetached
+	public boolean postDataDefinitionPermission(
+			@GraphQLName("data-definition-id") Long dataDefinitionId,
+			@GraphQLName("operation") String operation,
+			@GraphQLName("DataDefinitionPermission") DataDefinitionPermission
+				dataDefinitionPermission)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_dataDefinitionResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			dataDefinitionResource ->
+				dataDefinitionResource.postDataDefinitionPermission(
+					dataDefinitionId, operation, dataDefinitionPermission));
 	}
 
 	@GraphQLInvokeDetached

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/BaseDataDefinitionResourceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.data.engine.rest.internal.resource.v1_0;
 
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinition;
+import com.liferay.data.engine.rest.dto.v1_0.DataDefinitionPermission;
 import com.liferay.data.engine.rest.resource.v1_0.DataDefinitionResource;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
@@ -94,6 +95,21 @@ public abstract class BaseDataDefinitionResourceImpl
 		throws Exception {
 
 		return new DataDefinition();
+	}
+
+	@Override
+	@Consumes("application/json")
+	@POST
+	@Path("/data-definitions/{data-definition-id}/permissions")
+	@Produces("application/json")
+	@Tags(value = {@Tag(name = "DataDefinition")})
+	public boolean postDataDefinitionPermission(
+			@NotNull @PathParam("data-definition-id") Long dataDefinitionId,
+			@NotNull @QueryParam("operation") String operation,
+			DataDefinitionPermission dataDefinitionPermission)
+		throws Exception {
+
+		return false;
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/DataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/DataDefinitionResourceImpl.java
@@ -15,6 +15,8 @@
 package com.liferay.data.engine.rest.internal.resource.v1_0;
 
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinition;
+import com.liferay.data.engine.rest.internal.constants.DataActionKeys;
+import com.liferay.data.engine.rest.internal.constants.PermissionConstants;
 import com.liferay.data.engine.rest.internal.dto.v1_0.util.DataDefinitionUtil;
 import com.liferay.data.engine.rest.internal.dto.v1_0.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.internal.model.InternalDataDefinition;
@@ -114,7 +116,7 @@ public class DataDefinitionResourceImpl extends BaseDataDefinitionResourceImpl {
 			Long contentSpaceId, DataDefinition dataDefinition)
 		throws Exception {
 
-		_checkPermission(contentSpaceId, "ADD_DATA_DEFINITION");
+		_checkPermission(contentSpaceId, DataActionKeys.ADD_DATA_DEFINITION);
 
 		return DataDefinitionUtil.toDataDefinition(
 			_ddmStructureLocalService.addStructure(
@@ -171,13 +173,13 @@ public class DataDefinitionResourceImpl extends BaseDataDefinitionResourceImpl {
 			group = group.getLiveGroup();
 		}
 
-		String resourceName = "com.liferay.data.engine";
-
 		if (!permissionChecker.hasPermission(
-				group, resourceName, contentSpaceId, actionId)) {
+				group, PermissionConstants.RESOURCE_NAME, contentSpaceId,
+				actionId)) {
 
 			throw new PrincipalException.MustHavePermission(
-				permissionChecker, resourceName, contentSpaceId, actionId);
+				permissionChecker, PermissionConstants.RESOURCE_NAME,
+				contentSpaceId, actionId);
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/DataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/DataDefinitionResourceImpl.java
@@ -15,17 +15,25 @@
 package com.liferay.data.engine.rest.internal.resource.v1_0;
 
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinition;
+import com.liferay.data.engine.rest.dto.v1_0.DataDefinitionPermission;
 import com.liferay.data.engine.rest.internal.constants.DataActionKeys;
+import com.liferay.data.engine.rest.internal.constants.DataDefinitionConstants;
 import com.liferay.data.engine.rest.internal.constants.PermissionConstants;
 import com.liferay.data.engine.rest.internal.dto.v1_0.util.DataDefinitionUtil;
 import com.liferay.data.engine.rest.internal.dto.v1_0.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.internal.model.InternalDataDefinition;
 import com.liferay.data.engine.rest.resource.v1_0.DataDefinitionResource;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMStructureConstants;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureService;
+import com.liferay.portal.kernel.exception.NoSuchRoleException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -33,11 +41,24 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.permission.ModelPermissions;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+import javax.ws.rs.BadRequestException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -61,6 +82,107 @@ public class DataDefinitionResourceImpl extends BaseDataDefinitionResourceImpl {
 			ActionKeys.DELETE);
 
 		_ddmStructureLocalService.deleteStructure(dataDefinitionId);
+
+		return true;
+	}
+
+	@Override
+	public boolean postDataDefinitionPermission(
+			@NotNull Long dataDefinitionId, @NotNull String operation,
+			DataDefinitionPermission dataDefinitionPermission)
+		throws Exception {
+
+		if (Validator.isNull(operation) ||
+			ArrayUtil.contains(
+				new String[] {
+					PermissionConstants.SAVE_PERMISSION_OPERATION,
+				PermissionConstants.DELETE_PERMISSION_OPERATION
+					},
+				operation, true)) {
+
+			throw new BadRequestException(
+				"Operation parameter must be 'save' or 'delete'");
+		}
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
+			dataDefinitionId);
+
+		_checkPermission(
+			ddmStructure.getGroupId(), ActionKeys.DEFINE_PERMISSIONS);
+
+		List<String> actionIds = new ArrayList<>();
+
+		if (dataDefinitionPermission.getDelete()) {
+			actionIds.add(ActionKeys.DELETE);
+		}
+
+		if (dataDefinitionPermission.getUpdate()) {
+			actionIds.add(ActionKeys.UPDATE);
+		}
+
+		if (dataDefinitionPermission.getView()) {
+			actionIds.add(ActionKeys.VIEW);
+		}
+
+		if (actionIds.isEmpty()) {
+			return false;
+		}
+
+		List<String> roleNames = ListUtil.fromArray(
+			dataDefinitionPermission.getRoleNames());
+
+		if (PermissionConstants.SAVE_PERMISSION_OPERATION.equalsIgnoreCase(
+				operation)) {
+
+			ModelPermissions modelPermissions = new ModelPermissions();
+
+			for (String roleName : roleNames) {
+				modelPermissions.addRolePermissions(
+					roleName, ArrayUtil.toStringArray(actionIds));
+			}
+
+			_resourcePermissionLocalService.addModelResourcePermissions(
+				contextCompany.getCompanyId(), ddmStructure.getGroupId(),
+				PrincipalThreadLocal.getUserId(),
+				DataDefinitionConstants.MODEL_RESOURCE_NAME,
+				String.valueOf(dataDefinitionId), modelPermissions);
+		}
+		else {
+			List<String> noSuchRoleNames = new ArrayList<>();
+			List<Role> roles = new ArrayList<>();
+
+			for (String roleName : roleNames) {
+				try {
+					roles.add(
+						_roleLocalService.getRole(
+							contextCompany.getCompanyId(), roleName));
+				}
+				catch (NoSuchRoleException nsre) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(roleName, nsre);
+					}
+
+					noSuchRoleNames.add(roleName);
+				}
+			}
+
+			if (!noSuchRoleNames.isEmpty()) {
+				throw new BadRequestException(
+					"Invalid Roles: " +
+						ArrayUtil.toStringArray(noSuchRoleNames));
+			}
+
+			for (Role role : roles) {
+				for (String actionId : actionIds) {
+					_resourcePermissionLocalService.removeResourcePermission(
+						contextCompany.getCompanyId(),
+						DataDefinitionConstants.MODEL_RESOURCE_NAME,
+						ResourceConstants.SCOPE_INDIVIDUAL,
+						String.valueOf(dataDefinitionId), role.getRoleId(),
+						actionId);
+				}
+			}
+		}
 
 		return true;
 	}
@@ -183,6 +305,9 @@ public class DataDefinitionResourceImpl extends BaseDataDefinitionResourceImpl {
 		}
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		DataDefinitionResourceImpl.class);
+
 	private long _getClassNameId() {
 		return _portal.getClassNameId(InternalDataDefinition.class);
 	}
@@ -201,5 +326,11 @@ public class DataDefinitionResourceImpl extends BaseDataDefinitionResourceImpl {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 }

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/META-INF/resource-actions/default.xml
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/META-INF/resource-actions/default.xml
@@ -5,7 +5,7 @@
 	<model-resource>
 		<model-name>com.liferay.data.engine</model-name>
 		<portlet-ref>
-			<portlet-name>com_liferay_data_engine_web_portlet_DEDataDefinitionPortlet</portlet-name>
+			<portlet-name>com_liferay_data_engine_web_portlet_DataDefinitionPortlet</portlet-name>
 		</portlet-ref>
 		<root>true</root>
 		<weight>1</weight>
@@ -23,7 +23,7 @@
 	<model-resource>
 		<model-name>com.liferay.data.engine.rest.internal.model.InternalDataDefinition</model-name>
 		<portlet-ref>
-			<portlet-name>com_liferay_data_engine_web_portlet_DEDataDefinitionPortlet</portlet-name>
+			<portlet-name>com_liferay_data_engine_web_portlet_DataDefinitionPortlet</portlet-name>
 		</portlet-ref>
 		<weight>2</weight>
 		<permissions>

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataDefinitionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataDefinitionResourceTestCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinition;
+import com.liferay.data.engine.rest.dto.v1_0.DataDefinitionPermission;
 import com.liferay.data.engine.rest.resource.v1_0.DataDefinitionResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -339,6 +340,77 @@ public abstract class BaseDataDefinitionResourceTestCase {
 				_toPath(
 					"/content-spaces/{content-space-id}/data-definitions",
 					contentSpaceId);
+
+		options.setLocation(location);
+
+		options.setPost(true);
+
+		HttpUtil.URLtoString(options);
+
+		return options.getResponse();
+	}
+
+	@Test
+	public void testPostDataDefinitionPermission() throws Exception {
+		DataDefinition randomDataDefinition = randomDataDefinition();
+
+		DataDefinition postDataDefinition =
+			testPostDataDefinitionPermission_addDataDefinition(
+				randomDataDefinition);
+
+		assertEquals(randomDataDefinition, postDataDefinition);
+		assertValid(postDataDefinition);
+	}
+
+	protected DataDefinition testPostDataDefinitionPermission_addDataDefinition(
+			DataDefinition dataDefinition)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected boolean invokePostDataDefinitionPermission(
+			Long dataDefinitionId, String operation,
+			DataDefinitionPermission dataDefinitionPermission)
+		throws Exception {
+
+		Http.Options options = _createHttpOptions();
+
+		String location =
+			_resourceURL +
+				_toPath(
+					"/data-definitions/{data-definition-id}/permissions",
+					dataDefinitionId);
+
+		options.setLocation(location);
+
+		options.setPost(true);
+
+		String string = HttpUtil.URLtoString(options);
+
+		try {
+			return _outputObjectMapper.readValue(string, Boolean.class);
+		}
+		catch (Exception e) {
+			_log.error("Unable to process HTTP response: " + string, e);
+
+			throw e;
+		}
+	}
+
+	protected Http.Response invokePostDataDefinitionPermissionResponse(
+			Long dataDefinitionId, String operation,
+			DataDefinitionPermission dataDefinitionPermission)
+		throws Exception {
+
+		Http.Options options = _createHttpOptions();
+
+		String location =
+			_resourceURL +
+				_toPath(
+					"/data-definitions/{data-definition-id}/permissions",
+					dataDefinitionId);
 
 		options.setLocation(location);
 


### PR DESCRIPTION
I created the permissions method as a post, after a talk with Javier. It would be weird to pass a requestBody to a delete operation. 

Let me know what you think.