### PR TITLE
LPS-85386 dynamic-data-lists-test: Add integration test to check the indexed fields and reindexing for the DDLRecord and DDLRecordSet.

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/build.gradle
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/build.gradle
@@ -11,7 +11,9 @@ dependencies {
 	testIntegrationCompile group: "org.apache.poi", name: "poi", version: "3.15"
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
 	testIntegrationCompile project(":apps:export-import:export-import-test-util")
+	testIntegrationCompile project(":apps:portal-search:portal-search-test-util")
 	testIntegrationCompile project(":apps:portal:portal-upgrade-api")
+	testIntegrationCompile project(":apps:users-admin:users-admin-test-util")
 	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/helper/DDLRecordSetTestHelper.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/helper/DDLRecordSetTestHelper.java
@@ -24,6 +24,7 @@ import com.liferay.dynamic.data.mapping.storage.StorageType;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestHelper;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -41,8 +42,13 @@ import java.util.Map;
  */
 public class DDLRecordSetTestHelper {
 
-	public DDLRecordSetTestHelper(Group group) throws Exception {
+	public DDLRecordSetTestHelper(Group group) throws PortalException {
+		this(group, TestPropsValues.getUser());
+	}
+
+	public DDLRecordSetTestHelper(Group group, User user) {
 		_group = group;
+		_user = user;
 	}
 
 	public DDLRecordSet addRecordSet(DDMForm ddmForm) throws Exception {
@@ -74,7 +80,7 @@ public class DDLRecordSetTestHelper {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
 
 		return DDLRecordSetLocalServiceUtil.addRecordSet(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			_user.getUserId(), _group.getGroupId(),
 			ddmStructure.getStructureId(), null, nameMap, null,
 			DDLRecordSetConstants.MIN_DISPLAY_ROWS_DEFAULT, scope,
 			serviceContext);
@@ -105,5 +111,6 @@ public class DDLRecordSetTestHelper {
 	}
 
 	private final Group _group;
+	private final User _user;
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/helper/DDLRecordTestHelper.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/helper/DDLRecordTestHelper.java
@@ -26,6 +26,7 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -41,7 +42,14 @@ public class DDLRecordTestHelper {
 	public DDLRecordTestHelper(Group group, DDLRecordSet recordSet)
 		throws Exception {
 
+		this(group, TestPropsValues.getUser(), recordSet);
+	}
+
+	public DDLRecordTestHelper(Group group, User user, DDLRecordSet recordSet)
+		throws Exception {
+
 		_group = group;
+		_user = user;
 		_recordSet = recordSet;
 	}
 
@@ -76,8 +84,7 @@ public class DDLRecordTestHelper {
 			workflowAction);
 
 		return DDLRecordLocalServiceUtil.addRecord(
-			TestPropsValues.getUserId(), _group.getGroupId(),
-			_recordSet.getRecordSetId(),
+			_user.getUserId(), _group.getGroupId(), _recordSet.getRecordSetId(),
 			DDLRecordConstants.DISPLAY_INDEX_DEFAULT, ddmFormValues,
 			serviceContext);
 	}
@@ -99,7 +106,7 @@ public class DDLRecordTestHelper {
 			workflowAction);
 
 		return DDLRecordLocalServiceUtil.updateRecord(
-			TestPropsValues.getUserId(), recordId, majorVersion, displayIndex,
+			_user.getUserId(), recordId, majorVersion, displayIndex,
 			ddmFormValues, serviceContext);
 	}
 
@@ -125,5 +132,6 @@ public class DDLRecordTestHelper {
 
 	private final Group _group;
 	private final DDLRecordSet _recordSet;
+	private final User _user;
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordFixture.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordFixture.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.lists.search.test;
+
+import com.liferay.dynamic.data.lists.helper.DDLRecordSetTestHelper;
+import com.liferay.dynamic.data.lists.helper.DDLRecordTestHelper;
+import com.liferay.dynamic.data.lists.model.DDLRecord;
+import com.liferay.dynamic.data.lists.model.DDLRecordSet;
+import com.liferay.dynamic.data.lists.service.DDLRecordSetLocalService;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.LocalizedValue;
+import com.liferay.dynamic.data.mapping.model.Value;
+import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.storage.StorageType;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestHelper;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Luan Maoski
+ * @author Lucas Marques
+ */
+public class DDLRecordFixture {
+
+	public DDLRecordFixture(
+			DDLRecordSetLocalService ddlRecordSetLocalService, Group group,
+			User user)
+		throws Exception {
+
+		this.ddlRecordSetLocalService = ddlRecordSetLocalService;
+		_group = group;
+		_user = user;
+
+		setUpDdmStructureTestHelper();
+
+		setUpDdlRecordTestHelper();
+	}
+
+	public DDLRecord createDDLRecord(
+			String name, String description, Locale locale)
+		throws Exception {
+
+		DDLRecord ddlRecord = addRecord(name, description, locale);
+
+		_ddlRecords.add(ddlRecord);
+
+		return ddlRecord;
+	}
+
+	public List<DDLRecord> getDdlRecords() {
+		return _ddlRecords;
+	}
+
+	public void updateDisplaySettings(Locale locale) throws Exception {
+		Group group = GroupTestUtil.updateDisplaySettings(
+			_group.getGroupId(), null, locale);
+
+		_group.setModelAttributes(group.getModelAttributes());
+	}
+
+	protected DDLRecord addRecord(
+			String name, String description, Locale locale)
+		throws Exception {
+
+		Map<Locale, String> nameMap = new HashMap<>();
+
+		nameMap.put(locale, name);
+
+		Map<Locale, String> descriptionMap = new HashMap<>();
+
+		descriptionMap.put(locale, description);
+
+		Set<Locale> localesSet = nameMap.keySet();
+
+		Locale[] locales = new Locale[nameMap.size()];
+
+		localesSet.toArray(locales);
+
+		DDMFormValues ddmFormValues = createDDMFormValues(locales);
+
+		DDMFormFieldValue nameDDMFormFieldValue =
+			createLocalizedDDMFormFieldValue("name", nameMap, locale);
+
+		ddmFormValues.addDDMFormFieldValue(nameDDMFormFieldValue);
+
+		DDMFormFieldValue descriptionDDMFormFieldValue =
+			createLocalizedDDMFormFieldValue(
+				"description", descriptionMap, locale);
+
+		ddmFormValues.addDDMFormFieldValue(descriptionDDMFormFieldValue);
+
+		return recordTestHelper.addRecord(
+			ddmFormValues, WorkflowConstants.ACTION_PUBLISH);
+	}
+
+	protected DDLRecordSet addRecordSet() throws Exception {
+		DDLRecordSetTestHelper recordSetTestHelper = new DDLRecordSetTestHelper(
+			_group);
+
+		DDMStructure ddmStructure = ddmStructureTestHelper.addStructure(
+			createDDMForm(Locale.US), StorageType.JSON.toString());
+
+		return recordSetTestHelper.addRecordSet(ddmStructure);
+	}
+
+	protected DDMForm createDDMForm(Locale... locales) {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			DDMFormTestUtil.createAvailableLocales(locales), locales[0]);
+
+		DDMFormField nameDDMFormField = DDMFormTestUtil.createTextDDMFormField(
+			"name", true, false, false);
+
+		nameDDMFormField.setIndexType("keyword");
+
+		ddmForm.addDDMFormField(nameDDMFormField);
+
+		DDMFormField descriptionDDMFormField =
+			DDMFormTestUtil.createTextDDMFormField(
+				"description", true, false, false);
+
+		descriptionDDMFormField.setIndexType("text");
+
+		ddmForm.addDDMFormField(descriptionDDMFormField);
+
+		return ddmForm;
+	}
+
+	protected DDMFormValues createDDMFormValues(Locale... locales)
+		throws Exception {
+
+		DDLRecordSet recordSet = recordTestHelper.getRecordSet();
+
+		DDMStructure ddmStructure = recordSet.getDDMStructure();
+
+		return DDMFormValuesTestUtil.createDDMFormValues(
+			ddmStructure.getDDMForm(),
+			DDMFormValuesTestUtil.createAvailableLocales(locales), locales[0]);
+	}
+
+	protected DDMFormFieldValue createLocalizedDDMFormFieldValue(
+		String name, Map<Locale, String> values, Locale locale) {
+
+		Value localizedValue = new LocalizedValue(locale);
+
+		for (Map.Entry<Locale, String> value : values.entrySet()) {
+			localizedValue.addString(value.getKey(), value.getValue());
+		}
+
+		return DDMFormValuesTestUtil.createDDMFormFieldValue(
+			name, localizedValue);
+	}
+
+	protected DDLRecordSet getDdlRecordSet(long recordSetId)
+		throws PortalException {
+
+		return ddlRecordSetLocalService.getRecordSet(recordSetId);
+	}
+
+	protected void setUpDdlRecordTestHelper() throws Exception {
+		DDLRecordSet recordSet = addRecordSet();
+
+		recordTestHelper = new DDLRecordTestHelper(_group, _user, recordSet);
+	}
+
+	protected void setUpDdmStructureTestHelper() throws Exception {
+		ddmStructureTestHelper = new DDMStructureTestHelper(
+			PortalUtil.getClassNameId(DDLRecordSet.class), _group);
+	}
+
+	protected DDLRecordSetLocalService ddlRecordSetLocalService;
+	protected DDMStructureTestHelper ddmStructureTestHelper;
+	protected DDLRecordTestHelper recordTestHelper;
+
+	private final List<DDLRecord> _ddlRecords = new ArrayList<>();
+	private final Group _group;
+	private final User _user;
+
+}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordIndexerIndexedFieldsTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordIndexerIndexedFieldsTest.java
@@ -1,0 +1,410 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.lists.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.lists.model.DDLRecord;
+import com.liferay.dynamic.data.lists.model.DDLRecordSet;
+import com.liferay.dynamic.data.lists.model.DDLRecordVersion;
+import com.liferay.dynamic.data.lists.service.DDLRecordSetLocalService;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.storage.StorageEngine;
+import com.liferay.dynamic.data.mapping.util.DDMIndexer;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.test.util.FieldValuesAssert;
+import com.liferay.portal.search.test.util.IndexedFieldsFixture;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luan Maoski
+ * @author Lucas Marques
+ */
+@RunWith(Arquillian.class)
+public class DDLRecordIndexerIndexedFieldsTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		setUpUserSearchFixture();
+
+		setUpDDLRecordFixture();
+
+		setUpIndexedFieldsFixture();
+
+		setUpIndexerFixture();
+
+		defaultLocale = LocaleThreadLocal.getDefaultLocale();
+	}
+
+	@After
+	public void tearDown() {
+		LocaleThreadLocal.setDefaultLocale(defaultLocale);
+	}
+
+	@Test
+	public void testIndexedFields() throws Exception {
+		Locale locale = LocaleUtil.JAPAN;
+
+		setTestLocale(locale);
+
+		String name = "新規";
+
+		String description = RandomTestUtil.randomString();
+
+		DDLRecord ddlRecord = ddlRecordFixture.createDDLRecord(
+			name, description, locale);
+
+		String searchTerm = name;
+
+		Document document = ddlRecordIndexerFixture.searchOnlyOne(
+			searchTerm, locale);
+
+		indexedFieldsFixture.postProcessDocument(document);
+
+		FieldValuesAssert.assertFieldValues(
+			_expectedFieldValues(ddlRecord), document, searchTerm);
+	}
+
+	protected void setTestLocale(Locale locale) throws Exception {
+		ddlRecordFixture.updateDisplaySettings(locale);
+
+		LocaleThreadLocal.setDefaultLocale(locale);
+	}
+
+	protected void setUpDDLRecordFixture() throws Exception {
+		ddlRecordFixture = new DDLRecordFixture(
+			ddlRecordSetLocalService, group, user);
+
+		_ddlRecords = ddlRecordFixture.getDdlRecords();
+	}
+
+	protected void setUpIndexedFieldsFixture() {
+		indexedFieldsFixture = new IndexedFieldsFixture(
+			resourcePermissionLocalService, searchEngineHelper);
+	}
+
+	protected void setUpIndexerFixture() {
+		ddlRecordIndexerFixture = new IndexerFixture<>(DDLRecord.class);
+	}
+
+	protected void setUpUserSearchFixture() throws Exception {
+		userSearchFixture = new UserSearchFixture();
+
+		userSearchFixture.setUp();
+
+		_groups = userSearchFixture.getGroups();
+
+		_users = userSearchFixture.getUsers();
+
+		group = userSearchFixture.addGroup();
+
+		user = userSearchFixture.addUser(RandomTestUtil.randomString(), group);
+	}
+
+	protected DDLRecordFixture ddlRecordFixture;
+	protected IndexerFixture<DDLRecord> ddlRecordIndexerFixture;
+
+	@Inject
+	protected DDLRecordSetLocalService ddlRecordSetLocalService;
+
+	@Inject
+	protected DDMIndexer ddmIndexer;
+
+	protected Locale defaultLocale;
+	protected Group group;
+	protected IndexedFieldsFixture indexedFieldsFixture;
+
+	@Inject
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+
+	@Inject
+	protected SearchEngineHelper searchEngineHelper;
+
+	@Inject
+	protected StorageEngine storageEngine;
+
+	protected User user;
+	protected UserSearchFixture userSearchFixture;
+
+	private static Map<String, String> _getFieldValues(Document document) {
+		Map<String, Field> fieldsMap = document.getFields();
+
+		Set<Map.Entry<String, Field>> entrySet = fieldsMap.entrySet();
+
+		return entrySet.stream().collect(
+			Collectors.toMap(
+				Map.Entry::getKey,
+				entry -> {
+					Field field = entry.getValue();
+
+					String[] values = field.getValues();
+
+					if (values == null) {
+						return null;
+					}
+
+					if (values.length == 1) {
+						return values[0];
+					}
+
+					return String.valueOf(Arrays.asList(values));
+				}));
+	}
+
+	private Map<String, String> _expectedFieldValues(DDLRecord ddlRecord)
+		throws Exception {
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(Field.COMPANY_ID, String.valueOf(ddlRecord.getCompanyId()));
+
+		map.put(
+			Field.CLASS_NAME_ID,
+			String.valueOf(PortalUtil.getClassNameId(DDLRecordSet.class)));
+
+		DDLRecordSet ddlRecordSet = ddlRecord.getRecordSet();
+
+		map.put(Field.CLASS_PK, String.valueOf(ddlRecordSet.getPrimaryKey()));
+
+		map.put(
+			Field.CLASS_TYPE_ID, String.valueOf(ddlRecordSet.getPrimaryKey()));
+
+		map.put(Field.ENTRY_CLASS_NAME, DDLRecord.class.getName());
+
+		map.put(
+			Field.ENTRY_CLASS_PK, String.valueOf(ddlRecord.getPrimaryKey()));
+
+		map.put(Field.GROUP_ID, String.valueOf(ddlRecord.getGroupId()));
+
+		map.put(Field.RELATED_ENTRY, Boolean.TRUE.toString());
+
+		map.put(Field.SCOPE_GROUP_ID, String.valueOf(ddlRecord.getGroupId()));
+
+		map.put(Field.STAGING_GROUP, String.valueOf(group.isStagingGroup()));
+
+		map.put(Field.STATUS, String.valueOf(ddlRecord.getStatus()));
+
+		map.put(Field.USER_ID, String.valueOf(ddlRecord.getUserId()));
+
+		map.put(Field.USER_NAME, StringUtil.lowerCase(ddlRecord.getUserName()));
+
+		map.put(Field.VERSION, String.valueOf(ddlRecord.getVersion()));
+
+		map.put("recordSetId", String.valueOf(ddlRecord.getRecordSetId()));
+
+		map.put("viewCount", "0");
+
+		map.put("viewCount_sortable", "0");
+
+		map.put("visible", "true");
+
+		indexedFieldsFixture.populatePriority("0.0", map);
+
+		indexedFieldsFixture.populateUID(
+			DDLRecord.class.getName(), ddlRecord.getRecordId(), map);
+
+		_populateAttributes(ddlRecord, map);
+
+		_populateContent(ddlRecord, map);
+
+		_populateDates(ddlRecord, map);
+
+		_populateLocalizedTitles(ddlRecord, map);
+
+		_populateRoles(ddlRecord, map);
+
+		return map;
+	}
+
+	private String _extractContent(DDLRecord ddlRecord, Locale locale)
+		throws Exception {
+
+		DDLRecordVersion recordVersion = ddlRecord.getRecordVersion();
+
+		DDMFormValues ddmFormValues = storageEngine.getDDMFormValues(
+			recordVersion.getDDMStorageId());
+
+		if (ddmFormValues == null) {
+			return StringPool.BLANK;
+		}
+
+		DDLRecordSet recordSet = recordVersion.getRecordSet();
+
+		_ddlRecordsSet.add(recordSet);
+
+		String indexableAttributes = ddmIndexer.extractIndexableAttributes(
+			recordSet.getDDMStructure(), ddmFormValues, locale);
+
+		return indexableAttributes.trim();
+	}
+
+	private String _getTitle(long recordSetId, Locale locale) {
+		try {
+			DDLRecordSet recordSet = ddlRecordFixture.getDdlRecordSet(
+				recordSetId);
+
+			DDMStructure ddmStructure = recordSet.getDDMStructure();
+
+			String ddmStructureName = ddmStructure.getName(locale);
+
+			String recordSetName = recordSet.getName(locale);
+
+			return LanguageUtil.format(
+				locale, "new-x-for-list-x",
+				new Object[] {ddmStructureName, recordSetName}, false);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+		}
+
+		return StringPool.BLANK;
+	}
+
+	private void _populateAttributes(
+			DDLRecord ddlRecord, Map<String, String> map)
+		throws Exception {
+
+		DDLRecordSet recordSet = ddlRecordFixture.getDdlRecordSet(
+			ddlRecord.getRecordSetId());
+
+		DDMStructure ddmStructure = recordSet.getDDMStructure();
+
+		Document document = new DocumentImpl();
+
+		ddmIndexer.addAttributes(
+			document, ddmStructure, ddlRecord.getDDMFormValues());
+
+		Map<String, String> fieldValues = _getFieldValues(document);
+
+		fieldValues.forEach((k, v) -> map.put(k, v));
+	}
+
+	private void _populateContent(DDLRecord ddlRecord, Map<String, String> map)
+		throws Exception {
+
+		DDMFormValues ddmFormValues = ddlRecord.getDDMFormValues();
+
+		Set<Locale> locales = ddmFormValues.getAvailableLocales();
+
+		for (Locale locale : locales) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append("ddmContent");
+			sb.append(StringPool.UNDERLINE);
+			sb.append(LocaleUtil.toLanguageId(locale));
+
+			map.put(sb.toString(), _extractContent(ddlRecord, locale));
+		}
+	}
+
+	private void _populateDates(DDLRecord ddlRecord, Map<String, String> map) {
+		indexedFieldsFixture.populateDate(
+			Field.CREATE_DATE, ddlRecord.getCreateDate(), map);
+		indexedFieldsFixture.populateDate(
+			Field.MODIFIED_DATE, ddlRecord.getModifiedDate(), map);
+		indexedFieldsFixture.populateDate(
+			Field.PUBLISH_DATE, ddlRecord.getCreateDate(), map);
+		indexedFieldsFixture.populateExpirationDateWithForever(map);
+	}
+
+	private void _populateLocalizedTitles(
+		DDLRecord ddlRecord, Map<String, String> map) {
+
+		String title = StringUtil.lowerCase(
+			_getTitle(ddlRecord.getRecordSetId(), LocaleUtil.US));
+
+		map.put("localized_title", title);
+
+		for (Locale locale : LanguageUtil.getAvailableLocales()) {
+			String languageId = LocaleUtil.toLanguageId(locale);
+
+			String key = "localized_title_" + languageId;
+
+			map.put(key, title);
+			map.put(key.concat("_sortable"), title);
+		}
+	}
+
+	private void _populateRoles(DDLRecord ddlRecord, Map<String, String> map)
+		throws Exception {
+
+		indexedFieldsFixture.populateRoleIdFields(
+			ddlRecord.getCompanyId(), DDLRecordSet.class.getName(),
+			ddlRecord.getRecordSetId(), ddlRecord.getGroupId(), null, map);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DDLRecordIndexerIndexedFieldsTest.class);
+
+	@DeleteAfterTestRun
+	private List<DDLRecord> _ddlRecords;
+
+	@DeleteAfterTestRun
+	private final List<DDLRecordSet> _ddlRecordsSet = new ArrayList<>();
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordIndexerReindexTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordIndexerReindexTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.lists.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.lists.model.DDLRecord;
+import com.liferay.dynamic.data.lists.model.DDLRecordSet;
+import com.liferay.dynamic.data.lists.model.DDLRecordVersion;
+import com.liferay.dynamic.data.lists.service.DDLRecordSetLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luan Maoski
+ * @author Lucas Marques
+ */
+@RunWith(Arquillian.class)
+public class DDLRecordIndexerReindexTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		setUpUserSearchFixture();
+
+		setUpDDLRecordFixture();
+
+		setUpIndexerFixture();
+	}
+
+	@Test
+	public void testReindexing() throws Exception {
+		String name = RandomTestUtil.randomString();
+
+		String description = RandomTestUtil.randomString();
+
+		String searchTerm = name;
+
+		DDLRecord ddlRecord = ddlRecordFixture.createDDLRecord(
+			name, description, LocaleUtil.US);
+
+		_addToDeleteList(ddlRecord);
+
+		Document document = ddlRecordIndexerFixture.searchOnlyOne(searchTerm);
+
+		ddlRecordIndexerFixture.deleteDocument(document);
+
+		ddlRecordIndexerFixture.searchNoOne(searchTerm);
+
+		ddlRecordIndexerFixture.reindex(ddlRecord.getCompanyId());
+
+		ddlRecordIndexerFixture.searchOnlyOne(searchTerm);
+	}
+
+	protected void setUpDDLRecordFixture() throws Exception {
+		ddlRecordFixture = new DDLRecordFixture(
+			ddlRecordSetLocalService, group, user);
+
+		_ddlRecords = ddlRecordFixture.getDdlRecords();
+	}
+
+	protected void setUpIndexerFixture() {
+		ddlRecordIndexerFixture = new IndexerFixture<>(DDLRecord.class);
+	}
+
+	protected void setUpUserSearchFixture() throws Exception {
+		userSearchFixture = new UserSearchFixture();
+
+		userSearchFixture.setUp();
+
+		_groups = userSearchFixture.getGroups();
+
+		_users = userSearchFixture.getUsers();
+
+		group = userSearchFixture.addGroup();
+
+		user = userSearchFixture.addUser(RandomTestUtil.randomString(), group);
+	}
+
+	protected DDLRecordFixture ddlRecordFixture;
+	protected IndexerFixture<DDLRecord> ddlRecordIndexerFixture;
+
+	@Inject
+	protected DDLRecordSetLocalService ddlRecordSetLocalService;
+
+	protected Group group;
+	protected User user;
+	protected UserSearchFixture userSearchFixture;
+
+	private void _addToDeleteList(DDLRecord ddlRecord) throws PortalException {
+		DDLRecordVersion recordVersion = ddlRecord.getRecordVersion();
+
+		DDLRecordSet ddlRecordSet = recordVersion.getRecordSet();
+
+		_ddlRecordsSet.add(ddlRecordSet);
+	}
+
+	@DeleteAfterTestRun
+	private List<DDLRecord> _ddlRecords;
+
+	@DeleteAfterTestRun
+	private final List<DDLRecordSet> _ddlRecordsSet = new ArrayList<>();
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSetFixture.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSetFixture.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.lists.search.test;
+
+import com.liferay.dynamic.data.lists.helper.DDLRecordSetTestHelper;
+import com.liferay.dynamic.data.lists.helper.DDLRecordTestHelper;
+import com.liferay.dynamic.data.lists.model.DDLRecordSet;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.storage.StorageType;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestHelper;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * @author Luan Maoski
+ * @author Lucas Marques
+ */
+public class DDLRecordSetFixture {
+
+	public DDLRecordSetFixture(Group group, User user) throws Exception {
+		_group = group;
+		_user = user;
+
+		setUpDdlRecordTestHelper();
+	}
+
+	public DDLRecordSet createAnDDLRecordSet() throws Exception {
+		DDLRecordSet ddlRecordSet = addRecordSet();
+
+		_ddlRecordSets.add(ddlRecordSet);
+
+		return ddlRecordSet;
+	}
+
+	public DDLRecordSet getDdlRecordSet() {
+		return _ddlRecordSet;
+	}
+
+	public List<DDLRecordSet> getDdlRecordSets() {
+		return _ddlRecordSets;
+	}
+
+	protected DDLRecordSet addRecordSet() throws Exception {
+		DDLRecordSetTestHelper recordSetTestHelper = new DDLRecordSetTestHelper(
+			_group, _user);
+
+		DDMStructureTestHelper ddmStructureTestHelper =
+			new DDMStructureTestHelper(
+				PortalUtil.getClassNameId(DDLRecordSet.class), _group);
+
+		DDMStructure ddmStructure = ddmStructureTestHelper.addStructure(
+			createDDMForm(LocaleUtil.US), StorageType.JSON.toString());
+
+		return recordSetTestHelper.addRecordSet(ddmStructure);
+	}
+
+	protected DDMForm createDDMForm(Locale... locales) {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			DDMFormTestUtil.createAvailableLocales(locales), locales[0]);
+
+		DDMFormField nameDDMFormField = DDMFormTestUtil.createTextDDMFormField(
+			RandomTestUtil.randomString(), true, false, false);
+
+		nameDDMFormField.setIndexType("keyword");
+
+		ddmForm.addDDMFormField(nameDDMFormField);
+
+		DDMFormField descriptionDDMFormField =
+			DDMFormTestUtil.createTextDDMFormField(
+				RandomTestUtil.randomString(), true, false, false);
+
+		descriptionDDMFormField.setIndexType("text");
+
+		ddmForm.addDDMFormField(descriptionDDMFormField);
+
+		return ddmForm;
+	}
+
+	protected void setUpDdlRecordTestHelper() throws Exception {
+		_ddlRecordSet = createAnDDLRecordSet();
+
+		_recordTestHelper = new DDLRecordTestHelper(
+			_group, _user, _ddlRecordSet);
+	}
+
+	private DDLRecordSet _ddlRecordSet;
+	private final List<DDLRecordSet> _ddlRecordSets = new ArrayList<>();
+	private final Group _group;
+	private DDLRecordTestHelper _recordTestHelper;
+	private final User _user;
+
+}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSetIndexerIndexedFieldsTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSetIndexerIndexedFieldsTest.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.lists.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.lists.model.DDLRecordSet;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.test.util.FieldValuesAssert;
+import com.liferay.portal.search.test.util.IndexedFieldsFixture;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luan Maoski
+ * @author Lucas Marques
+ */
+@RunWith(Arquillian.class)
+public class DDLRecordSetIndexerIndexedFieldsTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		setUpUserSearchFixture();
+
+		setUpDdlRecordSetFixture();
+
+		setUpIndexedFieldsFixture();
+
+		setUpIndexerFixture();
+	}
+
+	@Test
+	public void testIndexedFields() throws Exception {
+		DDLRecordSet ddlRecortSet = ddlRecordSetFixture.getDdlRecordSet();
+
+		String searchTerm = user.getFullName();
+
+		Document document = ddlRecordSetIndexerFixture.searchOnlyOne(
+			searchTerm);
+
+		indexedFieldsFixture.postProcessDocument(document);
+
+		FieldValuesAssert.assertFieldValues(
+			_expectedFieldValues(ddlRecortSet), document, searchTerm);
+	}
+
+	protected void setUpDdlRecordSetFixture() throws Exception {
+		ddlRecordSetFixture = new DDLRecordSetFixture(group, user);
+
+		_ddlRecordSets = ddlRecordSetFixture.getDdlRecordSets();
+	}
+
+	protected void setUpIndexedFieldsFixture() {
+		indexedFieldsFixture = new IndexedFieldsFixture(
+			resourcePermissionLocalService, searchEngineHelper);
+	}
+
+	protected void setUpIndexerFixture() {
+		ddlRecordSetIndexerFixture = new IndexerFixture<>(DDLRecordSet.class);
+	}
+
+	protected void setUpUserSearchFixture() throws Exception {
+		userSearchFixture = new UserSearchFixture();
+
+		userSearchFixture.setUp();
+
+		_groups = userSearchFixture.getGroups();
+
+		_users = userSearchFixture.getUsers();
+
+		group = userSearchFixture.addGroup();
+
+		user = userSearchFixture.addUser(RandomTestUtil.randomString(), group);
+	}
+
+	protected DDLRecordSetFixture ddlRecordSetFixture;
+	protected IndexerFixture<DDLRecordSet> ddlRecordSetIndexerFixture;
+	protected Group group;
+	protected IndexedFieldsFixture indexedFieldsFixture;
+
+	@Inject
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+
+	@Inject
+	protected SearchEngineHelper searchEngineHelper;
+
+	protected User user;
+	protected UserSearchFixture userSearchFixture;
+
+	private Map<String, String> _expectedFieldValues(DDLRecordSet ddlRecortSet)
+		throws Exception {
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(Field.COMPANY_ID, String.valueOf(ddlRecortSet.getCompanyId()));
+
+		map.put(Field.ENTRY_CLASS_NAME, DDLRecordSet.class.getName());
+
+		map.put(
+			Field.ENTRY_CLASS_PK,
+			String.valueOf(ddlRecortSet.getRecordSetId()));
+
+		map.put(Field.GROUP_ID, String.valueOf(ddlRecortSet.getGroupId()));
+
+		map.put(
+			Field.SCOPE_GROUP_ID, String.valueOf(ddlRecortSet.getGroupId()));
+
+		map.put(Field.STAGING_GROUP, String.valueOf(group.isStagingGroup()));
+
+		map.put(Field.USER_ID, String.valueOf(ddlRecortSet.getUserId()));
+
+		map.put(
+			Field.USER_NAME, StringUtil.lowerCase(ddlRecortSet.getUserName()));
+
+		indexedFieldsFixture.populateUID(
+			DDLRecordSet.class.getName(), ddlRecortSet.getRecordSetId(), map);
+		_populateDates(ddlRecortSet, map);
+		_populateRoles(ddlRecortSet, map);
+
+		return map;
+	}
+
+	private void _populateDates(
+		DDLRecordSet ddlRecortSet, Map<String, String> map) {
+
+		indexedFieldsFixture.populateDate(
+			Field.CREATE_DATE, ddlRecortSet.getCreateDate(), map);
+		indexedFieldsFixture.populateDate(
+			Field.MODIFIED_DATE, ddlRecortSet.getModifiedDate(), map);
+	}
+
+	private void _populateRoles(
+			DDLRecordSet ddlRecortSet, Map<String, String> map)
+		throws Exception {
+
+		indexedFieldsFixture.populateRoleIdFields(
+			ddlRecortSet.getCompanyId(), DDLRecordSet.class.getName(),
+			ddlRecortSet.getRecordSetId(), ddlRecortSet.getGroupId(), null,
+			map);
+	}
+
+	@DeleteAfterTestRun
+	private List<DDLRecordSet> _ddlRecordSets;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSetIndexerReindexTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSetIndexerReindexTest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.lists.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.lists.model.DDLRecord;
+import com.liferay.dynamic.data.lists.model.DDLRecordSet;
+import com.liferay.dynamic.data.lists.service.DDLRecordSetLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luan Maoski
+ * @author Lucas Marques
+ */
+@RunWith(Arquillian.class)
+public class DDLRecordSetIndexerReindexTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		setUpUserSearchFixture();
+
+		setUpDdlRecordIndexerFixture();
+
+		setUpDdlRecordFixture();
+
+		setUpDdlRecordSetFixture();
+
+		setUpDdlRecordSetIndexerFixture();
+	}
+
+	@Test
+	public void testReindexing() throws Exception {
+		String searchTerm = user.getFullName();
+
+		ddlRecordSetIndexerFixture.searchOnlyOne(searchTerm);
+
+		Document document = ddlRecordSetIndexerFixture.searchOnlyOne(
+			searchTerm);
+
+		ddlRecordSetIndexerFixture.deleteDocument(document);
+
+		ddlRecordSetIndexerFixture.searchNoOne(searchTerm);
+
+		ddlRecordSetIndexerFixture.reindex(TestPropsValues.getCompanyId());
+
+		ddlRecordSetIndexerFixture.searchOnlyOne(searchTerm);
+	}
+
+	@Test
+	public void testReindexingChildren() throws Exception {
+		String name = RandomTestUtil.randomString();
+
+		String description = RandomTestUtil.randomString();
+
+		DDLRecord ddlRecord = createDDLRecord(name, description);
+
+		String searchTerm = user.getFullName();
+
+		ddlRecordIndexerFixture.searchOnlyOne(searchTerm);
+
+		Document document = ddlRecordIndexerFixture.searchOnlyOne(searchTerm);
+
+		ddlRecordIndexerFixture.deleteDocument(document);
+
+		ddlRecordIndexerFixture.searchNoOne(searchTerm);
+
+		ddlRecordSetIndexerFixture.reindex(ddlRecord.getCompanyId());
+
+		ddlRecordSetIndexerFixture.searchOnlyOne(searchTerm);
+	}
+
+	protected DDLRecord createDDLRecord(String name, String description)
+		throws Exception {
+
+		try {
+			DDLRecord ddmFormInstanceRecord = ddlRecordFixture.addRecord(
+				name, description, Locale.US);
+
+			return ddmFormInstanceRecord;
+		}
+		catch (PortalException pe) {
+			throw new RuntimeException(pe);
+		}
+	}
+
+	protected void setUpDdlRecordFixture() throws Exception {
+		ddlRecordFixture = new DDLRecordFixture(
+			ddlRecordSetLocalService, group, user);
+	}
+
+	protected void setUpDdlRecordIndexerFixture() {
+		ddlRecordIndexerFixture = new IndexerFixture<>(DDLRecord.class);
+	}
+
+	protected void setUpDdlRecordSetFixture() throws Exception {
+		ddlRecordSetFixture = new DDLRecordSetFixture(group, user);
+
+		_ddlRecordSets = ddlRecordSetFixture.getDdlRecordSets();
+	}
+
+	protected void setUpDdlRecordSetIndexerFixture() {
+		ddlRecordSetIndexerFixture = new IndexerFixture<>(DDLRecordSet.class);
+	}
+
+	protected void setUpUserSearchFixture() throws Exception {
+		userSearchFixture = new UserSearchFixture();
+
+		userSearchFixture.setUp();
+
+		_groups = userSearchFixture.getGroups();
+
+		_users = userSearchFixture.getUsers();
+
+		group = userSearchFixture.addGroup();
+
+		user = userSearchFixture.addUser(RandomTestUtil.randomString(), group);
+	}
+
+	protected DDLRecordFixture ddlRecordFixture;
+	protected IndexerFixture<DDLRecord> ddlRecordIndexerFixture;
+	protected DDLRecordSetFixture ddlRecordSetFixture;
+	protected IndexerFixture<DDLRecordSet> ddlRecordSetIndexerFixture;
+
+	@Inject
+	protected DDLRecordSetLocalService ddlRecordSetLocalService;
+
+	protected Group group;
+	protected User user;
+	protected UserSearchFixture userSearchFixture;
+
+	@DeleteAfterTestRun
+	private List<DDLRecordSet> _ddlRecordSets;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/DDMFormInstanceIndexer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/DDMFormInstanceIndexer.java
@@ -37,7 +37,9 @@ import javax.portlet.PortletResponse;
 
 /**
  * @author Leonardo Barros
+ * @deprecated As of Judson (7.1.x), since 7.1.0
  */
+@Deprecated
 public class DDMFormInstanceIndexer extends BaseIndexer<DDMFormInstance> {
 
 	public static final String CLASS_NAME = DDMFormInstance.class.getName();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/DDMFormInstanceRecordIndexer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/DDMFormInstanceRecordIndexer.java
@@ -63,7 +63,9 @@ import javax.portlet.PortletResponse;
 
 /**
  * @author Leonardo Barros
+ * @deprecated As of Judson (7.1.x), since 7.1.0
  */
+@Deprecated
 public class DDMFormInstanceRecordIndexer
 	extends BaseIndexer<DDMFormInstanceRecord> {
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-builder")
 	testIntegrationCompile project(":apps:export-import:export-import-test-util")
 	testIntegrationCompile project(":apps:portal:portal-upgrade-api")
+	testIntegrationCompile project(":apps:users-admin:users-admin-test-util")
 	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/helper/DDMFormInstanceRecordTestHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/helper/DDMFormInstanceRecordTestHelper.java
@@ -24,6 +24,7 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -36,9 +37,17 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 public class DDMFormInstanceRecordTestHelper {
 
 	public DDMFormInstanceRecordTestHelper(
-		Group group, DDMFormInstance ddmFormInstance) {
+			Group group, DDMFormInstance ddmFormInstance)
+		throws PortalException {
+
+		this(group, TestPropsValues.getUser(), ddmFormInstance);
+	}
+
+	public DDMFormInstanceRecordTestHelper(
+		Group group, User user, DDMFormInstance ddmFormInstance) {
 
 		_group = group;
+		_user = user;
 		_ddmFormInstance = ddmFormInstance;
 	}
 
@@ -72,10 +81,10 @@ public class DDMFormInstanceRecordTestHelper {
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId());
+				_group.getGroupId(), _user.getUserId());
 
 		return DDMFormInstanceRecordLocalServiceUtil.addFormInstanceRecord(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			_user.getUserId(), _group.getGroupId(),
 			_ddmFormInstance.getFormInstanceId(), ddmFormValues,
 			serviceContext);
 	}
@@ -96,5 +105,6 @@ public class DDMFormInstanceRecordTestHelper {
 
 	private final DDMFormInstance _ddmFormInstance;
 	private final Group _group;
+	private final User _user;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/helper/DDMFormInstanceTestHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/helper/DDMFormInstanceTestHelper.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -100,8 +101,13 @@ public class DDMFormInstanceTestHelper {
 		return formInstanceSettingsDDMFormValues;
 	}
 
-	public DDMFormInstanceTestHelper(Group group) {
+	public DDMFormInstanceTestHelper(Group group) throws PortalException {
+		this(group, TestPropsValues.getUser());
+	}
+
+	public DDMFormInstanceTestHelper(Group group, User user) {
 		_group = group;
+		_user = user;
 	}
 
 	public DDMFormInstance addDDMFormInstance(DDMForm ddmForm)
@@ -137,7 +143,7 @@ public class DDMFormInstanceTestHelper {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
 
 		return DDMFormInstanceLocalServiceUtil.addFormInstance(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			_user.getUserId(), _group.getGroupId(),
 			ddmStructure.getStructureId(), nameMap, descriptionMap,
 			settingsDDMFormValues, serviceContext);
 	}
@@ -195,9 +201,8 @@ public class DDMFormInstanceTestHelper {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
 
 		return DDMFormInstanceLocalServiceUtil.addFormInstance(
-			TestPropsValues.getUserId(), _group.getGroupId(), nameMap,
-			descriptionMap, fileEntryDDMForm, ddmFormLayout, ddmFormValues,
-			serviceContext);
+			_user.getUserId(), _group.getGroupId(), nameMap, descriptionMap,
+			fileEntryDDMForm, ddmFormLayout, ddmFormValues, serviceContext);
 	}
 
 	public DDMFormInstance updateFormInstance(
@@ -228,5 +233,6 @@ public class DDMFormInstanceTestHelper {
 	}
 
 	private final Group _group;
+	private final User _user;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormFixture.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormFixture.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.search.test;
+
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+
+import java.util.Locale;
+
+/**
+ * @author Luan Maoski
+ */
+public class DDMFormFixture {
+
+	protected static DDMForm createDDMForm(Locale... locales) {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			DDMFormTestUtil.createAvailableLocales(locales), locales[0]);
+
+		DDMFormField nameDDMFormField = DDMFormTestUtil.createTextDDMFormField(
+			"name", true, false, false);
+
+		nameDDMFormField.setIndexType("keyword");
+
+		ddmForm.addDDMFormField(nameDDMFormField);
+
+		DDMFormField descriptionDDMFormField =
+			DDMFormTestUtil.createTextDDMFormField(
+				"description", true, false, false);
+
+		descriptionDDMFormField.setIndexType("text");
+
+		ddmForm.addDDMFormField(descriptionDDMFormField);
+
+		return ddmForm;
+	}
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceFixture.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceFixture.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.search.test;
+
+import com.liferay.dynamic.data.mapping.helper.DDMFormInstanceTestHelper;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.storage.StorageType;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestHelper;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * @author Luan Maoski
+ * @author Lucas Marques
+ */
+public class DDMFormInstanceFixture {
+
+	public DDMFormInstanceFixture(Group group, User user) {
+		_group = group;
+		_user = user;
+	}
+
+	public DDMFormInstance createAnDDMFormInstance() throws Exception {
+		DDMFormInstance ddmFormInstance = addDDMFormInstance();
+
+		_ddmFormInstances.add(ddmFormInstance);
+
+		return ddmFormInstance;
+	}
+
+	public List<DDMFormInstance> getDdmFormInstances() {
+		return _ddmFormInstances;
+	}
+
+	public ServiceContext getServiceContext() throws Exception {
+		return ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId(), _user.getUserId());
+	}
+
+	public void updateDisplaySettings(Locale locale) throws Exception {
+		Group group = GroupTestUtil.updateDisplaySettings(
+			_group.getGroupId(), null, locale);
+
+		_group.setModelAttributes(group.getModelAttributes());
+	}
+
+	protected DDMFormInstance addDDMFormInstance() throws Exception {
+		DDMFormInstanceTestHelper ddmFormInstanceTestHelper =
+			new DDMFormInstanceTestHelper(_group, _user);
+
+		DDMStructureTestHelper ddmStructureTestHelper =
+			new DDMStructureTestHelper(
+				PortalUtil.getClassNameId(DDMFormInstance.class), _group);
+
+		DDMStructure ddmStructure = ddmStructureTestHelper.addStructure(
+			DDMFormFixture.createDDMForm(LocaleUtil.US),
+			StorageType.JSON.toString());
+
+		return ddmFormInstanceTestHelper.addDDMFormInstance(ddmStructure);
+	}
+
+	private final List<DDMFormInstance> _ddmFormInstances = new ArrayList<>();
+	private final Group _group;
+	private final User _user;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceIndexerIndexedFieldsTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceIndexerIndexedFieldsTest.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
+import com.liferay.dynamic.data.mapping.util.DDMIndexer;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.test.util.FieldValuesAssert;
+import com.liferay.portal.search.test.util.IndexedFieldsFixture;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luan Maoski
+ * @author Lucas Marques
+ */
+@RunWith(Arquillian.class)
+public class DDMFormInstanceIndexerIndexedFieldsTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		setUpUserSearchFixture();
+
+		setUpDDMFormInstanceFixture();
+
+		setUpDDMFormInstanceIndexerFixture();
+
+		setUpIndexedFieldsFixture();
+	}
+
+	@Test
+	public void testIndexedFields() throws Exception {
+		DDMFormInstance ddmFormInstance =
+			ddmFormInstanceFixture.createAnDDMFormInstance();
+
+		String searchTerm = user.getFullName();
+
+		Document document = ddmFormInstanceIndexerFixture.searchOnlyOne(
+			searchTerm);
+
+		indexedFieldsFixture.postProcessDocument(document);
+
+		Map<String, String> expected = _expectedFieldValues(ddmFormInstance);
+
+		FieldValuesAssert.assertFieldValues(expected, document, searchTerm);
+	}
+
+	protected void setUpDDMFormInstanceFixture() {
+		ddmFormInstanceFixture = new DDMFormInstanceFixture(group, user);
+
+		_ddmFormInstances = ddmFormInstanceFixture.getDdmFormInstances();
+	}
+
+	protected void setUpDDMFormInstanceIndexerFixture() {
+		ddmFormInstanceIndexerFixture = new IndexerFixture<>(
+			DDMFormInstance.class);
+	}
+
+	protected void setUpIndexedFieldsFixture() {
+		indexedFieldsFixture = new IndexedFieldsFixture(
+			resourcePermissionLocalService, searchEngineHelper);
+	}
+
+	protected void setUpUserSearchFixture() throws Exception {
+		userSearchFixture = new UserSearchFixture();
+
+		userSearchFixture.setUp();
+
+		_groups = userSearchFixture.getGroups();
+
+		_users = userSearchFixture.getUsers();
+
+		group = userSearchFixture.addGroup();
+
+		user = userSearchFixture.addUser(RandomTestUtil.randomString(), group);
+	}
+
+	protected DDMFormInstanceFixture ddmFormInstanceFixture;
+	protected IndexerFixture<DDMFormInstance> ddmFormInstanceIndexerFixture;
+
+	@Inject
+	protected DDMIndexer ddmIndexer;
+
+	protected Group group;
+	protected IndexedFieldsFixture indexedFieldsFixture;
+
+	@Inject
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+
+	@Inject
+	protected SearchEngineHelper searchEngineHelper;
+
+	protected User user;
+	protected UserSearchFixture userSearchFixture;
+
+	private Map<String, String> _expectedFieldValues(
+			DDMFormInstance ddmFormInstance)
+		throws Exception {
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			Field.COMPANY_ID, String.valueOf(ddmFormInstance.getCompanyId()));
+
+		map.put(Field.ENTRY_CLASS_NAME, DDMFormInstance.class.getName());
+
+		map.put(
+			Field.ENTRY_CLASS_PK,
+			String.valueOf(ddmFormInstance.getFormInstanceId()));
+
+		map.put(Field.GROUP_ID, String.valueOf(ddmFormInstance.getGroupId()));
+
+		map.put(
+			Field.SCOPE_GROUP_ID, String.valueOf(ddmFormInstance.getGroupId()));
+
+		map.put(Field.USER_ID, String.valueOf(ddmFormInstance.getUserId()));
+
+		map.put(
+			Field.USER_NAME,
+			StringUtil.lowerCase(ddmFormInstance.getUserName()));
+
+		map.put(Field.STAGING_GROUP, String.valueOf(group.isStagingGroup()));
+
+		indexedFieldsFixture.populateUID(
+			DDMFormInstance.class.getName(),
+			ddmFormInstance.getFormInstanceId(), map);
+
+		_populateDates(ddmFormInstance, map);
+
+		_populateRoles(ddmFormInstance, map);
+
+		return map;
+	}
+
+	private void _populateDates(
+		DDMFormInstance ddmFormInstance, Map<String, String> map) {
+
+		indexedFieldsFixture.populateDate(
+			Field.CREATE_DATE, ddmFormInstance.getCreateDate(), map);
+		indexedFieldsFixture.populateDate(
+			Field.MODIFIED_DATE, ddmFormInstance.getModifiedDate(), map);
+	}
+
+	private void _populateRoles(
+			DDMFormInstance ddmFormInstance, Map<String, String> map)
+		throws Exception {
+
+		indexedFieldsFixture.populateRoleIdFields(
+			ddmFormInstance.getCompanyId(), DDMFormInstance.class.getName(),
+			ddmFormInstance.getFormInstanceId(), ddmFormInstance.getGroupId(),
+			null, map);
+	}
+
+	@DeleteAfterTestRun
+	private List<DDMFormInstance> _ddmFormInstances;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceIndexerReindexTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceIndexerReindexTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luan Maoski
+ * @author Lucas Marques
+ */
+@RunWith(Arquillian.class)
+public class DDMFormInstanceIndexerReindexTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		setUpUserSearchFixture();
+
+		setUpDDMFormInstanceFixture();
+
+		setUpDDMFormInstanceIndexerFixture();
+	}
+
+	@Test
+	public void testReindexing() throws Exception {
+		Locale locale = LocaleUtil.US;
+
+		String searchTerm = user.getFullName();
+
+		ddmFormInstanceFixture.updateDisplaySettings(locale);
+
+		DDMFormInstance ddmFormInstance =
+			ddmFormInstanceFixture.addDDMFormInstance();
+
+		Document document = ddmFormInstanceIndexerFixture.searchOnlyOne(
+			searchTerm, locale);
+
+		ddmFormInstanceIndexerFixture.deleteDocument(document);
+
+		ddmFormInstanceIndexerFixture.searchNoOne(searchTerm, locale);
+
+		ddmFormInstanceIndexerFixture.reindex(ddmFormInstance.getCompanyId());
+
+		ddmFormInstanceIndexerFixture.searchOnlyOne(searchTerm);
+
+		ddmFormInstanceIndexerFixture.deleteDocument(document);
+	}
+
+	protected void setUpDDMFormInstanceFixture() {
+		ddmFormInstanceFixture = new DDMFormInstanceFixture(group, user);
+
+		_ddmFormInstances = ddmFormInstanceFixture.getDdmFormInstances();
+	}
+
+	protected void setUpDDMFormInstanceIndexerFixture() {
+		ddmFormInstanceIndexerFixture = new IndexerFixture<>(
+			DDMFormInstance.class);
+	}
+
+	protected void setUpUserSearchFixture() throws Exception {
+		userSearchFixture = new UserSearchFixture();
+
+		userSearchFixture.setUp();
+
+		_groups = userSearchFixture.getGroups();
+
+		_users = userSearchFixture.getUsers();
+
+		group = userSearchFixture.addGroup();
+
+		user = userSearchFixture.addUser(RandomTestUtil.randomString(), group);
+	}
+
+	protected DDMFormInstanceFixture ddmFormInstanceFixture;
+	protected IndexerFixture<DDMFormInstance> ddmFormInstanceIndexerFixture;
+	protected Group group;
+
+	@Inject
+	protected SearchEngineHelper searchEngineHelper;
+
+	protected User user;
+	protected UserSearchFixture userSearchFixture;
+
+	@DeleteAfterTestRun
+	private List<DDMFormInstance> _ddmFormInstances;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceRecordFixture.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceRecordFixture.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.search.test;
+
+import com.liferay.dynamic.data.mapping.helper.DDMFormInstanceRecordTestHelper;
+import com.liferay.dynamic.data.mapping.helper.DDMFormInstanceTestHelper;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.LocalizedValue;
+import com.liferay.dynamic.data.mapping.model.Value;
+import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.storage.StorageType;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestHelper;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Luan Maoski
+ * @author Lucas Marques
+ */
+public class DDMFormInstanceRecordFixture {
+
+	public DDMFormInstanceRecordFixture(Group group, User user)
+		throws Exception {
+
+		_group = group;
+		_user = user;
+
+		_setUpDDMFormInstanceRecordTestHelper();
+	}
+
+	public DDMFormInstanceRecord createDDMFormInstanceRecord()
+		throws Exception {
+
+		DDMFormInstanceRecord ddmFormInstanceRecord = addDDMFormInstanceRecord(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		_ddmFormInstanceRecords.add(ddmFormInstanceRecord);
+
+		return ddmFormInstanceRecord;
+	}
+
+	public List<DDMFormInstanceRecord> getDdmFormInstanceRecords() {
+		return _ddmFormInstanceRecords;
+	}
+
+	public DDMStructure getDdmStructure() {
+		return _ddmStructure;
+	}
+
+	public ServiceContext getServiceContext() throws Exception {
+		return ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId(), _user.getUserId());
+	}
+
+	protected DDMFormInstanceRecord addDDMFormInstanceRecord(
+			String name, String description)
+		throws Exception {
+
+		Map<Locale, String> nameMap = new HashMap<>();
+
+		nameMap.put(LocaleUtil.US, name);
+
+		Map<Locale, String> descriptionMap = new HashMap<>();
+
+		descriptionMap.put(LocaleUtil.US, description);
+
+		Set<Locale> localesSet = nameMap.keySet();
+
+		Locale[] locales = new Locale[nameMap.size()];
+
+		localesSet.toArray(locales);
+
+		DDMFormValues ddmFormValues = createDDMFormValues(locales);
+
+		DDMFormFieldValue nameDDMFormFieldValue =
+			createLocalizedDDMFormFieldValue("name", nameMap);
+
+		ddmFormValues.addDDMFormFieldValue(nameDDMFormFieldValue);
+
+		DDMFormFieldValue descriptionDDMFormFieldValue =
+			createLocalizedDDMFormFieldValue("description", descriptionMap);
+
+		ddmFormValues.addDDMFormFieldValue(descriptionDDMFormFieldValue);
+
+		return _ddmFormInstanceRecordTestHelper.addDDMFormInstanceRecord(
+			ddmFormValues);
+	}
+
+	protected DDMFormValues createDDMFormValues(Locale... locales)
+		throws Exception {
+
+		DDMFormInstance ddmFormInstance =
+			_ddmFormInstanceRecordTestHelper.getDDMFormInstance();
+
+		DDMStructure ddmStructure = ddmFormInstance.getStructure();
+
+		return DDMFormValuesTestUtil.createDDMFormValues(
+			ddmStructure.getDDMForm(),
+			DDMFormValuesTestUtil.createAvailableLocales(locales), locales[0]);
+	}
+
+	protected DDMFormFieldValue createLocalizedDDMFormFieldValue(
+		String name, Map<Locale, String> values) {
+
+		Value localizedValue = new LocalizedValue(LocaleUtil.US);
+
+		for (Map.Entry<Locale, String> value : values.entrySet()) {
+			localizedValue.addString(value.getKey(), value.getValue());
+		}
+
+		return DDMFormValuesTestUtil.createDDMFormFieldValue(
+			name, localizedValue);
+	}
+
+	private DDMFormInstance _addDDMFormInstance(DDMStructure ddmStructure)
+		throws Exception {
+
+		DDMFormInstanceTestHelper ddmFormInstanceTestHelper =
+			new DDMFormInstanceTestHelper(_group);
+
+		return ddmFormInstanceTestHelper.addDDMFormInstance(ddmStructure);
+	}
+
+	private void _setUpDDMFormInstanceRecordTestHelper() throws Exception {
+		DDMStructureTestHelper ddmStructureTestHelper =
+			new DDMStructureTestHelper(
+				PortalUtil.getClassNameId(DDMFormInstance.class), _group);
+
+		_ddmStructure = ddmStructureTestHelper.addStructure(
+			DDMFormFixture.createDDMForm(LocaleUtil.US),
+			StorageType.JSON.toString());
+
+		DDMFormInstance ddmFormInstance = _addDDMFormInstance(_ddmStructure);
+
+		_ddmFormInstanceRecordTestHelper = new DDMFormInstanceRecordTestHelper(
+			_group, _user, ddmFormInstance);
+	}
+
+	private final List<DDMFormInstanceRecord> _ddmFormInstanceRecords =
+		new ArrayList<>();
+	private DDMFormInstanceRecordTestHelper _ddmFormInstanceRecordTestHelper;
+	private DDMStructure _ddmStructure;
+	private final Group _group;
+	private final User _user;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceRecordIndexerIndexedFieldsTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceRecordIndexerIndexedFieldsTest.java
@@ -1,0 +1,335 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.util.DDMIndexer;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.test.util.FieldValuesAssert;
+import com.liferay.portal.search.test.util.IndexedFieldsFixture;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luan Maoski
+ * @author Lucas Marques
+ */
+@RunWith(Arquillian.class)
+public class DDMFormInstanceRecordIndexerIndexedFieldsTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		setUpIndexedFieldsFixture();
+
+		setUpDDMFormInstanceRecordIndexerFixture();
+
+		setUpUserSearchFixture();
+
+		setUpDDMFormInstanceRecordFixture();
+	}
+
+	@Test
+	public void testIndexedFields() throws Exception {
+		String searchTerm = user.getFullName();
+
+		DDMFormInstanceRecord ddmFormInstanceRecord =
+			ddmFormInstanceRecordFixture.createDDMFormInstanceRecord();
+
+		Document document = ddmFormInstanceRecordIndexerFixture.searchOnlyOne(
+			searchTerm);
+
+		indexedFieldsFixture.postProcessDocument(document);
+
+		Map<String, String> expected = _expectedFieldValues(
+			ddmFormInstanceRecord);
+
+		FieldValuesAssert.assertFieldValues(expected, document, searchTerm);
+	}
+
+	protected void setUpDDMFormInstanceRecordFixture() throws Exception {
+		ddmFormInstanceRecordFixture = new DDMFormInstanceRecordFixture(
+			group, user);
+
+		_ddmFormInstanceRecords =
+			ddmFormInstanceRecordFixture.getDdmFormInstanceRecords();
+	}
+
+	protected void setUpDDMFormInstanceRecordIndexerFixture() {
+		ddmFormInstanceRecordIndexerFixture = new IndexerFixture<>(
+			DDMFormInstanceRecord.class);
+	}
+
+	protected void setUpIndexedFieldsFixture() {
+		indexedFieldsFixture = new IndexedFieldsFixture(
+			resourcePermissionLocalService, searchEngineHelper);
+	}
+
+	protected void setUpUserSearchFixture() throws Exception {
+		userSearchFixture = new UserSearchFixture();
+
+		userSearchFixture.setUp();
+
+		_groups = userSearchFixture.getGroups();
+
+		_users = userSearchFixture.getUsers();
+
+		group = userSearchFixture.addGroup();
+
+		user = userSearchFixture.addUser(RandomTestUtil.randomString(), group);
+	}
+
+	protected DDMFormInstanceRecordFixture ddmFormInstanceRecordFixture;
+	protected IndexerFixture<DDMFormInstanceRecord>
+		ddmFormInstanceRecordIndexerFixture;
+	protected Group group;
+	protected IndexedFieldsFixture indexedFieldsFixture;
+
+	@Inject
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+
+	@Inject
+	protected SearchEngineHelper searchEngineHelper;
+
+	protected User user;
+	protected UserSearchFixture userSearchFixture;
+
+	private static Map<String, String> _getFieldValues(Document document) {
+		Map<String, Field> fieldsMap = document.getFields();
+
+		Set<Map.Entry<String, Field>> entrySet = fieldsMap.entrySet();
+
+		return entrySet.stream().collect(
+			Collectors.toMap(
+				Map.Entry::getKey,
+				entry -> {
+					Field field = entry.getValue();
+
+					String[] values = field.getValues();
+
+					if (values == null) {
+						return null;
+					}
+
+					if (values.length == 1) {
+						return values[0];
+					}
+
+					return String.valueOf(Arrays.asList(values));
+				}));
+	}
+
+	private Map<String, String> _expectedFieldValues(
+			DDMFormInstanceRecord ddmFormInstanceRecord)
+		throws Exception {
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			Field.CLASS_NAME_ID,
+			String.valueOf(PortalUtil.getClassNameId(DDMFormInstance.class)));
+
+		DDMFormInstance formInstance = ddmFormInstanceRecord.getFormInstance();
+
+		map.put(Field.CLASS_PK, String.valueOf(formInstance.getPrimaryKey()));
+
+		map.put(
+			Field.CLASS_TYPE_ID, String.valueOf(formInstance.getPrimaryKey()));
+
+		map.put(
+			Field.COMPANY_ID,
+			String.valueOf(ddmFormInstanceRecord.getCompanyId()));
+
+		map.put(Field.ENTRY_CLASS_NAME, DDMFormInstanceRecord.class.getName());
+
+		map.put(
+			Field.ENTRY_CLASS_PK,
+			String.valueOf(ddmFormInstanceRecord.getPrimaryKey()));
+
+		map.put(
+			Field.GROUP_ID, String.valueOf(ddmFormInstanceRecord.getGroupId()));
+
+		map.put(Field.RELATED_ENTRY, Boolean.TRUE.toString());
+
+		map.put(
+			Field.SCOPE_GROUP_ID,
+			String.valueOf(ddmFormInstanceRecord.getGroupId()));
+
+		map.put(Field.STAGING_GROUP, String.valueOf(group.isStagingGroup()));
+
+		map.put(
+			Field.STATUS, String.valueOf(ddmFormInstanceRecord.getStatus()));
+
+		map.put(
+			Field.USER_ID, String.valueOf(ddmFormInstanceRecord.getUserId()));
+
+		map.put(
+			Field.USER_NAME,
+			StringUtil.lowerCase(ddmFormInstanceRecord.getUserName()));
+
+		map.put(
+			Field.VERSION, String.valueOf(ddmFormInstanceRecord.getVersion()));
+
+		map.put(
+			"formInstanceId",
+			String.valueOf(ddmFormInstanceRecord.getFormInstanceId()));
+
+		indexedFieldsFixture.populateUID(
+			DDMFormInstanceRecord.class.getName(),
+			ddmFormInstanceRecord.getFormInstanceRecordId(), map);
+
+		_populateAttributes(ddmFormInstanceRecord, map);
+
+		_populateDates(ddmFormInstanceRecord, map);
+
+		_populateContent(ddmFormInstanceRecord, map);
+
+		_populateRoles(ddmFormInstanceRecord, map);
+
+		return map;
+	}
+
+	private String _extractContent(
+			DDMFormInstanceRecord ddmFormInstanceRecord, Locale locale)
+		throws Exception {
+
+		DDMFormValues ddmFormValues = ddmFormInstanceRecord.getDDMFormValues();
+
+		if (ddmFormValues == null) {
+			return StringPool.BLANK;
+		}
+
+		DDMFormInstance ddmFormInstance =
+			ddmFormInstanceRecord.getFormInstance();
+
+		String indexableAttributes = _ddmIndexer.extractIndexableAttributes(
+			ddmFormInstance.getStructure(), ddmFormValues, locale);
+
+		return indexableAttributes.trim();
+	}
+
+	private void _populateAttributes(
+			DDMFormInstanceRecord ddmFormInstanceRecord,
+			Map<String, String> map)
+		throws Exception {
+
+		Document document = new DocumentImpl();
+
+		_ddmIndexer.addAttributes(
+			document, ddmFormInstanceRecordFixture.getDdmStructure(),
+			ddmFormInstanceRecord.getDDMFormValues());
+
+		Map<String, String> fieldValues = _getFieldValues(document);
+
+		fieldValues.forEach((k, v) -> map.put(k, v));
+	}
+
+	private void _populateContent(
+			DDMFormInstanceRecord ddmFormInstanceRecord,
+			Map<String, String> map)
+		throws Exception {
+
+		DDMFormValues ddmFormValues = ddmFormInstanceRecord.getDDMFormValues();
+
+		Set<Locale> locales = ddmFormValues.getAvailableLocales();
+
+		for (Locale locale : locales) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append("ddmContent");
+			sb.append(StringPool.UNDERLINE);
+			sb.append(LocaleUtil.toLanguageId(locale));
+
+			map.put(
+				sb.toString(), _extractContent(ddmFormInstanceRecord, locale));
+		}
+	}
+
+	private void _populateDates(
+		DDMFormInstanceRecord ddmFormInstanceRecord, Map<String, String> map) {
+
+		indexedFieldsFixture.populateDate(
+			Field.CREATE_DATE, ddmFormInstanceRecord.getCreateDate(), map);
+		indexedFieldsFixture.populateDate(
+			Field.MODIFIED_DATE, ddmFormInstanceRecord.getModifiedDate(), map);
+	}
+
+	private void _populateRoles(
+			DDMFormInstanceRecord ddmFormInstanceRecord,
+			Map<String, String> map)
+		throws Exception {
+
+		indexedFieldsFixture.populateRoleIdFields(
+			ddmFormInstanceRecord.getCompanyId(),
+			DDMFormInstance.class.getName(),
+			ddmFormInstanceRecord.getFormInstanceId(),
+			ddmFormInstanceRecord.getGroupId(), null, map);
+	}
+
+	@DeleteAfterTestRun
+	private List<DDMFormInstanceRecord> _ddmFormInstanceRecords;
+
+	@Inject
+	private DDMIndexer _ddmIndexer;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceRecordIndexerReindexTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceRecordIndexerReindexTest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+import com.liferay.users.admin.test.util.search.UserSearchFixture;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luan Maoski
+ * @author Lucas Marques
+ */
+@RunWith(Arquillian.class)
+public class DDMFormInstanceRecordIndexerReindexTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		setUpUserIndexerFixture();
+
+		setUpUserSearchFixture();
+
+		setUpDDMFormInstanceRecordFixture();
+	}
+
+	@Test
+	public void testReindexing() throws Exception {
+		String searchTerm = user.getFullName();
+
+		DDMFormInstanceRecord ddmFormInstanceRecord =
+			ddmFormInstanceRecordFixture.createDDMFormInstanceRecord();
+
+		Document document = ddmFormInstanceRecordIndexerFixture.searchOnlyOne(
+			searchTerm);
+
+		ddmFormInstanceRecordIndexerFixture.deleteDocument(document);
+
+		ddmFormInstanceRecordIndexerFixture.searchNoOne(searchTerm);
+
+		ddmFormInstanceRecordIndexerFixture.reindex(
+			ddmFormInstanceRecord.getCompanyId());
+
+		ddmFormInstanceRecordIndexerFixture.searchOnlyOne(searchTerm);
+	}
+
+	protected void setUpDDMFormInstanceRecordFixture() throws Exception {
+		ddmFormInstanceRecordFixture = new DDMFormInstanceRecordFixture(
+			group, user);
+
+		_ddmFormInstanceRecords =
+			ddmFormInstanceRecordFixture.getDdmFormInstanceRecords();
+	}
+
+	protected void setUpUserIndexerFixture() {
+		ddmFormInstanceRecordIndexerFixture = new IndexerFixture<>(
+			DDMFormInstanceRecord.class);
+	}
+
+	protected void setUpUserSearchFixture() throws Exception {
+		userSearchFixture = new UserSearchFixture();
+
+		userSearchFixture.setUp();
+
+		_groups = userSearchFixture.getGroups();
+
+		_users = userSearchFixture.getUsers();
+
+		group = userSearchFixture.addGroup();
+
+		user = userSearchFixture.addUser(RandomTestUtil.randomString(), group);
+	}
+
+	protected DDMFormInstanceRecordFixture ddmFormInstanceRecordFixture;
+	protected IndexerFixture<DDMFormInstanceRecord>
+		ddmFormInstanceRecordIndexerFixture;
+	protected Group group;
+	protected User user;
+	protected UserSearchFixture userSearchFixture;
+
+	@DeleteAfterTestRun
+	private List<DDMFormInstanceRecord> _ddmFormInstanceRecords;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups;
+
+	@DeleteAfterTestRun
+	private List<User> _users;
+
+}


### PR DESCRIPTION
<h3>:heavy_check_mark: ci:test:search - 17 out of 17 jobs passed in 1 hour 45 minutes 6 seconds 576 ms</h3>

https://github.com/brandizzi/liferay-portal/pull/640#issuecomment-472079785

No failures

Authors: @luanmaoski
Reviewer: @brandizzi

[Task] Migrate DDLRecordSet to new indexer architecture
https://issues.liferay.com/browse/LPS-85386