### PR TITLE
LRCI-201 Use liferay-binaries-cache-2017

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1907,6 +1907,7 @@ rerun your task.
 					<propertyref name="aspectj.configuration" />
 					<propertyref name="baseline.jar.report.level" />
 					<propertyref name="baseline.jar.report.only.dirty.packages" />
+					<propertyref name="build.binaries.cache.dir" />
 					<propertyref name="git.working.branch.name" />
 					<propertyref name="jacoco.agent.configuration" />
 					<propertyref name="jacoco.agent.jar" />

--- a/modules/util.gradle
+++ b/modules/util.gradle
@@ -38,8 +38,6 @@ task wrapper(type: Wrapper)
 task wrapperSubrepo(type: Wrapper)
 
 FileTree libDependenciesFileTree = fileTree(dir: "../lib", include: "*/dependencies.properties")
-File nodeModulesCacheDir = new File(rootDir, "node_modules_cache")
-File userNodeModulesCacheDir = new File(System.getProperty("user.home"), ".liferay/node-modules-cache/" + Integer.toHexString(rootDir.canonicalPath.hashCode()))
 
 Map<File, Properties> libDependenciesMap = libDependenciesFileTree.collectEntries {
 	Properties properties = GUtil.loadProperties(it)
@@ -93,40 +91,36 @@ repositories {
 }
 
 setUpYarn {
-	File userNodeModulesCacheYarnLockFile = new File(userNodeModulesCacheDir, "yarn.lock")
-	File yarnLockFile = new File(rootDir, "yarn.lock")
-
 	args "install"
 	args "--frozen-lockfile"
 
 	scriptFile = new File(projectDir, "yarn-1.13.0.js")
 
 	doFirst {
+		String cacheDir = project.findProperty("build.binaries.cache.dir")
+
+		if (cacheDir) {
+			File yarnCacheDir = new File(rootDir.parentFile, cacheDir + "/.yarn")
+
+			if (yarnCacheDir.parentFile.exists()) {
+				logger.lifecycle "Using cache {}", yarnCacheDir
+
+				args "--cache-folder"
+				args yarnCacheDir
+			}
+		}
+
 		String registry = project.findProperty("nodejs.npm.ci.registry")
 
-		if (yarnLockFile.exists() && registry) {
-			logger.lifecycle "Using registry {}", registry
+		if (registry) {
+			File yarnLockFile = new File(rootDir, "yarn.lock")
 
-			yarnLockFile.text = yarnLockFile.text.replaceAll("https://registry.yarnpkg.com", registry)
+			if (yarnLockFile.exists()) {
+				logger.lifecycle "Using registry {}", registry
+
+				yarnLockFile.text = yarnLockFile.text.replaceAll("https://registry.yarnpkg.com", registry)
+			}
 		}
-
-		if (userNodeModulesCacheYarnLockFile.exists() && yarnLockFile.exists() && (userNodeModulesCacheYarnLockFile.text == yarnLockFile.text)) {
-			logger.lifecycle "Restoring node_modules_cache from {}", userNodeModulesCacheDir
-
-			FileUtil.syncDir(project, userNodeModulesCacheDir, nodeModulesCacheDir, true)
-
-			logger.lifecycle "Running Yarn install in offline mode"
-
-			args "--offline"
-		}
-	}
-
-	doLast {
-		logger.lifecycle "Caching node_modules_cache in {}", userNodeModulesCacheDir
-
-		FileUtil.syncDir(project, nodeModulesCacheDir, userNodeModulesCacheDir, true)
-
-		userNodeModulesCacheYarnLockFile.text = yarnLockFile.text
 	}
 }
 


### PR DESCRIPTION
Hi Brian, this pull updates the way Yarn caches packages to use the same system that the Gradle cache uses.

This is different than the Yarn offline-cache that's already implemented.

The Yarn cached files are here: https://github.com/liferay/liferay-binaries-cache-2017/tree/master/.yarn

Please let the tests finish.