### PR TITLE
LPS-96112 asset-auto-tagger-opennlp-impl checks bin files into bundle…

### DIFF
--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -833,7 +833,7 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 
 					String name = file.getName();
 
-					if (name.endsWith(".jar")) {
+					if (name.endsWith(".jar") || name.endsWith(".bin")) {
 						Files.delete(filePath);
 
 						return FileVisitResult.CONTINUE;


### PR DESCRIPTION
… classpath, which is totally wrong. They should be checked in as resource files. I am just going to work around it here for now.