### PR TITLE
LPS-95002 - Cannot edit a section's column width, columns, or padding.  Payload was not being sent for updateRowColumns action

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/utils/FragmentsEditorUpdateUtils.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/utils/FragmentsEditorUpdateUtils.es.js
@@ -279,8 +279,13 @@ function updateRow(store, updateAction, payload) {
 	store
 		.dispatch(enableSavingChangesStatusAction())
 		.dispatch(
-			updateAction,
-			payload
+			Object.assign(
+				{},
+				payload,
+				{
+					type: updateAction
+				}
+			)
 		)
 		.dispatch(
 			{


### PR DESCRIPTION
@brianchandotcom this is one of the blockers for 7.2

https://issues.liferay.com/browse/LPS-95002

tested here: https://github.com/brianchiu/liferay-portal/pull/1907

7.2.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/24259