### PR TITLE
LPS-95837 When configuring Organization Types, having no children type results in a blank entry

### DIFF
--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/service/internal/configuration/OrganizationTypeConfigurationWrapper.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/service/internal/configuration/OrganizationTypeConfigurationWrapper.java
@@ -15,6 +15,8 @@
 package com.liferay.organizations.service.internal.configuration;
 
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Map;
 
@@ -32,7 +34,9 @@ import org.osgi.service.component.annotations.Modified;
 public class OrganizationTypeConfigurationWrapper {
 
 	public String[] getChildrenTypes() {
-		return _organizationTypeConfiguration.childrenTypes();
+		return ArrayUtil.filter(
+			_organizationTypeConfiguration.childrenTypes(),
+			Validator::isNotNull);
 	}
 
 	public String getName() {


### PR DESCRIPTION
This is an update for [LPS-95837](https://issues.liferay.com/browse/LPS-95837).<br><br>See Chris's comment here: https://github.com/drewbrokke/liferay-portal/pull/823#issue-280570627<br><br>/cc @pei-jung @stsquared99 @alee8888 @ChrisKian @dejuknow