### PR TITLE
LPS-96198 add exception mappers because in our context the status codes are differrent than the default ones

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/jaxrs/exception/mapper/SettingsNoSuchCompanyExceptionMapper.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/jaxrs/exception/mapper/SettingsNoSuchCompanyExceptionMapper.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.kernel.exception.NoSuchCompanyException;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Máté Thurzó
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Change.Tracking.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Change.Tracking.REST.SettingsNoSuchCompanyExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class SettingsNoSuchCompanyExceptionMapper
+	implements ExceptionMapper<NoSuchCompanyException> {
+
+	@Override
+	public Response toResponse(NoSuchCompanyException nsce) {
+		return Response.status(
+			Response.Status.BAD_REQUEST
+		).type(
+			MediaType.TEXT_PLAIN
+		).entity(
+			nsce.getMessage()
+		).build();
+	}
+
+}

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/jaxrs/exception/mapper/SettingsNoSuchUserExceptionMapper.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/jaxrs/exception/mapper/SettingsNoSuchUserExceptionMapper.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.kernel.exception.NoSuchUserException;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Máté Thurzó
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Change.Tracking.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Change.Tracking.REST.SettingsNoSuchUserExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class SettingsNoSuchUserExceptionMapper
+	implements ExceptionMapper<NoSuchUserException> {
+
+	@Override
+	public Response toResponse(NoSuchUserException nsue) {
+		return Response.status(
+			Response.Status.BAD_REQUEST
+		).type(
+			MediaType.TEXT_PLAIN
+		).entity(
+			nsue.getMessage()
+		).build();
+	}
+
+}


### PR DESCRIPTION
@brianchandotcom compared to `portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/*` our status code is different.

In our context if there is no company it's a BAD_REQUEST, since the client tried to invoke an operation with a set of bad request params. In vulcan the NOT_FOUND and NO_CONTENT makes sense if you trying to get or delete the specific entity.
We are not looking for something where the reply can be not found to the query, we are requesting an operation, where the response could be bad request, if the request is not valid.

@danielkocsis @nhpatt