### PR TITLE
LPS-93362 Fix built themes pulling in wrong version of clay-css dependency

### DIFF
--- a/modules/apps/frontend-theme-fjord/frontend-theme-fjord/package.json
+++ b/modules/apps/frontend-theme-fjord/frontend-theme-fjord/package.json
@@ -17,7 +17,7 @@
 	"name": "liferay-fjord-theme",
 	"repository": "liferay/liferay-portal",
 	"scripts": {
-		"build": "gulp build"
+		"build": "gulp build --css-common-path ./build_gradle/frontend-css-common --styled-path ../../frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled --unstyled-path ../../frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled"
 	},
 	"version": "3.0.0"
 }

--- a/modules/apps/frontend-theme-porygon/frontend-theme-porygon/package.json
+++ b/modules/apps/frontend-theme-porygon/frontend-theme-porygon/package.json
@@ -25,7 +25,7 @@
 	"name": "liferay-porygon-theme",
 	"repository": "liferay/liferay-portal",
 	"scripts": {
-		"build": "gulp build"
+		"build": "gulp build --css-common-path ./build_gradle/frontend-css-common --styled-path ../../frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled --unstyled-path ../../frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled"
 	},
 	"version": "2.0.0"
 }

--- a/modules/apps/frontend-theme-westeros-bank/frontend-theme-westeros-bank/package.json
+++ b/modules/apps/frontend-theme-westeros-bank/frontend-theme-westeros-bank/package.json
@@ -17,7 +17,7 @@
 	"name": "liferay-westeros-bank-theme",
 	"repository": "liferay/liferay-portal",
 	"scripts": {
-		"build": "gulp build"
+		"build": "gulp build --css-common-path ./build_gradle/frontend-css-common --styled-path ../../frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled --unstyled-path ../../frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled"
 	},
 	"version": "3.0.0"
 }

--- a/modules/package.json
+++ b/modules/package.json
@@ -3,8 +3,6 @@
 		"compass-mixins": "0.12.10",
 		"gulp": "3.9.1",
 		"liferay-frontend-common-css": "1.0.4",
-		"liferay-frontend-theme-styled": "4.0.0-alpha.1552930087997",
-		"liferay-frontend-theme-unstyled": "4.0.0-alpha.1552930030671",
 		"liferay-jest-junit-reporter": "1.0.1",
 		"liferay-npm-bridge-generator": "2.7.1",
 		"liferay-npm-bundler": "2.7.1",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -3980,11 +3980,6 @@ clay-component@2.11.1, clay-component@^2.11.1:
     metal-dom "^2.16.0"
     metal-state "^2.16.0"
 
-clay-css@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.10.0.tgz#c9849944d78e94c86045ba16006fb4ae26e358d7"
-  integrity sha512-QDl0iUoCLQbMaCR1HyekPEAnKQFw7mMpdjNpVzkTQkzvcx9UAL5LP77+3cq4L/8Hq9voP2nw6YsvzQzR+zhXtw==
-
 clay-css@2.11.1:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.11.1.tgz#70cd1a4e77439fb6d47c275f0e821fdf4a6524be"
@@ -11028,18 +11023,6 @@ liferay-frontend-common-css@1.0.4, liferay-frontend-common-css@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/liferay-frontend-common-css/-/liferay-frontend-common-css-1.0.4.tgz#e4d73e406020d907c909bcacb2700a52fa1c7f16"
   integrity sha1-5Nc+QGAg2QfJCbyssnAKUvocfxY=
-
-liferay-frontend-theme-styled@4.0.0-alpha.1552930087997:
-  version "4.0.0-alpha.1552930087997"
-  resolved "https://registry.yarnpkg.com/liferay-frontend-theme-styled/-/liferay-frontend-theme-styled-4.0.0-alpha.1552930087997.tgz#24cdec06a0874be6358ebed7ab2c00b418fe6526"
-  integrity sha512-LWLH8LCrP7mtUoX/gg9pJa0Br4tbt8Th6ba9ycsck27lN2JTN2GdUTgo9ayLP0Pfuk8g2FpzRmgBU9cvyN4glw==
-
-liferay-frontend-theme-unstyled@4.0.0-alpha.1552930030671:
-  version "4.0.0-alpha.1552930030671"
-  resolved "https://registry.yarnpkg.com/liferay-frontend-theme-unstyled/-/liferay-frontend-theme-unstyled-4.0.0-alpha.1552930030671.tgz#a60678fb560ea085d4641148d65025d232b5aaf4"
-  integrity sha512-nom2B+86/EEUpT5QxPQgt81hk6mjvxqgWy7lSrAw0oR7lPqZ19q2ITQ5PaKT2hTJipio1gMCutWgUdljGoFFow==
-  dependencies:
-    clay-css "2.10.0"
 
 liferay-jest-junit-reporter@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Instead of relying on the stale snapshots of liferay-frontend-theme-styled and liferay-frontend-theme-unstyled, which pull in an old version of clay-css, always use the in-repo versions directly.

Test plan:

See that all themes build and deploy, ie. in "modules/apps/", run:

    for X in admin classic; do
      (cd frontend-theme/frontend-theme-$X && gradlew clean deploy)
    done

    for X in fjord westeros-bank porygon; do
      (cd frontend-theme-$X/frontend-theme-$X && gradlew clean deploy)
    done

And see these lines in the build output:

    Files of project ':apps:frontend-theme:frontend-theme-admin' deployed to /Users/greghurrell/code/portal/bundles/deploy
    Files of project ':apps:frontend-theme:frontend-theme-classic' deployed to /Users/greghurrell/code/portal/bundles/osgi/war
    Files of project ':apps:frontend-theme-fjord:frontend-theme-fjord' deployed to /Users/greghurrell/code/portal/bundles/deploy
    Files of project ':apps:frontend-theme-westeros-bank:frontend-theme-westeros-bank' deployed to /Users/greghurrell/code/portal/bundles/deploy
    Files of project ':apps:frontend-theme-porygon:frontend-theme-porygon' deployed to /Users/greghurrell/code/portal/bundles/deploy<Paste>

Look at portal and see header font has reverted to previous, desired size. Note that the yarn.lock no longer pulls in the old clay-css. Also, create three sites with the three marketplaces themes (porygon, westeros-bank and fjord) and see them all render correctly.

![widgets](https://user-images.githubusercontent.com/7074/55551364-e5d03e80-56da-11e9-9d7b-50a8a42fbf2b.png)

cc: @jbalsas