### PR TITLE
COMMERCE-1250 Fix tests

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -798,7 +798,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 		<#assign
 			invokeArguments = arguments?replace("filter", "filterString")?replace("sorts", "sortString")
-			invokeParameters = parameters?replace("com.liferay.portal.kernel.search.filter.Filter filter", "String filterString")?replace("com.liferay.portal.kernel.search.Sort[] sorts", "String sortString")
+			invokeParameters = parameters?replace("com.liferay.portal.kernel.search.filter.Filter filter", "String filterString")?replace("com.liferay.portal.kernel.search.Sort[] sorts", "String sortString")?replace("java.lang.String id", "Object id")
 		/>
 
 		protected ${javaMethodSignature.returnType} invoke${javaMethodSignature.methodName?cap_first}(${invokeParameters}) throws Exception {


### PR DESCRIPTION
Hi Brian, the commerce team uses the `id` parameter to contain either a External idenfitifer or Local identifier so its a `String`. In the schema, the `id` is defined as a `Long` because it only contains a `Local identifier`.

https://github.com/liferay/com-liferay-commerce/blob/7.1.x-next/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml#L15-L31

@ZoltanTakacs