### PR TITLE
LPS-96218 Use pointer as a fallback for IE11

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/css/DragDrop.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/css/DragDrop.scss
@@ -59,6 +59,7 @@
 
 	&.fragments-editor__drag-handler,
 	.fragments-editor__drag-handler {
+		cursor: pointer;
 		cursor: grab;
 	}
 }


### PR DESCRIPTION
Hey @brianchandotcom 
The order, in this case, matters, because the first one is used as a fallback of the second one