### PR TITLE
LPS-95615 dependency problem in weblogic

### DIFF
--- a/portal-web/docroot/WEB-INF/weblogic.xml
+++ b/portal-web/docroot/WEB-INF/weblogic.xml
@@ -21,6 +21,7 @@
 			<package-name>com.ctc.wstx.*</package-name>
 			<package-name>com.google.common.*</package-name>
 			<package-name>com.sun.xml.ws.*</package-name>
+			<package-name>javax.validation.*</package-name>
 			<package-name>org.antlr.*</package-name>
 			<package-name>org.apache.commons.fileupload.*</package-name>
 			<package-name>org.apache.commons.io.*</package-name>


### PR DESCRIPTION
We are using javax.validation 2.0 (@NotEmpty annotations, we would have to provide our own and regenerate everything) and weblogic embeds 1.2. We need to use our and to do that we have to change the flag.

There is also a classloader issue that can be prevented using a resolver.