### PR TITLE
LRQA-48733 Add back in macro that was accidentally removed

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/ChangeList.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ChangeList.macro
@@ -149,6 +149,12 @@ definition {
 			value1 = "${nbrOfDeletedItems}");
 	}
 
+	macro viewModifiedItemCounter {
+		AssertTextEquals(
+			locator1 = "ChangeList#CHANGE_LIST_MODIFIED",
+			value1 = "${nbrOfModifiedItems}");
+	}
+
 	macro viewNoStagingMenuitemsNotAvailable {
 		AssertElementNotPresent(locator1 = "Icon#HEADER_VERTICAL_ELLIPSIS");
 


### PR DESCRIPTION
This fixes poshi validation after macro was accidentally removed in https://github.com/liferay/liferay-portal/commit/75f771bb29423f94ef90ed6be157a82cd52e1981

https://issues.liferay.com/browse/LRQA-48733

7.2.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/24208

cc @kmaria

```
     [exec] Directory L:/ce/master/modules/apps/commerce/commerce-product-test/src/testFunctional does not exist.
     [exec] Exception in thread "main" java.lang.Exception
     [exec] 4 errors in POSHI
     [exec]     at com.liferay.poshi.runner.PoshiRunnerValidation._throwExceptions(PoshiRunnerValidation.java:1801)
     [exec]
     [exec]
     [exec] Invalid macro command ChangeList#viewModifiedItemCounter    at com.liferay.poshi.runner.PoshiRunnerValidation.validate(PoshiRunnerValidation.java:109)
     [exec]
     [exec]     at com.liferay.poshi.runner.PoshiRunnerValidation.main(PoshiRunnerValidation.java:66)
     [exec] L:\ce\master\portal-web\test\functional\com\liferay\portalweb\tests\enduser\changelist\SelectChangeList.testcase:121
     [exec]
     [exec] Invalid macro command ChangeList#viewModifiedItemCounter
     [exec] L:\ce\master\portal-web\test\functional\com\liferay\portalweb\tests\enduser\changelist\SelectChangeList.testcase:101
     [exec]
     [exec] Invalid macro command ChangeList#viewModifiedItemCounter
     [exec] L:\ce\master\portal-web\test\functional\com\liferay\portalweb\tests\enduser\changelist\ChangeListGlobalOverview.testcase:175
     [exec]
     [exec] Invalid macro command ChangeList#viewModifiedItemCounter
     [exec] L:\ce\master\portal-web\test\functional\com\liferay\portalweb\tests\enduser\changelist\ChangeListGlobalOverview.testcase:152
```