### PR TITLE
LPS-94263 Prevent stale update exception, copyLayout() does a fetch a…

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/DiscardDraftLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/DiscardDraftLayoutMVCActionCommand.java
@@ -23,6 +23,8 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
@@ -127,7 +129,7 @@ public class DiscardDraftLayoutMVCActionCommand extends BaseMVCActionCommand {
 				}
 			}
 
-			_layoutCopyHelper.copyLayout(layout, draftLayout);
+			draftLayout = _layoutCopyHelper.copyLayout(layout, draftLayout);
 
 			draftLayout.setModifiedDate(layout.getPublishDate());
 


### PR DESCRIPTION
…nd update so the 'draftLayout' var has the old values aand calling update with it would revert the changes from copyLayout().