### PR TITLE
LPS-94857 simplify by using library and common function

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/build.gradle
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "commons-lang", name: "commons-lang", version: "2.6"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -42,8 +42,12 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.commons.lang.ArrayUtils;
 
 /**
  * @author Javier Gamarra
@@ -107,12 +111,14 @@ public class CustomFieldsUtil {
 					else if (ExpandoColumnConstants.DOUBLE_ARRAY ==
 								attributeType) {
 
-						return _toDoubleArray((List)data);
+						return ArrayUtils.toPrimitive(
+							_toArray(data, Double[]::new, Number::doubleValue));
 					}
 					else if (ExpandoColumnConstants.FLOAT_ARRAY ==
 								attributeType) {
 
-						return _toFloatArray((List)data);
+						return ArrayUtils.toPrimitive(
+							_toArray(data, Float[]::new, Number::floatValue));
 					}
 					else if (ExpandoColumnConstants.GEOLOCATION ==
 								attributeType) {
@@ -128,12 +134,14 @@ public class CustomFieldsUtil {
 					else if (ExpandoColumnConstants.INTEGER_ARRAY ==
 								attributeType) {
 
-						return _toIntegerArray((List)data);
+						return ArrayUtils.toPrimitive(
+							_toArray(data, Integer[]::new, Number::intValue));
 					}
 					else if (ExpandoColumnConstants.LONG_ARRAY ==
 								attributeType) {
 
-						return _toLongArray((List)data);
+						return ArrayUtils.toPrimitive(
+							_toArray(data, Long[]::new, Number::longValue));
 					}
 					else if (ExpandoColumnConstants.STRING_ARRAY ==
 								attributeType) {
@@ -204,6 +212,18 @@ public class CustomFieldsUtil {
 		}
 	}
 
+	private static <E> E[] _toArray(
+		Object data, IntFunction<E[]> intFunction,
+		Function<Number, E> function) {
+
+		return ((List<Number>)data).stream(
+		).map(
+			function
+		).toArray(
+			intFunction
+		);
+	}
+
 	private static CustomField _toCustomField(
 		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
 		Locale locale) {
@@ -258,39 +278,6 @@ public class CustomFieldsUtil {
 				name = entry.getKey();
 			}
 		};
-	}
-
-	private static Serializable _toDoubleArray(List<Double> doubles) {
-		return doubles.stream(
-		).mapToDouble(
-			Double::doubleValue
-		).toArray();
-	}
-
-	private static Serializable _toFloatArray(List<Double> doubles) {
-		float[] floats = new float[doubles.size()];
-
-		for (int i = 0; i < doubles.size(); i++) {
-			Double aDouble = doubles.get(i);
-
-			floats[i] = aDouble.floatValue();
-		}
-
-		return floats;
-	}
-
-	private static Serializable _toIntegerArray(List<Integer> integers) {
-		return integers.stream(
-		).mapToInt(
-			Integer::intValue
-		).toArray();
-	}
-
-	private static Serializable _toLongArray(List<Integer> integers) {
-		return integers.stream(
-		).mapToLong(
-			Integer::longValue
-		).toArray();
 	}
 
 }


### PR DESCRIPTION
The main problem is that Jackson tries to infer the type and creates mixed lists of integer with longs and floats, that's why we use Number.

And then we have to convert it to the type of the expando, that works with primitives so we have to convert from Integer to int that has awful support in Java.