### PR TITLE
LPS-89569 Ignore the UnsupportedOperationException caused by portal-c…

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/module/framework/service/IdentifiableOSGiServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/module/framework/service/IdentifiableOSGiServiceUtil.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.kernel.module.framework.service;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
 import com.liferay.registry.ServiceReference;
@@ -37,6 +39,9 @@ public class IdentifiableOSGiServiceUtil {
 	private IdentifiableOSGiServiceUtil() {
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		IdentifiableOSGiServiceUtil.class);
+
 	private static final Map<String, IdentifiableOSGiService>
 		_identifiableOSGiServices = new ConcurrentHashMap<>();
 	private static final ServiceTracker
@@ -55,9 +60,21 @@ public class IdentifiableOSGiServiceUtil {
 			IdentifiableOSGiService identifiableOSGiService =
 				registry.getService(serviceReference);
 
-			_identifiableOSGiServices.put(
-				identifiableOSGiService.getOSGiServiceIdentifier(),
-				identifiableOSGiService);
+			try {
+				_identifiableOSGiServices.put(
+					identifiableOSGiService.getOSGiServiceIdentifier(),
+					identifiableOSGiService);
+			}
+			catch (UnsupportedOperationException uoe) {
+
+				// LPS-89569
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(uoe, uoe);
+				}
+
+				return null;
+			}
 
 			return identifiableOSGiService;
 		}


### PR DESCRIPTION
…ompat fake services getting tracked before corresponding wrappers becoming available. It is safe to not track fake services cause fake services are using same identifier as real services and real services are always tracked correctly, thus when you wants to get an service by identifier, you can always get a working one.