### PR TITLE
LPS-93292 Excludes unnecessary dependencies from frontend-taglib-chart

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-chart/.npmbundlerrc
+++ b/modules/apps/frontend-taglib/frontend-taglib-chart/.npmbundlerrc
@@ -1,4 +1,21 @@
 {
+	"config": {
+		"imports": {
+			"frontend-js-metal-web": {
+				"incremental-dom": ">=0.5.1",
+				"incremental-dom-string": ">=0.0.3",
+				"metal": ">=2.16.5",
+				"metal-component": ">=2.16.5",
+				"metal-dom": ">=2.16.5",
+				"metal-events": ">=2.16.5",
+				"metal-incremental-dom": ">=2.16.5",
+				"metal-jsx": ">=2.16.5",
+				"metal-soy": ">=2.16.5",
+				"metal-soy-bundle": ">=2.16.5",
+				"metal-state": ">=2.16.5"
+			}
+		}
+	},
 	"exclude": {
 		"clay-charts": [
 			"src/jsx/**/*",
@@ -169,10 +186,7 @@
 			"rollup.config.js",
 			"dist/d3.js"
 		],
-		"iconv-lite": [
-			"lib/extend-node.js",
-			"lib/streams.js"
-		],
+		"iconv-lite": true,
 		"rw": true,
 		"safer-buffer": [
 			"tests.js"


### PR DESCRIPTION
Hey Brian!

This is another round of perf improvements. In this PR, I've fine-tuned `taglib-chart` a bit more, so we get:

```
BEFORE: ✨  Done in 23.22s.
AFTER: ✨  Done in 18.82s.
```

I've sent other perf PRs through the teams:

https://github.com/brianchandotcom/liferay-portal/pull/70714

```
dynamic-data-mapping-form-web
BEFORE: ✨  Done in 31.45s.
AFTER: ✨  Done in 6.20s.

dynamic-data-mapping-form-field-type
BEFORE: ✨  Done in 29.06s.
AFTER: ✨  Done in 20.69s.

dynamic-data-mapping-form
BEFORE: ✨  Done in 51.51s.
AFTER: ✨  Done in 14.95s.
```

https://github.com/brianchandotcom/liferay-portal/pull/70697

```
segments-web
BEFORE: ✨  Done in 41.02s.
AFTER: ✨  Done in 28.88s.
```

With all these we should save another 60-90 seconds of build time, and that's as far as we can get with this approach I'm afraid.