### PR TITLE
LRCI-68 Fix else conditional

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -4064,12 +4064,12 @@ org.apache.catalina.startup.ClassLoaderFactory.level=INFO]]>
 										<arg value="${app.server.start.executable.arg.line}" />
 									</exec>
 								</then>
-								<elseif>
+								<else>
 									<exec dir="${test.app.server.bin.dir}" executable="${app.server.start.executable}" resolveexecutable="true">
 										<arg line="${app.server.start.executable.arg.line}" />
 										<env key="JAVA_HOME" path="${java.jdk.home}" />
 									</exec>
-								</elseif>
+								</else>
 							</if>
 
 							<wait-for-app-server app.server.bin.dir="@{app.server.bin.dir}" app.server.bundle.index="@{app.server.bundle.index}" />


### PR DESCRIPTION
fix for acceptance test: https://testray.liferay.com/home/-/testray/case_results/553770620

```
     [exec]     /opt/dev/projects/github/liferay-portal/build-test.xml:11454: The following error occurred while executing this line:
     [exec]     /opt/dev/projects/github/liferay-portal/build-test.xml:3952: The following error occurred while executing this line:
     [exec]     /opt/dev/projects/github/liferay-portal/build-test.xml:4050: elseif doesn't support the nested "exec" element.
```

cc @kevin-yen @pyoo47