### PR TITLE
LPS-92341 Fix random SearchEngineAdapterTest failure

### DIFF
--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/DocumentResourceImpl.java
@@ -246,8 +246,7 @@ public class DocumentResourceImpl
 		if ((multipartBody.getBinaryFile("file") == null) &&
 			!documentOptional.isPresent()) {
 
-			throw new BadRequestException(
-				"No document or file found in body");
+			throw new BadRequestException("No document or file found in body");
 		}
 
 		FileEntry existingFileEntry = _dlAppService.getFileEntry(documentId);

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/engine/adapter/test/SearchEngineAdapterTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/engine/adapter/test/SearchEngineAdapterTest.java
@@ -15,11 +15,10 @@
 package com.liferay.portal.search.engine.adapter.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
-import com.liferay.portal.search.engine.adapter.document.UpdateDocumentRequest;
+import com.liferay.portal.search.engine.adapter.index.DeleteIndexRequest;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -44,13 +43,10 @@ public class SearchEngineAdapterTest {
 	public void testExceptionBoundaries() {
 		String index = RandomTestUtil.randomString();
 
-		UpdateDocumentRequest updateDocumentRequest = new UpdateDocumentRequest(
-			index, RandomTestUtil.randomString(), new DocumentImpl());
-
-		updateDocumentRequest.setType(RandomTestUtil.randomString());
+		DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(index);
 
 		try {
-			_searchEngineAdapter.execute(updateDocumentRequest);
+			_searchEngineAdapter.execute(deleteIndexRequest);
 
 			Assert.fail("Exception was not thrown");
 		}


### PR DESCRIPTION
❌ **ci:test:search - 14 out of 17 jobs passed in 1 hour 44 minutes 39 seconds** - https://github.com/BryanEngler/liferay-portal/pull/326#issuecomment-477285356

Only failure is in common with upstream on Search CI, no unique failures on the pr. 

Author: @BryanEngler
Cc: @arboliveira

[Bug] Exceptions library specific must not cross boundaries of engine neutral Search modules
https://issues.liferay.com/browse/LPS-92341