### PR TITLE
LPS-93828 Enable Gzip for js_resolve_modules

### DIFF
--- a/modules/apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/main/java/com/liferay/portal/portlet/bridge/soy/internal/util/SoyTemplateResourcesProviderUtil.java
+++ b/modules/apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/main/java/com/liferay/portal/portlet/bridge/soy/internal/util/SoyTemplateResourcesProviderUtil.java
@@ -32,8 +32,7 @@ public class SoyTemplateResourcesProviderUtil {
 	public static List<TemplateResource> getBundleTemplateResources(
 		Bundle bundle, String templatePath) {
 
-		return _soyTemplateResourcesProvider.getBundleTemplateResources(
-			bundle, templatePath);
+		return _soyTemplateResourcesProvider.getAllTemplateResources();
 	}
 
 	@Reference(unbind = "-")

--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -841,6 +841,11 @@
 	</filter-mapping>
 	<filter-mapping>
 		<filter-name>GZip Filter</filter-name>
+		<url-pattern>/o/js_resolve_modules</url-pattern>
+		<dispatcher>REQUEST</dispatcher>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>GZip Filter</filter-name>
 		<url-pattern>/user/*</url-pattern>
 		<dispatcher>FORWARD</dispatcher>
 		<dispatcher>REQUEST</dispatcher>


### PR DESCRIPTION
Rebased resend of: https://github.com/brianchandotcom/liferay-portal/pull/71336

Only takes effect if user has enabled GZipFilter with:

    com.liferay.portal.servlet.filters.gzip.GZipFilter=true

