### PR TITLE
LPS-95239 Reindex all users

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
@@ -69,13 +69,15 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		UserLocalServiceUtil.deleteGroupUser(
 			testGroup.getGroupId(), _testUser.getUserId());
 
-		Indexer<User> indexer = IndexerRegistryUtil.getIndexer(
+		List<User> users = UserLocalServiceUtil.getUsers(
+			PortalUtil.getDefaultCompanyId(), false,
+			WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+
+		Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
 			_testUser.getModelClassName());
 
-		if (indexer != null) {
-			indexer.reindex(
-				_testUser.getModelClassName(), _testUser.getUserId());
-		}
+		indexer.reindex(users);
 	}
 
 	@Override


### PR DESCRIPTION
Hey @brianchandotcom 

We usually get that error when the index of elastic search is corrupted, removing the data folder and restarting the server or reindexing the User in the search configuration.

I would not merge this unless it fails on the CI, because as I said we got several of these failures locally but never in the CI. Just in case this is a possible solution

Thanks!