### PR TITLE
LPS-92724 Add read only information for users, workflow and taxonomies

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/Creator.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/Creator.java
@@ -64,7 +64,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String additionalName;
 
 	public String getFamilyName() {
@@ -91,7 +91,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String familyName;
 
 	public String getGivenName() {
@@ -118,7 +118,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String givenName;
 
 	public Long getId() {
@@ -143,7 +143,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getImage() {
@@ -170,7 +170,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String image;
 
 	public String getName() {
@@ -195,7 +195,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String name;
 
 	public String getProfileURL() {
@@ -222,7 +222,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String profileURL;
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/Keyword.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/Keyword.java
@@ -70,7 +70,7 @@ public class Keyword {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Creator creator;
 
 	public Date getDateCreated() {
@@ -97,7 +97,7 @@ public class Keyword {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateCreated;
 
 	public Date getDateModified() {
@@ -124,7 +124,7 @@ public class Keyword {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateModified;
 
 	public Long getId() {
@@ -149,7 +149,7 @@ public class Keyword {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public Number getKeywordUsageCount() {
@@ -176,7 +176,7 @@ public class Keyword {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Number keywordUsageCount;
 
 	public String getName() {
@@ -229,7 +229,7 @@ public class Keyword {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long siteId;
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyCategory.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyCategory.java
@@ -105,7 +105,7 @@ public class TaxonomyCategory {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String[] availableLanguages;
 
 	public Creator getCreator() {
@@ -159,7 +159,7 @@ public class TaxonomyCategory {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateCreated;
 
 	public Date getDateModified() {
@@ -186,7 +186,7 @@ public class TaxonomyCategory {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateModified;
 
 	public String getDescription() {
@@ -238,7 +238,7 @@ public class TaxonomyCategory {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getName() {
@@ -295,7 +295,7 @@ public class TaxonomyCategory {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Number numberOfTaxonomyCategories;
 
 	public ParentTaxonomyCategory getParentTaxonomyCategory() {
@@ -325,7 +325,7 @@ public class TaxonomyCategory {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected ParentTaxonomyCategory parentTaxonomyCategory;
 
 	public ParentTaxonomyVocabulary getParentTaxonomyVocabulary() {
@@ -358,33 +358,6 @@ public class TaxonomyCategory {
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected ParentTaxonomyVocabulary parentTaxonomyVocabulary;
-
-	public Long getParentVocabularyId() {
-		return parentVocabularyId;
-	}
-
-	public void setParentVocabularyId(Long parentVocabularyId) {
-		this.parentVocabularyId = parentVocabularyId;
-	}
-
-	@JsonIgnore
-	public void setParentVocabularyId(
-		UnsafeSupplier<Long, Exception> parentVocabularyIdUnsafeSupplier) {
-
-		try {
-			parentVocabularyId = parentVocabularyIdUnsafeSupplier.get();
-		}
-		catch (RuntimeException re) {
-			throw re;
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-	protected Long parentVocabularyId;
 
 	public ViewableBy getViewableBy() {
 		return viewableBy;
@@ -567,17 +540,6 @@ public class TaxonomyCategory {
 		}
 		else {
 			sb.append(parentTaxonomyVocabulary);
-		}
-
-		sb.append(", ");
-
-		sb.append("\"parentVocabularyId\": ");
-
-		if (parentVocabularyId == null) {
-			sb.append("null");
-		}
-		else {
-			sb.append(parentVocabularyId);
 		}
 
 		sb.append(", ");

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyVocabulary.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyVocabulary.java
@@ -132,7 +132,7 @@ public class TaxonomyVocabulary {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String[] availableLanguages;
 
 	public Creator getCreator() {
@@ -159,7 +159,7 @@ public class TaxonomyVocabulary {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Creator creator;
 
 	public Date getDateCreated() {
@@ -186,7 +186,7 @@ public class TaxonomyVocabulary {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateCreated;
 
 	public Date getDateModified() {
@@ -213,7 +213,7 @@ public class TaxonomyVocabulary {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateModified;
 
 	public String getDescription() {
@@ -265,7 +265,7 @@ public class TaxonomyVocabulary {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getName() {
@@ -322,7 +322,7 @@ public class TaxonomyVocabulary {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Number numberOfTaxonomyCategories;
 
 	public Long getSiteId() {
@@ -349,7 +349,7 @@ public class TaxonomyVocabulary {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long siteId;
 
 	public ViewableBy getViewableBy() {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/TaxonomyCategory.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/TaxonomyCategory.java
@@ -276,27 +276,6 @@ public class TaxonomyCategory {
 
 	protected ParentTaxonomyVocabulary parentTaxonomyVocabulary;
 
-	public Long getParentVocabularyId() {
-		return parentVocabularyId;
-	}
-
-	public void setParentVocabularyId(Long parentVocabularyId) {
-		this.parentVocabularyId = parentVocabularyId;
-	}
-
-	public void setParentVocabularyId(
-		UnsafeSupplier<Long, Exception> parentVocabularyIdUnsafeSupplier) {
-
-		try {
-			parentVocabularyId = parentVocabularyIdUnsafeSupplier.get();
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	protected Long parentVocabularyId;
-
 	public ViewableBy getViewableBy() {
 		return viewableBy;
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyCategorySerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyCategorySerDes.java
@@ -181,17 +181,6 @@ public class TaxonomyCategorySerDes {
 
 		sb.append(", ");
 
-		sb.append("\"parentVocabularyId\": ");
-
-		if (taxonomyCategory.getParentVocabularyId() == null) {
-			sb.append("null");
-		}
-		else {
-			sb.append(taxonomyCategory.getParentVocabularyId());
-		}
-
-		sb.append(", ");
-
 		sb.append("\"viewableBy\": ");
 
 		if (taxonomyCategory.getViewableBy() == null) {
@@ -312,14 +301,6 @@ public class TaxonomyCategorySerDes {
 					taxonomyCategory.setParentTaxonomyVocabulary(
 						ParentTaxonomyVocabularySerDes.toDTO(
 							(String)jsonParserFieldValue));
-				}
-			}
-			else if (Objects.equals(
-						jsonParserFieldName, "parentVocabularyId")) {
-
-				if (jsonParserFieldValue != null) {
-					taxonomyCategory.setParentVocabularyId(
-						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "viewableBy")) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -14,21 +14,28 @@ components:
             description: https://www.schema.org/Creator
             properties:
                 additionalName:
+                    readOnly: true
                     type: string
                 familyName:
+                    readOnly: true
                     type: string
                 givenName:
+                    readOnly: true
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 image:
                     format: uri
+                    readOnly: true
                     type: string
                 name:
+                    readOnly: true
                     type: string
                 profileURL:
                     format: uri
+                    readOnly: true
                     type: string
             type: object
         Keyword:
@@ -38,19 +45,24 @@ components:
                     $ref: "#/components/schemas/Creator"
                 dateCreated:
                     format: date-time
+                    readOnly: true
                     type: string
                 dateModified:
                     format: date-time
+                    readOnly: true
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 keywordUsageCount:
+                    readOnly: true
                     type: number
                 name:
                     type: string
                 siteId:
                     format: int64
+                    readOnly: true
                     type: integer
             required:
                 - name
@@ -61,6 +73,7 @@ components:
                 availableLanguages:
                     items:
                         type: string
+                    readOnly: true
                     type: array
                 creator:
                     allOf:
@@ -68,18 +81,22 @@ components:
                     readOnly: true
                 dateCreated:
                     format: date-time
+                    readOnly: true
                     type: string
                 dateModified:
                     format: date-time
+                    readOnly: true
                     type: string
                 description:
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 name:
                     type: string
                 numberOfTaxonomyCategories:
+                    readOnly: true
                     type: number
                 parentTaxonomyCategory:
                     properties:
@@ -88,6 +105,7 @@ components:
                             type: integer
                         name:
                             type: string
+                    readOnly: true
                     type: object
                 parentTaxonomyVocabulary:
                     properties:
@@ -98,10 +116,6 @@ components:
                             type: string
                     readOnly: true
                     type: object
-                parentVocabularyId:
-                    format: int64
-                    type: integer
-                    writeOnly: true
                 viewableBy:
                     enum: [Anyone, Members, Owner]
                     type: string
@@ -119,26 +133,32 @@ components:
                 availableLanguages:
                     items:
                         type: string
+                    readOnly: true
                     type: array
                 creator:
                     $ref: "#/components/schemas/Creator"
                 dateCreated:
                     format: date-time
+                    readOnly: true
                     type: string
                 dateModified:
                     format: date-time
+                    readOnly: true
                     type: string
                 description:
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 name:
                     type: string
                 numberOfTaxonomyCategories:
+                    readOnly: true
                     type: number
                 siteId:
                     format: int64
+                    readOnly: true
                     type: integer
                 viewableBy:
                     enum: [Anyone, Members, Owner]

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -42,7 +42,9 @@ components:
             description: https://www.schema.org/Keyword
             properties:
                 creator:
-                    $ref: "#/components/schemas/Creator"
+                    allOf:
+                        - $ref: "#/components/schemas/Creator"
+                    readOnly: true
                 dateCreated:
                     format: date-time
                     readOnly: true
@@ -136,7 +138,9 @@ components:
                     readOnly: true
                     type: array
                 creator:
-                    $ref: "#/components/schemas/Creator"
+                    allOf:
+                        - $ref: "#/components/schemas/Creator"
+                    readOnly: true
                 dateCreated:
                     format: date-time
                     readOnly: true

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -164,11 +164,6 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 				taxonomyCategory.getNumberOfTaxonomyCategories());
 		}
 
-		if (taxonomyCategory.getParentVocabularyId() != null) {
-			existingTaxonomyCategory.setParentVocabularyId(
-				taxonomyCategory.getParentVocabularyId());
-		}
-
 		if (taxonomyCategory.getViewableBy() != null) {
 			existingTaxonomyCategory.setViewableBy(
 				taxonomyCategory.getViewableBy());

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.admin.taxonomy.dto.v1_0.Creator;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.Keyword;
 import com.liferay.headless.admin.taxonomy.resource.v1_0.KeywordResource;
 import com.liferay.petra.string.StringBundler;
@@ -1004,6 +1005,7 @@ public abstract class BaseKeywordResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(Keyword.class, KeywordMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -1020,6 +1022,31 @@ public abstract class BaseKeywordResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class KeywordMixin {
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		Number keywordUsageCount;
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		Long siteId;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -21,6 +21,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.admin.taxonomy.dto.v1_0.Creator;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.ParentTaxonomyCategory;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.ParentTaxonomyVocabulary;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyCategory;
 import com.liferay.headless.admin.taxonomy.resource.v1_0.TaxonomyCategoryResource;
 import com.liferay.petra.string.StringBundler;
@@ -1829,6 +1832,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(TaxonomyCategory.class, TaxonomyCategoryMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -1845,6 +1849,46 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class TaxonomyCategoryMixin {
+
+		@JsonProperty
+		String[] availableLanguages;
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		Number numberOfTaxonomyCategories;
+
+		@JsonProperty
+		ParentTaxonomyCategory parentTaxonomyCategory;
+
+		@JsonProperty
+		ParentTaxonomyVocabulary parentTaxonomyVocabulary;
+
+		@JsonProperty
+		ViewableBy viewableBy;
+
+		public static enum ViewableBy {
+		}
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -1493,16 +1493,6 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals(
-					"parentVocabularyId", additionalAssertFieldName)) {
-
-				if (taxonomyCategory.getParentVocabularyId() == null) {
-					valid = false;
-				}
-
-				continue;
-			}
-
 			if (Objects.equals("viewableBy", additionalAssertFieldName)) {
 				if (taxonomyCategory.getViewableBy() == null) {
 					valid = false;
@@ -1668,19 +1658,6 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals(
-					"parentVocabularyId", additionalAssertFieldName)) {
-
-				if (!Objects.deepEquals(
-						taxonomyCategory1.getParentVocabularyId(),
-						taxonomyCategory2.getParentVocabularyId())) {
-
-					return false;
-				}
-
-				continue;
-			}
-
 			if (Objects.equals("viewableBy", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						taxonomyCategory1.getViewableBy(),
@@ -1804,11 +1781,6 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
-		if (entityFieldName.equals("parentVocabularyId")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
-		}
-
 		if (entityFieldName.equals("viewableBy")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -1826,7 +1798,6 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				description = RandomTestUtil.randomString();
 				id = RandomTestUtil.randomLong();
 				name = RandomTestUtil.randomString();
-				parentVocabularyId = RandomTestUtil.randomLong();
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.admin.taxonomy.dto.v1_0.AssetType;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.Creator;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyVocabulary;
 import com.liferay.headless.admin.taxonomy.resource.v1_0.TaxonomyVocabularyResource;
 import com.liferay.petra.string.StringBundler;
@@ -1344,6 +1346,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(
+					TaxonomyVocabulary.class, TaxonomyVocabularyMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -1360,6 +1364,46 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class TaxonomyVocabularyMixin {
+
+		@JsonProperty
+		AssetType[] assetTypes;
+
+		@JsonProperty
+		String[] availableLanguages;
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		Number numberOfTaxonomyCategories;
+
+		@JsonProperty
+		Long siteId;
+
+		@JsonProperty
+		ViewableBy viewableBy;
+
+		public static enum ViewableBy {
+		}
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/ContactInformation.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/ContactInformation.java
@@ -91,7 +91,7 @@ public class ContactInformation {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String facebook;
 
 	public Long getId() {
@@ -116,7 +116,7 @@ public class ContactInformation {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getJabber() {
@@ -143,7 +143,7 @@ public class ContactInformation {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String jabber;
 
 	public PostalAddress[] getPostalAddresses() {
@@ -198,7 +198,7 @@ public class ContactInformation {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String skype;
 
 	public String getSms() {
@@ -223,7 +223,7 @@ public class ContactInformation {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String sms;
 
 	public Phone[] getTelephones() {
@@ -277,7 +277,7 @@ public class ContactInformation {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String twitter;
 
 	public WebUrl[] getWebUrls() {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Creator.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Creator.java
@@ -64,7 +64,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String additionalName;
 
 	public String getFamilyName() {
@@ -91,7 +91,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String familyName;
 
 	public String getGivenName() {
@@ -118,7 +118,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String givenName;
 
 	public Long getId() {
@@ -143,7 +143,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getImage() {
@@ -170,7 +170,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String image;
 
 	public String getName() {
@@ -195,7 +195,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String name;
 
 	public String getProfileURL() {
@@ -222,7 +222,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String profileURL;
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Email.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Email.java
@@ -64,7 +64,7 @@ public class Email {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String email;
 
 	public Long getId() {
@@ -89,7 +89,7 @@ public class Email {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public Boolean getPrimary() {
@@ -116,7 +116,7 @@ public class Email {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Boolean primary;
 
 	public String getType() {
@@ -141,7 +141,7 @@ public class Email {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String type;
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/HoursAvailable.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/HoursAvailable.java
@@ -64,7 +64,7 @@ public class HoursAvailable {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String closes;
 
 	public String getDayOfWeek() {
@@ -91,7 +91,7 @@ public class HoursAvailable {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String dayOfWeek;
 
 	public Long getId() {
@@ -116,7 +116,7 @@ public class HoursAvailable {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getOpens() {
@@ -143,7 +143,7 @@ public class HoursAvailable {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String opens;
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Location.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Location.java
@@ -64,7 +64,7 @@ public class Location {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String addressCountry;
 
 	public String getAddressRegion() {
@@ -91,7 +91,7 @@ public class Location {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String addressRegion;
 
 	public Long getId() {
@@ -116,7 +116,7 @@ public class Location {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Organization.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Organization.java
@@ -67,7 +67,7 @@ public class Organization {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String comment;
 
 	@Schema(description = "https://www.schema.org/ContactInformation")
@@ -96,7 +96,7 @@ public class Organization {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected ContactInformation contactInformation;
 
 	public Date getDateCreated() {
@@ -123,7 +123,7 @@ public class Organization {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateCreated;
 
 	public Date getDateModified() {
@@ -150,7 +150,7 @@ public class Organization {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateModified;
 
 	public Long getId() {
@@ -175,7 +175,7 @@ public class Organization {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getImage() {
@@ -202,7 +202,7 @@ public class Organization {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String image;
 
 	public String[] getKeywords() {
@@ -229,7 +229,7 @@ public class Organization {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String[] keywords;
 
 	@Schema(description = "https://www.schema.org/PostalAddress")
@@ -257,7 +257,7 @@ public class Organization {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Location location;
 
 	public String getName() {
@@ -282,7 +282,7 @@ public class Organization {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String name;
 
 	public Number getNumberOfOrganizations() {
@@ -309,7 +309,7 @@ public class Organization {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Number numberOfOrganizations;
 
 	public Organization getParentOrganization() {
@@ -340,33 +340,6 @@ public class Organization {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Organization parentOrganization;
 
-	public Long getParentOrganizationId() {
-		return parentOrganizationId;
-	}
-
-	public void setParentOrganizationId(Long parentOrganizationId) {
-		this.parentOrganizationId = parentOrganizationId;
-	}
-
-	@JsonIgnore
-	public void setParentOrganizationId(
-		UnsafeSupplier<Long, Exception> parentOrganizationIdUnsafeSupplier) {
-
-		try {
-			parentOrganizationId = parentOrganizationIdUnsafeSupplier.get();
-		}
-		catch (RuntimeException re) {
-			throw re;
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-	protected Long parentOrganizationId;
-
 	@Schema(description = "https://www.schema.org/Service")
 	public Service[] getServices() {
 		return services;
@@ -392,7 +365,7 @@ public class Organization {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Service[] services;
 
 	@Override
@@ -551,17 +524,6 @@ public class Organization {
 		}
 		else {
 			sb.append(parentOrganization);
-		}
-
-		sb.append(", ");
-
-		sb.append("\"parentOrganizationId\": ");
-
-		if (parentOrganizationId == null) {
-			sb.append("null");
-		}
-		else {
-			sb.append(parentOrganizationId);
 		}
 
 		sb.append(", ");

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/OrganizationBrief.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/OrganizationBrief.java
@@ -62,7 +62,7 @@ public class OrganizationBrief {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getName() {
@@ -87,7 +87,7 @@ public class OrganizationBrief {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String name;
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Phone.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Phone.java
@@ -64,7 +64,7 @@ public class Phone {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String extension;
 
 	public Long getId() {
@@ -89,7 +89,7 @@ public class Phone {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getPhoneNumber() {
@@ -116,7 +116,7 @@ public class Phone {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String phoneNumber;
 
 	public String getPhoneType() {
@@ -143,7 +143,7 @@ public class Phone {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String phoneType;
 
 	public Boolean getPrimary() {
@@ -170,7 +170,7 @@ public class Phone {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Boolean primary;
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/PostalAddress.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/PostalAddress.java
@@ -64,7 +64,7 @@ public class PostalAddress {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String addressCountry;
 
 	public String getAddressLocality() {
@@ -91,7 +91,7 @@ public class PostalAddress {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String addressLocality;
 
 	public String getAddressRegion() {
@@ -118,7 +118,7 @@ public class PostalAddress {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String addressRegion;
 
 	public String getAddressType() {
@@ -145,7 +145,7 @@ public class PostalAddress {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String addressType;
 
 	public Long getId() {
@@ -170,7 +170,7 @@ public class PostalAddress {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getPostalCode() {
@@ -197,7 +197,7 @@ public class PostalAddress {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String postalCode;
 
 	public Boolean getPrimary() {
@@ -224,7 +224,7 @@ public class PostalAddress {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Boolean primary;
 
 	public String getStreetAddressLine1() {
@@ -251,7 +251,7 @@ public class PostalAddress {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String streetAddressLine1;
 
 	public String getStreetAddressLine2() {
@@ -278,7 +278,7 @@ public class PostalAddress {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String streetAddressLine2;
 
 	public String getStreetAddressLine3() {
@@ -305,7 +305,7 @@ public class PostalAddress {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String streetAddressLine3;
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Role.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Role.java
@@ -65,7 +65,7 @@ public class Role {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String[] availableLanguages;
 
 	public Creator getCreator() {
@@ -92,7 +92,7 @@ public class Role {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Creator creator;
 
 	public Date getDateCreated() {
@@ -119,7 +119,7 @@ public class Role {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateCreated;
 
 	public Date getDateModified() {
@@ -146,7 +146,7 @@ public class Role {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateModified;
 
 	public String getDescription() {
@@ -173,7 +173,7 @@ public class Role {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String description;
 
 	public Long getId() {
@@ -198,7 +198,7 @@ public class Role {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getName() {
@@ -223,7 +223,7 @@ public class Role {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String name;
 
 	public String getRoleType() {
@@ -250,7 +250,7 @@ public class Role {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String roleType;
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/RoleBrief.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/RoleBrief.java
@@ -62,7 +62,7 @@ public class RoleBrief {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getName() {
@@ -87,7 +87,7 @@ public class RoleBrief {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String name;
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Segment.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Segment.java
@@ -65,7 +65,7 @@ public class Segment {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Boolean active;
 
 	public String getCriteria() {
@@ -92,7 +92,7 @@ public class Segment {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String criteria;
 
 	public Date getDateCreated() {
@@ -119,7 +119,7 @@ public class Segment {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateCreated;
 
 	public Date getDateModified() {
@@ -146,7 +146,7 @@ public class Segment {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateModified;
 
 	public Long getId() {
@@ -171,7 +171,7 @@ public class Segment {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getName() {
@@ -196,7 +196,7 @@ public class Segment {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String name;
 
 	public Long getSiteId() {
@@ -223,7 +223,7 @@ public class Segment {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long siteId;
 
 	public String getSource() {
@@ -250,7 +250,7 @@ public class Segment {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String source;
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/SegmentUser.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/SegmentUser.java
@@ -64,7 +64,7 @@ public class SegmentUser {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String email;
 
 	public Long getId() {
@@ -89,7 +89,7 @@ public class SegmentUser {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getName() {
@@ -114,7 +114,7 @@ public class SegmentUser {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String name;
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Service.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Service.java
@@ -68,7 +68,7 @@ public class Service {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected HoursAvailable[] hoursAvailable;
 
 	public Long getId() {
@@ -93,7 +93,7 @@ public class Service {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getServiceType() {
@@ -120,7 +120,7 @@ public class Service {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String serviceType;
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/SiteBrief.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/SiteBrief.java
@@ -62,7 +62,7 @@ public class SiteBrief {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getName() {
@@ -87,7 +87,7 @@ public class SiteBrief {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String name;
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/UserAccount.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/UserAccount.java
@@ -67,7 +67,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String additionalName;
 
 	public String getAlternateName() {
@@ -94,7 +94,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String alternateName;
 
 	public Date getBirthDate() {
@@ -121,7 +121,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date birthDate;
 
 	@Schema(description = "https://www.schema.org/ContactInformation")
@@ -177,7 +177,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String dashboardURL;
 
 	public Date getDateCreated() {
@@ -204,7 +204,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateCreated;
 
 	public Date getDateModified() {
@@ -231,7 +231,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateModified;
 
 	public String getEmail() {
@@ -258,7 +258,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String email;
 
 	public String getFamilyName() {
@@ -285,7 +285,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String familyName;
 
 	public String getGivenName() {
@@ -312,7 +312,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String givenName;
 
 	public String getHonorificPrefix() {
@@ -339,7 +339,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String honorificPrefix;
 
 	public String getHonorificSuffix() {
@@ -366,7 +366,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String honorificSuffix;
 
 	public Long getId() {
@@ -391,7 +391,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getImage() {
@@ -418,7 +418,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String image;
 
 	public String getJobTitle() {
@@ -445,7 +445,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String jobTitle;
 
 	public String[] getKeywords() {
@@ -472,7 +472,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String[] keywords;
 
 	public String getName() {
@@ -497,7 +497,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String name;
 
 	public OrganizationBrief[] getOrganizationBriefs() {
@@ -552,7 +552,7 @@ public class UserAccount {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String profileURL;
 
 	public RoleBrief[] getRoleBriefs() {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/WebUrl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/WebUrl.java
@@ -62,7 +62,7 @@ public class WebUrl {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getUrl() {
@@ -87,7 +87,7 @@ public class WebUrl {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String url;
 
 	public String getUrlType() {
@@ -114,7 +114,7 @@ public class WebUrl {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String urlType;
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/Organization.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/Organization.java
@@ -256,27 +256,6 @@ public class Organization {
 
 	protected Organization parentOrganization;
 
-	public Long getParentOrganizationId() {
-		return parentOrganizationId;
-	}
-
-	public void setParentOrganizationId(Long parentOrganizationId) {
-		this.parentOrganizationId = parentOrganizationId;
-	}
-
-	public void setParentOrganizationId(
-		UnsafeSupplier<Long, Exception> parentOrganizationIdUnsafeSupplier) {
-
-		try {
-			parentOrganizationId = parentOrganizationIdUnsafeSupplier.get();
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	protected Long parentOrganizationId;
-
 	public Service[] getServices() {
 		return services;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/OrganizationSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/OrganizationSerDes.java
@@ -192,17 +192,6 @@ public class OrganizationSerDes {
 
 		sb.append(", ");
 
-		sb.append("\"parentOrganizationId\": ");
-
-		if (organization.getParentOrganizationId() == null) {
-			sb.append("null");
-		}
-		else {
-			sb.append(organization.getParentOrganizationId());
-		}
-
-		sb.append(", ");
-
 		sb.append("\"services\": ");
 
 		if (organization.getServices() == null) {
@@ -332,14 +321,6 @@ public class OrganizationSerDes {
 				if (jsonParserFieldValue != null) {
 					organization.setParentOrganization(
 						OrganizationSerDes.toDTO((String)jsonParserFieldValue));
-				}
-			}
-			else if (Objects.equals(
-						jsonParserFieldName, "parentOrganizationId")) {
-
-				if (jsonParserFieldValue != null) {
-					organization.setParentOrganizationId(
-						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "services")) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -4,40 +4,52 @@ components:
             description: https://www.schema.org/Creator
             properties:
                 additionalName:
+                    readOnly: true
                     type: string
                 familyName:
+                    readOnly: true
                     type: string
                 givenName:
+                    readOnly: true
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 image:
                     format: uri
+                    readOnly: true
                     type: string
                 name:
+                    readOnly: true
                     type: string
                 profileURL:
                     format: uri
+                    readOnly: true
                     type: string
             type: object
         Email:
             description: https://www.schema.org/Email
             properties:
                 email:
+                    readOnly: true
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 primary:
+                    readOnly: true
                     type: boolean
                 type:
+                    readOnly: true
                     type: string
             type: object
         Organization:
             description: https://www.schema.org/Organization
             properties:
                 comment:
+                    readOnly: true
                     type: string
                 contactInformation:
                     description: https://www.schema.org/ContactInformation
@@ -62,46 +74,53 @@ components:
                                 $ref: "#/components/schemas/WebUrl"
                             readOnly: true
                             type: array
+                    readOnly: true
                     type: object
                 dateCreated:
                     format: date-time
+                    readOnly: true
                     type: string
                 dateModified:
                     format: date-time
+                    readOnly: true
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 image:
                     format: uri
+                    readOnly: true
                     type: string
                 keywords:
                     items:
                         type: string
+                    readOnly: true
                     type: array
                 location:
                     description: https://www.schema.org/PostalAddress
                     properties:
                         addressCountry:
+                            readOnly: true
                             type: string
                         addressRegion:
+                            readOnly: true
                             type: string
                         id:
                             format: int64
+                            readOnly: true
                             type: integer
                     type: object
                 name:
+                    readOnly: true
                     type: string
                 numberOfOrganizations:
+                    readOnly: true
                     type: number
                 parentOrganization:
                     allOf:
                         - $ref: "#/components/schemas/Organization"
                     readOnly: true
-                parentOrganizationId:
-                    format: int64
-                    type: integer
-                    writeOnly: true
                 services:
                     description: https://www.schema.org/Service
                     items:
@@ -111,22 +130,30 @@ components:
                                 items:
                                     properties:
                                         closes:
+                                            readOnly: true
                                             type: string
                                         dayOfWeek:
+                                            readOnly: true
                                             type: string
                                         id:
                                             format: int64
+                                            readOnly: true
                                             type: integer
                                         opens:
+                                            readOnly: true
                                             type: string
                                     type: object
+                                readOnly: true
                                 type: array
                             id:
                                 format: int64
+                                readOnly: true
                                 type: integer
                             serviceType:
+                                readOnly: true
                                 type: string
                         type: object
+                    readOnly: true
                     type: array
             type: object
         OrganizationBrief:
@@ -134,48 +161,65 @@ components:
             properties:
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 name:
+                    readOnly: true
                     type: string
             type: object
         Phone:
             description: https://www.schema.org/Phone
             properties:
                 extension:
+                    readOnly: true
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 phoneNumber:
+                    readOnly: true
                     type: string
                 phoneType:
+                    readOnly: true
                     type: string
                 primary:
+                    readOnly: true
                     type: boolean
             type: object
         PostalAddress:
             description: https://www.schema.org/PostalAddress
             properties:
                 addressCountry:
+                    readOnly: true
                     type: string
                 addressLocality:
+                    readOnly: true
                     type: string
                 addressRegion:
+                    readOnly: true
                     type: string
                 addressType:
+                    readOnly: true
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 postalCode:
+                    readOnly: true
                     type: string
                 primary:
+                    readOnly: true
                     type: boolean
                 streetAddressLine1:
+                    readOnly: true
                     type: string
                 streetAddressLine2:
+                    readOnly: true
                     type: string
                 streetAddressLine3:
+                    readOnly: true
                     type: string
             type: object
         Role:
@@ -184,23 +228,30 @@ components:
                 availableLanguages:
                     items:
                         type: string
+                    readOnly: true
                     type: array
                 creator:
                     $ref: "#/components/schemas/Creator"
                 dateCreated:
                     format: date-time
+                    readOnly: true
                     type: string
                 dateModified:
                     format: date-time
+                    readOnly: true
                     type: string
                 description:
+                    readOnly: true
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 name:
+                    readOnly: true
                     type: string
                 roleType:
+                    readOnly: true
                     type: string
             type: object
         RoleBrief:
@@ -208,43 +259,56 @@ components:
             properties:
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 name:
+                    readOnly: true
                     type: string
             type: object
         Segment:
             description: https://schema.org/Audience
             properties:
                 active:
+                    readOnly: true
                     type: boolean
                 criteria:
+                    readOnly: true
                     type: string
                 dateCreated:
                     format: date-time
+                    readOnly: true
                     type: string
                 dateModified:
                     format: date-time
+                    readOnly: true
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 name:
+                    readOnly: true
                     type: string
                 siteId:
                     format: int64
+                    readOnly: true
                     type: integer
                 source:
+                    readOnly: true
                     type: string
             type: object
         SegmentUser:
             description: https://www.schema.org/UserAccount
             properties:
                 email:
+                    readOnly: true
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 name:
+                    readOnly: true
                     type: string
             type: object
         SiteBrief:
@@ -252,19 +316,24 @@ components:
             properties:
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 name:
+                    readOnly: true
                     type: string
             type: object
         UserAccount:
             description: https://www.schema.org/UserAccount
             properties:
                 additionalName:
+                    readOnly: true
                     type: string
                 alternateName:
+                    readOnly: true
                     type: string
                 birthDate:
                     format: date-time
+                    readOnly: true
                     type: string
                 contactInformation:
                     description: https://www.schema.org/ContactInformation
@@ -275,11 +344,14 @@ components:
                             readOnly: true
                             type: array
                         facebook:
+                            readOnly: true
                             type: string
                         id:
                             format: int64
+                            readOnly: true
                             type: integer
                         jabber:
+                            readOnly: true
                             type: string
                         postalAddresses:
                             items:
@@ -287,8 +359,10 @@ components:
                             readOnly: true
                             type: array
                         skype:
+                            readOnly: true
                             type: string
                         sms:
+                            readOnly: true
                             type: string
                         telephones:
                             items:
@@ -296,6 +370,7 @@ components:
                             readOnly: true
                             type: array
                         twitter:
+                            readOnly: true
                             type: string
                         webUrls:
                             items:
@@ -304,36 +379,49 @@ components:
                             type: array
                     type: object
                 dashboardURL:
+                    readOnly: true
                     type: string
                 dateCreated:
                     format: date-time
+                    readOnly: true
                     type: string
                 dateModified:
                     format: date-time
+                    readOnly: true
                     type: string
                 email:
+                    readOnly: true
                     type: string
                 familyName:
+                    readOnly: true
                     type: string
                 givenName:
+                    readOnly: true
                     type: string
                 honorificPrefix:
+                    readOnly: true
                     type: string
                 honorificSuffix:
+                    readOnly: true
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 image:
                     format: uri
+                    readOnly: true
                     type: string
                 jobTitle:
+                    readOnly: true
                     type: string
                 keywords:
                     items:
                         type: string
+                    readOnly: true
                     type: array
                 name:
+                    readOnly: true
                     type: string
                 organizationBriefs:
                     items:
@@ -341,6 +429,7 @@ components:
                     readOnly: true
                     type: array
                 profileURL:
+                    readOnly: true
                     type: string
                 roleBriefs:
                     items:
@@ -358,10 +447,13 @@ components:
             properties:
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 url:
+                    readOnly: true
                     type: string
                 urlType:
+                    readOnly: true
                     type: string
             type: object
 info:

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -110,6 +110,7 @@ components:
                             format: int64
                             readOnly: true
                             type: integer
+                    readOnly: true
                     type: object
                 name:
                     readOnly: true
@@ -231,7 +232,9 @@ components:
                     readOnly: true
                     type: array
                 creator:
-                    $ref: "#/components/schemas/Creator"
+                    allOf:
+                        - $ref: "#/components/schemas/Creator"
+                    readOnly: true
                 dateCreated:
                     format: date-time
                     readOnly: true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
@@ -263,14 +263,6 @@ public class OrganizationResourceImpl
 							WebServerServletTokenUtil.getToken(
 								organization.getLogoId()));
 					});
-				setParentOrganizationId(
-					() -> {
-						if (organization.getParentOrganizationId() <= 0) {
-							return null;
-						}
-
-						return organization.getParentOrganizationId();
-					});
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailResourceTestCase.java
@@ -622,6 +622,7 @@ public abstract class BaseEmailResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(Email.class, EmailMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -638,6 +639,22 @@ public abstract class BaseEmailResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class EmailMixin {
+
+		@JsonProperty
+		String email;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		Boolean primary;
+
+		@JsonProperty
+		String type;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -21,7 +21,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.admin.user.dto.v1_0.ContactInformation;
+import com.liferay.headless.admin.user.dto.v1_0.Location;
 import com.liferay.headless.admin.user.dto.v1_0.Organization;
+import com.liferay.headless.admin.user.dto.v1_0.Service;
 import com.liferay.headless.admin.user.resource.v1_0.OrganizationResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
@@ -1292,6 +1295,7 @@ public abstract class BaseOrganizationResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(Organization.class, OrganizationMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -1308,6 +1312,46 @@ public abstract class BaseOrganizationResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class OrganizationMixin {
+
+		@JsonProperty
+		String comment;
+
+		@JsonProperty
+		ContactInformation contactInformation;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String image;
+
+		@JsonProperty
+		String[] keywords;
+
+		@JsonProperty
+		Location location;
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		Number numberOfOrganizations;
+
+		@JsonProperty
+		Organization parentOrganization;
+
+		@JsonProperty
+		Service[] services;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -943,16 +943,6 @@ public abstract class BaseOrganizationResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals(
-					"parentOrganizationId", additionalAssertFieldName)) {
-
-				if (organization.getParentOrganizationId() == null) {
-					valid = false;
-				}
-
-				continue;
-			}
-
 			if (Objects.equals("services", additionalAssertFieldName)) {
 				if (organization.getServices() == null) {
 					valid = false;
@@ -1124,19 +1114,6 @@ public abstract class BaseOrganizationResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals(
-					"parentOrganizationId", additionalAssertFieldName)) {
-
-				if (!Objects.deepEquals(
-						organization1.getParentOrganizationId(),
-						organization2.getParentOrganizationId())) {
-
-					return false;
-				}
-
-				continue;
-			}
-
 			if (Objects.equals("services", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						organization1.getServices(),
@@ -1267,11 +1244,6 @@ public abstract class BaseOrganizationResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
-		if (entityFieldName.equals("parentOrganizationId")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
-		}
-
 		if (entityFieldName.equals("services")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -1290,7 +1262,6 @@ public abstract class BaseOrganizationResourceTestCase {
 				id = RandomTestUtil.randomLong();
 				image = RandomTestUtil.randomString();
 				name = RandomTestUtil.randomString();
-				parentOrganizationId = RandomTestUtil.randomLong();
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
@@ -653,6 +653,7 @@ public abstract class BasePhoneResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(Phone.class, PhoneMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -669,6 +670,25 @@ public abstract class BasePhoneResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class PhoneMixin {
+
+		@JsonProperty
+		String extension;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String phoneNumber;
+
+		@JsonProperty
+		String phoneType;
+
+		@JsonProperty
+		Boolean primary;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
@@ -857,6 +857,7 @@ public abstract class BasePostalAddressResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(PostalAddress.class, PostalAddressMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -873,6 +874,40 @@ public abstract class BasePostalAddressResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class PostalAddressMixin {
+
+		@JsonProperty
+		String addressCountry;
+
+		@JsonProperty
+		String addressLocality;
+
+		@JsonProperty
+		String addressRegion;
+
+		@JsonProperty
+		String addressType;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String postalCode;
+
+		@JsonProperty
+		Boolean primary;
+
+		@JsonProperty
+		String streetAddressLine1;
+
+		@JsonProperty
+		String streetAddressLine2;
+
+		@JsonProperty
+		String streetAddressLine3;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.admin.user.dto.v1_0.Creator;
 import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.resource.v1_0.RoleResource;
 import com.liferay.petra.string.StringBundler;
@@ -51,6 +52,7 @@ import java.text.DateFormat;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -575,6 +577,7 @@ public abstract class BaseRoleResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(Role.class, RoleMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -591,6 +594,34 @@ public abstract class BaseRoleResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class RoleMixin {
+
+		@JsonProperty
+		String[] availableLanguages;
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		String roleType;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
@@ -52,6 +52,7 @@ import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -787,6 +788,7 @@ public abstract class BaseSegmentResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(Segment.class, SegmentMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -803,6 +805,34 @@ public abstract class BaseSegmentResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class SegmentMixin {
+
+		@JsonProperty
+		Boolean active;
+
+		@JsonProperty
+		String criteria;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		Long siteId;
+
+		@JsonProperty
+		String source;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
@@ -523,6 +523,7 @@ public abstract class BaseSegmentUserResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(SegmentUser.class, SegmentUserMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -539,6 +540,19 @@ public abstract class BaseSegmentUserResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class SegmentUserMixin {
+
+		@JsonProperty
+		String email;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String name;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -21,6 +21,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.admin.user.dto.v1_0.ContactInformation;
+import com.liferay.headless.admin.user.dto.v1_0.OrganizationBrief;
+import com.liferay.headless.admin.user.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.dto.v1_0.SiteBrief;
 import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
 import com.liferay.headless.admin.user.resource.v1_0.UserAccountResource;
 import com.liferay.petra.string.StringBundler;
@@ -1916,6 +1920,7 @@ public abstract class BaseUserAccountResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(UserAccount.class, UserAccountMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -1932,6 +1937,73 @@ public abstract class BaseUserAccountResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class UserAccountMixin {
+
+		@JsonProperty
+		String additionalName;
+
+		@JsonProperty
+		String alternateName;
+
+		@JsonProperty
+		Date birthDate;
+
+		@JsonProperty
+		ContactInformation contactInformation;
+
+		@JsonProperty
+		String dashboardURL;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		String email;
+
+		@JsonProperty
+		String familyName;
+
+		@JsonProperty
+		String givenName;
+
+		@JsonProperty
+		String honorificPrefix;
+
+		@JsonProperty
+		String honorificSuffix;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String image;
+
+		@JsonProperty
+		String jobTitle;
+
+		@JsonProperty
+		String[] keywords;
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		OrganizationBrief[] organizationBriefs;
+
+		@JsonProperty
+		String profileURL;
+
+		@JsonProperty
+		RoleBrief[] roleBriefs;
+
+		@JsonProperty
+		SiteBrief[] siteBriefs;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
@@ -605,6 +605,7 @@ public abstract class BaseWebUrlResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(WebUrl.class, WebUrlMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -621,6 +622,19 @@ public abstract class BaseWebUrlResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class WebUrlMixin {
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String url;
+
+		@JsonProperty
+		String urlType;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/ChangeTransition.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/ChangeTransition.java
@@ -64,7 +64,7 @@ public class ChangeTransition {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	protected String transition;
 
 	@Override

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/Creator.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/Creator.java
@@ -64,7 +64,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String additionalName;
 
 	public String getFamilyName() {
@@ -91,7 +91,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String familyName;
 
 	public String getGivenName() {
@@ -118,7 +118,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String givenName;
 
 	public Long getId() {
@@ -143,7 +143,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getImage() {
@@ -170,7 +170,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String image;
 
 	public String getName() {
@@ -195,7 +195,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String name;
 
 	public String getProfileURL() {
@@ -222,7 +222,7 @@ public class Creator {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String profileURL;
 
 	@Override

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/ObjectReviewed.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/ObjectReviewed.java
@@ -62,7 +62,7 @@ public class ObjectReviewed {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getResourceType() {
@@ -89,7 +89,7 @@ public class ObjectReviewed {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String resourceType;
 
 	@Override

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowLog.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowLog.java
@@ -65,7 +65,7 @@ public class WorkflowLog {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Creator auditPerson;
 
 	public String getCommentLog() {
@@ -92,7 +92,7 @@ public class WorkflowLog {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String commentLog;
 
 	public Date getDateCreated() {
@@ -119,7 +119,7 @@ public class WorkflowLog {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateCreated;
 
 	public Long getId() {
@@ -144,7 +144,7 @@ public class WorkflowLog {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public Creator getPerson() {
@@ -171,7 +171,7 @@ public class WorkflowLog {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Creator person;
 
 	public Creator getPreviousPerson() {
@@ -198,7 +198,7 @@ public class WorkflowLog {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Creator previousPerson;
 
 	public String getPreviousState() {
@@ -225,7 +225,7 @@ public class WorkflowLog {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String previousState;
 
 	public String getState() {
@@ -252,7 +252,7 @@ public class WorkflowLog {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String state;
 
 	public Long getTaskId() {
@@ -279,7 +279,7 @@ public class WorkflowLog {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long taskId;
 
 	public String getType() {
@@ -304,7 +304,7 @@ public class WorkflowLog {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String type;
 
 	@Override

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTask.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTask.java
@@ -65,7 +65,7 @@ public class WorkflowTask {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Boolean completed;
 
 	public Date getDateCompleted() {
@@ -92,7 +92,7 @@ public class WorkflowTask {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateCompleted;
 
 	public Date getDateCreated() {
@@ -119,7 +119,7 @@ public class WorkflowTask {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateCreated;
 
 	public String getDefinitionName() {
@@ -146,7 +146,7 @@ public class WorkflowTask {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String definitionName;
 
 	public String getDescription() {
@@ -173,7 +173,7 @@ public class WorkflowTask {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String description;
 
 	public Date getDueDate() {
@@ -200,7 +200,7 @@ public class WorkflowTask {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dueDate;
 
 	public Long getId() {
@@ -225,7 +225,7 @@ public class WorkflowTask {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
 	public String getName() {
@@ -250,7 +250,7 @@ public class WorkflowTask {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String name;
 
 	public ObjectReviewed getObjectReviewed() {
@@ -278,7 +278,7 @@ public class WorkflowTask {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected ObjectReviewed objectReviewed;
 
 	public String[] getTransitions() {
@@ -305,7 +305,7 @@ public class WorkflowTask {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String[] transitions;
 
 	@Override

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTaskAssignToMe.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTaskAssignToMe.java
@@ -65,7 +65,7 @@ public class WorkflowTaskAssignToMe {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	protected String comment;
 
 	public Date getDueDate() {
@@ -92,7 +92,7 @@ public class WorkflowTaskAssignToMe {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	protected Date dueDate;
 
 	@Override

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTaskAssignToUser.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTaskAssignToUser.java
@@ -65,7 +65,7 @@ public class WorkflowTaskAssignToUser {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	protected Long assigneeId;
 
 	public String getComment() {
@@ -92,7 +92,7 @@ public class WorkflowTaskAssignToUser {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	protected String comment;
 
 	public Date getDueDate() {
@@ -119,7 +119,7 @@ public class WorkflowTaskAssignToUser {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	protected Date dueDate;
 
 	@Override

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
@@ -50,7 +50,9 @@ components:
             description: https://www.schema.org/WorkflowLog
             properties:
                 auditPerson:
-                    $ref: "#/components/schemas/Creator"
+                    allOf:
+                        - $ref: "#/components/schemas/Creator"
+                    readOnly: true
                 commentLog:
                     readOnly: true
                     type: string
@@ -63,9 +65,13 @@ components:
                     readOnly: true
                     type: integer
                 person:
-                    $ref: "#/components/schemas/Creator"
+                    allOf:
+                        - $ref: "#/components/schemas/Creator"
+                    readOnly: true
                 previousPerson:
-                    $ref: "#/components/schemas/Creator"
+                    allOf:
+                        - $ref: "#/components/schemas/Creator"
+                    readOnly: true
                 previousState:
                     readOnly: true
                     type: string
@@ -112,7 +118,9 @@ components:
                     readOnly: true
                     type: string
                 objectReviewed:
-                    $ref: "#/components/schemas/ObjectReviewed"
+                    allOf:
+                        - $ref: "#/components/schemas/ObjectReviewed"
+                    readOnly: true
                 transitions:
                     items:
                         type: string

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
@@ -5,26 +5,34 @@ components:
             properties:
                 transition:
                     type: string
+                    writeOnly: true
             type: object
         Creator:
             description: https://www.schema.org/Creator
             properties:
                 additionalName:
+                    readOnly: true
                     type: string
                 familyName:
+                    readOnly: true
                     type: string
                 givenName:
+                    readOnly: true
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 image:
                     format: uri
+                    readOnly: true
                     type: string
                 name:
+                    readOnly: true
                     type: string
                 profileURL:
                     format: uri
+                    readOnly: true
                     type: string
             type: object
         ObjectReviewed:
@@ -32,8 +40,10 @@ components:
             properties:
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 resourceType:
+                    readOnly: true
                     type: string
             type: object
         WorkflowLog:
@@ -42,55 +52,71 @@ components:
                 auditPerson:
                     $ref: "#/components/schemas/Creator"
                 commentLog:
+                    readOnly: true
                     type: string
                 dateCreated:
                     format: date-time
+                    readOnly: true
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 person:
                     $ref: "#/components/schemas/Creator"
                 previousPerson:
                     $ref: "#/components/schemas/Creator"
                 previousState:
+                    readOnly: true
                     type: string
                 state:
+                    readOnly: true
                     type: string
                 taskId:
                     format: int64
+                    readOnly: true
                     type: integer
                 type:
+                    readOnly: true
                     type: string
             type: object
         WorkflowTask:
             description: https://www.schema.org/WorkflowTask
             properties:
                 completed:
+                    readOnly: true
                     type: boolean
                 dateCompleted:
                     format: date-time
+                    readOnly: true
                     type: string
                 dateCreated:
                     format: date-time
+                    readOnly: true
                     type: string
                 definitionName:
+                    readOnly: true
                     type: string
                 description:
+                    readOnly: true
                     type: string
                 dueDate:
                     format: date-time
+                    readOnly: true
                     type: string
                 id:
                     format: int64
+                    readOnly: true
                     type: integer
                 name:
+                    readOnly: true
                     type: string
                 objectReviewed:
                     $ref: "#/components/schemas/ObjectReviewed"
                 transitions:
                     items:
                         type: string
+                    readOnly: true
                     type: array
             type: object
         WorkflowTaskAssignToMe:
@@ -98,9 +124,11 @@ components:
             properties:
                 comment:
                     type: string
+                    writeOnly: true
                 dueDate:
                     format: date-time
                     type: string
+                    writeOnly: true
             type: object
         WorkflowTaskAssignToUser:
             description: https://www.schema.org/WorkflowTaskAssignToUser
@@ -108,11 +136,14 @@ components:
                 assigneeId:
                     format: int64
                     type: integer
+                    writeOnly: true
                 comment:
                     type: string
+                    writeOnly: true
                 dueDate:
                     format: date-time
                     type: string
+                    writeOnly: true
             type: object
 info:
     description: ""

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/WorkflowTaskResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/WorkflowTaskResourceImpl.java
@@ -133,7 +133,9 @@ public class WorkflowTaskResourceImpl extends BaseWorkflowTaskResourceImpl {
 		return _toWorkflowTask(
 			_workflowTaskManager.assignWorkflowTaskToUser(
 				contextCompany.getCompanyId(), _user.getUserId(),
-				workflowTaskId, assigneeId, "", null, null));
+				workflowTaskId, assigneeId,
+				workflowTaskAssignToUser.getComment(),
+				workflowTaskAssignToUser.getDueDate(), null));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.admin.workflow.dto.v1_0.Creator;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowLog;
 import com.liferay.headless.admin.workflow.resource.v1_0.WorkflowLogResource;
 import com.liferay.petra.string.StringBundler;
@@ -52,6 +53,7 @@ import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -762,6 +764,7 @@ public abstract class BaseWorkflowLogResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(WorkflowLog.class, WorkflowLogMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -778,6 +781,40 @@ public abstract class BaseWorkflowLogResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class WorkflowLogMixin {
+
+		@JsonProperty
+		Creator auditPerson;
+
+		@JsonProperty
+		String commentLog;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		Creator person;
+
+		@JsonProperty
+		Creator previousPerson;
+
+		@JsonProperty
+		String previousState;
+
+		@JsonProperty
+		String state;
+
+		@JsonProperty
+		Long taskId;
+
+		@JsonProperty
+		String type;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
 import com.liferay.headless.admin.workflow.dto.v1_0.ChangeTransition;
+import com.liferay.headless.admin.workflow.dto.v1_0.ObjectReviewed;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTask;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTaskAssignToMe;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTaskAssignToUser;
@@ -55,6 +56,7 @@ import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1163,6 +1165,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(WorkflowTask.class, WorkflowTaskMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -1179,6 +1182,40 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class WorkflowTaskMixin {
+
+		@JsonProperty
+		Boolean completed;
+
+		@JsonProperty
+		Date dateCompleted;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		String definitionName;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		Date dueDate;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		ObjectReviewed objectReviewed;
+
+		@JsonProperty
+		String[] transitions;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -1051,6 +1051,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(BlogPostingImage.class, BlogPostingImageMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -1067,6 +1068,34 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class BlogPostingImageMixin {
+
+		@JsonProperty
+		String contentUrl;
+
+		@JsonProperty
+		String encodingFormat;
+
+		@JsonProperty
+		String fileExtension;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		Number sizeInBytes;
+
+		@JsonProperty
+		String title;
+
+		@JsonProperty
+		ViewableBy viewableBy;
+
+		public static enum ViewableBy {
+		}
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -21,8 +21,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.delivery.dto.v1_0.AggregateRating;
 import com.liferay.headless.delivery.dto.v1_0.BlogPosting;
+import com.liferay.headless.delivery.dto.v1_0.Creator;
+import com.liferay.headless.delivery.dto.v1_0.Image;
 import com.liferay.headless.delivery.dto.v1_0.Rating;
+import com.liferay.headless.delivery.dto.v1_0.TaxonomyCategory;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -1673,6 +1677,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(BlogPosting.class, BlogPostingMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -1689,6 +1694,70 @@ public abstract class BaseBlogPostingResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class BlogPostingMixin {
+
+		@JsonProperty
+		AggregateRating aggregateRating;
+
+		@JsonProperty
+		String alternativeHeadline;
+
+		@JsonProperty
+		String articleBody;
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		Date datePublished;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		String encodingFormat;
+
+		@JsonProperty
+		String friendlyUrlPath;
+
+		@JsonProperty
+		String headline;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		Image image;
+
+		@JsonProperty
+		String[] keywords;
+
+		@JsonProperty
+		Number numberOfComments;
+
+		@JsonProperty
+		Long siteId;
+
+		@JsonProperty
+		TaxonomyCategory[] taxonomyCategories;
+
+		@JsonProperty
+		Long[] taxonomyCategoryIds;
+
+		@JsonProperty
+		ViewableBy viewableBy;
+
+		public static enum ViewableBy {
+		}
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
 import com.liferay.headless.delivery.dto.v1_0.Comment;
+import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.headless.delivery.resource.v1_0.CommentResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -2227,6 +2228,7 @@ public abstract class BaseCommentResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(Comment.class, CommentMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -2243,6 +2245,28 @@ public abstract class BaseCommentResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class CommentMixin {
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		Number numberOfComments;
+
+		@JsonProperty
+		String text;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
@@ -971,6 +971,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(ContentSetElement.class, ContentSetElementMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -987,6 +988,22 @@ public abstract class BaseContentSetElementResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class ContentSetElementMixin {
+
+		@JsonProperty
+		Object content;
+
+		@JsonProperty
+		String contentType;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String title;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
 import com.liferay.headless.delivery.dto.v1_0.ContentStructure;
+import com.liferay.headless.delivery.dto.v1_0.ContentStructureField;
+import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.headless.delivery.resource.v1_0.ContentStructureResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
@@ -947,6 +949,7 @@ public abstract class BaseContentStructureResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(ContentStructure.class, ContentStructureMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -963,6 +966,37 @@ public abstract class BaseContentStructureResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class ContentStructureMixin {
+
+		@JsonProperty
+		String[] availableLanguages;
+
+		@JsonProperty
+		ContentStructureField[] contentStructureFields;
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		Long siteId;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.headless.delivery.dto.v1_0.DocumentFolder;
 import com.liferay.headless.delivery.resource.v1_0.DocumentFolderResource;
 import com.liferay.petra.string.StringBundler;
@@ -1712,6 +1713,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(DocumentFolder.class, DocumentFolderMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -1728,6 +1730,43 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class DocumentFolderMixin {
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		Number numberOfDocumentFolders;
+
+		@JsonProperty
+		Number numberOfDocuments;
+
+		@JsonProperty
+		Long siteId;
+
+		@JsonProperty
+		ViewableBy viewableBy;
+
+		public static enum ViewableBy {
+		}
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -21,8 +21,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.delivery.dto.v1_0.AdaptedImage;
+import com.liferay.headless.delivery.dto.v1_0.AggregateRating;
+import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.headless.delivery.dto.v1_0.Document;
 import com.liferay.headless.delivery.dto.v1_0.Rating;
+import com.liferay.headless.delivery.dto.v1_0.TaxonomyCategory;
 import com.liferay.headless.delivery.resource.v1_0.DocumentResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
@@ -1998,6 +2002,7 @@ public abstract class BaseDocumentResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(Document.class, DocumentMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -2014,6 +2019,67 @@ public abstract class BaseDocumentResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class DocumentMixin {
+
+		@JsonProperty
+		AdaptedImage[] adaptedImages;
+
+		@JsonProperty
+		AggregateRating aggregateRating;
+
+		@JsonProperty
+		String contentUrl;
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		Long documentFolderId;
+
+		@JsonProperty
+		String encodingFormat;
+
+		@JsonProperty
+		String fileExtension;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String[] keywords;
+
+		@JsonProperty
+		Number numberOfComments;
+
+		@JsonProperty
+		Number sizeInBytes;
+
+		@JsonProperty
+		TaxonomyCategory[] taxonomyCategories;
+
+		@JsonProperty
+		Long[] taxonomyCategoryIds;
+
+		@JsonProperty
+		String title;
+
+		@JsonProperty
+		ViewableBy viewableBy;
+
+		public static enum ViewableBy {
+		}
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -21,8 +21,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.delivery.dto.v1_0.AggregateRating;
+import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseArticle;
+import com.liferay.headless.delivery.dto.v1_0.ParentKnowledgeBaseFolder;
 import com.liferay.headless.delivery.dto.v1_0.Rating;
+import com.liferay.headless.delivery.dto.v1_0.TaxonomyCategory;
 import com.liferay.headless.delivery.resource.v1_0.KnowledgeBaseArticleResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -2809,6 +2813,9 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(
+					KnowledgeBaseArticle.class,
+					KnowledgeBaseArticleMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -2825,6 +2832,70 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class KnowledgeBaseArticleMixin {
+
+		@JsonProperty
+		AggregateRating aggregateRating;
+
+		@JsonProperty
+		String articleBody;
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		String encodingFormat;
+
+		@JsonProperty
+		String friendlyUrlPath;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String[] keywords;
+
+		@JsonProperty
+		Number numberOfAttachments;
+
+		@JsonProperty
+		Number numberOfKnowledgeBaseArticles;
+
+		@JsonProperty
+		ParentKnowledgeBaseFolder parentKnowledgeBaseFolder;
+
+		@JsonProperty
+		Long parentKnowledgeBaseFolderId;
+
+		@JsonProperty
+		Long siteId;
+
+		@JsonProperty
+		TaxonomyCategory[] taxonomyCategories;
+
+		@JsonProperty
+		Long[] taxonomyCategoryIds;
+
+		@JsonProperty
+		String title;
+
+		@JsonProperty
+		ViewableBy viewableBy;
+
+		public static enum ViewableBy {
+		}
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
@@ -828,6 +828,9 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(
+					KnowledgeBaseAttachment.class,
+					KnowledgeBaseAttachmentMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -844,6 +847,28 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class KnowledgeBaseAttachmentMixin {
+
+		@JsonProperty
+		String contentUrl;
+
+		@JsonProperty
+		String encodingFormat;
+
+		@JsonProperty
+		String fileExtension;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		Number sizeInBytes;
+
+		@JsonProperty
+		String title;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -21,7 +21,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseFolder;
+import com.liferay.headless.delivery.dto.v1_0.ParentKnowledgeBaseFolder;
 import com.liferay.headless.delivery.resource.v1_0.KnowledgeBaseFolderResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -54,6 +56,7 @@ import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1470,6 +1473,8 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(
+					KnowledgeBaseFolder.class, KnowledgeBaseFolderMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -1486,6 +1491,49 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class KnowledgeBaseFolderMixin {
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		Number numberOfKnowledgeBaseArticles;
+
+		@JsonProperty
+		Number numberOfKnowledgeBaseFolders;
+
+		@JsonProperty
+		ParentKnowledgeBaseFolder parentKnowledgeBaseFolder;
+
+		@JsonProperty
+		Long parentKnowledgeBaseFolderId;
+
+		@JsonProperty
+		Long siteId;
+
+		@JsonProperty
+		ViewableBy viewableBy;
+
+		public static enum ViewableBy {
+		}
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -1022,6 +1022,9 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(
+					MessageBoardAttachment.class,
+					MessageBoardAttachmentMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -1038,6 +1041,28 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class MessageBoardAttachmentMixin {
+
+		@JsonProperty
+		String contentUrl;
+
+		@JsonProperty
+		String encodingFormat;
+
+		@JsonProperty
+		String fileExtension;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		Number sizeInBytes;
+
+		@JsonProperty
+		String title;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.delivery.dto.v1_0.AggregateRating;
+import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.headless.delivery.dto.v1_0.MessageBoardMessage;
 import com.liferay.headless.delivery.dto.v1_0.Rating;
 import com.liferay.headless.delivery.resource.v1_0.MessageBoardMessageResource;
@@ -2209,6 +2211,8 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(
+					MessageBoardMessage.class, MessageBoardMessageMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -2225,6 +2229,58 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class MessageBoardMessageMixin {
+
+		@JsonProperty
+		AggregateRating aggregateRating;
+
+		@JsonProperty
+		Boolean anonymous;
+
+		@JsonProperty
+		String articleBody;
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		String encodingFormat;
+
+		@JsonProperty
+		String headline;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String[] keywords;
+
+		@JsonProperty
+		Integer numberOfMessageBoardAttachments;
+
+		@JsonProperty
+		Integer numberOfMessageBoardMessages;
+
+		@JsonProperty
+		Boolean showAsAnswer;
+
+		@JsonProperty
+		Long siteId;
+
+		@JsonProperty
+		ViewableBy viewableBy;
+
+		public static enum ViewableBy {
+		}
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.headless.delivery.dto.v1_0.MessageBoardSection;
 import com.liferay.headless.delivery.resource.v1_0.MessageBoardSectionResource;
 import com.liferay.petra.string.StringBundler;
@@ -1808,6 +1809,8 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(
+					MessageBoardSection.class, MessageBoardSectionMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -1824,6 +1827,43 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class MessageBoardSectionMixin {
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		Integer numberOfMessageBoardSections;
+
+		@JsonProperty
+		Integer numberOfMessageBoardThreads;
+
+		@JsonProperty
+		Long siteId;
+
+		@JsonProperty
+		String title;
+
+		@JsonProperty
+		ViewableBy viewableBy;
+
+		public static enum ViewableBy {
+		}
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.delivery.dto.v1_0.AggregateRating;
+import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.headless.delivery.dto.v1_0.MessageBoardThread;
 import com.liferay.headless.delivery.dto.v1_0.Rating;
 import com.liferay.headless.delivery.resource.v1_0.MessageBoardThreadResource;
@@ -2169,6 +2171,8 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(
+					MessageBoardThread.class, MessageBoardThreadMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -2185,6 +2189,58 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class MessageBoardThreadMixin {
+
+		@JsonProperty
+		AggregateRating aggregateRating;
+
+		@JsonProperty
+		String articleBody;
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		String encodingFormat;
+
+		@JsonProperty
+		String headline;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String[] keywords;
+
+		@JsonProperty
+		Integer numberOfMessageBoardAttachments;
+
+		@JsonProperty
+		Integer numberOfMessageBoardMessages;
+
+		@JsonProperty
+		Boolean showAsQuestion;
+
+		@JsonProperty
+		Long siteId;
+
+		@JsonProperty
+		String threadType;
+
+		@JsonProperty
+		ViewableBy viewableBy;
+
+		public static enum ViewableBy {
+		}
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.headless.delivery.dto.v1_0.StructuredContentFolder;
 import com.liferay.headless.delivery.resource.v1_0.StructuredContentFolderResource;
 import com.liferay.petra.string.StringBundler;
@@ -1879,6 +1880,9 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(
+					StructuredContentFolder.class,
+					StructuredContentFolderMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -1895,6 +1899,43 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class StructuredContentFolderMixin {
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		Number numberOfStructuredContentFolders;
+
+		@JsonProperty
+		Number numberOfStructuredContents;
+
+		@JsonProperty
+		Long siteId;
+
+		@JsonProperty
+		ViewableBy viewableBy;
+
+		public static enum ViewableBy {
+		}
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -21,8 +21,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.delivery.dto.v1_0.AggregateRating;
+import com.liferay.headless.delivery.dto.v1_0.ContentField;
+import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.headless.delivery.dto.v1_0.Rating;
+import com.liferay.headless.delivery.dto.v1_0.RenderedContent;
 import com.liferay.headless.delivery.dto.v1_0.StructuredContent;
+import com.liferay.headless.delivery.dto.v1_0.TaxonomyCategory;
 import com.liferay.headless.delivery.resource.v1_0.StructuredContentResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -2903,6 +2908,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(StructuredContent.class, StructuredContentMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -2919,6 +2925,79 @@ public abstract class BaseStructuredContentResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class StructuredContentMixin {
+
+		@JsonProperty
+		AggregateRating aggregateRating;
+
+		@JsonProperty
+		String[] availableLanguages;
+
+		@JsonProperty
+		ContentField[] contentFields;
+
+		@JsonProperty
+		Long contentStructureId;
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		Date datePublished;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		String friendlyUrlPath;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String key;
+
+		@JsonProperty
+		String[] keywords;
+
+		@JsonProperty
+		Date lastReviewed;
+
+		@JsonProperty
+		Number numberOfComments;
+
+		@JsonProperty
+		RenderedContent[] renderedContents;
+
+		@JsonProperty
+		Long siteId;
+
+		@JsonProperty
+		TaxonomyCategory[] taxonomyCategories;
+
+		@JsonProperty
+		Long[] taxonomyCategoryIds;
+
+		@JsonProperty
+		String title;
+
+		@JsonProperty
+		String uuid;
+
+		@JsonProperty
+		ViewableBy viewableBy;
+
+		public static enum ViewableBy {
+		}
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
@@ -562,6 +562,7 @@ public abstract class BaseFormDocumentResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(FormDocument.class, FormDocumentMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -578,6 +579,28 @@ public abstract class BaseFormDocumentResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class FormDocumentMixin {
+
+		@JsonProperty
+		String contentUrl;
+
+		@JsonProperty
+		String encodingFormat;
+
+		@JsonProperty
+		String fileExtension;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		Number sizeInBytes;
+
+		@JsonProperty
+		String title;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordFormResourceTestCase.java
@@ -410,6 +410,7 @@ public abstract class BaseFormRecordFormResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(FormRecordForm.class, FormRecordFormMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -426,6 +427,16 @@ public abstract class BaseFormRecordFormResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class FormRecordFormMixin {
+
+		@JsonProperty
+		Boolean draft;
+
+		@JsonProperty
+		String fieldValues;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
@@ -21,6 +21,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.form.dto.v1_0.Creator;
+import com.liferay.headless.form.dto.v1_0.FieldValue;
+import com.liferay.headless.form.dto.v1_0.Form;
 import com.liferay.headless.form.dto.v1_0.FormRecord;
 import com.liferay.headless.form.resource.v1_0.FormRecordResource;
 import com.liferay.petra.string.StringBundler;
@@ -54,6 +57,7 @@ import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -839,6 +843,7 @@ public abstract class BaseFormRecordResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(FormRecord.class, FormRecordMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -855,6 +860,37 @@ public abstract class BaseFormRecordResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class FormRecordMixin {
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		Date datePublished;
+
+		@JsonProperty
+		Boolean draft;
+
+		@JsonProperty
+		FieldValue[] fieldValues;
+
+		@JsonProperty
+		Form form;
+
+		@JsonProperty
+		Long formId;
+
+		@JsonProperty
+		Long id;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
@@ -21,8 +21,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.form.dto.v1_0.Creator;
 import com.liferay.headless.form.dto.v1_0.Form;
 import com.liferay.headless.form.dto.v1_0.FormDocument;
+import com.liferay.headless.form.dto.v1_0.FormRecord;
+import com.liferay.headless.form.dto.v1_0.FormStructure;
 import com.liferay.headless.form.resource.v1_0.FormResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -58,6 +61,7 @@ import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -930,6 +934,7 @@ public abstract class BaseFormResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(Form.class, FormMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -946,6 +951,52 @@ public abstract class BaseFormResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class FormMixin {
+
+		@JsonProperty
+		String[] availableLanguages;
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		Date datePublished;
+
+		@JsonProperty
+		String defaultLanguage;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		FormRecord[] formRecords;
+
+		@JsonProperty
+		Long[] formRecordsIds;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		Long siteId;
+
+		@JsonProperty
+		FormStructure structure;
+
+		@JsonProperty
+		Long structureId;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
@@ -21,7 +21,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import com.liferay.headless.form.dto.v1_0.Creator;
+import com.liferay.headless.form.dto.v1_0.FormPage;
 import com.liferay.headless.form.dto.v1_0.FormStructure;
+import com.liferay.headless.form.dto.v1_0.SuccessPage;
 import com.liferay.headless.form.resource.v1_0.FormStructureResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
@@ -52,6 +55,7 @@ import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -749,6 +753,7 @@ public abstract class BaseFormStructureResourceTestCase {
 	protected static final ObjectMapper outputObjectMapper =
 		new ObjectMapper() {
 			{
+				addMixIn(FormStructure.class, FormStructureMixin.class);
 				setFilterProvider(
 					new SimpleFilterProvider() {
 						{
@@ -765,6 +770,40 @@ public abstract class BaseFormStructureResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class FormStructureMixin {
+
+		@JsonProperty
+		String[] availableLanguages;
+
+		@JsonProperty
+		Creator creator;
+
+		@JsonProperty
+		Date dateCreated;
+
+		@JsonProperty
+		Date dateModified;
+
+		@JsonProperty
+		String description;
+
+		@JsonProperty
+		FormPage[] formPages;
+
+		@JsonProperty
+		Long id;
+
+		@JsonProperty
+		String name;
+
+		@JsonProperty
+		Long siteId;
+
+		@JsonProperty
+		SuccessPage successPage;
+
+	}
 
 	protected static class Page<T> {
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -1232,6 +1232,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 	};
 	protected static final ObjectMapper outputObjectMapper = new ObjectMapper() {
 		{
+			addMixIn(${schemaName}.class, ${schemaName}Mixin.class);
 			setFilterProvider(
 				new SimpleFilterProvider() {
 					{
@@ -1246,6 +1247,18 @@ public abstract class Base${schemaName}ResourceTestCase {
 	protected Group testGroup;
 	protected Locale testLocale;
 	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	protected static class ${schemaName}Mixin {
+	<#list properties?keys as propertyName>
+		@JsonProperty
+		${properties[propertyName]}  ${propertyName};
+		
+	</#list>
+	<#assign enumSchemas = freeMarkerTool.getDTOEnumSchemas(schema) />
+	<#list enumSchemas?keys as enumName>
+		public static enum ${enumName} {}
+	</#list>
+	}
 
 	protected static class Page<T> {
 


### PR DESCRIPTION
Hi!

We want to add readOnly/writeOnly information (that would prevent sending properties that can't be updated and appears in the documentation) for all APIs. 

But it would break the tests because we are using the response to instantiate an object, the mixin fixes it just for the tests. I'm afraid, there are no easier ways of doing it (disabling annotations that can't be done because several setters, subclassing annotation processing that is quite messy...)