### PR TITLE
 LPS-87307 Fix broken login over IPv6

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -1159,16 +1159,20 @@
 					Util._submitLocked = true;
 				}
 
-				var actionURL = new A.Url(action);
+				var searchParamsIndex = action.indexOf('?');
 
-				var authToken = actionURL.getParameter('p_auth') || '';
+				var searchParams = new URLSearchParams(
+					action.substring(searchParamsIndex)
+				);
+
+				var authToken = searchParams.get('p_auth') || '';
 
 				form.append('<input name="p_auth" type="hidden" value="' + authToken + '" />');
 
 				if (authToken) {
-					actionURL.removeParameter('p_auth');
+					searchParams.delete('p_auth');
 
-					action = actionURL.toString();
+					action = action.substring(0, searchParamsIndex + 1) + searchParams.toString();
 				}
 
 				form.attr('action', action);

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -1161,9 +1161,15 @@
 
 				var searchParamsIndex = action.indexOf('?');
 
-				var searchParams = new URLSearchParams(
-					action.substring(searchParamsIndex)
-				);
+				if (searchParamsIndex === -1) {
+					var baseURL = action;
+					var queryString = '';
+				} else {
+					var baseURL = action.slice(0, searchParamsIndex);
+					var queryString = action.slice(searchParamsIndex + 1);
+				}
+
+				var searchParams = new URLSearchParams(queryString);
 
 				var authToken = searchParams.get('p_auth') || '';
 
@@ -1172,7 +1178,7 @@
 				if (authToken) {
 					searchParams.delete('p_auth');
 
-					action = action.substring(0, searchParamsIndex + 1) + searchParams.toString();
+					action = baseURL + '?' + searchParams.toString();
 				}
 
 				form.attr('action', action);


### PR DESCRIPTION
When logging in via a literal IPv6 address (eg. http://[::1]:8080/), we had some legacy code in the login form that was assuming IPv4 and choking on the address, breaking login. Fix is to use the native `SearchParams` API instead, which handles IPv6 just fine and which we already polyfill in IE, so is available on all the browsers in our compatibility matrix.

@brianchandotcom: I'm sending this against "master", but please let me know if I should resend it anywhere else. In terms of urgency/priority, this was reported in December and isolated to the front-end a few days ago, but it only affects logging in via literal IPv6 addresses.