### PR TITLE
LPS-93386 Removes unnecessary jsCompile gradle dependency (avoids copy operation during build time)

### DIFF
--- a/modules/apps/change-tracking/change-tracking-change-lists-history-web/build.gradle
+++ b/modules/apps/change-tracking/change-tracking-change-lists-history-web/build.gradle
@@ -17,8 +17,4 @@ dependencies {
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
-
-	jsCompile project(":apps:frontend-js:frontend-js-web")
-	jsCompile project(":apps:frontend-taglib:frontend-taglib")
-	jsCompile project(":apps:frontend-taglib:frontend-taglib-clay")
 }

--- a/modules/apps/change-tracking/change-tracking-change-lists-indicator-web/build.gradle
+++ b/modules/apps/change-tracking/change-tracking-change-lists-indicator-web/build.gradle
@@ -16,8 +16,4 @@ dependencies {
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
-
-	jsCompile project(":apps:frontend-js:frontend-js-web")
-	jsCompile project(":apps:frontend-taglib:frontend-taglib")
-	jsCompile project(":apps:frontend-taglib:frontend-taglib-clay")
 }


### PR DESCRIPTION
/cc @matethurzo