### PR TITLE
LPS-93376, LPS-93373, LPS-93362 Consolidate on a single clay-css dependency version

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/package.json
@@ -13,7 +13,7 @@
 		}
 	},
 	"dependencies": {
-		"alloyeditor": "2.0.0-beta.6"
+		"alloyeditor": "2.0.0-beta.7"
 	},
 	"name": "frontend-editor-alloyeditor-web",
 	"scripts": {

--- a/modules/apps/frontend-theme-fjord/frontend-theme-fjord/package.json
+++ b/modules/apps/frontend-theme-fjord/frontend-theme-fjord/package.json
@@ -17,7 +17,7 @@
 	"name": "liferay-fjord-theme",
 	"repository": "liferay/liferay-portal",
 	"scripts": {
-		"build": "gulp build"
+		"build": "gulp build --css-common-path ./build_gradle/frontend-css-common --styled-path ../../frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled --unstyled-path ../../frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled"
 	},
 	"version": "3.0.0"
 }

--- a/modules/apps/frontend-theme-porygon/frontend-theme-porygon/package.json
+++ b/modules/apps/frontend-theme-porygon/frontend-theme-porygon/package.json
@@ -25,7 +25,7 @@
 	"name": "liferay-porygon-theme",
 	"repository": "liferay/liferay-portal",
 	"scripts": {
-		"build": "gulp build"
+		"build": "gulp build --css-common-path ./build_gradle/frontend-css-common --styled-path ../../frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled --unstyled-path ../../frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled"
 	},
 	"version": "2.0.0"
 }

--- a/modules/apps/frontend-theme-westeros-bank/frontend-theme-westeros-bank/package.json
+++ b/modules/apps/frontend-theme-westeros-bank/frontend-theme-westeros-bank/package.json
@@ -17,7 +17,7 @@
 	"name": "liferay-westeros-bank-theme",
 	"repository": "liferay/liferay-portal",
 	"scripts": {
-		"build": "gulp build"
+		"build": "gulp build --css-common-path ./build_gradle/frontend-css-common --styled-path ../../frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled --unstyled-path ../../frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled"
 	},
 	"version": "3.0.0"
 }

--- a/modules/apps/segments/segments-web/package.json
+++ b/modules/apps/segments/segments-web/package.json
@@ -29,6 +29,7 @@
 	},
 	"dependencies": {
 		"classnames": "^2.2.6",
+		"clay-css": "^2.11.1",
 		"date-fns": "^1.30.1",
 		"formik": "^1.4.1",
 		"metal": "^2.16.7",

--- a/modules/package.json
+++ b/modules/package.json
@@ -3,8 +3,6 @@
 		"compass-mixins": "0.12.10",
 		"gulp": "3.9.1",
 		"liferay-frontend-common-css": "1.0.4",
-		"liferay-frontend-theme-styled": "4.0.0-alpha.1552930087997",
-		"liferay-frontend-theme-unstyled": "4.0.0-alpha.1552930030671",
 		"liferay-jest-junit-reporter": "1.0.1",
 		"liferay-npm-bridge-generator": "2.7.1",
 		"liferay-npm-bundler": "2.7.1",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1499,12 +1499,12 @@ alloy-ui@^3.1.0-deprecated.1, alloy-ui@^3.1.0-deprecated.40:
   resolved "https://registry.yarnpkg.com/alloy-ui/-/alloy-ui-3.1.0.tgz#95842e4c793abbfe84aa8abfc5a637cd36dda823"
   integrity sha1-lYQuTHk6u/6Eqoq/xaY3zTbdqCM=
 
-alloyeditor@2.0.0-beta.6:
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/alloyeditor/-/alloyeditor-2.0.0-beta.6.tgz#8179f8edc928d25727a282f5753b768848f92372"
-  integrity sha512-76uXL261RESskOc/YR9IiUKGgi8GxD/yXcd6iEYWNi+SB1/Ra+p8qgCuiEC6J++8r/zbXlpprQT9fgDDD+WmyA==
+alloyeditor@2.0.0-beta.7:
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/alloyeditor/-/alloyeditor-2.0.0-beta.7.tgz#23acf20bee6ad369dd0ef1de6aaf75755e6f7527"
+  integrity sha512-gX8U0j4Kb6ItNCzdw/nVcp8nWBZ7oDouILbwUbk+EpfdoAQMnmCO8PeBrZ0h4VJYP5KRUeHJt3DdW3UKfgsnxw==
   dependencies:
-    clay-css "2.5.1"
+    clay-css "^2.11.1"
     prop-types "^15.6.2"
     react "^16.8.3"
     react-dom "^16.8.3"
@@ -3985,10 +3985,10 @@ clay-css@2.11.1:
   resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.11.1.tgz#70cd1a4e77439fb6d47c275f0e821fdf4a6524be"
   integrity sha512-KL5TR8Uktrq9nJ8v6r3UuUJ97OBZ/TLK4wckCZ/YY4K/yUDIwTcK1v4lMD8F+SQ/jqHk4tGBxJ++YYEXHxeKFQ==
 
-clay-css@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.5.1.tgz#e47a2427d16766502b09487441ec31dc48873720"
-  integrity sha512-J9EEbLe7X9BA1mS4DZXqKM/J6ukt5Gw++67KTMuwooSUc2TH3tLkadueBibNhxTGSkAHWQwPk4VU3BtONC89fQ==
+clay-css@^2.11.1:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.12.0.tgz#984163b32848a17691a76b99cdeaa3aef5653c5c"
+  integrity sha512-Jwh7oiZ3VSvJPC0OMXwfJe1IBUkaD/w5IOtLkkv+4E8z8JXG7m4C+iACxJxunJsPxnC66SgWt9Lq2RbZUvv87w==
 
 clay-data-provider@2.11.1, clay-data-provider@^2.11.1:
   version "2.11.1"

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -3980,11 +3980,6 @@ clay-component@2.11.1, clay-component@^2.11.1:
     metal-dom "^2.16.0"
     metal-state "^2.16.0"
 
-clay-css@2.11.1:
-  version "2.11.1"
-  resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.11.1.tgz#70cd1a4e77439fb6d47c275f0e821fdf4a6524be"
-  integrity sha512-KL5TR8Uktrq9nJ8v6r3UuUJ97OBZ/TLK4wckCZ/YY4K/yUDIwTcK1v4lMD8F+SQ/jqHk4tGBxJ++YYEXHxeKFQ==
-
 clay-css@^2.11.1:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.12.0.tgz#984163b32848a17691a76b99cdeaa3aef5653c5c"

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -3980,11 +3980,6 @@ clay-component@2.11.1, clay-component@^2.11.1:
     metal-dom "^2.16.0"
     metal-state "^2.16.0"
 
-clay-css@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.10.0.tgz#c9849944d78e94c86045ba16006fb4ae26e358d7"
-  integrity sha512-QDl0iUoCLQbMaCR1HyekPEAnKQFw7mMpdjNpVzkTQkzvcx9UAL5LP77+3cq4L/8Hq9voP2nw6YsvzQzR+zhXtw==
-
 clay-css@2.11.1:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.11.1.tgz#70cd1a4e77439fb6d47c275f0e821fdf4a6524be"
@@ -11028,18 +11023,6 @@ liferay-frontend-common-css@1.0.4, liferay-frontend-common-css@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/liferay-frontend-common-css/-/liferay-frontend-common-css-1.0.4.tgz#e4d73e406020d907c909bcacb2700a52fa1c7f16"
   integrity sha1-5Nc+QGAg2QfJCbyssnAKUvocfxY=
-
-liferay-frontend-theme-styled@4.0.0-alpha.1552930087997:
-  version "4.0.0-alpha.1552930087997"
-  resolved "https://registry.yarnpkg.com/liferay-frontend-theme-styled/-/liferay-frontend-theme-styled-4.0.0-alpha.1552930087997.tgz#24cdec06a0874be6358ebed7ab2c00b418fe6526"
-  integrity sha512-LWLH8LCrP7mtUoX/gg9pJa0Br4tbt8Th6ba9ycsck27lN2JTN2GdUTgo9ayLP0Pfuk8g2FpzRmgBU9cvyN4glw==
-
-liferay-frontend-theme-unstyled@4.0.0-alpha.1552930030671:
-  version "4.0.0-alpha.1552930030671"
-  resolved "https://registry.yarnpkg.com/liferay-frontend-theme-unstyled/-/liferay-frontend-theme-unstyled-4.0.0-alpha.1552930030671.tgz#a60678fb560ea085d4641148d65025d232b5aaf4"
-  integrity sha512-nom2B+86/EEUpT5QxPQgt81hk6mjvxqgWy7lSrAw0oR7lPqZ19q2ITQ5PaKT2hTJipio1gMCutWgUdljGoFFow==
-  dependencies:
-    clay-css "2.10.0"
 
 liferay-jest-junit-reporter@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- Fix configuration that made built themes pull in the wrong version of clay-css.
- Update to alloyeditor v2.0.0-beta.7, which moves it to latest clay-css.
- Move segments-web to latest clay-css.

Originally created #70786 and #70791 for this, but as all three changes touch the same part of the yarn.lock I am combining them into a single pull in order to avoid merge conflicts.

Follow-up to make those `gulp` tasks a bit more pleasant will take place in: https://github.com/liferay/liferay-npm-tools/issues/64