### PR TITLE
LPS-94004 FIX: Redeploying Elasticsearch Connector: "java.util.ServiceConfigurationError: org.elasticsearch.common.xcontent.XContentBuilderExtension: Provider org.elasticsearch.common.xcontent.XContentElasticsearchExtension not a subtype"

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/EmbeddedElasticsearchConnection.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/EmbeddedElasticsearchConnection.java
@@ -290,8 +290,6 @@ public class EmbeddedElasticsearchConnection
 
 		Settings settings = settingsBuilder.build();
 
-		installPlugins(settings);
-
 		if (_log.isDebugEnabled()) {
 			_log.debug(
 				"Starting embedded Elasticsearch cluster " +
@@ -345,6 +343,8 @@ public class EmbeddedElasticsearchConnection
 		System.setProperty("jna.tmpdir", _jnaTmpDirName);
 
 		try {
+			installPlugins(settings);
+
 			return EmbeddedElasticsearchNode.newInstance(settings);
 		}
 		finally {


### PR DESCRIPTION
**❌ ci:test:search - 13 out of 18 jobs passed in 1 hour 15 minutes 28 seconds 246 ms**
https://github.com/arboliveira/liferay-portal/pull/720#issuecomment-483095372

----

`master` is contaminated. Failures caused by https://github.com/liferay/liferay-portal/commit/58acbe5079f215d77a035e8159086a1169641b36#diff-d8ebe26fb9ddec820a23c4d43393897dR52 (`content` and `title` switched around) cc/ @cgoncas @xbrianlee @joshchong

----

_[Bug] Redeploying Elasticsearch Connector: "java.util.ServiceConfigurationError: org.elasticsearch.common.xcontent.XContentBuilderExtension: Provider org.elasticsearch.common.xcontent.XContentElasticsearchExtension not a subtype"_
https://issues.liferay.com/browse/LPS-94004