### PR TITLE
LPS-91971 Reorder  message

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -121,12 +121,14 @@ class AssetVocabularyCategoriesSelector extends Component {
 		if (!this.allowInputCreateItem) {
 			const itemAdded = selectedItems[selectedItems.length - 1];
 
-			if (itemAdded.label == itemAdded.value) {
+			this._unexistingCategoryError = itemAdded.label == itemAdded.value;
+
+			if (this._unexistingCategoryError) {
 				selectedItems = selectedItems.splice(-1, 1);
 
 				multiSelect.inputValue = event.data.item.label;
 
-				//TODO show error
+				this._typedCategory = event.data.item.label;
 			}
 		}
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -118,12 +118,16 @@ class AssetVocabularyCategoriesSelector extends Component {
 			selectedItems[selectedItems.length - 1].value = match.data.value;
 		}
 
-		if (!this.allowInputCreateItem && !match) {
-			selectedItems = selectedItems.splice(-1, 1);
+		if (!this.allowInputCreateItem) {
+			const itemAdded = selectedItems[selectedItems.length - 1];
 
-			multiSelect.inputValue = event.data.item.label;
+			if (itemAdded.label == itemAdded.value) {
+				selectedItems = selectedItems.splice(-1, 1);
 
-			//TODO show error
+				multiSelect.inputValue = event.data.item.label;
+
+				//TODO show error
+			}
 		}
 
 		this.categoryIds = this._getCategoryIds();

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -97,6 +97,16 @@ class AssetVocabularyCategoriesSelector extends Component {
 	}
 
 	/**
+	 * Hides the category error
+	 *
+	 * @private
+	 * @review
+	 */
+	_handleInputOnBlur() {
+		this._unexistingCategoryError = false;
+	}
+
+	/**
 	 * Updates tags fallback and notifies that a new tag has been added
 	 * @param {!Event} event
 	 * @private

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -112,10 +112,18 @@ class AssetVocabularyCategoriesSelector extends Component {
 			}
 		);
 
-		if (match) {
-			const selectedItems = multiSelect.selectedItems;
+		let selectedItems = multiSelect.selectedItems;
 
+		if (match) {
 			selectedItems[selectedItems.length - 1].value = match.data.value;
+		}
+
+		if (!this.allowInputCreateItem && !match) {
+			selectedItems = selectedItems.splice(-1, 1);
+
+			multiSelect.inputValue = event.data.item.label;
+
+			//TODO show error
 		}
 
 		this.categoryIds = this._getCategoryIds();
@@ -173,6 +181,16 @@ class AssetVocabularyCategoriesSelector extends Component {
 }
 
 AssetVocabularyCategoriesSelector.STATE = {
+
+	/**
+	 * Flag to indicate whether input can create item.
+	 * @default false
+	 * @instance
+	 * @memberof AssetVocabularyCategoriesSelector
+	 * @review
+	 * @type {?bool}
+	 */
+	allowInputCreateItem: Config.bool().value(false),
 
 	/**
 	 * A comma separated version of the list of selected items

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.soy
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.soy
@@ -12,6 +12,7 @@
 	{@param? useFallbackInput: bool}
 	{@param? _dataSource: ?}
 	{@param? _handleButtonClicked: any}
+	{@param? _handleInputOnBlur: any}
 	{@param? _handleItemAdded: any}
 	{@param? _handleItemRemoved: any}
 	{@param? _typedCategory: string}
@@ -26,6 +27,7 @@
 			{param dataSource: $_dataSource ?: [] /}
 			{param events: [
 				'buttonClicked': $_handleButtonClicked,
+				'inputOnBlur': $_handleInputOnBlur,
 				'itemAdded': $_handleItemAdded,
 				'itemRemoved': $_handleItemRemoved,
 				'itemSelected': $_handleItemAdded

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.soy
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.soy
@@ -42,7 +42,7 @@
 
 		{if $_unexistingCategoryError}
 			<div class="form-feedback-item">
-				{msg desc=""}{$_typedCategory}-category-does-not-exist{/msg}
+				{msg desc=""}category-{$_typedCategory}-does-not-exist{/msg}
 			</div>
 		{/if}
 	</div>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.soy
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.soy
@@ -14,8 +14,10 @@
 	{@param? _handleButtonClicked: any}
 	{@param? _handleItemAdded: any}
 	{@param? _handleItemRemoved: any}
+	{@param? _typedCategory: string}
+	{@param? _unexistingCategoryError: bool}
 
-	<div class="lfr-tags-selector-content" id="{$id}">
+	<div class="lfr-tags-selector-content {if $_unexistingCategoryError}has-error{/if}" id="{$id}">
 		{if $useFallbackInput}
 			<input id="{$inputName}" name="{$inputName}" type="hidden" value="{$categoryIds}" />
 		{/if}
@@ -35,5 +37,11 @@
 			{param selectedItems: $selectedItems /}
 			{param spritemap: $spritemap /}
 		{/call}
+
+		{if $_unexistingCategoryError}
+			<div class="form-feedback-item">
+				{msg desc=""}{$_typedCategory}-category-does-not-exist{/msg}
+			</div>
+		{/if}
 	</div>
 {/template}

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language.properties
@@ -6,3 +6,4 @@ no-display-page-selected=No Display Page Selected
 related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site.
 specific-display-page=Specific Display Page
 there-are-no-asset-entry-usages=There are no asset entry usages.
+x-category-does-not-exist={0} category does not exist.

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language.properties
@@ -1,3 +1,4 @@
+category-x-does-not-exist=Category {0} does not exist.
 default-display-page=Default Display Page
 fragment=Fragment
 no-default-display-page=No Default Display Page
@@ -6,4 +7,3 @@ no-display-page-selected=No Display Page Selected
 related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site.
 specific-display-page=Specific Display Page
 there-are-no-asset-entry-usages=There are no asset entry usages.
-x-category-does-not-exist={0} category does not exist.

--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_tag_selector.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_tag_selector.scss
@@ -13,6 +13,10 @@
 }
 
 .lfr-tags-selector-content {
+	&.has-error .form-feedback-item {
+		margin-top: -1.5em;
+	}
+
 	.toolbar {
 		position: static;
 	}


### PR DESCRIPTION
Hey Brian, about your comment: 
>@ambrinchaudhary I don't see how this can work...
>{msg desc=""}{$_typedCategory}-category-does-not-exist{/msg}
>vs.
>x-category-does-not-exist={0} category does not exist.
>Unless _typedCategory is always "x" this is bad code. Please test before sending it to me.
>I only caught this because I was going to rename this to
>category-x-does-not-exist

We are following this pattern in other soy files, ie: https://github.com/liferay/liferay-portal/blob/master/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/ManageCollaborators.soy#L125. **_typedCategory** will always be passed as the "x" part of the message, and this is currently working: 

![Category error message](https://user-images.githubusercontent.com/8373764/55150326-329c9e00-514c-11e9-80cc-175b7ee9c5e5.png)


I renamed the message in the last commit. 
Ping me back if you have any other questions. Thank you!
