### PR TITLE
LPS-89415 allow returning all results if page/pageSize is 0

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/pagination/Page.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/pagination/Page.java
@@ -94,8 +94,16 @@ public class Page<T> {
 
 	private Page(Collection<T> items, Pagination pagination, long totalCount) {
 		_items = items;
-		_page = pagination.getPage();
-		_pageSize = pagination.getPageSize();
+
+		if (pagination == null) {
+			_page = 0;
+			_pageSize = 0;
+		}
+		else {
+			_page = pagination.getPage();
+			_pageSize = pagination.getPageSize();
+		}
+
 		_totalCount = totalCount;
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/SearchUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/SearchUtil.java
@@ -95,10 +95,13 @@ public class SearchUtil {
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setBooleanClauses(new BooleanClause[] {booleanClause});
-		searchContext.setEnd(pagination.getEndPosition());
 		searchContext.setKeywords(keywords);
 		searchContext.setSorts(sorts);
-		searchContext.setStart(pagination.getStartPosition());
+
+		if (pagination != null) {
+			searchContext.setEnd(pagination.getEndPosition());
+			searchContext.setStart(pagination.getStartPosition());
+		}
 
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/PaginationContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/PaginationContextProvider.java
@@ -14,7 +14,8 @@
 
 package com.liferay.portal.vulcan.internal.jaxrs.context.provider;
 
-import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.servlet.http.HttpServletRequest;
@@ -35,10 +36,16 @@ public class PaginationContextProvider implements ContextProvider<Pagination> {
 		HttpServletRequest httpServletRequest =
 			ContextProviderUtil.getHttpServletRequest(message);
 
-		int page = ParamUtil.getInteger(httpServletRequest, "page", 1);
-		int pageSize = ParamUtil.getInteger(httpServletRequest, "pageSize", 20);
+		String page = httpServletRequest.getParameter("page");
+		String pageSize = httpServletRequest.getParameter("pageSize");
 
-		return Pagination.of(page, pageSize);
+		if (StringUtil.equals(page, "0") || StringUtil.equals(pageSize, "0")) {
+			return null;
+		}
+
+		return Pagination.of(
+			GetterUtil.getInteger(page, 1),
+			GetterUtil.getInteger(pageSize, 20));
 	}
 
 }


### PR DESCRIPTION
It's the same as before (when 0 return null pagination) but having to pass it explicitly (before null was being cast to 0).

But we'll discuss the use case tomorrow because it could be enough/valid to remove the pagination from the OpenAPI profile for that endpoint if you don't need pagination at all.

/cc @inacionery