### PR TITLE
LPS-95390 portal-search-web: Removes empty space below unconfigured alert

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/css/main.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/css/main.scss
@@ -1,13 +1,19 @@
-.search-bar {
-	.form-group.input-group-item {
+.portlet-search-bar {
+	.alert {
 		margin-bottom: 0;
 	}
-}
 
-.search-bar-keywords-input-wrapper {
-	min-width: 6.25rem;
-}
+	.search-bar {
+		.form-group.input-group-item {
+			margin-bottom: 0;
+		}
+	}
 
-.search-bar-search-select-wrapper {
-	max-width: 9.375rem;
+	.search-bar-keywords-input-wrapper {
+		min-width: 6.25rem;
+	}
+
+	.search-bar-search-select-wrapper {
+		max-width: 9.375rem;
+	}
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/suggestions/css/main.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/suggestions/css/main.scss
@@ -1,3 +1,5 @@
-.changed-keyword {
-	font-weight: bold;
+.portlet-suggestions {
+	.changed-keyword {
+		font-weight: bold;
+	}
 }


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-95390

This is a follow-up from https://github.com/brianchandotcom/liferay-portal/pull/73646 to remove the margin below the alert.

cc: @oliv-yu @BryanEngler @arboliveira @pat270