### PR TITLE
LPS-96369 Fix int - long ids

### DIFF
--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -34,8 +34,6 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
-import java.util.Collection;
-
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -107,7 +105,7 @@ public class Mutation {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Keyword> postKeywordsCommonPage(
+	public java.util.Collection<Keyword> postKeywordsCommonPage(
 			@GraphQLName("documentBulkSelection") DocumentBulkSelection
 				documentBulkSelection)
 		throws Exception {
@@ -167,7 +165,7 @@ public class Mutation {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<TaxonomyVocabulary>
+	public java.util.Collection<TaxonomyVocabulary>
 			postSiteTaxonomyVocabulariesCommonPage(
 				@GraphQLName("siteId") Long siteId,
 				@GraphQLName("documentBulkSelection") DocumentBulkSelection

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -27,7 +27,6 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -89,7 +88,7 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -103,7 +102,7 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseSelectionResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseSelectionResourceImpl.java
@@ -25,7 +25,6 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Generated;
@@ -67,7 +66,7 @@ public abstract class BaseSelectionResourceImpl implements SelectionResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -81,7 +80,7 @@ public abstract class BaseSelectionResourceImpl implements SelectionResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
@@ -24,7 +24,6 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Generated;
@@ -60,7 +59,7 @@ public abstract class BaseStatusResourceImpl implements StatusResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -74,7 +73,7 @@ public abstract class BaseStatusResourceImpl implements StatusResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -25,7 +25,6 @@ import com.liferay.portal.vulcan.util.TransformUtil;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Generated;
@@ -76,7 +75,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -90,7 +89,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -29,7 +29,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -79,7 +78,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -93,7 +92,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -264,7 +263,7 @@ public abstract class BaseKeywordResourceTestCase {
 	protected void assertValid(Page<Keyword> page) {
 		boolean valid = false;
 
-		Collection<Keyword> keywords = page.getItems();
+		java.util.Collection<Keyword> keywords = page.getItems();
 
 		int size = keywords.size();
 
@@ -312,7 +311,9 @@ public abstract class BaseKeywordResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_keywordResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -333,7 +334,7 @@ public abstract class BaseKeywordResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseSelectionResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseSelectionResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -263,7 +262,7 @@ public abstract class BaseSelectionResourceTestCase {
 	protected void assertValid(Page<Selection> page) {
 		boolean valid = false;
 
-		Collection<Selection> selections = page.getItems();
+		java.util.Collection<Selection> selections = page.getItems();
 
 		int size = selections.size();
 
@@ -311,7 +310,9 @@ public abstract class BaseSelectionResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_selectionResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -332,7 +333,7 @@ public abstract class BaseSelectionResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -249,7 +248,7 @@ public abstract class BaseStatusResourceTestCase {
 	protected void assertValid(Page<Status> page) {
 		boolean valid = false;
 
-		Collection<Status> statuses = page.getItems();
+		java.util.Collection<Status> statuses = page.getItems();
 
 		int size = statuses.size();
 
@@ -298,7 +297,9 @@ public abstract class BaseStatusResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_statusResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -319,7 +320,7 @@ public abstract class BaseStatusResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -279,7 +278,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	protected void assertValid(Page<TaxonomyCategory> page) {
 		boolean valid = false;
 
-		Collection<TaxonomyCategory> taxonomyCategories = page.getItems();
+		java.util.Collection<TaxonomyCategory> taxonomyCategories =
+			page.getItems();
 
 		int size = taxonomyCategories.size();
 
@@ -346,7 +346,9 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_taxonomyCategoryResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -367,7 +369,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -304,7 +303,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	protected void assertValid(Page<TaxonomyVocabulary> page) {
 		boolean valid = false;
 
-		Collection<TaxonomyVocabulary> taxonomyVocabularies = page.getItems();
+		java.util.Collection<TaxonomyVocabulary> taxonomyVocabularies =
+			page.getItems();
 
 		int size = taxonomyVocabularies.size();
 
@@ -404,7 +404,9 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_taxonomyVocabularyResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -425,7 +427,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/dto/v1_0/Collection.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/dto/v1_0/Collection.java
@@ -1,0 +1,478 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Mate Thurzo
+ * @generated
+ */
+@Generated("")
+@GraphQLName("Collection")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "Collection")
+public class Collection {
+
+	@Schema
+	public Integer getAdditionCount() {
+		return additionCount;
+	}
+
+	public void setAdditionCount(Integer additionCount) {
+		this.additionCount = additionCount;
+	}
+
+	@JsonIgnore
+	public void setAdditionCount(
+		UnsafeSupplier<Integer, Exception> additionCountUnsafeSupplier) {
+
+		try {
+			additionCount = additionCountUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Integer additionCount;
+
+	@Schema
+	public Integer getCollectionId() {
+		return collectionId;
+	}
+
+	public void setCollectionId(Integer collectionId) {
+		this.collectionId = collectionId;
+	}
+
+	@JsonIgnore
+	public void setCollectionId(
+		UnsafeSupplier<Integer, Exception> collectionIdUnsafeSupplier) {
+
+		try {
+			collectionId = collectionIdUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Integer collectionId;
+
+	@Schema
+	public Long getCompanyId() {
+		return companyId;
+	}
+
+	public void setCompanyId(Long companyId) {
+		this.companyId = companyId;
+	}
+
+	@JsonIgnore
+	public void setCompanyId(
+		UnsafeSupplier<Long, Exception> companyIdUnsafeSupplier) {
+
+		try {
+			companyId = companyIdUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long companyId;
+
+	@Schema
+	public Integer getDeletionCount() {
+		return deletionCount;
+	}
+
+	public void setDeletionCount(Integer deletionCount) {
+		this.deletionCount = deletionCount;
+	}
+
+	@JsonIgnore
+	public void setDeletionCount(
+		UnsafeSupplier<Integer, Exception> deletionCountUnsafeSupplier) {
+
+		try {
+			deletionCount = deletionCountUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Integer deletionCount;
+
+	@Schema
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@JsonIgnore
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String description;
+
+	@Schema
+	public Integer getModificationCount() {
+		return modificationCount;
+	}
+
+	public void setModificationCount(Integer modificationCount) {
+		this.modificationCount = modificationCount;
+	}
+
+	@JsonIgnore
+	public void setModificationCount(
+		UnsafeSupplier<Integer, Exception> modificationCountUnsafeSupplier) {
+
+		try {
+			modificationCount = modificationCountUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Integer modificationCount;
+
+	@Schema
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@JsonIgnore
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String name;
+
+	@Schema
+	public String getStatusByUserName() {
+		return statusByUserName;
+	}
+
+	public void setStatusByUserName(String statusByUserName) {
+		this.statusByUserName = statusByUserName;
+	}
+
+	@JsonIgnore
+	public void setStatusByUserName(
+		UnsafeSupplier<String, Exception> statusByUserNameUnsafeSupplier) {
+
+		try {
+			statusByUserName = statusByUserNameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String statusByUserName;
+
+	@Schema
+	public Date getStatusDate() {
+		return statusDate;
+	}
+
+	public void setStatusDate(Date statusDate) {
+		this.statusDate = statusDate;
+	}
+
+	@JsonIgnore
+	public void setStatusDate(
+		UnsafeSupplier<Date, Exception> statusDateUnsafeSupplier) {
+
+		try {
+			statusDate = statusDateUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Date statusDate;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Collection)) {
+			return false;
+		}
+
+		Collection collection = (Collection)object;
+
+		return Objects.equals(toString(), collection.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		if (additionCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"additionCount\": ");
+
+			sb.append(additionCount);
+		}
+
+		if (collectionId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"collectionId\": ");
+
+			sb.append(collectionId);
+		}
+
+		if (companyId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"companyId\": ");
+
+			sb.append(companyId);
+		}
+
+		if (deletionCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"deletionCount\": ");
+
+			sb.append(deletionCount);
+		}
+
+		if (description != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(description));
+
+			sb.append("\"");
+		}
+
+		if (modificationCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"modificationCount\": ");
+
+			sb.append(modificationCount);
+		}
+
+		if (name != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		if (statusByUserName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"statusByUserName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(statusByUserName));
+
+			sb.append("\"");
+		}
+
+		if (statusDate != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"statusDate\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(statusDate));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		return string.replaceAll("\"", "\\\\\"");
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\":");
+			sb.append("\"");
+			sb.append(entry.getValue());
+			sb.append("\"");
+
+			if (iterator.hasNext()) {
+				sb.append(",");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/dto/v1_0/CollectionUpdate.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/dto/v1_0/CollectionUpdate.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Mate Thurzo
+ * @generated
+ */
+@Generated("")
+@GraphQLName("CollectionUpdate")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "CollectionUpdate")
+public class CollectionUpdate {
+
+	@Schema
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@JsonIgnore
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String description;
+
+	@Schema
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@JsonIgnore
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String name;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof CollectionUpdate)) {
+			return false;
+		}
+
+		CollectionUpdate collectionUpdate = (CollectionUpdate)object;
+
+		return Objects.equals(toString(), collectionUpdate.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		if (description != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(description));
+
+			sb.append("\"");
+		}
+
+		if (name != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		return string.replaceAll("\"", "\\\\\"");
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\":");
+			sb.append("\"");
+			sb.append(entry.getValue());
+			sb.append("\"");
+
+			if (iterator.hasNext()) {
+				sb.append(",");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/dto/v1_0/Settings.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/dto/v1_0/Settings.java
@@ -137,17 +137,17 @@ public class Settings {
 	protected Boolean checkoutCTCollectionConfirmationEnabled;
 
 	@Schema
-	public Integer getCompanyId() {
+	public Long getCompanyId() {
 		return companyId;
 	}
 
-	public void setCompanyId(Integer companyId) {
+	public void setCompanyId(Long companyId) {
 		this.companyId = companyId;
 	}
 
 	@JsonIgnore
 	public void setCompanyId(
-		UnsafeSupplier<Integer, Exception> companyIdUnsafeSupplier) {
+		UnsafeSupplier<Long, Exception> companyIdUnsafeSupplier) {
 
 		try {
 			companyId = companyIdUnsafeSupplier.get();
@@ -162,7 +162,7 @@ public class Settings {
 
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected Integer companyId;
+	protected Long companyId;
 
 	@Schema
 	public String[] getSupportedContentTypeLanguageKeys() {
@@ -227,17 +227,17 @@ public class Settings {
 	protected String[] supportedContentTypes;
 
 	@Schema
-	public Integer getUserId() {
+	public Long getUserId() {
 		return userId;
 	}
 
-	public void setUserId(Integer userId) {
+	public void setUserId(Long userId) {
 		this.userId = userId;
 	}
 
 	@JsonIgnore
 	public void setUserId(
-		UnsafeSupplier<Integer, Exception> userIdUnsafeSupplier) {
+		UnsafeSupplier<Long, Exception> userIdUnsafeSupplier) {
 
 		try {
 			userId = userIdUnsafeSupplier.get();
@@ -252,7 +252,7 @@ public class Settings {
 
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected Integer userId;
+	protected Long userId;
 
 	@Override
 	public boolean equals(Object object) {

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/CollectionResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/CollectionResource.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.rest.resource.v1_0;
+
+import com.liferay.change.tracking.rest.dto.v1_0.Collection;
+import com.liferay.change.tracking.rest.dto.v1_0.CollectionUpdate;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import javax.annotation.Generated;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/change-tracking/v1.0
+ *
+ * @author Mate Thurzo
+ * @generated
+ */
+@Generated("")
+public interface CollectionResource {
+
+	public Page<Collection> getCollectionsPage(
+			Long companyId, String type, Long userId, Pagination pagination,
+			Sort[] sorts)
+		throws Exception;
+
+	public Collection postCollection(
+			Long companyId, Long userId, CollectionUpdate collectionUpdate)
+		throws Exception;
+
+	public void deleteCollection(Long collectionId) throws Exception;
+
+	public Collection getCollection(Long collectionId) throws Exception;
+
+	public void postCollectionCheckout(Long collectionId, Long userId)
+		throws Exception;
+
+	public void postCollectionPublish(
+			Long collectionId, Boolean ignoreCollision, Long userId)
+		throws Exception;
+
+	public void setContextCompany(Company contextCompany);
+
+}

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/dto/v1_0/Collection.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/dto/v1_0/Collection.java
@@ -1,0 +1,245 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.rest.client.dto.v1_0;
+
+import com.liferay.change.tracking.rest.client.function.UnsafeSupplier;
+import com.liferay.change.tracking.rest.client.serdes.v1_0.CollectionSerDes;
+
+import java.util.Date;
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Mate Thurzo
+ * @generated
+ */
+@Generated("")
+public class Collection {
+
+	public Integer getAdditionCount() {
+		return additionCount;
+	}
+
+	public void setAdditionCount(Integer additionCount) {
+		this.additionCount = additionCount;
+	}
+
+	public void setAdditionCount(
+		UnsafeSupplier<Integer, Exception> additionCountUnsafeSupplier) {
+
+		try {
+			additionCount = additionCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Integer additionCount;
+
+	public Integer getCollectionId() {
+		return collectionId;
+	}
+
+	public void setCollectionId(Integer collectionId) {
+		this.collectionId = collectionId;
+	}
+
+	public void setCollectionId(
+		UnsafeSupplier<Integer, Exception> collectionIdUnsafeSupplier) {
+
+		try {
+			collectionId = collectionIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Integer collectionId;
+
+	public Long getCompanyId() {
+		return companyId;
+	}
+
+	public void setCompanyId(Long companyId) {
+		this.companyId = companyId;
+	}
+
+	public void setCompanyId(
+		UnsafeSupplier<Long, Exception> companyIdUnsafeSupplier) {
+
+		try {
+			companyId = companyIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long companyId;
+
+	public Integer getDeletionCount() {
+		return deletionCount;
+	}
+
+	public void setDeletionCount(Integer deletionCount) {
+		this.deletionCount = deletionCount;
+	}
+
+	public void setDeletionCount(
+		UnsafeSupplier<Integer, Exception> deletionCountUnsafeSupplier) {
+
+		try {
+			deletionCount = deletionCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Integer deletionCount;
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String description;
+
+	public Integer getModificationCount() {
+		return modificationCount;
+	}
+
+	public void setModificationCount(Integer modificationCount) {
+		this.modificationCount = modificationCount;
+	}
+
+	public void setModificationCount(
+		UnsafeSupplier<Integer, Exception> modificationCountUnsafeSupplier) {
+
+		try {
+			modificationCount = modificationCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Integer modificationCount;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String name;
+
+	public String getStatusByUserName() {
+		return statusByUserName;
+	}
+
+	public void setStatusByUserName(String statusByUserName) {
+		this.statusByUserName = statusByUserName;
+	}
+
+	public void setStatusByUserName(
+		UnsafeSupplier<String, Exception> statusByUserNameUnsafeSupplier) {
+
+		try {
+			statusByUserName = statusByUserNameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String statusByUserName;
+
+	public Date getStatusDate() {
+		return statusDate;
+	}
+
+	public void setStatusDate(Date statusDate) {
+		this.statusDate = statusDate;
+	}
+
+	public void setStatusDate(
+		UnsafeSupplier<Date, Exception> statusDateUnsafeSupplier) {
+
+		try {
+			statusDate = statusDateUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date statusDate;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Collection)) {
+			return false;
+		}
+
+		Collection collection = (Collection)object;
+
+		return Objects.equals(toString(), collection.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return CollectionSerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/dto/v1_0/CollectionUpdate.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/dto/v1_0/CollectionUpdate.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.rest.client.dto.v1_0;
+
+import com.liferay.change.tracking.rest.client.function.UnsafeSupplier;
+import com.liferay.change.tracking.rest.client.serdes.v1_0.CollectionUpdateSerDes;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Mate Thurzo
+ * @generated
+ */
+@Generated("")
+public class CollectionUpdate {
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String description;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String name;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof CollectionUpdate)) {
+			return false;
+		}
+
+		CollectionUpdate collectionUpdate = (CollectionUpdate)object;
+
+		return Objects.equals(toString(), collectionUpdate.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return CollectionUpdateSerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/dto/v1_0/Settings.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/dto/v1_0/Settings.java
@@ -98,16 +98,16 @@ public class Settings {
 
 	protected Boolean checkoutCTCollectionConfirmationEnabled;
 
-	public Integer getCompanyId() {
+	public Long getCompanyId() {
 		return companyId;
 	}
 
-	public void setCompanyId(Integer companyId) {
+	public void setCompanyId(Long companyId) {
 		this.companyId = companyId;
 	}
 
 	public void setCompanyId(
-		UnsafeSupplier<Integer, Exception> companyIdUnsafeSupplier) {
+		UnsafeSupplier<Long, Exception> companyIdUnsafeSupplier) {
 
 		try {
 			companyId = companyIdUnsafeSupplier.get();
@@ -117,7 +117,7 @@ public class Settings {
 		}
 	}
 
-	protected Integer companyId;
+	protected Long companyId;
 
 	public String[] getSupportedContentTypeLanguageKeys() {
 		return supportedContentTypeLanguageKeys;
@@ -167,16 +167,16 @@ public class Settings {
 
 	protected String[] supportedContentTypes;
 
-	public Integer getUserId() {
+	public Long getUserId() {
 		return userId;
 	}
 
-	public void setUserId(Integer userId) {
+	public void setUserId(Long userId) {
 		this.userId = userId;
 	}
 
 	public void setUserId(
-		UnsafeSupplier<Integer, Exception> userIdUnsafeSupplier) {
+		UnsafeSupplier<Long, Exception> userIdUnsafeSupplier) {
 
 		try {
 			userId = userIdUnsafeSupplier.get();
@@ -186,7 +186,7 @@ public class Settings {
 		}
 	}
 
-	protected Integer userId;
+	protected Long userId;
 
 	@Override
 	public boolean equals(Object object) {

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/resource/v1_0/CollectionResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/resource/v1_0/CollectionResource.java
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.rest.client.resource.v1_0;
+
+import com.liferay.change.tracking.rest.client.dto.v1_0.Collection;
+import com.liferay.change.tracking.rest.client.http.HttpInvoker;
+import com.liferay.change.tracking.rest.client.pagination.Page;
+import com.liferay.change.tracking.rest.client.pagination.Pagination;
+import com.liferay.change.tracking.rest.client.serdes.v1_0.CollectionSerDes;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Mate Thurzo
+ * @generated
+ */
+@Generated("")
+public class CollectionResource {
+
+	public static Page<Collection> getCollectionsPage(
+			Long companyId, String type, Long userId, Pagination pagination,
+			String sortString)
+		throws Exception {
+
+		HttpInvoker.HttpResponse httpResponse = getCollectionsPageHttpResponse(
+			companyId, type, userId, pagination, sortString);
+
+		String content = httpResponse.getContent();
+
+		_logger.fine("HTTP response content: " + content);
+
+		_logger.fine("HTTP response message: " + httpResponse.getMessage());
+		_logger.fine(
+			"HTTP response status code: " + httpResponse.getStatusCode());
+
+		return Page.of(content, CollectionSerDes::toDTO);
+	}
+
+	public static HttpInvoker.HttpResponse getCollectionsPageHttpResponse(
+			Long companyId, String type, Long userId, Pagination pagination,
+			String sortString)
+		throws Exception {
+
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+		if (companyId != null) {
+			httpInvoker.parameter("companyId", String.valueOf(companyId));
+		}
+
+		if (type != null) {
+			httpInvoker.parameter("type", String.valueOf(type));
+		}
+
+		if (userId != null) {
+			httpInvoker.parameter("userId", String.valueOf(userId));
+		}
+
+		if (pagination != null) {
+			httpInvoker.parameter("page", String.valueOf(pagination.getPage()));
+			httpInvoker.parameter(
+				"pageSize", String.valueOf(pagination.getPageSize()));
+		}
+
+		if (sortString != null) {
+			httpInvoker.parameter("sort", sortString);
+		}
+
+		httpInvoker.path(
+			"http://localhost:8080/o/change-tracking/v1.0/collections");
+
+		httpInvoker.userNameAndPassword("test@liferay.com:test");
+
+		return httpInvoker.invoke();
+	}
+
+	public static Collection postCollection(
+			Long companyId, Long userId,
+			com.liferay.change.tracking.rest.client.dto.v1_0.CollectionUpdate
+				collectionUpdate)
+		throws Exception {
+
+		HttpInvoker.HttpResponse httpResponse = postCollectionHttpResponse(
+			companyId, userId, collectionUpdate);
+
+		String content = httpResponse.getContent();
+
+		_logger.fine("HTTP response content: " + content);
+
+		_logger.fine("HTTP response message: " + httpResponse.getMessage());
+		_logger.fine(
+			"HTTP response status code: " + httpResponse.getStatusCode());
+
+		try {
+			return CollectionSerDes.toDTO(content);
+		}
+		catch (Exception e) {
+			_logger.log(
+				Level.WARNING, "Unable to process HTTP response: " + content,
+				e);
+
+			throw e;
+		}
+	}
+
+	public static HttpInvoker.HttpResponse postCollectionHttpResponse(
+			Long companyId, Long userId,
+			com.liferay.change.tracking.rest.client.dto.v1_0.CollectionUpdate
+				collectionUpdate)
+		throws Exception {
+
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(collectionUpdate.toString(), "application/json");
+
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+		if (companyId != null) {
+			httpInvoker.parameter("companyId", String.valueOf(companyId));
+		}
+
+		if (userId != null) {
+			httpInvoker.parameter("userId", String.valueOf(userId));
+		}
+
+		httpInvoker.path(
+			"http://localhost:8080/o/change-tracking/v1.0/collections");
+
+		httpInvoker.userNameAndPassword("test@liferay.com:test");
+
+		return httpInvoker.invoke();
+	}
+
+	public static void deleteCollection(Long collectionId) throws Exception {
+		HttpInvoker.HttpResponse httpResponse = deleteCollectionHttpResponse(
+			collectionId);
+
+		String content = httpResponse.getContent();
+
+		_logger.fine("HTTP response content: " + content);
+
+		_logger.fine("HTTP response message: " + httpResponse.getMessage());
+		_logger.fine(
+			"HTTP response status code: " + httpResponse.getStatusCode());
+	}
+
+	public static HttpInvoker.HttpResponse deleteCollectionHttpResponse(
+			Long collectionId)
+		throws Exception {
+
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+		httpInvoker.path(
+			"http://localhost:8080/o/change-tracking/v1.0/collections/{collectionId}",
+			collectionId);
+
+		httpInvoker.userNameAndPassword("test@liferay.com:test");
+
+		return httpInvoker.invoke();
+	}
+
+	public static Collection getCollection(Long collectionId) throws Exception {
+		HttpInvoker.HttpResponse httpResponse = getCollectionHttpResponse(
+			collectionId);
+
+		String content = httpResponse.getContent();
+
+		_logger.fine("HTTP response content: " + content);
+
+		_logger.fine("HTTP response message: " + httpResponse.getMessage());
+		_logger.fine(
+			"HTTP response status code: " + httpResponse.getStatusCode());
+
+		try {
+			return CollectionSerDes.toDTO(content);
+		}
+		catch (Exception e) {
+			_logger.log(
+				Level.WARNING, "Unable to process HTTP response: " + content,
+				e);
+
+			throw e;
+		}
+	}
+
+	public static HttpInvoker.HttpResponse getCollectionHttpResponse(
+			Long collectionId)
+		throws Exception {
+
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+		httpInvoker.path(
+			"http://localhost:8080/o/change-tracking/v1.0/collections/{collectionId}",
+			collectionId);
+
+		httpInvoker.userNameAndPassword("test@liferay.com:test");
+
+		return httpInvoker.invoke();
+	}
+
+	public static void postCollectionCheckout(Long collectionId, Long userId)
+		throws Exception {
+
+		HttpInvoker.HttpResponse httpResponse =
+			postCollectionCheckoutHttpResponse(collectionId, userId);
+
+		String content = httpResponse.getContent();
+
+		_logger.fine("HTTP response content: " + content);
+
+		_logger.fine("HTTP response message: " + httpResponse.getMessage());
+		_logger.fine(
+			"HTTP response status code: " + httpResponse.getStatusCode());
+	}
+
+	public static HttpInvoker.HttpResponse postCollectionCheckoutHttpResponse(
+			Long collectionId, Long userId)
+		throws Exception {
+
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(userId.toString(), "application/json");
+
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+		if (userId != null) {
+			httpInvoker.parameter("userId", String.valueOf(userId));
+		}
+
+		httpInvoker.path(
+			"http://localhost:8080/o/change-tracking/v1.0/collections/{collectionId}/checkout",
+			collectionId);
+
+		httpInvoker.userNameAndPassword("test@liferay.com:test");
+
+		return httpInvoker.invoke();
+	}
+
+	public static void postCollectionPublish(
+			Long collectionId, Boolean ignoreCollision, Long userId)
+		throws Exception {
+
+		HttpInvoker.HttpResponse httpResponse =
+			postCollectionPublishHttpResponse(
+				collectionId, ignoreCollision, userId);
+
+		String content = httpResponse.getContent();
+
+		_logger.fine("HTTP response content: " + content);
+
+		_logger.fine("HTTP response message: " + httpResponse.getMessage());
+		_logger.fine(
+			"HTTP response status code: " + httpResponse.getStatusCode());
+	}
+
+	public static HttpInvoker.HttpResponse postCollectionPublishHttpResponse(
+			Long collectionId, Boolean ignoreCollision, Long userId)
+		throws Exception {
+
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(userId.toString(), "application/json");
+
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+		if (ignoreCollision != null) {
+			httpInvoker.parameter(
+				"ignoreCollision", String.valueOf(ignoreCollision));
+		}
+
+		if (userId != null) {
+			httpInvoker.parameter("userId", String.valueOf(userId));
+		}
+
+		httpInvoker.path(
+			"http://localhost:8080/o/change-tracking/v1.0/collections/{collectionId}/publish",
+			collectionId);
+
+		httpInvoker.userNameAndPassword("test@liferay.com:test");
+
+		return httpInvoker.invoke();
+	}
+
+	private static final Logger _logger = Logger.getLogger(
+		CollectionResource.class.getName());
+
+}

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/serdes/v1_0/CollectionSerDes.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/serdes/v1_0/CollectionSerDes.java
@@ -1,0 +1,375 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.rest.client.serdes.v1_0;
+
+import com.liferay.change.tracking.rest.client.dto.v1_0.Collection;
+import com.liferay.change.tracking.rest.client.json.BaseJSONParser;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Mate Thurzo
+ * @generated
+ */
+@Generated("")
+public class CollectionSerDes {
+
+	public static Collection toDTO(String json) {
+		CollectionJSONParser collectionJSONParser = new CollectionJSONParser();
+
+		return collectionJSONParser.parseToDTO(json);
+	}
+
+	public static Collection[] toDTOs(String json) {
+		CollectionJSONParser collectionJSONParser = new CollectionJSONParser();
+
+		return collectionJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(Collection collection) {
+		if (collection == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		if (collection.getAdditionCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"additionCount\": ");
+
+			sb.append(collection.getAdditionCount());
+		}
+
+		if (collection.getCollectionId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"collectionId\": ");
+
+			sb.append(collection.getCollectionId());
+		}
+
+		if (collection.getCompanyId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"companyId\": ");
+
+			sb.append(collection.getCompanyId());
+		}
+
+		if (collection.getDeletionCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"deletionCount\": ");
+
+			sb.append(collection.getDeletionCount());
+		}
+
+		if (collection.getDescription() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(collection.getDescription()));
+
+			sb.append("\"");
+		}
+
+		if (collection.getModificationCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"modificationCount\": ");
+
+			sb.append(collection.getModificationCount());
+		}
+
+		if (collection.getName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(collection.getName()));
+
+			sb.append("\"");
+		}
+
+		if (collection.getStatusByUserName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"statusByUserName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(collection.getStatusByUserName()));
+
+			sb.append("\"");
+		}
+
+		if (collection.getStatusDate() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"statusDate\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(collection.getStatusDate()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		CollectionJSONParser collectionJSONParser = new CollectionJSONParser();
+
+		return collectionJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(Collection collection) {
+		if (collection == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		if (collection.getAdditionCount() == null) {
+			map.put("additionCount", null);
+		}
+		else {
+			map.put(
+				"additionCount", String.valueOf(collection.getAdditionCount()));
+		}
+
+		if (collection.getCollectionId() == null) {
+			map.put("collectionId", null);
+		}
+		else {
+			map.put(
+				"collectionId", String.valueOf(collection.getCollectionId()));
+		}
+
+		if (collection.getCompanyId() == null) {
+			map.put("companyId", null);
+		}
+		else {
+			map.put("companyId", String.valueOf(collection.getCompanyId()));
+		}
+
+		if (collection.getDeletionCount() == null) {
+			map.put("deletionCount", null);
+		}
+		else {
+			map.put(
+				"deletionCount", String.valueOf(collection.getDeletionCount()));
+		}
+
+		if (collection.getDescription() == null) {
+			map.put("description", null);
+		}
+		else {
+			map.put("description", String.valueOf(collection.getDescription()));
+		}
+
+		if (collection.getModificationCount() == null) {
+			map.put("modificationCount", null);
+		}
+		else {
+			map.put(
+				"modificationCount",
+				String.valueOf(collection.getModificationCount()));
+		}
+
+		if (collection.getName() == null) {
+			map.put("name", null);
+		}
+		else {
+			map.put("name", String.valueOf(collection.getName()));
+		}
+
+		if (collection.getStatusByUserName() == null) {
+			map.put("statusByUserName", null);
+		}
+		else {
+			map.put(
+				"statusByUserName",
+				String.valueOf(collection.getStatusByUserName()));
+		}
+
+		map.put(
+			"statusDate",
+			liferayToJSONDateFormat.format(collection.getStatusDate()));
+
+		return map;
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		string = string.replace("\\", "\\\\");
+
+		return string.replace("\"", "\\\"");
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\":");
+			sb.append("\"");
+			sb.append(entry.getValue());
+			sb.append("\"");
+
+			if (iterator.hasNext()) {
+				sb.append(",");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static class CollectionJSONParser
+		extends BaseJSONParser<Collection> {
+
+		@Override
+		protected Collection createDTO() {
+			return new Collection();
+		}
+
+		@Override
+		protected Collection[] createDTOArray(int size) {
+			return new Collection[size];
+		}
+
+		@Override
+		protected void setField(
+			Collection collection, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "additionCount")) {
+				if (jsonParserFieldValue != null) {
+					collection.setAdditionCount(
+						Integer.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "collectionId")) {
+				if (jsonParserFieldValue != null) {
+					collection.setCollectionId(
+						Integer.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "companyId")) {
+				if (jsonParserFieldValue != null) {
+					collection.setCompanyId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "deletionCount")) {
+				if (jsonParserFieldValue != null) {
+					collection.setDeletionCount(
+						Integer.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "description")) {
+				if (jsonParserFieldValue != null) {
+					collection.setDescription((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "modificationCount")) {
+				if (jsonParserFieldValue != null) {
+					collection.setModificationCount(
+						Integer.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				if (jsonParserFieldValue != null) {
+					collection.setName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "statusByUserName")) {
+				if (jsonParserFieldValue != null) {
+					collection.setStatusByUserName(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "statusDate")) {
+				if (jsonParserFieldValue != null) {
+					collection.setStatusDate(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+	}
+
+}

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/serdes/v1_0/CollectionUpdateSerDes.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/serdes/v1_0/CollectionUpdateSerDes.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.rest.client.serdes.v1_0;
+
+import com.liferay.change.tracking.rest.client.dto.v1_0.CollectionUpdate;
+import com.liferay.change.tracking.rest.client.json.BaseJSONParser;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Mate Thurzo
+ * @generated
+ */
+@Generated("")
+public class CollectionUpdateSerDes {
+
+	public static CollectionUpdate toDTO(String json) {
+		CollectionUpdateJSONParser collectionUpdateJSONParser =
+			new CollectionUpdateJSONParser();
+
+		return collectionUpdateJSONParser.parseToDTO(json);
+	}
+
+	public static CollectionUpdate[] toDTOs(String json) {
+		CollectionUpdateJSONParser collectionUpdateJSONParser =
+			new CollectionUpdateJSONParser();
+
+		return collectionUpdateJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(CollectionUpdate collectionUpdate) {
+		if (collectionUpdate == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (collectionUpdate.getDescription() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(collectionUpdate.getDescription()));
+
+			sb.append("\"");
+		}
+
+		if (collectionUpdate.getName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(collectionUpdate.getName()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		CollectionUpdateJSONParser collectionUpdateJSONParser =
+			new CollectionUpdateJSONParser();
+
+		return collectionUpdateJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(CollectionUpdate collectionUpdate) {
+		if (collectionUpdate == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		if (collectionUpdate.getDescription() == null) {
+			map.put("description", null);
+		}
+		else {
+			map.put(
+				"description",
+				String.valueOf(collectionUpdate.getDescription()));
+		}
+
+		if (collectionUpdate.getName() == null) {
+			map.put("name", null);
+		}
+		else {
+			map.put("name", String.valueOf(collectionUpdate.getName()));
+		}
+
+		return map;
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		string = string.replace("\\", "\\\\");
+
+		return string.replace("\"", "\\\"");
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\":");
+			sb.append("\"");
+			sb.append(entry.getValue());
+			sb.append("\"");
+
+			if (iterator.hasNext()) {
+				sb.append(",");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static class CollectionUpdateJSONParser
+		extends BaseJSONParser<CollectionUpdate> {
+
+		@Override
+		protected CollectionUpdate createDTO() {
+			return new CollectionUpdate();
+		}
+
+		@Override
+		protected CollectionUpdate[] createDTOArray(int size) {
+			return new CollectionUpdate[size];
+		}
+
+		@Override
+		protected void setField(
+			CollectionUpdate collectionUpdate, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "description")) {
+				if (jsonParserFieldValue != null) {
+					collectionUpdate.setDescription(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				if (jsonParserFieldValue != null) {
+					collectionUpdate.setName((String)jsonParserFieldValue);
+				}
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+	}
+
+}

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/serdes/v1_0/SettingsSerDes.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/serdes/v1_0/SettingsSerDes.java
@@ -320,7 +320,7 @@ public class SettingsSerDes {
 			else if (Objects.equals(jsonParserFieldName, "companyId")) {
 				if (jsonParserFieldValue != null) {
 					settings.setCompanyId(
-						Integer.valueOf((String)jsonParserFieldValue));
+						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(
@@ -343,7 +343,7 @@ public class SettingsSerDes {
 			else if (Objects.equals(jsonParserFieldName, "userId")) {
 				if (jsonParserFieldValue != null) {
 					settings.setUserId(
-						Integer.valueOf((String)jsonParserFieldValue));
+						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
 			else {

--- a/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
@@ -1,5 +1,35 @@
 components:
     schemas:
+        Collection:
+            properties:
+                additionCount:
+                    type: integer
+                collectionId:
+                    type: integer
+                companyId:
+                    format: int64
+                    type: integer
+                deletionCount:
+                    type: integer
+                description:
+                    type: string
+                modificationCount:
+                    type: integer
+                name:
+                    type: string
+                statusByUserName:
+                    type: string
+                statusDate:
+                    format: date-time
+                    type: string
+            type: object
+        CollectionUpdate:
+            properties:
+                description:
+                    type: string
+                name:
+                    type: string
+            type: object
         Settings:
             properties:
                 changeTrackingAllowed:
@@ -9,6 +39,7 @@ components:
                 checkoutCTCollectionConfirmationEnabled:
                     type: boolean
                 companyId:
+                    format: int64
                     type: integer
                 supportedContentTypeLanguageKeys:
                     items:
@@ -19,6 +50,7 @@ components:
                         type: string
                     type: array
                 userId:
+                    format: int64
                     type: integer
             type: object
         SettingsUpdate:
@@ -30,10 +62,203 @@ components:
             type: object
 info:
     description: ""
-    title: ""
+    title: "Change Tracking REST"
     version: v1.0
 openapi: 3.0.1
 paths:
+    "/collections":
+        get:
+            operationId: getCollectionsPage
+            parameters:
+                - in: query
+                  name: companyId
+                  required: false
+                  schema:
+                      format: int64
+                      type: integer
+                - in: query
+                  name: page
+                  required: false
+                  schema:
+                      type: integer
+                - in: query
+                  name: pageSize
+                  required: false
+                  schema:
+                      type: integer
+                - in: query
+                  name: sort
+                  required: false
+                  schema:
+                      type: string
+                - in: query
+                  name: type
+                  required: false
+                  schema:
+                      default: "all"
+                      type: string
+                - in: query
+                  name: userId
+                  required: false
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Collection"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Collection"
+                                type: array
+                    description: ""
+            tags: ["Collection"]
+        post:
+            operationId: postCollection
+            parameters:
+                - in: query
+                  name: companyId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: query
+                  name: userId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CollectionUpdate"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/CollectionUpdate"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Collection"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Collection"
+                    description: ""
+            tags: ["Collection"]
+    "/collections/{collectionId}":
+        delete:
+            operationId: deleteCollection
+            parameters:
+                - in: path
+                  name: collectionId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                    description: ""
+                400:
+                    content:
+                        text/plain:
+                            schema:
+                                type: string
+                    description: ""
+                404:
+                    content:
+                        application/json: {}
+                    description: ""
+            tags: ["Collection"]
+        get:
+            operationId: getCollection
+            parameters:
+                - in: path
+                  name: collectionId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Collection"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Collection"
+                    description: ""
+                400:
+                    content:
+                        text/plain:
+                            schema:
+                                type: string
+                    description: ""
+            tags: ["Collection"]
+    "/collections/{collectionId}/checkout":
+        post:
+            operationId: postCollectionCheckout
+            parameters:
+                - in: path
+                  name: collectionId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: query
+                  name: userId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                202:
+                    content:
+                        application/json: {}
+                    description: ""
+            tags: ["Collection"]
+    "/collections/{collectionId}/publish":
+        post:
+            operationId: postCollectionPublish
+            parameters:
+                - in: path
+                  name: collectionId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: query
+                  name: ignoreCollision
+                  required: true
+                  schema:
+                      type: boolean
+                - in: query
+                  name: userId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                202:
+                    content:
+                        application/json: {}
+                    description: ""
+                400:
+                    content:
+                        text/plain:
+                            schema:
+                                type: string
+                    description: ""
+            tags: ["Collection"]
     "/settings":
         get:
             operationId: getSettingsPage

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -14,14 +14,18 @@
 
 package com.liferay.change.tracking.rest.internal.graphql.mutation.v1_0;
 
+import com.liferay.change.tracking.rest.dto.v1_0.Collection;
+import com.liferay.change.tracking.rest.dto.v1_0.CollectionUpdate;
 import com.liferay.change.tracking.rest.dto.v1_0.Settings;
 import com.liferay.change.tracking.rest.dto.v1_0.SettingsUpdate;
+import com.liferay.change.tracking.rest.resource.v1_0.CollectionResource;
 import com.liferay.change.tracking.rest.resource.v1_0.SettingsResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 
+import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
@@ -36,12 +40,75 @@ import org.osgi.service.component.ComponentServiceObjects;
 @Generated("")
 public class Mutation {
 
+	public static void setCollectionResourceComponentServiceObjects(
+		ComponentServiceObjects<CollectionResource>
+			collectionResourceComponentServiceObjects) {
+
+		_collectionResourceComponentServiceObjects =
+			collectionResourceComponentServiceObjects;
+	}
+
 	public static void setSettingsResourceComponentServiceObjects(
 		ComponentServiceObjects<SettingsResource>
 			settingsResourceComponentServiceObjects) {
 
 		_settingsResourceComponentServiceObjects =
 			settingsResourceComponentServiceObjects;
+	}
+
+	@GraphQLField
+	@GraphQLInvokeDetached
+	public Collection postCollection(
+			@GraphQLName("companyId") Long companyId,
+			@GraphQLName("userId") Long userId,
+			@GraphQLName("collectionUpdate") CollectionUpdate collectionUpdate)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collectionResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collectionResource -> collectionResource.postCollection(
+				companyId, userId, collectionUpdate));
+	}
+
+	@GraphQLInvokeDetached
+	public void deleteCollection(@GraphQLName("collectionId") Long collectionId)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_collectionResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collectionResource -> collectionResource.deleteCollection(
+				collectionId));
+	}
+
+	@GraphQLField
+	@GraphQLInvokeDetached
+	public void postCollectionCheckout(
+			@GraphQLName("collectionId") Long collectionId,
+			@GraphQLName("userId") Long userId)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_collectionResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collectionResource -> collectionResource.postCollectionCheckout(
+				collectionId, userId));
+	}
+
+	@GraphQLField
+	@GraphQLInvokeDetached
+	public void postCollectionPublish(
+			@GraphQLName("collectionId") Long collectionId,
+			@GraphQLName("ignoreCollision") Boolean ignoreCollision,
+			@GraphQLName("userId") Long userId)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_collectionResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collectionResource -> collectionResource.postCollectionPublish(
+				collectionId, ignoreCollision, userId));
 	}
 
 	@GraphQLInvokeDetached
@@ -96,6 +163,14 @@ public class Mutation {
 		}
 	}
 
+	private void _populateResourceContext(CollectionResource collectionResource)
+		throws Exception {
+
+		collectionResource.setContextCompany(
+			CompanyLocalServiceUtil.getCompany(
+				CompanyThreadLocal.getCompanyId()));
+	}
+
 	private void _populateResourceContext(SettingsResource settingsResource)
 		throws Exception {
 
@@ -104,6 +179,8 @@ public class Mutation {
 				CompanyThreadLocal.getCompanyId()));
 	}
 
+	private static ComponentServiceObjects<CollectionResource>
+		_collectionResourceComponentServiceObjects;
 	private static ComponentServiceObjects<SettingsResource>
 		_settingsResourceComponentServiceObjects;
 

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/graphql/query/v1_0/Query.java
@@ -14,19 +14,21 @@
 
 package com.liferay.change.tracking.rest.internal.graphql.query.v1_0;
 
+import com.liferay.change.tracking.rest.dto.v1_0.Collection;
 import com.liferay.change.tracking.rest.dto.v1_0.Settings;
+import com.liferay.change.tracking.rest.resource.v1_0.CollectionResource;
 import com.liferay.change.tracking.rest.resource.v1_0.SettingsResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
-
-import java.util.Collection;
 
 import javax.annotation.Generated;
 
@@ -39,6 +41,14 @@ import org.osgi.service.component.ComponentServiceObjects;
 @Generated("")
 public class Query {
 
+	public static void setCollectionResourceComponentServiceObjects(
+		ComponentServiceObjects<CollectionResource>
+			collectionResourceComponentServiceObjects) {
+
+		_collectionResourceComponentServiceObjects =
+			collectionResourceComponentServiceObjects;
+	}
+
 	public static void setSettingsResourceComponentServiceObjects(
 		ComponentServiceObjects<SettingsResource>
 			settingsResourceComponentServiceObjects) {
@@ -49,7 +59,42 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Settings> getSettingsPage(
+	public java.util.Collection<Collection> getCollectionsPage(
+			@GraphQLName("companyId") Long companyId,
+			@GraphQLName("type") String type,
+			@GraphQLName("userId") Long userId,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collectionResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collectionResource -> {
+				Page paginationPage = collectionResource.getCollectionsPage(
+					companyId, type, userId, Pagination.of(pageSize, page),
+					sorts);
+
+				return paginationPage.getItems();
+			});
+	}
+
+	@GraphQLField
+	@GraphQLInvokeDetached
+	public Collection getCollection(
+			@GraphQLName("collectionId") Long collectionId)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collectionResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collectionResource -> collectionResource.getCollection(
+				collectionId));
+	}
+
+	@GraphQLField
+	@GraphQLInvokeDetached
+	public java.util.Collection<Settings> getSettingsPage(
 			@GraphQLName("companyId") Long companyId,
 			@GraphQLName("userId") Long userId)
 		throws Exception {
@@ -84,6 +129,14 @@ public class Query {
 		}
 	}
 
+	private void _populateResourceContext(CollectionResource collectionResource)
+		throws Exception {
+
+		collectionResource.setContextCompany(
+			CompanyLocalServiceUtil.getCompany(
+				CompanyThreadLocal.getCompanyId()));
+	}
+
 	private void _populateResourceContext(SettingsResource settingsResource)
 		throws Exception {
 
@@ -92,6 +145,8 @@ public class Query {
 				CompanyThreadLocal.getCompanyId()));
 	}
 
+	private static ComponentServiceObjects<CollectionResource>
+		_collectionResourceComponentServiceObjects;
 	private static ComponentServiceObjects<SettingsResource>
 		_settingsResourceComponentServiceObjects;
 

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -16,6 +16,7 @@ package com.liferay.change.tracking.rest.internal.graphql.servlet.v1_0;
 
 import com.liferay.change.tracking.rest.internal.graphql.mutation.v1_0.Mutation;
 import com.liferay.change.tracking.rest.internal.graphql.query.v1_0.Query;
+import com.liferay.change.tracking.rest.resource.v1_0.CollectionResource;
 import com.liferay.change.tracking.rest.resource.v1_0.SettingsResource;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 
@@ -38,9 +39,13 @@ public class ServletDataImpl implements ServletData {
 
 	@Activate
 	public void activate(BundleContext bundleContext) {
+		Mutation.setCollectionResourceComponentServiceObjects(
+			_collectionResourceComponentServiceObjects);
 		Mutation.setSettingsResourceComponentServiceObjects(
 			_settingsResourceComponentServiceObjects);
 
+		Query.setCollectionResourceComponentServiceObjects(
+			_collectionResourceComponentServiceObjects);
 		Query.setSettingsResourceComponentServiceObjects(
 			_settingsResourceComponentServiceObjects);
 	}
@@ -59,6 +64,10 @@ public class ServletDataImpl implements ServletData {
 	public Query getQuery() {
 		return new Query();
 	}
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<CollectionResource>
+		_collectionResourceComponentServiceObjects;
 
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
 	private ComponentServiceObjects<SettingsResource>

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseCollectionResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseCollectionResourceImpl.java
@@ -1,0 +1,224 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.rest.internal.resource.v1_0;
+
+import com.liferay.change.tracking.rest.dto.v1_0.Collection;
+import com.liferay.change.tracking.rest.dto.v1_0.CollectionUpdate;
+import com.liferay.change.tracking.rest.resource.v1_0.CollectionResource;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.TransformUtil;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Generated;
+
+import javax.validation.constraints.NotNull;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * @author Mate Thurzo
+ * @generated
+ */
+@Generated("")
+@Path("/v1.0")
+public abstract class BaseCollectionResourceImpl implements CollectionResource {
+
+	@Override
+	@GET
+	@Parameters(
+		value = {
+			@Parameter(in = ParameterIn.QUERY, name = "companyId"),
+			@Parameter(in = ParameterIn.QUERY, name = "type"),
+			@Parameter(in = ParameterIn.QUERY, name = "userId"),
+			@Parameter(in = ParameterIn.QUERY, name = "page"),
+			@Parameter(in = ParameterIn.QUERY, name = "pageSize"),
+			@Parameter(in = ParameterIn.QUERY, name = "sort")
+		}
+	)
+	@Path("/collections")
+	@Produces({"application/json", "application/xml"})
+	@Tags(value = {@Tag(name = "Collection")})
+	public Page<Collection> getCollectionsPage(
+			@Parameter(hidden = true) @QueryParam("companyId") Long companyId,
+			@Parameter(hidden = true) @QueryParam("type") String type,
+			@Parameter(hidden = true) @QueryParam("userId") Long userId,
+			@Context Pagination pagination, @Context Sort[] sorts)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@Override
+	@Consumes({"application/json", "application/xml"})
+	@POST
+	@Parameters(
+		value = {
+			@Parameter(in = ParameterIn.QUERY, name = "companyId"),
+			@Parameter(in = ParameterIn.QUERY, name = "userId")
+		}
+	)
+	@Path("/collections")
+	@Produces({"application/json", "application/xml"})
+	@Tags(value = {@Tag(name = "Collection")})
+	public Collection postCollection(
+			@NotNull @Parameter(hidden = true) @QueryParam("companyId") Long
+				companyId,
+			@NotNull @Parameter(hidden = true) @QueryParam("userId") Long
+				userId,
+			CollectionUpdate collectionUpdate)
+		throws Exception {
+
+		return new Collection();
+	}
+
+	@Override
+	@DELETE
+	@Parameters(
+		value = {@Parameter(in = ParameterIn.PATH, name = "collectionId")}
+	)
+	@Path("/collections/{collectionId}")
+	@Produces({"application/json", "text/plain"})
+	@Tags(value = {@Tag(name = "Collection")})
+	public void deleteCollection(
+			@NotNull @Parameter(hidden = true) @PathParam("collectionId") Long
+				collectionId)
+		throws Exception {
+	}
+
+	@Override
+	@GET
+	@Parameters(
+		value = {@Parameter(in = ParameterIn.PATH, name = "collectionId")}
+	)
+	@Path("/collections/{collectionId}")
+	@Produces({"application/json", "application/xml", "text/plain"})
+	@Tags(value = {@Tag(name = "Collection")})
+	public Collection getCollection(
+			@NotNull @Parameter(hidden = true) @PathParam("collectionId") Long
+				collectionId)
+		throws Exception {
+
+		return new Collection();
+	}
+
+	@Override
+	@POST
+	@Parameters(
+		value = {
+			@Parameter(in = ParameterIn.PATH, name = "collectionId"),
+			@Parameter(in = ParameterIn.QUERY, name = "userId")
+		}
+	)
+	@Path("/collections/{collectionId}/checkout")
+	@Produces("application/json")
+	@Tags(value = {@Tag(name = "Collection")})
+	public void postCollectionCheckout(
+			@NotNull @Parameter(hidden = true) @PathParam("collectionId") Long
+				collectionId,
+			@NotNull @Parameter(hidden = true) @QueryParam("userId") Long
+				userId)
+		throws Exception {
+	}
+
+	@Override
+	@POST
+	@Parameters(
+		value = {
+			@Parameter(in = ParameterIn.PATH, name = "collectionId"),
+			@Parameter(in = ParameterIn.QUERY, name = "ignoreCollision"),
+			@Parameter(in = ParameterIn.QUERY, name = "userId")
+		}
+	)
+	@Path("/collections/{collectionId}/publish")
+	@Produces({"application/json", "text/plain"})
+	@Tags(value = {@Tag(name = "Collection")})
+	public void postCollectionPublish(
+			@NotNull @Parameter(hidden = true) @PathParam("collectionId") Long
+				collectionId,
+			@NotNull @Parameter(hidden = true) @QueryParam("ignoreCollision")
+				Boolean ignoreCollision,
+			@NotNull @Parameter(hidden = true) @QueryParam("userId") Long
+				userId)
+		throws Exception {
+	}
+
+	public void setContextCompany(Company contextCompany) {
+		this.contextCompany = contextCompany;
+	}
+
+	protected void preparePatch(
+		Collection collection, Collection existingCollection) {
+	}
+
+	protected <T, R> List<R> transform(
+		java.util.Collection<T> collection,
+		UnsafeFunction<T, R, Exception> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	protected <T, R> R[] transform(
+		T[] array, UnsafeFunction<T, R, Exception> unsafeFunction,
+		Class<?> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R> R[] transformToArray(
+		java.util.Collection<T> collection,
+		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, Exception> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	@Context
+	protected AcceptLanguage contextAcceptLanguage;
+
+	@Context
+	protected Company contextCompany;
+
+	@Context
+	protected UriInfo contextUriInfo;
+
+}

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseSettingsResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseSettingsResourceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.change.tracking.rest.internal.resource.v1_0;
 
+import com.liferay.change.tracking.rest.dto.v1_0.Collection;
 import com.liferay.change.tracking.rest.dto.v1_0.Settings;
 import com.liferay.change.tracking.rest.dto.v1_0.SettingsUpdate;
 import com.liferay.change.tracking.rest.resource.v1_0.SettingsResource;
@@ -29,7 +30,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -104,7 +104,7 @@ public abstract class BaseSettingsResourceImpl implements SettingsResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -118,7 +118,7 @@ public abstract class BaseSettingsResourceImpl implements SettingsResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CollectionResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CollectionResourceImpl.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.rest.internal.resource.v1_0;
+
+import com.liferay.change.tracking.rest.resource.v1_0.CollectionResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Máté Thurzó
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/collection.properties",
+	scope = ServiceScope.PROTOTYPE, service = CollectionResource.class
+)
+public class CollectionResourceImpl extends BaseCollectionResourceImpl {
+}

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -49,7 +49,9 @@ import org.osgi.service.component.annotations.Reference;
 	service = OpenAPIResourceImpl.class
 )
 @Generated("")
-@OpenAPIDefinition(info = @Info(description = "", title = "", version = "v1.0"))
+@OpenAPIDefinition(
+	info = @Info(description = "", title = "Change Tracking REST", version = "v1.0")
+)
 @Path("/v1.0")
 public class OpenAPIResourceImpl {
 
@@ -74,6 +76,8 @@ public class OpenAPIResourceImpl {
 
 	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
 		{
+			add(CollectionResourceImpl.class);
+
 			add(SettingsResourceImpl.class);
 
 			add(OpenAPIResourceImpl.class);

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/SettingsResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/SettingsResourceImpl.java
@@ -131,7 +131,7 @@ public class SettingsResourceImpl extends BaseSettingsResourceImpl {
 			_ctEngineManager.isChangeTrackingAllowed(companyId));
 		settings.setChangeTrackingEnabled(
 			_ctEngineManager.isChangeTrackingEnabled(companyId));
-		settings.setCompanyId(companyId.intValue());
+		settings.setCompanyId(companyId);
 		settings.setSupportedContentTypeLanguageKeys(
 			supportedContentTypeLanguageKeys.toArray(new String[0]));
 		settings.setSupportedContentTypes(
@@ -149,8 +149,8 @@ public class SettingsResourceImpl extends BaseSettingsResourceImpl {
 					userId,
 					CTSettingsKeys.CHECKOUT_CT_COLLECTION_CONFIRMATION_ENABLED,
 					"true")));
-		settings.setCompanyId(companyId.intValue());
-		settings.setUserId(userId.intValue());
+		settings.setCompanyId(companyId);
+		settings.setUserId(userId);
 
 		return settings;
 	}

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/collection.properties
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/collection.properties
@@ -1,0 +1,7 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Change.Tracking.REST)
+osgi.jaxrs.resource=true

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCollectionResourceTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCollectionResourceTestCase.java
@@ -1,0 +1,831 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.rest.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.change.tracking.rest.client.dto.v1_0.Collection;
+import com.liferay.change.tracking.rest.client.http.HttpInvoker;
+import com.liferay.change.tracking.rest.client.pagination.Page;
+import com.liferay.change.tracking.rest.client.pagination.Pagination;
+import com.liferay.change.tracking.rest.client.resource.v1_0.CollectionResource;
+import com.liferay.change.tracking.rest.client.serdes.v1_0.CollectionSerDes;
+import com.liferay.petra.function.UnsafeTriConsumer;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import java.lang.reflect.InvocationTargetException;
+
+import java.text.DateFormat;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+
+import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.beanutils.BeanUtilsBean;
+import org.apache.commons.lang.time.DateUtils;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Mate Thurzo
+ * @generated
+ */
+@Generated("")
+public abstract class BaseCollectionResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+		testLocale = LocaleUtil.getDefault();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_collectionResource.setContextCompany(testCompany);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+
+		Collection collection1 = randomCollection();
+
+		String json = objectMapper.writeValueAsString(collection1);
+
+		Collection collection2 = CollectionSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(collection1, collection2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+
+		Collection collection = randomCollection();
+
+		String json1 = objectMapper.writeValueAsString(collection);
+		String json2 = CollectionSerDes.toJSON(collection);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		Collection collection = randomCollection();
+
+		collection.setDescription(regex);
+		collection.setName(regex);
+		collection.setStatusByUserName(regex);
+
+		String json = CollectionSerDes.toJSON(collection);
+
+		Assert.assertFalse(json.contains(regex));
+
+		collection = CollectionSerDes.toDTO(json);
+
+		Assert.assertEquals(regex, collection.getDescription());
+		Assert.assertEquals(regex, collection.getName());
+		Assert.assertEquals(regex, collection.getStatusByUserName());
+	}
+
+	@Test
+	public void testGetCollectionsPage() throws Exception {
+		Page<Collection> page = CollectionResource.getCollectionsPage(
+			null, RandomTestUtil.randomString(), null, Pagination.of(1, 2),
+			null);
+
+		Assert.assertEquals(0, page.getTotalCount());
+
+		Collection collection1 = testGetCollectionsPage_addCollection(
+			randomCollection());
+
+		Collection collection2 = testGetCollectionsPage_addCollection(
+			randomCollection());
+
+		page = CollectionResource.getCollectionsPage(
+			null, null, null, Pagination.of(1, 2), null);
+
+		Assert.assertEquals(2, page.getTotalCount());
+
+		assertEqualsIgnoringOrder(
+			Arrays.asList(collection1, collection2),
+			(List<Collection>)page.getItems());
+		assertValid(page);
+	}
+
+	@Test
+	public void testGetCollectionsPageWithPagination() throws Exception {
+		Collection collection1 = testGetCollectionsPage_addCollection(
+			randomCollection());
+
+		Collection collection2 = testGetCollectionsPage_addCollection(
+			randomCollection());
+
+		Collection collection3 = testGetCollectionsPage_addCollection(
+			randomCollection());
+
+		Page<Collection> page1 = CollectionResource.getCollectionsPage(
+			null, null, null, Pagination.of(1, 2), null);
+
+		List<Collection> collections1 = (List<Collection>)page1.getItems();
+
+		Assert.assertEquals(collections1.toString(), 2, collections1.size());
+
+		Page<Collection> page2 = CollectionResource.getCollectionsPage(
+			null, null, null, Pagination.of(2, 2), null);
+
+		Assert.assertEquals(3, page2.getTotalCount());
+
+		List<Collection> collections2 = (List<Collection>)page2.getItems();
+
+		Assert.assertEquals(collections2.toString(), 1, collections2.size());
+
+		Page<Collection> page3 = CollectionResource.getCollectionsPage(
+			null, null, null, Pagination.of(1, 3), null);
+
+		assertEqualsIgnoringOrder(
+			Arrays.asList(collection1, collection2, collection3),
+			(List<Collection>)page3.getItems());
+	}
+
+	@Test
+	public void testGetCollectionsPageWithSortDateTime() throws Exception {
+		testGetCollectionsPageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, collection1, collection2) -> {
+				BeanUtils.setProperty(
+					collection1, entityField.getName(),
+					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetCollectionsPageWithSortInteger() throws Exception {
+		testGetCollectionsPageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, collection1, collection2) -> {
+				BeanUtils.setProperty(collection1, entityField.getName(), 0);
+				BeanUtils.setProperty(collection2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetCollectionsPageWithSortString() throws Exception {
+		testGetCollectionsPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, collection1, collection2) -> {
+				BeanUtils.setProperty(
+					collection1, entityField.getName(), "Aaa");
+				BeanUtils.setProperty(
+					collection2, entityField.getName(), "Bbb");
+			});
+	}
+
+	protected void testGetCollectionsPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer<EntityField, Collection, Collection, Exception>
+				unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Collection collection1 = randomCollection();
+		Collection collection2 = randomCollection();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(entityField, collection1, collection2);
+		}
+
+		collection1 = testGetCollectionsPage_addCollection(collection1);
+
+		collection2 = testGetCollectionsPage_addCollection(collection2);
+
+		for (EntityField entityField : entityFields) {
+			Page<Collection> ascPage = CollectionResource.getCollectionsPage(
+				null, null, null, Pagination.of(1, 2),
+				entityField.getName() + ":asc");
+
+			assertEquals(
+				Arrays.asList(collection1, collection2),
+				(List<Collection>)ascPage.getItems());
+
+			Page<Collection> descPage = CollectionResource.getCollectionsPage(
+				null, null, null, Pagination.of(1, 2),
+				entityField.getName() + ":desc");
+
+			assertEquals(
+				Arrays.asList(collection2, collection1),
+				(List<Collection>)descPage.getItems());
+		}
+	}
+
+	protected Collection testGetCollectionsPage_addCollection(
+			Collection collection)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testPostCollection() throws Exception {
+		Collection randomCollection = randomCollection();
+
+		Collection postCollection = testPostCollection_addCollection(
+			randomCollection);
+
+		assertEquals(randomCollection, postCollection);
+		assertValid(postCollection);
+	}
+
+	protected Collection testPostCollection_addCollection(Collection collection)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testDeleteCollection() throws Exception {
+		Assert.assertTrue(true);
+	}
+
+	@Test
+	public void testGetCollection() throws Exception {
+		Assert.assertTrue(true);
+	}
+
+	@Test
+	public void testPostCollectionCheckout() throws Exception {
+		Assert.assertTrue(true);
+	}
+
+	@Test
+	public void testPostCollectionPublish() throws Exception {
+		Assert.assertTrue(true);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		Collection collection1, Collection collection2) {
+
+		Assert.assertTrue(
+			collection1 + " does not equal " + collection2,
+			equals(collection1, collection2));
+	}
+
+	protected void assertEquals(
+		List<Collection> collections1, List<Collection> collections2) {
+
+		Assert.assertEquals(collections1.size(), collections2.size());
+
+		for (int i = 0; i < collections1.size(); i++) {
+			Collection collection1 = collections1.get(i);
+			Collection collection2 = collections2.get(i);
+
+			assertEquals(collection1, collection2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<Collection> collections1, List<Collection> collections2) {
+
+		Assert.assertEquals(collections1.size(), collections2.size());
+
+		for (Collection collection1 : collections1) {
+			boolean contains = false;
+
+			for (Collection collection2 : collections2) {
+				if (equals(collection1, collection2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				collections2 + " does not contain " + collection1, contains);
+		}
+	}
+
+	protected void assertValid(Collection collection) {
+		boolean valid = true;
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("additionCount", additionalAssertFieldName)) {
+				if (collection.getAdditionCount() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("collectionId", additionalAssertFieldName)) {
+				if (collection.getCollectionId() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("companyId", additionalAssertFieldName)) {
+				if (collection.getCompanyId() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("deletionCount", additionalAssertFieldName)) {
+				if (collection.getDeletionCount() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("description", additionalAssertFieldName)) {
+				if (collection.getDescription() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"modificationCount", additionalAssertFieldName)) {
+
+				if (collection.getModificationCount() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("name", additionalAssertFieldName)) {
+				if (collection.getName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("statusByUserName", additionalAssertFieldName)) {
+				if (collection.getStatusByUserName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("statusDate", additionalAssertFieldName)) {
+				if (collection.getStatusDate() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<Collection> page) {
+		boolean valid = false;
+
+		java.util.Collection<Collection> collections = page.getItems();
+
+		int size = collections.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(Collection collection1, Collection collection2) {
+		if (collection1 == collection2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("additionCount", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collection1.getAdditionCount(),
+						collection2.getAdditionCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("collectionId", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collection1.getCollectionId(),
+						collection2.getCollectionId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("companyId", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collection1.getCompanyId(),
+						collection2.getCompanyId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("deletionCount", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collection1.getDeletionCount(),
+						collection2.getDeletionCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("description", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collection1.getDescription(),
+						collection2.getDescription())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"modificationCount", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						collection1.getModificationCount(),
+						collection2.getModificationCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("name", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collection1.getName(), collection2.getName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("statusByUserName", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collection1.getStatusByUserName(),
+						collection2.getStatusByUserName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("statusDate", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collection1.getStatusDate(),
+						collection2.getStatusDate())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_collectionResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_collectionResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		java.util.Collection<EntityField> entityFields = getEntityFields();
+
+		Stream<EntityField> stream = entityFields.stream();
+
+		return stream.filter(
+			entityField ->
+				Objects.equals(entityField.getType(), type) &&
+				!ArrayUtil.contains(
+					getIgnoredEntityFieldNames(), entityField.getName())
+		).collect(
+			Collectors.toList()
+		);
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator, Collection collection) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("additionCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("collectionId")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("companyId")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("deletionCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("description")) {
+			sb.append("'");
+			sb.append(String.valueOf(collection.getDescription()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("modificationCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("name")) {
+			sb.append("'");
+			sb.append(String.valueOf(collection.getName()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("statusByUserName")) {
+			sb.append("'");
+			sb.append(String.valueOf(collection.getStatusByUserName()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("statusDate")) {
+			if (operator.equals("between")) {
+				sb = new StringBundler();
+
+				sb.append("(");
+				sb.append(entityFieldName);
+				sb.append(" gt ");
+				sb.append(
+					_dateFormat.format(
+						DateUtils.addSeconds(collection.getStatusDate(), -2)));
+				sb.append(" and ");
+				sb.append(entityFieldName);
+				sb.append(" lt ");
+				sb.append(
+					_dateFormat.format(
+						DateUtils.addSeconds(collection.getStatusDate(), 2)));
+				sb.append(")");
+			}
+			else {
+				sb.append(entityFieldName);
+
+				sb.append(" ");
+				sb.append(operator);
+				sb.append(" ");
+
+				sb.append(_dateFormat.format(collection.getStatusDate()));
+			}
+
+			return sb.toString();
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected Collection randomCollection() throws Exception {
+		return new Collection() {
+			{
+				companyId = RandomTestUtil.randomLong();
+				description = RandomTestUtil.randomString();
+				name = RandomTestUtil.randomString();
+				statusByUserName = RandomTestUtil.randomString();
+				statusDate = RandomTestUtil.nextDate();
+			}
+		};
+	}
+
+	protected Collection randomIrrelevantCollection() throws Exception {
+		Collection randomIrrelevantCollection = randomCollection();
+
+		return randomIrrelevantCollection;
+	}
+
+	protected Collection randomPatchCollection() throws Exception {
+		return randomCollection();
+	}
+
+	protected Group irrelevantGroup;
+	protected Company testCompany;
+	protected Group testGroup;
+	protected Locale testLocale;
+	protected String testUserNameAndPassword = "test@liferay.com:test";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseCollectionResourceTestCase.class);
+
+	private static BeanUtilsBean _beanUtilsBean = new BeanUtilsBean() {
+
+		@Override
+		public void copyProperty(Object bean, String name, Object value)
+			throws IllegalAccessException, InvocationTargetException {
+
+			if (value != null) {
+				super.copyProperty(bean, name, value);
+			}
+		}
+
+	};
+	private static DateFormat _dateFormat;
+
+	@Inject
+	private com.liferay.change.tracking.rest.resource.v1_0.CollectionResource
+		_collectionResource;
+
+}

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseSettingsResourceTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseSettingsResourceTestCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.change.tracking.rest.client.dto.v1_0.Collection;
 import com.liferay.change.tracking.rest.client.dto.v1_0.Settings;
 import com.liferay.change.tracking.rest.client.http.HttpInvoker;
 import com.liferay.change.tracking.rest.client.pagination.Page;
@@ -49,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -340,7 +340,7 @@ public abstract class BaseSettingsResourceTestCase {
 	protected void assertValid(Page<Settings> page) {
 		boolean valid = false;
 
-		Collection<Settings> settingses = page.getItems();
+		java.util.Collection<Settings> settingses = page.getItems();
 
 		int size = settingses.size();
 
@@ -466,7 +466,9 @@ public abstract class BaseSettingsResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_settingsResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -487,7 +489,7 @@ public abstract class BaseSettingsResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 
@@ -560,6 +562,8 @@ public abstract class BaseSettingsResourceTestCase {
 				changeTrackingEnabled = RandomTestUtil.randomBoolean();
 				checkoutCTCollectionConfirmationEnabled =
 					RandomTestUtil.randomBoolean();
+				companyId = RandomTestUtil.randomLong();
+				userId = RandomTestUtil.randomLong();
 			}
 		};
 	}

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/CollectionResourceTest.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/CollectionResourceTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.rest.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Máté Thurzó
+ */
+@Ignore
+@RunWith(Arquillian.class)
+public class CollectionResourceTest extends BaseCollectionResourceTestCase {
+}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/query/v1_0/Query.java
@@ -33,8 +33,6 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
-import java.util.Collection;
-
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -93,7 +91,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<DataDefinition> getSiteDataDefinitionsPage(
+	public java.util.Collection<DataDefinition> getSiteDataDefinitionsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("keywords") String keywords,
 			@GraphQLName("pageSize") int pageSize,
@@ -114,7 +112,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<DataLayout> getDataDefinitionDataLayoutsPage(
+	public java.util.Collection<DataLayout> getDataDefinitionDataLayoutsPage(
 			@GraphQLName("dataDefinitionId") Long dataDefinitionId,
 			@GraphQLName("keywords") String keywords,
 			@GraphQLName("pageSize") int pageSize,
@@ -149,7 +147,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<DataLayout> getSiteDataLayoutPage(
+	public java.util.Collection<DataLayout> getSiteDataLayoutPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("keywords") String keywords,
 			@GraphQLName("pageSize") int pageSize,
@@ -169,10 +167,12 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<DataRecord> getDataRecordCollectionDataRecordsPage(
-			@GraphQLName("dataRecordCollectionId") Long dataRecordCollectionId,
-			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page)
+	public java.util.Collection<DataRecord>
+			getDataRecordCollectionDataRecordsPage(
+				@GraphQLName("dataRecordCollectionId") Long
+					dataRecordCollectionId,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -218,7 +218,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<DataRecordCollection>
+	public java.util.Collection<DataRecordCollection>
 			getDataDefinitionDataRecordCollectionsPage(
 				@GraphQLName("dataDefinitionId") Long dataDefinitionId,
 				@GraphQLName("keywords") String keywords,
@@ -256,11 +256,12 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<DataRecordCollection> getSiteDataRecordCollectionsPage(
-			@GraphQLName("siteId") Long siteId,
-			@GraphQLName("keywords") String keywords,
-			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page)
+	public java.util.Collection<DataRecordCollection>
+			getSiteDataRecordCollectionsPage(
+				@GraphQLName("siteId") Long siteId,
+				@GraphQLName("keywords") String keywords,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page)
 		throws Exception {
 
 		return _applyComponentServiceObjects(

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/BaseDataDefinitionResourceImpl.java
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -194,7 +193,7 @@ public abstract class BaseDataDefinitionResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -208,7 +207,7 @@ public abstract class BaseDataDefinitionResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/BaseDataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/BaseDataLayoutResourceImpl.java
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -219,7 +218,7 @@ public abstract class BaseDataLayoutResourceImpl implements DataLayoutResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -233,7 +232,7 @@ public abstract class BaseDataLayoutResourceImpl implements DataLayoutResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/BaseDataRecordCollectionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/BaseDataRecordCollectionResourceImpl.java
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -231,7 +230,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -245,7 +244,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/BaseDataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/BaseDataRecordResourceImpl.java
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -178,7 +177,7 @@ public abstract class BaseDataRecordResourceImpl implements DataRecordResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -192,7 +191,7 @@ public abstract class BaseDataRecordResourceImpl implements DataRecordResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataDefinitionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataDefinitionResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -539,7 +538,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 	protected void assertValid(Page<DataDefinition> page) {
 		boolean valid = false;
 
-		Collection<DataDefinition> dataDefinitions = page.getItems();
+		java.util.Collection<DataDefinition> dataDefinitions = page.getItems();
 
 		int size = dataDefinitions.size();
 
@@ -686,7 +685,9 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_dataDefinitionResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -707,7 +708,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataLayoutResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataLayoutResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -626,7 +625,7 @@ public abstract class BaseDataLayoutResourceTestCase {
 	protected void assertValid(Page<DataLayout> page) {
 		boolean valid = false;
 
-		Collection<DataLayout> dataLayouts = page.getItems();
+		java.util.Collection<DataLayout> dataLayouts = page.getItems();
 
 		int size = dataLayouts.size();
 
@@ -773,7 +772,9 @@ public abstract class BaseDataLayoutResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_dataLayoutResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -794,7 +795,7 @@ public abstract class BaseDataLayoutResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataRecordCollectionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataRecordCollectionResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -666,7 +665,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 	protected void assertValid(Page<DataRecordCollection> page) {
 		boolean valid = false;
 
-		Collection<DataRecordCollection> dataRecordCollections =
+		java.util.Collection<DataRecordCollection> dataRecordCollections =
 			page.getItems();
 
 		int size = dataRecordCollections.size();
@@ -752,7 +751,9 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_dataRecordCollectionResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -773,7 +774,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataRecordResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataRecordResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -466,7 +465,7 @@ public abstract class BaseDataRecordResourceTestCase {
 	protected void assertValid(Page<DataRecord> page) {
 		boolean valid = false;
 
-		Collection<DataRecord> dataRecords = page.getItems();
+		java.util.Collection<DataRecord> dataRecords = page.getItems();
 
 		int size = dataRecords.size();
 
@@ -538,7 +537,9 @@ public abstract class BaseDataRecordResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_dataRecordResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -559,7 +560,7 @@ public abstract class BaseDataRecordResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
@@ -33,8 +33,6 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
-import java.util.Collection;
-
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -83,7 +81,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Keyword> getSiteKeywordsPage(
+	public java.util.Collection<Keyword> getSiteKeywordsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -105,7 +103,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<TaxonomyCategory>
+	public java.util.Collection<TaxonomyCategory>
 			getTaxonomyCategoryTaxonomyCategoriesPage(
 				@GraphQLName("parentTaxonomyCategoryId") Long
 					parentTaxonomyCategoryId,
@@ -146,7 +144,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<TaxonomyCategory>
+	public java.util.Collection<TaxonomyCategory>
 			getTaxonomyVocabularyTaxonomyCategoriesPage(
 				@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId,
 				@GraphQLName("search") String search,
@@ -172,12 +170,14 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<TaxonomyVocabulary> getSiteTaxonomyVocabulariesPage(
-			@GraphQLName("siteId") Long siteId,
-			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
-			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+	public java.util.Collection<TaxonomyVocabulary>
+			getSiteTaxonomyVocabulariesPage(
+				@GraphQLName("siteId") Long siteId,
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") Filter filter,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -32,7 +32,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -161,7 +160,7 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -175,7 +174,7 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -32,7 +32,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -294,7 +293,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -308,7 +307,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -32,7 +32,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -245,7 +244,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -259,7 +258,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -594,7 +593,7 @@ public abstract class BaseKeywordResourceTestCase {
 	protected void assertValid(Page<Keyword> page) {
 		boolean valid = false;
 
-		Collection<Keyword> keywords = page.getItems();
+		java.util.Collection<Keyword> keywords = page.getItems();
 
 		int size = keywords.size();
 
@@ -698,7 +697,9 @@ public abstract class BaseKeywordResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_keywordResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -719,7 +720,7 @@ public abstract class BaseKeywordResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -1107,7 +1106,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	protected void assertValid(Page<TaxonomyCategory> page) {
 		boolean valid = false;
 
-		Collection<TaxonomyCategory> taxonomyCategories = page.getItems();
+		java.util.Collection<TaxonomyCategory> taxonomyCategories =
+			page.getItems();
 
 		int size = taxonomyCategories.size();
 
@@ -1276,7 +1276,9 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_taxonomyCategoryResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -1297,7 +1299,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -761,7 +760,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	protected void assertValid(Page<TaxonomyVocabulary> page) {
 		boolean valid = false;
 
-		Collection<TaxonomyVocabulary> taxonomyVocabularies = page.getItems();
+		java.util.Collection<TaxonomyVocabulary> taxonomyVocabularies =
+			page.getItems();
 
 		int size = taxonomyVocabularies.size();
 
@@ -923,7 +923,9 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_taxonomyVocabularyResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -944,7 +946,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
@@ -45,8 +45,6 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
-import java.util.Collection;
-
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -145,7 +143,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<EmailAddress> getOrganizationEmailAddressesPage(
+	public java.util.Collection<EmailAddress> getOrganizationEmailAddressesPage(
 			@GraphQLName("organizationId") Long organizationId)
 		throws Exception {
 
@@ -163,7 +161,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<EmailAddress> getUserAccountEmailAddressesPage(
+	public java.util.Collection<EmailAddress> getUserAccountEmailAddressesPage(
 			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
@@ -181,7 +179,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Organization> getOrganizationsPage(
+	public java.util.Collection<Organization> getOrganizationsPage(
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
 			@GraphQLName("pageSize") int pageSize,
@@ -214,7 +212,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Organization> getOrganizationOrganizationsPage(
+	public java.util.Collection<Organization> getOrganizationOrganizationsPage(
 			@GraphQLName("parentOrganizationId") Long parentOrganizationId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -237,7 +235,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Phone> getOrganizationPhonesPage(
+	public java.util.Collection<Phone> getOrganizationPhonesPage(
 			@GraphQLName("organizationId") Long organizationId)
 		throws Exception {
 
@@ -265,7 +263,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Phone> getUserAccountPhonesPage(
+	public java.util.Collection<Phone> getUserAccountPhonesPage(
 			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
@@ -282,8 +280,9 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<PostalAddress> getOrganizationPostalAddressesPage(
-			@GraphQLName("organizationId") Long organizationId)
+	public java.util.Collection<PostalAddress>
+			getOrganizationPostalAddressesPage(
+				@GraphQLName("organizationId") Long organizationId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -313,8 +312,9 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<PostalAddress> getUserAccountPostalAddressesPage(
-			@GraphQLName("userAccountId") Long userAccountId)
+	public java.util.Collection<PostalAddress>
+			getUserAccountPostalAddressesPage(
+				@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -331,7 +331,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Role> getRolesPage(
+	public java.util.Collection<Role> getRolesPage(
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
 		throws Exception {
@@ -358,7 +358,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Segment> getSiteSegmentsPage(
+	public java.util.Collection<Segment> getSiteSegmentsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -377,7 +377,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Segment> getSiteUserAccountSegmentsPage(
+	public java.util.Collection<Segment> getSiteUserAccountSegmentsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
@@ -396,7 +396,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<SegmentUser> getSegmentUserAccountsPage(
+	public java.util.Collection<SegmentUser> getSegmentUserAccountsPage(
 			@GraphQLName("segmentId") Long segmentId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -425,7 +425,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<UserAccount> getOrganizationUserAccountsPage(
+	public java.util.Collection<UserAccount> getOrganizationUserAccountsPage(
 			@GraphQLName("organizationId") Long organizationId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -448,7 +448,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<UserAccount> getUserAccountsPage(
+	public java.util.Collection<UserAccount> getUserAccountsPage(
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
 			@GraphQLName("pageSize") int pageSize,
@@ -481,7 +481,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<UserAccount> getWebSiteUserAccountsPage(
+	public java.util.Collection<UserAccount> getWebSiteUserAccountsPage(
 			@GraphQLName("webSiteId") Long webSiteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -504,7 +504,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<WebUrl> getOrganizationWebUrlsPage(
+	public java.util.Collection<WebUrl> getOrganizationWebUrlsPage(
 			@GraphQLName("organizationId") Long organizationId)
 		throws Exception {
 
@@ -521,7 +521,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<WebUrl> getUserAccountWebUrlsPage(
+	public java.util.Collection<WebUrl> getUserAccountWebUrlsPage(
 			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
@@ -29,7 +29,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -113,7 +112,7 @@ public abstract class BaseEmailAddressResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -127,7 +126,7 @@ public abstract class BaseEmailAddressResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -32,7 +32,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -138,7 +137,7 @@ public abstract class BaseOrganizationResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -152,7 +151,7 @@ public abstract class BaseOrganizationResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
@@ -29,7 +29,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -109,7 +108,7 @@ public abstract class BasePhoneResourceImpl implements PhoneResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -123,7 +122,7 @@ public abstract class BasePhoneResourceImpl implements PhoneResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
@@ -29,7 +29,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -113,7 +112,7 @@ public abstract class BasePostalAddressResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -127,7 +126,7 @@ public abstract class BasePostalAddressResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -95,7 +94,7 @@ public abstract class BaseRoleResourceImpl implements RoleResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -109,7 +108,7 @@ public abstract class BaseRoleResourceImpl implements RoleResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -103,7 +102,7 @@ public abstract class BaseSegmentResourceImpl implements SegmentResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -117,7 +116,7 @@ public abstract class BaseSegmentResourceImpl implements SegmentResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -85,7 +84,7 @@ public abstract class BaseSegmentUserResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -99,7 +98,7 @@ public abstract class BaseSegmentUserResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -32,7 +32,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -179,7 +178,7 @@ public abstract class BaseUserAccountResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -193,7 +192,7 @@ public abstract class BaseUserAccountResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
@@ -29,7 +29,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -109,7 +108,7 @@ public abstract class BaseWebUrlResourceImpl implements WebUrlResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -123,7 +122,7 @@ public abstract class BaseWebUrlResourceImpl implements WebUrlResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailAddressResourceTestCase.java
@@ -49,7 +49,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -428,7 +427,7 @@ public abstract class BaseEmailAddressResourceTestCase {
 	protected void assertValid(Page<EmailAddress> page) {
 		boolean valid = false;
 
-		Collection<EmailAddress> emailAddresses = page.getItems();
+		java.util.Collection<EmailAddress> emailAddresses = page.getItems();
 
 		int size = emailAddresses.size();
 
@@ -510,7 +509,9 @@ public abstract class BaseEmailAddressResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_emailAddressResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -531,7 +532,7 @@ public abstract class BaseEmailAddressResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -856,7 +855,7 @@ public abstract class BaseOrganizationResourceTestCase {
 	protected void assertValid(Page<Organization> page) {
 		boolean valid = false;
 
-		Collection<Organization> organizations = page.getItems();
+		java.util.Collection<Organization> organizations = page.getItems();
 
 		int size = organizations.size();
 
@@ -1042,7 +1041,9 @@ public abstract class BaseOrganizationResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_organizationResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -1063,7 +1064,7 @@ public abstract class BaseOrganizationResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
@@ -49,7 +49,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -408,7 +407,7 @@ public abstract class BasePhoneResourceTestCase {
 	protected void assertValid(Page<Phone> page) {
 		boolean valid = false;
 
-		Collection<Phone> phones = page.getItems();
+		java.util.Collection<Phone> phones = page.getItems();
 
 		int size = phones.size();
 
@@ -494,7 +493,9 @@ public abstract class BasePhoneResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_phoneResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -515,7 +516,7 @@ public abstract class BasePhoneResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
@@ -49,7 +49,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -496,7 +495,7 @@ public abstract class BasePostalAddressResourceTestCase {
 	protected void assertValid(Page<PostalAddress> page) {
 		boolean valid = false;
 
-		Collection<PostalAddress> postalAddresses = page.getItems();
+		java.util.Collection<PostalAddress> postalAddresses = page.getItems();
 
 		int size = postalAddresses.size();
 
@@ -651,7 +650,9 @@ public abstract class BasePostalAddressResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_postalAddressResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -672,7 +673,7 @@ public abstract class BasePostalAddressResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -316,7 +315,7 @@ public abstract class BaseRoleResourceTestCase {
 	protected void assertValid(Page<Role> page) {
 		boolean valid = false;
 
-		Collection<Role> roles = page.getItems();
+		java.util.Collection<Role> roles = page.getItems();
 
 		int size = roles.size();
 
@@ -433,7 +432,9 @@ public abstract class BaseRoleResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_roleResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -454,7 +455,7 @@ public abstract class BaseRoleResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -464,7 +463,7 @@ public abstract class BaseSegmentResourceTestCase {
 	protected void assertValid(Page<Segment> page) {
 		boolean valid = false;
 
-		Collection<Segment> segments = page.getItems();
+		java.util.Collection<Segment> segments = page.getItems();
 
 		int size = segments.size();
 
@@ -575,7 +574,9 @@ public abstract class BaseSegmentResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_segmentResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -596,7 +597,7 @@ public abstract class BaseSegmentResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -375,7 +374,7 @@ public abstract class BaseSegmentUserResourceTestCase {
 	protected void assertValid(Page<SegmentUser> page) {
 		boolean valid = false;
 
-		Collection<SegmentUser> segmentUsers = page.getItems();
+		java.util.Collection<SegmentUser> segmentUsers = page.getItems();
 
 		int size = segmentUsers.size();
 
@@ -446,7 +445,9 @@ public abstract class BaseSegmentUserResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_segmentUserResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -467,7 +468,7 @@ public abstract class BaseSegmentUserResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -1211,7 +1210,7 @@ public abstract class BaseUserAccountResourceTestCase {
 	protected void assertValid(Page<UserAccount> page) {
 		boolean valid = false;
 
-		Collection<UserAccount> userAccounts = page.getItems();
+		java.util.Collection<UserAccount> userAccounts = page.getItems();
 
 		int size = userAccounts.size();
 
@@ -1494,7 +1493,9 @@ public abstract class BaseUserAccountResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_userAccountResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -1515,7 +1516,7 @@ public abstract class BaseUserAccountResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
@@ -49,7 +49,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -391,7 +390,7 @@ public abstract class BaseWebUrlResourceTestCase {
 	protected void assertValid(Page<WebUrl> page) {
 		boolean valid = false;
 
-		Collection<WebUrl> webUrls = page.getItems();
+		java.util.Collection<WebUrl> webUrls = page.getItems();
 
 		int size = webUrls.size();
 
@@ -455,7 +454,9 @@ public abstract class BaseWebUrlResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_webUrlResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -476,7 +477,7 @@ public abstract class BaseWebUrlResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/query/v1_0/Query.java
@@ -29,8 +29,6 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
-import java.util.Collection;
-
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -73,7 +71,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<WorkflowLog> getWorkflowTaskWorkflowLogsPage(
+	public java.util.Collection<WorkflowLog> getWorkflowTaskWorkflowLogsPage(
 			@GraphQLName("workflowTaskId") Long workflowTaskId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -93,7 +91,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<WorkflowTask> getRoleWorkflowTasksPage(
+	public java.util.Collection<WorkflowTask> getRoleWorkflowTasksPage(
 			@GraphQLName("roleId") Long roleId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -113,7 +111,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<WorkflowTask> getWorkflowTasksAssignedToMePage(
+	public java.util.Collection<WorkflowTask> getWorkflowTasksAssignedToMePage(
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
 		throws Exception {
@@ -132,9 +130,10 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<WorkflowTask> getWorkflowTasksAssignedToMyRolesPage(
-			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page)
+	public java.util.Collection<WorkflowTask>
+			getWorkflowTasksAssignedToMyRolesPage(
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page)
 		throws Exception {
 
 		return _applyComponentServiceObjects(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
@@ -29,7 +29,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -99,7 +98,7 @@ public abstract class BaseWorkflowLogResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -113,7 +112,7 @@ public abstract class BaseWorkflowLogResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskResourceImpl.java
@@ -32,7 +32,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -211,7 +210,7 @@ public abstract class BaseWorkflowTaskResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -225,7 +224,7 @@ public abstract class BaseWorkflowTaskResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -452,7 +451,7 @@ public abstract class BaseWorkflowLogResourceTestCase {
 	protected void assertValid(Page<WorkflowLog> page) {
 		boolean valid = false;
 
-		Collection<WorkflowLog> workflowLogs = page.getItems();
+		java.util.Collection<WorkflowLog> workflowLogs = page.getItems();
 
 		int size = workflowLogs.size();
 
@@ -597,7 +596,9 @@ public abstract class BaseWorkflowLogResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_workflowLogResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -618,7 +619,7 @@ public abstract class BaseWorkflowLogResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -538,7 +537,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 	protected void assertValid(Page<WorkflowTask> page) {
 		boolean valid = false;
 
-		Collection<WorkflowTask> workflowTasks = page.getItems();
+		java.util.Collection<WorkflowTask> workflowTasks = page.getItems();
 
 		int size = workflowTasks.size();
 
@@ -686,7 +685,9 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_workflowTaskResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -707,7 +708,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -60,8 +60,6 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
-import java.util.Collection;
-
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -231,7 +229,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<BlogPosting> getSiteBlogPostingsPage(
+	public java.util.Collection<BlogPosting> getSiteBlogPostingsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -268,7 +266,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<BlogPostingImage> getSiteBlogPostingImagesPage(
+	public java.util.Collection<BlogPostingImage> getSiteBlogPostingImagesPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -291,7 +289,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Comment> getBlogPostingCommentsPage(
+	public java.util.Collection<Comment> getBlogPostingCommentsPage(
 			@GraphQLName("blogPostingId") Long blogPostingId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -325,7 +323,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Comment> getCommentCommentsPage(
+	public java.util.Collection<Comment> getCommentCommentsPage(
 			@GraphQLName("parentCommentId") Long parentCommentId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -347,7 +345,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Comment> getDocumentCommentsPage(
+	public java.util.Collection<Comment> getDocumentCommentsPage(
 			@GraphQLName("documentId") Long documentId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -369,7 +367,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Comment> getStructuredContentCommentsPage(
+	public java.util.Collection<Comment> getStructuredContentCommentsPage(
 			@GraphQLName("structuredContentId") Long structuredContentId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -392,10 +390,11 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<ContentSetElement> getContentSetContentSetElementsPage(
-			@GraphQLName("contentSetId") Long contentSetId,
-			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page)
+	public java.util.Collection<ContentSetElement>
+			getContentSetContentSetElementsPage(
+				@GraphQLName("contentSetId") Long contentSetId,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -413,7 +412,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<ContentSetElement>
+	public java.util.Collection<ContentSetElement>
 			getSiteContentSetByKeyContentSetElementsPage(
 				@GraphQLName("siteId") Long siteId,
 				@GraphQLName("key") String key,
@@ -436,7 +435,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<ContentSetElement>
+	public java.util.Collection<ContentSetElement>
 			getSiteContentSetByUuidContentSetElementsPage(
 				@GraphQLName("siteId") Long siteId,
 				@GraphQLName("uuid") String uuid,
@@ -473,7 +472,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<ContentStructure> getSiteContentStructuresPage(
+	public java.util.Collection<ContentStructure> getSiteContentStructuresPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -496,7 +495,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Document> getDocumentFolderDocumentsPage(
+	public java.util.Collection<Document> getDocumentFolderDocumentsPage(
 			@GraphQLName("documentFolderId") Long documentFolderId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -543,7 +542,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Document> getSiteDocumentsPage(
+	public java.util.Collection<Document> getSiteDocumentsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
@@ -579,12 +578,15 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<DocumentFolder> getDocumentFolderDocumentFoldersPage(
-			@GraphQLName("parentDocumentFolderId") Long parentDocumentFolderId,
-			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
-			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+	public java.util.Collection<DocumentFolder>
+			getDocumentFolderDocumentFoldersPage(
+				@GraphQLName("parentDocumentFolderId") Long
+					parentDocumentFolderId,
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") Filter filter,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -602,7 +604,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<DocumentFolder> getSiteDocumentFoldersPage(
+	public java.util.Collection<DocumentFolder> getSiteDocumentFoldersPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
@@ -654,7 +656,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<KnowledgeBaseArticle>
+	public java.util.Collection<KnowledgeBaseArticle>
 			getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
 				@GraphQLName("parentKnowledgeBaseArticleId") Long
 					parentKnowledgeBaseArticleId,
@@ -681,7 +683,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<KnowledgeBaseArticle>
+	public java.util.Collection<KnowledgeBaseArticle>
 			getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
 				@GraphQLName("knowledgeBaseFolderId") Long
 					knowledgeBaseFolderId,
@@ -709,13 +711,15 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<KnowledgeBaseArticle> getSiteKnowledgeBaseArticlesPage(
-			@GraphQLName("siteId") Long siteId,
-			@GraphQLName("flatten") Boolean flatten,
-			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
-			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+	public java.util.Collection<KnowledgeBaseArticle>
+			getSiteKnowledgeBaseArticlesPage(
+				@GraphQLName("siteId") Long siteId,
+				@GraphQLName("flatten") Boolean flatten,
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") Filter filter,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -734,7 +738,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<KnowledgeBaseAttachment>
+	public java.util.Collection<KnowledgeBaseAttachment>
 			getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
 				@GraphQLName("knowledgeBaseArticleId") Long
 					knowledgeBaseArticleId)
@@ -784,7 +788,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<KnowledgeBaseFolder>
+	public java.util.Collection<KnowledgeBaseFolder>
 			getKnowledgeBaseFolderKnowledgeBaseFoldersPage(
 				@GraphQLName("parentKnowledgeBaseFolderId") Long
 					parentKnowledgeBaseFolderId,
@@ -808,10 +812,11 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<KnowledgeBaseFolder> getSiteKnowledgeBaseFoldersPage(
-			@GraphQLName("siteId") Long siteId,
-			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page)
+	public java.util.Collection<KnowledgeBaseFolder>
+			getSiteKnowledgeBaseFoldersPage(
+				@GraphQLName("siteId") Long siteId,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -843,7 +848,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<MessageBoardAttachment>
+	public java.util.Collection<MessageBoardAttachment>
 			getMessageBoardMessageMessageBoardAttachmentsPage(
 				@GraphQLName("messageBoardMessageId") Long
 					messageBoardMessageId)
@@ -864,7 +869,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<MessageBoardAttachment>
+	public java.util.Collection<MessageBoardAttachment>
 			getMessageBoardThreadMessageBoardAttachmentsPage(
 				@GraphQLName("messageBoardThreadId") Long messageBoardThreadId)
 		throws Exception {
@@ -912,7 +917,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<MessageBoardMessage>
+	public java.util.Collection<MessageBoardMessage>
 			getMessageBoardMessageMessageBoardMessagesPage(
 				@GraphQLName("parentMessageBoardMessageId") Long
 					parentMessageBoardMessageId,
@@ -939,7 +944,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<MessageBoardMessage>
+	public java.util.Collection<MessageBoardMessage>
 			getMessageBoardThreadMessageBoardMessagesPage(
 				@GraphQLName("messageBoardThreadId") Long messageBoardThreadId,
 				@GraphQLName("search") String search,
@@ -979,7 +984,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<MessageBoardSection>
+	public java.util.Collection<MessageBoardSection>
 			getMessageBoardSectionMessageBoardSectionsPage(
 				@GraphQLName("parentMessageBoardSectionId") Long
 					parentMessageBoardSectionId,
@@ -1006,13 +1011,15 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<MessageBoardSection> getSiteMessageBoardSectionsPage(
-			@GraphQLName("siteId") Long siteId,
-			@GraphQLName("flatten") Boolean flatten,
-			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
-			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+	public java.util.Collection<MessageBoardSection>
+			getSiteMessageBoardSectionsPage(
+				@GraphQLName("siteId") Long siteId,
+				@GraphQLName("flatten") Boolean flatten,
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") Filter filter,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -1030,7 +1037,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<MessageBoardThread>
+	public java.util.Collection<MessageBoardThread>
 			getMessageBoardSectionMessageBoardThreadsPage(
 				@GraphQLName("messageBoardSectionId") Long
 					messageBoardSectionId,
@@ -1085,13 +1092,15 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<MessageBoardThread> getSiteMessageBoardThreadsPage(
-			@GraphQLName("siteId") Long siteId,
-			@GraphQLName("flatten") Boolean flatten,
-			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
-			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+	public java.util.Collection<MessageBoardThread>
+			getSiteMessageBoardThreadsPage(
+				@GraphQLName("siteId") Long siteId,
+				@GraphQLName("flatten") Boolean flatten,
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") Filter filter,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -1109,7 +1118,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<StructuredContent>
+	public java.util.Collection<StructuredContent>
 			getContentStructureStructuredContentsPage(
 				@GraphQLName("contentStructureId") Long contentStructureId,
 				@GraphQLName("search") String search,
@@ -1135,13 +1144,15 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<StructuredContent> getSiteStructuredContentsPage(
-			@GraphQLName("siteId") Long siteId,
-			@GraphQLName("flatten") Boolean flatten,
-			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
-			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+	public java.util.Collection<StructuredContent>
+			getSiteStructuredContentsPage(
+				@GraphQLName("siteId") Long siteId,
+				@GraphQLName("flatten") Boolean flatten,
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") Filter filter,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -1188,7 +1199,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<StructuredContent>
+	public java.util.Collection<StructuredContent>
 			getStructuredContentFolderStructuredContentsPage(
 				@GraphQLName("structuredContentFolderId") Long
 					structuredContentFolderId,
@@ -1259,7 +1270,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<StructuredContentFolder>
+	public java.util.Collection<StructuredContentFolder>
 			getSiteStructuredContentFoldersPage(
 				@GraphQLName("siteId") Long siteId,
 				@GraphQLName("flatten") Boolean flatten,
@@ -1286,7 +1297,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<StructuredContentFolder>
+	public java.util.Collection<StructuredContentFolder>
 			getStructuredContentFolderStructuredContentFoldersPage(
 				@GraphQLName("parentStructuredContentFolderId") Long
 					parentStructuredContentFolderId,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -33,7 +33,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -151,7 +150,7 @@ public abstract class BaseBlogPostingImageResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -165,7 +164,7 @@ public abstract class BaseBlogPostingImageResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -33,7 +33,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -336,7 +335,7 @@ public abstract class BaseBlogPostingResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -350,7 +349,7 @@ public abstract class BaseBlogPostingResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -32,7 +32,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -313,7 +312,7 @@ public abstract class BaseCommentResourceImpl implements CommentResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -327,7 +326,7 @@ public abstract class BaseCommentResourceImpl implements CommentResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -141,7 +140,7 @@ public abstract class BaseContentSetElementResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -155,7 +154,7 @@ public abstract class BaseContentSetElementResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -32,7 +32,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -112,7 +111,7 @@ public abstract class BaseContentStructureResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -126,7 +125,7 @@ public abstract class BaseContentStructureResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -32,7 +32,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -288,7 +287,7 @@ public abstract class BaseDocumentFolderResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -302,7 +301,7 @@ public abstract class BaseDocumentFolderResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -34,7 +34,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -321,7 +320,7 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -335,7 +334,7 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -33,7 +33,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -484,7 +483,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -498,7 +497,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -163,7 +162,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -177,7 +176,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -300,7 +299,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -314,7 +313,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -205,7 +204,7 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -219,7 +218,7 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -33,7 +33,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -425,7 +424,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -439,7 +438,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -32,7 +32,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -311,7 +310,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -325,7 +324,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -33,7 +33,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -408,7 +407,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -422,7 +421,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -32,7 +32,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -326,7 +325,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -340,7 +339,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -34,7 +34,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -521,7 +520,7 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -535,7 +534,7 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -53,7 +53,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -657,7 +656,8 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 	protected void assertValid(Page<BlogPostingImage> page) {
 		boolean valid = false;
 
-		Collection<BlogPostingImage> blogPostingImages = page.getItems();
+		java.util.Collection<BlogPostingImage> blogPostingImages =
+			page.getItems();
 
 		int size = blogPostingImages.size();
 
@@ -774,7 +774,9 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_blogPostingImageResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -795,7 +797,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -816,7 +815,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 	protected void assertValid(Page<BlogPosting> page) {
 		boolean valid = false;
 
-		Collection<BlogPosting> blogPostings = page.getItems();
+		java.util.Collection<BlogPosting> blogPostings = page.getItems();
 
 		int size = blogPostings.size();
 
@@ -1085,7 +1084,9 @@ public abstract class BaseBlogPostingResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_blogPostingResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -1106,7 +1107,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -1396,7 +1395,7 @@ public abstract class BaseCommentResourceTestCase {
 	protected void assertValid(Page<Comment> page) {
 		boolean valid = false;
 
-		Collection<Comment> comments = page.getItems();
+		java.util.Collection<Comment> comments = page.getItems();
 
 		int size = comments.size();
 
@@ -1494,7 +1493,9 @@ public abstract class BaseCommentResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_commentResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -1515,7 +1516,7 @@ public abstract class BaseCommentResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -689,7 +688,8 @@ public abstract class BaseContentSetElementResourceTestCase {
 	protected void assertValid(Page<ContentSetElement> page) {
 		boolean valid = false;
 
-		Collection<ContentSetElement> contentSetElements = page.getItems();
+		java.util.Collection<ContentSetElement> contentSetElements =
+			page.getItems();
 
 		int size = contentSetElements.size();
 
@@ -774,7 +774,9 @@ public abstract class BaseContentSetElementResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_contentSetElementResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -795,7 +797,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -619,7 +618,8 @@ public abstract class BaseContentStructureResourceTestCase {
 	protected void assertValid(Page<ContentStructure> page) {
 		boolean valid = false;
 
-		Collection<ContentStructure> contentStructures = page.getItems();
+		java.util.Collection<ContentStructure> contentStructures =
+			page.getItems();
 
 		int size = contentStructures.size();
 
@@ -757,7 +757,9 @@ public abstract class BaseContentStructureResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_contentStructureResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -778,7 +780,7 @@ public abstract class BaseContentStructureResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -1040,7 +1039,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	protected void assertValid(Page<DocumentFolder> page) {
 		boolean valid = false;
 
-		Collection<DocumentFolder> documentFolders = page.getItems();
+		java.util.Collection<DocumentFolder> documentFolders = page.getItems();
 
 		int size = documentFolders.size();
 
@@ -1198,7 +1197,9 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_documentFolderResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -1219,7 +1220,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -53,7 +53,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -1026,7 +1025,7 @@ public abstract class BaseDocumentResourceTestCase {
 	protected void assertValid(Page<Document> page) {
 		boolean valid = false;
 
-		Collection<Document> documents = page.getItems();
+		java.util.Collection<Document> documents = page.getItems();
 
 		int size = documents.size();
 
@@ -1280,7 +1279,9 @@ public abstract class BaseDocumentResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_documentResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -1301,7 +1302,7 @@ public abstract class BaseDocumentResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -1610,7 +1609,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	protected void assertValid(Page<KnowledgeBaseArticle> page) {
 		boolean valid = false;
 
-		Collection<KnowledgeBaseArticle> knowledgeBaseArticles =
+		java.util.Collection<KnowledgeBaseArticle> knowledgeBaseArticles =
 			page.getItems();
 
 		int size = knowledgeBaseArticles.size();
@@ -1895,7 +1894,9 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_knowledgeBaseArticleResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -1916,7 +1917,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -467,7 +466,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 	protected void assertValid(Page<KnowledgeBaseAttachment> page) {
 		boolean valid = false;
 
-		Collection<KnowledgeBaseAttachment> knowledgeBaseAttachments =
+		java.util.Collection<KnowledgeBaseAttachment> knowledgeBaseAttachments =
 			page.getItems();
 
 		int size = knowledgeBaseAttachments.size();
@@ -575,7 +574,9 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_knowledgeBaseAttachmentResource instanceof
 				EntityModelResource)) {
 
@@ -598,7 +599,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -779,7 +778,8 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	protected void assertValid(Page<KnowledgeBaseFolder> page) {
 		boolean valid = false;
 
-		Collection<KnowledgeBaseFolder> knowledgeBaseFolders = page.getItems();
+		java.util.Collection<KnowledgeBaseFolder> knowledgeBaseFolders =
+			page.getItems();
 
 		int size = knowledgeBaseFolders.size();
 
@@ -972,7 +972,9 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_knowledgeBaseFolderResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -993,7 +995,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -557,7 +556,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 	protected void assertValid(Page<MessageBoardAttachment> page) {
 		boolean valid = false;
 
-		Collection<MessageBoardAttachment> messageBoardAttachments =
+		java.util.Collection<MessageBoardAttachment> messageBoardAttachments =
 			page.getItems();
 
 		int size = messageBoardAttachments.size();
@@ -665,7 +664,9 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_messageBoardAttachmentResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -686,7 +687,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -1237,7 +1236,8 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	protected void assertValid(Page<MessageBoardMessage> page) {
 		boolean valid = false;
 
-		Collection<MessageBoardMessage> messageBoardMessages = page.getItems();
+		java.util.Collection<MessageBoardMessage> messageBoardMessages =
+			page.getItems();
 
 		int size = messageBoardMessages.size();
 
@@ -1470,7 +1470,9 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_messageBoardMessageResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -1491,7 +1493,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -1105,7 +1104,8 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	protected void assertValid(Page<MessageBoardSection> page) {
 		boolean valid = false;
 
-		Collection<MessageBoardSection> messageBoardSections = page.getItems();
+		java.util.Collection<MessageBoardSection> messageBoardSections =
+			page.getItems();
 
 		int size = messageBoardSections.size();
 
@@ -1270,7 +1270,9 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_messageBoardSectionResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -1291,7 +1293,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -1199,7 +1198,8 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	protected void assertValid(Page<MessageBoardThread> page) {
 		boolean valid = false;
 
-		Collection<MessageBoardThread> messageBoardThreads = page.getItems();
+		java.util.Collection<MessageBoardThread> messageBoardThreads =
+			page.getItems();
 
 		int size = messageBoardThreads.size();
 
@@ -1432,7 +1432,9 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_messageBoardThreadResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -1453,7 +1455,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -1161,7 +1160,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	protected void assertValid(Page<StructuredContentFolder> page) {
 		boolean valid = false;
 
-		Collection<StructuredContentFolder> structuredContentFolders =
+		java.util.Collection<StructuredContentFolder> structuredContentFolders =
 			page.getItems();
 
 		int size = structuredContentFolders.size();
@@ -1329,7 +1328,9 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_structuredContentFolderResource instanceof
 				EntityModelResource)) {
 
@@ -1352,7 +1353,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -51,7 +51,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -1585,7 +1584,8 @@ public abstract class BaseStructuredContentResourceTestCase {
 	protected void assertValid(Page<StructuredContent> page) {
 		boolean valid = false;
 
-		Collection<StructuredContent> structuredContents = page.getItems();
+		java.util.Collection<StructuredContent> structuredContents =
+			page.getItems();
 
 		int size = structuredContents.size();
 
@@ -1883,7 +1883,9 @@ public abstract class BaseStructuredContentResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_structuredContentResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -1904,7 +1906,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/query/v1_0/Query.java
@@ -33,8 +33,6 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
-import java.util.Collection;
-
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -89,7 +87,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<Form> getSiteFormsPage(
+	public java.util.Collection<Form> getSiteFormsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -134,7 +132,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<FormRecord> getFormFormRecordsPage(
+	public java.util.Collection<FormRecord> getFormFormRecordsPage(
 			@GraphQLName("formId") Long formId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -179,7 +177,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Collection<FormStructure> getSiteFormStructuresPage(
+	public java.util.Collection<FormStructure> getSiteFormStructuresPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
@@ -27,7 +27,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Generated;
@@ -90,7 +89,7 @@ public abstract class BaseFormDocumentResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -104,7 +103,7 @@ public abstract class BaseFormDocumentResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
@@ -29,7 +29,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -146,7 +145,7 @@ public abstract class BaseFormRecordResourceImpl implements FormRecordResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -160,7 +159,7 @@ public abstract class BaseFormRecordResourceImpl implements FormRecordResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
@@ -32,7 +32,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -128,7 +127,7 @@ public abstract class BaseFormResourceImpl implements FormResource {
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -142,7 +141,7 @@ public abstract class BaseFormResourceImpl implements FormResource {
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
@@ -29,7 +29,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -98,7 +97,7 @@ public abstract class BaseFormStructureResourceImpl
 	}
 
 	protected <T, R> List<R> transform(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction) {
 
 		return TransformUtil.transform(collection, unsafeFunction);
@@ -112,7 +111,7 @@ public abstract class BaseFormStructureResourceImpl
 	}
 
 	protected <T, R> R[] transformToArray(
-		Collection<T> collection,
+		java.util.Collection<T> collection,
 		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 
 		return TransformUtil.transformToArray(

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
@@ -48,7 +48,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import java.text.DateFormat;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -359,7 +358,7 @@ public abstract class BaseFormDocumentResourceTestCase {
 	protected void assertValid(Page<FormDocument> page) {
 		boolean valid = false;
 
-		Collection<FormDocument> formDocuments = page.getItems();
+		java.util.Collection<FormDocument> formDocuments = page.getItems();
 
 		int size = formDocuments.size();
 
@@ -491,7 +490,9 @@ public abstract class BaseFormDocumentResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_formDocumentResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -512,7 +513,7 @@ public abstract class BaseFormDocumentResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -475,7 +474,7 @@ public abstract class BaseFormRecordResourceTestCase {
 	protected void assertValid(Page<FormRecord> page) {
 		boolean valid = false;
 
-		Collection<FormRecord> formRecords = page.getItems();
+		java.util.Collection<FormRecord> formRecords = page.getItems();
 
 		int size = formRecords.size();
 
@@ -607,7 +606,9 @@ public abstract class BaseFormRecordResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_formRecordResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -628,7 +629,7 @@ public abstract class BaseFormRecordResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -448,7 +447,7 @@ public abstract class BaseFormResourceTestCase {
 	protected void assertValid(Page<Form> page) {
 		boolean valid = false;
 
-		Collection<Form> forms = page.getItems();
+		java.util.Collection<Form> forms = page.getItems();
 
 		int size = forms.size();
 
@@ -620,7 +619,9 @@ public abstract class BaseFormResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_formResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -641,7 +642,7 @@ public abstract class BaseFormResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
@@ -50,7 +50,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -446,7 +445,7 @@ public abstract class BaseFormStructureResourceTestCase {
 	protected void assertValid(Page<FormStructure> page) {
 		boolean valid = false;
 
-		Collection<FormStructure> formStructures = page.getItems();
+		java.util.Collection<FormStructure> formStructures = page.getItems();
 
 		int size = formStructures.size();
 
@@ -591,7 +590,9 @@ public abstract class BaseFormStructureResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
 		if (!(_formStructureResource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException(
 				"Resource is not an instance of EntityModelResource");
@@ -612,7 +613,7 @@ public abstract class BaseFormStructureResourceTestCase {
 	protected List<EntityField> getEntityFields(EntityField.Type type)
 		throws Exception {
 
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -25,7 +25,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -104,7 +103,7 @@ public abstract class Base${schemaName}ResourceImpl implements ${schemaName}Reso
 	protected void preparePatch(${schemaName} ${schemaVarName}, ${schemaName} existing${schemaVarName?cap_first}) {
 	}
 
-	protected <T, R> List<R> transform(Collection<T> collection, UnsafeFunction<T, R, Exception> unsafeFunction) {
+	protected <T, R> List<R> transform(java.util.Collection<T> collection, UnsafeFunction<T, R, Exception> unsafeFunction) {
 		return TransformUtil.transform(collection, unsafeFunction);
 	}
 
@@ -112,7 +111,7 @@ public abstract class Base${schemaName}ResourceImpl implements ${schemaName}Reso
 		return TransformUtil.transform(array, unsafeFunction, clazz);
 	}
 
-	protected <T, R> R[] transformToArray(Collection<T> collection, UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
+	protected <T, R> R[] transformToArray(java.util.Collection<T> collection, UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
 		return TransformUtil.transformToArray(collection, unsafeFunction, clazz);
 	}
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -49,7 +49,6 @@ import java.text.DateFormat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -976,7 +975,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 		}
 	}
 
-	protected void assertValid(${schemaName} ${schemaVarName}) {
+	protected void assertValid(${configYAML.apiPackagePath}.client.dto.${escapedVersion}.${schemaName} ${schemaVarName}) {
 		boolean valid = true;
 
 		<#if properties?keys?seq_contains("dateCreated")>
@@ -1037,7 +1036,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 	protected void assertValid(Page<${schemaName}> page) {
 		boolean valid = false;
 
-		Collection<${schemaName}> ${schemaVarNames} = page.getItems();
+		java.util.Collection<${schemaName}> ${schemaVarNames} = page.getItems();
 
 		int size = ${schemaVarNames}.size();
 
@@ -1094,7 +1093,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 		return true;
 	}
 
-	protected Collection<EntityField> getEntityFields() throws Exception {
+	protected java.util.Collection<EntityField> getEntityFields() throws Exception {
 		if (!(_${schemaVarName}Resource instanceof EntityModelResource)) {
 			throw new UnsupportedOperationException("Resource is not an instance of EntityModelResource");
 		}
@@ -1109,7 +1108,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 	}
 
 	protected List<EntityField> getEntityFields(EntityField.Type type) throws Exception {
-		Collection<EntityField> entityFields = getEntityFields();
+		java.util.Collection<EntityField> entityFields = getEntityFields();
 
 		Stream<EntityField> stream = entityFields.stream();
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
@@ -15,7 +15,6 @@ import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_mutation.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_mutation.ftl
@@ -19,7 +19,6 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
-import java.util.Collection;
 import java.util.Date;
 
 import javax.annotation.Generated;
@@ -50,7 +49,7 @@ public class Mutation {
 	<#list javaMethodSignatures as javaMethodSignature>
 		${freeMarkerTool.getGraphQLMethodAnnotations(javaMethodSignature)}
 		public ${javaMethodSignature.returnType} ${javaMethodSignature.methodName}(${freeMarkerTool.getGraphQLParameters(javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, true)}) throws Exception {
-			<#if javaMethodSignature.returnType?contains("Collection<")>
+			<#if javaMethodSignature.returnType?contains("java.util.Collection<")>
 				return _applyComponentServiceObjects(
 					_${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}ResourceComponentServiceObjects, this::_populateResourceContext,
 					${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource -> {

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_query.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_query.ftl
@@ -19,7 +19,6 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
-import java.util.Collection;
 import java.util.Date;
 
 import javax.annotation.Generated;


### PR DESCRIPTION
@brianchandotcom this is the next step in migrating our rest services, only contains the openapi definition the implementation coming after.

I've run into an interesting problem, if the schema name is something similar to a java class name we use in the generated classes it generates a compile error, such as `Collection` as a DTO in our API and `java.util.Collection`. Thinking ahead I changed the `Collection` to `java.util.Collection` in the generated classes to avoid possible errors in the future. I've asked @nhpatt to verify this change and he agreed with it.

@danielkocsis