### PR TITLE
LPS-95374 IE11 - Personal Icon in Personal Bar is the wrong size

### DIFF
--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,7 +1,7 @@
 .portlet-user-personal-bar {
 	.personal-menu-dropdown {
 		.btn .sticker .inline-item {
-			font-size: unset;
+			font-size: 1.25rem;
 		}
 
 		.sticker-lg .lexicon-icon {


### PR DESCRIPTION
/cc @drewbrokke @stsquared99 @alee8888 @ChrisKian