### PR TITLE
LPS-94477 available_languages.jsp should be minified

### DIFF
--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -22,7 +22,7 @@
 		<filter-class>com.liferay.portal.servlet.filters.aggregate.AggregateFilter</filter-class>
 		<init-param>
 			<param-name>url-regex-pattern</param-name>
-			<param-value>.+/(aui_lang|barebone|css|everything|main)\.jsp</param-value>
+			<param-value>.+/(aui_lang|available_languages|barebone|css|everything|main)\.jsp</param-value>
 		</init-param>
 	</filter>
 	<filter>


### PR DESCRIPTION
In production (ie. when "javascript.fast.load" is true) this file should be served minified.

Content will be cached, dependent on locale, but the `languageId` is part of the cache key [as discussed here](https://github.com/jbalsas/liferay-portal/pull/1768), so we shouldn't have to worry about cache poisoning here.