### PR TITLE
Lps 83966

### DIFF
--- a/util-taglib/src/META-INF/liferay-util.tld
+++ b/util-taglib/src/META-INF/liferay-util.tld
@@ -10,7 +10,6 @@
 		<name>body-bottom</name>
 		<tag-class>com.liferay.taglib.util.BodyBottomTag</tag-class>
 		<body-content>JSP</body-content>
-		<description>Deprecated since 7.2, unused.</description>
 		<attribute>
 			<name>outputKey</name>
 			<required>false</required>

--- a/util-taglib/src/com/liferay/taglib/ui/SearchFormTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchFormTag.java
@@ -21,9 +21,7 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated As of Mueller (7.2.x), since 7.2, unused
  */
-@Deprecated
 public class SearchFormTag<R> extends IncludeTag {
 
 	public SearchContainer<?> getSearchContainer() {

--- a/util-taglib/src/com/liferay/taglib/ui/UserSearchFormTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/UserSearchFormTag.java
@@ -16,7 +16,9 @@ package com.liferay.taglib.ui;
 
 /**
  * @author Eudaldo Alonso
+ * @deprecated As of Mueller (7.2.x), since 7.2, unused
  */
+@Deprecated
 public class UserSearchFormTag<R> extends SearchFormTag<R> {
 
 	@Override

--- a/util-taglib/src/com/liferay/taglib/util/BodyBottomTag.java
+++ b/util-taglib/src/com/liferay/taglib/util/BodyBottomTag.java
@@ -18,9 +18,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated As of Mueller (7.2.x), since 7.2, unused
  */
-@Deprecated
 public class BodyBottomTag extends OutputTag {
 
 	public BodyBottomTag() {


### PR DESCRIPTION
@mateomustapic @markocikos @julien

For https://github.com/brianchandotcom/liferay-portal/commit/621f0661c884715540f90be19ecd415668dcaa22, if you really need to deprecated them, you must remove all the exist usages first, for both taglib and java code. We can not deprecate something while there are still usages.
