### PR TITLE
LPS-96319 fix flaky tests

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -363,14 +362,12 @@ public abstract class BaseKeywordResourceTestCase {
 
 		Assert.assertEquals(keywords2.toString(), 1, keywords2.size());
 
+		Page<Keyword> page3 = KeywordResource.getSiteKeywordsPage(
+			siteId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(keyword1, keyword2, keyword3),
-			new ArrayList<Keyword>() {
-				{
-					addAll(keywords1);
-					addAll(keywords2);
-				}
-			});
+			(List<Keyword>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -349,15 +348,15 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Assert.assertEquals(
 			taxonomyCategories2.toString(), 1, taxonomyCategories2.size());
 
+		Page<TaxonomyCategory> page3 =
+			TaxonomyCategoryResource.getTaxonomyCategoryTaxonomyCategoriesPage(
+				parentTaxonomyCategoryId, null, null, Pagination.of(1, 3),
+				null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				taxonomyCategory1, taxonomyCategory2, taxonomyCategory3),
-			new ArrayList<TaxonomyCategory>() {
-				{
-					addAll(taxonomyCategories1);
-					addAll(taxonomyCategories2);
-				}
-			});
+			(List<TaxonomyCategory>)page3.getItems());
 	}
 
 	@Test
@@ -792,15 +791,16 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Assert.assertEquals(
 			taxonomyCategories2.toString(), 1, taxonomyCategories2.size());
 
+		Page<TaxonomyCategory> page3 =
+			TaxonomyCategoryResource.
+				getTaxonomyVocabularyTaxonomyCategoriesPage(
+					taxonomyVocabularyId, null, null, Pagination.of(1, 3),
+					null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				taxonomyCategory1, taxonomyCategory2, taxonomyCategory3),
-			new ArrayList<TaxonomyCategory>() {
-				{
-					addAll(taxonomyCategories1);
-					addAll(taxonomyCategories2);
-				}
-			});
+			(List<TaxonomyCategory>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -336,15 +335,14 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		Assert.assertEquals(
 			taxonomyVocabularies2.toString(), 1, taxonomyVocabularies2.size());
 
+		Page<TaxonomyVocabulary> page3 =
+			TaxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
+				siteId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				taxonomyVocabulary1, taxonomyVocabulary2, taxonomyVocabulary3),
-			new ArrayList<TaxonomyVocabulary>() {
-				{
-					addAll(taxonomyVocabularies1);
-					addAll(taxonomyVocabularies2);
-				}
-			});
+			(List<TaxonomyVocabulary>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -291,14 +290,12 @@ public abstract class BaseOrganizationResourceTestCase {
 		Assert.assertEquals(
 			organizations2.toString(), 1, organizations2.size());
 
+		Page<Organization> page3 = OrganizationResource.getOrganizationsPage(
+			null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(organization1, organization2, organization3),
-			new ArrayList<Organization>() {
-				{
-					addAll(organizations1);
-					addAll(organizations2);
-				}
-			});
+			(List<Organization>)page3.getItems());
 	}
 
 	@Test
@@ -567,14 +564,13 @@ public abstract class BaseOrganizationResourceTestCase {
 		Assert.assertEquals(
 			organizations2.toString(), 1, organizations2.size());
 
+		Page<Organization> page3 =
+			OrganizationResource.getOrganizationOrganizationsPage(
+				parentOrganizationId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(organization1, organization2, organization3),
-			new ArrayList<Organization>() {
-				{
-					addAll(organizations1);
-					addAll(organizations2);
-				}
-			});
+			(List<Organization>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -248,14 +247,12 @@ public abstract class BaseSegmentResourceTestCase {
 
 		Assert.assertEquals(segments2.toString(), 1, segments2.size());
 
+		Page<Segment> page3 = SegmentResource.getSiteSegmentsPage(
+			siteId, Pagination.of(1, 3));
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(segment1, segment2, segment3),
-			new ArrayList<Segment>() {
-				{
-					addAll(segments1);
-					addAll(segments2);
-				}
-			});
+			(List<Segment>)page3.getItems());
 	}
 
 	protected Segment testGetSiteSegmentsPage_addSegment(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -258,14 +257,13 @@ public abstract class BaseSegmentUserResourceTestCase {
 
 		Assert.assertEquals(segmentUsers2.toString(), 1, segmentUsers2.size());
 
+		Page<SegmentUser> page3 =
+			SegmentUserResource.getSegmentUserAccountsPage(
+				segmentId, Pagination.of(1, 3));
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(segmentUser1, segmentUser2, segmentUser3),
-			new ArrayList<SegmentUser>() {
-				{
-					addAll(segmentUsers1);
-					addAll(segmentUsers2);
-				}
-			});
+			(List<SegmentUser>)page3.getItems());
 	}
 
 	protected SegmentUser testGetSegmentUserAccountsPage_addSegmentUser(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -371,14 +370,13 @@ public abstract class BaseUserAccountResourceTestCase {
 
 		Assert.assertEquals(userAccounts2.toString(), 1, userAccounts2.size());
 
+		Page<UserAccount> page3 =
+			UserAccountResource.getOrganizationUserAccountsPage(
+				organizationId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(userAccount1, userAccount2, userAccount3),
-			new ArrayList<UserAccount>() {
-				{
-					addAll(userAccounts1);
-					addAll(userAccounts2);
-				}
-			});
+			(List<UserAccount>)page3.getItems());
 	}
 
 	@Test
@@ -603,14 +601,12 @@ public abstract class BaseUserAccountResourceTestCase {
 
 		Assert.assertEquals(userAccounts2.toString(), 1, userAccounts2.size());
 
+		Page<UserAccount> page3 = UserAccountResource.getUserAccountsPage(
+			null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(userAccount1, userAccount2, userAccount3),
-			new ArrayList<UserAccount>() {
-				{
-					addAll(userAccounts1);
-					addAll(userAccounts2);
-				}
-			});
+			(List<UserAccount>)page3.getItems());
 	}
 
 	@Test
@@ -864,14 +860,13 @@ public abstract class BaseUserAccountResourceTestCase {
 
 		Assert.assertEquals(userAccounts2.toString(), 1, userAccounts2.size());
 
+		Page<UserAccount> page3 =
+			UserAccountResource.getWebSiteUserAccountsPage(
+				webSiteId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(userAccount1, userAccount2, userAccount3),
-			new ArrayList<UserAccount>() {
-				{
-					addAll(userAccounts1);
-					addAll(userAccounts2);
-				}
-			});
+			(List<UserAccount>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -282,14 +281,13 @@ public abstract class BaseWorkflowLogResourceTestCase {
 
 		Assert.assertEquals(workflowLogs2.toString(), 1, workflowLogs2.size());
 
+		Page<WorkflowLog> page3 =
+			WorkflowLogResource.getWorkflowTaskWorkflowLogsPage(
+				workflowTaskId, Pagination.of(1, 3));
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(workflowLog1, workflowLog2, workflowLog3),
-			new ArrayList<WorkflowLog>() {
-				{
-					addAll(workflowLogs1);
-					addAll(workflowLogs2);
-				}
-			});
+			(List<WorkflowLog>)page3.getItems());
 	}
 
 	protected WorkflowLog testGetWorkflowTaskWorkflowLogsPage_addWorkflowLog(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -263,14 +262,13 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 		Assert.assertEquals(
 			workflowTasks2.toString(), 1, workflowTasks2.size());
 
+		Page<WorkflowTask> page3 =
+			WorkflowTaskResource.getRoleWorkflowTasksPage(
+				roleId, Pagination.of(1, 3));
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(workflowTask1, workflowTask2, workflowTask3),
-			new ArrayList<WorkflowTask>() {
-				{
-					addAll(workflowTasks1);
-					addAll(workflowTasks2);
-				}
-			});
+			(List<WorkflowTask>)page3.getItems());
 	}
 
 	protected WorkflowTask testGetRoleWorkflowTasksPage_addWorkflowTask(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -388,15 +387,14 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		Assert.assertEquals(
 			blogPostingImages2.toString(), 1, blogPostingImages2.size());
 
+		Page<BlogPostingImage> page3 =
+			BlogPostingImageResource.getSiteBlogPostingImagesPage(
+				siteId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				blogPostingImage1, blogPostingImage2, blogPostingImage3),
-			new ArrayList<BlogPostingImage>() {
-				{
-					addAll(blogPostingImages1);
-					addAll(blogPostingImages2);
-				}
-			});
+			(List<BlogPostingImage>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -460,14 +459,12 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 		Assert.assertEquals(blogPostings2.toString(), 1, blogPostings2.size());
 
+		Page<BlogPosting> page3 = BlogPostingResource.getSiteBlogPostingsPage(
+			siteId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(blogPosting1, blogPosting2, blogPosting3),
-			new ArrayList<BlogPosting>() {
-				{
-					addAll(blogPostings1);
-					addAll(blogPostings2);
-				}
-			});
+			(List<BlogPosting>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -313,14 +312,12 @@ public abstract class BaseCommentResourceTestCase {
 
 		Assert.assertEquals(comments2.toString(), 1, comments2.size());
 
+		Page<Comment> page3 = CommentResource.getBlogPostingCommentsPage(
+			blogPostingId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(comment1, comment2, comment3),
-			new ArrayList<Comment>() {
-				{
-					addAll(comments1);
-					addAll(comments2);
-				}
-			});
+			(List<Comment>)page3.getItems());
 	}
 
 	@Test
@@ -640,14 +637,12 @@ public abstract class BaseCommentResourceTestCase {
 
 		Assert.assertEquals(comments2.toString(), 1, comments2.size());
 
+		Page<Comment> page3 = CommentResource.getCommentCommentsPage(
+			parentCommentId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(comment1, comment2, comment3),
-			new ArrayList<Comment>() {
-				{
-					addAll(comments1);
-					addAll(comments2);
-				}
-			});
+			(List<Comment>)page3.getItems());
 	}
 
 	@Test
@@ -902,14 +897,12 @@ public abstract class BaseCommentResourceTestCase {
 
 		Assert.assertEquals(comments2.toString(), 1, comments2.size());
 
+		Page<Comment> page3 = CommentResource.getDocumentCommentsPage(
+			documentId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(comment1, comment2, comment3),
-			new ArrayList<Comment>() {
-				{
-					addAll(comments1);
-					addAll(comments2);
-				}
-			});
+			(List<Comment>)page3.getItems());
 	}
 
 	@Test
@@ -1173,14 +1166,12 @@ public abstract class BaseCommentResourceTestCase {
 
 		Assert.assertEquals(comments2.toString(), 1, comments2.size());
 
+		Page<Comment> page3 = CommentResource.getStructuredContentCommentsPage(
+			structuredContentId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(comment1, comment2, comment3),
-			new ArrayList<Comment>() {
-				{
-					addAll(comments1);
-					addAll(comments2);
-				}
-			});
+			(List<Comment>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -267,15 +266,14 @@ public abstract class BaseContentSetElementResourceTestCase {
 		Assert.assertEquals(
 			contentSetElements2.toString(), 1, contentSetElements2.size());
 
+		Page<ContentSetElement> page3 =
+			ContentSetElementResource.getContentSetContentSetElementsPage(
+				contentSetId, Pagination.of(1, 3));
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				contentSetElement1, contentSetElement2, contentSetElement3),
-			new ArrayList<ContentSetElement>() {
-				{
-					addAll(contentSetElements1);
-					addAll(contentSetElements2);
-				}
-			});
+			(List<ContentSetElement>)page3.getItems());
 	}
 
 	protected ContentSetElement
@@ -397,15 +395,15 @@ public abstract class BaseContentSetElementResourceTestCase {
 		Assert.assertEquals(
 			contentSetElements2.toString(), 1, contentSetElements2.size());
 
+		Page<ContentSetElement> page3 =
+			ContentSetElementResource.
+				getSiteContentSetByKeyContentSetElementsPage(
+					siteId, key, Pagination.of(1, 3));
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				contentSetElement1, contentSetElement2, contentSetElement3),
-			new ArrayList<ContentSetElement>() {
-				{
-					addAll(contentSetElements1);
-					addAll(contentSetElements2);
-				}
-			});
+			(List<ContentSetElement>)page3.getItems());
 	}
 
 	protected ContentSetElement
@@ -542,15 +540,15 @@ public abstract class BaseContentSetElementResourceTestCase {
 		Assert.assertEquals(
 			contentSetElements2.toString(), 1, contentSetElements2.size());
 
+		Page<ContentSetElement> page3 =
+			ContentSetElementResource.
+				getSiteContentSetByUuidContentSetElementsPage(
+					siteId, uuid, Pagination.of(1, 3));
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				contentSetElement1, contentSetElement2, contentSetElement3),
-			new ArrayList<ContentSetElement>() {
-				{
-					addAll(contentSetElements1);
-					addAll(contentSetElements2);
-				}
-			});
+			(List<ContentSetElement>)page3.getItems());
 	}
 
 	protected ContentSetElement

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -354,15 +353,14 @@ public abstract class BaseContentStructureResourceTestCase {
 		Assert.assertEquals(
 			contentStructures2.toString(), 1, contentStructures2.size());
 
+		Page<ContentStructure> page3 =
+			ContentStructureResource.getSiteContentStructuresPage(
+				siteId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				contentStructure1, contentStructure2, contentStructure3),
-			new ArrayList<ContentStructure>() {
-				{
-					addAll(contentStructures1);
-					addAll(contentStructures2);
-				}
-			});
+			(List<ContentStructure>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -446,14 +445,13 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Assert.assertEquals(
 			documentFolders2.toString(), 1, documentFolders2.size());
 
+		Page<DocumentFolder> page3 =
+			DocumentFolderResource.getDocumentFolderDocumentFoldersPage(
+				parentDocumentFolderId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(documentFolder1, documentFolder2, documentFolder3),
-			new ArrayList<DocumentFolder>() {
-				{
-					addAll(documentFolders1);
-					addAll(documentFolders2);
-				}
-			});
+			(List<DocumentFolder>)page3.getItems());
 	}
 
 	@Test
@@ -757,14 +755,13 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Assert.assertEquals(
 			documentFolders2.toString(), 1, documentFolders2.size());
 
+		Page<DocumentFolder> page3 =
+			DocumentFolderResource.getSiteDocumentFoldersPage(
+				siteId, null, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(documentFolder1, documentFolder2, documentFolder3),
-			new ArrayList<DocumentFolder>() {
-				{
-					addAll(documentFolders1);
-					addAll(documentFolders2);
-				}
-			});
+			(List<DocumentFolder>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -332,14 +331,12 @@ public abstract class BaseDocumentResourceTestCase {
 
 		Assert.assertEquals(documents2.toString(), 1, documents2.size());
 
+		Page<Document> page3 = DocumentResource.getDocumentFolderDocumentsPage(
+			documentFolderId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(document1, document2, document3),
-			new ArrayList<Document>() {
-				{
-					addAll(documents1);
-					addAll(documents2);
-				}
-			});
+			(List<Document>)page3.getItems());
 	}
 
 	@Test
@@ -698,14 +695,12 @@ public abstract class BaseDocumentResourceTestCase {
 
 		Assert.assertEquals(documents2.toString(), 1, documents2.size());
 
+		Page<Document> page3 = DocumentResource.getSiteDocumentsPage(
+			siteId, null, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(document1, document2, document3),
-			new ArrayList<Document>() {
-				{
-					addAll(documents1);
-					addAll(documents2);
-				}
-			});
+			(List<Document>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -529,16 +528,17 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			knowledgeBaseArticles2.toString(), 1,
 			knowledgeBaseArticles2.size());
 
+		Page<KnowledgeBaseArticle> page3 =
+			KnowledgeBaseArticleResource.
+				getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
+					parentKnowledgeBaseArticleId, null, null,
+					Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				knowledgeBaseArticle1, knowledgeBaseArticle2,
 				knowledgeBaseArticle3),
-			new ArrayList<KnowledgeBaseArticle>() {
-				{
-					addAll(knowledgeBaseArticles1);
-					addAll(knowledgeBaseArticles2);
-				}
-			});
+			(List<KnowledgeBaseArticle>)page3.getItems());
 	}
 
 	@Test
@@ -878,16 +878,17 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			knowledgeBaseArticles2.toString(), 1,
 			knowledgeBaseArticles2.size());
 
+		Page<KnowledgeBaseArticle> page3 =
+			KnowledgeBaseArticleResource.
+				getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
+					knowledgeBaseFolderId, null, null, null,
+					Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				knowledgeBaseArticle1, knowledgeBaseArticle2,
 				knowledgeBaseArticle3),
-			new ArrayList<KnowledgeBaseArticle>() {
-				{
-					addAll(knowledgeBaseArticles1);
-					addAll(knowledgeBaseArticles2);
-				}
-			});
+			(List<KnowledgeBaseArticle>)page3.getItems());
 	}
 
 	@Test
@@ -1210,16 +1211,15 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			knowledgeBaseArticles2.toString(), 1,
 			knowledgeBaseArticles2.size());
 
+		Page<KnowledgeBaseArticle> page3 =
+			KnowledgeBaseArticleResource.getSiteKnowledgeBaseArticlesPage(
+				siteId, null, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				knowledgeBaseArticle1, knowledgeBaseArticle2,
 				knowledgeBaseArticle3),
-			new ArrayList<KnowledgeBaseArticle>() {
-				{
-					addAll(knowledgeBaseArticles1);
-					addAll(knowledgeBaseArticles2);
-				}
-			});
+			(List<KnowledgeBaseArticle>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -391,16 +390,16 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		Assert.assertEquals(
 			knowledgeBaseFolders2.toString(), 1, knowledgeBaseFolders2.size());
 
+		Page<KnowledgeBaseFolder> page3 =
+			KnowledgeBaseFolderResource.
+				getKnowledgeBaseFolderKnowledgeBaseFoldersPage(
+					parentKnowledgeBaseFolderId, Pagination.of(1, 3));
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				knowledgeBaseFolder1, knowledgeBaseFolder2,
 				knowledgeBaseFolder3),
-			new ArrayList<KnowledgeBaseFolder>() {
-				{
-					addAll(knowledgeBaseFolders1);
-					addAll(knowledgeBaseFolders2);
-				}
-			});
+			(List<KnowledgeBaseFolder>)page3.getItems());
 	}
 
 	protected KnowledgeBaseFolder
@@ -538,16 +537,15 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		Assert.assertEquals(
 			knowledgeBaseFolders2.toString(), 1, knowledgeBaseFolders2.size());
 
+		Page<KnowledgeBaseFolder> page3 =
+			KnowledgeBaseFolderResource.getSiteKnowledgeBaseFoldersPage(
+				siteId, Pagination.of(1, 3));
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				knowledgeBaseFolder1, knowledgeBaseFolder2,
 				knowledgeBaseFolder3),
-			new ArrayList<KnowledgeBaseFolder>() {
-				{
-					addAll(knowledgeBaseFolders1);
-					addAll(knowledgeBaseFolders2);
-				}
-			});
+			(List<KnowledgeBaseFolder>)page3.getItems());
 	}
 
 	protected KnowledgeBaseFolder

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -517,16 +516,17 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Assert.assertEquals(
 			messageBoardMessages2.toString(), 1, messageBoardMessages2.size());
 
+		Page<MessageBoardMessage> page3 =
+			MessageBoardMessageResource.
+				getMessageBoardMessageMessageBoardMessagesPage(
+					parentMessageBoardMessageId, null, null,
+					Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				messageBoardMessage1, messageBoardMessage2,
 				messageBoardMessage3),
-			new ArrayList<MessageBoardMessage>() {
-				{
-					addAll(messageBoardMessages1);
-					addAll(messageBoardMessages2);
-				}
-			});
+			(List<MessageBoardMessage>)page3.getItems());
 	}
 
 	@Test
@@ -859,16 +859,17 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Assert.assertEquals(
 			messageBoardMessages2.toString(), 1, messageBoardMessages2.size());
 
+		Page<MessageBoardMessage> page3 =
+			MessageBoardMessageResource.
+				getMessageBoardThreadMessageBoardMessagesPage(
+					messageBoardThreadId, null, null, Pagination.of(1, 3),
+					null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				messageBoardMessage1, messageBoardMessage2,
 				messageBoardMessage3),
-			new ArrayList<MessageBoardMessage>() {
-				{
-					addAll(messageBoardMessages1);
-					addAll(messageBoardMessages2);
-				}
-			});
+			(List<MessageBoardMessage>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -469,16 +468,17 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		Assert.assertEquals(
 			messageBoardSections2.toString(), 1, messageBoardSections2.size());
 
+		Page<MessageBoardSection> page3 =
+			MessageBoardSectionResource.
+				getMessageBoardSectionMessageBoardSectionsPage(
+					parentMessageBoardSectionId, null, null,
+					Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				messageBoardSection1, messageBoardSection2,
 				messageBoardSection3),
-			new ArrayList<MessageBoardSection>() {
-				{
-					addAll(messageBoardSections1);
-					addAll(messageBoardSections2);
-				}
-			});
+			(List<MessageBoardSection>)page3.getItems());
 	}
 
 	@Test
@@ -794,16 +794,15 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		Assert.assertEquals(
 			messageBoardSections2.toString(), 1, messageBoardSections2.size());
 
+		Page<MessageBoardSection> page3 =
+			MessageBoardSectionResource.getSiteMessageBoardSectionsPage(
+				siteId, null, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				messageBoardSection1, messageBoardSection2,
 				messageBoardSection3),
-			new ArrayList<MessageBoardSection>() {
-				{
-					addAll(messageBoardSections1);
-					addAll(messageBoardSections2);
-				}
-			});
+			(List<MessageBoardSection>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -357,15 +356,16 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Assert.assertEquals(
 			messageBoardThreads2.toString(), 1, messageBoardThreads2.size());
 
+		Page<MessageBoardThread> page3 =
+			MessageBoardThreadResource.
+				getMessageBoardSectionMessageBoardThreadsPage(
+					messageBoardSectionId, null, null, Pagination.of(1, 3),
+					null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				messageBoardThread1, messageBoardThread2, messageBoardThread3),
-			new ArrayList<MessageBoardThread>() {
-				{
-					addAll(messageBoardThreads1);
-					addAll(messageBoardThreads2);
-				}
-			});
+			(List<MessageBoardThread>)page3.getItems());
 	}
 
 	@Test
@@ -841,15 +841,14 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Assert.assertEquals(
 			messageBoardThreads2.toString(), 1, messageBoardThreads2.size());
 
+		Page<MessageBoardThread> page3 =
+			MessageBoardThreadResource.getSiteMessageBoardThreadsPage(
+				siteId, null, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				messageBoardThread1, messageBoardThread2, messageBoardThread3),
-			new ArrayList<MessageBoardThread>() {
-				{
-					addAll(messageBoardThreads1);
-					addAll(messageBoardThreads2);
-				}
-			});
+			(List<MessageBoardThread>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -351,16 +350,15 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			structuredContentFolders2.toString(), 1,
 			structuredContentFolders2.size());
 
+		Page<StructuredContentFolder> page3 =
+			StructuredContentFolderResource.getSiteStructuredContentFoldersPage(
+				siteId, null, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				structuredContentFolder1, structuredContentFolder2,
 				structuredContentFolder3),
-			new ArrayList<StructuredContentFolder>() {
-				{
-					addAll(structuredContentFolders1);
-					addAll(structuredContentFolders2);
-				}
-			});
+			(List<StructuredContentFolder>)page3.getItems());
 	}
 
 	@Test
@@ -702,16 +700,17 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			structuredContentFolders2.toString(), 1,
 			structuredContentFolders2.size());
 
+		Page<StructuredContentFolder> page3 =
+			StructuredContentFolderResource.
+				getStructuredContentFolderStructuredContentFoldersPage(
+					parentStructuredContentFolderId, null, null,
+					Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				structuredContentFolder1, structuredContentFolder2,
 				structuredContentFolder3),
-			new ArrayList<StructuredContentFolder>() {
-				{
-					addAll(structuredContentFolders1);
-					addAll(structuredContentFolders2);
-				}
-			});
+			(List<StructuredContentFolder>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -353,15 +352,14 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Assert.assertEquals(
 			structuredContents2.toString(), 1, structuredContents2.size());
 
+		Page<StructuredContent> page3 =
+			StructuredContentResource.getContentStructureStructuredContentsPage(
+				contentStructureId, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				structuredContent1, structuredContent2, structuredContent3),
-			new ArrayList<StructuredContent>() {
-				{
-					addAll(structuredContents1);
-					addAll(structuredContents2);
-				}
-			});
+			(List<StructuredContent>)page3.getItems());
 	}
 
 	@Test
@@ -648,15 +646,14 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Assert.assertEquals(
 			structuredContents2.toString(), 1, structuredContents2.size());
 
+		Page<StructuredContent> page3 =
+			StructuredContentResource.getSiteStructuredContentsPage(
+				siteId, null, null, null, Pagination.of(1, 3), null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				structuredContent1, structuredContent2, structuredContent3),
-			new ArrayList<StructuredContent>() {
-				{
-					addAll(structuredContents1);
-					addAll(structuredContents2);
-				}
-			});
+			(List<StructuredContent>)page3.getItems());
 	}
 
 	@Test
@@ -1016,15 +1013,16 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Assert.assertEquals(
 			structuredContents2.toString(), 1, structuredContents2.size());
 
+		Page<StructuredContent> page3 =
+			StructuredContentResource.
+				getStructuredContentFolderStructuredContentsPage(
+					structuredContentFolderId, null, null, Pagination.of(1, 3),
+					null);
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(
 				structuredContent1, structuredContent2, structuredContent3),
-			new ArrayList<StructuredContent>() {
-				{
-					addAll(structuredContents1);
-					addAll(structuredContents2);
-				}
-			});
+			(List<StructuredContent>)page3.getItems());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -283,14 +282,12 @@ public abstract class BaseFormRecordResourceTestCase {
 
 		Assert.assertEquals(formRecords2.toString(), 1, formRecords2.size());
 
+		Page<FormRecord> page3 = FormRecordResource.getFormFormRecordsPage(
+			formId, Pagination.of(1, 3));
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(formRecord1, formRecord2, formRecord3),
-			new ArrayList<FormRecord>() {
-				{
-					addAll(formRecords1);
-					addAll(formRecords2);
-				}
-			});
+			(List<FormRecord>)page3.getItems());
 	}
 
 	protected FormRecord testGetFormFormRecordsPage_addFormRecord(

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -267,14 +266,11 @@ public abstract class BaseFormResourceTestCase {
 
 		Assert.assertEquals(forms2.toString(), 1, forms2.size());
 
+		Page<Form> page3 = FormResource.getSiteFormsPage(
+			siteId, Pagination.of(1, 3));
+
 		assertEqualsIgnoringOrder(
-			Arrays.asList(form1, form2, form3),
-			new ArrayList<Form>() {
-				{
-					addAll(forms1);
-					addAll(forms2);
-				}
-			});
+			Arrays.asList(form1, form2, form3), (List<Form>)page3.getItems());
 	}
 
 	protected Form testGetSiteFormsPage_addForm(Long siteId, Form form)

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -281,14 +280,13 @@ public abstract class BaseFormStructureResourceTestCase {
 		Assert.assertEquals(
 			formStructures2.toString(), 1, formStructures2.size());
 
+		Page<FormStructure> page3 =
+			FormStructureResource.getSiteFormStructuresPage(
+				siteId, Pagination.of(1, 3));
+
 		assertEqualsIgnoringOrder(
 			Arrays.asList(formStructure1, formStructure2, formStructure3),
-			new ArrayList<FormStructure>() {
-				{
-					addAll(formStructures1);
-					addAll(formStructures2);
-				}
-			});
+			(List<FormStructure>)page3.getItems());
 	}
 
 	protected FormStructure testGetSiteFormStructuresPage_addFormStructure(

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -530,14 +530,27 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 						Assert.assertEquals(${schemaVarNames}2.toString(), 1, ${schemaVarNames}2.size());
 
-						assertEqualsIgnoringOrder(
+						Page<${schemaName}> page3 = ${schemaName}Resource.${javaMethodSignature.methodName}(
+
+						<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
+							<#if !javaMethodParameter?is_first>
+								,
+							</#if>
+
+							<#if stringUtil.equals(javaMethodParameter.parameterName, "pagination")>
+								Pagination.of(1, 3)
+							<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
+								${javaMethodParameter.parameterName}
+							<#else>
+								null
+							</#if>
+						</#list>
+
+						);
+
+					assertEqualsIgnoringOrder(
 							Arrays.asList(${schemaVarName}1, ${schemaVarName}2, ${schemaVarName}3),
-							new ArrayList<${schemaName}>() {
-								{
-									addAll(${schemaVarNames}1);
-									addAll(${schemaVarNames}2);
-								}
-							});
+							(List<${schemaName}>)page3.getItems());
 					}
 				</#if>
 


### PR DESCRIPTION
Retrieving without an id sort and delays return sometimes the same element in both pages (and a missing third), doing an explicit query to retrieve all.