### PR TITLE
LPS-82585 portal-search-web: Validate invalid range aliases

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/portlet/action/ModifiedFacetPortletConfigurationAction.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/portlet/action/ModifiedFacetPortletConfigurationAction.java
@@ -14,9 +14,23 @@
 
 package com.liferay.portal.search.web.internal.modified.facet.portlet.action;
 
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.PropertiesParamUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.search.web.internal.modified.facet.builder.DateRangeFactory;
 import com.liferay.portal.search.web.internal.modified.facet.constants.ModifiedFacetPortletKeys;
+
+import java.text.ParseException;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.PortletConfig;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -37,5 +51,37 @@ public class ModifiedFacetPortletConfigurationAction
 	public String getJspPath(HttpServletRequest httpServletRequest) {
 		return "/modified/facet/configuration.jsp";
 	}
+
+	@Override
+	public void processAction(
+			PortletConfig portletConfig, ActionRequest actionRequest,
+			ActionResponse actionResponse)
+		throws Exception {
+
+		UnicodeProperties properties = PropertiesParamUtil.getProperties(
+			actionRequest, _PARAMETER_NAME_PREFIX);
+
+		String ranges = properties.getProperty("ranges");
+
+		try {
+			DateRangeFactory dateRangeFactory = new DateRangeFactory(
+				DateFormatFactoryUtil.getDateFormatFactory());
+
+			dateRangeFactory.validateRange(ranges);
+		}
+		catch (JSONException | ParseException e) {
+			SessionErrors.add(actionRequest, "unparsableDate");
+			_log.error(e.getMessage());
+		}
+
+		if (SessionErrors.isEmpty(actionRequest)) {
+			super.processAction(portletConfig, actionRequest, actionResponse);
+		}
+	}
+
+	private static final String _PARAMETER_NAME_PREFIX = "preferences--";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ModifiedFacetPortletConfigurationAction.class);
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/configuration.jsp
@@ -26,7 +26,8 @@ page import="com.liferay.portal.search.web.internal.util.PortletPreferencesJspUt
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
-taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %>
+taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <portlet:defineObjects />
 
@@ -47,6 +48,7 @@ JSONArray rangesJSONArray = modifiedFacetPortletPreferences.getRangesJSONArray()
 >
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
 	<aui:input name="redirect" type="hidden" value="<%= configurationRenderURL %>" />
+	<liferay-ui:error key="unparsableDate" message="unparsable-date" />
 
 	<liferay-frontend:edit-form-body>
 		<liferay-frontend:fieldset-group>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/content/Language.properties
@@ -124,6 +124,7 @@ this-widget-is-not-visible-to-users-yet=This widget is not visible to users yet.
 threshold-for-displaying-did-you-mean=Threshold for Displaying "Did you mean: ..."
 threshold-for-displaying-related-queries=Threshold for Displaying "Related queries: ..."
 type-parameter-name=Type Parameter Name
+unparsable-date=Unparsable Date
 use-advanced-search-syntax=Use Advanced Search Syntax
 use-advanced-search-syntax-help=Enable this to parse the query using Lucene syntax instead of keywords. Malformed Lucene expressions may be rejected.
 user-parameter-name=User Parameter Name

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/modified/facet/builder/DateRangeFactoryTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/modified/facet/builder/DateRangeFactoryTest.java
@@ -14,12 +14,17 @@
 
 package com.liferay.portal.search.web.internal.modified.facet.builder;
 
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.util.DateFormatFactoryImpl;
+
+import java.text.ParseException;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -27,11 +32,33 @@ import org.junit.Test;
  */
 public class DateRangeFactoryTest {
 
+	@Before
+	public void setUp() {
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+	}
+
 	@Test
 	public void testBoundedRange() {
 		Assert.assertEquals(
 			"[20180131000000 TO 20180228235959]",
 			_dateRangeFactory.getRangeString("2018-01-31", "2018-02-28"));
+	}
+
+	@Test(expected = ParseException.class)
+	public void testDateFormatShouldBeyyyyMMddHHmmss() throws Exception {
+		_dateRangeFactory.validateRange(_INVALID_DATE_FORMAT);
+	}
+
+	@Test(expected = ParseException.class)
+	public void testInvalidRangeAliases() throws Exception {
+		_dateRangeFactory.validateRange(_INVALID_RANGE_ALIASES);
+	}
+
+	@Test(expected = ParseException.class)
+	public void testInvalidRangeWithoutBrackets() throws Exception {
+		_dateRangeFactory.validateRange(_WITHOUT_BRACKETS);
 	}
 
 	@Test
@@ -100,6 +127,15 @@ public class DateRangeFactoryTest {
 			_dateRangeFactory.replaceAliases(
 				"[past-year TO past-month]", calendar));
 	}
+
+	private static final String _INVALID_DATE_FORMAT =
+		"[{\"label\":\"past-hour\",\"range\":\"20190908 TO *\"}]";
+
+	private static final String _INVALID_RANGE_ALIASES =
+		"[{\"label\":\"past-hour\",\"range\":\"[past-test TO *]\"}]";
+
+	private static final String _WITHOUT_BRACKETS =
+		"[{\"label\":\"past-hour\",\"range\":\"past-hour TO *\"}]";
 
 	private final DateRangeFactory _dateRangeFactory = new DateRangeFactory(
 		new DateFormatFactoryImpl());


### PR DESCRIPTION
<h3>:x: ci:test:search - 19 out of 21 jobs passed in 1 hour 15 minutes 57 seconds 585 ms</h3>

https://github.com/brandizzi/liferay-portal/pull/740#issuecomment-494646339

Only unique failure was a baseline error in portal-kernel (which we did not change.)


Author: @foshiro
Reviewer: @brandizzi

[Bug] Modified Facet Portlet - Configuring an invalid range removes all search results
https://issues.liferay.com/browse/LPS-82585