### PR TITLE
LPS-93387 Dont display folder ids to users without view permission

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/builder/FolderSearchFacetDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/builder/FolderSearchFacetDisplayBuilder.java
@@ -129,7 +129,7 @@ public class FolderSearchFacetDisplayBuilder {
 
 		String displayName = getDisplayName(folderId);
 
-		if ((folderId == 0) || Validator.isNull(displayName)) {
+		if ((folderId == 0) || (displayName == null)) {
 			return null;
 		}
 
@@ -180,11 +180,11 @@ public class FolderSearchFacetDisplayBuilder {
 	protected String getDisplayName(long folderId) {
 		String title = _folderTitleLookup.getFolderTitle(folderId);
 
-		if (title != null) {
+		if (Validator.isNotNull(title)) {
 			return title;
 		}
 
-		return StringPool.BLANK;
+		return null;
 	}
 
 	protected FolderSearchFacetTermDisplayContext

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/builder/FolderSearchFacetDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/builder/FolderSearchFacetDisplayBuilder.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
 import com.liferay.portal.kernel.search.facet.collector.TermCollector;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.web.internal.facet.display.context.FolderSearchFacetDisplayContext;
 import com.liferay.portal.search.web.internal.facet.display.context.FolderSearchFacetTermDisplayContext;
 import com.liferay.portal.search.web.internal.facet.display.context.FolderTitleLookup;
@@ -126,12 +127,14 @@ public class FolderSearchFacetDisplayBuilder {
 
 		long folderId = GetterUtil.getLong(termCollector.getTerm());
 
-		if (folderId == 0) {
+		String displayName = getDisplayName(folderId);
+
+		if ((folderId == 0) || Validator.isNull(displayName)) {
 			return null;
 		}
 
 		return buildFolderSearchFacetTermDisplayContext(
-			folderId, getDisplayName(folderId), termCollector.getFrequency(),
+			folderId, displayName, termCollector.getFrequency(),
 			isSelected(folderId));
 	}
 
@@ -181,7 +184,7 @@ public class FolderSearchFacetDisplayBuilder {
 			return title;
 		}
 
-		return StringPool.OPEN_BRACKET + folderId + StringPool.CLOSE_BRACKET;
+		return StringPool.BLANK;
 	}
 
 	protected FolderSearchFacetTermDisplayContext


### PR DESCRIPTION
✔️ **ci:test:search - 18 out of 18 jobs passed in 3 hours 31 minutes 39 seconds** https://github.com/BryanEngler/liferay-portal/pull/336#issuecomment-484229308

Authors: @brianikim @BryanEngler
Reviewers: @arboliveira @BryanEngler

---
*[Bug] FolderSearchFacet lists Folder Names or Ids to folders a user does not have VIEW permissions to.*
https://issues.liferay.com/browse/LPS-93387