### PR TITLE
LPS-90872 portal-search-admin-web: Make index information optional.

### DIFF
--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/constants/SearchAdminWebKeys.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/constants/SearchAdminWebKeys.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.admin.web.internal.constants;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class SearchAdminWebKeys {
+
+	public static final String FIELD_MAPPINGS_DISPLAY_CONTEXT =
+		"FIELD_MAPPINGS_DISPLAY_CONTEXT";
+
+	public static final String INDEX_ACTIONS_DISPLAY_CONTEXT =
+		"INDEX_ACTIONS_DISPLAY_CONTEXT";
+
+}

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/display/context/IndexActionsDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/display/context/IndexActionsDisplayBuilder.java
@@ -19,25 +19,25 @@ import com.liferay.portal.search.engine.SearchEngineInformation;
 /**
  * @author Adam Brandizzi
  */
-public class SearchAdminDisplayBuilder {
+public class IndexActionsDisplayBuilder {
 
-	public SearchAdminDisplayContext build() {
-		SearchAdminDisplayContext searchAdminDisplayContext =
-			new SearchAdminDisplayContext();
+	public IndexActionsDisplayContext build() {
+		IndexActionsDisplayContext indexActionsDisplayContext =
+			new IndexActionsDisplayContext();
 
 		if (_searchEngineInformation != null) {
-			searchAdminDisplayContext.setClientVersionString(
+			indexActionsDisplayContext.setClientVersionString(
 				_searchEngineInformation.getClientVersionString());
-			searchAdminDisplayContext.setNodesString(
+			indexActionsDisplayContext.setNodesString(
 				_searchEngineInformation.getNodesString());
-			searchAdminDisplayContext.setVendorString(
+			indexActionsDisplayContext.setVendorString(
 				_searchEngineInformation.getVendorString());
 		}
 		else {
-			searchAdminDisplayContext.setMissingSearchEngine(true);
+			indexActionsDisplayContext.setMissingSearchEngine(true);
 		}
 
-		return searchAdminDisplayContext;
+		return indexActionsDisplayContext;
 	}
 
 	public void setSearchEngineInformation(

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/display/context/IndexActionsDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/display/context/IndexActionsDisplayContext.java
@@ -17,7 +17,7 @@ package com.liferay.portal.search.admin.web.internal.display.context;
 /**
  * @author Adam Brandizzi
  */
-public class SearchAdminDisplayContext {
+public class IndexActionsDisplayContext {
 
 	public String getClientVersionString() {
 		return _clientVersionString;

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/display/context/SearchAdminDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/display/context/SearchAdminDisplayBuilder.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.admin.web.internal.display.context;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemList;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.search.index.IndexInformation;
+
+import java.util.Objects;
+
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class SearchAdminDisplayBuilder {
+
+	public SearchAdminDisplayBuilder(
+		Language language, Portal portal, RenderRequest renderRequest,
+		RenderResponse renderResponse) {
+
+		_language = language;
+		_portal = portal;
+		_renderRequest = renderRequest;
+		_renderResponse = renderResponse;
+	}
+
+	public SearchAdminDisplayContext build() {
+		SearchAdminDisplayContext searchAdminDisplayContext =
+			new SearchAdminDisplayContext();
+
+		boolean indexInformationAvailable = isIndexInformationAvailable();
+
+		searchAdminDisplayContext.setIndexInformationAvailable(
+			indexInformationAvailable);
+
+		NavigationItemList navigationItemList = new NavigationItemList();
+		String selectedTab = getSelectedTab();
+
+		addNavigationItemList(navigationItemList, "index-actions", selectedTab);
+
+		if (indexInformationAvailable) {
+			addNavigationItemList(
+				navigationItemList, "field-mappings", selectedTab);
+		}
+
+		searchAdminDisplayContext.setNavigationItemList(navigationItemList);
+		searchAdminDisplayContext.setSelectedTab(selectedTab);
+
+		return searchAdminDisplayContext;
+	}
+
+	public void setIndexInformation(IndexInformation indexInformation) {
+		_indexInformation = indexInformation;
+	}
+
+	protected void addNavigationItemList(
+		NavigationItemList navigationItemList, String label,
+		String selectedTab) {
+
+		navigationItemList.add(
+			navigationItem -> {
+				navigationItem.setActive(selectedTab.equals(label));
+				navigationItem.setHref(
+					_renderResponse.createRenderURL(), "tabs1", label);
+				navigationItem.setLabel(
+					_language.get(
+						_portal.getHttpServletRequest(_renderRequest), label));
+			});
+	}
+
+	protected String getSelectedTab() {
+		String selectedTab = ParamUtil.getString(
+			_renderRequest, "tabs1", "index-actions");
+
+		if (isIndexInformationAvailable() &&
+			Objects.equals(selectedTab, "field-mappings")) {
+
+			selectedTab = "field-mappings";
+		}
+		else {
+			selectedTab = "index-actions";
+		}
+
+		return selectedTab;
+	}
+
+	protected boolean isIndexInformationAvailable() {
+		if (_indexInformation != null) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private IndexInformation _indexInformation;
+	private final Language _language;
+	private final Portal _portal;
+	private final RenderRequest _renderRequest;
+	private final RenderResponse _renderResponse;
+
+}

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/display/context/SearchAdminDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/display/context/SearchAdminDisplayContext.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.admin.web.internal.display.context;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemList;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class SearchAdminDisplayContext {
+
+	public NavigationItemList getNavigationItemList() {
+		return _navigationItemList;
+	}
+
+	public String getSelectedTab() {
+		return _selectedTab;
+	}
+
+	public boolean isIndexInformationAvailable() {
+		return _indexInformationAvailable;
+	}
+
+	public void setIndexInformationAvailable(
+		boolean indexInformationAvailable) {
+
+		_indexInformationAvailable = indexInformationAvailable;
+	}
+
+	public void setNavigationItemList(NavigationItemList navigationItemList) {
+		_navigationItemList = navigationItemList;
+	}
+
+	public void setSelectedTab(String selectedTab) {
+		_selectedTab = selectedTab;
+	}
+
+	private boolean _indexInformationAvailable;
+	private NavigationItemList _navigationItemList;
+	private String _selectedTab;
+
+}

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/portlet/SearchAdminPortlet.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/portlet/SearchAdminPortlet.java
@@ -126,8 +126,12 @@ public class SearchAdminPortlet extends MVCPortlet {
 		super.render(renderRequest, renderResponse);
 	}
 
-	@Reference
-	protected IndexInformation indexInformation;
+	@Reference(
+		cardinality = ReferenceCardinality.OPTIONAL,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
+	protected volatile IndexInformation indexInformation;
 
 	@Reference(
 		cardinality = ReferenceCardinality.OPTIONAL,

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/portlet/SearchAdminPortlet.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/portlet/SearchAdminPortlet.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.admin.web.internal.constants.SearchAdminPortletKeys;
 import com.liferay.portal.search.admin.web.internal.display.context.FieldMappingsDisplayBuilder;
-import com.liferay.portal.search.admin.web.internal.display.context.SearchAdminDisplayBuilder;
+import com.liferay.portal.search.admin.web.internal.display.context.IndexActionsDisplayBuilder;
 import com.liferay.portal.search.engine.SearchEngineInformation;
 import com.liferay.portal.search.index.IndexInformation;
 
@@ -76,15 +76,15 @@ public class SearchAdminPortlet extends MVCPortlet {
 			renderRequest, "tabs1", "index-actions");
 
 		if (tabs1.equals("index-actions")) {
-			SearchAdminDisplayBuilder searchAdminDisplayBuilder =
-				new SearchAdminDisplayBuilder();
+			IndexActionsDisplayBuilder indexActionsDisplayBuilder =
+				new IndexActionsDisplayBuilder();
 
-			searchAdminDisplayBuilder.setSearchEngineInformation(
+			indexActionsDisplayBuilder.setSearchEngineInformation(
 				searchEngineInformation);
 
 			renderRequest.setAttribute(
 				WebKeys.PORTLET_DISPLAY_CONTEXT,
-				searchAdminDisplayBuilder.build());
+				indexActionsDisplayBuilder.build());
 		}
 		else {
 			FieldMappingsDisplayBuilder fieldMappingsDisplayBuilder =

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/portlet/SearchAdminPortlet.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/portlet/SearchAdminPortlet.java
@@ -14,14 +14,18 @@
 
 package com.liferay.portal.search.admin.web.internal.portlet;
 
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.admin.web.internal.constants.SearchAdminPortletKeys;
+import com.liferay.portal.search.admin.web.internal.constants.SearchAdminWebKeys;
 import com.liferay.portal.search.admin.web.internal.display.context.FieldMappingsDisplayBuilder;
 import com.liferay.portal.search.admin.web.internal.display.context.IndexActionsDisplayBuilder;
+import com.liferay.portal.search.admin.web.internal.display.context.SearchAdminDisplayBuilder;
+import com.liferay.portal.search.admin.web.internal.display.context.SearchAdminDisplayContext;
 import com.liferay.portal.search.engine.SearchEngineInformation;
 import com.liferay.portal.search.index.IndexInformation;
 
@@ -72,10 +76,21 @@ public class SearchAdminPortlet extends MVCPortlet {
 			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws IOException, PortletException {
 
-		String tabs1 = ParamUtil.getString(
-			renderRequest, "tabs1", "index-actions");
+		SearchAdminDisplayBuilder searchAdminDisplayBuilder =
+			new SearchAdminDisplayBuilder(
+				_language, _portal, renderRequest, renderResponse);
 
-		if (tabs1.equals("index-actions")) {
+		searchAdminDisplayBuilder.setIndexInformation(indexInformation);
+
+		SearchAdminDisplayContext searchAdminDisplayContext =
+			searchAdminDisplayBuilder.build();
+
+		renderRequest.setAttribute(
+			WebKeys.PORTLET_DISPLAY_CONTEXT, searchAdminDisplayContext);
+
+		String tab = searchAdminDisplayContext.getSelectedTab();
+
+		if (tab.equals("index-actions")) {
 			IndexActionsDisplayBuilder indexActionsDisplayBuilder =
 				new IndexActionsDisplayBuilder();
 
@@ -83,7 +98,7 @@ public class SearchAdminPortlet extends MVCPortlet {
 				searchEngineInformation);
 
 			renderRequest.setAttribute(
-				WebKeys.PORTLET_DISPLAY_CONTEXT,
+				SearchAdminWebKeys.INDEX_ACTIONS_DISPLAY_CONTEXT,
 				indexActionsDisplayBuilder.build());
 		}
 		else {
@@ -104,7 +119,7 @@ public class SearchAdminPortlet extends MVCPortlet {
 			fieldMappingsDisplayBuilder.setSelectedIndexName(selectedIndexName);
 
 			renderRequest.setAttribute(
-				WebKeys.PORTLET_DISPLAY_CONTEXT,
+				SearchAdminWebKeys.FIELD_MAPPINGS_DISPLAY_CONTEXT,
 				fieldMappingsDisplayBuilder.build());
 		}
 
@@ -123,6 +138,9 @@ public class SearchAdminPortlet extends MVCPortlet {
 
 	@Reference
 	private Http _http;
+
+	@Reference
+	private Language _language;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/field_mappings.jsp
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/field_mappings.jsp
@@ -17,7 +17,7 @@
 <%@ taglib uri="http://liferay.com/tld/soy" prefix="soy" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
-<%@ page import="com.liferay.portal.kernel.util.WebKeys" %><%@
+<%@ page import="com.liferay.portal.search.admin.web.internal.constants.SearchAdminWebKeys" %><%@
 page import="com.liferay.portal.search.admin.web.internal.display.context.FieldMappingsDisplayContext" %>
 
 <%@ page import="java.util.HashMap" %><%@
@@ -26,7 +26,7 @@ page import="java.util.Map" %>
 <liferay-theme:defineObjects />
 
 <%
-FieldMappingsDisplayContext fieldMappingsDisplayContext = (FieldMappingsDisplayContext)request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT);
+FieldMappingsDisplayContext fieldMappingsDisplayContext = (FieldMappingsDisplayContext)request.getAttribute(SearchAdminWebKeys.FIELD_MAPPINGS_DISPLAY_CONTEXT);
 
 Map<String, Object> context = new HashMap<>();
 

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/index_actions.jsp
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/index_actions.jsp
@@ -33,7 +33,7 @@ page import="com.liferay.portal.kernel.search.IndexerClassNameComparator" %><%@
 page import="com.liferay.portal.kernel.search.IndexerRegistryUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
-page import="com.liferay.portal.search.admin.web.internal.display.context.SearchAdminDisplayContext" %>
+page import="com.liferay.portal.search.admin.web.internal.display.context.IndexActionsDisplayContext" %>
 
 <%@ page import="java.io.Serializable" %>
 
@@ -48,7 +48,7 @@ page import="java.util.Map" %>
 <portlet:defineObjects />
 
 <%
-SearchAdminDisplayContext searchAdminDisplayContext = (SearchAdminDisplayContext)request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT);
+IndexActionsDisplayContext indexActionsDisplayContext = (IndexActionsDisplayContext)request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT);
 
 PortletURL portletURL = renderResponse.createRenderURL();
 
@@ -70,11 +70,11 @@ portletURL.setParameter("mvcRenderCommandName", "/search_admin/view");
 		<div class="panel panel-default search-admin-tabs" id="adminSearchInformationPanel">
 			<div class="panel-body">
 				<c:choose>
-					<c:when test="<%= !searchAdminDisplayContext.isMissingSearchEngine() %>">
+					<c:when test="<%= !indexActionsDisplayContext.isMissingSearchEngine() %>">
 						<div class="alert alert-info">
-							<liferay-ui:message key="search-engine-vendor" />: <strong><%= searchAdminDisplayContext.getVendorString() %></strong>,
-							<liferay-ui:message key="client-version" />: <strong><%= searchAdminDisplayContext.getClientVersionString() %></strong>,
-							<liferay-ui:message key="nodes" />: <strong><%= searchAdminDisplayContext.getNodesString() %></strong>
+							<liferay-ui:message key="search-engine-vendor" />: <strong><%= indexActionsDisplayContext.getVendorString() %></strong>,
+							<liferay-ui:message key="client-version" />: <strong><%= indexActionsDisplayContext.getClientVersionString() %></strong>,
+							<liferay-ui:message key="nodes" />: <strong><%= indexActionsDisplayContext.getNodesString() %></strong>
 						</div>
 					</c:when>
 					<c:otherwise>

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/index_actions.jsp
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/index_actions.jsp
@@ -32,7 +32,7 @@ page import="com.liferay.portal.kernel.search.Indexer" %><%@
 page import="com.liferay.portal.kernel.search.IndexerClassNameComparator" %><%@
 page import="com.liferay.portal.kernel.search.IndexerRegistryUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
-page import="com.liferay.portal.kernel.util.WebKeys" %><%@
+page import="com.liferay.portal.search.admin.web.internal.constants.SearchAdminWebKeys" %><%@
 page import="com.liferay.portal.search.admin.web.internal.display.context.IndexActionsDisplayContext" %>
 
 <%@ page import="java.io.Serializable" %>
@@ -48,7 +48,7 @@ page import="java.util.Map" %>
 <portlet:defineObjects />
 
 <%
-IndexActionsDisplayContext indexActionsDisplayContext = (IndexActionsDisplayContext)request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT);
+IndexActionsDisplayContext indexActionsDisplayContext = (IndexActionsDisplayContext)request.getAttribute(SearchAdminWebKeys.INDEX_ACTIONS_DISPLAY_CONTEXT);
 
 PortletURL portletURL = renderResponse.createRenderURL();
 

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -16,55 +16,34 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
-
 <%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
-<%@ page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.JSPNavigationItemList" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
-page import="com.liferay.portal.kernel.util.ParamUtil" %>
+<%@ page import="com.liferay.portal.kernel.util.WebKeys" %><%@
+page import="com.liferay.portal.search.admin.web.internal.display.context.SearchAdminDisplayContext" %>
 
 <liferay-frontend:defineObjects />
 
 <liferay-theme:defineObjects />
 
-<portlet:defineObjects />
-
 <%
-String tabs1 = ParamUtil.getString(request, "tabs1", "index-actions");
+SearchAdminDisplayContext searchAdminDisplayContext = (SearchAdminDisplayContext)request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT);
+
+String selectedTab = searchAdminDisplayContext.getSelectedTab();
 %>
 
 <clay:navigation-bar
 	inverted="<%= true %>"
-	navigationItems="<%=
-		new JSPNavigationItemList(pageContext) {
-			{
-				add(
-					navigationItem -> {
-						navigationItem.setActive(tabs1.equals("index-actions"));
-						navigationItem.setHref(renderResponse.createRenderURL(), "tabs1", "index-actions");
-						navigationItem.setLabel(LanguageUtil.get(request, "index-actions"));
-					});
-
-				add(
-					navigationItem -> {
-						navigationItem.setActive(tabs1.equals("field-mappings"));
-						navigationItem.setHref(renderResponse.createRenderURL(), "tabs1", "field-mappings");
-						navigationItem.setLabel(LanguageUtil.get(request, "field-mappings"));
-					});
-			}
-		}
-	%>"
+	navigationItems="<%= searchAdminDisplayContext.getNavigationItemList() %>"
 />
 
 <c:choose>
-	<c:when test='<%= tabs1.equals("index-actions") %>'>
+	<c:when test='<%= selectedTab.equals("index-actions") %>'>
 		<liferay-util:include page="/index_actions.jsp" servletContext="<%= application %>" />
 	</c:when>
-	<c:when test='<%= tabs1.equals("field-mappings") %>'>
+	<c:when test='<%= selectedTab.equals("field-mappings") %>'>
 		<liferay-util:include page="/field_mappings.jsp" servletContext="<%= application %>" />
 	</c:when>
 </c:choose>

--- a/modules/apps/portal-search/portal-search-admin-web/src/test/java/com/liferay/portal/search/admin/web/internal/display/context/SearchAdminDisplayContextTest.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/test/java/com/liferay/portal/search/admin/web/internal/display/context/SearchAdminDisplayContextTest.java
@@ -1,0 +1,278 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.admin.web.internal.display.context;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemList;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.language.LanguageImpl;
+import com.liferay.portal.search.index.IndexInformation;
+import com.liferay.portal.util.HttpImpl;
+
+import javax.portlet.RenderRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.portlet.MockRenderRequest;
+import org.springframework.mock.web.portlet.MockRenderResponse;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class SearchAdminDisplayContextTest {
+
+	@Before
+	public void setUp() {
+		setUpHttpUtil();
+		setUpIndexInformation();
+		setUpLanguage();
+		setUpParamUtil();
+		setUpPortalUtil();
+	}
+
+	@Test
+	public void testGetNavigationItemListWithIndexInformation() {
+		SearchAdminDisplayBuilder searchAdminDisplayBuilder =
+			new SearchAdminDisplayBuilder(
+				_language, _portal, new MockRenderRequest(),
+				new MockRenderResponse());
+
+		searchAdminDisplayBuilder.setIndexInformation(
+			Mockito.mock(IndexInformation.class));
+
+		SearchAdminDisplayContext searchAdminDisplayContext =
+			searchAdminDisplayBuilder.build();
+
+		NavigationItemList navigationItemList =
+			searchAdminDisplayContext.getNavigationItemList();
+
+		Assert.assertEquals(
+			navigationItemList.toString(), 2, navigationItemList.size());
+	}
+
+	@Test
+	public void testGetNavigationItemListWithoutIndexInformation() {
+		SearchAdminDisplayBuilder searchAdminDisplayBuilder =
+			new SearchAdminDisplayBuilder(
+				_language, _portal, new MockRenderRequest(),
+				new MockRenderResponse());
+
+		searchAdminDisplayBuilder.setIndexInformation(null);
+
+		SearchAdminDisplayContext searchAdminDisplayContext =
+			searchAdminDisplayBuilder.build();
+
+		NavigationItemList navigationItemList =
+			searchAdminDisplayContext.getNavigationItemList();
+
+		Assert.assertEquals(
+			navigationItemList.toString(), 1, navigationItemList.size());
+	}
+
+	@Test
+	public void testGetTabDefault() {
+		SearchAdminDisplayBuilder searchAdminDisplayBuilder =
+			new SearchAdminDisplayBuilder(
+				_language, _portal, new MockRenderRequest(),
+				new MockRenderResponse());
+
+		searchAdminDisplayBuilder.setIndexInformation(
+			Mockito.mock(IndexInformation.class));
+
+		SearchAdminDisplayContext searchAdminDisplayContext =
+			searchAdminDisplayBuilder.build();
+
+		Assert.assertEquals(
+			"index-actions", searchAdminDisplayContext.getSelectedTab());
+	}
+
+	@Test
+	public void testGetTabFieldMappings() {
+		SearchAdminDisplayBuilder searchAdminDisplayBuilder =
+			new SearchAdminDisplayBuilder(
+				_language, _portal,
+				getRenderRequestWithSelectedTab("field-mappings"),
+				new MockRenderResponse());
+
+		searchAdminDisplayBuilder.setIndexInformation(
+			Mockito.mock(IndexInformation.class));
+
+		SearchAdminDisplayContext searchAdminDisplayContext =
+			searchAdminDisplayBuilder.build();
+
+		Assert.assertEquals(
+			"field-mappings", searchAdminDisplayContext.getSelectedTab());
+	}
+
+	@Test
+	public void testGetTabFieldMappingsNoIndexInformation() {
+		SearchAdminDisplayBuilder searchAdminDisplayBuilder =
+			new SearchAdminDisplayBuilder(
+				_language, _portal,
+				getRenderRequestWithSelectedTab("field-mappings"),
+				new MockRenderResponse());
+
+		searchAdminDisplayBuilder.setIndexInformation(null);
+
+		SearchAdminDisplayContext searchAdminDisplayContext =
+			searchAdminDisplayBuilder.build();
+
+		Assert.assertEquals(
+			"index-actions", searchAdminDisplayContext.getSelectedTab());
+	}
+
+	@Test
+	public void testGetTabIndexActions() {
+		SearchAdminDisplayBuilder searchAdminDisplayBuilder =
+			new SearchAdminDisplayBuilder(
+				_language, _portal,
+				getRenderRequestWithSelectedTab("index-actions"),
+				new MockRenderResponse());
+
+		searchAdminDisplayBuilder.setIndexInformation(
+			Mockito.mock(IndexInformation.class));
+
+		SearchAdminDisplayContext searchAdminDisplayContext =
+			searchAdminDisplayBuilder.build();
+
+		Assert.assertEquals(
+			"index-actions", searchAdminDisplayContext.getSelectedTab());
+	}
+
+	@Test
+	public void testGetTabUnavailable() {
+		SearchAdminDisplayBuilder searchAdminDisplayBuilder =
+			new SearchAdminDisplayBuilder(
+				_language, _portal,
+				getRenderRequestWithSelectedTab(RandomTestUtil.randomString()),
+				new MockRenderResponse());
+
+		searchAdminDisplayBuilder.setIndexInformation(
+			Mockito.mock(IndexInformation.class));
+
+		SearchAdminDisplayContext searchAdminDisplayContext =
+			searchAdminDisplayBuilder.build();
+
+		Assert.assertEquals(
+			"index-actions", searchAdminDisplayContext.getSelectedTab());
+	}
+
+	@Test
+	public void testIsIndexInformationAvailable() {
+		SearchAdminDisplayBuilder searchAdminDisplayBuilder =
+			new SearchAdminDisplayBuilder(
+				_language, _portal, new MockRenderRequest(),
+				new MockRenderResponse());
+
+		searchAdminDisplayBuilder.setIndexInformation(
+			Mockito.mock(IndexInformation.class));
+
+		SearchAdminDisplayContext searchAdminDisplayContext =
+			searchAdminDisplayBuilder.build();
+
+		Assert.assertTrue(
+			searchAdminDisplayContext.isIndexInformationAvailable());
+	}
+
+	@Test
+	public void testIsIndexInformationAvailableFalse() {
+		SearchAdminDisplayBuilder searchAdminDisplayBuilder =
+			new SearchAdminDisplayBuilder(
+				_language, _portal, new MockRenderRequest(),
+				new MockRenderResponse());
+
+		searchAdminDisplayBuilder.setIndexInformation(null);
+
+		SearchAdminDisplayContext searchAdminDisplayContext =
+			searchAdminDisplayBuilder.build();
+
+		Assert.assertTrue(
+			!searchAdminDisplayContext.isIndexInformationAvailable());
+	}
+
+	protected RenderRequest getRenderRequestWithSelectedTab(
+		String selectedTab) {
+
+		MockRenderRequest mockRenderRequest = new MockRenderRequest();
+
+		mockRenderRequest.setParameter("tabs1", selectedTab);
+
+		return mockRenderRequest;
+	}
+
+	protected void setUpHttpUtil() {
+		http = new HttpImpl();
+	}
+
+	protected void setUpIndexInformation() {
+		indexInformation = Mockito.mock(IndexInformation.class);
+
+		Mockito.when(
+			indexInformation.getIndexNames()
+		).thenReturn(
+			new String[] {"index1", "index2"}
+		);
+
+		Mockito.when(
+			indexInformation.getCompanyIndexName(Matchers.anyLong())
+		).thenAnswer(
+			invocation -> "index" + invocation.getArguments()[0]
+		);
+	}
+
+	protected void setUpLanguage() {
+		_language = new LanguageImpl();
+	}
+
+	protected void setUpParamUtil() {
+		PropsUtil.setProps(Mockito.mock(Props.class));
+	}
+
+	protected void setUpPortalUtil() {
+		_portal = Mockito.mock(Portal.class);
+
+		Mockito.doAnswer(
+			invocation -> new String[] {
+				invocation.getArgumentAt(0, String.class), StringPool.BLANK
+			}
+		).when(
+			_portal
+		).stripURLAnchor(
+			Mockito.anyString(), Mockito.anyString()
+		);
+
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(_portal);
+	}
+
+	protected Http http;
+	protected IndexInformation indexInformation;
+
+	private Language _language;
+	private Portal _portal;
+
+}


### PR DESCRIPTION
<h3>:x: ci:test:search - 16 out of 18 jobs passed in 1 hour 22 minutes 6 seconds 175 ms</h3>

https://github.com/brandizzi/liferay-portal/pull/682#issuecomment-482608141

No unique failures

Author: @brandizzi

[Story] As a Search Admin I want to view effective Field Mappings, as reported by the search engine, from within Portal UI
https://issues.liferay.com/browse/LPS-90872