### PR TITLE
LPS-84696 (CRITICAL FIX) Undo usage of MutableRenderParameters, causing UnsupportedOperationException: Requires 3.0 opt-in

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultContentDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultContentDisplayBuilder.java
@@ -25,7 +25,6 @@ import com.liferay.portal.search.web.internal.result.display.context.SearchResul
 
 import java.util.Locale;
 
-import javax.portlet.MutableRenderParameters;
 import javax.portlet.PortletURL;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
@@ -100,10 +99,7 @@ public class SearchResultContentDisplayBuilder {
 				PortletURL redirectPortletURL =
 					_renderResponse.createRenderURL();
 
-				MutableRenderParameters mutableRenderParameters =
-					redirectPortletURL.getRenderParameters();
-
-				mutableRenderParameters.setValue(
+				redirectPortletURL.setParameter(
 					"mvcPath", "/edit_content_redirect.jsp");
 
 				PortletURL editPortletURL = assetRenderer.getURLEdit(


### PR DESCRIPTION
cc: @arboliveira

[Story] As a site visitor, I want to see Portal and non-Portal results from the same query terms
https://issues.liferay.com/browse/LPS-84696