### PR TITLE
LPS-93376, LPS-93373, LPS-93362 Consolidate on a single clay-css dependency version

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/package.json
@@ -13,7 +13,7 @@
 		}
 	},
 	"dependencies": {
-		"alloyeditor": "2.0.0-beta.6"
+		"alloyeditor": "2.0.0-beta.7"
 	},
 	"name": "frontend-editor-alloyeditor-web",
 	"scripts": {

--- a/modules/apps/frontend-theme-fjord/frontend-theme-fjord/package.json
+++ b/modules/apps/frontend-theme-fjord/frontend-theme-fjord/package.json
@@ -17,7 +17,7 @@
 	"name": "liferay-fjord-theme",
 	"repository": "liferay/liferay-portal",
 	"scripts": {
-		"build": "gulp build"
+		"build": "gulp build --css-common-path ./build_gradle/frontend-css-common --styled-path ../../frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled --unstyled-path ../../frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled"
 	},
 	"version": "3.0.0"
 }

--- a/modules/apps/frontend-theme-porygon/frontend-theme-porygon/package.json
+++ b/modules/apps/frontend-theme-porygon/frontend-theme-porygon/package.json
@@ -25,7 +25,7 @@
 	"name": "liferay-porygon-theme",
 	"repository": "liferay/liferay-portal",
 	"scripts": {
-		"build": "gulp build"
+		"build": "gulp build --css-common-path ./build_gradle/frontend-css-common --styled-path ../../frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled --unstyled-path ../../frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled"
 	},
 	"version": "2.0.0"
 }

--- a/modules/apps/frontend-theme-westeros-bank/frontend-theme-westeros-bank/package.json
+++ b/modules/apps/frontend-theme-westeros-bank/frontend-theme-westeros-bank/package.json
@@ -17,7 +17,7 @@
 	"name": "liferay-westeros-bank-theme",
 	"repository": "liferay/liferay-portal",
 	"scripts": {
-		"build": "gulp build"
+		"build": "gulp build --css-common-path ./build_gradle/frontend-css-common --styled-path ../../frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled --unstyled-path ../../frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled"
 	},
 	"version": "3.0.0"
 }

--- a/modules/apps/segments/segments-web/package.json
+++ b/modules/apps/segments/segments-web/package.json
@@ -49,7 +49,7 @@
 		"babel-loader": "^8.0.5",
 		"babel-plugin-module-resolver": "^3.2.0",
 		"check-source-formatting": "^2.0.14",
-		"clay-css": "2.12.1",
+		"clay-css": "^2.12.1",
 		"css-loader": "^2.0.1",
 		"eslint": "^5.8.0",
 		"eslint-config-liferay": "^2.0.18",

--- a/modules/package.json
+++ b/modules/package.json
@@ -3,8 +3,6 @@
 		"compass-mixins": "0.12.10",
 		"gulp": "3.9.1",
 		"liferay-frontend-common-css": "1.0.4",
-		"liferay-frontend-theme-styled": "4.0.0-alpha.1552930087997",
-		"liferay-frontend-theme-unstyled": "4.0.0-alpha.1552930030671",
 		"liferay-jest-junit-reporter": "1.0.1",
 		"liferay-npm-bridge-generator": "2.7.1",
 		"liferay-npm-bundler": "2.7.1",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1982,7 +1982,7 @@ axios@^0.15.3:
   dependencies:
     follow-redirects "1.0.0"
 
-babel-cli@6.26.0, babel-cli@^6.26.0:
+babel-cli@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1"
   integrity sha1-UCq1SHTX24itALiHoGODzgPQAvE=
@@ -3980,11 +3980,6 @@ clay-component@2.12.1, clay-component@^2.12.1:
     metal-dom "^2.16.0"
     metal-state "^2.16.0"
 
-clay-css@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.10.0.tgz#c9849944d78e94c86045ba16006fb4ae26e358d7"
-  integrity sha512-QDl0iUoCLQbMaCR1HyekPEAnKQFw7mMpdjNpVzkTQkzvcx9UAL5LP77+3cq4L/8Hq9voP2nw6YsvzQzR+zhXtw==
-
 clay-css@2.12.1:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.12.1.tgz#5b67ead1dd334c0a50b8658ab342d300dd956f41"
@@ -4861,7 +4856,7 @@ create-react-context@^0.2.2:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
-cross-env@^5.1.3, cross-env@^5.2.0:
+cross-env@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
   integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
@@ -11034,18 +11029,6 @@ liferay-frontend-common-css@1.0.4, liferay-frontend-common-css@^1.0.4:
   resolved "https://registry.yarnpkg.com/liferay-frontend-common-css/-/liferay-frontend-common-css-1.0.4.tgz#e4d73e406020d907c909bcacb2700a52fa1c7f16"
   integrity sha1-5Nc+QGAg2QfJCbyssnAKUvocfxY=
 
-liferay-frontend-theme-styled@4.0.0-alpha.1552930087997:
-  version "4.0.0-alpha.1552930087997"
-  resolved "https://registry.yarnpkg.com/liferay-frontend-theme-styled/-/liferay-frontend-theme-styled-4.0.0-alpha.1552930087997.tgz#24cdec06a0874be6358ebed7ab2c00b418fe6526"
-  integrity sha512-LWLH8LCrP7mtUoX/gg9pJa0Br4tbt8Th6ba9ycsck27lN2JTN2GdUTgo9ayLP0Pfuk8g2FpzRmgBU9cvyN4glw==
-
-liferay-frontend-theme-unstyled@4.0.0-alpha.1552930030671:
-  version "4.0.0-alpha.1552930030671"
-  resolved "https://registry.yarnpkg.com/liferay-frontend-theme-unstyled/-/liferay-frontend-theme-unstyled-4.0.0-alpha.1552930030671.tgz#a60678fb560ea085d4641148d65025d232b5aaf4"
-  integrity sha512-nom2B+86/EEUpT5QxPQgt81hk6mjvxqgWy7lSrAw0oR7lPqZ19q2ITQ5PaKT2hTJipio1gMCutWgUdljGoFFow==
-  dependencies:
-    clay-css "2.10.0"
-
 liferay-jest-junit-reporter@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/liferay-jest-junit-reporter/-/liferay-jest-junit-reporter-1.0.1.tgz#20e9c8a690017c6e3659a0bf15e7c6534d31c9e7"
@@ -12520,7 +12503,7 @@ metal-tools-soy@4.3.2, metal-tools-soy@^4.1.2:
     vinyl-fs "^2.2.1"
     yargs "^8.0.2"
 
-metal-tools-soy@^4.0.0, metal-tools-soy@^4.2.1:
+metal-tools-soy@^4.2.1:
   version "4.2.9"
   resolved "https://registry.yarnpkg.com/metal-tools-soy/-/metal-tools-soy-4.2.9.tgz#6fdbd06cf3da1b6822b1e87122c6090d71f3b6a6"
   integrity sha512-4HY1JkMThHIypnqAZeB0iJ+LjzURnok5Vl5Zh3XGZRuktVmHF5wRIOZT2thmgQZ2VwY/EAjCw/5tLCFmPc8tdQ==

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1499,12 +1499,12 @@ alloy-ui@^3.1.0-deprecated.1, alloy-ui@^3.1.0-deprecated.40:
   resolved "https://registry.yarnpkg.com/alloy-ui/-/alloy-ui-3.1.0.tgz#95842e4c793abbfe84aa8abfc5a637cd36dda823"
   integrity sha1-lYQuTHk6u/6Eqoq/xaY3zTbdqCM=
 
-alloyeditor@2.0.0-beta.6:
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/alloyeditor/-/alloyeditor-2.0.0-beta.6.tgz#8179f8edc928d25727a282f5753b768848f92372"
-  integrity sha512-76uXL261RESskOc/YR9IiUKGgi8GxD/yXcd6iEYWNi+SB1/Ra+p8qgCuiEC6J++8r/zbXlpprQT9fgDDD+WmyA==
+alloyeditor@2.0.0-beta.7:
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/alloyeditor/-/alloyeditor-2.0.0-beta.7.tgz#23acf20bee6ad369dd0ef1de6aaf75755e6f7527"
+  integrity sha512-gX8U0j4Kb6ItNCzdw/nVcp8nWBZ7oDouILbwUbk+EpfdoAQMnmCO8PeBrZ0h4VJYP5KRUeHJt3DdW3UKfgsnxw==
   dependencies:
-    clay-css "2.5.1"
+    clay-css "^2.11.1"
     prop-types "^15.6.2"
     react "^16.8.3"
     react-dom "^16.8.3"
@@ -3985,10 +3985,10 @@ clay-css@2.12.1:
   resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.12.1.tgz#5b67ead1dd334c0a50b8658ab342d300dd956f41"
   integrity sha512-qpYMacnXS1VInedk8VkH5gVRXB6dsgKL+wUKenkSfnE+if66h4AWCk4ao90S2gD2C6TMfk4bSJxDTgk/Z7guSw==
 
-clay-css@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.5.1.tgz#e47a2427d16766502b09487441ec31dc48873720"
-  integrity sha512-J9EEbLe7X9BA1mS4DZXqKM/J6ukt5Gw++67KTMuwooSUc2TH3tLkadueBibNhxTGSkAHWQwPk4VU3BtONC89fQ==
+clay-css@^2.11.1:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.12.0.tgz#984163b32848a17691a76b99cdeaa3aef5653c5c"
+  integrity sha512-Jwh7oiZ3VSvJPC0OMXwfJe1IBUkaD/w5IOtLkkv+4E8z8JXG7m4C+iACxJxunJsPxnC66SgWt9Lq2RbZUvv87w==
 
 clay-data-provider@2.12.1, clay-data-provider@^2.12.1:
   version "2.12.1"

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -3980,15 +3980,10 @@ clay-component@2.12.1, clay-component@^2.12.1:
     metal-dom "^2.16.0"
     metal-state "^2.16.0"
 
-clay-css@2.12.1:
+clay-css@^2.11.1, clay-css@^2.12.1:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.12.1.tgz#5b67ead1dd334c0a50b8658ab342d300dd956f41"
   integrity sha512-qpYMacnXS1VInedk8VkH5gVRXB6dsgKL+wUKenkSfnE+if66h4AWCk4ao90S2gD2C6TMfk4bSJxDTgk/Z7guSw==
-
-clay-css@^2.11.1:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.12.0.tgz#984163b32848a17691a76b99cdeaa3aef5653c5c"
-  integrity sha512-Jwh7oiZ3VSvJPC0OMXwfJe1IBUkaD/w5IOtLkkv+4E8z8JXG7m4C+iACxJxunJsPxnC66SgWt9Lq2RbZUvv87w==
 
 clay-data-provider@2.12.1, clay-data-provider@^2.12.1:
   version "2.12.1"
@@ -14907,14 +14902,14 @@ react-dom@^16.6.3:
     scheduler "^0.12.0"
 
 react-dom@^16.8.3:
-  version "16.8.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.4.tgz#1061a8e01a2b3b0c8160037441c3bf00a0e3bc48"
-  integrity sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.4"
+    scheduler "^0.13.6"
 
 react-fast-compare@^2.0.1:
   version "2.0.4"
@@ -14959,14 +14954,14 @@ react@^16.6.3:
     scheduler "^0.12.0"
 
 react@^16.8.3:
-  version "16.8.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.4.tgz#fdf7bd9ae53f03a9c4cd1a371432c206be1c4768"
-  integrity sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.4"
+    scheduler "^0.13.6"
 
 read-all-stream@^3.0.0:
   version "3.1.0"
@@ -15881,10 +15876,10 @@ scheduler@^0.12.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-scheduler@^0.13.4:
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.4.tgz#8fef05e7a3580c76c0364d2df5e550e4c9140298"
-  integrity sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
- Fix configuration that made built themes pull in the wrong version of clay-css.
- Update to alloyeditor v2.0.0-beta.7, which moves it to latest clay-css.
- Move segments-web to latest clay-css.

Originally created #70786 and #70791 for this, but as all three changes touch the same part of the yarn.lock I am combining them into a single pull in order to avoid merge conflicts.

Follow-up to make those `gulp` tasks a bit more pleasant will take place in: https://github.com/liferay/liferay-npm-tools/issues/64

This is a rebase of: https://github.com/brianchandotcom/liferay-portal/pull/70792