### PR TITLE
LPS-95046 No success message after changing user's language through account settings

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_user_navigation.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_user_navigation.jsp
@@ -61,7 +61,7 @@ if (!portletName.equals(UsersAdminPortletKeys.MY_ACCOUNT)) {
 
 <portlet:actionURL name="<%= actionCommandName %>" var="actionCommandURL" />
 
-<aui:form action="<%= actionCommandURL %>" cssClass="portlet-users-admin-edit-user" method="post" name="fm">
+<aui:form action="<%= actionCommandURL %>" cssClass="portlet-users-admin-edit-user" data-senna-off="true" method="post" name="fm">
 	<aui:input name="redirect" type="hidden" value="<%= redirect.toString() %>" />
 	<aui:input name="p_u_i_d" type="hidden" value="<%= selUserId %>" />
 	<aui:input name="screenNavigationCategoryKey" type="hidden" value="<%= screenNavigationCategoryKey %>" />


### PR DESCRIPTION
This is a temporary fix for now until we find the actual root cause of the issue.

When SPA is enabled, there's a few js error on form submission after changing user's language. This happens consistently every other time the form is submitted, and only when javascript.fast.load is enabled. Disabling SPA solves the issue. We'll need to investigate further, but we don't want to block testing because of this. So, we're sending this as temp fix for now.

/cc @drewbrokke @stsquared99 @alee8888 @ChrisKian @jbalsas