### PR TITLE
LPS-90254 Make System Settings portlet renderable at different scopes

### DIFF
--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/authentication.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/authentication.jsp
@@ -38,7 +38,7 @@ tabsNames = ArrayUtil.append(tabsNames, (String)request.getAttribute(PortalSetti
 	refresh="<%= false %>"
 >
 	<liferay-ui:section>
-		<liferay-util:include page='<%= "/authentication/general.jsp" %>' portletId="<%= portletDisplay.getRootPortletId() %>" />
+		<liferay-util:include page='<%= "/authentication/general.jsp" %>' servletContext="<%= application %>" />
 	</liferay-ui:section>
 
 	<%


### PR DESCRIPTION
This is an update for [LPS-90254](https://issues.liferay.com/browse/LPS-90254).

Hey Brian, this fixes an issue rendering one section in the old Instance Settings section of the new Instance Settings portlet.

/cc @pei-jung @stsquared99 @alee8888 @ChrisKian @dejuknow