### PR TITLE
LPS-93219 Add permissions to data records

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/constants/DataActionKeys.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/constants/DataActionKeys.java
@@ -23,9 +23,19 @@ public class DataActionKeys {
 
 	public static final String ADD_DATA_LAYOUT = "ADD_DATA_LAYOUT";
 
+	public static final String ADD_DATA_RECORD = "ADD_DATA_RECORD";
+
 	public static final String ADD_DATA_RECORD_COLLECTION =
 		"ADD_DATA_RECORD_COLLECTION";
 
 	public static final String DEFINE_PERMISSIONS = "DEFINE_PERMISSIONS";
+
+	public static final String DELETE_DATA_RECORD = "DELETE_DATA_RECORD";
+
+	public static final String EXPORT_DATA_RECORDS = "EXPORT_DATA_RECORDS";
+
+	public static final String UPDATE_DATA_RECORD = "UPDATE_DATA_RECORD";
+
+	public static final String VIEW_DATA_RECORD = "VIEW_DATA_RECORD";
 
 }

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/DataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/DataLayoutResourceImpl.java
@@ -109,7 +109,7 @@ public class DataLayoutResourceImpl extends BaseDataLayoutResourceImpl {
 		DDMStructureLayout ddmStructureLayout =
 			_ddmStructureLayoutLocalService.addStructureLayout(
 				PrincipalThreadLocal.getUserId(), ddmStructure.getGroupId(),
-				_getDDMStructureVersionId(dataLayout.getDataDefinitionId()),
+				_getDDMStructureVersionId(dataDefinitionId),
 				LocalizedValueUtil.toLocalizationMap(dataLayout.getName()),
 				LocalizedValueUtil.toLocalizationMap(
 					dataLayout.getDescription()),

--- a/modules/apps/data-engine/data-engine-service/src/main/resources/META-INF/resource-actions/default.xml
+++ b/modules/apps/data-engine/data-engine-service/src/main/resources/META-INF/resource-actions/default.xml
@@ -173,21 +173,32 @@
 		<weight>3</weight>
 		<permissions>
 			<supports>
+				<action-key>ADD_DATA_RECORD</action-key>
 				<action-key>DELETE</action-key>
+				<action-key>DELETE_DATA_RECORD</action-key>
+				<action-key>EXPORT_DATA_RECORDS</action-key>
 				<action-key>PERMISSIONS</action-key>
 				<action-key>UPDATE</action-key>
+				<action-key>UPDATE_DATA_RECORD</action-key>
 				<action-key>VIEW</action-key>
+				<action-key>VIEW_DATA_RECORD</action-key>
 			</supports>
 			<site-member-defaults>
 				<action-key>VIEW</action-key>
+				<action-key>VIEW_DATA_RECORD</action-key>
 			</site-member-defaults>
 			<guest-defaults>
 				<action-key>VIEW</action-key>
+				<action-key>VIEW_DATA_RECORD</action-key>
 			</guest-defaults>
 			<guest-unsupported>
+				<action-key>ADD_DATA_RECORD</action-key>
 				<action-key>DELETE</action-key>
+				<action-key>DELETE_DATA_RECORD</action-key>
+				<action-key>EXPORT_DATA_RECORDS</action-key>
 				<action-key>PERMISSIONS</action-key>
 				<action-key>UPDATE</action-key>
+				<action-key>UPDATE_DATA_RECORD</action-key>
 			</guest-unsupported>
 		</permissions>
 	</model-resource>


### PR DESCRIPTION
The record permissions are attached to DataRecordCollections because it doesn't make sense, from the business perspective, to give permission on a single data record. Instead, we give permissions that apply to all the data records in a data record collection.