### PR TITLE
 LPS-94781 Add theme contributor resources only conditionally

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/bnd.bnd
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/bnd.bnd
@@ -1,5 +1,4 @@
 Bundle-Name: Liferay Product Navigation Control Menu Theme Contributor
 Bundle-SymbolicName: com.liferay.product.navigation.control.menu.theme.contributor
 Bundle-Version: 5.0.0
-Liferay-Theme-Contributor-Type: product-navigation-control-menu
 Web-ContextPath: /product-navigation-control-menu-theme-contributor

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/build.gradle
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:portal-url-builder:portal-url-builder-api")
 	compileOnly project(":apps:product-navigation:product-navigation-control-menu-api")
 }

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/servlet/taglib/ProductNavigationControlMenuTopHeadDynamicInclude.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/servlet/taglib/ProductNavigationControlMenuTopHeadDynamicInclude.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.product.navigation.control.menu.theme.contributor.internal.servlet.taglib;
+
+import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Iván Zaera Avellón
+ */
+@Component(immediate = true, service = DynamicInclude.class)
+public class ProductNavigationControlMenuTopHeadDynamicInclude
+	implements DynamicInclude {
+
+	@Override
+	public void include(
+			HttpServletRequest request, HttpServletResponse response,
+			String key)
+		throws IOException {
+
+		PrintWriter printWriter = response.getWriter();
+
+		StringBundler sb = new StringBundler(6);
+
+		AbsolutePortalURLBuilder absolutePortalURLBuilder =
+			_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+				request);
+
+		sb.append("<link data-senna-track=\"permanent\" href=\"");
+		sb.append(
+			absolutePortalURLBuilder.forModule(
+				_bundle, "/product_navigation_control_menu.css"
+			).build());
+		sb.append("\" rel=\"stylesheet\" type = \"text/css\" />\n");
+
+		sb.append("<script data-senna-track=\"permanent\" src=\"");
+		sb.append(
+			absolutePortalURLBuilder.forModule(
+				_bundle, "/product_navigation_control_menu.js"
+			).build());
+		sb.append("\" type=\"text/javascript\"></script>");
+
+		printWriter.println(sb.toString());
+	}
+
+	@Override
+	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
+		dynamicIncludeRegistry.register(
+			"/html/common/themes/top_head.jsp#post");
+	}
+
+	@Activate
+	@Modified
+	protected void activate(BundleContext bundleContext) {
+		_bundle = bundleContext.getBundle();
+	}
+
+	@Reference
+	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
+
+	private Bundle _bundle;
+
+}

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/servlet/taglib/ProductNavigationControlMenuTopHeadDynamicInclude.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/servlet/taglib/ProductNavigationControlMenuTopHeadDynamicInclude.java
@@ -15,7 +15,9 @@
 package com.liferay.product.navigation.control.menu.theme.contributor.internal.servlet.taglib;
 
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
 import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
 
@@ -44,6 +46,13 @@ public class ProductNavigationControlMenuTopHeadDynamicInclude
 			HttpServletRequest request, HttpServletResponse response,
 			String key)
 		throws IOException {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		if (!themeDisplay.isSignedIn()) {
+			return;
+		}
 
 		PrintWriter printWriter = response.getWriter();
 

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/servlet/taglib/ProductNavigationControlMenuTopHeadDynamicInclude.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/servlet/taglib/ProductNavigationControlMenuTopHeadDynamicInclude.java
@@ -14,6 +14,7 @@
 
 package com.liferay.product.navigation.control.menu.theme.contributor.internal.servlet.taglib;
 
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -51,6 +52,12 @@ public class ProductNavigationControlMenuTopHeadDynamicInclude
 			WebKeys.THEME_DISPLAY);
 
 		if (!themeDisplay.isSignedIn()) {
+			return;
+		}
+
+		Layout layout = themeDisplay.getLayout();
+
+		if (layout.isTypeControlPanel()) {
 			return;
 		}
 

--- a/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/bnd.bnd
+++ b/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/bnd.bnd
@@ -1,5 +1,4 @@
 Bundle-Name: Liferay Product Navigation Product Menu Theme Contributor
 Bundle-SymbolicName: com.liferay.product.navigation.product.menu.theme.contributor
 Bundle-Version: 5.0.0
-Liferay-Theme-Contributor-Type: product-navigation-product-menu
 Web-ContextPath: /product-navigation-product-menu-theme-contributor

--- a/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/build.gradle
+++ b/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/build.gradle
@@ -2,8 +2,10 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:application-list:application-list-api")
+	compileOnly project(":apps:portal-url-builder:portal-url-builder-api")
 	compileOnly project(":apps:product-navigation:product-navigation-product-menu-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/java/com/liferay/product/navigation/product/menu/theme/contributor/internal/servlet/taglib/ProductNavigationProductMenuTopHeadDynamicInclude.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/java/com/liferay/product/navigation/product/menu/theme/contributor/internal/servlet/taglib/ProductNavigationProductMenuTopHeadDynamicInclude.java
@@ -15,7 +15,9 @@
 package com.liferay.product.navigation.product.menu.theme.contributor.internal.servlet.taglib;
 
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
 import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
 
@@ -44,6 +46,13 @@ public class ProductNavigationProductMenuTopHeadDynamicInclude
 			HttpServletRequest request, HttpServletResponse response,
 			String key)
 		throws IOException {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		if (!themeDisplay.isSignedIn()) {
+			return;
+		}
 
 		PrintWriter printWriter = response.getWriter();
 

--- a/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/java/com/liferay/product/navigation/product/menu/theme/contributor/internal/servlet/taglib/ProductNavigationProductMenuTopHeadDynamicInclude.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/java/com/liferay/product/navigation/product/menu/theme/contributor/internal/servlet/taglib/ProductNavigationProductMenuTopHeadDynamicInclude.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.product.navigation.product.menu.theme.contributor.internal.servlet.taglib;
+
+import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Iván Zaera Avellón
+ */
+@Component(immediate = true, service = DynamicInclude.class)
+public class ProductNavigationProductMenuTopHeadDynamicInclude
+	implements DynamicInclude {
+
+	@Override
+	public void include(
+			HttpServletRequest request, HttpServletResponse response,
+			String key)
+		throws IOException {
+
+		PrintWriter printWriter = response.getWriter();
+
+		StringBundler sb = new StringBundler(3);
+
+		AbsolutePortalURLBuilder absolutePortalURLBuilder =
+			_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+				request);
+
+		sb.append("<link data-senna-track=\"permanent\" href=\"");
+		sb.append(
+			absolutePortalURLBuilder.forModule(
+				_bundle, "/product_navigation_product_menu.css"
+			).build());
+		sb.append("\" rel=\"stylesheet\" type = \"text/css\" />\n");
+
+		printWriter.println(sb.toString());
+	}
+
+	@Override
+	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
+		dynamicIncludeRegistry.register(
+			"/html/common/themes/top_head.jsp#post");
+	}
+
+	@Activate
+	@Modified
+	protected void activate(BundleContext bundleContext) {
+		_bundle = bundleContext.getBundle();
+	}
+
+	@Reference
+	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
+
+	private Bundle _bundle;
+
+}

--- a/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/bnd.bnd
+++ b/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/bnd.bnd
@@ -1,5 +1,4 @@
 Bundle-Name: Liferay Product Navigation Simulation Theme Contributor
 Bundle-SymbolicName: com.liferay.product.navigation.simulation.theme.contributor
 Bundle-Version: 5.0.0
-Liferay-Theme-Contributor-Type: simulation-panel
 Web-ContextPath: /product-navigation-simulation-theme-contributor

--- a/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/build.gradle
+++ b/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:portal-url-builder:portal-url-builder-api")
+}

--- a/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/java/com/liferay/product/navigation/simulation/theme/contributor/internal/servlet/taglib/ProductNavigationSimulationTopHeadDynamicInclude.java
+++ b/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/java/com/liferay/product/navigation/simulation/theme/contributor/internal/servlet/taglib/ProductNavigationSimulationTopHeadDynamicInclude.java
@@ -15,7 +15,9 @@
 package com.liferay.product.navigation.simulation.theme.contributor.internal.servlet.taglib;
 
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
 import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
 
@@ -44,6 +46,13 @@ public class ProductNavigationSimulationTopHeadDynamicInclude
 			HttpServletRequest request, HttpServletResponse response,
 			String key)
 		throws IOException {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		if (!themeDisplay.isSignedIn()) {
+			return;
+		}
 
 		PrintWriter printWriter = response.getWriter();
 

--- a/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/java/com/liferay/product/navigation/simulation/theme/contributor/internal/servlet/taglib/ProductNavigationSimulationTopHeadDynamicInclude.java
+++ b/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/java/com/liferay/product/navigation/simulation/theme/contributor/internal/servlet/taglib/ProductNavigationSimulationTopHeadDynamicInclude.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.product.navigation.simulation.theme.contributor.internal.servlet.taglib;
+
+import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Iván Zaera Avellón
+ */
+@Component(immediate = true, service = DynamicInclude.class)
+public class ProductNavigationSimulationTopHeadDynamicInclude
+	implements DynamicInclude {
+
+	@Override
+	public void include(
+			HttpServletRequest request, HttpServletResponse response,
+			String key)
+		throws IOException {
+
+		PrintWriter printWriter = response.getWriter();
+
+		StringBundler sb = new StringBundler(3);
+
+		AbsolutePortalURLBuilder absolutePortalURLBuilder =
+			_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+				request);
+
+		sb.append("<link data-senna-track=\"permanent\" href=\"");
+		sb.append(
+			absolutePortalURLBuilder.forModule(
+				_bundle, "/css/simulation_panel.css"
+			).build());
+		sb.append("\" rel=\"stylesheet\" type = \"text/css\" />\n");
+
+		printWriter.println(sb.toString());
+	}
+
+	@Override
+	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
+		dynamicIncludeRegistry.register(
+			"/html/common/themes/top_head.jsp#post");
+	}
+
+	@Activate
+	@Modified
+	protected void activate(BundleContext bundleContext) {
+		_bundle = bundleContext.getBundle();
+	}
+
+	@Reference
+	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
+
+	private Bundle _bundle;
+
+}

--- a/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/java/com/liferay/product/navigation/simulation/theme/contributor/internal/servlet/taglib/ProductNavigationSimulationTopHeadDynamicInclude.java
+++ b/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/java/com/liferay/product/navigation/simulation/theme/contributor/internal/servlet/taglib/ProductNavigationSimulationTopHeadDynamicInclude.java
@@ -14,6 +14,7 @@
 
 package com.liferay.product.navigation.simulation.theme.contributor.internal.servlet.taglib;
 
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -51,6 +52,12 @@ public class ProductNavigationSimulationTopHeadDynamicInclude
 			WebKeys.THEME_DISPLAY);
 
 		if (!themeDisplay.isSignedIn()) {
+			return;
+		}
+
+		Layout layout = themeDisplay.getLayout();
+
+		if (layout.isTypeControlPanel()) {
 			return;
 		}
 


### PR DESCRIPTION
Product and simulation menu CSS and JS shouldn't be shipped unconditionally to the client (for example, when logged out, or when not in the control panel).

Example before:

![before home signed out](https://user-images.githubusercontent.com/7074/57235320-e71ac100-7022-11e9-862a-fc2b9f022d0b.png)

After:

![after logged out](https://user-images.githubusercontent.com/7074/57235328-eaae4800-7022-11e9-9630-5f6d182df5bc.png)
