### PR TITLE
LPS-89415 pagination

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/pagination/Page.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/pagination/Page.java
@@ -47,7 +47,7 @@ public class Page<T> {
 	}
 
 	public long getLastPage() {
-		if (_totalCount == 0) {
+		if ((_pageSize == 0) || (_totalCount == 0)) {
 			return 1;
 		}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/PaginationContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/PaginationContextProvider.java
@@ -35,12 +35,8 @@ public class PaginationContextProvider implements ContextProvider<Pagination> {
 		HttpServletRequest httpServletRequest =
 			ContextProviderUtil.getHttpServletRequest(message);
 
-		int page = ParamUtil.getInteger(httpServletRequest, "page");
-		int pageSize = ParamUtil.getInteger(httpServletRequest, "pageSize");
-
-		if ((page == 0) && (pageSize == 0)) {
-			return null;
-		}
+		int page = ParamUtil.getInteger(httpServletRequest, "page", 1);
+		int pageSize = ParamUtil.getInteger(httpServletRequest, "pageSize", 20);
 
 		return Pagination.of(page, pageSize);
 	}


### PR DESCRIPTION
I'll discuss it with @inacionery through slack to see their needs. If you don't need pagination at all, page and pageSize shouldn't be present in the OpenAPI profile and that would generate methods without the pagination object in the resources and tests.

Right now, returning a null pagination makes no-pagination the default state because ParamUtil.getInteger returns an int so is always going to return 0 if that param is not present. I would prefer having pagination by default... it's safer for performance and more common in other APIs.

If the problem is that sometimes you want to request all possible results, I would make it explicit, either passing it a very large pageSize or setting pageSize=0 as the convention, that would mean changing SearchUtil to check for null and Pagination class to return the right page, because right now is crashing. I can make that change if you want.

/cc @inacionery