### PR TITLE
LPS-89415 Make the hasMethodName check more strict

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -243,7 +243,7 @@ public class FreeMarkerTool {
 
 			String methodName = javaMethodSignature.getMethodName();
 
-			if (!methodName.startsWith(sb.toString())) {
+			if (!Objects.equals(methodName, sb.toString())) {
 				continue;
 			}
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -222,16 +222,50 @@ public class FreeMarkerTool {
 			javaMethodSignature, httpMethods);
 	}
 
-	public boolean hasMethodName(
-		List<JavaMethodSignature> javaMethodSignatures,
-		String methodNamePrefix) {
+	public boolean hasJavaMethodSignature(
+		List<JavaMethodSignature> javaMethodSignatures, String httpMethod,
+		String... arguments) {
 
 		for (JavaMethodSignature javaMethodSignature : javaMethodSignatures) {
+			Operation operation = javaMethodSignature.getOperation();
+
+			if (!Objects.equals(httpMethod, getHTTPMethod(operation))) {
+				continue;
+			}
+
+			StringBuilder sb = new StringBuilder();
+
+			sb.append(httpMethod);
+
+			for (String argument : arguments) {
+				sb.append(StringUtil.upperCaseFirstLetter(argument));
+			}
+
 			String methodName = javaMethodSignature.getMethodName();
 
-			if (methodName.startsWith(methodNamePrefix)) {
-				return true;
+			if (!methodName.startsWith(sb.toString())) {
+				continue;
 			}
+
+			List<JavaMethodParameter> javaMethodParameters =
+				javaMethodSignature.getJavaMethodParameters();
+
+			if (javaMethodParameters.size() != arguments.length) {
+				continue;
+			}
+
+			for (int i = 0; i < (javaMethodParameters.size() - 1); i++) {
+				JavaMethodParameter javaMethodParameter =
+					javaMethodParameters.get(i);
+
+				String parameterName = javaMethodParameter.getParameterName();
+
+				if (!Objects.equals(parameterName, arguments[i])) {
+					continue;
+				}
+			}
+
+			return true;
 		}
 
 		return false;

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -224,7 +224,7 @@ public class FreeMarkerTool {
 
 	public boolean hasJavaMethodSignature(
 		List<JavaMethodSignature> javaMethodSignatures, String httpMethod,
-		String... arguments) {
+		String... parameterNames) {
 
 		for (JavaMethodSignature javaMethodSignature : javaMethodSignatures) {
 			Operation operation = javaMethodSignature.getOperation();
@@ -237,8 +237,8 @@ public class FreeMarkerTool {
 
 			sb.append(httpMethod);
 
-			for (String argument : arguments) {
-				sb.append(StringUtil.upperCaseFirstLetter(argument));
+			for (String parameterName : parameterNames) {
+				sb.append(StringUtil.upperCaseFirstLetter(parameterName));
 			}
 
 			String methodName = javaMethodSignature.getMethodName();
@@ -250,7 +250,7 @@ public class FreeMarkerTool {
 			List<JavaMethodParameter> javaMethodParameters =
 				javaMethodSignature.getJavaMethodParameters();
 
-			if (javaMethodParameters.size() != arguments.length) {
+			if (javaMethodParameters.size() != parameterNames.length) {
 				continue;
 			}
 
@@ -260,7 +260,7 @@ public class FreeMarkerTool {
 
 				String parameterName = javaMethodParameter.getParameterName();
 
-				if (!Objects.equals(parameterName, arguments[i])) {
+				if (!Objects.equals(parameterName, parameterNames[i])) {
 					continue;
 				}
 			}


### PR DESCRIPTION
Example:

```
<#if freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "post", "site", schemaName)>
	...
</#if>
```