### PR TITLE
LPS-91644

### DIFF
--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/KeywordResourceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -34,6 +35,7 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
 import javax.ws.rs.ClientErrorException;
@@ -64,6 +66,8 @@ public class KeywordResourceImpl
 			Long contentSpaceId, Filter filter, Pagination pagination,
 			Sort[] sorts)
 		throws Exception {
+
+		GroupUtil.checkGroupExists(contentSpaceId, _groupLocalService);
 
 		return SearchUtil.search(
 			booleanQuery -> {
@@ -176,6 +180,9 @@ public class KeywordResourceImpl
 
 	@Reference
 	private AssetTagService _assetTagService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/GroupUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/GroupUtil.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.util;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.service.GroupLocalService;
+
+import javax.ws.rs.NotFoundException;
+
+/**
+ * @author Víctor Galán
+ */
+public class GroupUtil {
+
+	public static void checkGroupExists(
+		long groupId, GroupLocalService groupLocalService) {
+
+		try {
+			groupLocalService.getGroup(groupId);
+		}
+		catch (PortalException pe) {
+			throw new NotFoundException(
+				"No group exist with ID " + groupId, pe);
+		}
+	}
+
+}


### PR DESCRIPTION
Hey, sorry I didn't give you know enough context, we do have an ExceptionMapper for the NoSuch*Exceptions.

The thing here is that when you pass a nonvalid group Id the services behave in very different ways, for example, in some cases the NoSuchGroupException is wrapped in a RuntimeException, whereas in other services is wrapped in a SearchException, or wrapped in a RuntimeException which is wrapped in a RuntimeException... Things like that. With this approach, we obtain a consistent way of checking it across all APIs

Thanks :)