### PR TITLE
LPS-90632 Re-add check for resources too, not only resource

### DIFF
--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -175,6 +175,8 @@ public class FragmentsImporterTest {
 		);
 
 		Assert.assertTrue(fragmentEntryNames.contains("resource"));
+
+		Assert.assertTrue(fragmentEntryNames.contains("resources"));
 	}
 
 	@Test


### PR DESCRIPTION
Hey @brianchandotcom, we have fragments that are named resource and resources, so that's why I was checking both of them 