### PR TITLE
LPS-89566 Setup DNS properties for RemoteElasticsearchConnectionTest

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/view.jsp
@@ -28,7 +28,7 @@ if (ddmDisplay.getTitle(locale) != null) {
 }
 %>
 
-<c:if test="<%= ListUtil.isEmpty(ddmDisplay.getTabItems()) && ddmDisplay.isShowBackURLInTitleBar() && showBackURL%>">
+<c:if test="<%= ListUtil.isEmpty(ddmDisplay.getTabItems()) && ddmDisplay.isShowBackURLInTitleBar() && showBackURL %>">
 
 	<%
 	portletDisplay.setShowBackIcon(true);

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/RemoteElasticsearchConnectionTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/RemoteElasticsearchConnectionTest.java
@@ -18,13 +18,14 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.util.PropsTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.search.elasticsearch6.configuration.OperationMode;
 
 import java.net.InetSocketAddress;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -40,10 +41,19 @@ public class RemoteElasticsearchConnectionTest {
 
 	@Before
 	public void setUp() {
+		Map<String, Object> propertiesMap = new HashMap<String, Object>() {
+			{
+				put(
+					PropsKeys.DNS_SECURITY_ADDRESS_TIMEOUT_SECONDS,
+					String.valueOf(2));
+				put(PropsKeys.DNS_SECURITY_THREAD_LIMIT, String.valueOf(10));
+			}
+		};
+
 		_remoteElasticsearchConnection = new RemoteElasticsearchConnection();
 
 		_remoteElasticsearchConnection.props = PropsTestUtil.setProps(
-			Collections.emptyMap());
+			propertiesMap);
 	}
 
 	@Test


### PR DESCRIPTION
Yesterday at https://github.com/brianchandotcom/liferay-portal/pull/71807 I missed setting the properties for this test, sorry about it, here is the fix

cc/ @arboliveira