### PR TITLE
LPS-95225 Tracks Liferay portlet services rather than javax.portlet instances

### DIFF
--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/adapter/PortletPanelAppAdapterRegistry.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/adapter/PortletPanelAppAdapterRegistry.java
@@ -18,11 +18,10 @@ import com.liferay.application.list.PanelApp;
 import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Portlet;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
-import javax.portlet.Portlet;
 
 import javax.servlet.ServletContext;
 

--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/adapter/PortletPanelAppAdapterServiceTrackerCustomizer.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/adapter/PortletPanelAppAdapterServiceTrackerCustomizer.java
@@ -15,6 +15,7 @@
 package com.liferay.application.list.adapter;
 
 import com.liferay.application.list.PanelApp;
+import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.Validator;
@@ -22,8 +23,6 @@ import com.liferay.portal.util.PortletCategoryUtil;
 
 import java.util.Dictionary;
 import java.util.Map;
-
-import javax.portlet.Portlet;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;


### PR DESCRIPTION
This is an update for [LPS-95225](https://issues.liferay.com/browse/LPS-95225).<br><br>Hey Brian, this solves a race condition where multiple javax.portlet.Portlet trackers would call back in the wrong order. Only PortletTracker should track javax.portlet.Portlet instances, and every other tracker should track com.liferay.portal.kernel.model.Portlet.  That way there is a guarantee that all the portlet setup logic has run first, and in this case it guarantees that the portlet has been persisted to the Portlet table.

@hhuijser is it reasonable to add a SF rule for this?

/cc @pei-jung @stsquared99 @alee8888 @ChrisKian @dejuknow @ctampoya