### PR TITLE
LPS-94407 Get Document operation in Low Level Search API

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/document/DocumentFieldsTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/document/DocumentFieldsTranslator.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.document;
+
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.document.DocumentBuilder;
+import com.liferay.portal.search.geolocation.GeoBuilders;
+
+import java.util.Map;
+
+import org.elasticsearch.common.document.DocumentField;
+
+/**
+ * @author Bryan Engler
+ */
+public class DocumentFieldsTranslator {
+
+	public DocumentFieldsTranslator(GeoBuilders geoBuilders) {
+		_geoBuilders = geoBuilders;
+	}
+
+	public void populateAlternateUID(
+		Map<String, DocumentField> documentFieldsMap,
+		DocumentBuilder documentBuilder, String alternateUidFieldName) {
+
+		if (MapUtil.isEmpty(documentFieldsMap)) {
+			return;
+		}
+
+		if (documentFieldsMap.containsKey(_UID_FIELD_NAME)) {
+			return;
+		}
+
+		if (Validator.isBlank(alternateUidFieldName)) {
+			return;
+		}
+
+		DocumentField documentField = documentFieldsMap.get(
+			alternateUidFieldName);
+
+		if (documentField != null) {
+			documentBuilder.setValues(
+				_UID_FIELD_NAME, documentField.getValues());
+		}
+	}
+
+	public void translate(
+		Map<String, DocumentField> documentFieldsMap,
+		DocumentBuilder documentBuilder) {
+
+		if (MapUtil.isEmpty(documentFieldsMap)) {
+			return;
+		}
+
+		documentFieldsMap.forEach(
+			(name, documentField) -> translate(documentField, documentBuilder));
+	}
+
+	protected void translate(
+		DocumentField documentField, DocumentBuilder documentBuilder) {
+
+		String fieldName = documentField.getName();
+
+		if (fieldName.endsWith(_GEOPOINT_SUFFIX)) {
+			documentBuilder.setGeoLocationPoint(
+				fieldName,
+				_geoBuilders.geoLocationPoint(documentField.getValue()));
+		}
+		else {
+			documentBuilder.setValues(fieldName, documentField.getValues());
+		}
+	}
+
+	private static final String _GEOPOINT_SUFFIX = ".geopoint";
+
+	private static final String _UID_FIELD_NAME = "uid";
+
+	private final GeoBuilders _geoBuilders;
+
+}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/geolocation/GeoLocationPointTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/geolocation/GeoLocationPointTranslator.java
@@ -29,7 +29,7 @@ public class GeoLocationPointTranslator {
 		}
 
 		if (geoLocationPoint.getGeoHash() != null) {
-			return GeoPoint.fromGeohash(geoLocationPoint.getGeoHash());
+			return new GeoPoint(geoLocationPoint.getGeoHash());
 		}
 
 		return new GeoPoint(

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/BulkDocumentRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/BulkDocumentRequestExecutorImpl.java
@@ -119,16 +119,25 @@ public class BulkDocumentRequestExecutorImpl
 			bulkableDocumentRequest.accept(
 				request -> {
 					if (request instanceof DeleteDocumentRequest) {
-						_bulkableDocumentRequestTranslator.translate(
-							(DeleteDocumentRequest)request, bulkRequestBuilder);
+						DeleteRequestBuilder deleteRequestBuilder =
+							_bulkableDocumentRequestTranslator.translate(
+								(DeleteDocumentRequest)request);
+
+						bulkRequestBuilder.add(deleteRequestBuilder);
 					}
 					else if (request instanceof IndexDocumentRequest) {
-						_bulkableDocumentRequestTranslator.translate(
-							(IndexDocumentRequest)request, bulkRequestBuilder);
+						IndexRequestBuilder indexRequestBuilder =
+							_bulkableDocumentRequestTranslator.translate(
+								(IndexDocumentRequest)request);
+
+						bulkRequestBuilder.add(indexRequestBuilder);
 					}
 					else if (request instanceof UpdateDocumentRequest) {
-						_bulkableDocumentRequestTranslator.translate(
-							(UpdateDocumentRequest)request, bulkRequestBuilder);
+						UpdateRequestBuilder updateRequestBuilder =
+							_bulkableDocumentRequestTranslator.translate(
+								(UpdateDocumentRequest)request);
+
+						bulkRequestBuilder.add(updateRequestBuilder);
 					}
 					else {
 						throw new IllegalArgumentException(
@@ -142,9 +151,7 @@ public class BulkDocumentRequestExecutorImpl
 
 	@Reference(target = "(search.engine.impl=Elasticsearch)", unbind = "-")
 	protected void setBulkableDocumentRequestTranslator(
-		BulkableDocumentRequestTranslator
-			<DeleteRequestBuilder, IndexRequestBuilder, UpdateRequestBuilder,
-			 BulkRequestBuilder> bulkableDocumentRequestTranslator) {
+		BulkableDocumentRequestTranslator bulkableDocumentRequestTranslator) {
 
 		_bulkableDocumentRequestTranslator = bulkableDocumentRequestTranslator;
 	}
@@ -160,8 +167,7 @@ public class BulkDocumentRequestExecutorImpl
 		BulkDocumentRequestExecutorImpl.class);
 
 	private BulkableDocumentRequestTranslator
-		<DeleteRequestBuilder, IndexRequestBuilder, UpdateRequestBuilder,
-		 BulkRequestBuilder> _bulkableDocumentRequestTranslator;
+		_bulkableDocumentRequestTranslator;
 	private ElasticsearchClientResolver _elasticsearchClientResolver;
 
 }

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/DeleteDocumentRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/DeleteDocumentRequestExecutorImpl.java
@@ -18,11 +18,8 @@ import com.liferay.portal.search.engine.adapter.document.BulkableDocumentRequest
 import com.liferay.portal.search.engine.adapter.document.DeleteDocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.DeleteDocumentResponse;
 
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.delete.DeleteRequestBuilder;
 import org.elasticsearch.action.delete.DeleteResponse;
-import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.rest.RestStatus;
 
 import org.osgi.service.component.annotations.Component;
@@ -40,8 +37,7 @@ public class DeleteDocumentRequestExecutorImpl
 		DeleteDocumentRequest deleteDocumentRequest) {
 
 		DeleteRequestBuilder deleteRequestBuilder =
-			_bulkableDocumentRequestTranslator.translate(
-				deleteDocumentRequest, null);
+			_bulkableDocumentRequestTranslator.translate(deleteDocumentRequest);
 
 		DeleteResponse deleteResponse = deleteRequestBuilder.get();
 
@@ -55,15 +51,12 @@ public class DeleteDocumentRequestExecutorImpl
 
 	@Reference(target = "(search.engine.impl=Elasticsearch)", unbind = "-")
 	protected void setBulkableDocumentRequestTranslator(
-		BulkableDocumentRequestTranslator
-			<DeleteRequestBuilder, IndexRequestBuilder, UpdateRequestBuilder,
-			 BulkRequestBuilder> bulkableDocumentRequestTranslator) {
+		BulkableDocumentRequestTranslator bulkableDocumentRequestTranslator) {
 
 		_bulkableDocumentRequestTranslator = bulkableDocumentRequestTranslator;
 	}
 
 	private BulkableDocumentRequestTranslator
-		<DeleteRequestBuilder, IndexRequestBuilder, UpdateRequestBuilder,
-		 BulkRequestBuilder> _bulkableDocumentRequestTranslator;
+		_bulkableDocumentRequestTranslator;
 
 }

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslator.java
@@ -24,7 +24,6 @@ import com.liferay.portal.search.engine.adapter.document.DeleteDocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.IndexDocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.UpdateDocumentRequest;
 
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.delete.DeleteAction;
 import org.elasticsearch.action.delete.DeleteRequestBuilder;
 import org.elasticsearch.action.index.IndexAction;
@@ -47,14 +46,11 @@ import org.osgi.service.component.annotations.Reference;
 	service = BulkableDocumentRequestTranslator.class
 )
 public class ElasticsearchBulkableDocumentRequestTranslator
-	implements BulkableDocumentRequestTranslator
-		<DeleteRequestBuilder, IndexRequestBuilder, UpdateRequestBuilder,
-		 BulkRequestBuilder> {
+	implements BulkableDocumentRequestTranslator {
 
 	@Override
 	public DeleteRequestBuilder translate(
-		DeleteDocumentRequest deleteDocumentRequest,
-		BulkRequestBuilder searchEngineAdapterRequest) {
+		DeleteDocumentRequest deleteDocumentRequest) {
 
 		Client client = _elasticsearchClientResolver.getClient();
 
@@ -71,17 +67,12 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 
 		deleteRequestBuilder.setType(deleteDocumentRequest.getType());
 
-		if (searchEngineAdapterRequest != null) {
-			searchEngineAdapterRequest.add(deleteRequestBuilder);
-		}
-
 		return deleteRequestBuilder;
 	}
 
 	@Override
 	public IndexRequestBuilder translate(
-		IndexDocumentRequest indexDocumentRequest,
-		BulkRequestBuilder searchEngineAdapterRequest) {
+		IndexDocumentRequest indexDocumentRequest) {
 
 		Client client = _elasticsearchClientResolver.getClient();
 
@@ -101,17 +92,12 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 
 		setSource(indexDocumentRequest, indexRequestBuilder);
 
-		if (searchEngineAdapterRequest != null) {
-			searchEngineAdapterRequest.add(indexRequestBuilder);
-		}
-
 		return indexRequestBuilder;
 	}
 
 	@Override
 	public UpdateRequestBuilder translate(
-		UpdateDocumentRequest updateDocumentRequest,
-		BulkRequestBuilder searchEngineAdapterRequest) {
+		UpdateDocumentRequest updateDocumentRequest) {
 
 		Client client = _elasticsearchClientResolver.getClient();
 
@@ -130,10 +116,6 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 		updateRequestBuilder.setType(updateDocumentRequest.getType());
 
 		setDoc(updateDocumentRequest, updateRequestBuilder);
-
-		if (searchEngineAdapterRequest != null) {
-			searchEngineAdapterRequest.add(updateRequestBuilder);
-		}
 
 		return updateRequestBuilder;
 	}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslator.java
@@ -21,11 +21,14 @@ import com.liferay.portal.search.elasticsearch6.internal.connection.Elasticsearc
 import com.liferay.portal.search.elasticsearch6.internal.document.ElasticsearchDocumentFactory;
 import com.liferay.portal.search.engine.adapter.document.BulkableDocumentRequestTranslator;
 import com.liferay.portal.search.engine.adapter.document.DeleteDocumentRequest;
+import com.liferay.portal.search.engine.adapter.document.GetDocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.IndexDocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.UpdateDocumentRequest;
 
 import org.elasticsearch.action.delete.DeleteAction;
 import org.elasticsearch.action.delete.DeleteRequestBuilder;
+import org.elasticsearch.action.get.GetAction;
+import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.support.WriteRequest;
@@ -68,6 +71,25 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 		deleteRequestBuilder.setType(deleteDocumentRequest.getType());
 
 		return deleteRequestBuilder;
+	}
+
+	@Override
+	public GetRequestBuilder translate(GetDocumentRequest getDocumentRequest) {
+		Client client = _elasticsearchClientResolver.getClient();
+
+		GetRequestBuilder getRequestBuilder =
+			GetAction.INSTANCE.newRequestBuilder(client);
+
+		getRequestBuilder.setId(getDocumentRequest.getId());
+		getRequestBuilder.setIndex(getDocumentRequest.getIndexName());
+		getRequestBuilder.setRefresh(getDocumentRequest.isRefresh());
+		getRequestBuilder.setFetchSource(
+			getDocumentRequest.getFetchSourceIncludes(),
+			getDocumentRequest.getFetchSourceExcludes());
+		getRequestBuilder.setStoredFields(getDocumentRequest.getStoredFields());
+		getRequestBuilder.setType(getDocumentRequest.getType());
+
+		return getRequestBuilder;
 	}
 
 	@Override

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchDocumentRequestExecutor.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchDocumentRequestExecutor.java
@@ -21,6 +21,8 @@ import com.liferay.portal.search.engine.adapter.document.DeleteByQueryDocumentRe
 import com.liferay.portal.search.engine.adapter.document.DeleteDocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.DeleteDocumentResponse;
 import com.liferay.portal.search.engine.adapter.document.DocumentRequestExecutor;
+import com.liferay.portal.search.engine.adapter.document.GetDocumentRequest;
+import com.liferay.portal.search.engine.adapter.document.GetDocumentResponse;
 import com.liferay.portal.search.engine.adapter.document.IndexDocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.IndexDocumentResponse;
 import com.liferay.portal.search.engine.adapter.document.UpdateByQueryDocumentRequest;
@@ -61,6 +63,13 @@ public class ElasticsearchDocumentRequestExecutor
 		DeleteDocumentRequest deleteDocumentRequest) {
 
 		return _deleteDocumentRequestExecutor.execute(deleteDocumentRequest);
+	}
+
+	@Override
+	public GetDocumentResponse executeDocumentRequest(
+		GetDocumentRequest getDocumentRequest) {
+
+		return _getDocumentRequestExecutor.execute(getDocumentRequest);
 	}
 
 	@Override
@@ -109,6 +118,13 @@ public class ElasticsearchDocumentRequestExecutor
 	}
 
 	@Reference(unbind = "-")
+	protected void setGetDocumentRequestExecutor(
+		GetDocumentRequestExecutor getDocumentRequestExecutor) {
+
+		_getDocumentRequestExecutor = getDocumentRequestExecutor;
+	}
+
+	@Reference(unbind = "-")
 	protected void setIndexDocumentRequestExecutor(
 		IndexDocumentRequestExecutor indexDocumentRequestExecutor) {
 
@@ -135,6 +151,7 @@ public class ElasticsearchDocumentRequestExecutor
 	private DeleteByQueryDocumentRequestExecutor
 		_deleteByQueryDocumentRequestExecutor;
 	private DeleteDocumentRequestExecutor _deleteDocumentRequestExecutor;
+	private GetDocumentRequestExecutor _getDocumentRequestExecutor;
 	private IndexDocumentRequestExecutor _indexDocumentRequestExecutor;
 	private UpdateByQueryDocumentRequestExecutor
 		_updateByQueryDocumentRequestExecutor;

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/GetDocumentRequestExecutor.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/GetDocumentRequestExecutor.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.search.engine.adapter.document;
+
+import com.liferay.portal.search.engine.adapter.document.GetDocumentRequest;
+import com.liferay.portal.search.engine.adapter.document.GetDocumentResponse;
+
+/**
+ * @author Bryan Engler
+ */
+public interface GetDocumentRequestExecutor {
+
+	public GetDocumentResponse execute(GetDocumentRequest getDocumentRequest);
+
+}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/GetDocumentRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/GetDocumentRequestExecutorImpl.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.search.engine.adapter.document;
+
+import com.liferay.portal.search.document.DocumentBuilder;
+import com.liferay.portal.search.document.DocumentBuilderFactory;
+import com.liferay.portal.search.elasticsearch6.internal.document.DocumentFieldsTranslator;
+import com.liferay.portal.search.engine.adapter.document.BulkableDocumentRequestTranslator;
+import com.liferay.portal.search.engine.adapter.document.GetDocumentRequest;
+import com.liferay.portal.search.engine.adapter.document.GetDocumentResponse;
+import com.liferay.portal.search.geolocation.GeoBuilders;
+
+import org.elasticsearch.action.get.GetRequestBuilder;
+import org.elasticsearch.action.get.GetResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Bryan Engler
+ */
+@Component(immediate = true, service = GetDocumentRequestExecutor.class)
+public class GetDocumentRequestExecutorImpl
+	implements GetDocumentRequestExecutor {
+
+	@Override
+	public GetDocumentResponse execute(GetDocumentRequest getDocumentRequest) {
+		GetRequestBuilder getRequestBuilder =
+			_bulkableDocumentRequestTranslator.translate(getDocumentRequest);
+
+		GetResponse getResponse = getRequestBuilder.get();
+
+		GetDocumentResponse getDocumentResponse = new GetDocumentResponse(
+			getResponse.isExists());
+
+		if (!getResponse.isExists()) {
+			return getDocumentResponse;
+		}
+
+		getDocumentResponse.setSource(getResponse.getSourceAsString());
+		getDocumentResponse.setVersion(getResponse.getVersion());
+
+		DocumentFieldsTranslator documentFieldsTranslator =
+			new DocumentFieldsTranslator(_geoBuilders);
+
+		DocumentBuilder documentBuilder = _documentBuilderFactory.builder();
+
+		documentFieldsTranslator.translate(
+			getResponse.getFields(), documentBuilder);
+
+		getDocumentResponse.setDocument(documentBuilder.build());
+
+		return getDocumentResponse;
+	}
+
+	@Reference(target = "(search.engine.impl=Elasticsearch)", unbind = "-")
+	protected void setBulkableDocumentRequestTranslator(
+		BulkableDocumentRequestTranslator bulkableDocumentRequestTranslator) {
+
+		_bulkableDocumentRequestTranslator = bulkableDocumentRequestTranslator;
+	}
+
+	@Reference(unbind = "-")
+	protected void setDocumentBuilderFactory(
+		DocumentBuilderFactory documentBuilderFactory) {
+
+		_documentBuilderFactory = documentBuilderFactory;
+	}
+
+	@Reference(unbind = "-")
+	protected void setGeoBuilders(GeoBuilders geoBuilders) {
+		_geoBuilders = geoBuilders;
+	}
+
+	private BulkableDocumentRequestTranslator
+		_bulkableDocumentRequestTranslator;
+	private DocumentBuilderFactory _documentBuilderFactory;
+	private GeoBuilders _geoBuilders;
+
+}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/IndexDocumentRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/IndexDocumentRequestExecutorImpl.java
@@ -18,11 +18,8 @@ import com.liferay.portal.search.engine.adapter.document.BulkableDocumentRequest
 import com.liferay.portal.search.engine.adapter.document.IndexDocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.IndexDocumentResponse;
 
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
-import org.elasticsearch.action.delete.DeleteRequestBuilder;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
-import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.rest.RestStatus;
 
 import org.osgi.service.component.annotations.Component;
@@ -40,8 +37,7 @@ public class IndexDocumentRequestExecutorImpl
 		IndexDocumentRequest indexDocumentRequest) {
 
 		IndexRequestBuilder indexRequestBuilder =
-			_bulkableDocumentRequestTranslator.translate(
-				indexDocumentRequest, null);
+			_bulkableDocumentRequestTranslator.translate(indexDocumentRequest);
 
 		IndexResponse indexResponse = indexRequestBuilder.get();
 
@@ -55,15 +51,12 @@ public class IndexDocumentRequestExecutorImpl
 
 	@Reference(target = "(search.engine.impl=Elasticsearch)", unbind = "-")
 	protected void setBulkableDocumentRequestTranslator(
-		BulkableDocumentRequestTranslator
-			<DeleteRequestBuilder, IndexRequestBuilder, UpdateRequestBuilder,
-			 BulkRequestBuilder> bulkableDocumentRequestTranslator) {
+		BulkableDocumentRequestTranslator bulkableDocumentRequestTranslator) {
 
 		_bulkableDocumentRequestTranslator = bulkableDocumentRequestTranslator;
 	}
 
 	private BulkableDocumentRequestTranslator
-		<DeleteRequestBuilder, IndexRequestBuilder, UpdateRequestBuilder,
-		 BulkRequestBuilder> _bulkableDocumentRequestTranslator;
+		_bulkableDocumentRequestTranslator;
 
 }

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/UpdateDocumentRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/UpdateDocumentRequestExecutorImpl.java
@@ -18,9 +18,6 @@ import com.liferay.portal.search.engine.adapter.document.BulkableDocumentRequest
 import com.liferay.portal.search.engine.adapter.document.UpdateDocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.UpdateDocumentResponse;
 
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
-import org.elasticsearch.action.delete.DeleteRequestBuilder;
-import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.rest.RestStatus;
@@ -40,8 +37,7 @@ public class UpdateDocumentRequestExecutorImpl
 		UpdateDocumentRequest updateDocumentRequest) {
 
 		UpdateRequestBuilder updateRequestBuilder =
-			_bulkableDocumentRequestTranslator.translate(
-				updateDocumentRequest, null);
+			_bulkableDocumentRequestTranslator.translate(updateDocumentRequest);
 
 		UpdateResponse updateResponse = updateRequestBuilder.get();
 
@@ -55,15 +51,12 @@ public class UpdateDocumentRequestExecutorImpl
 
 	@Reference(target = "(search.engine.impl=Elasticsearch)", unbind = "-")
 	protected void setBulkableDocumentRequestTranslator(
-		BulkableDocumentRequestTranslator
-			<DeleteRequestBuilder, IndexRequestBuilder, UpdateRequestBuilder,
-			 BulkRequestBuilder> bulkableDocumentRequestTranslator) {
+		BulkableDocumentRequestTranslator bulkableDocumentRequestTranslator) {
 
 		_bulkableDocumentRequestTranslator = bulkableDocumentRequestTranslator;
 	}
 
 	private BulkableDocumentRequestTranslator
-		<DeleteRequestBuilder, IndexRequestBuilder, UpdateRequestBuilder,
-		 BulkRequestBuilder> _bulkableDocumentRequestTranslator;
+		_bulkableDocumentRequestTranslator;
 
 }

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/DocumentRequestExecutorFixture.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/DocumentRequestExecutorFixture.java
@@ -20,11 +20,6 @@ import com.liferay.portal.search.elasticsearch6.internal.legacy.query.Elasticsea
 import com.liferay.portal.search.engine.adapter.document.BulkableDocumentRequestTranslator;
 import com.liferay.portal.search.engine.adapter.document.DocumentRequestExecutor;
 
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
-import org.elasticsearch.action.delete.DeleteRequestBuilder;
-import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.update.UpdateRequestBuilder;
-
 /**
  * @author Dylan Rebelak
  */
@@ -40,8 +35,7 @@ public class DocumentRequestExecutorFixture {
 	}
 
 	protected static BulkableDocumentRequestTranslator
-		<DeleteRequestBuilder, IndexRequestBuilder, UpdateRequestBuilder,
-		 BulkRequestBuilder> createBulkableDocumentRequestTranslator(
+		createBulkableDocumentRequestTranslator(
 			ElasticsearchClientResolver elasticsearchClientResolver,
 			ElasticsearchDocumentFactory elasticsearchDocumentFactory) {
 
@@ -57,9 +51,7 @@ public class DocumentRequestExecutorFixture {
 		createBulkDocumentRequestExecutor(
 			ElasticsearchClientResolver elasticsearchClientResolver,
 			BulkableDocumentRequestTranslator
-				<DeleteRequestBuilder, IndexRequestBuilder,
-				 UpdateRequestBuilder, BulkRequestBuilder>
-					bulkableDocumentRequestTranslator) {
+				bulkableDocumentRequestTranslator) {
 
 		return new BulkDocumentRequestExecutorImpl() {
 			{
@@ -92,9 +84,7 @@ public class DocumentRequestExecutorFixture {
 	protected static DeleteDocumentRequestExecutor
 		createDeleteDocumentRequestExecutor(
 			BulkableDocumentRequestTranslator
-				<DeleteRequestBuilder, IndexRequestBuilder,
-				 UpdateRequestBuilder, BulkRequestBuilder>
-					bulkableDocumentRequestTranslator) {
+				bulkableDocumentRequestTranslator) {
 
 		return new DeleteDocumentRequestExecutorImpl() {
 			{
@@ -108,11 +98,9 @@ public class DocumentRequestExecutorFixture {
 		ElasticsearchClientResolver elasticsearchClientResolver,
 		ElasticsearchDocumentFactory elasticsearchDocumentFactory) {
 
-		BulkableDocumentRequestTranslator
-			<DeleteRequestBuilder, IndexRequestBuilder, UpdateRequestBuilder,
-			 BulkRequestBuilder> bulkableDocumentRequestTranslator =
-				createBulkableDocumentRequestTranslator(
-					elasticsearchClientResolver, elasticsearchDocumentFactory);
+		BulkableDocumentRequestTranslator bulkableDocumentRequestTranslator =
+			createBulkableDocumentRequestTranslator(
+				elasticsearchClientResolver, elasticsearchDocumentFactory);
 
 		return new ElasticsearchDocumentRequestExecutor() {
 			{
@@ -142,9 +130,7 @@ public class DocumentRequestExecutorFixture {
 	protected static IndexDocumentRequestExecutor
 		createIndexDocumentRequestExecutor(
 			BulkableDocumentRequestTranslator
-				<DeleteRequestBuilder, IndexRequestBuilder,
-				 UpdateRequestBuilder, BulkRequestBuilder>
-					bulkableDocumentRequestTranslator) {
+				bulkableDocumentRequestTranslator) {
 
 		return new IndexDocumentRequestExecutorImpl() {
 			{
@@ -176,9 +162,7 @@ public class DocumentRequestExecutorFixture {
 	protected static UpdateDocumentRequestExecutor
 		createUpdateDocumentRequestExecutor(
 			BulkableDocumentRequestTranslator
-				<DeleteRequestBuilder, IndexRequestBuilder,
-				 UpdateRequestBuilder, BulkRequestBuilder>
-					bulkableDocumentRequestTranslator) {
+				bulkableDocumentRequestTranslator) {
 
 		return new UpdateDocumentRequestExecutorImpl() {
 			{

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslatorTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslatorTest.java
@@ -190,7 +190,7 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 
 		DeleteRequestBuilder deleteRequestBuilder =
 			_elasticsearchBulkableDocumentRequestTranslator.translate(
-				deleteDocumentRequest, null);
+				deleteDocumentRequest);
 
 		DeleteRequest deleteRequest = deleteRequestBuilder.request();
 
@@ -205,8 +205,9 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 		BulkRequestBuilder bulkRequestBuilder =
 			BulkAction.INSTANCE.newRequestBuilder(client);
 
-		_elasticsearchBulkableDocumentRequestTranslator.translate(
-			deleteDocumentRequest, bulkRequestBuilder);
+		bulkRequestBuilder.add(
+			_elasticsearchBulkableDocumentRequestTranslator.translate(
+				deleteDocumentRequest));
 
 		Assert.assertEquals(1, bulkRequestBuilder.numberOfActions());
 	}
@@ -228,7 +229,7 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 
 		IndexRequestBuilder indexRequestBuilder =
 			_elasticsearchBulkableDocumentRequestTranslator.translate(
-				indexDocumentRequest, null);
+				indexDocumentRequest);
 
 		IndexRequest indexRequest = indexRequestBuilder.request();
 
@@ -250,8 +251,9 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 		BulkRequestBuilder bulkRequestBuilder =
 			BulkAction.INSTANCE.newRequestBuilder(client);
 
-		_elasticsearchBulkableDocumentRequestTranslator.translate(
-			indexDocumentRequest, bulkRequestBuilder);
+		bulkRequestBuilder.add(
+			_elasticsearchBulkableDocumentRequestTranslator.translate(
+				indexDocumentRequest));
 
 		Assert.assertEquals(1, bulkRequestBuilder.numberOfActions());
 	}
@@ -273,7 +275,7 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 
 		UpdateRequestBuilder updateRequestBuilder =
 			_elasticsearchBulkableDocumentRequestTranslator.translate(
-				updateDocumentRequest, null);
+				updateDocumentRequest);
 
 		UpdateRequest updateRequest = updateRequestBuilder.request();
 
@@ -296,8 +298,9 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 		BulkRequestBuilder bulkRequestBuilder =
 			BulkAction.INSTANCE.newRequestBuilder(client);
 
-		_elasticsearchBulkableDocumentRequestTranslator.translate(
-			updateDocumentRequest, bulkRequestBuilder);
+		bulkRequestBuilder.add(
+			_elasticsearchBulkableDocumentRequestTranslator.translate(
+				updateDocumentRequest));
 
 		Assert.assertEquals(1, bulkRequestBuilder.numberOfActions());
 	}

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/BulkableDocumentRequestTranslator.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/BulkableDocumentRequestTranslator.java
@@ -24,6 +24,8 @@ public interface BulkableDocumentRequestTranslator {
 
 	public <T> T translate(DeleteDocumentRequest deleteDocumentRequest);
 
+	public <T> T translate(GetDocumentRequest getDocumentRequest);
+
 	public <T> T translate(IndexDocumentRequest indexDocumentRequest);
 
 	public <T> T translate(UpdateDocumentRequest updateDocumentRequest);

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/BulkableDocumentRequestTranslator.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/BulkableDocumentRequestTranslator.java
@@ -14,21 +14,18 @@
 
 package com.liferay.portal.search.engine.adapter.document;
 
+import aQute.bnd.annotation.ProviderType;
+
 /**
  * @author Michael C. Han
  */
-public interface BulkableDocumentRequestTranslator<R, S, T, U> {
+@ProviderType
+public interface BulkableDocumentRequestTranslator {
 
-	public R translate(
-		DeleteDocumentRequest deleteDocumentRequest,
-		U searchEngineAdapterRequest);
+	public <T> T translate(DeleteDocumentRequest deleteDocumentRequest);
 
-	public S translate(
-		IndexDocumentRequest indexDocumentRequest,
-		U searchEngineAdapterRequest);
+	public <T> T translate(IndexDocumentRequest indexDocumentRequest);
 
-	public T translate(
-		UpdateDocumentRequest updateDocumentRequest,
-		U searchEngineAdapterRequest);
+	public <T> T translate(UpdateDocumentRequest updateDocumentRequest);
 
 }

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/DocumentRequestExecutor.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/DocumentRequestExecutor.java
@@ -31,6 +31,9 @@ public interface DocumentRequestExecutor {
 	public DeleteDocumentResponse executeDocumentRequest(
 		DeleteDocumentRequest deleteDocumentRequest);
 
+	public GetDocumentResponse executeDocumentRequest(
+		GetDocumentRequest getDocumentRequest);
+
 	public IndexDocumentResponse executeDocumentRequest(
 		IndexDocumentRequest indexDocumentRequest);
 

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/GetDocumentRequest.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/GetDocumentRequest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.engine.adapter.document;
+
+import aQute.bnd.annotation.ProviderType;
+
+import java.util.function.Consumer;
+
+/**
+ * @author Bryan Engler
+ */
+@ProviderType
+public class GetDocumentRequest
+	implements BulkableDocumentRequest<GetDocumentRequest>,
+			   DocumentRequest<GetDocumentResponse> {
+
+	public GetDocumentRequest(String indexName, String id) {
+		_indexName = indexName;
+		_id = id;
+	}
+
+	@Override
+	public void accept(Consumer<GetDocumentRequest> consumer) {
+		consumer.accept(this);
+	}
+
+	@Override
+	public GetDocumentResponse accept(
+		DocumentRequestExecutor documentRequestExecutor) {
+
+		return documentRequestExecutor.executeDocumentRequest(this);
+	}
+
+	public String[] getFetchSourceExcludes() {
+		return _fetchSourceExclude;
+	}
+
+	public String[] getFetchSourceIncludes() {
+		return _fetchSourceInclude;
+	}
+
+	public String getId() {
+		return _id;
+	}
+
+	public String getIndexName() {
+		return _indexName;
+	}
+
+	public String[] getStoredFields() {
+		return _storedFields;
+	}
+
+	public String getType() {
+		return _type;
+	}
+
+	public boolean isRefresh() {
+		return _refresh;
+	}
+
+	public void setFetchSourceExclude(String... fetchSourceExclude) {
+		_fetchSourceExclude = fetchSourceExclude;
+	}
+
+	public void setFetchSourceInclude(String... fetchSourceInclude) {
+		_fetchSourceInclude = fetchSourceInclude;
+	}
+
+	public void setRefresh(boolean refresh) {
+		_refresh = refresh;
+	}
+
+	public void setStoredFields(String... storedFields) {
+		_storedFields = storedFields;
+	}
+
+	public void setType(String type) {
+		_type = type;
+	}
+
+	private String[] _fetchSourceExclude;
+	private String[] _fetchSourceInclude;
+	private final String _id;
+	private final String _indexName;
+	private boolean _refresh;
+	private String[] _storedFields;
+	private String _type;
+
+}

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/GetDocumentResponse.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/GetDocumentResponse.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.engine.adapter.document;
+
+import aQute.bnd.annotation.ProviderType;
+
+import com.liferay.portal.search.document.Document;
+
+/**
+ * @author Bryan Engler
+ */
+@ProviderType
+public class GetDocumentResponse implements DocumentResponse {
+
+	public GetDocumentResponse(boolean exists) {
+		_exists = exists;
+	}
+
+	public Document getDocument() {
+		return _document;
+	}
+
+	public String getSource() {
+		return _source;
+	}
+
+	public long getVersion() {
+		return _version;
+	}
+
+	public boolean isExists() {
+		return _exists;
+	}
+
+	public void setDocument(Document document) {
+		_document = document;
+	}
+
+	public void setSource(String source) {
+		_source = source;
+	}
+
+	public void setVersion(long version) {
+		_version = version;
+	}
+
+	private Document _document;
+	private final boolean _exists;
+	private String _source;
+	private long _version;
+
+}


### PR DESCRIPTION
**❌ ci:test:search - 18 out of 20 jobs passed in 1 hour 16 minutes 20 seconds 33 ms**
https://github.com/arboliveira/liferay-portal/pull/730

----

1 unique failure, unlikely to be related. I'm confident this story can be merged. Will continue monitoring.

`Search#ViewFacetPersistence`
`SearchResultPortlet#viewSearchResults --> FAILED
Assert that 'ASSET_ENTRY_TABLE_TITLE_SPECIFIC' contains the value 'Test Test' --> FAILED`
`Element is not present at "//li[@data-qa-id='row' and contains(.,'Test Test')]//h6[contains(.,'User')]/..//a"` 

@xbrianlee @joshchong Heads up: CI PR Tester comments are generating 404 links to Poshi Summary, Poshi Report and Console Output. Prevents immediate inspection of screenshots and stacktraces. Bad paths contain several `null` : testray.liferay.com/reports/production/logs/**null/null/null/null**/functional-tomcat90-mysql57-jdk8/9/0/LocalFile.Search_ViewFacetPersistence/summary.html.gz

----

Author: @BryanEngler
Reviewer: @arboliveira

_[Story] Get Document operation in Low Level Search API_
https://issues.liferay.com/browse/LPS-94407