### PR TITLE
LPS-94365 Now that the bundle is not unregistered between tests we ca…

### DIFF
--- a/modules/core/registry-test/src/testIntegration/java/com/liferay/registry/internal/test/ListServiceTrackerMapTest.java
+++ b/modules/core/registry-test/src/testIntegration/java/com/liferay/registry/internal/test/ListServiceTrackerMapTest.java
@@ -182,11 +182,16 @@ public class ListServiceTrackerMapTest {
 		try (ServiceTrackerMap<String, List<TrackedOne>> serviceTrackerMap =
 				createServiceTrackerMap()) {
 
-			registerService(new TrackedOne(), "aTarget");
-			registerService(new TrackedOne(), "anotherTarget");
-			registerService(new TrackedOne(), "aTarget");
-			registerService(new TrackedOne(), "anotherTarget");
-			registerService(new TrackedOne(), "anotherTarget");
+			_serviceRegistrations.add(
+				registerService(new TrackedOne(), "aTarget"));
+			_serviceRegistrations.add(
+				registerService(new TrackedOne(), "anotherTarget"));
+			_serviceRegistrations.add(
+				registerService(new TrackedOne(), "aTarget"));
+			_serviceRegistrations.add(
+				registerService(new TrackedOne(), "anotherTarget"));
+			_serviceRegistrations.add(
+				registerService(new TrackedOne(), "anotherTarget"));
 
 			List<TrackedOne> aTargetList = serviceTrackerMap.getService(
 				"aTarget");


### PR DESCRIPTION
…n leak service registrations between integration tests in the same test bundle. Fix leaked registrations from ListServiceTrackerMapTest causing ObjectServiceTrackerMapTest to fail.