### PR TITLE
LRCI-168 Rename 'stable' suite to 'stable-current-hash' (master)

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -28,7 +28,7 @@ ci.test.available.suites=\
     sharing,\
     sf,\
     solr,\
-    stable,\
+    stable-current-hash,\
     staging,\
     tck,\
     upgrade
@@ -62,6 +62,7 @@ ci.test.suite.description[security]=Test only security tests.
 ci.test.suite.description[sf]=Test with only source formatter.
 ci.test.suite.description[sharing]=Test DM Asset Sharing tests.
 ci.test.suite.description[solr]=Test acceptance tests with Solr search engine.
+ci.test.suite.description[stable-current-hash]=Tests the stability of the current hash.
 ci.test.suite.description[staging]=Test only staging tests.
 ci.test.suite.description[tck]=Test only TCK tests.
 ci.test.suite.description[upgrade]=Test only upgrade tests.

--- a/test.properties
+++ b/test.properties
@@ -1994,12 +1994,12 @@
     test.batch.names[sf]=source-format-current-branch-jdk8
 
     #
-    # Stable
+    # Stable Current-Hash
     #
 
-    test.batch.dist.app.servers[stable]=tomcat
+    test.batch.dist.app.servers[stable-current-hash]=tomcat
 
-    test.batch.names[stable]=\
+    test.batch.names[stable-current-hash]=\
         central-requirements-jdk8,\
         functional-smoke-tomcat90-mysql57-jdk8,\
         #functional-upgrade-tomcat90-mysql57-jdk8,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-168

Related:
7.2.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/24133