### PR TITLE
LPS-92553 Baseline

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-blogs-web/build.gradle
+++ b/modules/apps/adaptive-media/adaptive-media-blogs-web/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly project(":apps:asset:asset-display-api")
 	compileOnly project(":apps:blogs:blogs-api")
 	compileOnly project(":apps:export-import:export-import-api")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":core:petra:petra-string")
 
 	testCompile project(":core:petra:petra-lang")

--- a/modules/apps/asset/asset-display-api/build.gradle
+++ b/modules/apps/asset/asset-display-api/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/asset/asset-display-api/src/main/java/com/liferay/asset/display/contributor/AssetDisplayContributorField.java
+++ b/modules/apps/asset/asset-display-api/src/main/java/com/liferay/asset/display/contributor/AssetDisplayContributorField.java
@@ -14,19 +14,11 @@
 
 package com.liferay.asset.display.contributor;
 
-import java.util.Locale;
+import com.liferay.info.display.contributor.InfoDisplayContributorField;
 
 /**
  * @author Jürgen Kappler
  */
-public interface AssetDisplayContributorField<T> {
-
-	public String getKey();
-
-	public String getLabel(Locale locale);
-
-	public String getType();
-
-	public Object getValue(T model, Locale locale);
-
+public interface AssetDisplayContributorField<T>
+	extends InfoDisplayContributorField<T> {
 }

--- a/modules/apps/asset/asset-display-api/src/main/java/com/liferay/asset/display/contributor/AssetDisplayField.java
+++ b/modules/apps/asset/asset-display-api/src/main/java/com/liferay/asset/display/contributor/AssetDisplayField.java
@@ -14,84 +14,19 @@
 
 package com.liferay.asset.display.contributor;
 
-import com.liferay.petra.lang.HashUtil;
-import com.liferay.portal.kernel.json.JSONFactoryUtil;
-import com.liferay.portal.kernel.json.JSONObject;
-
-import java.util.Objects;
+import com.liferay.info.display.contributor.InfoDisplayField;
 
 /**
  * @author Jürgen Kappler
  */
-public class AssetDisplayField {
+public class AssetDisplayField extends InfoDisplayField {
 
 	public AssetDisplayField(String key, String label) {
-		this(key, label, _TYPE);
+		super(key, label);
 	}
 
 	public AssetDisplayField(String key, String label, String type) {
-		_key = key;
-		_label = label;
-		_type = type;
+		super(key, label, type);
 	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-
-		if (!(obj instanceof AssetDisplayField)) {
-			return false;
-		}
-
-		AssetDisplayField assetDisplayField = (AssetDisplayField)obj;
-
-		if (Objects.equals(_key, assetDisplayField._key) &&
-			Objects.equals(_label, assetDisplayField._label) &&
-			Objects.equals(_type, assetDisplayField._type)) {
-
-			return true;
-		}
-
-		return false;
-	}
-
-	public String getKey() {
-		return _key;
-	}
-
-	public String getLabel() {
-		return _label;
-	}
-
-	public String getType() {
-		return _type;
-	}
-
-	@Override
-	public int hashCode() {
-		int hash = HashUtil.hash(0, _key);
-
-		hash = HashUtil.hash(hash, _label);
-
-		return HashUtil.hash(hash, _type);
-	}
-
-	public JSONObject toJSONObject() {
-		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
-
-		jsonObject.put("key", getKey());
-		jsonObject.put("label", getLabel());
-		jsonObject.put("type", getType());
-
-		return jsonObject;
-	}
-
-	private static final String _TYPE = "text";
-
-	private final String _key;
-	private final String _label;
-	private final String _type;
 
 }

--- a/modules/apps/asset/asset-display-api/src/main/java/com/liferay/asset/display/contributor/AssetInfoDisplayContributor.java
+++ b/modules/apps/asset/asset-display-api/src/main/java/com/liferay/asset/display/contributor/AssetInfoDisplayContributor.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.display.contributor;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.ClassType;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
+import com.liferay.info.display.contributor.InfoDisplayField;
+import com.liferay.portal.kernel.exception.PortalException;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class AssetInfoDisplayContributor
+	implements InfoDisplayContributor<AssetEntry> {
+
+	public AssetInfoDisplayContributor(
+		AssetDisplayContributor assetDisplayContributor) {
+
+		_assetDisplayContributor = assetDisplayContributor;
+	}
+
+	@Override
+	public String getClassName() {
+		return _assetDisplayContributor.getClassName();
+	}
+
+	@Override
+	public List<InfoDisplayField> getClassTypeFields(
+			long classTypeId, Locale locale)
+		throws PortalException {
+
+		List<InfoDisplayField> infoDisplayFields = new ArrayList<>();
+
+		List<AssetDisplayField> assetDisplayFields =
+			_assetDisplayContributor.getClassTypeFields(classTypeId, locale);
+
+		for (AssetDisplayField assetDisplayField : assetDisplayFields) {
+			infoDisplayFields.add(assetDisplayField);
+		}
+
+		return infoDisplayFields;
+	}
+
+	@Override
+	public List<ClassType> getClassTypes(long groupId, Locale locale)
+		throws PortalException {
+
+		return _assetDisplayContributor.getClassTypes(groupId, locale);
+	}
+
+	@Override
+	public Set<InfoDisplayField> getInfoDisplayFields(
+			long classTypeId, Locale locale)
+		throws PortalException {
+
+		Set<InfoDisplayField> infoDisplayFields = new HashSet<>();
+
+		Set<AssetDisplayField> assetDisplayFields =
+			_assetDisplayContributor.getAssetDisplayFields(classTypeId, locale);
+
+		for (AssetDisplayField assetDisplayField : assetDisplayFields) {
+			infoDisplayFields.add(assetDisplayField);
+		}
+
+		return infoDisplayFields;
+	}
+
+	@Override
+	public Map<String, Object> getInfoDisplayFieldsValues(
+			AssetEntry assetEntry, Locale locale)
+		throws PortalException {
+
+		return _assetDisplayContributor.getAssetDisplayFieldsValues(
+			assetEntry, locale);
+	}
+
+	@Override
+	public Object getInfoDisplayFieldValue(
+			AssetEntry assetEntry, String fieldName, Locale locale)
+		throws PortalException {
+
+		return _assetDisplayContributor.getAssetDisplayFieldValue(
+			assetEntry, fieldName, locale);
+	}
+
+	@Override
+	public String getInfoURLSeparator() {
+		return _assetDisplayContributor.getAssetURLSeparator();
+	}
+
+	@Override
+	public Map<String, Object> getInfoVersionDisplayFieldsValues(
+			AssetEntry assetEntry, long versionClassPK, Locale locale)
+		throws PortalException {
+
+		return _assetDisplayContributor.getAssetDisplayFieldsValues(
+			assetEntry, versionClassPK, locale);
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		return _assetDisplayContributor.getLabel(locale);
+	}
+
+	private final AssetDisplayContributor _assetDisplayContributor;
+
+}

--- a/modules/apps/asset/asset-display-api/src/main/java/com/liferay/asset/display/contributor/constants/AssetDisplayWebKeys.java
+++ b/modules/apps/asset/asset-display-api/src/main/java/com/liferay/asset/display/contributor/constants/AssetDisplayWebKeys.java
@@ -19,9 +19,6 @@ package com.liferay.asset.display.contributor.constants;
  */
 public class AssetDisplayWebKeys {
 
-	public static final String ASSET_DISPLAY_CONTRIBUTOR =
-		"ASSET_DISPLAY_CONTRIBUTOR";
-
 	/**
 	 * @deprecated As of Judson (7.1.x), with no direct replacement
 	 */
@@ -30,6 +27,9 @@ public class AssetDisplayWebKeys {
 
 	public static final String CURRENT_I18N_LANGUAGE_ID =
 		"CURRENT_I18N_LANGUAGE_ID";
+
+	public static final String INFO_DISPLAY_CONTRIBUTOR =
+		"INFO_DISPLAY_CONTRIBUTOR";
 
 	public static final String VERSION_CLASS_PK = "VERSION_CLASS_PK";
 

--- a/modules/apps/asset/asset-display-api/src/main/resources/com/liferay/asset/display/contributor/constants/packageinfo
+++ b/modules/apps/asset/asset-display-api/src/main/resources/com/liferay/asset/display/contributor/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/asset/asset-display-impl/build.gradle
+++ b/modules/apps/asset/asset-display-impl/build.gradle
@@ -5,5 +5,6 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.http.whiteboard", version: "1.0.0"
 	compileOnly project(":apps:asset:asset-display-api")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/asset/asset-display-page-item-selector-web/build.gradle
+++ b/modules/apps/asset/asset-display-page-item-selector-web/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:layout:layout-page-template-api")

--- a/modules/apps/asset/asset-display-page-item-selector-web/src/main/java/com/liferay/asset/display/page/item/selector/web/internal/AssetDisplayPagesItemSelectorView.java
+++ b/modules/apps/asset/asset-display-page-item-selector-web/src/main/java/com/liferay/asset/display/page/item/selector/web/internal/AssetDisplayPagesItemSelectorView.java
@@ -85,7 +85,7 @@ public class AssetDisplayPagesItemSelectorView
 
 		request.setAttribute(
 			AssetDisplayPageItemSelectorWebKeys.
-				ASSET_DISPLAY_CONTRIBUTOR_TRACKER,
+				INFO_DISPLAY_CONTRIBUTOR_TRACKER,
 			_assetDisplayContributorTracker);
 
 		HttpServletRequest httpServletRequest = (HttpServletRequest)request;

--- a/modules/apps/asset/asset-display-page-item-selector-web/src/main/java/com/liferay/asset/display/page/item/selector/web/internal/AssetDisplayPagesItemSelectorView.java
+++ b/modules/apps/asset/asset-display-page-item-selector-web/src/main/java/com/liferay/asset/display/page/item/selector/web/internal/AssetDisplayPagesItemSelectorView.java
@@ -14,10 +14,10 @@
 
 package com.liferay.asset.display.page.item.selector.web.internal;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
 import com.liferay.asset.display.page.item.selector.criterion.AssetDisplayPageSelectorCriterion;
 import com.liferay.asset.display.page.item.selector.web.internal.constants.AssetDisplayPageItemSelectorWebKeys;
 import com.liferay.asset.display.page.item.selector.web.internal.display.context.AssetDisplayPagesItemSelectorViewDisplayContext;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.item.selector.criteria.UUIDItemSelectorReturnType;
@@ -86,7 +86,7 @@ public class AssetDisplayPagesItemSelectorView
 		request.setAttribute(
 			AssetDisplayPageItemSelectorWebKeys.
 				INFO_DISPLAY_CONTRIBUTOR_TRACKER,
-			_assetDisplayContributorTracker);
+			_infoDisplayContributorTracker);
 
 		HttpServletRequest httpServletRequest = (HttpServletRequest)request;
 
@@ -117,7 +117,7 @@ public class AssetDisplayPagesItemSelectorView
 				}));
 
 	@Reference
-	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
+	private InfoDisplayContributorTracker _infoDisplayContributorTracker;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.asset.display.page.item.selector.web)"

--- a/modules/apps/asset/asset-display-page-item-selector-web/src/main/java/com/liferay/asset/display/page/item/selector/web/internal/constants/AssetDisplayPageItemSelectorWebKeys.java
+++ b/modules/apps/asset/asset-display-page-item-selector-web/src/main/java/com/liferay/asset/display/page/item/selector/web/internal/constants/AssetDisplayPageItemSelectorWebKeys.java
@@ -19,11 +19,11 @@ package com.liferay.asset.display.page.item.selector.web.internal.constants;
  */
 public class AssetDisplayPageItemSelectorWebKeys {
 
-	public static final String ASSET_DISPLAY_CONTRIBUTOR_TRACKER =
-		"ASSET_DISPLAY_CONTRIBUTOR_TRACKER";
-
 	public static final String
 		ASSET_DISPLAY_PAGES_ITEM_SELECTOR_VIEW_DISPLAY_CONTEXT =
 			"ASSET_DISPLAY_PAGES_ITEM_SELECTOR_VIEW_DISPLAY_CONTEXT";
+
+	public static final String INFO_DISPLAY_CONTRIBUTOR_TRACKER =
+		"INFO_DISPLAY_CONTRIBUTOR_TRACKER";
 
 }

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/DisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/DisplayPageFriendlyURLResolver.java
@@ -14,8 +14,6 @@
 
 package com.liferay.asset.publisher.web.internal.portlet;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributor;
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
 import com.liferay.asset.display.contributor.constants.AssetDisplayWebKeys;
 import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
 import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
@@ -31,6 +29,8 @@ import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
 import com.liferay.asset.util.AssetHelper;
 import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 import com.liferay.journal.exception.NoSuchArticleException;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleConstants;
@@ -377,11 +377,11 @@ public class DisplayPageFriendlyURLResolver implements FriendlyURLResolver {
 			Map<String, Object> requestContext, String urlTitle)
 		throws PortalException {
 
-		AssetDisplayContributor assetDisplayContributor =
-			_assetDisplayContributorTracker.getAssetDisplayContributor(
+		InfoDisplayContributor infoDisplayContributor =
+			_infoDisplayContributorTracker.getInfoDisplayContributor(
 				assetEntry.getClassName());
 
-		if (assetDisplayContributor == null) {
+		if (infoDisplayContributor == null) {
 			throw new PortalException();
 		}
 
@@ -390,7 +390,7 @@ public class DisplayPageFriendlyURLResolver implements FriendlyURLResolver {
 
 		request.setAttribute(
 			AssetDisplayWebKeys.INFO_DISPLAY_CONTRIBUTOR,
-			assetDisplayContributor);
+			infoDisplayContributor);
 		request.setAttribute(WebKeys.LAYOUT_ASSET_ENTRY, assetEntry);
 
 		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
@@ -429,9 +429,6 @@ public class DisplayPageFriendlyURLResolver implements FriendlyURLResolver {
 		DisplayPageFriendlyURLResolver.class);
 
 	@Reference
-	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
-
-	@Reference
 	private AssetDisplayPageEntryLocalService
 		_assetDisplayPageEntryLocalService;
 
@@ -452,6 +449,9 @@ public class DisplayPageFriendlyURLResolver implements FriendlyURLResolver {
 
 	@Reference
 	private Http _http;
+
+	@Reference
+	private InfoDisplayContributorTracker _infoDisplayContributorTracker;
 
 	@Reference
 	private JournalArticleLocalService _journalArticleLocalService;

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/DisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/DisplayPageFriendlyURLResolver.java
@@ -389,7 +389,7 @@ public class DisplayPageFriendlyURLResolver implements FriendlyURLResolver {
 			"request");
 
 		request.setAttribute(
-			AssetDisplayWebKeys.ASSET_DISPLAY_CONTRIBUTOR,
+			AssetDisplayWebKeys.INFO_DISPLAY_CONTRIBUTOR,
 			assetDisplayContributor);
 		request.setAttribute(WebKeys.LAYOUT_ASSET_ENTRY, assetEntry);
 

--- a/modules/apps/blogs/blogs-reading-time/build.gradle
+++ b/modules/apps/blogs/blogs-reading-time/build.gradle
@@ -4,5 +4,6 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:asset:asset-display-api")
 	compileOnly project(":apps:blogs:blogs-api")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:reading-time:reading-time-api")
 }

--- a/modules/apps/blogs/blogs-web/build.gradle
+++ b/modules/apps/blogs/blogs-web/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:item-selector:item-selector-taglib")

--- a/modules/apps/document-library/document-library-web/build.gradle
+++ b/modules/apps/document-library/document-library-web/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-dynamic-section")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":apps:portlet-display-template:portlet-display-template-api")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/form.soy
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/form.soy
@@ -402,7 +402,16 @@
 	<div class="lfr-ddm-form-container" id="{$containerId}">
 		<div class="lfr-ddm-settings-form">
 			{foreach $page in $pages}
-				<div class="active advanced{/if} basic{/if}{if isLast($page)} lfr-ddm-form-page{if isFirst($page)}">
+				{let $classes kind="text"}
+					lfr-ddm-form-page
+					{if isFirst($page)}
+						{sp}active basic
+					{elseif isLast($page)}
+						{sp}advanced
+					{/if}
+				{/let}
+
+				<div class="{$classes}">
 					{call .form_rows data="all"}
 						{param rows: $page.rows /}
 					{/call}

--- a/modules/apps/fragment/fragment-api/build.gradle
+++ b/modules/apps/fragment/fragment-api/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:asset:asset-display-api")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/build.gradle
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/build.gradle
@@ -7,5 +7,6 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:asset:asset-display-api")
 	compileOnly project(":apps:fragment:fragment-api")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/EditableFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/EditableFragmentEntryProcessor.java
@@ -14,8 +14,6 @@
 
 package com.liferay.fragment.entry.processor.editable;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributor;
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
 import com.liferay.asset.display.contributor.util.ContentAccessor;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
@@ -24,6 +22,8 @@ import com.liferay.fragment.entry.processor.editable.parser.EditableElementParse
 import com.liferay.fragment.exception.FragmentEntryContentException;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.FragmentEntryProcessor;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -404,13 +404,13 @@ public class EditableFragmentEntryProcessor implements FragmentEntryProcessor {
 			return StringPool.BLANK;
 		}
 
-		AssetDisplayContributor assetDisplayContributor =
-			_assetDisplayContributorTracker.getAssetDisplayContributor(
+		InfoDisplayContributor infoDisplayContributor =
+			_infoDisplayContributorTracker.getInfoDisplayContributor(
 				_portal.getClassName(classNameId));
 
 		String fieldId = jsonObject.getString("fieldId");
 
-		Object fieldValue = assetDisplayContributor.getAssetDisplayFieldValue(
+		Object fieldValue = infoDisplayContributor.getInfoDisplayFieldValue(
 			assetEntry, fieldId, locale);
 
 		if (fieldValue instanceof ContentAccessor) {
@@ -647,13 +647,13 @@ public class EditableFragmentEntryProcessor implements FragmentEntryProcessor {
 		"([^\\{]+)\\s*\\{([^\\}]+)\\}");
 
 	@Reference
-	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
-
-	@Reference
 	private AssetEntryLocalService _assetEntryLocalService;
 
 	private final Map<String, EditableElementParser> _editableElementParsers =
 		new HashMap<>();
+
+	@Reference
+	private InfoDisplayContributorTracker _infoDisplayContributorTracker;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/display/contributor/InfoDisplayContributor.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/display/contributor/InfoDisplayContributor.java
@@ -14,8 +14,10 @@
 
 package com.liferay.info.display.contributor;
 
+import com.liferay.asset.kernel.model.ClassType;
 import com.liferay.portal.kernel.exception.PortalException;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -26,6 +28,13 @@ import java.util.Set;
 public interface InfoDisplayContributor<T> {
 
 	public String getClassName();
+
+	public List<InfoDisplayField> getClassTypeFields(
+			long classTypeId, Locale locale)
+		throws PortalException;
+
+	public List<ClassType> getClassTypes(long groupId, Locale locale)
+		throws PortalException;
 
 	public Set<InfoDisplayField> getInfoDisplayFields(
 			long classTypeId, Locale locale)

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/display/contributor/InfoDisplayContributorTracker.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/display/contributor/InfoDisplayContributorTracker.java
@@ -21,6 +21,11 @@ import java.util.List;
  */
 public interface InfoDisplayContributorTracker {
 
+	public InfoDisplayContributor getInfoDisplayContributor(String className);
+
+	public InfoDisplayContributor getInfoDisplayContributorByURLSeparator(
+		String urlSeparator);
+
 	public List<InfoDisplayContributor> getInfoDisplayContributors();
 
 }

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/display/contributor/InfoDisplayContributorTrackerImpl.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/display/contributor/InfoDisplayContributorTrackerImpl.java
@@ -17,9 +17,10 @@ package com.liferay.info.internal.display.contributor;
 import com.liferay.info.display.contributor.InfoDisplayContributor;
 import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -34,8 +35,22 @@ public class InfoDisplayContributorTrackerImpl
 	implements InfoDisplayContributorTracker {
 
 	@Override
+	public InfoDisplayContributor getInfoDisplayContributor(
+		String className) {
+
+		return _infoDisplayContributor.get(className);
+	}
+
+	@Override
+	public InfoDisplayContributor getInfoDisplayContributorByURLSeparator(
+		String urlSeparator) {
+
+		return _infoDisplayContributorByURLSeparator.get(urlSeparator);
+	}
+
+	@Override
 	public List<InfoDisplayContributor> getInfoDisplayContributors() {
-		return Collections.unmodifiableList(_infoDisplayContributors);
+		return new ArrayList(_infoDisplayContributor.values());
 	}
 
 	@Reference(
@@ -45,16 +60,24 @@ public class InfoDisplayContributorTrackerImpl
 	protected void setInfoDisplayContributor(
 		InfoDisplayContributor infoDisplayContributor) {
 
-		_infoDisplayContributors.add(infoDisplayContributor);
+		_infoDisplayContributor.put(
+			infoDisplayContributor.getClassName(), infoDisplayContributor);
+		_infoDisplayContributorByURLSeparator.put(
+			infoDisplayContributor.getInfoURLSeparator(),
+			infoDisplayContributor);
 	}
 
 	protected void unsetInfoDisplayContributor(
 		InfoDisplayContributor infoDisplayContributor) {
 
-		_infoDisplayContributors.remove(infoDisplayContributor);
+		_infoDisplayContributor.remove(infoDisplayContributor.getClassName());
+		_infoDisplayContributorByURLSeparator.remove(
+			infoDisplayContributor.getInfoURLSeparator());
 	}
 
-	private final List<InfoDisplayContributor> _infoDisplayContributors =
-		new CopyOnWriteArrayList();
+	private final Map<String, InfoDisplayContributor>
+		_infoDisplayContributor = new ConcurrentHashMap<>();
+	private final Map<String, InfoDisplayContributor>
+		_infoDisplayContributorByURLSeparator = new ConcurrentHashMap<>();
 
 }

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/display/contributor/InfoDisplayContributorTrackerImpl.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/display/contributor/InfoDisplayContributorTrackerImpl.java
@@ -35,9 +35,7 @@ public class InfoDisplayContributorTrackerImpl
 	implements InfoDisplayContributorTracker {
 
 	@Override
-	public InfoDisplayContributor getInfoDisplayContributor(
-		String className) {
-
+	public InfoDisplayContributor getInfoDisplayContributor(String className) {
 		return _infoDisplayContributor.get(className);
 	}
 
@@ -75,8 +73,8 @@ public class InfoDisplayContributorTrackerImpl
 			infoDisplayContributor.getInfoURLSeparator());
 	}
 
-	private final Map<String, InfoDisplayContributor>
-		_infoDisplayContributor = new ConcurrentHashMap<>();
+	private final Map<String, InfoDisplayContributor> _infoDisplayContributor =
+		new ConcurrentHashMap<>();
 	private final Map<String, InfoDisplayContributor>
 		_infoDisplayContributorByURLSeparator = new ConcurrentHashMap<>();
 

--- a/modules/apps/journal/journal-web/build.gradle
+++ b/modules/apps/journal/journal-web/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-form-navigator")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:journal:journal-api")

--- a/modules/apps/layout/layout-admin-web/build.gradle
+++ b/modules/apps/layout/layout-admin-web/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
 	compileOnly project(":apps:html-preview:html-preview-api")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:journal:journal-api")

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/constants/LayoutAdminWebKeys.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/constants/LayoutAdminWebKeys.java
@@ -19,11 +19,11 @@ package com.liferay.layout.admin.web.internal.constants;
  */
 public class LayoutAdminWebKeys {
 
-	public static final String ASSET_DISPLAY_CONTRIBUTOR_TRACKER =
-		"ASSET_DISPLAY_CONTRIBUTOR_TRACKER";
-
 	public static final String DISPLAY_PAGE_DROPDOWN_DEFAULT_EVENT_HANDLER =
 		"DISPLAY_PAGE_DROPDOWN_DEFAULT_EVENT_HANDLER";
+
+	public static final String INFO_DISPLAY_CONTRIBUTOR_TRACKER =
+		"INFO_DISPLAY_CONTRIBUTOR_TRACKER";
 
 	public static final String ITEM_SELECTOR = "ITEM_SELECTOR";
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/GroupPagesPortlet.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/GroupPagesPortlet.java
@@ -186,7 +186,7 @@ public class GroupPagesPortlet extends MVCPortlet {
 				LayoutAdminWebConfiguration.class.getName(),
 				_layoutAdminWebConfiguration);
 			renderRequest.setAttribute(
-				LayoutAdminWebKeys.ASSET_DISPLAY_CONTRIBUTOR_TRACKER,
+				LayoutAdminWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER,
 				_assetDisplayContributorTracker);
 			renderRequest.setAttribute(
 				ApplicationListWebKeys.GROUP_PROVIDER, _groupProvider);

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/GroupPagesPortlet.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/GroupPagesPortlet.java
@@ -16,8 +16,8 @@ package com.liferay.layout.admin.web.internal.portlet;
 
 import com.liferay.application.list.GroupProvider;
 import com.liferay.application.list.constants.ApplicationListWebKeys;
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
 import com.liferay.asset.kernel.exception.AssetCategoryException;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.admin.web.internal.configuration.LayoutAdminWebConfiguration;
@@ -186,10 +186,10 @@ public class GroupPagesPortlet extends MVCPortlet {
 				LayoutAdminWebConfiguration.class.getName(),
 				_layoutAdminWebConfiguration);
 			renderRequest.setAttribute(
-				LayoutAdminWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER,
-				_assetDisplayContributorTracker);
-			renderRequest.setAttribute(
 				ApplicationListWebKeys.GROUP_PROVIDER, _groupProvider);
+			renderRequest.setAttribute(
+				LayoutAdminWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER,
+				_infoDisplayContributorTracker);
 			renderRequest.setAttribute(
 				LayoutAdminWebKeys.ITEM_SELECTOR, _itemSelector);
 			renderRequest.setAttribute(
@@ -236,10 +236,10 @@ public class GroupPagesPortlet extends MVCPortlet {
 		GroupPagesPortlet.class);
 
 	@Reference
-	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
+	private GroupProvider _groupProvider;
 
 	@Reference
-	private GroupProvider _groupProvider;
+	private InfoDisplayContributorTracker _infoDisplayContributorTracker;
 
 	@Reference
 	private ItemSelector _itemSelector;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/AssetDisplayContributorFieldsMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/AssetDisplayContributorFieldsMVCActionCommand.java
@@ -14,9 +14,9 @@
 
 package com.liferay.layout.admin.web.internal.portlet.action;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributor;
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
-import com.liferay.asset.display.contributor.AssetDisplayField;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
+import com.liferay.info.display.contributor.InfoDisplayField;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -26,6 +26,8 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.Set;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -54,11 +56,10 @@ public class AssetDisplayContributorFieldsMVCActionCommand
 
 		String className = ParamUtil.getString(actionRequest, "className");
 
-		AssetDisplayContributor assetDisplayContributor =
-			_assetDisplayContributorTracker.getAssetDisplayContributor(
-				className);
+		InfoDisplayContributor infoDisplayContributor =
+			_infoDisplayContributorTracker.getInfoDisplayContributor(className);
 
-		if (assetDisplayContributor == null) {
+		if (infoDisplayContributor == null) {
 			JSONPortletResponseUtil.writeJSON(
 				actionRequest, actionResponse,
 				JSONFactoryUtil.createJSONArray());
@@ -73,11 +74,12 @@ public class AssetDisplayContributorFieldsMVCActionCommand
 
 		long classTypeId = ParamUtil.getLong(actionRequest, "classTypeId");
 
-		for (AssetDisplayField assetDisplayField :
-				assetDisplayContributor.getAssetDisplayFields(
-					classTypeId, themeDisplay.getLocale())) {
+		Set<InfoDisplayField> infoDisplayFields =
+			infoDisplayContributor.getInfoDisplayFields(
+				classTypeId, themeDisplay.getLocale());
 
-			jsonArray.put(assetDisplayField.toJSONObject());
+		for (InfoDisplayField infoDisplayField : infoDisplayFields) {
+			jsonArray.put(infoDisplayField.toJSONObject());
 		}
 
 		JSONPortletResponseUtil.writeJSON(
@@ -85,6 +87,6 @@ public class AssetDisplayContributorFieldsMVCActionCommand
 	}
 
 	@Reference
-	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
+	private InfoDisplayContributorTracker _infoDisplayContributorTracker;
 
 }

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/DisplayPageVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/DisplayPageVerticalCard.java
@@ -69,7 +69,7 @@ public class DisplayPageVerticalCard
 
 		_assetDisplayContributorTracker =
 			(AssetDisplayContributorTracker)renderRequest.getAttribute(
-				LayoutAdminWebKeys.ASSET_DISPLAY_CONTRIBUTOR_TRACKER);
+				LayoutAdminWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER);
 		_layoutPageTemplateEntry = (LayoutPageTemplateEntry)baseModel;
 		_themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/DisplayPageVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/DisplayPageVerticalCard.java
@@ -14,8 +14,6 @@
 
 package com.liferay.layout.admin.web.internal.servlet.taglib.clay;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributor;
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
 import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.model.ClassType;
@@ -25,6 +23,8 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.soy.VerticalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItemList;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 import com.liferay.layout.admin.web.internal.constants.LayoutAdminWebKeys;
 import com.liferay.layout.admin.web.internal.servlet.taglib.util.DisplayPageActionDropdownItemsProvider;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
@@ -67,8 +67,8 @@ public class DisplayPageVerticalCard
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 
-		_assetDisplayContributorTracker =
-			(AssetDisplayContributorTracker)renderRequest.getAttribute(
+		_infoDisplayContributorTracker =
+			(InfoDisplayContributorTracker)renderRequest.getAttribute(
 				LayoutAdminWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER);
 		_layoutPageTemplateEntry = (LayoutPageTemplateEntry)baseModel;
 		_themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
@@ -231,19 +231,18 @@ public class DisplayPageVerticalCard
 	}
 
 	private String _getTypeLabel() {
-		AssetDisplayContributor assetDisplayContributor =
-			_assetDisplayContributorTracker.getAssetDisplayContributor(
+		InfoDisplayContributor infoDisplayContributor =
+			_infoDisplayContributorTracker.getInfoDisplayContributor(
 				_layoutPageTemplateEntry.getClassName());
 
-		if (assetDisplayContributor == null) {
+		if (infoDisplayContributor == null) {
 			return StringPool.BLANK;
 		}
 
-		return assetDisplayContributor.getLabel(_themeDisplay.getLocale());
+		return infoDisplayContributor.getLabel(_themeDisplay.getLocale());
 	}
 
-	private final AssetDisplayContributorTracker
-		_assetDisplayContributorTracker;
+	private final InfoDisplayContributorTracker _infoDisplayContributorTracker;
 	private final LayoutPageTemplateEntry _layoutPageTemplateEntry;
 	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;

--- a/modules/apps/layout/layout-content-page-editor-api/src/main/java/com/liferay/layout/content/page/editor/constants/ContentPageEditorWebKeys.java
+++ b/modules/apps/layout/layout-content-page-editor-api/src/main/java/com/liferay/layout/content/page/editor/constants/ContentPageEditorWebKeys.java
@@ -19,15 +19,15 @@ package com.liferay.layout.content.page.editor.constants;
  */
 public class ContentPageEditorWebKeys {
 
-	public static final String ASSET_DISPLAY_CONTRIBUTOR_TRACKER =
-		"ASSET_DISPLAY_CONTRIBUTOR_TRACKER";
-
 	public static final String CLASS_NAME = "CLASS_NAME";
 
 	public static final String CLASS_PK = "CLASS_PK";
 
 	public static final String FRAGMENT_COLLECTION_CONTRIBUTOR_TRACKER =
 		"FRAGMENT_COLLECTION_CONTRIBUTOR_TRACKER";
+
+	public static final String INFO_DISPLAY_CONTRIBUTOR_TRACKER =
+		"INFO_DISPLAY_CONTRIBUTOR_TRACKER";
 
 	public static final String ITEM_SELECTOR = "ITEM_SELECTOR";
 

--- a/modules/apps/layout/layout-content-page-editor-web/build.gradle
+++ b/modules/apps/layout/layout-content-page-editor-web/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	compileOnly project(":apps:frontend-editor:frontend-editor-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:layout:layout-admin-api")

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -14,8 +14,6 @@
 
 package com.liferay.layout.content.page.editor.web.internal.display.context;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributor;
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.fragment.constants.FragmentEntryLinkConstants;
@@ -29,6 +27,8 @@ import com.liferay.fragment.service.FragmentCollectionServiceUtil;
 import com.liferay.fragment.service.FragmentEntryLinkLocalServiceUtil;
 import com.liferay.fragment.service.FragmentEntryServiceUtil;
 import com.liferay.fragment.util.FragmentEntryRenderUtil;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.ItemSelectorReturnType;
@@ -128,10 +128,10 @@ public class ContentPageEditorDisplayContext {
 		_renderResponse = renderResponse;
 		this.classPK = classPK;
 
-		assetDisplayContributorTracker =
-			(AssetDisplayContributorTracker)request.getAttribute(
-				ContentPageEditorWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER);
 		classNameId = PortalUtil.getClassNameId(className);
+		infoDisplayContributorTracker =
+			(InfoDisplayContributorTracker)request.getAttribute(
+				ContentPageEditorWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER);
 		themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 		_fragmentCollectionContributorTracker =
@@ -394,10 +394,9 @@ public class ContentPageEditorDisplayContext {
 		return _sidebarPanelSoyContexts;
 	}
 
-	protected final AssetDisplayContributorTracker
-		assetDisplayContributorTracker;
 	protected final long classNameId;
 	protected final long classPK;
+	protected final InfoDisplayContributorTracker infoDisplayContributorTracker;
 	protected final HttpServletRequest request;
 	protected final ThemeDisplay themeDisplay;
 
@@ -410,18 +409,18 @@ public class ContentPageEditorDisplayContext {
 
 		List<SoyContext> soyContexts = new ArrayList<>();
 
-		List<AssetDisplayContributor> assetDisplayContributors =
-			assetDisplayContributorTracker.getAssetDisplayContributors();
+		List<InfoDisplayContributor> infoDisplayContributors =
+			infoDisplayContributorTracker.getInfoDisplayContributors();
 
-		for (AssetDisplayContributor assetDisplayContributor :
-				assetDisplayContributors) {
+		for (InfoDisplayContributor infoDisplayContributor :
+				infoDisplayContributors) {
 
-			if (assetDisplayContributor == null) {
+			if (infoDisplayContributor == null) {
 				continue;
 			}
 
 			PortletURL assetBrowserURL = PortletProviderUtil.getPortletURL(
-				request, assetDisplayContributor.getClassName(),
+				request, infoDisplayContributor.getClassName(),
 				PortletProvider.Action.BROWSE);
 
 			if (assetBrowserURL == null) {
@@ -437,7 +436,7 @@ public class ContentPageEditorDisplayContext {
 				"selectedGroupIds",
 				String.valueOf(themeDisplay.getScopeGroupId()));
 			assetBrowserURL.setParameter(
-				"typeSelection", assetDisplayContributor.getClassName());
+				"typeSelection", infoDisplayContributor.getClassName());
 			assetBrowserURL.setParameter(
 				"showNonindexable", String.valueOf(Boolean.TRUE));
 			assetBrowserURL.setParameter(
@@ -451,7 +450,7 @@ public class ContentPageEditorDisplayContext {
 				"href", assetBrowserURL.toString()
 			).put(
 				"typeName",
-				assetDisplayContributor.getLabel(themeDisplay.getLocale())
+				infoDisplayContributor.getLabel(themeDisplay.getLocale())
 			);
 
 			soyContexts.add(assetBrowserSoyContext);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -130,7 +130,7 @@ public class ContentPageEditorDisplayContext {
 
 		assetDisplayContributorTracker =
 			(AssetDisplayContributorTracker)request.getAttribute(
-				ContentPageEditorWebKeys.ASSET_DISPLAY_CONTRIBUTOR_TRACKER);
+				ContentPageEditorWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER);
 		classNameId = PortalUtil.getClassNameId(className);
 		themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorLayoutPageTemplateDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorLayoutPageTemplateDisplayContext.java
@@ -14,11 +14,11 @@
 
 package com.liferay.layout.content.page.editor.web.internal.display.context;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributor;
 import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.model.ClassType;
 import com.liferay.asset.kernel.model.ClassTypeReader;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
@@ -173,15 +173,15 @@ public class ContentPageEditorLayoutPageTemplateDisplayContext
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			_getLayoutPageTemplateEntry();
 
-		AssetDisplayContributor assetDisplayContributor =
-			assetDisplayContributorTracker.getAssetDisplayContributor(
+		InfoDisplayContributor infoDisplayContributor =
+			infoDisplayContributorTracker.getInfoDisplayContributor(
 				layoutPageTemplateEntry.getClassName());
 
-		if (assetDisplayContributor == null) {
+		if (infoDisplayContributor == null) {
 			return null;
 		}
 
-		return assetDisplayContributor.getLabel(themeDisplay.getLocale());
+		return infoDisplayContributor.getLabel(themeDisplay.getLocale());
 	}
 
 	private SoyContext _getSelectedMappingTypes() throws PortalException {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetAssetClassTypesMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetAssetClassTypesMVCActionCommand.java
@@ -14,9 +14,9 @@
 
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributor;
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
 import com.liferay.asset.kernel.model.ClassType;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -59,15 +59,15 @@ public class GetAssetClassTypesMVCActionCommand extends BaseMVCActionCommand {
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		AssetDisplayContributor assetDisplayContributor =
-			_assetDisplayContributorTracker.getAssetDisplayContributor(
+		InfoDisplayContributor infoDisplayContributor =
+			_infoDisplayContributorTracker.getInfoDisplayContributor(
 				_portal.getClassName(classNameId));
 
-		if (assetDisplayContributor != null) {
+		if (infoDisplayContributor != null) {
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
 
-			List<ClassType> classTypes = assetDisplayContributor.getClassTypes(
+			List<ClassType> classTypes = infoDisplayContributor.getClassTypes(
 				themeDisplay.getScopeGroupId(), themeDisplay.getLocale());
 
 			for (ClassType classType : classTypes) {
@@ -85,7 +85,7 @@ public class GetAssetClassTypesMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	@Reference
-	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
+	private InfoDisplayContributorTracker _infoDisplayContributorTracker;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetAssetDisplayContributorsMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetAssetDisplayContributorsMVCActionCommand.java
@@ -14,8 +14,8 @@
 
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributor;
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -57,17 +57,17 @@ public class GetAssetDisplayContributorsMVCActionCommand
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		for (AssetDisplayContributor assetDisplayContributor :
-				_assetDisplayContributorTracker.getAssetDisplayContributors()) {
+		for (InfoDisplayContributor infoDisplayContributor :
+				_infoDisplayContributorTracker.getInfoDisplayContributors()) {
 
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
 			jsonObject.put(
 				"id",
-				_portal.getClassNameId(assetDisplayContributor.getClassName()));
+				_portal.getClassNameId(infoDisplayContributor.getClassName()));
 			jsonObject.put(
 				"label",
-				assetDisplayContributor.getLabel(themeDisplay.getLocale()));
+				infoDisplayContributor.getLabel(themeDisplay.getLocale()));
 
 			jsonArray.put(jsonObject);
 		}
@@ -77,7 +77,7 @@ public class GetAssetDisplayContributorsMVCActionCommand
 	}
 
 	@Reference
-	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
+	private InfoDisplayContributorTracker _infoDisplayContributorTracker;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetAssetFieldValueMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetAssetFieldValueMVCResourceCommand.java
@@ -14,10 +14,10 @@
 
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributor;
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -56,11 +56,11 @@ public class GetAssetFieldValueMVCResourceCommand
 
 		long classNameId = ParamUtil.getLong(resourceRequest, "classNameId");
 
-		AssetDisplayContributor assetDisplayContributor =
-			_assetDisplayContributorTracker.getAssetDisplayContributor(
+		InfoDisplayContributor infoDisplayContributor =
+			_infoDisplayContributorTracker.getInfoDisplayContributor(
 				_portal.getClassName(classNameId));
 
-		if (assetDisplayContributor == null) {
+		if (infoDisplayContributor == null) {
 			JSONPortletResponseUtil.writeJSON(
 				resourceRequest, resourceResponse,
 				JSONFactoryUtil.createJSONObject());
@@ -93,7 +93,7 @@ public class GetAssetFieldValueMVCResourceCommand
 		jsonObject.put("fieldId", fieldId);
 		jsonObject.put(
 			"fieldValue",
-			assetDisplayContributor.getAssetDisplayFieldValue(
+			infoDisplayContributor.getInfoDisplayFieldValue(
 				assetEntry, fieldId, themeDisplay.getLocale()));
 
 		JSONPortletResponseUtil.writeJSON(
@@ -101,10 +101,10 @@ public class GetAssetFieldValueMVCResourceCommand
 	}
 
 	@Reference
-	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
+	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
-	private AssetEntryLocalService _assetEntryLocalService;
+	private InfoDisplayContributorTracker _infoDisplayContributorTracker;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetAssetMappingFieldsMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetAssetMappingFieldsMVCResourceCommand.java
@@ -14,11 +14,11 @@
 
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributor;
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
-import com.liferay.asset.display.contributor.AssetDisplayField;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
+import com.liferay.info.display.contributor.InfoDisplayField;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -60,11 +60,11 @@ public class GetAssetMappingFieldsMVCResourceCommand
 
 		long classNameId = ParamUtil.getLong(resourceRequest, "classNameId");
 
-		AssetDisplayContributor assetDisplayContributor =
-			_assetDisplayContributorTracker.getAssetDisplayContributor(
+		InfoDisplayContributor infoDisplayContributor =
+			_infoDisplayContributorTracker.getInfoDisplayContributor(
 				_portal.getClassName(classNameId));
 
-		if (assetDisplayContributor == null) {
+		if (infoDisplayContributor == null) {
 			JSONPortletResponseUtil.writeJSON(
 				resourceRequest, resourceResponse,
 				JSONFactoryUtil.createJSONArray());
@@ -90,16 +90,16 @@ public class GetAssetMappingFieldsMVCResourceCommand
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		Set<AssetDisplayField> assetEntryFields =
-			assetDisplayContributor.getAssetDisplayFields(
+		Set<InfoDisplayField> infoEntryFields =
+			infoDisplayContributor.getInfoDisplayFields(
 				assetEntry.getClassTypeId(), themeDisplay.getLocale());
 
-		for (AssetDisplayField assetEntryField : assetEntryFields) {
+		for (InfoDisplayField infoEntryField : infoEntryFields) {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
-			jsonObject.put("key", assetEntryField.getKey());
-			jsonObject.put("label", assetEntryField.getLabel());
-			jsonObject.put("type", assetEntryField.getType());
+			jsonObject.put("key", infoEntryField.getKey());
+			jsonObject.put("label", infoEntryField.getLabel());
+			jsonObject.put("type", infoEntryField.getType());
 
 			jsonArray.put(jsonObject);
 		}
@@ -109,10 +109,10 @@ public class GetAssetMappingFieldsMVCResourceCommand
 	}
 
 	@Reference
-	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
+	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
-	private AssetEntryLocalService _assetEntryLocalService;
+	private InfoDisplayContributorTracker _infoDisplayContributorTracker;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetMappingFieldsMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetMappingFieldsMVCActionCommand.java
@@ -14,9 +14,9 @@
 
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributor;
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
-import com.liferay.asset.display.contributor.AssetDisplayField;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
+import com.liferay.info.display.contributor.InfoDisplayField;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -59,25 +59,25 @@ public class GetMappingFieldsMVCActionCommand extends BaseMVCActionCommand {
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		AssetDisplayContributor assetDisplayContributor =
-			_assetDisplayContributorTracker.getAssetDisplayContributor(
+		InfoDisplayContributor infoDisplayContributor =
+			_infoDisplayContributorTracker.getInfoDisplayContributor(
 				_portal.getClassName(classNameId));
 
-		if (assetDisplayContributor != null) {
+		if (infoDisplayContributor != null) {
 			long classTypeId = ParamUtil.getLong(actionRequest, "classTypeId");
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
 
-			Set<AssetDisplayField> assetEntryFields =
-				assetDisplayContributor.getAssetDisplayFields(
+			Set<InfoDisplayField> infoEntryFields =
+				infoDisplayContributor.getInfoDisplayFields(
 					classTypeId, themeDisplay.getLocale());
 
-			for (AssetDisplayField assetEntryField : assetEntryFields) {
+			for (InfoDisplayField infoEntryField : infoEntryFields) {
 				JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
-				jsonObject.put("key", assetEntryField.getKey());
-				jsonObject.put("label", assetEntryField.getLabel());
-				jsonObject.put("type", assetEntryField.getType());
+				jsonObject.put("key", infoEntryField.getKey());
+				jsonObject.put("label", infoEntryField.getLabel());
+				jsonObject.put("type", infoEntryField.getType());
 
 				jsonArray.put(jsonObject);
 			}
@@ -88,7 +88,7 @@ public class GetMappingFieldsMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	@Reference
-	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
+	private InfoDisplayContributorTracker _infoDisplayContributorTracker;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/build.gradle
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:layout:layout-admin-api")
 	compileOnly project(":apps:layout:layout-api")

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/controller/AssetDisplayLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/controller/AssetDisplayLayoutTypeController.java
@@ -140,7 +140,7 @@ public class AssetDisplayLayoutTypeController
 			}
 
 			request.setAttribute(
-				ContentPageEditorWebKeys.ASSET_DISPLAY_CONTRIBUTOR_TRACKER,
+				ContentPageEditorWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER,
 				_assetDisplayContributorTracker);
 
 			addAttributes(request);

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/controller/AssetDisplayLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/controller/AssetDisplayLayoutTypeController.java
@@ -14,8 +14,8 @@
 
 package com.liferay.layout.type.controller.asset.display.internal.controller;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
 import com.liferay.fragment.contributor.FragmentCollectionContributorTracker;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorWebKeys;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
@@ -141,7 +141,7 @@ public class AssetDisplayLayoutTypeController
 
 			request.setAttribute(
 				ContentPageEditorWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER,
-				_assetDisplayContributorTracker);
+				_infoDisplayContributorTracker);
 
 			addAttributes(request);
 
@@ -250,11 +250,11 @@ public class AssetDisplayLayoutTypeController
 	private static final String _VIEW_PAGE = "/layout/view/asset_display.jsp";
 
 	@Reference
-	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
-
-	@Reference
 	private FragmentCollectionContributorTracker
 		_fragmentCollectionContributorTracker;
+
+	@Reference
+	private InfoDisplayContributorTracker _infoDisplayContributorTracker;
 
 	@Reference
 	private ItemSelector _itemSelector;

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/display/context/AssetDisplayLayoutTypeControllerDisplayContext.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/display/context/AssetDisplayLayoutTypeControllerDisplayContext.java
@@ -14,14 +14,14 @@
 
 package com.liferay.layout.type.controller.asset.display.internal.display.context;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributor;
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
 import com.liferay.asset.display.contributor.constants.AssetDisplayWebKeys;
 import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
 import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalServiceUtil;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorWebKeys;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil;
@@ -60,21 +60,21 @@ public class AssetDisplayLayoutTypeControllerDisplayContext {
 
 		_assetEntry = assetEntry;
 
-		AssetDisplayContributor assetDisplayContributor =
-			(AssetDisplayContributor)_request.getAttribute(
+		InfoDisplayContributor infoDisplayContributor =
+			(InfoDisplayContributor)_request.getAttribute(
 				AssetDisplayWebKeys.INFO_DISPLAY_CONTRIBUTOR);
 
-		if ((assetDisplayContributor == null) && (assetEntry != null)) {
-			AssetDisplayContributorTracker assetDisplayContributorTracker =
-				(AssetDisplayContributorTracker)request.getAttribute(
+		if ((infoDisplayContributor == null) && (assetEntry != null)) {
+			InfoDisplayContributorTracker infoDisplayContributorTracker =
+				(InfoDisplayContributorTracker)request.getAttribute(
 					ContentPageEditorWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER);
 
-			assetDisplayContributor =
-				assetDisplayContributorTracker.getAssetDisplayContributor(
+			infoDisplayContributor =
+				infoDisplayContributorTracker.getInfoDisplayContributor(
 					_assetEntry.getClassName());
 		}
 
-		_assetDisplayContributor = assetDisplayContributor;
+		_infoDisplayContributor = infoDisplayContributor;
 	}
 
 	public Map<String, Object> getAssetDisplayFieldsValues()
@@ -87,11 +87,11 @@ public class AssetDisplayLayoutTypeControllerDisplayContext {
 			_request.getAttribute(AssetDisplayWebKeys.VERSION_CLASS_PK));
 
 		if (versionClassPK > 0) {
-			return _assetDisplayContributor.getAssetDisplayFieldsValues(
+			return _infoDisplayContributor.getInfoVersionDisplayFieldsValues(
 				_assetEntry, versionClassPK, themeDisplay.getLocale());
 		}
 
-		return _assetDisplayContributor.getAssetDisplayFieldsValues(
+		return _infoDisplayContributor.getInfoDisplayFieldsValues(
 			_assetEntry, themeDisplay.getLocale());
 	}
 
@@ -132,8 +132,8 @@ public class AssetDisplayLayoutTypeControllerDisplayContext {
 		return 0;
 	}
 
-	private final AssetDisplayContributor _assetDisplayContributor;
 	private final AssetEntry _assetEntry;
+	private final InfoDisplayContributor _infoDisplayContributor;
 	private final HttpServletRequest _request;
 
 }

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/display/context/AssetDisplayLayoutTypeControllerDisplayContext.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/display/context/AssetDisplayLayoutTypeControllerDisplayContext.java
@@ -62,12 +62,12 @@ public class AssetDisplayLayoutTypeControllerDisplayContext {
 
 		AssetDisplayContributor assetDisplayContributor =
 			(AssetDisplayContributor)_request.getAttribute(
-				AssetDisplayWebKeys.ASSET_DISPLAY_CONTRIBUTOR);
+				AssetDisplayWebKeys.INFO_DISPLAY_CONTRIBUTOR);
 
 		if ((assetDisplayContributor == null) && (assetEntry != null)) {
 			AssetDisplayContributorTracker assetDisplayContributorTracker =
 				(AssetDisplayContributorTracker)request.getAttribute(
-					ContentPageEditorWebKeys.ASSET_DISPLAY_CONTRIBUTOR_TRACKER);
+					ContentPageEditorWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER);
 
 			assetDisplayContributor =
 				assetDisplayContributorTracker.getAssetDisplayContributor(

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLProviderImpl.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLProviderImpl.java
@@ -14,13 +14,13 @@
 
 package com.liferay.layout.type.controller.asset.display.internal.portlet;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributor;
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.display.page.util.AssetDisplayPageHelper;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 import com.liferay.layout.type.controller.asset.display.internal.constants.AssetDisplayPageFriendlyURLResolverConstants;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -50,11 +50,11 @@ public class AssetDisplayPageFriendlyURLProviderImpl
 			return null;
 		}
 
-		AssetDisplayContributor assetDisplayContributor =
-			_assetDisplayContributorTracker.getAssetDisplayContributor(
+		InfoDisplayContributor infoDisplayContributor =
+			_infoDisplayContributorTracker.getInfoDisplayContributor(
 				assetEntry.getClassName());
 
-		if (assetDisplayContributor == null) {
+		if (infoDisplayContributor == null) {
 			return null;
 		}
 
@@ -77,7 +77,7 @@ public class AssetDisplayPageFriendlyURLProviderImpl
 		}
 
 		if (Validator.isNotNull(urlTitle)) {
-			sb.append(assetDisplayContributor.getAssetURLSeparator());
+			sb.append(infoDisplayContributor.getInfoURLSeparator());
 			sb.append(StringPool.SLASH);
 			sb.append(assetRenderer.getUrlTitle(themeDisplay.getLocale()));
 		}
@@ -104,10 +104,10 @@ public class AssetDisplayPageFriendlyURLProviderImpl
 	}
 
 	@Reference
-	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
+	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
-	private AssetEntryLocalService _assetEntryLocalService;
+	private InfoDisplayContributorTracker _infoDisplayContributorTracker;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLResolver.java
@@ -14,8 +14,6 @@
 
 package com.liferay.layout.type.controller.asset.display.internal.portlet;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributor;
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
 import com.liferay.asset.display.contributor.constants.AssetDisplayWebKeys;
 import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
 import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
@@ -26,6 +24,8 @@ import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.service.AssetEntryService;
 import com.liferay.asset.util.AssetHelper;
+import com.liferay.info.display.contributor.InfoDisplayContributor;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.layout.type.controller.asset.display.internal.constants.AssetDisplayPageFriendlyURLResolverConstants;
@@ -70,7 +70,7 @@ public class AssetDisplayPageFriendlyURLResolver
 
 		request.setAttribute(
 			AssetDisplayWebKeys.INFO_DISPLAY_CONTRIBUTOR,
-			_getAssetDisplayContributor(groupId, friendlyURL));
+			_getInfoDisplayContributor(groupId, friendlyURL));
 
 		AssetEntry assetEntry = _getAssetEntry(groupId, friendlyURL);
 
@@ -114,36 +114,6 @@ public class AssetDisplayPageFriendlyURLResolver
 			ASSET_DISPLAY_PAGE_URL_SEPARATOR;
 	}
 
-	private AssetDisplayContributor _getAssetDisplayContributor(
-			long groupId, String friendlyURL)
-		throws PortalException {
-
-		String assetURLSeparator = _getAssetURLSeparator(friendlyURL);
-
-		AssetDisplayContributor assetDisplayContributor = null;
-
-		if (Validator.isNotNull(assetURLSeparator)) {
-			assetDisplayContributor =
-				_assetDisplayContributorTracker.
-					getAssetDisplayContributorByAssetURLSeparator(
-						assetURLSeparator);
-		}
-		else {
-			AssetEntry assetEntry = _getAssetEntry(groupId, friendlyURL);
-
-			assetDisplayContributor =
-				_assetDisplayContributorTracker.getAssetDisplayContributor(
-					assetEntry.getClassName());
-		}
-
-		if (assetDisplayContributor == null) {
-			throw new PortalException(
-				"Display page is not available for " + assetURLSeparator);
-		}
-
-		return assetDisplayContributor;
-	}
-
 	private AssetEntry _getAssetEntry(long groupId, String friendlyURL)
 		throws PortalException {
 
@@ -153,10 +123,10 @@ public class AssetDisplayPageFriendlyURLResolver
 			return _assetEntryService.getEntry(assetEntryId);
 		}
 
-		AssetDisplayContributor assetDisplayContributor =
-			_getAssetDisplayContributor(groupId, friendlyURL);
+		InfoDisplayContributor infoDisplayContributor =
+			_getInfoDisplayContributor(groupId, friendlyURL);
 
-		String className = assetDisplayContributor.getClassName();
+		String className = infoDisplayContributor.getClassName();
 
 		AssetRendererFactory assetRendererFactory =
 			AssetRendererFactoryRegistryUtil.
@@ -224,6 +194,35 @@ public class AssetDisplayPageFriendlyURLResolver
 		return assetURLSeparator;
 	}
 
+	private InfoDisplayContributor _getInfoDisplayContributor(
+			long groupId, String friendlyURL)
+		throws PortalException {
+
+		String assetURLSeparator = _getAssetURLSeparator(friendlyURL);
+
+		InfoDisplayContributor infoDisplayContributor = null;
+
+		if (Validator.isNotNull(assetURLSeparator)) {
+			infoDisplayContributor =
+				_infoDisplayContributorTracker.
+					getInfoDisplayContributorByURLSeparator(assetURLSeparator);
+		}
+		else {
+			AssetEntry assetEntry = _getAssetEntry(groupId, friendlyURL);
+
+			infoDisplayContributor =
+				_infoDisplayContributorTracker.getInfoDisplayContributor(
+					assetEntry.getClassName());
+		}
+
+		if (infoDisplayContributor == null) {
+			throw new PortalException(
+				"Display page is not available for " + assetURLSeparator);
+		}
+
+		return infoDisplayContributor;
+	}
+
 	private String _getUrlTitle(String friendlyURL) {
 		List<String> paths = StringUtil.split(friendlyURL, CharPool.SLASH);
 
@@ -257,9 +256,6 @@ public class AssetDisplayPageFriendlyURLResolver
 	}
 
 	@Reference
-	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
-
-	@Reference
 	private AssetDisplayPageEntryLocalService
 		_assetDisplayPageEntryLocalService;
 
@@ -268,6 +264,9 @@ public class AssetDisplayPageFriendlyURLResolver
 
 	@Reference
 	private AssetHelper _assetHelper;
+
+	@Reference
+	private InfoDisplayContributorTracker _infoDisplayContributorTracker;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLResolver.java
@@ -182,30 +182,18 @@ public class AssetDisplayPageFriendlyURLResolver
 		return null;
 	}
 
-	private String _getAssetURLSeparator(String friendlyURL) {
-		List<String> paths = StringUtil.split(friendlyURL, CharPool.SLASH);
-
-		String assetURLSeparator = paths.get(1);
-
-		if (Validator.isNumber(assetURLSeparator)) {
-			return StringPool.BLANK;
-		}
-
-		return assetURLSeparator;
-	}
-
 	private InfoDisplayContributor _getInfoDisplayContributor(
 			long groupId, String friendlyURL)
 		throws PortalException {
 
-		String assetURLSeparator = _getAssetURLSeparator(friendlyURL);
+		String urlSeparator = _getUrlSeparator(friendlyURL);
 
 		InfoDisplayContributor infoDisplayContributor = null;
 
-		if (Validator.isNotNull(assetURLSeparator)) {
+		if (Validator.isNotNull(urlSeparator)) {
 			infoDisplayContributor =
 				_infoDisplayContributorTracker.
-					getInfoDisplayContributorByURLSeparator(assetURLSeparator);
+					getInfoDisplayContributorByURLSeparator(urlSeparator);
 		}
 		else {
 			AssetEntry assetEntry = _getAssetEntry(groupId, friendlyURL);
@@ -217,10 +205,22 @@ public class AssetDisplayPageFriendlyURLResolver
 
 		if (infoDisplayContributor == null) {
 			throw new PortalException(
-				"Display page is not available for " + assetURLSeparator);
+				"Display page is not available for " + urlSeparator);
 		}
 
 		return infoDisplayContributor;
+	}
+
+	private String _getUrlSeparator(String friendlyURL) {
+		List<String> paths = StringUtil.split(friendlyURL, CharPool.SLASH);
+
+		String urlSeparator = paths.get(1);
+
+		if (Validator.isNumber(urlSeparator)) {
+			return StringPool.BLANK;
+		}
+
+		return urlSeparator;
 	}
 
 	private String _getUrlTitle(String friendlyURL) {

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLResolver.java
@@ -69,7 +69,7 @@ public class AssetDisplayPageFriendlyURLResolver
 			"request");
 
 		request.setAttribute(
-			AssetDisplayWebKeys.ASSET_DISPLAY_CONTRIBUTOR,
+			AssetDisplayWebKeys.INFO_DISPLAY_CONTRIBUTOR,
 			_getAssetDisplayContributor(groupId, friendlyURL));
 
 		AssetEntry assetEntry = _getAssetEntry(groupId, friendlyURL);

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/build.gradle
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly project(":apps:asset:asset-display-api")
 	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:layout:layout-api")
 	compileOnly project(":apps:layout:layout-content-page-editor-api")

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/controller/ContentLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/controller/ContentLayoutTypeController.java
@@ -14,8 +14,8 @@
 
 package com.liferay.layout.type.controller.content.internal.controller;
 
-import com.liferay.asset.display.contributor.AssetDisplayContributorTracker;
 import com.liferay.fragment.contributor.FragmentCollectionContributorTracker;
+import com.liferay.info.display.contributor.InfoDisplayContributorTracker;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorWebKeys;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
@@ -96,13 +96,13 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 
 		if (layoutMode.equals(Constants.EDIT)) {
 			request.setAttribute(
-				ContentPageEditorWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER,
-				_assetDisplayContributorTracker);
-
-			request.setAttribute(
 				ContentPageEditorWebKeys.
 					FRAGMENT_COLLECTION_CONTRIBUTOR_TRACKER,
 				_fragmentCollectionContributorTracker);
+
+			request.setAttribute(
+				ContentPageEditorWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER,
+				_infoDisplayContributorTracker);
 
 			request.setAttribute(
 				ContentLayoutTypeControllerWebKeys.ITEM_SELECTOR,
@@ -264,11 +264,11 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 	private static final String _VIEW_PAGE = "/layout/view/content.jsp";
 
 	@Reference
-	private AssetDisplayContributorTracker _assetDisplayContributorTracker;
-
-	@Reference
 	private FragmentCollectionContributorTracker
 		_fragmentCollectionContributorTracker;
+
+	@Reference
+	private InfoDisplayContributorTracker _infoDisplayContributorTracker;
 
 	@Reference
 	private ItemSelector _itemSelector;

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/controller/ContentLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/controller/ContentLayoutTypeController.java
@@ -96,7 +96,7 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 
 		if (layoutMode.equals(Constants.EDIT)) {
 			request.setAttribute(
-				ContentPageEditorWebKeys.ASSET_DISPLAY_CONTRIBUTOR_TRACKER,
+				ContentPageEditorWebKeys.INFO_DISPLAY_CONTRIBUTOR_TRACKER,
 				_assetDisplayContributorTracker);
 
 			request.setAttribute(


### PR DESCRIPTION
Hey @brianchandotcom, I was trying to change the classes to Asset*Info*Display... but it will break backwards compatibility with 7.1. 

Also, we are going to refactor this to remove getClassTypeFields in a follow up pull. But we didn't want to lose backwards compatibility so we left it like this for the moment

I don't know if its the right time for it, but If we decide to go with the renaming, I have already made some progress...just let me know what you think please.

Thanks