### PR TITLE
LPS-94981 Fix broken IDE setup, caused by 8f2a0cf59e41bb7facddae5d6e7…

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -41,6 +41,7 @@
 	<classpathentry kind="lib" path="lib/development/ant-contrib.jar"/>
 	<classpathentry kind="lib" path="lib/development/antelope.jar"/>
 	<classpathentry kind="lib" path="lib/development/appium.jar"/>
+	<classpathentry kind="lib" path="lib/development/biz.aQute.bnd.jar"/>
 	<classpathentry kind="lib" path="lib/development/bsh.jar"/>
 	<classpathentry kind="lib" path="lib/development/catalina.jar"/>
 	<classpathentry kind="lib" path="lib/development/com.liferay.ant.beanshell.jar"/>

--- a/lib/ide-ignore.txt
+++ b/lib/ide-ignore.txt
@@ -1,4 +1,3 @@
-lib/development/biz.aQute.bnd.jar
 tmp/lib-pre/com.liferay.petra.concurrent.jar
 tmp/lib-pre/com.liferay.petra.content.jar
 tmp/lib-pre/com.liferay.petra.encryptor.jar

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -6,6 +6,7 @@ javac.classpath=\
     lib/development/ant-contrib.jar:\
     lib/development/antelope.jar:\
     lib/development/appium.jar:\
+    lib/development/biz.aQute.bnd.jar:\
     lib/development/bsh.jar:\
     lib/development/catalina.jar:\
     lib/development/com.liferay.ant.beanshell.jar:\


### PR DESCRIPTION
…6eb951b0811f3. This was shielded by the lib/portal/bnd.jar, which was removed by 278db9a4a6b2c16da775de932d8471fa2c570501, thus the problem is exposed now.