### PR TITLE
Revert "LPS-95571 Revert "LPS-95219 Since we need to process the whole table anyway we don't need the where clause""

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_3/UpgradeLayoutTemplateId.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_3/UpgradeLayoutTemplateId.java
@@ -31,8 +31,7 @@ public class UpgradeLayoutTemplateId extends UpgradeProcess {
 		String sql = StringBundler.concat(
 			"update Layout set typeSettings = REPLACE(typeSettings, ",
 			"'layout-template-id=1_2_1_columns', ",
-			"'layout-template-id=1_2_1_columns_ii') where typesettings like ",
-			"'%layout-template-id=1_2_1_columns%'");
+			"'layout-template-id=1_2_1_columns_ii')");
 
 		runSQL(sql);
 	}


### PR DESCRIPTION
Hi @brianchandotcom,

Previous revert made in LPS-95219 adds a new issue and does not solve the problem. It also adds an unnecessary FULL SCAN of the table during the upgrade.

We will solve LPS-95219 (only Sybase) accordingly in another pull.

Thanks.

@tinatian @shuyangzhou @vicnate5