### PR TITLE
COMMERCE-1217 

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/source-formatter-suppressions.xml
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/source-formatter-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<suppressions>
+	<checkstyle>
+		<suppress checks="StaticBlockCheck" files="com/liferay/portal/vulcan/internal/jaxrs/context/resolver/*" />
+	</checkstyle>
+</suppressions>

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/resolver/ObjectMapperContextResolver.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/resolver/ObjectMapperContextResolver.java
@@ -35,13 +35,14 @@ public class ObjectMapperContextResolver
 		return _OBJECT_MAPPER;
 	}
 
-	private static final ObjectMapper _OBJECT_MAPPER = new ObjectMapper() {
-		{
-			configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
-			enable(SerializationFeature.INDENT_OUTPUT);
-			setDateFormat(new ISO8601DateFormat());
-			setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-		}
-	};
+	private static final ObjectMapper _OBJECT_MAPPER = new ObjectMapper();
+
+	static {
+		_OBJECT_MAPPER.configure(
+			MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+		_OBJECT_MAPPER.enable(SerializationFeature.INDENT_OUTPUT);
+		_OBJECT_MAPPER.setDateFormat(new ISO8601DateFormat());
+		_OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+	}
 
 }


### PR DESCRIPTION
Double braces initialisation breaks the tests because jackson needs to have the copy() method

I could also initialise the singleton the old way with a != null check that wouldn't need a supression in sf.

