### PR TITLE
[DO-NOT-MERGE] LPS-93844 add transactioncontainerfilter

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
@@ -15,7 +15,10 @@
 package com.liferay.headless.delivery.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.blogs.service.BlogsEntryLocalServiceUtil;
 import com.liferay.headless.delivery.dto.v1_0.BlogPostingImage;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -30,6 +33,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -38,6 +43,32 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class BlogPostingImageResourceTest
 	extends BaseBlogPostingImageResourceTestCase {
+
+	@Test
+	public void testPostSiteBlogPostingImageUsesTransation() throws Exception {
+		Folder folder = BlogsEntryLocalServiceUtil.fetchAttachmentsFolder(
+			UserLocalServiceUtil.getDefaultUserId(testGroup.getCompanyId()),
+			testGroup.getGroupId());
+
+		Assert.assertNull(folder);
+
+		BlogPostingImage blogPostingImage = randomBlogPostingImage();
+
+		blogPostingImage.setTitle("*,?");
+
+		try {
+			testPostSiteBlogPostingImage_addBlogPostingImage(blogPostingImage);
+		}
+		catch (Throwable e) {
+			Assert.assertTrue(e instanceof AssertionError);
+		}
+
+		folder = BlogsEntryLocalServiceUtil.fetchAttachmentsFolder(
+			UserLocalServiceUtil.getDefaultUserId(testGroup.getCompanyId()),
+			testGroup.getGroupId());
+
+		Assert.assertNull(folder);
+	}
 
 	@Override
 	protected List<EntityField> getEntityFields(EntityField.Type type)

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
@@ -48,10 +48,13 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.jaxrs", version: "1.0.0"
+	compileOnly group: "org.springframework", name: "spring-tx", version: "4.1.9.RELEASE"
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
+	compileOnly project(":apps:portal:portal-spring-extender-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":core:osgi-service-tracker-collections")
+	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 
 	testCompile group: "org.hamcrest", name: "hamcrest-all", version: "1.3"

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
@@ -50,6 +50,7 @@ import com.liferay.portal.vulcan.internal.jaxrs.message.body.JSONMessageBodyWrit
 import com.liferay.portal.vulcan.internal.jaxrs.message.body.MultipartBodyMessageBodyReader;
 import com.liferay.portal.vulcan.internal.jaxrs.message.body.XMLMessageBodyReader;
 import com.liferay.portal.vulcan.internal.jaxrs.message.body.XMLMessageBodyWriter;
+import com.liferay.portal.vulcan.internal.jaxrs.transaction.TransactionContainerFilter;
 import com.liferay.portal.vulcan.internal.jaxrs.validation.BeanValidationInterceptor;
 
 import javax.ws.rs.core.Feature;
@@ -98,6 +99,7 @@ public class VulcanFeature implements Feature {
 		featureContext.register(PortalExceptionMapper.class);
 		featureContext.register(PrincipalExceptionMapper.class);
 		featureContext.register(ServiceEventsContainerRequestFilter.class);
+		featureContext.register(TransactionContainerFilter.class);
 		featureContext.register(UnrecognizedPropertyExceptionMapper.class);
 		featureContext.register(ValidationExceptionMapper.class);
 		featureContext.register(WebApplicationExceptionMapper.class);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/transaction/TransactionContainerFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/transaction/TransactionContainerFilter.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.transaction;
+
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.spring.transaction.DefaultTransactionExecutor;
+import com.liferay.portal.spring.transaction.TransactionAttributeAdapter;
+import com.liferay.portal.spring.transaction.TransactionAttributeBuilder;
+import com.liferay.portal.spring.transaction.TransactionExecutor;
+import com.liferay.portal.spring.transaction.TransactionInvokerImpl;
+import com.liferay.portal.spring.transaction.TransactionStatusAdapter;
+
+import java.io.IOException;
+
+import java.lang.reflect.Field;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * @author Javier Gamarra
+ */
+@Provider
+public class TransactionContainerFilter
+	implements ContainerRequestFilter, ContainerResponseFilter {
+
+	@Override
+	public void filter(ContainerRequestContext containerRequestContext)
+		throws IOException {
+
+		if (_transactionVerbs.contains(containerRequestContext.getMethod())) {
+			DefaultTransactionExecutor defaultTransactionExecutor =
+				_getDefaultTransactionExecutor();
+
+			TransactionAttributeAdapter transactionAttributeAdapter =
+				_getTransactionAttributeAdapter();
+
+			TransactionStatusThreadLocal.setTransactionStatusAdapter(
+				defaultTransactionExecutor.start(transactionAttributeAdapter));
+		}
+	}
+
+	@Override
+	public void filter(
+			ContainerRequestContext requestContext,
+			ContainerResponseContext responseContext)
+		throws IOException {
+
+		if (_transactionVerbs.contains(requestContext.getMethod())) {
+			DefaultTransactionExecutor defaultTransactionExecutor =
+				_getDefaultTransactionExecutor();
+
+			TransactionStatusAdapter transactionStatusAdapter =
+				TransactionStatusThreadLocal.getTransactionStatusAdapter();
+
+			if (transactionStatusAdapter != null) {
+				TransactionAttributeAdapter transactionAttributeAdapter =
+					_getTransactionAttributeAdapter();
+
+				if (Response.Status.Family.familyOf(
+						responseContext.getStatus()).equals(
+							Response.Status.Family.SUCCESSFUL)) {
+
+					defaultTransactionExecutor.commit(
+						transactionAttributeAdapter, transactionStatusAdapter);
+				}
+				else {
+					try {
+						defaultTransactionExecutor.rollback(
+							new RuntimeException(), transactionAttributeAdapter,
+							transactionStatusAdapter);
+					}
+					catch (Throwable throwable) {
+
+						// We are crashing either way and we don't want
+						// to swallow the real exception and create another
+						// request
+
+					}
+				}
+			}
+		}
+	}
+
+	private DefaultTransactionExecutor _getDefaultTransactionExecutor() {
+		try {
+			Field field = TransactionInvokerImpl.class.getDeclaredField(
+				"_transactionExecutor");
+
+			field.setAccessible(true);
+
+			TransactionExecutor transactionExecutor =
+				(TransactionExecutor)field.get(null);
+
+			return new DefaultTransactionExecutor(
+				transactionExecutor.getPlatformTransactionManager());
+		}
+		catch (IllegalAccessException | NoSuchFieldException e) {
+			throw new ServerErrorException(
+				Response.Status.INTERNAL_SERVER_ERROR, e);
+		}
+	}
+
+	private TransactionAttributeAdapter _getTransactionAttributeAdapter() {
+		TransactionConfig transactionConfig = TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+		return new TransactionAttributeAdapter(
+			TransactionAttributeBuilder.build(
+				true, transactionConfig.getIsolation(),
+				transactionConfig.getPropagation(),
+				transactionConfig.isReadOnly(), transactionConfig.getTimeout(),
+				transactionConfig.getRollbackForClasses(),
+				transactionConfig.getRollbackForClassNames(),
+				transactionConfig.getNoRollbackForClasses(),
+				transactionConfig.getNoRollbackForClassNames()));
+	}
+
+	private static final List<String> _transactionVerbs = Arrays.asList(
+		"DELETE", "PATCH", "POST", "PUT");
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/transaction/TransactionContainerFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/transaction/TransactionContainerFilter.java
@@ -63,11 +63,11 @@ public class TransactionContainerFilter
 
 	@Override
 	public void filter(
-			ContainerRequestContext requestContext,
-			ContainerResponseContext responseContext)
+			ContainerRequestContext containerRequestContext,
+			ContainerResponseContext containerResponseContext)
 		throws IOException {
 
-		if (_transactionVerbs.contains(requestContext.getMethod())) {
+		if (_transactionVerbs.contains(containerRequestContext.getMethod())) {
 			DefaultTransactionExecutor defaultTransactionExecutor =
 				_getDefaultTransactionExecutor();
 
@@ -79,7 +79,7 @@ public class TransactionContainerFilter
 					_getTransactionAttributeAdapter();
 
 				if (Response.Status.Family.familyOf(
-						responseContext.getStatus()).equals(
+						containerResponseContext.getStatus()).equals(
 							Response.Status.Family.SUCCESSFUL)) {
 
 					defaultTransactionExecutor.commit(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/transaction/TransactionContainerFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/transaction/TransactionContainerFilter.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.vulcan.internal.jaxrs.transaction;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.spring.transaction.DefaultTransactionExecutor;
@@ -92,11 +94,10 @@ public class TransactionContainerFilter
 							transactionStatusAdapter);
 					}
 					catch (Throwable throwable) {
-
-						// We are crashing either way and we don't want
-						// to swallow the real exception and create another
-						// request
-
+						if (_log.isDebugEnabled()) {
+							_log.debug(
+								"Could not rollback the transation", throwable);
+						}
 					}
 				}
 			}
@@ -136,6 +137,9 @@ public class TransactionContainerFilter
 				transactionConfig.getNoRollbackForClasses(),
 				transactionConfig.getNoRollbackForClassNames()));
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		TransactionContainerFilter.class);
 
 	private static final List<String> _transactionVerbs = Arrays.asList(
 		"DELETE", "PATCH", "POST", "PUT");

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/transaction/TransactionStatusThreadLocal.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/transaction/TransactionStatusThreadLocal.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.transaction;
+
+import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.portal.spring.transaction.TransactionStatusAdapter;
+
+/**
+ * @author Javier Gamarra
+ */
+public class TransactionStatusThreadLocal {
+
+	public static TransactionStatusAdapter getTransactionStatusAdapter() {
+		return _transactionStatusAdapterThreadLocal.get();
+	}
+
+	public static void setTransactionStatusAdapter(
+		TransactionStatusAdapter transactionStatusAdapter) {
+
+		_transactionStatusAdapterThreadLocal.set(transactionStatusAdapter);
+	}
+
+	private static final ThreadLocal<TransactionStatusAdapter>
+		_transactionStatusAdapterThreadLocal = new CentralizedThreadLocal<>(
+			TransactionStatusThreadLocal.class +
+				"._transactionStatusAdapterThreadLocal");
+
+}


### PR DESCRIPTION
I've not found a way of accessing commit()/rollback() directly without using DefaultTransactionExecutor and to be able to create it I need a PlatformTransactionManager that I'm getting through reflection. I'm sure there is a better way to do this.

I'm also not sure if the threadlocal is needed or would be enough (and safer) passing several properties in the ContainerRequestContext...