### PR TITLE
LPS-93165 When a high service ranking TransactionExecutor is concurre…

### DIFF
--- a/modules/apps/portal/portal-aop-test/src/testIntegration/java/com/liferay/portal/aop/test/AopServiceManagerConcurrencyTest.java
+++ b/modules/apps/portal/portal-aop-test/src/testIntegration/java/com/liferay/portal/aop/test/AopServiceManagerConcurrencyTest.java
@@ -137,9 +137,12 @@ public class AopServiceManagerConcurrencyTest {
 						Arrays.toString(serviceReferences), 1,
 						serviceReferences.length);
 
-					TestService testService =
-						(TestService)_bundleContext.getService(
+					TestService testService = null;
+
+					while (testService == null) {
+						testService = (TestService)_bundleContext.getService(
 							serviceReferences[0]);
+					}
 
 					TestTransactionExecutor actualTestTransactionExecutor =
 						testService.getTransactionExecutor();


### PR DESCRIPTION
…ntly registered, it will unregister and re-register all the exist AopService, this creates a window time that the AopServices do not exist, which could lead to NPE in other racing thread on getting the AopService object.