### PR TITLE
LPS-93091 Enable browser cache for js_bundle_config because we have the parameter t for update URL when it is require to ask for a new content. This will be fixed in in 7.1.x and 7.0.x as part of the LPS-92810

### DIFF
--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -583,6 +583,10 @@
 	</filter-mapping>
 	<filter-mapping>
 		<filter-name>Header Filter</filter-name>
+		<url-pattern>/o/js_bundle_config</url-pattern>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>Header Filter</filter-name>
 		<url-pattern>*.css</url-pattern>
 	</filter-mapping>
 	<filter-mapping>


### PR DESCRIPTION
/CC @jcampoy 