### PR TITLE
Revert "LPS-94229 Reads bodyCssClass from the queryString so portlets can send classes ahead of time"

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
@@ -710,7 +710,6 @@
 						requires: [
 							'aui-dialog-iframe-deprecated',
 							'aui-modal',
-							'aui-url',
 							'event-resize',
 							'liferay-widget-zindex'
 						]

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
@@ -246,14 +246,6 @@ AUI.add(
 							uri = Liferay.Util.addParams(A.guid() + '=' + Date.now(), uri);
 						}
 
-						var iframeURL = new A.Url(uri);
-
-						var namespace = iframeURL.getParameter('p_p_id');
-
-						iframeURL.addParameter('_' + namespace + '_bodyCssClass', 'dialog-iframe-popup ' + config.dialogIframe.bodyCssClass);
-
-						uri = iframeURL.toString();
-
 						var defaultDialogIframeConfig = {
 							bodyCssClass: ''
 						};
@@ -531,6 +523,6 @@ AUI.add(
 	},
 	'',
 	{
-		requires: ['aui-dialog-iframe-deprecated', 'aui-modal', 'aui-url', 'event-resize', 'liferay-widget-zindex']
+		requires: ['aui-dialog-iframe-deprecated', 'aui-modal', 'event-resize', 'liferay-widget-zindex']
 	}
 );

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss
@@ -21,7 +21,6 @@
 
 .modal-body {
 	overflow: auto;
-	padding: 0;
 
 	&.dialog-iframe-bd {
 		overflow: hidden;

--- a/portal-impl/src/com/liferay/portal/template/TemplateContextHelper.java
+++ b/portal-impl/src/com/liferay/portal/template/TemplateContextHelper.java
@@ -74,7 +74,6 @@ import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListMergeable;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.ParamUtil_IW;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
@@ -293,18 +292,7 @@ public class TemplateContextHelper {
 			Layout layout = themeDisplay.getLayout();
 			List<Layout> layouts = themeDisplay.getLayouts();
 
-			HttpServletRequest originalRequest =
-				PortalUtil.getOriginalServletRequest(request);
-
-			String namespace =
-				PortalUtil.getPortletNamespace(
-					ParamUtil.getString(request, "p_p_id"));
-
-			String bodyCssClass =
-				ParamUtil.getString(
-					originalRequest, namespace + "bodyCssClass");
-
-			contextObjects.put("bodyCssClass", bodyCssClass);
+			contextObjects.put("bodyCssClass", StringPool.BLANK);
 			contextObjects.put("colorScheme", themeDisplay.getColorScheme());
 			contextObjects.put("company", themeDisplay.getCompany());
 			contextObjects.put("layout", layout);

--- a/portal-impl/src/com/liferay/portal/template/TemplateContextHelper.java
+++ b/portal-impl/src/com/liferay/portal/template/TemplateContextHelper.java
@@ -296,14 +296,15 @@ public class TemplateContextHelper {
 			HttpServletRequest originalRequest =
 				PortalUtil.getOriginalServletRequest(request);
 
-			String namespace = PortalUtil.getPortletNamespace(
-				ParamUtil.getString(request, "p_p_id"));
+			String namespace =
+				PortalUtil.getPortletNamespace(
+					ParamUtil.getString(request, "p_p_id"));
 
-			String bodyCssClass = ParamUtil.getString(
-				originalRequest, namespace + "bodyCssClass");
+			String bodyCssClass =
+				ParamUtil.getString(
+					originalRequest, namespace + "bodyCssClass");
 
 			contextObjects.put("bodyCssClass", bodyCssClass);
-
 			contextObjects.put("colorScheme", themeDisplay.getColorScheme());
 			contextObjects.put("company", themeDisplay.getCompany());
 			contextObjects.put("layout", layout);


### PR DESCRIPTION
@jbalsas @brianchandotcom
[LPS-94229](https://issues.liferay.com/browse/LPS-94229) causes [LPS-94285](https://issues.liferay.com/browse/LPS-94285) (where many buttons are broken). Originally it also caused [LPS-94278](https://issues.liferay.com/browse/LPS-94278) but it seems LPS-94278 is fixed.

Original pull: https://github.com/brianchandotcom/liferay-portal/pull/71783

cc @ealonso