### PR TITLE
LPS-96026 (+6 others) Bugfixes needed for Search Tuning Result Rankings (Pin and Hide results)

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexSearcher.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexSearcher.java
@@ -46,12 +46,8 @@ import com.liferay.portal.search.engine.adapter.search.CountSearchRequest;
 import com.liferay.portal.search.engine.adapter.search.CountSearchResponse;
 import com.liferay.portal.search.engine.adapter.search.SearchSearchRequest;
 import com.liferay.portal.search.engine.adapter.search.SearchSearchResponse;
-import com.liferay.portal.search.filter.ComplexQueryBuilderFactory;
-import com.liferay.portal.search.filter.ComplexQueryPart;
 import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.legacy.searcher.SearchResponseBuilderFactory;
-import com.liferay.portal.search.query.BooleanQuery;
-import com.liferay.portal.search.query.Queries;
 import com.liferay.portal.search.searcher.SearchRequest;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.searcher.SearchResponseBuilder;
@@ -347,36 +343,6 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 		return new String[] {indexName};
 	}
 
-	protected com.liferay.portal.search.query.Query getQuery(
-		SearchRequest searchRequest) {
-
-		com.liferay.portal.search.query.Query query = searchRequest.getQuery();
-
-		List<ComplexQueryPart> complexQueryParts =
-			searchRequest.getComplexQueryParts();
-
-		if (complexQueryParts.isEmpty()) {
-			if (query != null) {
-				return query;
-			}
-
-			return null;
-		}
-
-		BooleanQuery booleanQuery = _queries.booleanQuery();
-
-		if (query != null) {
-			booleanQuery.addMustQueryClauses(query);
-		}
-
-		return _complexQueryBuilderFactory.builder(
-		).addParts(
-			complexQueryParts
-		).root(
-			booleanQuery
-		).build();
-	}
-
 	protected SearchRequest getSearchRequest(SearchContext searchContext) {
 		SearchRequestBuilder searchRequestBuilder = _getSearchRequestBuilder(
 			searchContext);
@@ -429,6 +395,8 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 		BaseSearchRequest baseSearchRequest, SearchRequest searchRequest,
 		Query query, SearchContext searchContext) {
 
+		baseSearchRequest.addComplexQueryParts(
+			searchRequest.getComplexQueryParts());
 		baseSearchRequest.setExplain(searchRequest.isExplain());
 		baseSearchRequest.setIncludeResponseString(
 			searchRequest.isIncludeResponseString());
@@ -453,13 +421,6 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 		for (Aggregation aggregation : map.values()) {
 			baseSearchRequest.addAggregation(aggregation);
 		}
-	}
-
-	@Reference(unbind = "-")
-	protected void setComplexQueryBuilderFactory(
-		ComplexQueryBuilderFactory complexQueryBuilderFactory) {
-
-		_complexQueryBuilderFactory = complexQueryBuilderFactory;
 	}
 
 	@Reference(unbind = "-")
@@ -505,15 +466,10 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 		_props = props;
 	}
 
-	@Reference(unbind = "-")
-	protected void setQueries(Queries queries) {
-		_queries = queries;
-	}
-
 	protected void setQuery(
 		BaseSearchRequest baseSearchRequest, SearchRequest searchRequest) {
 
-		baseSearchRequest.setQuery(getQuery(searchRequest));
+		baseSearchRequest.setQuery(searchRequest.getQuery());
 	}
 
 	@Reference(target = "(search.engine.impl=Elasticsearch)", unbind = "-")
@@ -552,12 +508,10 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 	private static final Log _log = LogFactoryUtil.getLog(
 		ElasticsearchIndexSearcher.class);
 
-	private ComplexQueryBuilderFactory _complexQueryBuilderFactory;
 	private volatile ElasticsearchConfiguration _elasticsearchConfiguration;
 	private IndexNameBuilder _indexNameBuilder;
 	private boolean _logExceptionsOnly;
 	private Props _props;
-	private Queries _queries;
 	private SearchEngineAdapter _searchEngineAdapter;
 	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 	private SearchResponseBuilderFactory _searchResponseBuilderFactory;

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/document/DocumentFieldsTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/document/DocumentFieldsTranslator.java
@@ -59,6 +59,18 @@ public class DocumentFieldsTranslator {
 	}
 
 	public void translate(
+		DocumentBuilder documentBuilder,
+		Map<String, Object> documentSourceMap) {
+
+		if (MapUtil.isEmpty(documentSourceMap)) {
+			return;
+		}
+
+		documentSourceMap.forEach(
+			(name, value) -> translate(name, value, documentBuilder));
+	}
+
+	public void translate(
 		Map<String, DocumentField> documentFieldsMap,
 		DocumentBuilder documentBuilder) {
 
@@ -83,6 +95,18 @@ public class DocumentFieldsTranslator {
 
 		documentBuilder.setValues(
 			documentField.getName(), documentField.getValues());
+	}
+
+	protected void translate(
+		String name, Object value, DocumentBuilder documentBuilder) {
+
+		if (name.endsWith(_GEOPOINT_SUFFIX)) {
+			documentBuilder.setGeoLocationPoint(
+				name, _geoBuilders.geoLocationPoint((String)value));
+		}
+		else {
+			documentBuilder.setValue(name, value);
+		}
 	}
 
 	protected boolean translateGeoLocationPoint(

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/index/IndexSynchronizerImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/index/IndexSynchronizerImpl.java
@@ -27,10 +27,11 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import org.elasticsearch.ResourceAlreadyExistsException;
-import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.common.xcontent.XContentType;
 
 import org.osgi.service.component.annotations.Component;
@@ -139,8 +140,12 @@ public class IndexSynchronizerImpl implements IndexSynchronizer {
 
 		Client client = _elasticsearchClientResolver.getClient();
 
+		AdminClient adminClient = client.admin();
+
+		IndicesAdminClient indicesAdminClient = adminClient.indices();
+
 		CreateIndexRequestBuilder createIndexRequestBuilder =
-			CreateIndexAction.INSTANCE.newRequestBuilder(client);
+			indicesAdminClient.prepareCreate(null);
 
 		createIndexRequestBuilderConsumer.accept(createIndexRequestBuilder);
 

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/GetDocumentRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/GetDocumentRequestExecutorImpl.java
@@ -58,7 +58,7 @@ public class GetDocumentRequestExecutorImpl
 		DocumentBuilder documentBuilder = _documentBuilderFactory.builder();
 
 		documentFieldsTranslator.translate(
-			getResponse.getFields(), documentBuilder);
+			documentBuilder, getResponse.getSourceAsMap());
 
 		getDocumentResponse.setDocument(documentBuilder.build());
 

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/index/RefreshIndexRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/index/RefreshIndexRequestExecutorImpl.java
@@ -21,10 +21,11 @@ import com.liferay.portal.search.engine.adapter.index.RefreshIndexRequest;
 import com.liferay.portal.search.engine.adapter.index.RefreshIndexResponse;
 
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequestBuilder;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.IndicesAdminClient;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -76,12 +77,12 @@ public class RefreshIndexRequestExecutorImpl
 
 		Client client = _elasticsearchClientResolver.getClient();
 
-		RefreshRequestBuilder refreshRequestBuilder =
-			RefreshAction.INSTANCE.newRequestBuilder(client);
+		AdminClient adminClient = client.admin();
 
-		refreshRequestBuilder.setIndices(refreshIndexRequest.getIndexNames());
+		IndicesAdminClient indicesAdminClient = adminClient.indices();
 
-		return refreshRequestBuilder;
+		return indicesAdminClient.prepareRefresh(
+			refreshIndexRequest.getIndexNames());
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/search/SearchSearchResponseAssemblerImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/search/SearchSearchResponseAssemblerImpl.java
@@ -205,7 +205,7 @@ public class SearchSearchResponseAssemblerImpl
 			searchResponse.getHits();
 
 		SearchHits searchHits = searchHitsTranslator.translate(
-			elasticsearchSearchHits,
+			searchSearchRequest, elasticsearchSearchHits,
 			searchSearchRequest.getAlternateUidFieldName());
 
 		searchSearchResponse.setSearchHits(searchHits);

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/document/DocumentBuilderFactory.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/document/DocumentBuilderFactory.java
@@ -25,4 +25,6 @@ public interface DocumentBuilderFactory {
 
 	public DocumentBuilder builder();
 
+	public DocumentBuilder builder(Document document);
+
 }

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/filter/ComplexQueryPart.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/filter/ComplexQueryPart.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.search.filter;
 
+import com.liferay.portal.search.query.Query;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -31,6 +33,8 @@ public interface ComplexQueryPart {
 	public String getOccur();
 
 	public String getParent();
+
+	public Query getQuery();
 
 	public String getType();
 

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/filter/ComplexQueryPartBuilder.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/filter/ComplexQueryPartBuilder.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.search.filter;
 
+import com.liferay.portal.search.query.Query;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -35,6 +37,8 @@ public interface ComplexQueryPartBuilder {
 	public ComplexQueryPartBuilder occur(String occur);
 
 	public ComplexQueryPartBuilder parent(String parent);
+
+	public ComplexQueryPartBuilder query(Query query);
 
 	public ComplexQueryPartBuilder type(String type);
 

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/document/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/document/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.1
+version 1.1.0

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/filter/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/filter/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.1
+version 1.2.0

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/search/BaseSearchRequest.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/search/BaseSearchRequest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.search.aggregation.Aggregation;
 import com.liferay.portal.search.aggregation.pipeline.PipelineAggregation;
+import com.liferay.portal.search.filter.ComplexQueryPart;
 import com.liferay.portal.search.query.Query;
 import com.liferay.portal.search.stats.StatsRequest;
 
@@ -40,6 +41,12 @@ public abstract class BaseSearchRequest {
 		_aggregationsMap.put(aggregation.getName(), aggregation);
 	}
 
+	public void addComplexQueryParts(
+		Collection<ComplexQueryPart> complexQueryParts) {
+
+		_complexQueryParts.addAll(complexQueryParts);
+	}
+
 	public void addIndexBoost(String index, float boost) {
 		_indexBoosts.put(index, boost);
 	}
@@ -53,6 +60,10 @@ public abstract class BaseSearchRequest {
 
 	public Map<String, Aggregation> getAggregationsMap() {
 		return Collections.unmodifiableMap(_aggregationsMap);
+	}
+
+	public List<ComplexQueryPart> getComplexQueryParts() {
+		return Collections.unmodifiableList(_complexQueryParts);
 	}
 
 	public Boolean getExplain() {
@@ -222,6 +233,7 @@ public abstract class BaseSearchRequest {
 	private final Map<String, Aggregation> _aggregationsMap =
 		new LinkedHashMap<>();
 	private boolean _basicFacetSelection;
+	private final List<ComplexQueryPart> _complexQueryParts = new ArrayList<>();
 	private Boolean _explain;
 	private final Map<String, Facet> _facets = new LinkedHashMap<>();
 	private boolean _includeResponseString;

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/resources/com/liferay/portal/search/engine/adapter/search/packageinfo
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/resources/com/liferay/portal/search/engine/adapter/search/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.1
+version 3.1.0

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/document/DocumentBuilderFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/document/DocumentBuilderFactoryImpl.java
@@ -14,8 +14,12 @@
 
 package com.liferay.portal.search.internal.document;
 
+import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.document.DocumentBuilder;
 import com.liferay.portal.search.document.DocumentBuilderFactory;
+import com.liferay.portal.search.document.Field;
+
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -28,6 +32,19 @@ public class DocumentBuilderFactoryImpl implements DocumentBuilderFactory {
 	@Override
 	public DocumentBuilder builder() {
 		return new DocumentBuilderImpl();
+	}
+
+	@Override
+	public DocumentBuilder builder(Document document) {
+		DocumentBuilder documentBuilder = new DocumentBuilderImpl();
+
+		Map<String, Field> map = document.getFields();
+
+		map.forEach(
+			(name, field) -> documentBuilder.setValues(
+				name, field.getValues()));
+
+		return documentBuilder;
 	}
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryBuilderImpl.java
@@ -65,7 +65,7 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 				Collectors.toMap(ComplexQueryPart::getName, Function.identity())
 			);
 
-		Build build = new Build(complexQueryPartsMap);
+		Build build = new Build(complexQueryPartsMap, _getRootBooleanQuery());
 
 		return build.build();
 	}
@@ -77,6 +77,14 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 		return this;
 	}
 
+	private BooleanQuery _getRootBooleanQuery() {
+		if (_booleanQuery != null) {
+			return _booleanQuery;
+		}
+
+		return _queries.booleanQuery();
+	}
+
 	private BooleanQuery _booleanQuery;
 	private final List<ComplexQueryPart> _complexQueryParts = new ArrayList<>();
 	private final Queries _queries;
@@ -84,8 +92,12 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 
 	private class Build {
 
-		public Build(Map<String, ComplexQueryPart> complexQueryPartsMap) {
+		public Build(
+			Map<String, ComplexQueryPart> complexQueryPartsMap,
+			BooleanQuery rootBooleanQuery) {
+
 			_complexQueryPartsMap = complexQueryPartsMap;
+			_rootBooleanQuery = rootBooleanQuery;
 		}
 
 		public Query build() {
@@ -156,6 +168,10 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 			}
 
 			if (Objects.equals(type, "fuzzy")) {
+				if (Validator.isBlank(value)) {
+					return null;
+				}
+
 				return _queries.fuzzy(field, value);
 			}
 
@@ -168,10 +184,18 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 			}
 
 			if (Objects.equals(type, "match_phrase")) {
+				if (Validator.isBlank(value)) {
+					return null;
+				}
+
 				return _queries.matchPhrase(field, value);
 			}
 
 			if (Objects.equals(type, "match_phrase_prefix")) {
+				if (Validator.isBlank(value)) {
+					return null;
+				}
+
 				return _queries.matchPhrasePrefix(field, value);
 			}
 
@@ -185,10 +209,18 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 			}
 
 			if (Objects.equals(type, "prefix")) {
+				if (Validator.isBlank(value)) {
+					return null;
+				}
+
 				return _queries.prefix(field, value);
 			}
 
 			if (Objects.equals(type, "query_string")) {
+				if (Validator.isBlank(value)) {
+					return null;
+				}
+
 				StringQuery stringQuery = _queries.string(value);
 
 				if (!Validator.isBlank(field)) {
@@ -199,14 +231,26 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 			}
 
 			if (Objects.equals(type, "regexp")) {
+				if (Validator.isBlank(value)) {
+					return null;
+				}
+
 				return _queries.regex(field, value);
 			}
 
 			if (Objects.equals(type, "script")) {
+				if (Validator.isBlank(value)) {
+					return null;
+				}
+
 				return _queries.script(_scripts.script(value));
 			}
 
 			if (Objects.equals(type, "simple_query_string")) {
+				if (Validator.isBlank(value)) {
+					return null;
+				}
+
 				SimpleStringQuery simpleStringQuery = _queries.simpleString(
 					value);
 
@@ -218,10 +262,18 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 			}
 
 			if (Objects.equals(type, "term")) {
+				if (Validator.isBlank(value)) {
+					return null;
+				}
+
 				return _queries.term(field, value);
 			}
 
 			if (Objects.equals(type, "wildcard")) {
+				if (Validator.isBlank(value)) {
+					return null;
+				}
+
 				return _queries.wildcard(field, value);
 			}
 
@@ -250,7 +302,7 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 		}
 
 		protected BooleanQuery getRootBooleanQuery() {
-			return _booleanQuery;
+			return _rootBooleanQuery;
 		}
 
 		protected Query hydrate(ComplexQueryPart complexQueryPart) {
@@ -276,6 +328,7 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 
 		private final Map<String, ComplexQueryPart> _complexQueryPartsMap;
 		private final Map<String, Query> _queriesMap = new HashMap<>();
+		private final BooleanQuery _rootBooleanQuery;
 
 	}
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryBuilderImpl.java
@@ -142,11 +142,7 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 				return null;
 			}
 
-			String field = GetterUtil.getString(complexQueryPart.getField());
-			String type = GetterUtil.getString(complexQueryPart.getType());
-			String value = GetterUtil.getString(complexQueryPart.getValue());
-
-			Query query = buildQuery(type, field, value);
+			Query query = getQuery(complexQueryPart);
 
 			if (query == null) {
 				return null;
@@ -299,6 +295,18 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 			}
 
 			return getRootBooleanQuery();
+		}
+
+		protected Query getQuery(ComplexQueryPart complexQueryPart) {
+			if (complexQueryPart.getQuery() != null) {
+				return complexQueryPart.getQuery();
+			}
+
+			String field = GetterUtil.getString(complexQueryPart.getField());
+			String type = GetterUtil.getString(complexQueryPart.getType());
+			String value = GetterUtil.getString(complexQueryPart.getValue());
+
+			return buildQuery(type, field, value);
 		}
 
 		protected BooleanQuery getRootBooleanQuery() {

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryPartImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryPartImpl.java
@@ -16,6 +16,7 @@ package com.liferay.portal.search.internal.filter;
 
 import com.liferay.portal.search.filter.ComplexQueryPart;
 import com.liferay.portal.search.filter.ComplexQueryPartBuilder;
+import com.liferay.portal.search.query.Query;
 
 /**
  * @author André de Oliveira
@@ -32,6 +33,7 @@ public class ComplexQueryPartImpl implements ComplexQueryPart {
 		_name = complexQueryPartImpl._name;
 		_occur = complexQueryPartImpl._occur;
 		_parent = complexQueryPartImpl._parent;
+		_query = complexQueryPartImpl._query;
 		_type = complexQueryPartImpl._type;
 		_value = complexQueryPartImpl._value;
 	}
@@ -59,6 +61,11 @@ public class ComplexQueryPartImpl implements ComplexQueryPart {
 	@Override
 	public String getParent() {
 		return _parent;
+	}
+
+	@Override
+	public Query getQuery() {
+		return _query;
 	}
 
 	@Override
@@ -126,6 +133,13 @@ public class ComplexQueryPartImpl implements ComplexQueryPart {
 		}
 
 		@Override
+		public ComplexQueryPartBuilder query(Query query) {
+			_complexQueryPartImpl._query = query;
+
+			return this;
+		}
+
+		@Override
 		public Builder type(String type) {
 			_complexQueryPartImpl._type = type;
 
@@ -150,6 +164,7 @@ public class ComplexQueryPartImpl implements ComplexQueryPart {
 	private String _name;
 	private String _occur;
 	private String _parent;
+	private Query _query;
 	private String _type;
 	private String _value;
 


### PR DESCRIPTION
**✔️ ci:test:search - 18 out of 18 jobs passed in 1 hour 33 minutes 34 seconds 881 ms**
https://github.com/arboliveira/liferay-portal/pull/743#issuecomment-495156225

----

@brianchandotcom @jhendley These are fixes for Search framework bugs we uncovered while building the new DXP-only "Search Tuning - Result Rankings" application that lets admins pin and hide search results. There's 3 minor API changes in there (sorry about that) but I'm very confident this pull won't cause any disruptions. I know it's coming a bit late... but it would be super nice if we could have these auto backported ;) 

----

Authors: @arboliveira @BryanEngler
Reviewer: @arboliveira 

_[Bug] Complex Query Parts with "should" should widen results with extra condition; "must" and "filter" must filter to specific condition_
https://issues.liferay.com/browse/LPS-95824

_[Bug] Complex Query Parts with a blank value wrongly lead to an impossible condition and zero results_
https://issues.liferay.com/browse/LPS-95912

_[Task] Early detect NPE when redeploy activates component but connection not reopened yet_
https://issues.liferay.com/browse/LPS-96008

_[Bug] Low Level Search API must accept requests without a type, same as Elasticsearch_
https://issues.liferay.com/browse/LPS-96011

_[Bug] DocumentBuilder must be able to modify an existing document_
https://issues.liferay.com/browse/LPS-96024

_[Bug] Get Document API is unable to reconstitute nested fields_
https://issues.liferay.com/browse/LPS-96025

_[Bug] Complex Query Builder is unable to accept a prebuilt query_
https://issues.liferay.com/browse/LPS-96026
