### PR TITLE
LPS-95842 Count first to avoid cache miss as possible as we can. The …

### DIFF
--- a/modules/apps/subscription/subscription-service/src/main/java/com/liferay/subscription/service/impl/SubscriptionLocalServiceImpl.java
+++ b/modules/apps/subscription/subscription-service/src/main/java/com/liferay/subscription/service/impl/SubscriptionLocalServiceImpl.java
@@ -440,6 +440,10 @@ public class SubscriptionLocalServiceImpl
 
 		long classNameId = classNameLocalService.getClassNameId(className);
 
+		if (subscriptionPersistence.countByU_C(userId, classNameId) == 0) {
+			return false;
+		}
+
 		Subscription subscription = subscriptionPersistence.fetchByC_U_C_C(
 			companyId, userId, classNameId, classPK);
 
@@ -466,6 +470,10 @@ public class SubscriptionLocalServiceImpl
 		long companyId, long userId, String className, long[] classPKs) {
 
 		long classNameId = classNameLocalService.getClassNameId(className);
+
+		if (subscriptionPersistence.countByU_C(userId, classNameId) == 0) {
+			return false;
+		}
 
 		int count = subscriptionPersistence.countByC_U_C_C(
 			companyId, userId, classNameId, classPKs);


### PR DESCRIPTION
…reason is the combination of user, className and classPK would be too large to hit cache, most time we end up seeing new combination and create new entry in cache.