### PR TITLE
LPS-89371 Modularize Search unit test classes remaining in legacy core

### DIFF
--- a/modules/apps/document-library/document-library-service/build.gradle
+++ b/modules/apps/document-library/document-library-service/build.gradle
@@ -38,5 +38,6 @@ dependencies {
 	compileOnly project(":core:petra:petra-string")
 
 	testCompile project(":apps:portal-search:portal-search")
+	testCompile project(":apps:portal-search:portal-search-test-util")
 	testCompile project(":core:registry-api")
 }

--- a/modules/apps/document-library/document-library-service/src/test/java/com/liferay/document/library/internal/search/SearchResultUtilDLFileEntryTest.java
+++ b/modules/apps/document-library/document-library-service/src/test/java/com/liferay/document/library/internal/search/SearchResultUtilDLFileEntryTest.java
@@ -31,8 +31,6 @@ import com.liferay.portal.kernel.search.Summary;
 import com.liferay.portal.kernel.search.SummaryFactory;
 import com.liferay.portal.kernel.search.result.SearchResultContributor;
 import com.liferay.portal.kernel.search.result.SearchResultTranslator;
-import com.liferay.portal.kernel.search.test.BaseSearchResultUtilTestCase;
-import com.liferay.portal.kernel.search.test.SearchTestUtil;
 import com.liferay.portal.kernel.test.CaptureHandler;
 import com.liferay.portal.kernel.test.JDKLoggerTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -40,6 +38,8 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.search.internal.result.SearchResultManagerImpl;
 import com.liferay.portal.search.internal.result.SearchResultTranslatorImpl;
 import com.liferay.portal.search.internal.result.SummaryFactoryImpl;
+import com.liferay.portal.search.test.util.BaseSearchResultUtilTestCase;
+import com.liferay.portal.search.test.util.SearchTestUtil;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;

--- a/modules/apps/journal/journal-test/build.gradle
+++ b/modules/apps/journal/journal-test/build.gradle
@@ -18,6 +18,8 @@ dependencies {
 	testCompile project(":core:registry-api")
 
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testIntegrationCompile group: "log4j", name: "log4j", version: "1.2.17"
+	testIntegrationCompile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	testIntegrationCompile project(":apps:asset:asset-api")
 	testIntegrationCompile project(":apps:asset:asset-test-util")
 	testIntegrationCompile project(":apps:change-tracking:change-tracking-api")

--- a/modules/apps/journal/journal-test/src/test/java/com/liferay/journal/search/SearchResultUtilJournalArticleTest.java
+++ b/modules/apps/journal/journal-test/src/test/java/com/liferay/journal/search/SearchResultUtilJournalArticleTest.java
@@ -24,14 +24,14 @@ import com.liferay.portal.kernel.search.SearchResult;
 import com.liferay.portal.kernel.search.SearchResultManager;
 import com.liferay.portal.kernel.search.SummaryFactory;
 import com.liferay.portal.kernel.search.result.SearchResultTranslator;
-import com.liferay.portal.kernel.search.test.BaseSearchResultUtilTestCase;
-import com.liferay.portal.kernel.search.test.SearchTestUtil;
 import com.liferay.portal.kernel.test.CaptureHandler;
 import com.liferay.portal.kernel.test.JDKLoggerTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.internal.result.SearchResultManagerImpl;
 import com.liferay.portal.search.internal.result.SearchResultTranslatorImpl;
 import com.liferay.portal.search.internal.result.SummaryFactoryImpl;
+import com.liferay.portal.search.test.util.BaseSearchResultUtilTestCase;
+import com.liferay.portal.search.test.util.SearchTestUtil;
 
 import java.util.List;
 import java.util.logging.Level;

--- a/modules/apps/message-boards/message-boards-comment/build.gradle
+++ b/modules/apps/message-boards/message-boards-comment/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-string")
 
 	testCompile project(":apps:portal-search:portal-search")
+	testCompile project(":apps:portal-search:portal-search-test-util")
 	testCompile project(":core:petra:petra-lang")
 	testCompile project(":core:registry-api")
 }

--- a/modules/apps/message-boards/message-boards-comment/src/test/java/com/liferay/message/boards/comment/internal/search/SearchResultUtilMBMessageTest.java
+++ b/modules/apps/message-boards/message-boards-comment/src/test/java/com/liferay/message/boards/comment/internal/search/SearchResultUtilMBMessageTest.java
@@ -26,11 +26,11 @@ import com.liferay.portal.kernel.search.SearchResultManager;
 import com.liferay.portal.kernel.search.SummaryFactory;
 import com.liferay.portal.kernel.search.result.SearchResultContributor;
 import com.liferay.portal.kernel.search.result.SearchResultTranslator;
-import com.liferay.portal.kernel.search.test.BaseSearchResultUtilTestCase;
-import com.liferay.portal.kernel.search.test.SearchTestUtil;
 import com.liferay.portal.search.internal.result.SearchResultManagerImpl;
 import com.liferay.portal.search.internal.result.SearchResultTranslatorImpl;
 import com.liferay.portal.search.internal.result.SummaryFactoryImpl;
+import com.liferay.portal.search.test.util.BaseSearchResultUtilTestCase;
+import com.liferay.portal.search.test.util.SearchTestUtil;
 
 import java.util.List;
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/BaseSearchResultUtilTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/BaseSearchResultUtilTestCase.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.kernel.search.test;
+package com.liferay.portal.search.test.util;
 
 import com.liferay.portal.kernel.comment.Comment;
 import com.liferay.portal.kernel.model.ClassName;

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/SearchTestUtil.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/SearchTestUtil.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.kernel.search.test;
+package com.liferay.portal.search.test.util;
 
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentHelper;

--- a/modules/apps/portal-search/portal-search-test/build.gradle
+++ b/modules/apps/portal-search/portal-search-test/build.gradle
@@ -1,11 +1,13 @@
 dependencies {
 	testCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testCompile group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	testCompile project(":apps:calendar:calendar-api")
+	testCompile project(":apps:portal-search:portal-search")
 	testCompile project(":apps:portal-search:portal-search-test-util")
 	testCompile project(":core:petra:petra-lang")
+	testCompile project(":core:petra:petra-string")
 
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
-	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	testIntegrationCompile group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
 	testIntegrationCompile group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	testIntegrationCompile project(":apps:blogs:blogs-api")
@@ -18,6 +20,5 @@ dependencies {
 	testIntegrationCompile project(":apps:portal-search:portal-search-engine-adapter-api")
 	testIntegrationCompile project(":apps:static:osgi:osgi-util")
 	testIntegrationCompile project(":apps:users-admin:users-admin-test-util")
-	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/portal-search/portal-search-test/src/test/java/com/liferay/portal/search/internal/result/SearchResultUtilTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/test/java/com/liferay/portal/search/internal/result/SearchResultUtilTest.java
@@ -26,9 +26,9 @@ import com.liferay.portal.kernel.search.SearchResult;
 import com.liferay.portal.kernel.search.Summary;
 import com.liferay.portal.kernel.search.SummaryFactory;
 import com.liferay.portal.kernel.search.result.SearchResultTranslator;
-import com.liferay.portal.kernel.search.test.BaseSearchResultUtilTestCase;
-import com.liferay.portal.kernel.search.test.SearchTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.test.util.BaseSearchResultUtilTestCase;
+import com.liferay.portal.search.test.util.SearchTestUtil;
 
 import java.util.List;
 import java.util.Locale;

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilderTest.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.Summary;
-import com.liferay.portal.kernel.search.test.SearchTestUtil;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.test.util.PropsTestUtil;
@@ -439,7 +438,7 @@ public class SearchResultSummaryDisplayBuilderTest {
 
 	protected void setUpAssetRenderer() throws Exception {
 		Mockito.doReturn(
-			SearchTestUtil.SUMMARY_CONTENT
+			_SUMMARY_CONTENT
 		).when(
 			assetRenderer
 		).getSearchSummary(
@@ -447,7 +446,7 @@ public class SearchResultSummaryDisplayBuilderTest {
 		);
 
 		Mockito.doReturn(
-			SearchTestUtil.SUMMARY_TITLE
+			_SUMMARY_TITLE
 		).when(
 			assetRenderer
 		).getTitle(
@@ -558,5 +557,10 @@ public class SearchResultSummaryDisplayBuilderTest {
 	protected PortletURLFactory portletURLFactory;
 
 	protected ThemeDisplay themeDisplay;
+
+	private static final String _SUMMARY_CONTENT =
+		RandomTestUtil.randomString();
+
+	private static final String _SUMMARY_TITLE = RandomTestUtil.randomString();
 
 }


### PR DESCRIPTION
**❌ ci:test:search - 15 out of 18 jobs passed in 1 hour 44 minutes 6 seconds 910 ms**
https://github.com/arboliveira/liferay-portal/pull/718#issuecomment-481973942

----

1 functional failure, not possibly related. Only unit tests changed in this pull. cc/ @xbrianlee @joshchong

`Search#SearchDeletedWebContent` `TestCase#setUpPortalInstance --> FAILED` `Element is not present at "//div[contains(@class,'alert-success')][contains(@class,'alert-dismissible')] | //div[contains(@class,'alert-success')][contains(@class,'alert-dismissable')]"`

----

Author: @wcao20170619 
Reviewer: @arboliveira

_[Task] Modularize Search unit test classes remaining in legacy core_
https://issues.liferay.com/browse/LPS-89371