### PR TITLE
LPS-92618.18 Remove ObjectMappers from tests

### DIFF
--- a/modules/apps/bulk/bulk-rest-api/src/main/java/com/liferay/bulk/rest/resource/v1_0/KeywordResource.java
+++ b/modules/apps/bulk/bulk-rest-api/src/main/java/com/liferay/bulk/rest/resource/v1_0/KeywordResource.java
@@ -22,8 +22,6 @@ import com.liferay.portal.vulcan.pagination.Page;
 
 import javax.annotation.Generated;
 
-import javax.ws.rs.core.Response;
-
 /**
  * To access this resource, run:
  *
@@ -35,10 +33,10 @@ import javax.ws.rs.core.Response;
 @Generated("")
 public interface KeywordResource {
 
-	public Response patchKeywordBatch(KeywordBulkSelection keywordBulkSelection)
+	public void patchKeywordBatch(KeywordBulkSelection keywordBulkSelection)
 		throws Exception;
 
-	public Response putKeywordBatch(KeywordBulkSelection keywordBulkSelection)
+	public void putKeywordBatch(KeywordBulkSelection keywordBulkSelection)
 		throws Exception;
 
 	public Page<Keyword> postKeywordsCommonPage(

--- a/modules/apps/bulk/bulk-rest-api/src/main/java/com/liferay/bulk/rest/resource/v1_0/TaxonomyCategoryResource.java
+++ b/modules/apps/bulk/bulk-rest-api/src/main/java/com/liferay/bulk/rest/resource/v1_0/TaxonomyCategoryResource.java
@@ -19,8 +19,6 @@ import com.liferay.portal.kernel.model.Company;
 
 import javax.annotation.Generated;
 
-import javax.ws.rs.core.Response;
-
 /**
  * To access this resource, run:
  *
@@ -32,11 +30,11 @@ import javax.ws.rs.core.Response;
 @Generated("")
 public interface TaxonomyCategoryResource {
 
-	public Response patchTaxonomyCategoryBatch(
+	public void patchTaxonomyCategoryBatch(
 			TaxonomyCategoryBulkSelection taxonomyCategoryBulkSelection)
 		throws Exception;
 
-	public Response putTaxonomyCategoryBatch(
+	public void putTaxonomyCategoryBatch(
 			TaxonomyCategoryBulkSelection taxonomyCategoryBulkSelection)
 		throws Exception;
 

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/DocumentBulkSelectionSerDes.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/DocumentBulkSelectionSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.bulk.rest.client.serdes.v1_0;
 import com.liferay.bulk.rest.client.dto.v1_0.DocumentBulkSelection;
 import com.liferay.bulk.rest.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -87,6 +89,27 @@ public class DocumentBulkSelectionSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		DocumentBulkSelection documentBulkSelection) {
+
+		if (documentBulkSelection == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"documentIds",
+			String.valueOf(documentBulkSelection.getDocumentIds()));
+
+		map.put(
+			"selectionScope",
+			SelectionScopeSerDes.toJSON(
+				documentBulkSelection.getSelectionScope()));
+
+		return map;
 	}
 
 	private static class DocumentBulkSelectionJSONParser

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/GenericErrorSerDes.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/GenericErrorSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.bulk.rest.client.serdes.v1_0;
 import com.liferay.bulk.rest.client.dto.v1_0.GenericError;
 import com.liferay.bulk.rest.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -67,6 +69,18 @@ public class GenericErrorSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(GenericError genericError) {
+		if (genericError == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("message", String.valueOf(genericError.getMessage()));
+
+		return map;
 	}
 
 	private static class GenericErrorJSONParser

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/KeywordBulkSelectionSerDes.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/KeywordBulkSelectionSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.bulk.rest.client.serdes.v1_0;
 import com.liferay.bulk.rest.client.dto.v1_0.KeywordBulkSelection;
 import com.liferay.bulk.rest.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -115,6 +117,31 @@ public class KeywordBulkSelectionSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		KeywordBulkSelection keywordBulkSelection) {
+
+		if (keywordBulkSelection == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"documentBulkSelection",
+			DocumentBulkSelectionSerDes.toJSON(
+				keywordBulkSelection.getDocumentBulkSelection()));
+
+		map.put(
+			"keywordsToAdd",
+			String.valueOf(keywordBulkSelection.getKeywordsToAdd()));
+
+		map.put(
+			"keywordsToRemove",
+			String.valueOf(keywordBulkSelection.getKeywordsToRemove()));
+
+		return map;
 	}
 
 	private static class KeywordBulkSelectionJSONParser

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/KeywordSerDes.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/KeywordSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.bulk.rest.client.serdes.v1_0;
 import com.liferay.bulk.rest.client.dto.v1_0.Keyword;
 import com.liferay.bulk.rest.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -65,6 +67,18 @@ public class KeywordSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Keyword keyword) {
+		if (keyword == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("name", String.valueOf(keyword.getName()));
+
+		return map;
 	}
 
 	private static class KeywordJSONParser extends BaseJSONParser<Keyword> {

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/SelectionScopeSerDes.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/SelectionScopeSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.bulk.rest.client.serdes.v1_0;
 import com.liferay.bulk.rest.client.dto.v1_0.SelectionScope;
 import com.liferay.bulk.rest.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -85,6 +87,23 @@ public class SelectionScopeSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(SelectionScope selectionScope) {
+		if (selectionScope == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("folderId", String.valueOf(selectionScope.getFolderId()));
+
+		map.put(
+			"repositoryId", String.valueOf(selectionScope.getRepositoryId()));
+
+		map.put("selectAll", String.valueOf(selectionScope.getSelectAll()));
+
+		return map;
 	}
 
 	private static class SelectionScopeJSONParser

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/SelectionSerDes.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/SelectionSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.bulk.rest.client.serdes.v1_0;
 import com.liferay.bulk.rest.client.dto.v1_0.Selection;
 import com.liferay.bulk.rest.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -61,6 +63,18 @@ public class SelectionSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Selection selection) {
+		if (selection == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("size", String.valueOf(selection.getSize()));
+
+		return map;
 	}
 
 	private static class SelectionJSONParser extends BaseJSONParser<Selection> {

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/StatusSerDes.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/StatusSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.bulk.rest.client.serdes.v1_0;
 import com.liferay.bulk.rest.client.dto.v1_0.Status;
 import com.liferay.bulk.rest.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -61,6 +63,19 @@ public class StatusSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Status status) {
+		if (status == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"actionInProgress", String.valueOf(status.getActionInProgress()));
+
+		return map;
 	}
 
 	private static class StatusJSONParser extends BaseJSONParser<Status> {

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/TaxonomyCategoryBulkSelectionSerDes.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/TaxonomyCategoryBulkSelectionSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.bulk.rest.client.serdes.v1_0;
 import com.liferay.bulk.rest.client.dto.v1_0.TaxonomyCategoryBulkSelection;
 import com.liferay.bulk.rest.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -125,6 +127,34 @@ public class TaxonomyCategoryBulkSelectionSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		TaxonomyCategoryBulkSelection taxonomyCategoryBulkSelection) {
+
+		if (taxonomyCategoryBulkSelection == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"documentBulkSelection",
+			DocumentBulkSelectionSerDes.toJSON(
+				taxonomyCategoryBulkSelection.getDocumentBulkSelection()));
+
+		map.put(
+			"taxonomyCategoryIdsToAdd",
+			String.valueOf(
+				taxonomyCategoryBulkSelection.getTaxonomyCategoryIdsToAdd()));
+
+		map.put(
+			"taxonomyCategoryIdsToRemove",
+			String.valueOf(
+				taxonomyCategoryBulkSelection.
+					getTaxonomyCategoryIdsToRemove()));
+
+		return map;
 	}
 
 	private static class TaxonomyCategoryBulkSelectionJSONParser

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/TaxonomyCategorySerDes.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/TaxonomyCategorySerDes.java
@@ -17,6 +17,8 @@ package com.liferay.bulk.rest.client.serdes.v1_0;
 import com.liferay.bulk.rest.client.dto.v1_0.TaxonomyCategory;
 import com.liferay.bulk.rest.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -78,6 +80,24 @@ public class TaxonomyCategorySerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(TaxonomyCategory taxonomyCategory) {
+		if (taxonomyCategory == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"taxonomyCategoryId",
+			String.valueOf(taxonomyCategory.getTaxonomyCategoryId()));
+
+		map.put(
+			"taxonomyCategoryName",
+			String.valueOf(taxonomyCategory.getTaxonomyCategoryName()));
+
+		return map;
 	}
 
 	private static class TaxonomyCategoryJSONParser

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/TaxonomyVocabularySerDes.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/serdes/v1_0/TaxonomyVocabularySerDes.java
@@ -18,6 +18,8 @@ import com.liferay.bulk.rest.client.dto.v1_0.TaxonomyCategory;
 import com.liferay.bulk.rest.client.dto.v1_0.TaxonomyVocabulary;
 import com.liferay.bulk.rest.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -129,6 +131,33 @@ public class TaxonomyVocabularySerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		TaxonomyVocabulary taxonomyVocabulary) {
+
+		if (taxonomyVocabulary == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"multiValued", String.valueOf(taxonomyVocabulary.getMultiValued()));
+
+		map.put("name", String.valueOf(taxonomyVocabulary.getName()));
+
+		map.put("required", String.valueOf(taxonomyVocabulary.getRequired()));
+
+		map.put(
+			"taxonomyCategories",
+			String.valueOf(taxonomyVocabulary.getTaxonomyCategories()));
+
+		map.put(
+			"taxonomyVocabularyId",
+			String.valueOf(taxonomyVocabulary.getTaxonomyVocabularyId()));
+
+		return map;
 	}
 
 	private static class TaxonomyVocabularyJSONParser

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -38,8 +38,6 @@ import java.util.Collection;
 
 import javax.annotation.Generated;
 
-import javax.ws.rs.core.Response;
-
 import org.osgi.service.component.ComponentServiceObjects;
 
 /**
@@ -82,12 +80,12 @@ public class Mutation {
 	}
 
 	@GraphQLInvokeDetached
-	public Response patchKeywordBatch(
+	public void patchKeywordBatch(
 			@GraphQLName("keywordBulkSelection") KeywordBulkSelection
 				keywordBulkSelection)
 		throws Exception {
 
-		return _applyComponentServiceObjects(
+		_applyVoidComponentServiceObjects(
 			_keywordResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			keywordResource -> keywordResource.patchKeywordBatch(
@@ -95,12 +93,12 @@ public class Mutation {
 	}
 
 	@GraphQLInvokeDetached
-	public Response putKeywordBatch(
+	public void putKeywordBatch(
 			@GraphQLName("keywordBulkSelection") KeywordBulkSelection
 				keywordBulkSelection)
 		throws Exception {
 
-		return _applyComponentServiceObjects(
+		_applyVoidComponentServiceObjects(
 			_keywordResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			keywordResource -> keywordResource.putKeywordBatch(
@@ -140,12 +138,12 @@ public class Mutation {
 	}
 
 	@GraphQLInvokeDetached
-	public Response patchTaxonomyCategoryBatch(
+	public void patchTaxonomyCategoryBatch(
 			@GraphQLName("taxonomyCategoryBulkSelection")
 				TaxonomyCategoryBulkSelection taxonomyCategoryBulkSelection)
 		throws Exception {
 
-		return _applyComponentServiceObjects(
+		_applyVoidComponentServiceObjects(
 			_taxonomyCategoryResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			taxonomyCategoryResource ->
@@ -154,12 +152,12 @@ public class Mutation {
 	}
 
 	@GraphQLInvokeDetached
-	public Response putTaxonomyCategoryBatch(
+	public void putTaxonomyCategoryBatch(
 			@GraphQLName("taxonomyCategoryBulkSelection")
 				TaxonomyCategoryBulkSelection taxonomyCategoryBulkSelection)
 		throws Exception {
 
-		return _applyComponentServiceObjects(
+		_applyVoidComponentServiceObjects(
 			_taxonomyCategoryResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			taxonomyCategoryResource ->

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -40,7 +40,6 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 /**
@@ -56,12 +55,8 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	@PATCH
 	@Path("/keywords/batch")
 	@Tags(value = {@Tag(name = "Keyword")})
-	public Response patchKeywordBatch(KeywordBulkSelection keywordBulkSelection)
+	public void patchKeywordBatch(KeywordBulkSelection keywordBulkSelection)
 		throws Exception {
-
-		Response.ResponseBuilder responseBuilder = Response.ok();
-
-		return responseBuilder.build();
 	}
 
 	@Override
@@ -69,12 +64,8 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	@PUT
 	@Path("/keywords/batch")
 	@Tags(value = {@Tag(name = "Keyword")})
-	public Response putKeywordBatch(KeywordBulkSelection keywordBulkSelection)
+	public void putKeywordBatch(KeywordBulkSelection keywordBulkSelection)
 		throws Exception {
-
-		Response.ResponseBuilder responseBuilder = Response.ok();
-
-		return responseBuilder.build();
 	}
 
 	@Override

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -35,7 +35,6 @@ import javax.ws.rs.PATCH;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 /**
@@ -52,13 +51,9 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	@PATCH
 	@Path("/taxonomy-categories/batch")
 	@Tags(value = {@Tag(name = "TaxonomyCategory")})
-	public Response patchTaxonomyCategoryBatch(
+	public void patchTaxonomyCategoryBatch(
 			TaxonomyCategoryBulkSelection taxonomyCategoryBulkSelection)
 		throws Exception {
-
-		Response.ResponseBuilder responseBuilder = Response.ok();
-
-		return responseBuilder.build();
 	}
 
 	@Override
@@ -66,13 +61,9 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	@PUT
 	@Path("/taxonomy-categories/batch")
 	@Tags(value = {@Tag(name = "TaxonomyCategory")})
-	public Response putTaxonomyCategoryBatch(
+	public void putTaxonomyCategoryBatch(
 			TaxonomyCategoryBulkSelection taxonomyCategoryBulkSelection)
 		throws Exception {
-
-		Response.ResponseBuilder responseBuilder = Response.ok();
-
-		return responseBuilder.build();
 	}
 
 	public void setContextCompany(Company contextCompany) {

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/KeywordResourceImpl.java
@@ -43,7 +43,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -59,14 +58,10 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 
 	@Override
-	public Response patchKeywordBatch(KeywordBulkSelection keywordBulkSelection)
+	public void patchKeywordBatch(KeywordBulkSelection keywordBulkSelection)
 		throws Exception {
 
 		_update(true, keywordBulkSelection);
-
-		Response.ResponseBuilder responseBuilder = Response.ok();
-
-		return responseBuilder.build();
 	}
 
 	@Override
@@ -83,14 +78,10 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 	}
 
 	@Override
-	public Response putKeywordBatch(KeywordBulkSelection keywordBulkSelection)
+	public void putKeywordBatch(KeywordBulkSelection keywordBulkSelection)
 		throws Exception {
 
 		_update(false, keywordBulkSelection);
-
-		Response.ResponseBuilder responseBuilder = Response.ok();
-
-		return responseBuilder.build();
 	}
 
 	private Set<String> _getAssetTagNames(

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -29,7 +29,6 @@ import java.io.Serializable;
 import java.util.HashMap;
 
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -46,27 +45,19 @@ public class TaxonomyCategoryResourceImpl
 	extends BaseTaxonomyCategoryResourceImpl {
 
 	@Override
-	public Response patchTaxonomyCategoryBatch(
+	public void patchTaxonomyCategoryBatch(
 			TaxonomyCategoryBulkSelection taxonomyCategoryBulkSelection)
 		throws Exception {
 
 		_update(true, taxonomyCategoryBulkSelection);
-
-		Response.ResponseBuilder responseBuilder = Response.ok();
-
-		return responseBuilder.build();
 	}
 
 	@Override
-	public Response putTaxonomyCategoryBatch(
+	public void putTaxonomyCategoryBatch(
 			TaxonomyCategoryBulkSelection documentSelection)
 		throws Exception {
 
 		_update(false, documentSelection);
-
-		Response.ResponseBuilder responseBuilder = Response.ok();
-
-		return responseBuilder.build();
 	}
 
 	private void _update(

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.bulk.rest.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.bulk.rest.client.dto.v1_0.DocumentBulkSelection;
 import com.liferay.bulk.rest.client.dto.v1_0.Keyword;
 import com.liferay.bulk.rest.client.dto.v1_0.KeywordBulkSelection;
@@ -110,7 +105,7 @@ public abstract class BaseKeywordResourceTestCase {
 		Assert.assertTrue(true);
 	}
 
-	protected Response invokePatchKeywordBatch(
+	protected void invokePatchKeywordBatch(
 			KeywordBulkSelection keywordBulkSelection)
 		throws Exception {
 
@@ -126,17 +121,6 @@ public abstract class BaseKeywordResourceTestCase {
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("HTTP response: " + string);
-		}
-
-		try {
-			return outputObjectMapper.readValue(string, Response.class);
-		}
-		catch (Exception e) {
-			if (_log.isDebugEnabled()) {
-				_log.debug("Unable to process HTTP response: " + string, e);
-			}
-
-			throw e;
 		}
 	}
 
@@ -162,7 +146,7 @@ public abstract class BaseKeywordResourceTestCase {
 		Assert.assertTrue(true);
 	}
 
-	protected Response invokePutKeywordBatch(
+	protected void invokePutKeywordBatch(
 			KeywordBulkSelection keywordBulkSelection)
 		throws Exception {
 
@@ -178,17 +162,6 @@ public abstract class BaseKeywordResourceTestCase {
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("HTTP response: " + string);
-		}
-
-		try {
-			return outputObjectMapper.readValue(string, Response.class);
-		}
-		catch (Exception e) {
-			if (_log.isDebugEnabled()) {
-				_log.debug("Unable to process HTTP response: " + string, e);
-			}
-
-			throw e;
 		}
 	}
 
@@ -443,32 +416,27 @@ public abstract class BaseKeywordResourceTestCase {
 		return randomKeyword();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseSelectionResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseSelectionResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.bulk.rest.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.bulk.rest.client.dto.v1_0.DocumentBulkSelection;
 import com.liferay.bulk.rest.client.dto.v1_0.Selection;
 import com.liferay.bulk.rest.client.pagination.Page;
@@ -357,32 +352,27 @@ public abstract class BaseSelectionResourceTestCase {
 		return randomSelection();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.bulk.rest.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.bulk.rest.client.dto.v1_0.Status;
 import com.liferay.bulk.rest.client.pagination.Page;
 import com.liferay.bulk.rest.resource.v1_0.StatusResource;
@@ -333,32 +328,27 @@ public abstract class BaseStatusResourceTestCase {
 		return randomStatus();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.bulk.rest.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.bulk.rest.client.dto.v1_0.TaxonomyCategory;
 import com.liferay.bulk.rest.client.dto.v1_0.TaxonomyCategoryBulkSelection;
 import com.liferay.bulk.rest.client.pagination.Page;
@@ -108,7 +103,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Assert.assertTrue(true);
 	}
 
-	protected Response invokePatchTaxonomyCategoryBatch(
+	protected void invokePatchTaxonomyCategoryBatch(
 			TaxonomyCategoryBulkSelection taxonomyCategoryBulkSelection)
 		throws Exception {
 
@@ -124,17 +119,6 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("HTTP response: " + string);
-		}
-
-		try {
-			return outputObjectMapper.readValue(string, Response.class);
-		}
-		catch (Exception e) {
-			if (_log.isDebugEnabled()) {
-				_log.debug("Unable to process HTTP response: " + string, e);
-			}
-
-			throw e;
 		}
 	}
 
@@ -160,7 +144,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Assert.assertTrue(true);
 	}
 
-	protected Response invokePutTaxonomyCategoryBatch(
+	protected void invokePutTaxonomyCategoryBatch(
 			TaxonomyCategoryBulkSelection taxonomyCategoryBulkSelection)
 		throws Exception {
 
@@ -176,17 +160,6 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("HTTP response: " + string);
-		}
-
-		try {
-			return outputObjectMapper.readValue(string, Response.class);
-		}
-		catch (Exception e) {
-			if (_log.isDebugEnabled()) {
-				_log.debug("Unable to process HTTP response: " + string, e);
-			}
-
-			throw e;
 		}
 	}
 
@@ -446,32 +419,27 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		return randomTaxonomyCategory();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.bulk.rest.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.bulk.rest.client.dto.v1_0.DocumentBulkSelection;
 import com.liferay.bulk.rest.client.dto.v1_0.TaxonomyVocabulary;
 import com.liferay.bulk.rest.client.pagination.Page;
@@ -470,32 +465,27 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		return randomTaxonomyVocabulary();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/AssetTypeSerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/AssetTypeSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.taxonomy.client.serdes.v1_0;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.AssetType;
 import com.liferay.headless.admin.taxonomy.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -91,6 +93,22 @@ public class AssetTypeSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(AssetType assetType) {
+		if (assetType == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("required", String.valueOf(assetType.getRequired()));
+
+		map.put("subtype", String.valueOf(assetType.getSubtype()));
+
+		map.put("type", String.valueOf(assetType.getType()));
+
+		return map;
 	}
 
 	private static class AssetTypeJSONParser extends BaseJSONParser<AssetType> {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/CreatorSerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/CreatorSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.taxonomy.client.serdes.v1_0;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.Creator;
 import com.liferay.headless.admin.taxonomy.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -151,6 +153,30 @@ public class CreatorSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Creator creator) {
+		if (creator == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("additionalName", String.valueOf(creator.getAdditionalName()));
+
+		map.put("familyName", String.valueOf(creator.getFamilyName()));
+
+		map.put("givenName", String.valueOf(creator.getGivenName()));
+
+		map.put("id", String.valueOf(creator.getId()));
+
+		map.put("image", String.valueOf(creator.getImage()));
+
+		map.put("name", String.valueOf(creator.getName()));
+
+		map.put("profileURL", String.valueOf(creator.getProfileURL()));
+
+		return map;
 	}
 
 	private static class CreatorJSONParser extends BaseJSONParser<Creator> {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/KeywordSerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/KeywordSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.admin.taxonomy.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -140,6 +142,39 @@ public class KeywordSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Keyword keyword) {
+		if (keyword == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put("creator", CreatorSerDes.toJSON(keyword.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(keyword.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(keyword.getDateModified()));
+
+		map.put("id", String.valueOf(keyword.getId()));
+
+		map.put(
+			"keywordUsageCount",
+			String.valueOf(keyword.getKeywordUsageCount()));
+
+		map.put("name", String.valueOf(keyword.getName()));
+
+		map.put("siteId", String.valueOf(keyword.getSiteId()));
+
+		return map;
 	}
 
 	private static class KeywordJSONParser extends BaseJSONParser<Keyword> {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/ParentTaxonomyCategorySerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/ParentTaxonomyCategorySerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.taxonomy.client.serdes.v1_0;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.ParentTaxonomyCategory;
 import com.liferay.headless.admin.taxonomy.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -78,6 +80,22 @@ public class ParentTaxonomyCategorySerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		ParentTaxonomyCategory parentTaxonomyCategory) {
+
+		if (parentTaxonomyCategory == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("id", String.valueOf(parentTaxonomyCategory.getId()));
+
+		map.put("name", String.valueOf(parentTaxonomyCategory.getName()));
+
+		return map;
 	}
 
 	private static class ParentTaxonomyCategoryJSONParser

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/ParentTaxonomyVocabularySerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/ParentTaxonomyVocabularySerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.taxonomy.client.serdes.v1_0;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.ParentTaxonomyVocabulary;
 import com.liferay.headless.admin.taxonomy.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -80,6 +82,22 @@ public class ParentTaxonomyVocabularySerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		ParentTaxonomyVocabulary parentTaxonomyVocabulary) {
+
+		if (parentTaxonomyVocabulary == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("id", String.valueOf(parentTaxonomyVocabulary.getId()));
+
+		map.put("name", String.valueOf(parentTaxonomyVocabulary.getName()));
+
+		return map;
 	}
 
 	private static class ParentTaxonomyVocabularyJSONParser

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyCategorySerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyCategorySerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.admin.taxonomy.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -205,6 +207,56 @@ public class TaxonomyCategorySerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(TaxonomyCategory taxonomyCategory) {
+		if (taxonomyCategory == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"availableLanguages",
+			String.valueOf(taxonomyCategory.getAvailableLanguages()));
+
+		map.put("creator", CreatorSerDes.toJSON(taxonomyCategory.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(taxonomyCategory.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(taxonomyCategory.getDateModified()));
+
+		map.put(
+			"description", String.valueOf(taxonomyCategory.getDescription()));
+
+		map.put("id", String.valueOf(taxonomyCategory.getId()));
+
+		map.put("name", String.valueOf(taxonomyCategory.getName()));
+
+		map.put(
+			"numberOfTaxonomyCategories",
+			String.valueOf(taxonomyCategory.getNumberOfTaxonomyCategories()));
+
+		map.put(
+			"parentTaxonomyCategory",
+			ParentTaxonomyCategorySerDes.toJSON(
+				taxonomyCategory.getParentTaxonomyCategory()));
+
+		map.put(
+			"parentTaxonomyVocabulary",
+			ParentTaxonomyVocabularySerDes.toJSON(
+				taxonomyCategory.getParentTaxonomyVocabulary()));
+
+		map.put("viewableBy", String.valueOf(taxonomyCategory.getViewableBy()));
+
+		return map;
 	}
 
 	private static class TaxonomyCategoryJSONParser

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyVocabularySerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyVocabularySerDes.java
@@ -21,6 +21,8 @@ import com.liferay.headless.admin.taxonomy.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -231,6 +233,57 @@ public class TaxonomyVocabularySerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		TaxonomyVocabulary taxonomyVocabulary) {
+
+		if (taxonomyVocabulary == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"assetTypes", String.valueOf(taxonomyVocabulary.getAssetTypes()));
+
+		map.put(
+			"availableLanguages",
+			String.valueOf(taxonomyVocabulary.getAvailableLanguages()));
+
+		map.put(
+			"creator", CreatorSerDes.toJSON(taxonomyVocabulary.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(
+				taxonomyVocabulary.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(
+				taxonomyVocabulary.getDateModified()));
+
+		map.put(
+			"description", String.valueOf(taxonomyVocabulary.getDescription()));
+
+		map.put("id", String.valueOf(taxonomyVocabulary.getId()));
+
+		map.put("name", String.valueOf(taxonomyVocabulary.getName()));
+
+		map.put(
+			"numberOfTaxonomyCategories",
+			String.valueOf(taxonomyVocabulary.getNumberOfTaxonomyCategories()));
+
+		map.put("siteId", String.valueOf(taxonomyVocabulary.getSiteId()));
+
+		map.put(
+			"viewableBy", String.valueOf(taxonomyVocabulary.getViewableBy()));
+
+		return map;
 	}
 
 	private static class TaxonomyVocabularyJSONParser

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.admin.taxonomy.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.Keyword;
 import com.liferay.headless.admin.taxonomy.client.pagination.Page;
 import com.liferay.headless.admin.taxonomy.client.serdes.v1_0.KeywordSerDes;
@@ -1027,32 +1022,27 @@ public abstract class BaseKeywordResourceTestCase {
 		return randomKeyword();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.admin.taxonomy.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.TaxonomyCategory;
 import com.liferay.headless.admin.taxonomy.client.pagination.Page;
 import com.liferay.headless.admin.taxonomy.client.serdes.v1_0.TaxonomyCategorySerDes;
@@ -1842,32 +1837,27 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		return randomTaxonomyCategory();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.admin.taxonomy.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.TaxonomyVocabulary;
 import com.liferay.headless.admin.taxonomy.client.pagination.Page;
 import com.liferay.headless.admin.taxonomy.client.serdes.v1_0.TaxonomyVocabularySerDes;
@@ -1370,32 +1365,27 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		return randomTaxonomyVocabulary();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/ContactInformationSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/ContactInformationSerDes.java
@@ -21,6 +21,8 @@ import com.liferay.headless.admin.user.client.dto.v1_0.PostalAddress;
 import com.liferay.headless.admin.user.client.dto.v1_0.WebUrl;
 import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -239,6 +241,43 @@ public class ContactInformationSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		ContactInformation contactInformation) {
+
+		if (contactInformation == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"emailAddresses",
+			String.valueOf(contactInformation.getEmailAddresses()));
+
+		map.put("facebook", String.valueOf(contactInformation.getFacebook()));
+
+		map.put("id", String.valueOf(contactInformation.getId()));
+
+		map.put("jabber", String.valueOf(contactInformation.getJabber()));
+
+		map.put(
+			"postalAddresses",
+			String.valueOf(contactInformation.getPostalAddresses()));
+
+		map.put("skype", String.valueOf(contactInformation.getSkype()));
+
+		map.put("sms", String.valueOf(contactInformation.getSms()));
+
+		map.put(
+			"telephones", String.valueOf(contactInformation.getTelephones()));
+
+		map.put("twitter", String.valueOf(contactInformation.getTwitter()));
+
+		map.put("webUrls", String.valueOf(contactInformation.getWebUrls()));
+
+		return map;
 	}
 
 	private static class ContactInformationJSONParser

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/CreatorSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/CreatorSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.user.client.serdes.v1_0;
 import com.liferay.headless.admin.user.client.dto.v1_0.Creator;
 import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -151,6 +153,30 @@ public class CreatorSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Creator creator) {
+		if (creator == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("additionalName", String.valueOf(creator.getAdditionalName()));
+
+		map.put("familyName", String.valueOf(creator.getFamilyName()));
+
+		map.put("givenName", String.valueOf(creator.getGivenName()));
+
+		map.put("id", String.valueOf(creator.getId()));
+
+		map.put("image", String.valueOf(creator.getImage()));
+
+		map.put("name", String.valueOf(creator.getName()));
+
+		map.put("profileURL", String.valueOf(creator.getProfileURL()));
+
+		return map;
 	}
 
 	private static class CreatorJSONParser extends BaseJSONParser<Creator> {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/EmailAddressSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/EmailAddressSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.user.client.serdes.v1_0;
 import com.liferay.headless.admin.user.client.dto.v1_0.EmailAddress;
 import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -104,6 +106,24 @@ public class EmailAddressSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(EmailAddress emailAddress) {
+		if (emailAddress == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("emailAddress", String.valueOf(emailAddress.getEmailAddress()));
+
+		map.put("id", String.valueOf(emailAddress.getId()));
+
+		map.put("primary", String.valueOf(emailAddress.getPrimary()));
+
+		map.put("type", String.valueOf(emailAddress.getType()));
+
+		return map;
 	}
 
 	private static class EmailAddressJSONParser

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/HoursAvailableSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/HoursAvailableSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.user.client.serdes.v1_0;
 import com.liferay.headless.admin.user.client.dto.v1_0.HoursAvailable;
 import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -108,6 +110,24 @@ public class HoursAvailableSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(HoursAvailable hoursAvailable) {
+		if (hoursAvailable == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("closes", String.valueOf(hoursAvailable.getCloses()));
+
+		map.put("dayOfWeek", String.valueOf(hoursAvailable.getDayOfWeek()));
+
+		map.put("id", String.valueOf(hoursAvailable.getId()));
+
+		map.put("opens", String.valueOf(hoursAvailable.getOpens()));
+
+		return map;
 	}
 
 	private static class HoursAvailableJSONParser

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/LocationSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/LocationSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.user.client.serdes.v1_0;
 import com.liferay.headless.admin.user.client.dto.v1_0.Location;
 import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -91,6 +93,22 @@ public class LocationSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Location location) {
+		if (location == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("addressCountry", String.valueOf(location.getAddressCountry()));
+
+		map.put("addressRegion", String.valueOf(location.getAddressRegion()));
+
+		map.put("id", String.valueOf(location.getId()));
+
+		return map;
 	}
 
 	private static class LocationJSONParser extends BaseJSONParser<Location> {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/OrganizationBriefSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/OrganizationBriefSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.user.client.serdes.v1_0;
 import com.liferay.headless.admin.user.client.dto.v1_0.OrganizationBrief;
 import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -78,6 +80,22 @@ public class OrganizationBriefSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		OrganizationBrief organizationBrief) {
+
+		if (organizationBrief == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("id", String.valueOf(organizationBrief.getId()));
+
+		map.put("name", String.valueOf(organizationBrief.getName()));
+
+		return map;
 	}
 
 	private static class OrganizationBriefJSONParser

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/OrganizationSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/OrganizationSerDes.java
@@ -21,6 +21,8 @@ import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -223,6 +225,54 @@ public class OrganizationSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Organization organization) {
+		if (organization == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put("comment", String.valueOf(organization.getComment()));
+
+		map.put(
+			"contactInformation",
+			ContactInformationSerDes.toJSON(
+				organization.getContactInformation()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(organization.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(organization.getDateModified()));
+
+		map.put("id", String.valueOf(organization.getId()));
+
+		map.put("image", String.valueOf(organization.getImage()));
+
+		map.put("keywords", String.valueOf(organization.getKeywords()));
+
+		map.put("location", LocationSerDes.toJSON(organization.getLocation()));
+
+		map.put("name", String.valueOf(organization.getName()));
+
+		map.put(
+			"numberOfOrganizations",
+			String.valueOf(organization.getNumberOfOrganizations()));
+
+		map.put(
+			"parentOrganization",
+			OrganizationSerDes.toJSON(organization.getParentOrganization()));
+
+		map.put("services", String.valueOf(organization.getServices()));
+
+		return map;
 	}
 
 	private static class OrganizationJSONParser

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/PhoneSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/PhoneSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.user.client.serdes.v1_0;
 import com.liferay.headless.admin.user.client.dto.v1_0.Phone;
 import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -117,6 +119,26 @@ public class PhoneSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Phone phone) {
+		if (phone == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("extension", String.valueOf(phone.getExtension()));
+
+		map.put("id", String.valueOf(phone.getId()));
+
+		map.put("phoneNumber", String.valueOf(phone.getPhoneNumber()));
+
+		map.put("phoneType", String.valueOf(phone.getPhoneType()));
+
+		map.put("primary", String.valueOf(phone.getPrimary()));
+
+		return map;
 	}
 
 	private static class PhoneJSONParser extends BaseJSONParser<Phone> {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/PostalAddressSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/PostalAddressSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.user.client.serdes.v1_0;
 import com.liferay.headless.admin.user.client.dto.v1_0.PostalAddress;
 import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -194,6 +196,47 @@ public class PostalAddressSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(PostalAddress postalAddress) {
+		if (postalAddress == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"addressCountry",
+			String.valueOf(postalAddress.getAddressCountry()));
+
+		map.put(
+			"addressLocality",
+			String.valueOf(postalAddress.getAddressLocality()));
+
+		map.put(
+			"addressRegion", String.valueOf(postalAddress.getAddressRegion()));
+
+		map.put("addressType", String.valueOf(postalAddress.getAddressType()));
+
+		map.put("id", String.valueOf(postalAddress.getId()));
+
+		map.put("postalCode", String.valueOf(postalAddress.getPostalCode()));
+
+		map.put("primary", String.valueOf(postalAddress.getPrimary()));
+
+		map.put(
+			"streetAddressLine1",
+			String.valueOf(postalAddress.getStreetAddressLine1()));
+
+		map.put(
+			"streetAddressLine2",
+			String.valueOf(postalAddress.getStreetAddressLine2()));
+
+		map.put(
+			"streetAddressLine3",
+			String.valueOf(postalAddress.getStreetAddressLine3()));
+
+		return map;
 	}
 
 	private static class PostalAddressJSONParser

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/RoleBriefSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/RoleBriefSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.user.client.serdes.v1_0;
 import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
 import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -76,6 +78,20 @@ public class RoleBriefSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(RoleBrief roleBrief) {
+		if (roleBrief == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("id", String.valueOf(roleBrief.getId()));
+
+		map.put("name", String.valueOf(roleBrief.getName()));
+
+		return map;
 	}
 
 	private static class RoleBriefJSONParser extends BaseJSONParser<RoleBrief> {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/RoleSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/RoleSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -172,6 +174,40 @@ public class RoleSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Role role) {
+		if (role == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"availableLanguages", String.valueOf(role.getAvailableLanguages()));
+
+		map.put("creator", CreatorSerDes.toJSON(role.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(role.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(role.getDateModified()));
+
+		map.put("description", String.valueOf(role.getDescription()));
+
+		map.put("id", String.valueOf(role.getId()));
+
+		map.put("name", String.valueOf(role.getName()));
+
+		map.put("roleType", String.valueOf(role.getRoleType()));
+
+		return map;
 	}
 
 	private static class RoleJSONParser extends BaseJSONParser<Role> {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SegmentSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SegmentSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -165,6 +167,39 @@ public class SegmentSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Segment segment) {
+		if (segment == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put("active", String.valueOf(segment.getActive()));
+
+		map.put("criteria", String.valueOf(segment.getCriteria()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(segment.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(segment.getDateModified()));
+
+		map.put("id", String.valueOf(segment.getId()));
+
+		map.put("name", String.valueOf(segment.getName()));
+
+		map.put("siteId", String.valueOf(segment.getSiteId()));
+
+		map.put("source", String.valueOf(segment.getSource()));
+
+		return map;
 	}
 
 	private static class SegmentJSONParser extends BaseJSONParser<Segment> {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SegmentUserSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SegmentUserSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.user.client.serdes.v1_0;
 import com.liferay.headless.admin.user.client.dto.v1_0.SegmentUser;
 import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -93,6 +95,22 @@ public class SegmentUserSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(SegmentUser segmentUser) {
+		if (segmentUser == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("emailAddress", String.valueOf(segmentUser.getEmailAddress()));
+
+		map.put("id", String.valueOf(segmentUser.getId()));
+
+		map.put("name", String.valueOf(segmentUser.getName()));
+
+		return map;
 	}
 
 	private static class SegmentUserJSONParser

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/ServiceSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/ServiceSerDes.java
@@ -18,6 +18,8 @@ import com.liferay.headless.admin.user.client.dto.v1_0.HoursAvailable;
 import com.liferay.headless.admin.user.client.dto.v1_0.Service;
 import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -101,6 +103,22 @@ public class ServiceSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Service service) {
+		if (service == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("hoursAvailable", String.valueOf(service.getHoursAvailable()));
+
+		map.put("id", String.valueOf(service.getId()));
+
+		map.put("serviceType", String.valueOf(service.getServiceType()));
+
+		return map;
 	}
 
 	private static class ServiceJSONParser extends BaseJSONParser<Service> {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SiteBriefSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SiteBriefSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.user.client.serdes.v1_0;
 import com.liferay.headless.admin.user.client.dto.v1_0.SiteBrief;
 import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -76,6 +78,20 @@ public class SiteBriefSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(SiteBrief siteBrief) {
+		if (siteBrief == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("id", String.valueOf(siteBrief.getId()));
+
+		map.put("name", String.valueOf(siteBrief.getName()));
+
+		return map;
 	}
 
 	private static class SiteBriefJSONParser extends BaseJSONParser<SiteBrief> {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/UserAccountSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/UserAccountSerDes.java
@@ -23,6 +23,8 @@ import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -402,6 +404,78 @@ public class UserAccountSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(UserAccount userAccount) {
+		if (userAccount == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"additionalName", String.valueOf(userAccount.getAdditionalName()));
+
+		map.put(
+			"alternateName", String.valueOf(userAccount.getAlternateName()));
+
+		map.put(
+			"birthDate",
+			liferayToJSONDateFormat.format(userAccount.getBirthDate()));
+
+		map.put(
+			"contactInformation",
+			ContactInformationSerDes.toJSON(
+				userAccount.getContactInformation()));
+
+		map.put("dashboardURL", String.valueOf(userAccount.getDashboardURL()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(userAccount.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(userAccount.getDateModified()));
+
+		map.put("emailAddress", String.valueOf(userAccount.getEmailAddress()));
+
+		map.put("familyName", String.valueOf(userAccount.getFamilyName()));
+
+		map.put("givenName", String.valueOf(userAccount.getGivenName()));
+
+		map.put(
+			"honorificPrefix",
+			String.valueOf(userAccount.getHonorificPrefix()));
+
+		map.put(
+			"honorificSuffix",
+			String.valueOf(userAccount.getHonorificSuffix()));
+
+		map.put("id", String.valueOf(userAccount.getId()));
+
+		map.put("image", String.valueOf(userAccount.getImage()));
+
+		map.put("jobTitle", String.valueOf(userAccount.getJobTitle()));
+
+		map.put("keywords", String.valueOf(userAccount.getKeywords()));
+
+		map.put("name", String.valueOf(userAccount.getName()));
+
+		map.put(
+			"organizationBriefs",
+			String.valueOf(userAccount.getOrganizationBriefs()));
+
+		map.put("profileURL", String.valueOf(userAccount.getProfileURL()));
+
+		map.put("roleBriefs", String.valueOf(userAccount.getRoleBriefs()));
+
+		map.put("siteBriefs", String.valueOf(userAccount.getSiteBriefs()));
+
+		return map;
 	}
 
 	private static class UserAccountJSONParser

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/WebUrlSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/WebUrlSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.user.client.serdes.v1_0;
 import com.liferay.headless.admin.user.client.dto.v1_0.WebUrl;
 import com.liferay.headless.admin.user.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -91,6 +93,22 @@ public class WebUrlSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(WebUrl webUrl) {
+		if (webUrl == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("id", String.valueOf(webUrl.getId()));
+
+		map.put("url", String.valueOf(webUrl.getUrl()));
+
+		map.put("urlType", String.valueOf(webUrl.getUrlType()));
+
+		return map;
 	}
 
 	private static class WebUrlJSONParser extends BaseJSONParser<WebUrl> {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailAddressResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.admin.user.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.admin.user.client.dto.v1_0.EmailAddress;
 import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.serdes.v1_0.EmailAddressSerDes;
@@ -652,32 +647,27 @@ public abstract class BaseEmailAddressResourceTestCase {
 		return randomEmailAddress();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.admin.user.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
 import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.serdes.v1_0.OrganizationSerDes;
@@ -1298,32 +1293,27 @@ public abstract class BaseOrganizationResourceTestCase {
 		return randomOrganization();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.admin.user.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.admin.user.client.dto.v1_0.Phone;
 import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.serdes.v1_0.PhoneSerDes;
@@ -631,32 +626,27 @@ public abstract class BasePhoneResourceTestCase {
 		return randomPhone();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.admin.user.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.admin.user.client.dto.v1_0.PostalAddress;
 import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.serdes.v1_0.PostalAddressSerDes;
@@ -835,32 +830,27 @@ public abstract class BasePostalAddressResourceTestCase {
 		return randomPostalAddress();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.admin.user.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.admin.user.client.dto.v1_0.Role;
 import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.serdes.v1_0.RoleSerDes;
@@ -607,32 +602,27 @@ public abstract class BaseRoleResourceTestCase {
 		return randomRole();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.admin.user.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.admin.user.client.dto.v1_0.Segment;
 import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.serdes.v1_0.SegmentSerDes;
@@ -815,32 +810,27 @@ public abstract class BaseSegmentResourceTestCase {
 		return randomSegment();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.admin.user.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.admin.user.client.dto.v1_0.SegmentUser;
 import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.serdes.v1_0.SegmentUserSerDes;
@@ -504,32 +499,27 @@ public abstract class BaseSegmentUserResourceTestCase {
 		return randomSegmentUser();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.admin.user.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.serdes.v1_0.UserAccountSerDes;
@@ -1932,32 +1927,27 @@ public abstract class BaseUserAccountResourceTestCase {
 		return randomUserAccount();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.admin.user.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.admin.user.client.dto.v1_0.WebUrl;
 import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.serdes.v1_0.WebUrlSerDes;
@@ -583,32 +578,27 @@ public abstract class BaseWebUrlResourceTestCase {
 		return randomWebUrl();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/ChangeTransitionSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/ChangeTransitionSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.workflow.client.serdes.v1_0;
 import com.liferay.headless.admin.workflow.client.dto.v1_0.ChangeTransition;
 import com.liferay.headless.admin.workflow.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -67,6 +69,18 @@ public class ChangeTransitionSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(ChangeTransition changeTransition) {
+		if (changeTransition == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("transition", String.valueOf(changeTransition.getTransition()));
+
+		return map;
 	}
 
 	private static class ChangeTransitionJSONParser

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/CreatorSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/CreatorSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.workflow.client.serdes.v1_0;
 import com.liferay.headless.admin.workflow.client.dto.v1_0.Creator;
 import com.liferay.headless.admin.workflow.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -151,6 +153,30 @@ public class CreatorSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Creator creator) {
+		if (creator == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("additionalName", String.valueOf(creator.getAdditionalName()));
+
+		map.put("familyName", String.valueOf(creator.getFamilyName()));
+
+		map.put("givenName", String.valueOf(creator.getGivenName()));
+
+		map.put("id", String.valueOf(creator.getId()));
+
+		map.put("image", String.valueOf(creator.getImage()));
+
+		map.put("name", String.valueOf(creator.getName()));
+
+		map.put("profileURL", String.valueOf(creator.getProfileURL()));
+
+		return map;
 	}
 
 	private static class CreatorJSONParser extends BaseJSONParser<Creator> {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/ObjectReviewedSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/ObjectReviewedSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.admin.workflow.client.serdes.v1_0;
 import com.liferay.headless.admin.workflow.client.dto.v1_0.ObjectReviewed;
 import com.liferay.headless.admin.workflow.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -78,6 +80,21 @@ public class ObjectReviewedSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(ObjectReviewed objectReviewed) {
+		if (objectReviewed == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("id", String.valueOf(objectReviewed.getId()));
+
+		map.put(
+			"resourceType", String.valueOf(objectReviewed.getResourceType()));
+
+		return map;
 	}
 
 	private static class ObjectReviewedJSONParser

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowLogSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowLogSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.admin.workflow.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -171,6 +173,45 @@ public class WorkflowLogSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(WorkflowLog workflowLog) {
+		if (workflowLog == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"auditPerson", CreatorSerDes.toJSON(workflowLog.getAuditPerson()));
+
+		map.put("commentLog", String.valueOf(workflowLog.getCommentLog()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(workflowLog.getDateCreated()));
+
+		map.put("id", String.valueOf(workflowLog.getId()));
+
+		map.put("person", CreatorSerDes.toJSON(workflowLog.getPerson()));
+
+		map.put(
+			"previousPerson",
+			CreatorSerDes.toJSON(workflowLog.getPreviousPerson()));
+
+		map.put(
+			"previousState", String.valueOf(workflowLog.getPreviousState()));
+
+		map.put("state", String.valueOf(workflowLog.getState()));
+
+		map.put("taskId", String.valueOf(workflowLog.getTaskId()));
+
+		map.put("type", String.valueOf(workflowLog.getType()));
+
+		return map;
 	}
 
 	private static class WorkflowLogJSONParser

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTaskAssignToMeSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTaskAssignToMeSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.admin.workflow.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -90,6 +92,28 @@ public class WorkflowTaskAssignToMeSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		WorkflowTaskAssignToMe workflowTaskAssignToMe) {
+
+		if (workflowTaskAssignToMe == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put("comment", String.valueOf(workflowTaskAssignToMe.getComment()));
+
+		map.put(
+			"dueDate",
+			liferayToJSONDateFormat.format(
+				workflowTaskAssignToMe.getDueDate()));
+
+		return map;
 	}
 
 	private static class WorkflowTaskAssignToMeJSONParser

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTaskAssignToUserSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTaskAssignToUserSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.admin.workflow.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -103,6 +105,33 @@ public class WorkflowTaskAssignToUserSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		WorkflowTaskAssignToUser workflowTaskAssignToUser) {
+
+		if (workflowTaskAssignToUser == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"assigneeId",
+			String.valueOf(workflowTaskAssignToUser.getAssigneeId()));
+
+		map.put(
+			"comment", String.valueOf(workflowTaskAssignToUser.getComment()));
+
+		map.put(
+			"dueDate",
+			liferayToJSONDateFormat.format(
+				workflowTaskAssignToUser.getDueDate()));
+
+		return map;
 	}
 
 	private static class WorkflowTaskAssignToUserJSONParser

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTaskSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTaskSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.admin.workflow.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -205,6 +207,48 @@ public class WorkflowTaskSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(WorkflowTask workflowTask) {
+		if (workflowTask == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put("completed", String.valueOf(workflowTask.getCompleted()));
+
+		map.put(
+			"dateCompleted",
+			liferayToJSONDateFormat.format(workflowTask.getDateCompleted()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(workflowTask.getDateCreated()));
+
+		map.put(
+			"definitionName", String.valueOf(workflowTask.getDefinitionName()));
+
+		map.put("description", String.valueOf(workflowTask.getDescription()));
+
+		map.put(
+			"dueDate",
+			liferayToJSONDateFormat.format(workflowTask.getDueDate()));
+
+		map.put("id", String.valueOf(workflowTask.getId()));
+
+		map.put("name", String.valueOf(workflowTask.getName()));
+
+		map.put(
+			"objectReviewed",
+			ObjectReviewedSerDes.toJSON(workflowTask.getObjectReviewed()));
+
+		map.put("transitions", String.valueOf(workflowTask.getTransitions()));
+
+		return map;
 	}
 
 	private static class WorkflowTaskJSONParser

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.admin.workflow.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.admin.workflow.client.dto.v1_0.WorkflowLog;
 import com.liferay.headless.admin.workflow.client.pagination.Page;
 import com.liferay.headless.admin.workflow.client.serdes.v1_0.WorkflowLogSerDes;
@@ -771,32 +766,27 @@ public abstract class BaseWorkflowLogResourceTestCase {
 		return randomWorkflowLog();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.admin.workflow.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.admin.workflow.client.dto.v1_0.ChangeTransition;
 import com.liferay.headless.admin.workflow.client.dto.v1_0.WorkflowTask;
 import com.liferay.headless.admin.workflow.client.dto.v1_0.WorkflowTaskAssignToMe;
@@ -1227,32 +1222,27 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 		return randomWorkflowTask();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/AdaptedImageSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/AdaptedImageSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.AdaptedImage;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -115,6 +117,27 @@ public class AdaptedImageSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(AdaptedImage adaptedImage) {
+		if (adaptedImage == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("contentUrl", String.valueOf(adaptedImage.getContentUrl()));
+
+		map.put("height", String.valueOf(adaptedImage.getHeight()));
+
+		map.put(
+			"resolutionName", String.valueOf(adaptedImage.getResolutionName()));
+
+		map.put("sizeInBytes", String.valueOf(adaptedImage.getSizeInBytes()));
+
+		map.put("width", String.valueOf(adaptedImage.getWidth()));
+
+		return map;
 	}
 
 	private static class AdaptedImageJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/AggregateRatingSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/AggregateRatingSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.AggregateRating;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -96,6 +98,27 @@ public class AggregateRatingSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(AggregateRating aggregateRating) {
+		if (aggregateRating == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("bestRating", String.valueOf(aggregateRating.getBestRating()));
+
+		map.put(
+			"ratingCount", String.valueOf(aggregateRating.getRatingCount()));
+
+		map.put(
+			"ratingValue", String.valueOf(aggregateRating.getRatingValue()));
+
+		map.put(
+			"worstRating", String.valueOf(aggregateRating.getWorstRating()));
+
+		return map;
 	}
 
 	private static class AggregateRatingJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/BlogPostingImageSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/BlogPostingImageSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.BlogPostingImage;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -149,6 +151,35 @@ public class BlogPostingImageSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(BlogPostingImage blogPostingImage) {
+		if (blogPostingImage == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("contentUrl", String.valueOf(blogPostingImage.getContentUrl()));
+
+		map.put(
+			"encodingFormat",
+			String.valueOf(blogPostingImage.getEncodingFormat()));
+
+		map.put(
+			"fileExtension",
+			String.valueOf(blogPostingImage.getFileExtension()));
+
+		map.put("id", String.valueOf(blogPostingImage.getId()));
+
+		map.put(
+			"sizeInBytes", String.valueOf(blogPostingImage.getSizeInBytes()));
+
+		map.put("title", String.valueOf(blogPostingImage.getTitle()));
+
+		map.put("viewableBy", String.valueOf(blogPostingImage.getViewableBy()));
+
+		return map;
 	}
 
 	private static class BlogPostingImageJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/BlogPostingSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/BlogPostingSerDes.java
@@ -21,6 +21,8 @@ import com.liferay.headless.delivery.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -335,6 +337,76 @@ public class BlogPostingSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(BlogPosting blogPosting) {
+		if (blogPosting == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"aggregateRating",
+			AggregateRatingSerDes.toJSON(blogPosting.getAggregateRating()));
+
+		map.put(
+			"alternativeHeadline",
+			String.valueOf(blogPosting.getAlternativeHeadline()));
+
+		map.put("articleBody", String.valueOf(blogPosting.getArticleBody()));
+
+		map.put("creator", CreatorSerDes.toJSON(blogPosting.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(blogPosting.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(blogPosting.getDateModified()));
+
+		map.put(
+			"datePublished",
+			liferayToJSONDateFormat.format(blogPosting.getDatePublished()));
+
+		map.put("description", String.valueOf(blogPosting.getDescription()));
+
+		map.put(
+			"encodingFormat", String.valueOf(blogPosting.getEncodingFormat()));
+
+		map.put(
+			"friendlyUrlPath",
+			String.valueOf(blogPosting.getFriendlyUrlPath()));
+
+		map.put("headline", String.valueOf(blogPosting.getHeadline()));
+
+		map.put("id", String.valueOf(blogPosting.getId()));
+
+		map.put("image", ImageSerDes.toJSON(blogPosting.getImage()));
+
+		map.put("keywords", String.valueOf(blogPosting.getKeywords()));
+
+		map.put(
+			"numberOfComments",
+			String.valueOf(blogPosting.getNumberOfComments()));
+
+		map.put("siteId", String.valueOf(blogPosting.getSiteId()));
+
+		map.put(
+			"taxonomyCategories",
+			String.valueOf(blogPosting.getTaxonomyCategories()));
+
+		map.put(
+			"taxonomyCategoryIds",
+			String.valueOf(blogPosting.getTaxonomyCategoryIds()));
+
+		map.put("viewableBy", String.valueOf(blogPosting.getViewableBy()));
+
+		return map;
 	}
 
 	private static class BlogPostingJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/CommentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/CommentSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.delivery.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -129,6 +131,36 @@ public class CommentSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Comment comment) {
+		if (comment == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put("creator", CreatorSerDes.toJSON(comment.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(comment.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(comment.getDateModified()));
+
+		map.put("id", String.valueOf(comment.getId()));
+
+		map.put(
+			"numberOfComments", String.valueOf(comment.getNumberOfComments()));
+
+		map.put("text", String.valueOf(comment.getText()));
+
+		return map;
 	}
 
 	private static class CommentJSONParser extends BaseJSONParser<Comment> {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentDocumentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentDocumentSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentDocument;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -149,6 +151,36 @@ public class ContentDocumentSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(ContentDocument contentDocument) {
+		if (contentDocument == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("contentUrl", String.valueOf(contentDocument.getContentUrl()));
+
+		map.put(
+			"description", String.valueOf(contentDocument.getDescription()));
+
+		map.put(
+			"encodingFormat",
+			String.valueOf(contentDocument.getEncodingFormat()));
+
+		map.put(
+			"fileExtension",
+			String.valueOf(contentDocument.getFileExtension()));
+
+		map.put("id", String.valueOf(contentDocument.getId()));
+
+		map.put(
+			"sizeInBytes", String.valueOf(contentDocument.getSizeInBytes()));
+
+		map.put("title", String.valueOf(contentDocument.getTitle()));
+
+		return map;
 	}
 
 	private static class ContentDocumentJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentFieldSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentFieldSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentField;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -153,6 +155,30 @@ public class ContentFieldSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(ContentField contentField) {
+		if (contentField == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("dataType", String.valueOf(contentField.getDataType()));
+
+		map.put("inputControl", String.valueOf(contentField.getInputControl()));
+
+		map.put("label", String.valueOf(contentField.getLabel()));
+
+		map.put("name", String.valueOf(contentField.getName()));
+
+		map.put("nestedFields", String.valueOf(contentField.getNestedFields()));
+
+		map.put("repeatable", String.valueOf(contentField.getRepeatable()));
+
+		map.put("value", ValueSerDes.toJSON(contentField.getValue()));
+
+		return map;
 	}
 
 	private static class ContentFieldJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentSetElementSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentSetElementSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentSetElement;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -104,6 +106,27 @@ public class ContentSetElementSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		ContentSetElement contentSetElement) {
+
+		if (contentSetElement == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("content", String.valueOf(contentSetElement.getContent()));
+
+		map.put(
+			"contentType", String.valueOf(contentSetElement.getContentType()));
+
+		map.put("id", String.valueOf(contentSetElement.getId()));
+
+		map.put("title", String.valueOf(contentSetElement.getTitle()));
+
+		return map;
 	}
 
 	private static class ContentSetElementJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentStructureFieldSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentStructureFieldSerDes.java
@@ -18,6 +18,8 @@ import com.liferay.headless.delivery.client.dto.v1_0.ContentStructureField;
 import com.liferay.headless.delivery.client.dto.v1_0.Option;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -238,6 +240,57 @@ public class ContentStructureFieldSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		ContentStructureField contentStructureField) {
+
+		if (contentStructureField == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"dataType", String.valueOf(contentStructureField.getDataType()));
+
+		map.put(
+			"inputControl",
+			String.valueOf(contentStructureField.getInputControl()));
+
+		map.put("label", String.valueOf(contentStructureField.getLabel()));
+
+		map.put(
+			"localizable",
+			String.valueOf(contentStructureField.getLocalizable()));
+
+		map.put(
+			"multiple", String.valueOf(contentStructureField.getMultiple()));
+
+		map.put("name", String.valueOf(contentStructureField.getName()));
+
+		map.put(
+			"nestedContentStructureFields",
+			String.valueOf(
+				contentStructureField.getNestedContentStructureFields()));
+
+		map.put("options", String.valueOf(contentStructureField.getOptions()));
+
+		map.put(
+			"predefinedValue",
+			String.valueOf(contentStructureField.getPredefinedValue()));
+
+		map.put(
+			"repeatable",
+			String.valueOf(contentStructureField.getRepeatable()));
+
+		map.put(
+			"required", String.valueOf(contentStructureField.getRequired()));
+
+		map.put(
+			"showLabel", String.valueOf(contentStructureField.getShowLabel()));
+
+		return map;
 	}
 
 	private static class ContentStructureFieldJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentStructureSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentStructureSerDes.java
@@ -21,6 +21,8 @@ import com.liferay.headless.delivery.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -205,6 +207,46 @@ public class ContentStructureSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(ContentStructure contentStructure) {
+		if (contentStructure == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"availableLanguages",
+			String.valueOf(contentStructure.getAvailableLanguages()));
+
+		map.put(
+			"contentStructureFields",
+			String.valueOf(contentStructure.getContentStructureFields()));
+
+		map.put("creator", CreatorSerDes.toJSON(contentStructure.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(contentStructure.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(contentStructure.getDateModified()));
+
+		map.put(
+			"description", String.valueOf(contentStructure.getDescription()));
+
+		map.put("id", String.valueOf(contentStructure.getId()));
+
+		map.put("name", String.valueOf(contentStructure.getName()));
+
+		map.put("siteId", String.valueOf(contentStructure.getSiteId()));
+
+		return map;
 	}
 
 	private static class ContentStructureJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/CreatorSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/CreatorSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.Creator;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -151,6 +153,30 @@ public class CreatorSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Creator creator) {
+		if (creator == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("additionalName", String.valueOf(creator.getAdditionalName()));
+
+		map.put("familyName", String.valueOf(creator.getFamilyName()));
+
+		map.put("givenName", String.valueOf(creator.getGivenName()));
+
+		map.put("id", String.valueOf(creator.getId()));
+
+		map.put("image", String.valueOf(creator.getImage()));
+
+		map.put("name", String.valueOf(creator.getName()));
+
+		map.put("profileURL", String.valueOf(creator.getProfileURL()));
+
+		return map;
 	}
 
 	private static class CreatorJSONParser extends BaseJSONParser<Creator> {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentFolderSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentFolderSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.delivery.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -186,6 +188,47 @@ public class DocumentFolderSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(DocumentFolder documentFolder) {
+		if (documentFolder == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put("creator", CreatorSerDes.toJSON(documentFolder.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(documentFolder.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(documentFolder.getDateModified()));
+
+		map.put("description", String.valueOf(documentFolder.getDescription()));
+
+		map.put("id", String.valueOf(documentFolder.getId()));
+
+		map.put("name", String.valueOf(documentFolder.getName()));
+
+		map.put(
+			"numberOfDocumentFolders",
+			String.valueOf(documentFolder.getNumberOfDocumentFolders()));
+
+		map.put(
+			"numberOfDocuments",
+			String.valueOf(documentFolder.getNumberOfDocuments()));
+
+		map.put("siteId", String.valueOf(documentFolder.getSiteId()));
+
+		map.put("viewableBy", String.valueOf(documentFolder.getViewableBy()));
+
+		return map;
 	}
 
 	private static class DocumentFolderJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentSerDes.java
@@ -22,6 +22,8 @@ import com.liferay.headless.delivery.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -326,6 +328,67 @@ public class DocumentSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Document document) {
+		if (document == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put("adaptedImages", String.valueOf(document.getAdaptedImages()));
+
+		map.put(
+			"aggregateRating",
+			AggregateRatingSerDes.toJSON(document.getAggregateRating()));
+
+		map.put("contentUrl", String.valueOf(document.getContentUrl()));
+
+		map.put("creator", CreatorSerDes.toJSON(document.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(document.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(document.getDateModified()));
+
+		map.put("description", String.valueOf(document.getDescription()));
+
+		map.put(
+			"documentFolderId", String.valueOf(document.getDocumentFolderId()));
+
+		map.put("encodingFormat", String.valueOf(document.getEncodingFormat()));
+
+		map.put("fileExtension", String.valueOf(document.getFileExtension()));
+
+		map.put("id", String.valueOf(document.getId()));
+
+		map.put("keywords", String.valueOf(document.getKeywords()));
+
+		map.put(
+			"numberOfComments", String.valueOf(document.getNumberOfComments()));
+
+		map.put("sizeInBytes", String.valueOf(document.getSizeInBytes()));
+
+		map.put(
+			"taxonomyCategories",
+			String.valueOf(document.getTaxonomyCategories()));
+
+		map.put(
+			"taxonomyCategoryIds",
+			String.valueOf(document.getTaxonomyCategoryIds()));
+
+		map.put("title", String.valueOf(document.getTitle()));
+
+		map.put("viewableBy", String.valueOf(document.getViewableBy()));
+
+		return map;
 	}
 
 	private static class DocumentJSONParser extends BaseJSONParser<Document> {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/GeoSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/GeoSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.Geo;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -72,6 +74,20 @@ public class GeoSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Geo geo) {
+		if (geo == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("latitude", String.valueOf(geo.getLatitude()));
+
+		map.put("longitude", String.valueOf(geo.getLongitude()));
+
+		return map;
 	}
 
 	private static class GeoJSONParser extends BaseJSONParser<Geo> {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ImageSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ImageSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.Image;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -91,6 +93,22 @@ public class ImageSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Image image) {
+		if (image == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("caption", String.valueOf(image.getCaption()));
+
+		map.put("contentUrl", String.valueOf(image.getContentUrl()));
+
+		map.put("imageId", String.valueOf(image.getImageId()));
+
+		return map;
 	}
 
 	private static class ImageJSONParser extends BaseJSONParser<Image> {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/KnowledgeBaseArticleSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/KnowledgeBaseArticleSerDes.java
@@ -21,6 +21,8 @@ import com.liferay.headless.delivery.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -338,6 +340,93 @@ public class KnowledgeBaseArticleSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		KnowledgeBaseArticle knowledgeBaseArticle) {
+
+		if (knowledgeBaseArticle == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"aggregateRating",
+			AggregateRatingSerDes.toJSON(
+				knowledgeBaseArticle.getAggregateRating()));
+
+		map.put(
+			"articleBody",
+			String.valueOf(knowledgeBaseArticle.getArticleBody()));
+
+		map.put(
+			"creator", CreatorSerDes.toJSON(knowledgeBaseArticle.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(
+				knowledgeBaseArticle.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(
+				knowledgeBaseArticle.getDateModified()));
+
+		map.put(
+			"description",
+			String.valueOf(knowledgeBaseArticle.getDescription()));
+
+		map.put(
+			"encodingFormat",
+			String.valueOf(knowledgeBaseArticle.getEncodingFormat()));
+
+		map.put(
+			"friendlyUrlPath",
+			String.valueOf(knowledgeBaseArticle.getFriendlyUrlPath()));
+
+		map.put("id", String.valueOf(knowledgeBaseArticle.getId()));
+
+		map.put("keywords", String.valueOf(knowledgeBaseArticle.getKeywords()));
+
+		map.put(
+			"numberOfAttachments",
+			String.valueOf(knowledgeBaseArticle.getNumberOfAttachments()));
+
+		map.put(
+			"numberOfKnowledgeBaseArticles",
+			String.valueOf(
+				knowledgeBaseArticle.getNumberOfKnowledgeBaseArticles()));
+
+		map.put(
+			"parentKnowledgeBaseFolder",
+			ParentKnowledgeBaseFolderSerDes.toJSON(
+				knowledgeBaseArticle.getParentKnowledgeBaseFolder()));
+
+		map.put(
+			"parentKnowledgeBaseFolderId",
+			String.valueOf(
+				knowledgeBaseArticle.getParentKnowledgeBaseFolderId()));
+
+		map.put("siteId", String.valueOf(knowledgeBaseArticle.getSiteId()));
+
+		map.put(
+			"taxonomyCategories",
+			String.valueOf(knowledgeBaseArticle.getTaxonomyCategories()));
+
+		map.put(
+			"taxonomyCategoryIds",
+			String.valueOf(knowledgeBaseArticle.getTaxonomyCategoryIds()));
+
+		map.put("title", String.valueOf(knowledgeBaseArticle.getTitle()));
+
+		map.put(
+			"viewableBy", String.valueOf(knowledgeBaseArticle.getViewableBy()));
+
+		return map;
 	}
 
 	private static class KnowledgeBaseArticleJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/KnowledgeBaseAttachmentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/KnowledgeBaseAttachmentSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.KnowledgeBaseAttachment;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -136,6 +138,38 @@ public class KnowledgeBaseAttachmentSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		KnowledgeBaseAttachment knowledgeBaseAttachment) {
+
+		if (knowledgeBaseAttachment == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"contentUrl",
+			String.valueOf(knowledgeBaseAttachment.getContentUrl()));
+
+		map.put(
+			"encodingFormat",
+			String.valueOf(knowledgeBaseAttachment.getEncodingFormat()));
+
+		map.put(
+			"fileExtension",
+			String.valueOf(knowledgeBaseAttachment.getFileExtension()));
+
+		map.put("id", String.valueOf(knowledgeBaseAttachment.getId()));
+
+		map.put(
+			"sizeInBytes",
+			String.valueOf(knowledgeBaseAttachment.getSizeInBytes()));
+
+		map.put("title", String.valueOf(knowledgeBaseAttachment.getTitle()));
+
+		return map;
 	}
 
 	private static class KnowledgeBaseAttachmentJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/KnowledgeBaseFolderSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/KnowledgeBaseFolderSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.delivery.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -204,6 +206,67 @@ public class KnowledgeBaseFolderSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		KnowledgeBaseFolder knowledgeBaseFolder) {
+
+		if (knowledgeBaseFolder == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"creator", CreatorSerDes.toJSON(knowledgeBaseFolder.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(
+				knowledgeBaseFolder.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(
+				knowledgeBaseFolder.getDateModified()));
+
+		map.put(
+			"description",
+			String.valueOf(knowledgeBaseFolder.getDescription()));
+
+		map.put("id", String.valueOf(knowledgeBaseFolder.getId()));
+
+		map.put("name", String.valueOf(knowledgeBaseFolder.getName()));
+
+		map.put(
+			"numberOfKnowledgeBaseArticles",
+			String.valueOf(
+				knowledgeBaseFolder.getNumberOfKnowledgeBaseArticles()));
+
+		map.put(
+			"numberOfKnowledgeBaseFolders",
+			String.valueOf(
+				knowledgeBaseFolder.getNumberOfKnowledgeBaseFolders()));
+
+		map.put(
+			"parentKnowledgeBaseFolder",
+			ParentKnowledgeBaseFolderSerDes.toJSON(
+				knowledgeBaseFolder.getParentKnowledgeBaseFolder()));
+
+		map.put(
+			"parentKnowledgeBaseFolderId",
+			String.valueOf(
+				knowledgeBaseFolder.getParentKnowledgeBaseFolderId()));
+
+		map.put("siteId", String.valueOf(knowledgeBaseFolder.getSiteId()));
+
+		map.put(
+			"viewableBy", String.valueOf(knowledgeBaseFolder.getViewableBy()));
+
+		return map;
 	}
 
 	private static class KnowledgeBaseFolderJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardAttachmentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardAttachmentSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.MessageBoardAttachment;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -134,6 +136,38 @@ public class MessageBoardAttachmentSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		MessageBoardAttachment messageBoardAttachment) {
+
+		if (messageBoardAttachment == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"contentUrl",
+			String.valueOf(messageBoardAttachment.getContentUrl()));
+
+		map.put(
+			"encodingFormat",
+			String.valueOf(messageBoardAttachment.getEncodingFormat()));
+
+		map.put(
+			"fileExtension",
+			String.valueOf(messageBoardAttachment.getFileExtension()));
+
+		map.put("id", String.valueOf(messageBoardAttachment.getId()));
+
+		map.put(
+			"sizeInBytes",
+			String.valueOf(messageBoardAttachment.getSizeInBytes()));
+
+		map.put("title", String.valueOf(messageBoardAttachment.getTitle()));
+
+		return map;
 	}
 
 	private static class MessageBoardAttachmentJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardMessageSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardMessageSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.delivery.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -255,6 +257,75 @@ public class MessageBoardMessageSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		MessageBoardMessage messageBoardMessage) {
+
+		if (messageBoardMessage == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"aggregateRating",
+			AggregateRatingSerDes.toJSON(
+				messageBoardMessage.getAggregateRating()));
+
+		map.put(
+			"anonymous", String.valueOf(messageBoardMessage.getAnonymous()));
+
+		map.put(
+			"articleBody",
+			String.valueOf(messageBoardMessage.getArticleBody()));
+
+		map.put(
+			"creator", CreatorSerDes.toJSON(messageBoardMessage.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(
+				messageBoardMessage.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(
+				messageBoardMessage.getDateModified()));
+
+		map.put(
+			"encodingFormat",
+			String.valueOf(messageBoardMessage.getEncodingFormat()));
+
+		map.put("headline", String.valueOf(messageBoardMessage.getHeadline()));
+
+		map.put("id", String.valueOf(messageBoardMessage.getId()));
+
+		map.put("keywords", String.valueOf(messageBoardMessage.getKeywords()));
+
+		map.put(
+			"numberOfMessageBoardAttachments",
+			String.valueOf(
+				messageBoardMessage.getNumberOfMessageBoardAttachments()));
+
+		map.put(
+			"numberOfMessageBoardMessages",
+			String.valueOf(
+				messageBoardMessage.getNumberOfMessageBoardMessages()));
+
+		map.put(
+			"showAsAnswer",
+			String.valueOf(messageBoardMessage.getShowAsAnswer()));
+
+		map.put("siteId", String.valueOf(messageBoardMessage.getSiteId()));
+
+		map.put(
+			"viewableBy", String.valueOf(messageBoardMessage.getViewableBy()));
+
+		return map;
 	}
 
 	private static class MessageBoardMessageJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardSectionSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardSectionSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.delivery.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -186,6 +188,57 @@ public class MessageBoardSectionSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		MessageBoardSection messageBoardSection) {
+
+		if (messageBoardSection == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"creator", CreatorSerDes.toJSON(messageBoardSection.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(
+				messageBoardSection.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(
+				messageBoardSection.getDateModified()));
+
+		map.put(
+			"description",
+			String.valueOf(messageBoardSection.getDescription()));
+
+		map.put("id", String.valueOf(messageBoardSection.getId()));
+
+		map.put(
+			"numberOfMessageBoardSections",
+			String.valueOf(
+				messageBoardSection.getNumberOfMessageBoardSections()));
+
+		map.put(
+			"numberOfMessageBoardThreads",
+			String.valueOf(
+				messageBoardSection.getNumberOfMessageBoardThreads()));
+
+		map.put("siteId", String.valueOf(messageBoardSection.getSiteId()));
+
+		map.put("title", String.valueOf(messageBoardSection.getTitle()));
+
+		map.put(
+			"viewableBy", String.valueOf(messageBoardSection.getViewableBy()));
+
+		return map;
 	}
 
 	private static class MessageBoardSectionJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardThreadSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardThreadSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.delivery.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -259,6 +261,74 @@ public class MessageBoardThreadSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		MessageBoardThread messageBoardThread) {
+
+		if (messageBoardThread == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"aggregateRating",
+			AggregateRatingSerDes.toJSON(
+				messageBoardThread.getAggregateRating()));
+
+		map.put(
+			"articleBody", String.valueOf(messageBoardThread.getArticleBody()));
+
+		map.put(
+			"creator", CreatorSerDes.toJSON(messageBoardThread.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(
+				messageBoardThread.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(
+				messageBoardThread.getDateModified()));
+
+		map.put(
+			"encodingFormat",
+			String.valueOf(messageBoardThread.getEncodingFormat()));
+
+		map.put("headline", String.valueOf(messageBoardThread.getHeadline()));
+
+		map.put("id", String.valueOf(messageBoardThread.getId()));
+
+		map.put("keywords", String.valueOf(messageBoardThread.getKeywords()));
+
+		map.put(
+			"numberOfMessageBoardAttachments",
+			String.valueOf(
+				messageBoardThread.getNumberOfMessageBoardAttachments()));
+
+		map.put(
+			"numberOfMessageBoardMessages",
+			String.valueOf(
+				messageBoardThread.getNumberOfMessageBoardMessages()));
+
+		map.put(
+			"showAsQuestion",
+			String.valueOf(messageBoardThread.getShowAsQuestion()));
+
+		map.put("siteId", String.valueOf(messageBoardThread.getSiteId()));
+
+		map.put(
+			"threadType", String.valueOf(messageBoardThread.getThreadType()));
+
+		map.put(
+			"viewableBy", String.valueOf(messageBoardThread.getViewableBy()));
+
+		return map;
 	}
 
 	private static class MessageBoardThreadJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/OptionSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/OptionSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.Option;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -80,6 +82,20 @@ public class OptionSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Option option) {
+		if (option == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("label", String.valueOf(option.getLabel()));
+
+		map.put("value", String.valueOf(option.getValue()));
+
+		return map;
 	}
 
 	private static class OptionJSONParser extends BaseJSONParser<Option> {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ParentKnowledgeBaseFolderSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ParentKnowledgeBaseFolderSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.ParentKnowledgeBaseFolder;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -82,6 +84,26 @@ public class ParentKnowledgeBaseFolderSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		ParentKnowledgeBaseFolder parentKnowledgeBaseFolder) {
+
+		if (parentKnowledgeBaseFolder == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"folderId",
+			String.valueOf(parentKnowledgeBaseFolder.getFolderId()));
+
+		map.put(
+			"folderName",
+			String.valueOf(parentKnowledgeBaseFolder.getFolderName()));
+
+		return map;
 	}
 
 	private static class ParentKnowledgeBaseFolderJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/RatingSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/RatingSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.delivery.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -135,6 +137,37 @@ public class RatingSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Rating rating) {
+		if (rating == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put("bestRating", String.valueOf(rating.getBestRating()));
+
+		map.put("creator", CreatorSerDes.toJSON(rating.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(rating.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(rating.getDateModified()));
+
+		map.put("id", String.valueOf(rating.getId()));
+
+		map.put("ratingValue", String.valueOf(rating.getRatingValue()));
+
+		map.put("worstRating", String.valueOf(rating.getWorstRating()));
+
+		return map;
 	}
 
 	private static class RatingJSONParser extends BaseJSONParser<Rating> {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/RenderedContentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/RenderedContentSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.RenderedContent;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -82,6 +84,23 @@ public class RenderedContentSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(RenderedContent renderedContent) {
+		if (renderedContent == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"renderedContentURL",
+			String.valueOf(renderedContent.getRenderedContentURL()));
+
+		map.put(
+			"templateName", String.valueOf(renderedContent.getTemplateName()));
+
+		return map;
 	}
 
 	private static class RenderedContentJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/StructuredContentFolderSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/StructuredContentFolderSerDes.java
@@ -20,6 +20,8 @@ import com.liferay.headless.delivery.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -191,6 +193,59 @@ public class StructuredContentFolderSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		StructuredContentFolder structuredContentFolder) {
+
+		if (structuredContentFolder == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"creator",
+			CreatorSerDes.toJSON(structuredContentFolder.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(
+				structuredContentFolder.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(
+				structuredContentFolder.getDateModified()));
+
+		map.put(
+			"description",
+			String.valueOf(structuredContentFolder.getDescription()));
+
+		map.put("id", String.valueOf(structuredContentFolder.getId()));
+
+		map.put("name", String.valueOf(structuredContentFolder.getName()));
+
+		map.put(
+			"numberOfStructuredContentFolders",
+			String.valueOf(
+				structuredContentFolder.getNumberOfStructuredContentFolders()));
+
+		map.put(
+			"numberOfStructuredContents",
+			String.valueOf(
+				structuredContentFolder.getNumberOfStructuredContents()));
+
+		map.put("siteId", String.valueOf(structuredContentFolder.getSiteId()));
+
+		map.put(
+			"viewableBy",
+			String.valueOf(structuredContentFolder.getViewableBy()));
+
+		return map;
 	}
 
 	private static class StructuredContentFolderJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/StructuredContentLinkSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/StructuredContentLinkSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.StructuredContentLink;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -78,6 +80,22 @@ public class StructuredContentLinkSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		StructuredContentLink structuredContentLink) {
+
+		if (structuredContentLink == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("id", String.valueOf(structuredContentLink.getId()));
+
+		map.put("title", String.valueOf(structuredContentLink.getTitle()));
+
+		return map;
 	}
 
 	private static class StructuredContentLinkJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/StructuredContentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/StructuredContentSerDes.java
@@ -23,6 +23,8 @@ import com.liferay.headless.delivery.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -415,6 +417,93 @@ public class StructuredContentSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(
+		StructuredContent structuredContent) {
+
+		if (structuredContent == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"aggregateRating",
+			AggregateRatingSerDes.toJSON(
+				structuredContent.getAggregateRating()));
+
+		map.put(
+			"availableLanguages",
+			String.valueOf(structuredContent.getAvailableLanguages()));
+
+		map.put(
+			"contentFields",
+			String.valueOf(structuredContent.getContentFields()));
+
+		map.put(
+			"contentStructureId",
+			String.valueOf(structuredContent.getContentStructureId()));
+
+		map.put(
+			"creator", CreatorSerDes.toJSON(structuredContent.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(structuredContent.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(
+				structuredContent.getDateModified()));
+
+		map.put(
+			"datePublished",
+			liferayToJSONDateFormat.format(
+				structuredContent.getDatePublished()));
+
+		map.put(
+			"description", String.valueOf(structuredContent.getDescription()));
+
+		map.put(
+			"friendlyUrlPath",
+			String.valueOf(structuredContent.getFriendlyUrlPath()));
+
+		map.put("id", String.valueOf(structuredContent.getId()));
+
+		map.put("key", String.valueOf(structuredContent.getKey()));
+
+		map.put("keywords", String.valueOf(structuredContent.getKeywords()));
+
+		map.put(
+			"numberOfComments",
+			String.valueOf(structuredContent.getNumberOfComments()));
+
+		map.put(
+			"renderedContents",
+			String.valueOf(structuredContent.getRenderedContents()));
+
+		map.put("siteId", String.valueOf(structuredContent.getSiteId()));
+
+		map.put(
+			"taxonomyCategories",
+			String.valueOf(structuredContent.getTaxonomyCategories()));
+
+		map.put(
+			"taxonomyCategoryIds",
+			String.valueOf(structuredContent.getTaxonomyCategoryIds()));
+
+		map.put("title", String.valueOf(structuredContent.getTitle()));
+
+		map.put("uuid", String.valueOf(structuredContent.getUuid()));
+
+		map.put(
+			"viewableBy", String.valueOf(structuredContent.getViewableBy()));
+
+		return map;
 	}
 
 	private static class StructuredContentJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/TaxonomyCategorySerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/TaxonomyCategorySerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.TaxonomyCategory;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -78,6 +80,24 @@ public class TaxonomyCategorySerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(TaxonomyCategory taxonomyCategory) {
+		if (taxonomyCategory == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"taxonomyCategoryId",
+			String.valueOf(taxonomyCategory.getTaxonomyCategoryId()));
+
+		map.put(
+			"taxonomyCategoryName",
+			String.valueOf(taxonomyCategory.getTaxonomyCategoryName()));
+
+		return map;
 	}
 
 	private static class TaxonomyCategoryJSONParser

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ValueSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ValueSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.delivery.client.serdes.v1_0;
 import com.liferay.headless.delivery.client.dto.v1_0.Value;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -103,6 +105,31 @@ public class ValueSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Value value) {
+		if (value == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("data", String.valueOf(value.getData()));
+
+		map.put("document", ContentDocumentSerDes.toJSON(value.getDocument()));
+
+		map.put("geo", GeoSerDes.toJSON(value.getGeo()));
+
+		map.put("image", ContentDocumentSerDes.toJSON(value.getImage()));
+
+		map.put("link", String.valueOf(value.getLink()));
+
+		map.put(
+			"structuredContentLink",
+			StructuredContentLinkSerDes.toJSON(
+				value.getStructuredContentLink()));
+
+		return map;
 	}
 
 	private static class ValueJSONParser extends BaseJSONParser<Value> {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.BlogPostingImage;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.serdes.v1_0.BlogPostingImageSerDes;
@@ -603,8 +598,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.addPart(
-			"blogPostingImage",
-			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+			"blogPostingImage", mapToJSON(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -1020,32 +1014,27 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 			"This method needs to be implemented");
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.BlogPosting;
 import com.liferay.headless.delivery.client.dto.v1_0.Rating;
 import com.liferay.headless.delivery.client.pagination.Page;
@@ -1737,32 +1732,27 @@ public abstract class BaseBlogPostingResourceTestCase {
 		return randomBlogPosting();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.Comment;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.serdes.v1_0.CommentSerDes;
@@ -2206,32 +2201,27 @@ public abstract class BaseCommentResourceTestCase {
 		return randomComment();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.ContentSetElement;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.serdes.v1_0.ContentSetElementSerDes;
@@ -945,32 +940,27 @@ public abstract class BaseContentSetElementResourceTestCase {
 		return randomContentSetElement();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.ContentStructure;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.serdes.v1_0.ContentStructureSerDes;
@@ -970,32 +965,27 @@ public abstract class BaseContentStructureResourceTestCase {
 		return randomContentStructure();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.DocumentFolder;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.serdes.v1_0.DocumentFolderSerDes;
@@ -1724,32 +1719,27 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		return randomDocumentFolder();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.Document;
 import com.liferay.headless.delivery.client.dto.v1_0.Rating;
 import com.liferay.headless.delivery.client.pagination.Page;
@@ -461,9 +456,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 		Http.Options options = _createHttpOptions();
 
-		options.addPart(
-			"document",
-			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+		options.addPart("document", mapToJSON(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -641,9 +634,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 		Http.Options options = _createHttpOptions();
 
-		options.addPart(
-			"document",
-			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+		options.addPart("document", mapToJSON(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -711,9 +702,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 		Http.Options options = _createHttpOptions();
 
-		options.addPart(
-			"document",
-			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+		options.addPart("document", mapToJSON(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -1298,9 +1287,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 		Http.Options options = _createHttpOptions();
 
-		options.addPart(
-			"document",
-			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+		options.addPart("document", mapToJSON(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -2017,32 +2004,27 @@ public abstract class BaseDocumentResourceTestCase {
 			"This method needs to be implemented");
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.KnowledgeBaseArticle;
 import com.liferay.headless.delivery.client.dto.v1_0.Rating;
 import com.liferay.headless.delivery.client.pagination.Page;
@@ -2807,32 +2802,27 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		return randomKnowledgeBaseArticle();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.KnowledgeBaseAttachment;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.serdes.v1_0.KnowledgeBaseAttachmentSerDes;
@@ -249,8 +244,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.addPart(
-			"knowledgeBaseAttachment",
-			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+			"knowledgeBaseAttachment", mapToJSON(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -809,32 +803,27 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 			"This method needs to be implemented");
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.KnowledgeBaseFolder;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.serdes.v1_0.KnowledgeBaseFolderSerDes;
@@ -1508,32 +1503,27 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		return randomKnowledgeBaseFolder();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.MessageBoardAttachment;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.serdes.v1_0.MessageBoardAttachmentSerDes;
@@ -388,8 +383,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.addPart(
-			"messageBoardAttachment",
-			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+			"messageBoardAttachment", mapToJSON(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -589,8 +583,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.addPart(
-			"messageBoardAttachment",
-			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+			"messageBoardAttachment", mapToJSON(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -1001,32 +994,27 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 			"This method needs to be implemented");
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.MessageBoardMessage;
 import com.liferay.headless.delivery.client.dto.v1_0.Rating;
 import com.liferay.headless.delivery.client.pagination.Page;
@@ -2227,32 +2222,27 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		return randomMessageBoardMessage();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.MessageBoardSection;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.serdes.v1_0.MessageBoardSectionSerDes;
@@ -1817,32 +1812,27 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		return randomMessageBoardSection();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.MessageBoardThread;
 import com.liferay.headless.delivery.client.dto.v1_0.Rating;
 import com.liferay.headless.delivery.client.pagination.Page;
@@ -2188,32 +2183,27 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		return randomMessageBoardThread();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.StructuredContentFolder;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.serdes.v1_0.StructuredContentFolderSerDes;
@@ -1885,32 +1880,27 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		return randomStructuredContentFolder();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.delivery.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.delivery.client.dto.v1_0.Rating;
 import com.liferay.headless.delivery.client.dto.v1_0.StructuredContent;
 import com.liferay.headless.delivery.client.pagination.Page;
@@ -2906,32 +2901,27 @@ public abstract class BaseStructuredContentResourceTestCase {
 		return randomStructuredContent();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
@@ -16,6 +16,7 @@ package com.liferay.headless.delivery.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.delivery.client.dto.v1_0.BlogPostingImage;
+import com.liferay.headless.delivery.client.serdes.v1_0.BlogPostingImageSerDes;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -70,8 +71,8 @@ public class BlogPostingImageResourceTest
 				new ByteArrayInputStream(randomString.getBytes()), 0));
 
 		return MultipartBody.of(
-			binaryFileMap, __ -> inputObjectMapper,
-			inputObjectMapper.convertValue(blogPostingImage, HashMap.class));
+			binaryFileMap, __ -> null,
+			BlogPostingImageSerDes.toMap(blogPostingImage));
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -17,6 +17,7 @@ package com.liferay.headless.delivery.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.headless.delivery.client.dto.v1_0.Document;
+import com.liferay.headless.delivery.client.serdes.v1_0.DocumentSerDes;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
@@ -90,8 +91,7 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 				new ByteArrayInputStream(randomString.getBytes()), 0));
 
 		return MultipartBody.of(
-			binaryFileMap, __ -> inputObjectMapper,
-			inputObjectMapper.convertValue(document, HashMap.class));
+			binaryFileMap, __ -> null, DocumentSerDes.toMap(document));
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/KnowledgeBaseAttachmentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/KnowledgeBaseAttachmentResourceTest.java
@@ -16,6 +16,7 @@ package com.liferay.headless.delivery.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.delivery.client.dto.v1_0.KnowledgeBaseAttachment;
+import com.liferay.headless.delivery.client.serdes.v1_0.KnowledgeBaseAttachmentSerDes;
 import com.liferay.knowledge.base.model.KBArticle;
 import com.liferay.knowledge.base.model.KBFolder;
 import com.liferay.knowledge.base.service.KBArticleLocalServiceUtil;
@@ -107,9 +108,8 @@ public class KnowledgeBaseAttachmentResourceTest
 				new ByteArrayInputStream(randomString.getBytes()), 0));
 
 		return MultipartBody.of(
-			binaryFileMap, __ -> inputObjectMapper,
-			inputObjectMapper.convertValue(
-				knowledgeBaseAttachment, HashMap.class));
+			binaryFileMap, __ -> null,
+			KnowledgeBaseAttachmentSerDes.toMap(knowledgeBaseAttachment));
 	}
 
 	private KBArticle _kbArticle;

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardAttachmentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardAttachmentResourceTest.java
@@ -16,6 +16,7 @@ package com.liferay.headless.delivery.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.delivery.client.dto.v1_0.MessageBoardAttachment;
+import com.liferay.headless.delivery.client.serdes.v1_0.MessageBoardAttachmentSerDes;
 import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.model.MBThread;
 import com.liferay.message.boards.test.util.MBTestUtil;
@@ -113,9 +114,8 @@ public class MessageBoardAttachmentResourceTest
 				new ByteArrayInputStream(randomString.getBytes()), 0));
 
 		return MultipartBody.of(
-			binaryFileMap, __ -> inputObjectMapper,
-			inputObjectMapper.convertValue(
-				messageBoardAttachment, HashMap.class));
+			binaryFileMap, __ -> null,
+			MessageBoardAttachmentSerDes.toMap(messageBoardAttachment));
 	}
 
 	private MBThread _mbThread;

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/ColumnSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/ColumnSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.form.client.serdes.v1_0;
 import com.liferay.headless.form.client.dto.v1_0.Column;
 import com.liferay.headless.form.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -91,6 +93,22 @@ public class ColumnSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Column column) {
+		if (column == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("id", String.valueOf(column.getId()));
+
+		map.put("label", String.valueOf(column.getLabel()));
+
+		map.put("value", String.valueOf(column.getValue()));
+
+		return map;
 	}
 
 	private static class ColumnJSONParser extends BaseJSONParser<Column> {

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/CreatorSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/CreatorSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.form.client.serdes.v1_0;
 import com.liferay.headless.form.client.dto.v1_0.Creator;
 import com.liferay.headless.form.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -151,6 +153,30 @@ public class CreatorSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Creator creator) {
+		if (creator == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("additionalName", String.valueOf(creator.getAdditionalName()));
+
+		map.put("familyName", String.valueOf(creator.getFamilyName()));
+
+		map.put("givenName", String.valueOf(creator.getGivenName()));
+
+		map.put("id", String.valueOf(creator.getId()));
+
+		map.put("image", String.valueOf(creator.getImage()));
+
+		map.put("name", String.valueOf(creator.getName()));
+
+		map.put("profileURL", String.valueOf(creator.getProfileURL()));
+
+		return map;
 	}
 
 	private static class CreatorJSONParser extends BaseJSONParser<Creator> {

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FieldSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FieldSerDes.java
@@ -18,6 +18,8 @@ import com.liferay.headless.form.client.dto.v1_0.Field;
 import com.liferay.headless.form.client.dto.v1_0.Option;
 import com.liferay.headless.form.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -381,6 +383,68 @@ public class FieldSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Field field) {
+		if (field == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("autocomplete", String.valueOf(field.getAutocomplete()));
+
+		map.put("dataSourceType", String.valueOf(field.getDataSourceType()));
+
+		map.put("dataType", String.valueOf(field.getDataType()));
+
+		map.put("displayStyle", String.valueOf(field.getDisplayStyle()));
+
+		map.put("grid", GridSerDes.toJSON(field.getGrid()));
+
+		map.put("hasFormRules", String.valueOf(field.getHasFormRules()));
+
+		map.put("id", String.valueOf(field.getId()));
+
+		map.put("immutable", String.valueOf(field.getImmutable()));
+
+		map.put("inline", String.valueOf(field.getInline()));
+
+		map.put("inputControl", String.valueOf(field.getInputControl()));
+
+		map.put("label", String.valueOf(field.getLabel()));
+
+		map.put("localizable", String.valueOf(field.getLocalizable()));
+
+		map.put("multiple", String.valueOf(field.getMultiple()));
+
+		map.put("name", String.valueOf(field.getName()));
+
+		map.put("options", String.valueOf(field.getOptions()));
+
+		map.put("placeholder", String.valueOf(field.getPlaceholder()));
+
+		map.put("predefinedValue", String.valueOf(field.getPredefinedValue()));
+
+		map.put("readOnly", String.valueOf(field.getReadOnly()));
+
+		map.put("repeatable", String.valueOf(field.getRepeatable()));
+
+		map.put("required", String.valueOf(field.getRequired()));
+
+		map.put("showAsSwitcher", String.valueOf(field.getShowAsSwitcher()));
+
+		map.put("showLabel", String.valueOf(field.getShowLabel()));
+
+		map.put("style", String.valueOf(field.getStyle()));
+
+		map.put("text", String.valueOf(field.getText()));
+
+		map.put("tooltip", String.valueOf(field.getTooltip()));
+
+		map.put("validation", ValidationSerDes.toJSON(field.getValidation()));
+
+		return map;
 	}
 
 	private static class FieldJSONParser extends BaseJSONParser<Field> {

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FieldValueSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FieldValueSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.form.client.serdes.v1_0;
 import com.liferay.headless.form.client.dto.v1_0.FieldValue;
 import com.liferay.headless.form.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -107,6 +109,27 @@ public class FieldValueSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(FieldValue fieldValue) {
+		if (fieldValue == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put(
+			"document", FormDocumentSerDes.toJSON(fieldValue.getDocument()));
+
+		map.put("documentId", String.valueOf(fieldValue.getDocumentId()));
+
+		map.put("id", String.valueOf(fieldValue.getId()));
+
+		map.put("name", String.valueOf(fieldValue.getName()));
+
+		map.put("value", String.valueOf(fieldValue.getValue()));
+
+		return map;
 	}
 
 	private static class FieldValueJSONParser

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormDocumentSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormDocumentSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.form.client.serdes.v1_0;
 import com.liferay.headless.form.client.dto.v1_0.FormDocument;
 import com.liferay.headless.form.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -134,6 +136,30 @@ public class FormDocumentSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(FormDocument formDocument) {
+		if (formDocument == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("contentUrl", String.valueOf(formDocument.getContentUrl()));
+
+		map.put(
+			"encodingFormat", String.valueOf(formDocument.getEncodingFormat()));
+
+		map.put(
+			"fileExtension", String.valueOf(formDocument.getFileExtension()));
+
+		map.put("id", String.valueOf(formDocument.getId()));
+
+		map.put("sizeInBytes", String.valueOf(formDocument.getSizeInBytes()));
+
+		map.put("title", String.valueOf(formDocument.getTitle()));
+
+		return map;
 	}
 
 	private static class FormDocumentJSONParser

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormPageSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormPageSerDes.java
@@ -18,6 +18,8 @@ import com.liferay.headless.form.client.dto.v1_0.Field;
 import com.liferay.headless.form.client.dto.v1_0.FormPage;
 import com.liferay.headless.form.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -114,6 +116,24 @@ public class FormPageSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(FormPage formPage) {
+		if (formPage == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("fields", String.valueOf(formPage.getFields()));
+
+		map.put("headline", String.valueOf(formPage.getHeadline()));
+
+		map.put("id", String.valueOf(formPage.getId()));
+
+		map.put("text", String.valueOf(formPage.getText()));
+
+		return map;
 	}
 
 	private static class FormPageJSONParser extends BaseJSONParser<FormPage> {

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormRecordFormSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormRecordFormSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.form.client.serdes.v1_0;
 import com.liferay.headless.form.client.dto.v1_0.FormRecordForm;
 import com.liferay.headless.form.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -78,6 +80,20 @@ public class FormRecordFormSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(FormRecordForm formRecordForm) {
+		if (formRecordForm == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("draft", String.valueOf(formRecordForm.getDraft()));
+
+		map.put("fieldValues", String.valueOf(formRecordForm.getFieldValues()));
+
+		return map;
 	}
 
 	private static class FormRecordFormJSONParser

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormRecordSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormRecordSerDes.java
@@ -21,6 +21,8 @@ import com.liferay.headless.form.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -171,6 +173,43 @@ public class FormRecordSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(FormRecord formRecord) {
+		if (formRecord == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put("creator", CreatorSerDes.toJSON(formRecord.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(formRecord.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(formRecord.getDateModified()));
+
+		map.put(
+			"datePublished",
+			liferayToJSONDateFormat.format(formRecord.getDatePublished()));
+
+		map.put("draft", String.valueOf(formRecord.getDraft()));
+
+		map.put("fieldValues", String.valueOf(formRecord.getFieldValues()));
+
+		map.put("form", FormSerDes.toJSON(formRecord.getForm()));
+
+		map.put("formId", String.valueOf(formRecord.getFormId()));
+
+		map.put("id", String.valueOf(formRecord.getId()));
+
+		return map;
 	}
 
 	private static class FormRecordJSONParser

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormSerDes.java
@@ -21,6 +21,8 @@ import com.liferay.headless.form.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -258,6 +260,54 @@ public class FormSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Form form) {
+		if (form == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"availableLanguages", String.valueOf(form.getAvailableLanguages()));
+
+		map.put("creator", CreatorSerDes.toJSON(form.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(form.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(form.getDateModified()));
+
+		map.put(
+			"datePublished",
+			liferayToJSONDateFormat.format(form.getDatePublished()));
+
+		map.put("defaultLanguage", String.valueOf(form.getDefaultLanguage()));
+
+		map.put("description", String.valueOf(form.getDescription()));
+
+		map.put("formRecords", String.valueOf(form.getFormRecords()));
+
+		map.put("formRecordsIds", String.valueOf(form.getFormRecordsIds()));
+
+		map.put("id", String.valueOf(form.getId()));
+
+		map.put("name", String.valueOf(form.getName()));
+
+		map.put("siteId", String.valueOf(form.getSiteId()));
+
+		map.put("structure", FormStructureSerDes.toJSON(form.getStructure()));
+
+		map.put("structureId", String.valueOf(form.getStructureId()));
+
+		return map;
 	}
 
 	private static class FormJSONParser extends BaseJSONParser<Form> {

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormStructureSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormStructureSerDes.java
@@ -21,6 +21,8 @@ import com.liferay.headless.form.client.json.BaseJSONParser;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -205,6 +207,47 @@ public class FormStructureSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(FormStructure formStructure) {
+		if (formStructure == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		map.put(
+			"availableLanguages",
+			String.valueOf(formStructure.getAvailableLanguages()));
+
+		map.put("creator", CreatorSerDes.toJSON(formStructure.getCreator()));
+
+		map.put(
+			"dateCreated",
+			liferayToJSONDateFormat.format(formStructure.getDateCreated()));
+
+		map.put(
+			"dateModified",
+			liferayToJSONDateFormat.format(formStructure.getDateModified()));
+
+		map.put("description", String.valueOf(formStructure.getDescription()));
+
+		map.put("formPages", String.valueOf(formStructure.getFormPages()));
+
+		map.put("id", String.valueOf(formStructure.getId()));
+
+		map.put("name", String.valueOf(formStructure.getName()));
+
+		map.put("siteId", String.valueOf(formStructure.getSiteId()));
+
+		map.put(
+			"successPage",
+			SuccessPageSerDes.toJSON(formStructure.getSuccessPage()));
+
+		return map;
 	}
 
 	private static class FormStructureJSONParser

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/GridSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/GridSerDes.java
@@ -19,6 +19,8 @@ import com.liferay.headless.form.client.dto.v1_0.Grid;
 import com.liferay.headless.form.client.dto.v1_0.Row;
 import com.liferay.headless.form.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -106,6 +108,22 @@ public class GridSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Grid grid) {
+		if (grid == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("columns", String.valueOf(grid.getColumns()));
+
+		map.put("id", String.valueOf(grid.getId()));
+
+		map.put("rows", String.valueOf(grid.getRows()));
+
+		return map;
 	}
 
 	private static class GridJSONParser extends BaseJSONParser<Grid> {

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/MediaFormSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/MediaFormSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.form.client.serdes.v1_0;
 import com.liferay.headless.form.client.dto.v1_0.MediaForm;
 import com.liferay.headless.form.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -106,6 +108,24 @@ public class MediaFormSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(MediaForm mediaForm) {
+		if (mediaForm == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("description", String.valueOf(mediaForm.getDescription()));
+
+		map.put("folderId", String.valueOf(mediaForm.getFolderId()));
+
+		map.put("name", String.valueOf(mediaForm.getName()));
+
+		map.put("title", String.valueOf(mediaForm.getTitle()));
+
+		return map;
 	}
 
 	private static class MediaFormJSONParser extends BaseJSONParser<MediaForm> {

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/OptionSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/OptionSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.form.client.serdes.v1_0;
 import com.liferay.headless.form.client.dto.v1_0.Option;
 import com.liferay.headless.form.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -91,6 +93,22 @@ public class OptionSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Option option) {
+		if (option == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("id", String.valueOf(option.getId()));
+
+		map.put("label", String.valueOf(option.getLabel()));
+
+		map.put("value", String.valueOf(option.getValue()));
+
+		return map;
 	}
 
 	private static class OptionJSONParser extends BaseJSONParser<Option> {

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/RowSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/RowSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.form.client.serdes.v1_0;
 import com.liferay.headless.form.client.dto.v1_0.Row;
 import com.liferay.headless.form.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -91,6 +93,22 @@ public class RowSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Row row) {
+		if (row == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("id", String.valueOf(row.getId()));
+
+		map.put("label", String.valueOf(row.getLabel()));
+
+		map.put("value", String.valueOf(row.getValue()));
+
+		return map;
 	}
 
 	private static class RowJSONParser extends BaseJSONParser<Row> {

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/SuccessPageSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/SuccessPageSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.form.client.serdes.v1_0;
 import com.liferay.headless.form.client.dto.v1_0.SuccessPage;
 import com.liferay.headless.form.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -93,6 +95,22 @@ public class SuccessPageSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(SuccessPage successPage) {
+		if (successPage == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("description", String.valueOf(successPage.getDescription()));
+
+		map.put("headline", String.valueOf(successPage.getHeadline()));
+
+		map.put("id", String.valueOf(successPage.getId()));
+
+		return map;
 	}
 
 	private static class SuccessPageJSONParser

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/ValidationSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/ValidationSerDes.java
@@ -17,6 +17,8 @@ package com.liferay.headless.form.client.serdes.v1_0;
 import com.liferay.headless.form.client.dto.v1_0.Validation;
 import com.liferay.headless.form.client.json.BaseJSONParser;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -91,6 +93,22 @@ public class ValidationSerDes {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	public static Map<String, String> toMap(Validation validation) {
+		if (validation == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		map.put("errorMessage", String.valueOf(validation.getErrorMessage()));
+
+		map.put("expression", String.valueOf(validation.getExpression()));
+
+		map.put("id", String.valueOf(validation.getId()));
+
+		return map;
 	}
 
 	private static class ValidationJSONParser

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.form.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.form.client.dto.v1_0.FormDocument;
 import com.liferay.headless.form.client.pagination.Page;
 import com.liferay.headless.form.resource.v1_0.FormDocumentResource;
@@ -547,32 +542,27 @@ public abstract class BaseFormDocumentResourceTestCase {
 		return randomFormDocument();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordFormResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.form.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.form.client.dto.v1_0.FormRecord;
 import com.liferay.headless.form.client.dto.v1_0.FormRecordForm;
 import com.liferay.headless.form.client.pagination.Page;
@@ -396,32 +391,27 @@ public abstract class BaseFormRecordFormResourceTestCase {
 		return randomFormRecordForm();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.form.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.form.client.dto.v1_0.FormRecord;
 import com.liferay.headless.form.client.pagination.Page;
 import com.liferay.headless.form.client.serdes.v1_0.FormRecordSerDes;
@@ -904,32 +899,27 @@ public abstract class BaseFormRecordResourceTestCase {
 		return randomFormRecord();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.form.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.form.client.dto.v1_0.Form;
 import com.liferay.headless.form.client.dto.v1_0.FormDocument;
 import com.liferay.headless.form.client.pagination.Page;
@@ -251,9 +246,7 @@ public abstract class BaseFormResourceTestCase {
 
 		Http.Options options = _createHttpOptions();
 
-		options.addPart(
-			"form",
-			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+		options.addPart("form", mapToJSON(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -993,32 +986,27 @@ public abstract class BaseFormResourceTestCase {
 		return randomForm();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
@@ -14,11 +14,6 @@
 
 package com.liferay.headless.form.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
 import com.liferay.headless.form.client.dto.v1_0.FormStructure;
 import com.liferay.headless.form.client.pagination.Page;
 import com.liferay.headless.form.client.serdes.v1_0.FormStructureSerDes;
@@ -786,32 +781,27 @@ public abstract class BaseFormStructureResourceTestCase {
 		return randomFormStructure();
 	}
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter(
-							"Liferay.Vulcan",
-							SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper =
-		new ObjectMapper() {
-			{
-				setFilterProvider(
-					new SimpleFilterProvider() {
-						{
-							addFilter(
-								"Liferay.Vulcan",
-								SimpleBeanPropertyFilter.serializeAll());
-						}
-					});
-			}
-		};
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
+		}
+
+		sb.setLength(sb.length() - 1);
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -585,6 +585,10 @@ public class ResourceOpenAPIParser {
 
 			sortedContents.putAll(response.getContent());
 
+			if (sortedContents.isEmpty()) {
+				return void.class.getName();
+			}
+
 			for (Content content : sortedContents.values()) {
 				Schema schema = content.getSchema();
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -72,7 +72,7 @@ public abstract class Base${schemaName}ResourceImpl implements ${schemaName}Reso
 				return responseBuilder.build();
 			<#elseif javaMethodSignature.returnType?contains("Page<")>
 				return Page.of(Collections.emptyList());
-			<#elseif freeMarkerTool.hasHTTPMethod(javaMethodSignature, "patch") && !javaMethodSignature.operation.requestBody.content?keys?seq_contains("multipart/form-data")>
+			<#elseif freeMarkerTool.hasHTTPMethod(javaMethodSignature, "patch") && !javaMethodSignature.operation.requestBody.content?keys?seq_contains("multipart/form-data") && !stringUtil.equals(javaMethodSignature.returnType, "void")>
 				<#assign firstJavaMethodParameter = javaMethodSignature.javaMethodParameters[0] />
 
 				${schemaName} existing${schemaName} = get${schemaName}(${firstJavaMethodParameter.parameterName});

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -897,11 +897,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 				return string;
 			<#elseif !stringUtil.equals(javaMethodSignature.returnType, "void")>
 				try {
-					<#if stringUtil.equals(javaMethodSignature.returnType, "javax.ws.rs.core.Response")>
-						return outputObjectMapper.readValue(string, ${javaMethodSignature.returnType}.class);
-					<#else>
-						return ${javaMethodSignature.returnType?replace(".dto.", ".client.serdes.")}SerDes.toDTO(string);
-					</#if>
+					return ${javaMethodSignature.returnType?replace(".dto.", ".client.serdes.")}SerDes.toDTO(string);
 				}
 				catch (Exception e) {
 					if (_log.isDebugEnabled()) {

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -839,7 +839,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 			<#if freeMarkerTool.hasHTTPMethod(javaMethodSignature, "patch", "post", "put") && invokeArguments?ends_with("${schemaVarName}")>
 				options.setBody(${schemaName}SerDes.toJSON(${schemaVarName}), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 			<#elseif freeMarkerTool.hasHTTPMethod(javaMethodSignature, "patch", "post", "put") && invokeArguments?ends_with("multipartBody")>
-				options.addPart("${schemaVarName}", inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+				options.addPart("${schemaVarName}", mapToJSON(multipartBody.getValues()));
 
 				BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -1232,27 +1232,25 @@ public abstract class Base${schemaName}ResourceTestCase {
 		}
 	</#if>
 
-	protected static final ObjectMapper inputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter("Liferay.Vulcan", SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
-			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+	private String mapToJSON(Map<String, String> map) {
+
+		if (map == null) {
+			return "null";
 		}
-	};
-	protected static final ObjectMapper outputObjectMapper = new ObjectMapper() {
-		{
-			setFilterProvider(
-				new SimpleFilterProvider() {
-					{
-						addFilter("Liferay.Vulcan", SimpleBeanPropertyFilter.serializeAll());
-					}
-				});
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			sb.append("\"" + entry.getKey() + "\": ");
+			sb.append("\"" + entry.getValue() + "\"");
 		}
-	};
+
+		sb.append("}");
+
+		return sb.toString();
+	}
 
 	protected Group irrelevantGroup;
 	protected String testContentType = "application/json";

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -891,18 +891,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 				_log.debug("HTTP response: " + string);
 			}
 
-			<#if stringUtil.equals(javaMethodSignature.returnType, "boolean")>
-				try {
-					return outputObjectMapper.readValue(string, Boolean.class);
-				}
-				catch (Exception e) {
-					if (_log.isDebugEnabled()) {
-						_log.debug("Unable to process HTTP response: " + string, e);
-					}
-
-					throw e;
-				}
-			<#elseif javaMethodSignature.returnType?contains("Page<")>
+			<#if javaMethodSignature.returnType?contains("Page<")>
 				return Page.of(string, ${schemaName}SerDes::toDTO);
 			<#elseif javaMethodSignature.returnType?ends_with("String")>
 				return string;

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -1234,7 +1234,9 @@ public abstract class Base${schemaName}ResourceTestCase {
 		for (Map.Entry<String, String> entry : map.entrySet()) {
 			sb.append("\"" + entry.getKey() + "\": ");
 			sb.append("\"" + entry.getValue() + "\"");
+			sb.append(",");
 		}
+		sb.setLength(sb.length() - 1);
 
 		sb.append("}");
 


### PR DESCRIPTION
About Response object... we don't have any APIs using it (bulk was a mistake, it doesn't return anything) in master.

The test adaptation isn't straightforward as returning Response/creating a ResponseDTO... because when the method returns Response, the APIs is going to return an underlying entity (there is no Response DTO received, just the json of the entity).

So basically the generator should check the OpenAPI schema and generate as many tests as entities returned in the response method and call their respective SerDes. I've checked some OpenAPI definitions in commerce and they return only one entity (they return response to set the status code). I'll confirm it with Marco because the implementation would be very different in the 2 cases.