### PR TITLE
LPS-84696 (CRITICAL FIX) solr7/internal/SolrIndexSearcher.java:1015: error: cannot find symbol | method getSearchRequestBuilder(SearchContext)

### DIFF
--- a/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/main/java/com/liferay/portal/search/solr7/internal/SolrIndexSearcher.java
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/main/java/com/liferay/portal/search/solr7/internal/SolrIndexSearcher.java
@@ -1012,15 +1012,13 @@ public class SolrIndexSearcher extends BaseIndexSearcher {
 	private SearchRequestBuilder _getSearchRequestBuilder(
 		SearchContext searchContext) {
 
-		return _searchRequestBuilderFactory.getSearchRequestBuilder(
-			searchContext);
+		return _searchRequestBuilderFactory.builder(searchContext);
 	}
 
 	private SearchResponseBuilder _getSearchResponseBuilder(
 		SearchContext searchContext) {
 
-		return _searchResponseBuilderFactory.getSearchResponseBuilder(
-			searchContext);
+		return _searchResponseBuilderFactory.builder(searchContext);
 	}
 
 	private static final String _VERSION_FIELD = "_version_";


### PR DESCRIPTION
Minor change to fix `modules-compile`, currently unusable in CI.

Missed the Solr module in my changes yesterday. Search CI went red, but only noticed this morning.

https://issues.liferay.com/browse/LPS-84696
