### PR TITLE
OAUTH2-258 Regression: Application authorization view no longer rendering remote host info

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/application_authorizations.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/application_authorizations.jsp
@@ -101,7 +101,8 @@ OAuth2AuthorizationsManagementToolbarDisplayContext oAuth2AuthorizationsManageme
 				/>
 
 				<liferay-ui:search-container-column-text
-					property="remoteIPInfo"
+					name="remoteIPInfo"
+					value='<%= oAuth2Authorization.getRemoteIPInfo() + ", " + oAuth2Authorization.getRemoteHostInfo() %>'
 				/>
 
 				<liferay-ui:search-container-column-jsp

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view_application.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view_application.jsp
@@ -118,7 +118,7 @@ renderResponse.setTitle(oAuth2Application.getName());
 
 				<p class="authorization text-truncate">
 					<span><liferay-ui:message key="remoteIPInfo" /></span>:
-					<%= HtmlUtil.escape(oAuth2Authorization.getRemoteIPInfo()) %>
+					<%= HtmlUtil.escape(oAuth2Authorization.getRemoteIPInfo()) %>, <%= HtmlUtil.escape(oAuth2Authorization.getRemoteHostInfo()) %>
 				</p>
 
 				<p class="buttons">


### PR DESCRIPTION
Hi Brian. We forgot to update the view to concatenate the split model values back together.

/cc @csierra