### PR TITLE
LPS-96529 Remove unused testCompile config

### DIFF
--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/build.gradle
@@ -16,10 +16,4 @@ dependencies {
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-string")
-
-	testCompile group: "com.liferay.portal", name: "com.liferay.util.java", version: "default"
-	testCompile group: "easyconf", name: "easyconf", version: "0.9.5"
-	testCompile group: "org.springframework", name: "spring-web", version: "4.1.9.RELEASE"
-	testCompile project(":core:petra:petra-lang")
-	testCompile project(":core:registry-api")
 }


### PR DESCRIPTION
Tests were removed in 8e62321471f6b7d373fceb953221f10e94def3f3, so this is no longer relevant. Additionally should fix this error that ModulesStructureTest was complaining about as described in the LPS-96529.