### PR TITLE
LPS-92022 Jacoco has issues with SerializedLambda. It modifies the fi…

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -343,7 +343,7 @@
 
     jacoco.agent.jar=${project.dir}/lib/development/jacocoagent.jar
     jacoco.dump.file=${project.dir}/jacoco/liferay-jacoco.exec
-    jacoco.excludes=
+    jacoco.excludes=com.liferay.arquillian.extension.junit.bridge.command.*
     jacoco.includes=*
     jacoco.report.folder=${project.dir}/jacoco/html-report
     jacoco.report.include.source.file=true


### PR DESCRIPTION
…xed serialization id to a runtime calculated value. It is a bug of jacoco, but without spending too much effort fixing it, we can exclude the only SerializedLambda user from being instrumented for now.