### PR TITLE
LRQA-47906 Fix poshi validation

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
@@ -996,7 +996,7 @@ definition {
 			AssertClick(
 				locator1 = "BreadcrumbPortlet#BREADCRUMB_FOLDER",
 				value1 = "Home",
-				var key_breadcrumbName = "Home"
+				key_breadcrumbName = "Home"
 			);
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-47906

cc @Hanlf 

@brianchandotcom in case you notice it, the vars aren't sorted right now because the key_breadcrumbName is a different type of var than the other two (and is being used differently). We haven't yet come up with a different way to represent them

@kenjiheigel has a task for it here.
https://issues.liferay.com/browse/LRQA-45547