### PR TITLE
LPS-94047 Remove all org.osgi.enterprise usages from build.gradle fil…

### DIFF
--- a/modules/apps/analytics/analytics-client-osgi/build.gradle
+++ b/modules/apps/analytics/analytics-client-osgi/build.gradle
@@ -2,7 +2,7 @@ dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
-	compileOnly group: "org.osgi", name: "org.osgi.enterprise", version: "5.0.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:analytics:analytics-api")
 	compileOnly project(":apps:petra:petra-json-web-service-client")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	compileOnly group: "org.antlr", name: "antlr4", version: "4.3"
 	compileOnly group: "org.antlr", name: "antlr4-annotations", version: "4.3"
 	compileOnly group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
-	compileOnly group: "org.osgi", name: "org.osgi.enterprise", version: "5.0.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":core:osgi-service-tracker-collections")

--- a/modules/apps/segments/segments-content-targeting-upgrade/build.gradle
+++ b/modules/apps/segments/segments-content-targeting-upgrade/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 	compileOnly group: "org.apache.cxf", name: "cxf-rt-rs-client", version: "3.2.5"
 	compileOnly group: "org.apache.cxf", name: "cxf-rt-rs-extension-providers", version: "3.2.5"
 	compileOnly group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
-	compileOnly group: "org.osgi", name: "org.osgi.enterprise", version: "5.0.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal:portal-upgrade-api")

--- a/modules/apps/segments/segments-service/build.gradle
+++ b/modules/apps/segments/segments-service/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 	compileOnly group: "org.apache.cxf", name: "cxf-rt-rs-client", version: "3.2.5"
 	compileOnly group: "org.apache.cxf", name: "cxf-rt-rs-extension-providers", version: "3.2.5"
 	compileOnly group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
-	compileOnly group: "org.osgi", name: "org.osgi.enterprise", version: "5.0.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:layout:layout-api")


### PR DESCRIPTION
…es.  We shouldn't be using this jar for compile since it's using old package versions of other jars like osgi.core.