### PR TITLE
Lps 93910

### DIFF
--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/bnd.bnd
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/bnd.bnd
@@ -5,4 +5,7 @@ Provide-Capability:\
 	soy;\
 		type="image-editor-web";\
 		version:Version="${Bundle-Version}"
+Require-Capability:\
+	soy;\
+		filter:="(type=clay-taglib)"
 Web-ContextPath: /frontend-image-editor-web

--- a/modules/apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/main/java/com/liferay/portal/portlet/bridge/soy/internal/util/SoyTemplateResourcesProviderUtil.java
+++ b/modules/apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/main/java/com/liferay/portal/portlet/bridge/soy/internal/util/SoyTemplateResourcesProviderUtil.java
@@ -32,7 +32,8 @@ public class SoyTemplateResourcesProviderUtil {
 	public static List<TemplateResource> getBundleTemplateResources(
 		Bundle bundle, String templatePath) {
 
-		return _soyTemplateResourcesProvider.getAllTemplateResources();
+		return _soyTemplateResourcesProvider.getBundleTemplateResources(
+			bundle, templatePath);
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/sharing/sharing-web/bnd.bnd
+++ b/modules/apps/sharing/sharing-web/bnd.bnd
@@ -13,6 +13,8 @@ Require-Capability:\
 	liferay.resource.bundle;\
 		filter:="(bundle.symbolic.name=com.liferay.sharing.lang)",\
 	soy;\
+		filter:="(type=clay-taglib)",\
+	soy;\
 		filter:="(type=frontend-js-web)"
 Web-ContextPath: /sharing-web
 -dsannotations-options: inherit


### PR DESCRIPTION
From @mtambara:

> Some history on this:
> 
> In https://github.com/liferay/liferay-portal/commit/1f420be6eaea470bb40ffac78a263e34bf193a3b, I accidentally changed ```SoyPortlet``` to use ```SoyTemplateResourcesProvider.getAllTemplateResources``` instead of ```SoyTemplateResourcesProvider.getBundleTemplateResources```. This didn't break anything so it's been unnoticed until now. The problem is that things have been built on top of this since then. I fixed an issue with using template-path in https://github.com/liferay/liferay-portal/commit/9f9aec762dd2a34024aed5914b220d431a200496 and am attempting to resolve a clay dependency issue in this pull. This resolves all of the issues in https://issues.liferay.com/browse/LPS-93910, but can you see if this causes any other problems with soy portlets?
> 
> cc @shuyangzhou

Thanks @mtambara, @shuyagzhou for the patience to sort this out!

/cc @ambrinchaudhary, @boton