### PR TITLE
Revert "LPS-93930 Do not inject default segment and experience un segment pre-action"

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureImpl.java
@@ -56,6 +56,7 @@ public class LayoutPageTemplateStructureImpl
 	}
 
 	private long _getFirstSegmentsExperienceId(long[] segmentsExperienceIds) {
+
 		LongStream stream = Arrays.stream(segmentsExperienceIds);
 
 		return stream.filter(

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureImpl.java
@@ -20,7 +20,6 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.segments.constants.SegmentsConstants;
 
 import java.util.Arrays;
 import java.util.stream.LongStream;
@@ -55,7 +54,8 @@ public class LayoutPageTemplateStructureImpl
 		return getData(segmentsExperienceId);
 	}
 
-	private long _getFirstSegmentsExperienceId(long[] segmentsExperienceIds) {
+	private long _getFirstSegmentsExperienceId(long[] segmentsExperienceIds)
+		throws PortalException {
 
 		LongStream stream = Arrays.stream(segmentsExperienceIds);
 
@@ -70,8 +70,10 @@ public class LayoutPageTemplateStructureImpl
 				return layoutPageTemplateStructureRel != null;
 			}
 		).findFirst(
-		).orElse(
-			SegmentsConstants.SEGMENTS_EXPERIENCE_ID_DEFAULT
+		).orElseThrow(
+			() -> new PortalException(
+				"No segment experience was found for layout page template " +
+					"structure " + getLayoutPageTemplateStructureId())
 		);
 	}
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/events/SegmentsServicePreAction.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/events/SegmentsServicePreAction.java
@@ -26,8 +26,10 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.segments.constants.SegmentsConstants;
 import com.liferay.segments.constants.SegmentsWebKeys;
 import com.liferay.segments.internal.configuration.SegmentsServiceConfiguration;
 import com.liferay.segments.internal.context.RequestContextMapper;
@@ -84,7 +86,7 @@ public class SegmentsServicePreAction extends Action {
 			return;
 		}
 
-		long[] segmentsEntryIds = new long[0];
+		long[] segmentsEntryIds = {SegmentsConstants.SEGMENTS_ENTRY_ID_DEFAULT};
 
 		Layout layout = themeDisplay.getLayout();
 
@@ -92,10 +94,12 @@ public class SegmentsServicePreAction extends Action {
 			!layout.isTypeControlPanel()) {
 
 			try {
-				segmentsEntryIds = _segmentsEntryProvider.getSegmentsEntryIds(
-					themeDisplay.getScopeGroupId(), User.class.getName(),
-					themeDisplay.getUserId(),
-					_requestContextMapper.map(request));
+				segmentsEntryIds = ArrayUtil.append(
+					_segmentsEntryProvider.getSegmentsEntryIds(
+						themeDisplay.getScopeGroupId(), User.class.getName(),
+						themeDisplay.getUserId(),
+						_requestContextMapper.map(request)),
+					segmentsEntryIds);
 			}
 			catch (PortalException pe) {
 				if (_log.isWarnEnabled()) {
@@ -125,9 +129,11 @@ public class SegmentsServicePreAction extends Action {
 
 		Stream<SegmentsExperience> stream = segmentsExperiences.stream();
 
-		return stream.mapToLong(
-			SegmentsExperienceModel::getSegmentsExperienceId
-		).toArray();
+		return ArrayUtil.append(
+			stream.mapToLong(
+				SegmentsExperienceModel::getSegmentsExperienceId
+			).toArray(),
+			new long[] {SegmentsConstants.SEGMENTS_EXPERIENCE_ID_DEFAULT});
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
@brianchandotcom @darquesdev @epgarcia
Unfortunately, [LPS-93930](https://issues.liferay.com/browse/LPS-93930) causes [LPS-94168](https://issues.liferay.com/browse/LPS-94168) where edits to the text on a page do not get applied when published. Could you guys take a look?

Verified that the bug starts occurring here: 
https://test-1-1.liferay.com/userContent/jobs/root-cause-analysis-tool/builds/389/jenkins-report.html
https://test-1-1.liferay.com/userContent/jobs/root-cause-analysis-tool/builds/390/jenkins-report.html

Verified that reverting fixes the bug here: https://test-1-1.liferay.com/userContent/jobs/root-cause-analysis-tool/builds/391/jenkins-report.html

Original pull: https://github.com/brianchandotcom/liferay-portal/pull/71656

cc @ealonso @jkappler @kyle-miho
