### PR TITLE
LRCI-264 Set com.liferay.gradle.plugins.poshi.runner poshi runner version to 1.0.222

### DIFF
--- a/modules/sdk/gradle-plugins-poshi-runner/src/main/java/com/liferay/gradle/plugins/poshi/runner/PoshiRunnerExtension.java
+++ b/modules/sdk/gradle-plugins-poshi-runner/src/main/java/com/liferay/gradle/plugins/poshi/runner/PoshiRunnerExtension.java
@@ -115,6 +115,6 @@ public class PoshiRunnerExtension {
 	private Object _poshiPropertiesFile = "poshi.properties";
 	private final Project _project;
 	private final Set<Object> _testNames = new LinkedHashSet<>();
-	private Object _version = "latest.release";
+	private Object _version = "1.0.222";
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-264

@brianchandotcom, I consulted with @petershin, and I'm going to make some changes to the poshi gradle plugin, so that we can make updating poshi versions across gradle projects easier. Basically, will end up only having to send you one pull when we're ready to update, instead of the normal 7 backports. There'll be a few more changes after this. 

cc-ing: @pyoo47