### PR TITLE
LPS-79338 portal-search-web: Make folder searcher also consider localized titles; make folder title lookup behave gracefully when field is not found.

### DIFF
--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/FieldValuesAssert.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/FieldValuesAssert.java
@@ -24,7 +24,8 @@ import java.util.stream.Stream;
 
 /**
  * @author André de Oliveira
- * @deprecated As of Judson (7.1.x), with no direct replacement
+ * @deprecated As of Judson (7.1.x), replaced by {@link
+ *             com.liferay.portal.search.test.util.FieldValuesAssert}
  */
 @Deprecated
 public class FieldValuesAssert {

--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
@@ -693,6 +693,15 @@ public class JournalTestUtil {
 			long parentFolderId, String name, ServiceContext serviceContext)
 		throws Exception {
 
+		return addFolder(
+			parentFolderId, name, "This is a test folder.", serviceContext);
+	}
+
+	public static JournalFolder addFolder(
+			long parentFolderId, String name, String description,
+			ServiceContext serviceContext)
+		throws Exception {
+
 		JournalFolder folder = JournalFolderLocalServiceUtil.fetchFolder(
 			serviceContext.getScopeGroupId(), parentFolderId, name);
 
@@ -702,7 +711,7 @@ public class JournalTestUtil {
 
 		return JournalFolderLocalServiceUtil.addFolder(
 			serviceContext.getUserId(), serviceContext.getScopeGroupId(),
-			parentFolderId, name, "This is a test folder.", serviceContext);
+			parentFolderId, name, description, serviceContext);
 	}
 
 	public static Element addMetadataElement(

--- a/modules/apps/journal/journal-test-util/src/main/resources/com/liferay/journal/test/util/packageinfo
+++ b/modules/apps/journal/journal-test-util/src/main/resources/com/liferay/journal/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalFolderIndexerLocalizedTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalFolderIndexerLocalizedTest.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.model.JournalFolder;
+import com.liferay.journal.model.JournalFolderConstants;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.QueryConfig;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.test.util.FieldValuesAssert;
+import com.liferay.portal.service.test.ServiceTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Yasuyuki Takeo
+ * @author André de Oliveira
+ */
+@RunWith(Arquillian.class)
+public class JournalFolderIndexerLocalizedTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_indexer = _indexerRegistry.getIndexer(JournalFolder.class);
+
+		ServiceTestUtil.setUser(TestPropsValues.getUser());
+
+		CompanyThreadLocal.setCompanyId(TestPropsValues.getCompanyId());
+
+		List<Locale> availableLocales = Collections.singletonList(
+			LocaleUtil.JAPAN);
+
+		GroupTestUtil.updateDisplaySettings(
+			_group.getGroupId(), availableLocales, LocaleUtil.JAPAN);
+	}
+
+	@Test
+	public void testJapaneseDescription() throws Exception {
+		ServiceContext serviceContext = _getServiceContext();
+
+		String description = "諸行無常";
+		String title = "平家物語";
+
+		_addFolder(serviceContext, title, description);
+
+		String searchTerm = "諸行";
+
+		Document document = _search(searchTerm, LocaleUtil.JAPAN);
+
+		FieldValuesAssert.assertFieldValues(
+			Collections.singletonMap("description_ja_JP", "諸行無常"),
+			"description", document, searchTerm);
+	}
+
+	@Test
+	public void testJapaneseSearchWithSimilarTexts() throws Exception {
+		ServiceContext serviceContext = _getServiceContext();
+
+		String description1 = "渋谷";
+		String title1 = "東京都";
+
+		_addFolder(serviceContext, title1, description1);
+
+		String description2 = "三年坂";
+		String title2 = "京都";
+
+		_addFolder(serviceContext, title2, description2);
+
+		String searchTerm = "東京";
+
+		Document document = _search(searchTerm, LocaleUtil.JAPAN);
+
+		FieldValuesAssert.assertFieldValues(
+			Collections.singletonMap("title_ja_JP", "東京都"), "title", document,
+			searchTerm);
+	}
+
+	@Test
+	public void testJapaneseTitle() throws Exception {
+		ServiceContext serviceContext = _getServiceContext();
+
+		String description = "諸行無常";
+		String title = "平家物語";
+
+		_addFolder(serviceContext, title, description);
+
+		String searchTerm = "平家";
+
+		Document document = _search(searchTerm, LocaleUtil.JAPAN);
+
+		FieldValuesAssert.assertFieldValues(
+			Collections.singletonMap("title_ja_JP", "平家物語"), "title", document,
+			searchTerm);
+	}
+
+	private void _addFolder(
+			ServiceContext serviceContext, String title, String description)
+		throws Exception {
+
+		JournalTestUtil.addFolder(
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, title, description,
+			serviceContext);
+	}
+
+	private SearchContext _getSearchContext(String searchTerm, Locale locale)
+		throws Exception {
+
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
+			_group.getGroupId());
+
+		searchContext.setKeywords(searchTerm);
+
+		searchContext.setLocale(locale);
+
+		QueryConfig queryConfig = searchContext.getQueryConfig();
+
+		queryConfig.setSelectedFieldNames(StringPool.STAR);
+
+		return searchContext;
+	}
+
+	private ServiceContext _getServiceContext() throws Exception {
+		return ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId(), TestPropsValues.getUserId());
+	}
+
+	private Document _getSingleDocument(String searchTerm, Hits hits) {
+		List<Document> documents = hits.toList();
+
+		if (documents.size() == 1) {
+			return documents.get(0);
+		}
+
+		throw new AssertionError(searchTerm + "->" + documents);
+	}
+
+	private Document _search(String searchTerm, Locale locale) {
+		try {
+			SearchContext searchContext = _getSearchContext(searchTerm, locale);
+
+			Hits hits = _indexer.search(searchContext);
+
+			return _getSingleDocument(searchTerm, hits);
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Inject
+	private static IndexerRegistry _indexerRegistry;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Indexer<JournalFolder> _indexer;
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/context/FolderSearcher.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/context/FolderSearcher.java
@@ -31,6 +31,7 @@ public class FolderSearcher extends BaseSearcher {
 
 	public FolderSearcher() {
 		setDefaultSelectedFieldNames(Field.TITLE, Field.UID);
+		setDefaultSelectedLocalizedFieldNames(Field.TITLE);
 		setFilterSearch(true);
 		setPermissionAware(true);
 	}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/folder/facet/portlet/FolderFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/folder/facet/portlet/FolderFacetPortlet.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.web.internal.facet.display.builder.FolderSearchFacetDisplayBuilder;
 import com.liferay.portal.search.web.internal.facet.display.context.FolderSearchFacetDisplayContext;
+import com.liferay.portal.search.web.internal.facet.display.context.FolderSearcher;
 import com.liferay.portal.search.web.internal.facet.display.context.FolderTitleLookup;
 import com.liferay.portal.search.web.internal.facet.display.context.FolderTitleLookupImpl;
 import com.liferay.portal.search.web.internal.folder.facet.constants.FolderFacetPortletKeys;
@@ -97,7 +98,7 @@ public class FolderFacetPortlet extends MVCPortlet {
 			getAggregationName(renderRequest));
 
 		FolderTitleLookup folderTitleLookup = new FolderTitleLookupImpl(
-			portal.getHttpServletRequest(renderRequest));
+			new FolderSearcher(), portal.getHttpServletRequest(renderRequest));
 
 		FolderFacetConfiguration folderFacetConfiguration =
 			new FolderFacetConfigurationImpl(facet.getFacetConfiguration());

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/init.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/init.jsp
@@ -15,7 +15,6 @@
 --%>
 
 <%@ include file="/init.jsp" %>
-
 <%@ page import="com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.builder.AssetCategoriesSearchFacetDisplayBuilder" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.builder.AssetCategoryPermissionCheckerImpl" %><%@
@@ -32,6 +31,7 @@ page import="com.liferay.portal.search.web.internal.facet.display.context.AssetT
 page import="com.liferay.portal.search.web.internal.facet.display.context.AssetTagsSearchFacetTermDisplayContext" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.context.FolderSearchFacetDisplayContext" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.context.FolderSearchFacetTermDisplayContext" %><%@
+page import="com.liferay.portal.search.web.internal.facet.display.context.FolderSearcher" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.context.FolderTitleLookupImpl" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.context.ScopeSearchFacetDisplayContext" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.context.ScopeSearchFacetTermDisplayContext" %><%@

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/folders.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/folders.jsp
@@ -20,7 +20,7 @@
 FolderSearchFacetDisplayBuilder folderSearchFacetDisplayBuilder = new FolderSearchFacetDisplayBuilder();
 
 folderSearchFacetDisplayBuilder.setFacet(facet);
-folderSearchFacetDisplayBuilder.setFolderTitleLookup(new FolderTitleLookupImpl(request));
+folderSearchFacetDisplayBuilder.setFolderTitleLookup(new FolderTitleLookupImpl(new FolderSearcher(), request));
 folderSearchFacetDisplayBuilder.setFrequenciesVisible(dataJSONObject.getBoolean("showAssetCount", true));
 folderSearchFacetDisplayBuilder.setFrequencyThreshold(dataJSONObject.getInt("frequencyThreshold"));
 folderSearchFacetDisplayBuilder.setMaxTerms(dataJSONObject.getInt("maxTerms", 10));

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/facet/display/context/FolderTitleLookupTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/facet/display/context/FolderTitleLookupTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.internal.facet.display.context;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.HitsImpl;
+import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.PropsImpl;
+
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Adam Brandizzi
+ */
+@RunWith(PowerMockRunner.class)
+@SuppressStaticInitializationFor("com.liferay.portal.kernel.search.BaseIndexer")
+public class FolderTitleLookupTest {
+
+	@Before
+	public void setUp() {
+		setUpPropsUtil();
+	}
+
+	@Test
+	public void testGetFolderTitle() throws SearchException {
+		Hits hits = getHitsWithDocument(
+			getTitleLocalizedFieldName(LocaleUtil.BRAZIL), "My Title");
+
+		FolderTitleLookup folderTitleLookup = new FolderTitleLookupImpl(
+			mockFolderSearcher(hits), mockHttpServletRequest(LocaleUtil.US));
+
+		Assert.assertEquals(
+			"My Title",
+			folderTitleLookup.getFolderTitle(RandomTestUtil.randomLong()));
+	}
+
+	@Test
+	public void testGetFolderTitleFromAnyLocalizedField()
+		throws SearchException {
+
+		Hits hits = getHitsWithDocument(Field.TITLE, "My Title");
+
+		FolderTitleLookup folderTitleLookup = new FolderTitleLookupImpl(
+			mockFolderSearcher(hits),
+			mockHttpServletRequest(LocaleUtil.BRAZIL));
+
+		Assert.assertEquals(
+			"My Title",
+			folderTitleLookup.getFolderTitle(RandomTestUtil.randomLong()));
+	}
+
+	@Test
+	public void testGetFolderTitleFromDisplayLocaleLocalizedField()
+		throws SearchException {
+
+		Hits hits = getHitsWithDocument(
+			getTitleLocalizedFieldName(LocaleUtil.BRAZIL), "My Title");
+
+		FolderTitleLookup folderTitleLookup = new FolderTitleLookupImpl(
+			mockFolderSearcher(hits),
+			mockHttpServletRequest(LocaleUtil.BRAZIL));
+
+		Assert.assertEquals(
+			"My Title",
+			folderTitleLookup.getFolderTitle(RandomTestUtil.randomLong()));
+	}
+
+	protected Hits getHitsWithDocument(String fieldName, String value) {
+		Document document = new DocumentImpl();
+
+		document.addText(fieldName, value);
+
+		Hits hits = new HitsImpl();
+
+		hits.setLength(1);
+		hits.setDocs(new Document[] {document});
+
+		return hits;
+	}
+
+	protected String getTitleLocalizedFieldName(Locale locale) {
+		return Field.TITLE + StringPool.UNDERLINE + locale;
+	}
+
+	protected FolderSearcher mockFolderSearcher(Hits hits)
+		throws SearchException {
+
+		FolderSearcher folderSearcher = Mockito.mock(FolderSearcher.class);
+
+		Mockito.when(
+			folderSearcher.search(Matchers.any())
+		).thenReturn(
+			hits
+		);
+
+		return folderSearcher;
+	}
+
+	protected MockHttpServletRequest mockHttpServletRequest(Locale locale) {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getLocale()
+		).thenReturn(
+			locale
+		);
+
+		request.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		return request;
+	}
+
+	protected void setUpPropsUtil() {
+		PropsUtil.setProps(new PropsImpl());
+	}
+
+}


### PR DESCRIPTION
<h3>:heavy_check_mark: ci:test:search - 20 out of 20 jobs passed in 1 hour 12 minutes 34 seconds 581 ms</h3>

https://github.com/brandizzi/liferay-portal/pull/713#issuecomment-488808360
Author: @yasuflatland-lf @ealonso
Reviewer: @arboliveira @brandizzi

[Bug] Journal Folder is missing Multi language search functionality
https://issues.liferay.com/browse/LPS-79338