### PR TITLE
LPS-94527 Set Marketplace to false for 7.2

### DIFF
--- a/modules/apps/bookmarks/app.bnd
+++ b/modules/apps/bookmarks/app.bnd
@@ -6,7 +6,7 @@ Liferay-Releng-Demo-Url:
 Liferay-Releng-Deprecated: true
 Liferay-Releng-Fix-Delivery-Method:
 Liferay-Releng-Labs: false
-Liferay-Releng-Marketplace: true
+Liferay-Releng-Marketplace: false
 Liferay-Releng-Portal-Required: false
 Liferay-Releng-Public: ${liferay.releng.public}
 Liferay-Releng-Restart-Required: true


### PR DESCRIPTION
Do not backport to 7.1.x

I'm using this to filter out code that we don't need the security vendor to scan.