### PR TITLE
LPS-95328 portal-search-admin-web: Fix editor to be responsive

### DIFF
--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/js/FieldMappings.es.js
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/js/FieldMappings.es.js
@@ -20,7 +20,8 @@ class FieldMappings extends PortletBase {
 						mode: 'json',
 						readOnly: 'true',
 						tabSize: 4,
-						value: this.fieldMappingsJson
+						value: this.fieldMappingsJson,
+						width: '100%'
 					}
 				).render();
 			}


### PR DESCRIPTION
<h3>:x: ci:test:search - 18 out of 21 jobs passed in 1 hour 31 minutes 27 seconds 221 ms</h3>

https://github.com/brandizzi/liferay-portal/pull/726#issuecomment-492794752

Author: @foshiro
Reviewer: @brandizzi

[Bug] Field Mappings Admin should use available screen space optimally
https://issues.liferay.com/browse/LPS-95328