### PR TITLE
LPS-94991 support Map<String, Object>

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
@@ -168,9 +168,6 @@ public class OpenAPIParserUtil {
 				javaDataType = javaDataTypeMap.get(
 					getReferenceName(items.getReference()));
 			}
-			else if (Objects.equals(items.getType(), "object")) {
-				javaDataType = Object.class.getName();
-			}
 
 			return getArrayClassName(javaDataType);
 		}
@@ -342,6 +339,9 @@ public class OpenAPIParserUtil {
 				put(
 					new AbstractMap.SimpleImmutableEntry<>("number", "double"),
 					Double.class.getName());
+				put(
+					new AbstractMap.SimpleImmutableEntry<>("object", null),
+					Object.class.getName());
 				put(
 					new AbstractMap.SimpleImmutableEntry<>("string", null),
 					String.class.getName());


### PR DESCRIPTION
```
type: object
additionalProperties:
  type: object
```
should generate a Map<String, Object> (like specified in https://swagger.io/docs/specification/data-models/dictionaries/) while 
```
type: object
additionalProperties: true
```
is Ok if it generates a Map<String, ?> as it is doing right now.

/cc @jeyvison @petershin @ZoltanTakacs