### PR TITLE
LPS-93844 fix vulcan tests

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/test/TransactionContainerRequestFilterTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/test/TransactionContainerRequestFilterTest.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.vulcan.internal.jaxrs.context.provider.test;
+package com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
@@ -49,7 +49,7 @@ import org.junit.runner.RunWith;
  * @author Javier Gamarra
  */
 @RunWith(Arquillian.class)
-public class TransactionContainerFilterTest {
+public class TransactionContainerRequestFilterTest {
 
 	@ClassRule
 	@Rule
@@ -70,7 +70,8 @@ public class TransactionContainerFilterTest {
 
 		_serviceRegistration = registry.registerService(
 			Application.class,
-			new TransactionContainerFilterTest.TestApplication(), properties);
+			new TransactionContainerRequestFilterTest.TestApplication(),
+			properties);
 	}
 
 	@After

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/test/TransactionContainerRequestFilterTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/test/TransactionContainerRequestFilterTest.java
@@ -24,9 +24,14 @@ import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
 import com.liferay.registry.ServiceRegistration;
 
+import java.io.IOException;
+
 import java.net.HttpURLConnection;
 import java.net.URL;
 
+import java.nio.charset.StandardCharsets;
+
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -87,12 +92,7 @@ public class TransactionContainerRequestFilterTest {
 			"http://localhost:8080/o/test-vulcan/failure/" +
 				group.getGroupId());
 
-		HttpURLConnection httpURLConnection =
-			(HttpURLConnection)url.openConnection();
-
-		httpURLConnection.setRequestMethod("DELETE");
-
-		Assert.assertEquals(500, httpURLConnection.getResponseCode());
+		Assert.assertEquals(500, _getHttpResponseCode(url));
 
 		Assert.assertNotNull(
 			GroupLocalServiceUtil.getGroup(group.getGroupId()));
@@ -106,13 +106,7 @@ public class TransactionContainerRequestFilterTest {
 			"http://localhost:8080/o/test-vulcan/success/" +
 				group.getGroupId());
 
-		HttpURLConnection httpURLConnection =
-			(HttpURLConnection)url.openConnection();
-
-		httpURLConnection.setDoOutput(true);
-		httpURLConnection.setRequestMethod("DELETE");
-
-		Assert.assertEquals(204, httpURLConnection.getResponseCode());
+		Assert.assertEquals(204, _getHttpResponseCode(url));
 
 		Assert.assertNull(GroupLocalServiceUtil.getGroup(group.getGroupId()));
 	}
@@ -142,6 +136,22 @@ public class TransactionContainerRequestFilterTest {
 			GroupLocalServiceUtil.deleteGroup(siteId);
 		}
 
+	}
+
+	private int _getHttpResponseCode(URL url) throws IOException {
+		HttpURLConnection httpURLConnection =
+			(HttpURLConnection)url.openConnection();
+
+		Base64.Encoder encoder = Base64.getEncoder();
+
+		String basicAuth = encoder.encodeToString(
+			"test@liferay.com:test".getBytes(StandardCharsets.UTF_8));
+
+		httpURLConnection.setRequestMethod("DELETE");
+		httpURLConnection.setRequestProperty(
+			"Authorization", "Basic " + basicAuth);
+
+		return httpURLConnection.getResponseCode();
 	}
 
 	private ServiceRegistration<Application> _serviceRegistration;

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/JSONMessageBodyWriterTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/JSONMessageBodyWriterTest.java
@@ -24,8 +24,15 @@ import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
 import com.liferay.registry.ServiceRegistration;
 
-import java.net.URL;
+import java.io.IOException;
+import java.io.InputStream;
 
+import java.net.URL;
+import java.net.URLConnection;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -77,7 +84,7 @@ public class JSONMessageBodyWriterTest {
 				"fields=string,testClass,testClass.number");
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
-			StringUtil.read(url.openStream()));
+			StringUtil.read(_getInputStream(url)));
 
 		Assert.assertFalse(jsonObject.has("number"));
 		Assert.assertEquals("hello", jsonObject.getString("string"));
@@ -95,7 +102,7 @@ public class JSONMessageBodyWriterTest {
 			"http://localhost:8080/o/test-vulcan/test-class?fields=string");
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
-			StringUtil.read(url.openStream()));
+			StringUtil.read(_getInputStream(url)));
 
 		Assert.assertFalse(jsonObject.has("number"));
 		Assert.assertFalse(jsonObject.has("testClass"));
@@ -107,7 +114,7 @@ public class JSONMessageBodyWriterTest {
 		URL url = new URL("http://localhost:8080/o/test-vulcan/test-class");
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
-			StringUtil.read(url.openStream()));
+			StringUtil.read(_getInputStream(url)));
 
 		Assert.assertEquals(1L, jsonObject.getLong("number"));
 		Assert.assertEquals("hello", jsonObject.getString("string"));
@@ -154,6 +161,21 @@ public class JSONMessageBodyWriterTest {
 
 		}
 
+	}
+
+	private InputStream _getInputStream(URL url) throws IOException {
+		URLConnection urlConnection = url.openConnection();
+
+		Base64.Encoder encoder = Base64.getEncoder();
+
+		String basicAuth = encoder.encodeToString(
+			"test@liferay.com:test".getBytes(StandardCharsets.UTF_8));
+
+		urlConnection.setRequestProperty("Authorization", "Basic " + basicAuth);
+
+		urlConnection.connect();
+
+		return urlConnection.getInputStream();
 	}
 
 	private ServiceRegistration<Application> _serviceRegistration;

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/TransactionContainerFilterTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/TransactionContainerFilterTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.context.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.exception.NoSuchGroupException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.registry.Registry;
+import com.liferay.registry.RegistryUtil;
+import com.liferay.registry.ServiceRegistration;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Application;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Javier Gamarra
+ */
+@RunWith(Arquillian.class)
+public class TransactionContainerFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() {
+		Registry registry = RegistryUtil.getRegistry();
+
+		Map<String, Object> properties = new HashMap<>();
+
+		properties.put("liferay.auth.verifier", true);
+		properties.put("liferay.oauth2", false);
+		properties.put("osgi.jaxrs.application.base", "/test-vulcan");
+		properties.put(
+			"osgi.jaxrs.extension.select", "(osgi.jaxrs.name=Liferay.Vulcan)");
+
+		_serviceRegistration = registry.registerService(
+			Application.class,
+			new TransactionContainerFilterTest.TestApplication(), properties);
+	}
+
+	@After
+	public void tearDown() {
+		_serviceRegistration.unregister();
+	}
+
+	@Test
+	public void testFailureRequest() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		URL url = new URL(
+			"http://localhost:8080/o/test-vulcan/failure/" +
+				group.getGroupId());
+
+		HttpURLConnection httpURLConnection =
+			(HttpURLConnection)url.openConnection();
+
+		httpURLConnection.setRequestMethod("DELETE");
+
+		Assert.assertEquals(500, httpURLConnection.getResponseCode());
+
+		Assert.assertNotNull(
+			GroupLocalServiceUtil.getGroup(group.getGroupId()));
+	}
+
+	@Test(expected = NoSuchGroupException.class)
+	public void testSuccessRequest() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		URL url = new URL(
+			"http://localhost:8080/o/test-vulcan/success/" +
+				group.getGroupId());
+
+		HttpURLConnection httpURLConnection =
+			(HttpURLConnection)url.openConnection();
+
+		httpURLConnection.setDoOutput(true);
+		httpURLConnection.setRequestMethod("DELETE");
+
+		Assert.assertEquals(204, httpURLConnection.getResponseCode());
+
+		Assert.assertNull(GroupLocalServiceUtil.getGroup(group.getGroupId()));
+	}
+
+	public static class TestApplication extends Application {
+
+		@Override
+		public Set<Object> getSingletons() {
+			return Collections.singleton(this);
+		}
+
+		@DELETE
+		@Path("/failure/{siteId}")
+		public void testFailure(@PathParam("siteId") long siteId)
+			throws Exception {
+
+			GroupLocalServiceUtil.deleteGroup(siteId);
+
+			throw new RuntimeException();
+		}
+
+		@DELETE
+		@Path("/success/{siteId}")
+		public void testSuccess(@PathParam("siteId") long siteId)
+			throws Exception {
+
+			GroupLocalServiceUtil.deleteGroup(siteId);
+		}
+
+	}
+
+	private ServiceRegistration<Application> _serviceRegistration;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/XMLMessageBodyReaderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/XMLMessageBodyReaderTest.java
@@ -30,6 +30,9 @@ import java.io.OutputStreamWriter;
 import java.net.URL;
 import java.net.URLConnection;
 
+import java.nio.charset.StandardCharsets;
+
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -80,7 +83,13 @@ public class XMLMessageBodyReaderTest {
 
 		URLConnection urlConnection = url.openConnection();
 
+		Base64.Encoder encoder = Base64.getEncoder();
+
+		String basicAuth = encoder.encodeToString(
+			"test@liferay.com:test".getBytes(StandardCharsets.UTF_8));
+
 		urlConnection.setDoOutput(true);
+		urlConnection.setRequestProperty("Authorization", "Basic " + basicAuth);
 		urlConnection.setRequestProperty(
 			"Content-Type", MediaType.APPLICATION_XML);
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/XMLMessageBodyWriterTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/XMLMessageBodyWriterTest.java
@@ -33,7 +33,10 @@ import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
 
+import java.nio.charset.StandardCharsets;
+
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -194,7 +197,13 @@ public class XMLMessageBodyWriterTest {
 
 		URLConnection urlConnection = url.openConnection();
 
+		Base64.Encoder encoder = Base64.getEncoder();
+
+		String basicAuth = encoder.encodeToString(
+			"test@liferay.com:test".getBytes(StandardCharsets.UTF_8));
+
 		urlConnection.setRequestProperty("Accept", MediaType.APPLICATION_XML);
+		urlConnection.setRequestProperty("Authorization", "Basic " + basicAuth);
 
 		try (InputStream inputStream = urlConnection.getInputStream()) {
 			String content = StringUtil.read(inputStream);


### PR DESCRIPTION
Now tests need authentication because a default value change in AuthVerifier.