### PR TITLE
LPS-96546 locale in graphql

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/KeywordResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/KeywordResource.java
@@ -18,6 +18,7 @@ import com.liferay.headless.admin.taxonomy.dto.v1_0.Keyword;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -47,6 +48,8 @@ public interface KeywordResource {
 
 	public Keyword postSiteKeyword(Long siteId, Keyword keyword)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyCategoryResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyCategoryResource.java
@@ -18,6 +18,7 @@ import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyCategory;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -65,6 +66,8 @@ public interface TaxonomyCategoryResource {
 	public TaxonomyCategory postTaxonomyVocabularyTaxonomyCategory(
 			Long taxonomyVocabularyId, TaxonomyCategory taxonomyCategory)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyVocabularyResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyVocabularyResource.java
@@ -18,6 +18,7 @@ import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyVocabulary;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -56,6 +57,8 @@ public interface TaxonomyVocabularyResource {
 	public TaxonomyVocabulary putTaxonomyVocabulary(
 			Long taxonomyVocabularyId, TaxonomyVocabulary taxonomyVocabulary)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
+	compileOnly group: "com.graphql-java", name: "graphql-java", version: "8.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "commons-collections", name: "commons-collections", version: "3.2.2"

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/mutation/v1_0/Mutation.java
@@ -24,10 +24,15 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
+
+import graphql.schema.DataFetchingEnvironment;
+
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -65,37 +70,44 @@ public class Mutation {
 	}
 
 	@GraphQLInvokeDetached
-	public void deleteKeyword(@GraphQLName("keywordId") Long keywordId)
+	public void deleteKeyword(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			@GraphQLName("keywordId") Long keywordId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_keywordResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			keywordResource -> _populateResourceContext(
+				dataFetchingEnvironment, keywordResource),
 			keywordResource -> keywordResource.deleteKeyword(keywordId));
 	}
 
 	@GraphQLInvokeDetached
 	public Keyword putKeyword(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("keywordId") Long keywordId,
 			@GraphQLName("keyword") Keyword keyword)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_keywordResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			keywordResource -> _populateResourceContext(
+				dataFetchingEnvironment, keywordResource),
 			keywordResource -> keywordResource.putKeyword(keywordId, keyword));
 	}
 
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Keyword postSiteKeyword(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("keyword") Keyword keyword)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_keywordResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			keywordResource -> _populateResourceContext(
+				dataFetchingEnvironment, keywordResource),
 			keywordResource -> keywordResource.postSiteKeyword(
 				siteId, keyword));
 	}
@@ -103,6 +115,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public TaxonomyCategory postTaxonomyCategoryTaxonomyCategory(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("parentTaxonomyCategoryId") Long
 				parentTaxonomyCategoryId,
 			@GraphQLName("taxonomyCategory") TaxonomyCategory taxonomyCategory)
@@ -110,7 +123,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_taxonomyCategoryResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			taxonomyCategoryResource -> _populateResourceContext(
+				dataFetchingEnvironment, taxonomyCategoryResource),
 			taxonomyCategoryResource ->
 				taxonomyCategoryResource.postTaxonomyCategoryTaxonomyCategory(
 					parentTaxonomyCategoryId, taxonomyCategory));
@@ -118,12 +132,14 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteTaxonomyCategory(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("taxonomyCategoryId") Long taxonomyCategoryId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_taxonomyCategoryResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			taxonomyCategoryResource -> _populateResourceContext(
+				dataFetchingEnvironment, taxonomyCategoryResource),
 			taxonomyCategoryResource ->
 				taxonomyCategoryResource.deleteTaxonomyCategory(
 					taxonomyCategoryId));
@@ -131,13 +147,15 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public TaxonomyCategory patchTaxonomyCategory(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("taxonomyCategoryId") Long taxonomyCategoryId,
 			@GraphQLName("taxonomyCategory") TaxonomyCategory taxonomyCategory)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_taxonomyCategoryResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			taxonomyCategoryResource -> _populateResourceContext(
+				dataFetchingEnvironment, taxonomyCategoryResource),
 			taxonomyCategoryResource ->
 				taxonomyCategoryResource.patchTaxonomyCategory(
 					taxonomyCategoryId, taxonomyCategory));
@@ -145,13 +163,15 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public TaxonomyCategory putTaxonomyCategory(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("taxonomyCategoryId") Long taxonomyCategoryId,
 			@GraphQLName("taxonomyCategory") TaxonomyCategory taxonomyCategory)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_taxonomyCategoryResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			taxonomyCategoryResource -> _populateResourceContext(
+				dataFetchingEnvironment, taxonomyCategoryResource),
 			taxonomyCategoryResource ->
 				taxonomyCategoryResource.putTaxonomyCategory(
 					taxonomyCategoryId, taxonomyCategory));
@@ -160,13 +180,15 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public TaxonomyCategory postTaxonomyVocabularyTaxonomyCategory(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId,
 			@GraphQLName("taxonomyCategory") TaxonomyCategory taxonomyCategory)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_taxonomyCategoryResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			taxonomyCategoryResource -> _populateResourceContext(
+				dataFetchingEnvironment, taxonomyCategoryResource),
 			taxonomyCategoryResource ->
 				taxonomyCategoryResource.postTaxonomyVocabularyTaxonomyCategory(
 					taxonomyVocabularyId, taxonomyCategory));
@@ -175,6 +197,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public TaxonomyVocabulary postSiteTaxonomyVocabulary(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("taxonomyVocabulary") TaxonomyVocabulary
 				taxonomyVocabulary)
@@ -182,7 +205,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_taxonomyVocabularyResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			taxonomyVocabularyResource -> _populateResourceContext(
+				dataFetchingEnvironment, taxonomyVocabularyResource),
 			taxonomyVocabularyResource ->
 				taxonomyVocabularyResource.postSiteTaxonomyVocabulary(
 					siteId, taxonomyVocabulary));
@@ -190,12 +214,14 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteTaxonomyVocabulary(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_taxonomyVocabularyResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			taxonomyVocabularyResource -> _populateResourceContext(
+				dataFetchingEnvironment, taxonomyVocabularyResource),
 			taxonomyVocabularyResource ->
 				taxonomyVocabularyResource.deleteTaxonomyVocabulary(
 					taxonomyVocabularyId));
@@ -203,6 +229,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public TaxonomyVocabulary patchTaxonomyVocabulary(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId,
 			@GraphQLName("taxonomyVocabulary") TaxonomyVocabulary
 				taxonomyVocabulary)
@@ -210,7 +237,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_taxonomyVocabularyResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			taxonomyVocabularyResource -> _populateResourceContext(
+				dataFetchingEnvironment, taxonomyVocabularyResource),
 			taxonomyVocabularyResource ->
 				taxonomyVocabularyResource.patchTaxonomyVocabulary(
 					taxonomyVocabularyId, taxonomyVocabulary));
@@ -218,6 +246,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public TaxonomyVocabulary putTaxonomyVocabulary(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId,
 			@GraphQLName("taxonomyVocabulary") TaxonomyVocabulary
 				taxonomyVocabulary)
@@ -225,7 +254,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_taxonomyVocabularyResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			taxonomyVocabularyResource -> _populateResourceContext(
+				dataFetchingEnvironment, taxonomyVocabularyResource),
 			taxonomyVocabularyResource ->
 				taxonomyVocabularyResource.putTaxonomyVocabulary(
 					taxonomyVocabularyId, taxonomyVocabulary));
@@ -269,8 +299,14 @@ public class Mutation {
 		}
 	}
 
-	private void _populateResourceContext(KeywordResource keywordResource)
+	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			KeywordResource keywordResource)
 		throws Exception {
+
+		keywordResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		keywordResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -278,8 +314,13 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			TaxonomyCategoryResource taxonomyCategoryResource)
 		throws Exception {
+
+		taxonomyCategoryResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		taxonomyCategoryResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -287,14 +328,26 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			TaxonomyVocabularyResource taxonomyVocabularyResource)
 		throws Exception {
+
+		taxonomyVocabularyResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		taxonomyVocabularyResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
+	public static void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		_acceptLanguageFunction = acceptLanguageFunction;
+	}
+
+	private static Function<Object, AcceptLanguage> _acceptLanguageFunction;
 	private static ComponentServiceObjects<KeywordResource>
 		_keywordResourceComponentServiceObjects;
 	private static ComponentServiceObjects<TaxonomyCategoryResource>

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -33,7 +34,10 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
+import graphql.schema.DataFetchingEnvironment;
+
 import java.util.Collection;
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -72,18 +76,22 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Keyword getKeyword(@GraphQLName("keywordId") Long keywordId)
+	public Keyword getKeyword(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			@GraphQLName("keywordId") Long keywordId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_keywordResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			keywordResource -> _populateResourceContext(
+				dataFetchingEnvironment, keywordResource),
 			keywordResource -> keywordResource.getKeyword(keywordId));
 	}
 
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Keyword> getSiteKeywordsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -93,7 +101,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_keywordResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			keywordResource -> _populateResourceContext(
+				dataFetchingEnvironment, keywordResource),
 			keywordResource -> {
 				Page paginationPage = keywordResource.getSiteKeywordsPage(
 					siteId, search, filter, Pagination.of(pageSize, page),
@@ -107,6 +116,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<TaxonomyCategory>
 			getTaxonomyCategoryTaxonomyCategoriesPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("parentTaxonomyCategoryId") Long
 					parentTaxonomyCategoryId,
 				@GraphQLName("search") String search,
@@ -118,7 +128,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_taxonomyCategoryResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			taxonomyCategoryResource -> _populateResourceContext(
+				dataFetchingEnvironment, taxonomyCategoryResource),
 			taxonomyCategoryResource -> {
 				Page paginationPage =
 					taxonomyCategoryResource.
@@ -133,12 +144,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public TaxonomyCategory getTaxonomyCategory(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("taxonomyCategoryId") Long taxonomyCategoryId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_taxonomyCategoryResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			taxonomyCategoryResource -> _populateResourceContext(
+				dataFetchingEnvironment, taxonomyCategoryResource),
 			taxonomyCategoryResource ->
 				taxonomyCategoryResource.getTaxonomyCategory(
 					taxonomyCategoryId));
@@ -148,6 +161,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<TaxonomyCategory>
 			getTaxonomyVocabularyTaxonomyCategoriesPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId,
 				@GraphQLName("search") String search,
 				@GraphQLName("filter") Filter filter,
@@ -158,7 +172,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_taxonomyCategoryResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			taxonomyCategoryResource -> _populateResourceContext(
+				dataFetchingEnvironment, taxonomyCategoryResource),
 			taxonomyCategoryResource -> {
 				Page paginationPage =
 					taxonomyCategoryResource.
@@ -173,6 +188,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<TaxonomyVocabulary> getSiteTaxonomyVocabulariesPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -182,7 +198,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_taxonomyVocabularyResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			taxonomyVocabularyResource -> _populateResourceContext(
+				dataFetchingEnvironment, taxonomyVocabularyResource),
 			taxonomyVocabularyResource -> {
 				Page paginationPage =
 					taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
@@ -196,12 +213,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public TaxonomyVocabulary getTaxonomyVocabulary(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_taxonomyVocabularyResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			taxonomyVocabularyResource -> _populateResourceContext(
+				dataFetchingEnvironment, taxonomyVocabularyResource),
 			taxonomyVocabularyResource ->
 				taxonomyVocabularyResource.getTaxonomyVocabulary(
 					taxonomyVocabularyId));
@@ -226,8 +245,14 @@ public class Query {
 		}
 	}
 
-	private void _populateResourceContext(KeywordResource keywordResource)
+	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			KeywordResource keywordResource)
 		throws Exception {
+
+		keywordResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		keywordResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -235,8 +260,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			TaxonomyCategoryResource taxonomyCategoryResource)
 		throws Exception {
+
+		taxonomyCategoryResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		taxonomyCategoryResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -244,14 +274,26 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			TaxonomyVocabularyResource taxonomyVocabularyResource)
 		throws Exception {
+
+		taxonomyVocabularyResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		taxonomyVocabularyResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
+	public static void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		_acceptLanguageFunction = acceptLanguageFunction;
+	}
+
+	private static Function<Object, AcceptLanguage> _acceptLanguageFunction;
 	private static ComponentServiceObjects<KeywordResource>
 		_keywordResourceComponentServiceObjects;
 	private static ComponentServiceObjects<TaxonomyCategoryResource>

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -19,7 +19,10 @@ import com.liferay.headless.admin.taxonomy.internal.graphql.query.v1_0.Query;
 import com.liferay.headless.admin.taxonomy.resource.v1_0.KeywordResource;
 import com.liferay.headless.admin.taxonomy.resource.v1_0.TaxonomyCategoryResource;
 import com.liferay.headless.admin.taxonomy.resource.v1_0.TaxonomyVocabularyResource;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -68,6 +71,14 @@ public class ServletDataImpl implements ServletData {
 	@Override
 	public Query getQuery() {
 		return new Query();
+	}
+
+	@Override
+	public void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		Query.setAcceptLanguageFunction(acceptLanguageFunction);
+		Mutation.setAcceptLanguageFunction(acceptLanguageFunction);
 	}
 
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -153,6 +153,10 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 		return new Keyword();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -284,6 +284,10 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 		return new TaxonomyCategory();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -235,6 +235,10 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 		return new TaxonomyVocabulary();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/EmailAddressResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/EmailAddressResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.admin.user.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.EmailAddress;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import javax.annotation.Generated;
@@ -40,6 +41,8 @@ public interface EmailAddressResource {
 	public Page<EmailAddress> getUserAccountEmailAddressesPage(
 			Long userAccountId)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/OrganizationResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/OrganizationResource.java
@@ -18,6 +18,7 @@ import com.liferay.headless.admin.user.dto.v1_0.Organization;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -44,6 +45,8 @@ public interface OrganizationResource {
 			Long parentOrganizationId, String search, Filter filter,
 			Pagination pagination, Sort[] sorts)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/PhoneResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/PhoneResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.admin.user.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.Phone;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import javax.annotation.Generated;
@@ -38,6 +39,8 @@ public interface PhoneResource {
 
 	public Page<Phone> getUserAccountPhonesPage(Long userAccountId)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/PostalAddressResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/PostalAddressResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.admin.user.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.PostalAddress;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import javax.annotation.Generated;
@@ -41,6 +42,8 @@ public interface PostalAddressResource {
 	public Page<PostalAddress> getUserAccountPostalAddressesPage(
 			Long userAccountId)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/RoleResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/RoleResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.admin.user.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -35,6 +36,8 @@ public interface RoleResource {
 	public Page<Role> getRolesPage(Pagination pagination) throws Exception;
 
 	public Role getRole(Long roleId) throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SegmentResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SegmentResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.admin.user.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.Segment;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -38,6 +39,8 @@ public interface SegmentResource {
 	public Page<Segment> getSiteUserAccountSegmentsPage(
 			Long siteId, Long userAccountId)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SegmentUserResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SegmentUserResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.admin.user.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.SegmentUser;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -35,6 +36,8 @@ public interface SegmentUserResource {
 	public Page<SegmentUser> getSegmentUserAccountsPage(
 			Long segmentId, Pagination pagination)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserAccountResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserAccountResource.java
@@ -18,6 +18,7 @@ import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -51,6 +52,8 @@ public interface UserAccountResource {
 			Long webSiteId, String search, Filter filter, Pagination pagination,
 			Sort[] sorts)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/WebUrlResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/WebUrlResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.admin.user.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.WebUrl;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import javax.annotation.Generated;
@@ -38,6 +39,8 @@ public interface WebUrlResource {
 		throws Exception;
 
 	public WebUrl getWebUrl(Long webUrlId) throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
+	compileOnly group: "com.graphql-java", name: "graphql-java", version: "8.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "commons-collections", name: "commons-collections", version: "3.2.2"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
@@ -16,6 +16,9 @@ package com.liferay.headless.admin.user.internal.graphql.mutation.v1_0;
 
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -65,5 +68,13 @@ public class Mutation {
 			componentServiceObjects.ungetService(resource);
 		}
 	}
+
+	public static void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		_acceptLanguageFunction = acceptLanguageFunction;
+	}
+
+	private static Function<Object, AcceptLanguage> _acceptLanguageFunction;
 
 }

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -45,7 +46,10 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
+import graphql.schema.DataFetchingEnvironment;
+
 import java.util.Collection;
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -133,12 +137,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public EmailAddress getEmailAddress(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("emailAddressId") Long emailAddressId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_emailAddressResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			emailAddressResource -> _populateResourceContext(
+				dataFetchingEnvironment, emailAddressResource),
 			emailAddressResource -> emailAddressResource.getEmailAddress(
 				emailAddressId));
 	}
@@ -146,12 +152,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<EmailAddress> getOrganizationEmailAddressesPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("organizationId") Long organizationId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_emailAddressResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			emailAddressResource -> _populateResourceContext(
+				dataFetchingEnvironment, emailAddressResource),
 			emailAddressResource -> {
 				Page paginationPage =
 					emailAddressResource.getOrganizationEmailAddressesPage(
@@ -164,12 +172,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<EmailAddress> getUserAccountEmailAddressesPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_emailAddressResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			emailAddressResource -> _populateResourceContext(
+				dataFetchingEnvironment, emailAddressResource),
 			emailAddressResource -> {
 				Page paginationPage =
 					emailAddressResource.getUserAccountEmailAddressesPage(
@@ -182,6 +192,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Organization> getOrganizationsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
 			@GraphQLName("pageSize") int pageSize,
@@ -190,7 +201,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_organizationResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			organizationResource -> _populateResourceContext(
+				dataFetchingEnvironment, organizationResource),
 			organizationResource -> {
 				Page paginationPage = organizationResource.getOrganizationsPage(
 					search, filter, Pagination.of(pageSize, page), sorts);
@@ -202,12 +214,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Organization getOrganization(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("organizationId") Long organizationId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_organizationResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			organizationResource -> _populateResourceContext(
+				dataFetchingEnvironment, organizationResource),
 			organizationResource -> organizationResource.getOrganization(
 				organizationId));
 	}
@@ -215,6 +229,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Organization> getOrganizationOrganizationsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("parentOrganizationId") Long parentOrganizationId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -224,7 +239,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_organizationResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			organizationResource -> _populateResourceContext(
+				dataFetchingEnvironment, organizationResource),
 			organizationResource -> {
 				Page paginationPage =
 					organizationResource.getOrganizationOrganizationsPage(
@@ -238,12 +254,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Phone> getOrganizationPhonesPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("organizationId") Long organizationId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_phoneResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			phoneResource -> _populateResourceContext(
+				dataFetchingEnvironment, phoneResource),
 			phoneResource -> {
 				Page paginationPage = phoneResource.getOrganizationPhonesPage(
 					organizationId);
@@ -254,24 +272,29 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Phone getPhone(@GraphQLName("phoneId") Long phoneId)
+	public Phone getPhone(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			@GraphQLName("phoneId") Long phoneId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_phoneResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			phoneResource -> _populateResourceContext(
+				dataFetchingEnvironment, phoneResource),
 			phoneResource -> phoneResource.getPhone(phoneId));
 	}
 
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Phone> getUserAccountPhonesPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_phoneResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			phoneResource -> _populateResourceContext(
+				dataFetchingEnvironment, phoneResource),
 			phoneResource -> {
 				Page paginationPage = phoneResource.getUserAccountPhonesPage(
 					userAccountId);
@@ -283,12 +306,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<PostalAddress> getOrganizationPostalAddressesPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("organizationId") Long organizationId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_postalAddressResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			postalAddressResource -> _populateResourceContext(
+				dataFetchingEnvironment, postalAddressResource),
 			postalAddressResource -> {
 				Page paginationPage =
 					postalAddressResource.getOrganizationPostalAddressesPage(
@@ -301,12 +326,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public PostalAddress getPostalAddress(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("postalAddressId") Long postalAddressId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_postalAddressResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			postalAddressResource -> _populateResourceContext(
+				dataFetchingEnvironment, postalAddressResource),
 			postalAddressResource -> postalAddressResource.getPostalAddress(
 				postalAddressId));
 	}
@@ -314,12 +341,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<PostalAddress> getUserAccountPostalAddressesPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_postalAddressResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			postalAddressResource -> _populateResourceContext(
+				dataFetchingEnvironment, postalAddressResource),
 			postalAddressResource -> {
 				Page paginationPage =
 					postalAddressResource.getUserAccountPostalAddressesPage(
@@ -332,13 +361,15 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Role> getRolesPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_roleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			roleResource -> _populateResourceContext(
+				dataFetchingEnvironment, roleResource),
 			roleResource -> {
 				Page paginationPage = roleResource.getRolesPage(
 					Pagination.of(pageSize, page));
@@ -349,16 +380,22 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Role getRole(@GraphQLName("roleId") Long roleId) throws Exception {
+	public Role getRole(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			@GraphQLName("roleId") Long roleId)
+		throws Exception {
+
 		return _applyComponentServiceObjects(
 			_roleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			roleResource -> _populateResourceContext(
+				dataFetchingEnvironment, roleResource),
 			roleResource -> roleResource.getRole(roleId));
 	}
 
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Segment> getSiteSegmentsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -366,7 +403,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_segmentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			segmentResource -> _populateResourceContext(
+				dataFetchingEnvironment, segmentResource),
 			segmentResource -> {
 				Page paginationPage = segmentResource.getSiteSegmentsPage(
 					siteId, Pagination.of(pageSize, page));
@@ -378,13 +416,15 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Segment> getSiteUserAccountSegmentsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_segmentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			segmentResource -> _populateResourceContext(
+				dataFetchingEnvironment, segmentResource),
 			segmentResource -> {
 				Page paginationPage =
 					segmentResource.getSiteUserAccountSegmentsPage(
@@ -397,6 +437,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<SegmentUser> getSegmentUserAccountsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("segmentId") Long segmentId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -404,7 +445,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_segmentUserResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			segmentUserResource -> _populateResourceContext(
+				dataFetchingEnvironment, segmentUserResource),
 			segmentUserResource -> {
 				Page paginationPage =
 					segmentUserResource.getSegmentUserAccountsPage(
@@ -416,16 +458,21 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public UserAccount getMyUserAccount() throws Exception {
+	public UserAccount getMyUserAccount(
+			DataFetchingEnvironment dataFetchingEnvironment)
+		throws Exception {
+
 		return _applyComponentServiceObjects(
 			_userAccountResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			userAccountResource -> _populateResourceContext(
+				dataFetchingEnvironment, userAccountResource),
 			userAccountResource -> userAccountResource.getMyUserAccount());
 	}
 
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<UserAccount> getOrganizationUserAccountsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("organizationId") Long organizationId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -435,7 +482,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_userAccountResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			userAccountResource -> _populateResourceContext(
+				dataFetchingEnvironment, userAccountResource),
 			userAccountResource -> {
 				Page paginationPage =
 					userAccountResource.getOrganizationUserAccountsPage(
@@ -449,6 +497,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<UserAccount> getUserAccountsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
 			@GraphQLName("pageSize") int pageSize,
@@ -457,7 +506,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_userAccountResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			userAccountResource -> _populateResourceContext(
+				dataFetchingEnvironment, userAccountResource),
 			userAccountResource -> {
 				Page paginationPage = userAccountResource.getUserAccountsPage(
 					search, filter, Pagination.of(pageSize, page), sorts);
@@ -469,12 +519,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public UserAccount getUserAccount(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_userAccountResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			userAccountResource -> _populateResourceContext(
+				dataFetchingEnvironment, userAccountResource),
 			userAccountResource -> userAccountResource.getUserAccount(
 				userAccountId));
 	}
@@ -482,6 +534,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<UserAccount> getWebSiteUserAccountsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("webSiteId") Long webSiteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -491,7 +544,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_userAccountResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			userAccountResource -> _populateResourceContext(
+				dataFetchingEnvironment, userAccountResource),
 			userAccountResource -> {
 				Page paginationPage =
 					userAccountResource.getWebSiteUserAccountsPage(
@@ -505,12 +559,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<WebUrl> getOrganizationWebUrlsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("organizationId") Long organizationId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_webUrlResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			webUrlResource -> _populateResourceContext(
+				dataFetchingEnvironment, webUrlResource),
 			webUrlResource -> {
 				Page paginationPage = webUrlResource.getOrganizationWebUrlsPage(
 					organizationId);
@@ -522,12 +578,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<WebUrl> getUserAccountWebUrlsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_webUrlResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			webUrlResource -> _populateResourceContext(
+				dataFetchingEnvironment, webUrlResource),
 			webUrlResource -> {
 				Page paginationPage = webUrlResource.getUserAccountWebUrlsPage(
 					userAccountId);
@@ -538,12 +596,15 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public WebUrl getWebUrl(@GraphQLName("webUrlId") Long webUrlId)
+	public WebUrl getWebUrl(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			@GraphQLName("webUrlId") Long webUrlId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_webUrlResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			webUrlResource -> _populateResourceContext(
+				dataFetchingEnvironment, webUrlResource),
 			webUrlResource -> webUrlResource.getWebUrl(webUrlId));
 	}
 
@@ -567,8 +628,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			EmailAddressResource emailAddressResource)
 		throws Exception {
+
+		emailAddressResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		emailAddressResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -576,16 +642,27 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			OrganizationResource organizationResource)
 		throws Exception {
+
+		organizationResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		organizationResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
-	private void _populateResourceContext(PhoneResource phoneResource)
+	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			PhoneResource phoneResource)
 		throws Exception {
+
+		phoneResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		phoneResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -593,24 +670,41 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			PostalAddressResource postalAddressResource)
 		throws Exception {
+
+		postalAddressResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		postalAddressResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
-	private void _populateResourceContext(RoleResource roleResource)
+	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			RoleResource roleResource)
 		throws Exception {
+
+		roleResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		roleResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
-	private void _populateResourceContext(SegmentResource segmentResource)
+	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			SegmentResource segmentResource)
 		throws Exception {
+
+		segmentResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		segmentResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -618,8 +712,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			SegmentUserResource segmentUserResource)
 		throws Exception {
+
+		segmentUserResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		segmentUserResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -627,22 +726,40 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			UserAccountResource userAccountResource)
 		throws Exception {
+
+		userAccountResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		userAccountResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
-	private void _populateResourceContext(WebUrlResource webUrlResource)
+	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			WebUrlResource webUrlResource)
 		throws Exception {
+
+		webUrlResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		webUrlResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
+	public static void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		_acceptLanguageFunction = acceptLanguageFunction;
+	}
+
+	private static Function<Object, AcceptLanguage> _acceptLanguageFunction;
 	private static ComponentServiceObjects<EmailAddressResource>
 		_emailAddressResourceComponentServiceObjects;
 	private static ComponentServiceObjects<OrganizationResource>

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -25,7 +25,10 @@ import com.liferay.headless.admin.user.resource.v1_0.SegmentResource;
 import com.liferay.headless.admin.user.resource.v1_0.SegmentUserResource;
 import com.liferay.headless.admin.user.resource.v1_0.UserAccountResource;
 import com.liferay.headless.admin.user.resource.v1_0.WebUrlResource;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -79,6 +82,13 @@ public class ServletDataImpl implements ServletData {
 	@Override
 	public Query getQuery() {
 		return new Query();
+	}
+
+	@Override
+	public void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		Query.setAcceptLanguageFunction(acceptLanguageFunction);
 	}
 
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
@@ -104,6 +104,10 @@ public abstract class BaseEmailAddressResourceImpl
 		return Page.of(Collections.emptyList());
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -129,6 +129,10 @@ public abstract class BaseOrganizationResourceImpl
 		return Page.of(Collections.emptyList());
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
@@ -101,6 +101,10 @@ public abstract class BasePhoneResourceImpl implements PhoneResource {
 		return Page.of(Collections.emptyList());
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
@@ -104,6 +104,10 @@ public abstract class BasePostalAddressResourceImpl
 		return Page.of(Collections.emptyList());
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -87,6 +87,10 @@ public abstract class BaseRoleResourceImpl implements RoleResource {
 		return new Role();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
@@ -95,6 +95,10 @@ public abstract class BaseSegmentResourceImpl implements SegmentResource {
 		return Page.of(Collections.emptyList());
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
@@ -76,6 +76,10 @@ public abstract class BaseSegmentUserResourceImpl
 		return Page.of(Collections.emptyList());
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -170,6 +170,10 @@ public abstract class BaseUserAccountResourceImpl
 		return Page.of(Collections.emptyList());
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
@@ -101,6 +101,10 @@ public abstract class BaseWebUrlResourceImpl implements WebUrlResource {
 		return new WebUrl();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/resource/v1_0/WorkflowLogResource.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/resource/v1_0/WorkflowLogResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.admin.workflow.resource.v1_0;
 
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowLog;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -37,6 +38,8 @@ public interface WorkflowLogResource {
 	public Page<WorkflowLog> getWorkflowTaskWorkflowLogsPage(
 			Long workflowTaskId, Pagination pagination)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/resource/v1_0/WorkflowTaskResource.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/resource/v1_0/WorkflowTaskResource.java
@@ -19,6 +19,7 @@ import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTask;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTaskAssignToMe;
 import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTaskAssignToUser;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -65,6 +66,8 @@ public interface WorkflowTaskResource {
 	public WorkflowTask postWorkflowTaskUpdateDueDate(
 			Long workflowTaskId, WorkflowTaskAssignToMe workflowTaskAssignToMe)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
+	compileOnly group: "com.graphql-java", name: "graphql-java", version: "8.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/mutation/v1_0/Mutation.java
@@ -23,10 +23,15 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
+
+import graphql.schema.DataFetchingEnvironment;
+
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -50,6 +55,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public WorkflowTask postWorkflowTaskAssignToMe(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("workflowTaskId") Long workflowTaskId,
 			@GraphQLName("workflowTaskAssignToMe") WorkflowTaskAssignToMe
 				workflowTaskAssignToMe)
@@ -57,7 +63,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_workflowTaskResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			workflowTaskResource -> _populateResourceContext(
+				dataFetchingEnvironment, workflowTaskResource),
 			workflowTaskResource ->
 				workflowTaskResource.postWorkflowTaskAssignToMe(
 					workflowTaskId, workflowTaskAssignToMe));
@@ -66,6 +73,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public WorkflowTask postWorkflowTaskAssignToUser(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("workflowTaskId") Long workflowTaskId,
 			@GraphQLName("workflowTaskAssignToUser") WorkflowTaskAssignToUser
 				workflowTaskAssignToUser)
@@ -73,7 +81,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_workflowTaskResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			workflowTaskResource -> _populateResourceContext(
+				dataFetchingEnvironment, workflowTaskResource),
 			workflowTaskResource ->
 				workflowTaskResource.postWorkflowTaskAssignToUser(
 					workflowTaskId, workflowTaskAssignToUser));
@@ -82,13 +91,15 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public WorkflowTask postWorkflowTaskChangeTransition(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("workflowTaskId") Long workflowTaskId,
 			@GraphQLName("changeTransition") ChangeTransition changeTransition)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_workflowTaskResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			workflowTaskResource -> _populateResourceContext(
+				dataFetchingEnvironment, workflowTaskResource),
 			workflowTaskResource ->
 				workflowTaskResource.postWorkflowTaskChangeTransition(
 					workflowTaskId, changeTransition));
@@ -97,6 +108,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public WorkflowTask postWorkflowTaskUpdateDueDate(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("workflowTaskId") Long workflowTaskId,
 			@GraphQLName("workflowTaskAssignToMe") WorkflowTaskAssignToMe
 				workflowTaskAssignToMe)
@@ -104,7 +116,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_workflowTaskResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			workflowTaskResource -> _populateResourceContext(
+				dataFetchingEnvironment, workflowTaskResource),
 			workflowTaskResource ->
 				workflowTaskResource.postWorkflowTaskUpdateDueDate(
 					workflowTaskId, workflowTaskAssignToMe));
@@ -149,14 +162,26 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			WorkflowTaskResource workflowTaskResource)
 		throws Exception {
+
+		workflowTaskResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		workflowTaskResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
+	public static void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		_acceptLanguageFunction = acceptLanguageFunction;
+	}
+
+	private static Function<Object, AcceptLanguage> _acceptLanguageFunction;
 	private static ComponentServiceObjects<WorkflowTaskResource>
 		_workflowTaskResourceComponentServiceObjects;
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/query/v1_0/Query.java
@@ -22,6 +22,7 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -29,7 +30,10 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
+import graphql.schema.DataFetchingEnvironment;
+
 import java.util.Collection;
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -61,12 +65,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public WorkflowLog getWorkflowLog(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("workflowLogId") Long workflowLogId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_workflowLogResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			workflowLogResource -> _populateResourceContext(
+				dataFetchingEnvironment, workflowLogResource),
 			workflowLogResource -> workflowLogResource.getWorkflowLog(
 				workflowLogId));
 	}
@@ -74,6 +80,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<WorkflowLog> getWorkflowTaskWorkflowLogsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("workflowTaskId") Long workflowTaskId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -81,7 +88,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_workflowLogResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			workflowLogResource -> _populateResourceContext(
+				dataFetchingEnvironment, workflowLogResource),
 			workflowLogResource -> {
 				Page paginationPage =
 					workflowLogResource.getWorkflowTaskWorkflowLogsPage(
@@ -94,6 +102,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<WorkflowTask> getRoleWorkflowTasksPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("roleId") Long roleId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -101,7 +110,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_workflowTaskResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			workflowTaskResource -> _populateResourceContext(
+				dataFetchingEnvironment, workflowTaskResource),
 			workflowTaskResource -> {
 				Page paginationPage =
 					workflowTaskResource.getRoleWorkflowTasksPage(
@@ -114,13 +124,15 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<WorkflowTask> getWorkflowTasksAssignedToMePage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_workflowTaskResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			workflowTaskResource -> _populateResourceContext(
+				dataFetchingEnvironment, workflowTaskResource),
 			workflowTaskResource -> {
 				Page paginationPage =
 					workflowTaskResource.getWorkflowTasksAssignedToMePage(
@@ -133,13 +145,15 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<WorkflowTask> getWorkflowTasksAssignedToMyRolesPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_workflowTaskResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			workflowTaskResource -> _populateResourceContext(
+				dataFetchingEnvironment, workflowTaskResource),
 			workflowTaskResource -> {
 				Page paginationPage =
 					workflowTaskResource.getWorkflowTasksAssignedToMyRolesPage(
@@ -152,12 +166,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public WorkflowTask getWorkflowTask(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("workflowTaskId") Long workflowTaskId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_workflowTaskResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			workflowTaskResource -> _populateResourceContext(
+				dataFetchingEnvironment, workflowTaskResource),
 			workflowTaskResource -> workflowTaskResource.getWorkflowTask(
 				workflowTaskId));
 	}
@@ -182,8 +198,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			WorkflowLogResource workflowLogResource)
 		throws Exception {
+
+		workflowLogResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		workflowLogResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -191,14 +212,26 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			WorkflowTaskResource workflowTaskResource)
 		throws Exception {
+
+		workflowTaskResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		workflowTaskResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
+	public static void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		_acceptLanguageFunction = acceptLanguageFunction;
+	}
+
+	private static Function<Object, AcceptLanguage> _acceptLanguageFunction;
 	private static ComponentServiceObjects<WorkflowLogResource>
 		_workflowLogResourceComponentServiceObjects;
 	private static ComponentServiceObjects<WorkflowTaskResource>

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -18,7 +18,10 @@ import com.liferay.headless.admin.workflow.internal.graphql.mutation.v1_0.Mutati
 import com.liferay.headless.admin.workflow.internal.graphql.query.v1_0.Query;
 import com.liferay.headless.admin.workflow.resource.v1_0.WorkflowLogResource;
 import com.liferay.headless.admin.workflow.resource.v1_0.WorkflowTaskResource;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -61,6 +64,14 @@ public class ServletDataImpl implements ServletData {
 	@Override
 	public Query getQuery() {
 		return new Query();
+	}
+
+	@Override
+	public void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		Query.setAcceptLanguageFunction(acceptLanguageFunction);
+		Mutation.setAcceptLanguageFunction(acceptLanguageFunction);
 	}
 
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
@@ -90,6 +90,10 @@ public abstract class BaseWorkflowLogResourceImpl
 		return Page.of(Collections.emptyList());
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskResourceImpl.java
@@ -202,6 +202,10 @@ public abstract class BaseWorkflowTaskResourceImpl
 		return new WorkflowTask();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingImageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingImageResource.java
@@ -18,6 +18,7 @@ import com.liferay.headless.delivery.dto.v1_0.BlogPostingImage;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -49,6 +50,8 @@ public interface BlogPostingImageResource {
 	public BlogPostingImage postSiteBlogPostingImage(
 			Long siteId, MultipartBody multipartBody)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingResource.java
@@ -19,6 +19,7 @@ import com.liferay.headless.delivery.dto.v1_0.Rating;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -64,6 +65,8 @@ public interface BlogPostingResource {
 
 	public BlogPosting postSiteBlogPosting(Long siteId, BlogPosting blogPosting)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/CommentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/CommentResource.java
@@ -18,6 +18,7 @@ import com.liferay.headless.delivery.dto.v1_0.Comment;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -72,6 +73,8 @@ public interface CommentResource {
 	public Comment postStructuredContentComment(
 			Long structuredContentId, Comment comment)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentSetElementResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentSetElementResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.delivery.resource.v1_0;
 
 import com.liferay.headless.delivery.dto.v1_0.ContentSetElement;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -44,6 +45,8 @@ public interface ContentSetElementResource {
 			getSiteContentSetByUuidContentSetElementsPage(
 				Long siteId, String uuid, Pagination pagination)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentStructureResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentStructureResource.java
@@ -18,6 +18,7 @@ import com.liferay.headless.delivery.dto.v1_0.ContentStructure;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -41,6 +42,8 @@ public interface ContentStructureResource {
 			Long siteId, String search, Filter filter, Pagination pagination,
 			Sort[] sorts)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentFolderResource.java
@@ -18,6 +18,7 @@ import com.liferay.headless.delivery.dto.v1_0.DocumentFolder;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -64,6 +65,8 @@ public interface DocumentFolderResource {
 	public DocumentFolder postSiteDocumentFolder(
 			Long siteId, DocumentFolder documentFolder)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentResource.java
@@ -19,6 +19,7 @@ import com.liferay.headless.delivery.dto.v1_0.Rating;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -72,6 +73,8 @@ public interface DocumentResource {
 
 	public Document postSiteDocument(Long siteId, MultipartBody multipartBody)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseArticleResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseArticleResource.java
@@ -19,6 +19,7 @@ import com.liferay.headless.delivery.dto.v1_0.Rating;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -96,6 +97,8 @@ public interface KnowledgeBaseArticleResource {
 	public KnowledgeBaseArticle postSiteKnowledgeBaseArticle(
 			Long siteId, KnowledgeBaseArticle knowledgeBaseArticle)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseAttachmentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseAttachmentResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.delivery.resource.v1_0;
 
 import com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseAttachment;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 
@@ -48,6 +49,8 @@ public interface KnowledgeBaseAttachmentResource {
 	public KnowledgeBaseAttachment getKnowledgeBaseAttachment(
 			Long knowledgeBaseAttachmentId)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseFolderResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.delivery.resource.v1_0;
 
 import com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseFolder;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -64,6 +65,8 @@ public interface KnowledgeBaseFolderResource {
 	public KnowledgeBaseFolder postSiteKnowledgeBaseFolder(
 			Long siteId, KnowledgeBaseFolder knowledgeBaseFolder)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardAttachmentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardAttachmentResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.delivery.resource.v1_0;
 
 import com.liferay.headless.delivery.dto.v1_0.MessageBoardAttachment;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 
@@ -56,6 +57,8 @@ public interface MessageBoardAttachmentResource {
 	public MessageBoardAttachment postMessageBoardThreadMessageBoardAttachment(
 			Long messageBoardThreadId, MultipartBody multipartBody)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardMessageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardMessageResource.java
@@ -19,6 +19,7 @@ import com.liferay.headless.delivery.dto.v1_0.Rating;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -84,6 +85,8 @@ public interface MessageBoardMessageResource {
 	public MessageBoardMessage postMessageBoardThreadMessageBoardMessage(
 			Long messageBoardThreadId, MessageBoardMessage messageBoardMessage)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardSectionResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardSectionResource.java
@@ -18,6 +18,7 @@ import com.liferay.headless.delivery.dto.v1_0.MessageBoardSection;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -68,6 +69,8 @@ public interface MessageBoardSectionResource {
 	public MessageBoardSection postSiteMessageBoardSection(
 			Long siteId, MessageBoardSection messageBoardSection)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardThreadResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardThreadResource.java
@@ -19,6 +19,7 @@ import com.liferay.headless.delivery.dto.v1_0.Rating;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -81,6 +82,8 @@ public interface MessageBoardThreadResource {
 	public MessageBoardThread postSiteMessageBoardThread(
 			Long siteId, MessageBoardThread messageBoardThread)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentFolderResource.java
@@ -18,6 +18,7 @@ import com.liferay.headless.delivery.dto.v1_0.StructuredContentFolder;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -71,6 +72,8 @@ public interface StructuredContentFolderResource {
 			Long structuredContentFolderId,
 			StructuredContentFolder structuredContentFolder)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentResource.java
@@ -19,6 +19,7 @@ import com.liferay.headless.delivery.dto.v1_0.StructuredContent;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -98,6 +99,8 @@ public interface StructuredContentResource {
 	public String getStructuredContentRenderedContentTemplate(
 			Long structuredContentId, Long templateId)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/build.gradle
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
+	compileOnly group: "com.graphql-java", name: "graphql-java", version: "8.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -47,11 +47,16 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
+
+import graphql.schema.DataFetchingEnvironment;
+
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -180,50 +185,58 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteBlogPosting(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("blogPostingId") Long blogPostingId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			blogPostingResource -> _populateResourceContext(
+				dataFetchingEnvironment, blogPostingResource),
 			blogPostingResource -> blogPostingResource.deleteBlogPosting(
 				blogPostingId));
 	}
 
 	@GraphQLInvokeDetached
 	public BlogPosting patchBlogPosting(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("blogPostingId") Long blogPostingId,
 			@GraphQLName("blogPosting") BlogPosting blogPosting)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			blogPostingResource -> _populateResourceContext(
+				dataFetchingEnvironment, blogPostingResource),
 			blogPostingResource -> blogPostingResource.patchBlogPosting(
 				blogPostingId, blogPosting));
 	}
 
 	@GraphQLInvokeDetached
 	public BlogPosting putBlogPosting(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("blogPostingId") Long blogPostingId,
 			@GraphQLName("blogPosting") BlogPosting blogPosting)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			blogPostingResource -> _populateResourceContext(
+				dataFetchingEnvironment, blogPostingResource),
 			blogPostingResource -> blogPostingResource.putBlogPosting(
 				blogPostingId, blogPosting));
 	}
 
 	@GraphQLInvokeDetached
 	public void deleteBlogPostingMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("blogPostingId") Long blogPostingId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			blogPostingResource -> _populateResourceContext(
+				dataFetchingEnvironment, blogPostingResource),
 			blogPostingResource ->
 				blogPostingResource.deleteBlogPostingMyRating(blogPostingId));
 	}
@@ -231,26 +244,30 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Rating postBlogPostingMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("blogPostingId") Long blogPostingId,
 			@GraphQLName("rating") Rating rating)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			blogPostingResource -> _populateResourceContext(
+				dataFetchingEnvironment, blogPostingResource),
 			blogPostingResource -> blogPostingResource.postBlogPostingMyRating(
 				blogPostingId, rating));
 	}
 
 	@GraphQLInvokeDetached
 	public Rating putBlogPostingMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("blogPostingId") Long blogPostingId,
 			@GraphQLName("rating") Rating rating)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			blogPostingResource -> _populateResourceContext(
+				dataFetchingEnvironment, blogPostingResource),
 			blogPostingResource -> blogPostingResource.putBlogPostingMyRating(
 				blogPostingId, rating));
 	}
@@ -258,25 +275,29 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public BlogPosting postSiteBlogPosting(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("blogPosting") BlogPosting blogPosting)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			blogPostingResource -> _populateResourceContext(
+				dataFetchingEnvironment, blogPostingResource),
 			blogPostingResource -> blogPostingResource.postSiteBlogPosting(
 				siteId, blogPosting));
 	}
 
 	@GraphQLInvokeDetached
 	public void deleteBlogPostingImage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("blogPostingImageId") Long blogPostingImageId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_blogPostingImageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			blogPostingImageResource -> _populateResourceContext(
+				dataFetchingEnvironment, blogPostingImageResource),
 			blogPostingImageResource ->
 				blogPostingImageResource.deleteBlogPostingImage(
 					blogPostingImageId));
@@ -286,13 +307,15 @@ public class Mutation {
 	@GraphQLInvokeDetached
 	@GraphQLName("postSiteBlogPostingImageSiteIdMultipartBody")
 	public BlogPostingImage postSiteBlogPostingImage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("multipartBody") MultipartBody multipartBody)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_blogPostingImageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			blogPostingImageResource -> _populateResourceContext(
+				dataFetchingEnvironment, blogPostingImageResource),
 			blogPostingImageResource ->
 				blogPostingImageResource.postSiteBlogPostingImage(
 					siteId, multipartBody));
@@ -301,49 +324,58 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Comment postBlogPostingComment(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("blogPostingId") Long blogPostingId,
 			@GraphQLName("comment") Comment comment)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			commentResource -> _populateResourceContext(
+				dataFetchingEnvironment, commentResource),
 			commentResource -> commentResource.postBlogPostingComment(
 				blogPostingId, comment));
 	}
 
 	@GraphQLInvokeDetached
-	public void deleteComment(@GraphQLName("commentId") Long commentId)
+	public void deleteComment(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			@GraphQLName("commentId") Long commentId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			commentResource -> _populateResourceContext(
+				dataFetchingEnvironment, commentResource),
 			commentResource -> commentResource.deleteComment(commentId));
 	}
 
 	@GraphQLInvokeDetached
 	public Comment putComment(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("commentId") Long commentId,
 			@GraphQLName("comment") Comment comment)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			commentResource -> _populateResourceContext(
+				dataFetchingEnvironment, commentResource),
 			commentResource -> commentResource.putComment(commentId, comment));
 	}
 
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Comment postCommentComment(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("parentCommentId") Long parentCommentId,
 			@GraphQLName("comment") Comment comment)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			commentResource -> _populateResourceContext(
+				dataFetchingEnvironment, commentResource),
 			commentResource -> commentResource.postCommentComment(
 				parentCommentId, comment));
 	}
@@ -351,13 +383,15 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Comment postDocumentComment(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("documentId") Long documentId,
 			@GraphQLName("comment") Comment comment)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			commentResource -> _populateResourceContext(
+				dataFetchingEnvironment, commentResource),
 			commentResource -> commentResource.postDocumentComment(
 				documentId, comment));
 	}
@@ -365,13 +399,15 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Comment postStructuredContentComment(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentId") Long structuredContentId,
 			@GraphQLName("comment") Comment comment)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			commentResource -> _populateResourceContext(
+				dataFetchingEnvironment, commentResource),
 			commentResource -> commentResource.postStructuredContentComment(
 				structuredContentId, comment));
 	}
@@ -380,37 +416,44 @@ public class Mutation {
 	@GraphQLInvokeDetached
 	@GraphQLName("postDocumentFolderDocumentDocumentFolderIdMultipartBody")
 	public Document postDocumentFolderDocument(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("documentFolderId") Long documentFolderId,
 			@GraphQLName("multipartBody") MultipartBody multipartBody)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentResource),
 			documentResource -> documentResource.postDocumentFolderDocument(
 				documentFolderId, multipartBody));
 	}
 
 	@GraphQLInvokeDetached
-	public void deleteDocument(@GraphQLName("documentId") Long documentId)
+	public void deleteDocument(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			@GraphQLName("documentId") Long documentId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentResource),
 			documentResource -> documentResource.deleteDocument(documentId));
 	}
 
 	@GraphQLInvokeDetached
 	@GraphQLName("patchDocumentDocumentIdMultipartBody")
 	public Document patchDocument(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("documentId") Long documentId,
 			@GraphQLName("multipartBody") MultipartBody multipartBody)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentResource),
 			documentResource -> documentResource.patchDocument(
 				documentId, multipartBody));
 	}
@@ -418,25 +461,29 @@ public class Mutation {
 	@GraphQLInvokeDetached
 	@GraphQLName("putDocumentDocumentIdMultipartBody")
 	public Document putDocument(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("documentId") Long documentId,
 			@GraphQLName("multipartBody") MultipartBody multipartBody)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentResource),
 			documentResource -> documentResource.putDocument(
 				documentId, multipartBody));
 	}
 
 	@GraphQLInvokeDetached
 	public void deleteDocumentMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("documentId") Long documentId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentResource),
 			documentResource -> documentResource.deleteDocumentMyRating(
 				documentId));
 	}
@@ -444,26 +491,30 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Rating postDocumentMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("documentId") Long documentId,
 			@GraphQLName("rating") Rating rating)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentResource),
 			documentResource -> documentResource.postDocumentMyRating(
 				documentId, rating));
 	}
 
 	@GraphQLInvokeDetached
 	public Rating putDocumentMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("documentId") Long documentId,
 			@GraphQLName("rating") Rating rating)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentResource),
 			documentResource -> documentResource.putDocumentMyRating(
 				documentId, rating));
 	}
@@ -472,38 +523,44 @@ public class Mutation {
 	@GraphQLInvokeDetached
 	@GraphQLName("postSiteDocumentSiteIdMultipartBody")
 	public Document postSiteDocument(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("multipartBody") MultipartBody multipartBody)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentResource),
 			documentResource -> documentResource.postSiteDocument(
 				siteId, multipartBody));
 	}
 
 	@GraphQLInvokeDetached
 	public void deleteDocumentFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("documentFolderId") Long documentFolderId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_documentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentFolderResource),
 			documentFolderResource ->
 				documentFolderResource.deleteDocumentFolder(documentFolderId));
 	}
 
 	@GraphQLInvokeDetached
 	public DocumentFolder patchDocumentFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("documentFolderId") Long documentFolderId,
 			@GraphQLName("documentFolder") DocumentFolder documentFolder)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_documentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentFolderResource),
 			documentFolderResource ->
 				documentFolderResource.patchDocumentFolder(
 					documentFolderId, documentFolder));
@@ -511,13 +568,15 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public DocumentFolder putDocumentFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("documentFolderId") Long documentFolderId,
 			@GraphQLName("documentFolder") DocumentFolder documentFolder)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_documentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentFolderResource),
 			documentFolderResource -> documentFolderResource.putDocumentFolder(
 				documentFolderId, documentFolder));
 	}
@@ -525,13 +584,15 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public DocumentFolder postDocumentFolderDocumentFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("parentDocumentFolderId") Long parentDocumentFolderId,
 			@GraphQLName("documentFolder") DocumentFolder documentFolder)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_documentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentFolderResource),
 			documentFolderResource ->
 				documentFolderResource.postDocumentFolderDocumentFolder(
 					parentDocumentFolderId, documentFolder));
@@ -540,13 +601,15 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public DocumentFolder postSiteDocumentFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("documentFolder") DocumentFolder documentFolder)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_documentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentFolderResource),
 			documentFolderResource ->
 				documentFolderResource.postSiteDocumentFolder(
 					siteId, documentFolder));
@@ -554,12 +617,14 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteKnowledgeBaseArticle(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseArticleId") Long knowledgeBaseArticleId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseArticleResource),
 			knowledgeBaseArticleResource ->
 				knowledgeBaseArticleResource.deleteKnowledgeBaseArticle(
 					knowledgeBaseArticleId));
@@ -567,6 +632,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public KnowledgeBaseArticle patchKnowledgeBaseArticle(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseArticleId") Long knowledgeBaseArticleId,
 			@GraphQLName("knowledgeBaseArticle") KnowledgeBaseArticle
 				knowledgeBaseArticle)
@@ -574,7 +640,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseArticleResource),
 			knowledgeBaseArticleResource ->
 				knowledgeBaseArticleResource.patchKnowledgeBaseArticle(
 					knowledgeBaseArticleId, knowledgeBaseArticle));
@@ -582,6 +649,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public KnowledgeBaseArticle putKnowledgeBaseArticle(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseArticleId") Long knowledgeBaseArticleId,
 			@GraphQLName("knowledgeBaseArticle") KnowledgeBaseArticle
 				knowledgeBaseArticle)
@@ -589,7 +657,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseArticleResource),
 			knowledgeBaseArticleResource ->
 				knowledgeBaseArticleResource.putKnowledgeBaseArticle(
 					knowledgeBaseArticleId, knowledgeBaseArticle));
@@ -597,12 +666,14 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteKnowledgeBaseArticleMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseArticleId") Long knowledgeBaseArticleId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseArticleResource),
 			knowledgeBaseArticleResource ->
 				knowledgeBaseArticleResource.deleteKnowledgeBaseArticleMyRating(
 					knowledgeBaseArticleId));
@@ -611,13 +682,15 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Rating postKnowledgeBaseArticleMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseArticleId") Long knowledgeBaseArticleId,
 			@GraphQLName("rating") Rating rating)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseArticleResource),
 			knowledgeBaseArticleResource ->
 				knowledgeBaseArticleResource.postKnowledgeBaseArticleMyRating(
 					knowledgeBaseArticleId, rating));
@@ -625,13 +698,15 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public Rating putKnowledgeBaseArticleMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseArticleId") Long knowledgeBaseArticleId,
 			@GraphQLName("rating") Rating rating)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseArticleResource),
 			knowledgeBaseArticleResource ->
 				knowledgeBaseArticleResource.putKnowledgeBaseArticleMyRating(
 					knowledgeBaseArticleId, rating));
@@ -640,6 +715,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public KnowledgeBaseArticle postKnowledgeBaseArticleKnowledgeBaseArticle(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("parentKnowledgeBaseArticleId") Long
 				parentKnowledgeBaseArticleId,
 			@GraphQLName("knowledgeBaseArticle") KnowledgeBaseArticle
@@ -648,7 +724,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseArticleResource),
 			knowledgeBaseArticleResource ->
 				knowledgeBaseArticleResource.
 					postKnowledgeBaseArticleKnowledgeBaseArticle(
@@ -658,6 +735,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public KnowledgeBaseArticle postKnowledgeBaseFolderKnowledgeBaseArticle(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseFolderId") Long knowledgeBaseFolderId,
 			@GraphQLName("knowledgeBaseArticle") KnowledgeBaseArticle
 				knowledgeBaseArticle)
@@ -665,7 +743,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseArticleResource),
 			knowledgeBaseArticleResource ->
 				knowledgeBaseArticleResource.
 					postKnowledgeBaseFolderKnowledgeBaseArticle(
@@ -675,6 +754,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public KnowledgeBaseArticle postSiteKnowledgeBaseArticle(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("knowledgeBaseArticle") KnowledgeBaseArticle
 				knowledgeBaseArticle)
@@ -682,7 +762,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseArticleResource),
 			knowledgeBaseArticleResource ->
 				knowledgeBaseArticleResource.postSiteKnowledgeBaseArticle(
 					siteId, knowledgeBaseArticle));
@@ -695,6 +776,7 @@ public class Mutation {
 	)
 	public KnowledgeBaseAttachment
 			postKnowledgeBaseArticleKnowledgeBaseAttachment(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("knowledgeBaseArticleId") Long
 					knowledgeBaseArticleId,
 				@GraphQLName("multipartBody") MultipartBody multipartBody)
@@ -702,7 +784,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseAttachmentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseAttachmentResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseAttachmentResource),
 			knowledgeBaseAttachmentResource ->
 				knowledgeBaseAttachmentResource.
 					postKnowledgeBaseArticleKnowledgeBaseAttachment(
@@ -711,13 +794,15 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteKnowledgeBaseAttachment(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseAttachmentId") Long
 				knowledgeBaseAttachmentId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_knowledgeBaseAttachmentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseAttachmentResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseAttachmentResource),
 			knowledgeBaseAttachmentResource ->
 				knowledgeBaseAttachmentResource.deleteKnowledgeBaseAttachment(
 					knowledgeBaseAttachmentId));
@@ -725,12 +810,14 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteKnowledgeBaseFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseFolderId") Long knowledgeBaseFolderId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_knowledgeBaseFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseFolderResource),
 			knowledgeBaseFolderResource ->
 				knowledgeBaseFolderResource.deleteKnowledgeBaseFolder(
 					knowledgeBaseFolderId));
@@ -738,6 +825,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public KnowledgeBaseFolder patchKnowledgeBaseFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseFolderId") Long knowledgeBaseFolderId,
 			@GraphQLName("knowledgeBaseFolder") KnowledgeBaseFolder
 				knowledgeBaseFolder)
@@ -745,7 +833,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseFolderResource),
 			knowledgeBaseFolderResource ->
 				knowledgeBaseFolderResource.patchKnowledgeBaseFolder(
 					knowledgeBaseFolderId, knowledgeBaseFolder));
@@ -753,6 +842,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public KnowledgeBaseFolder putKnowledgeBaseFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseFolderId") Long knowledgeBaseFolderId,
 			@GraphQLName("knowledgeBaseFolder") KnowledgeBaseFolder
 				knowledgeBaseFolder)
@@ -760,7 +850,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseFolderResource),
 			knowledgeBaseFolderResource ->
 				knowledgeBaseFolderResource.putKnowledgeBaseFolder(
 					knowledgeBaseFolderId, knowledgeBaseFolder));
@@ -769,6 +860,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public KnowledgeBaseFolder postKnowledgeBaseFolderKnowledgeBaseFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("parentKnowledgeBaseFolderId") Long
 				parentKnowledgeBaseFolderId,
 			@GraphQLName("knowledgeBaseFolder") KnowledgeBaseFolder
@@ -777,7 +869,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseFolderResource),
 			knowledgeBaseFolderResource ->
 				knowledgeBaseFolderResource.
 					postKnowledgeBaseFolderKnowledgeBaseFolder(
@@ -787,6 +880,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public KnowledgeBaseFolder postSiteKnowledgeBaseFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("knowledgeBaseFolder") KnowledgeBaseFolder
 				knowledgeBaseFolder)
@@ -794,7 +888,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseFolderResource),
 			knowledgeBaseFolderResource ->
 				knowledgeBaseFolderResource.postSiteKnowledgeBaseFolder(
 					siteId, knowledgeBaseFolder));
@@ -802,13 +897,15 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteMessageBoardAttachment(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardAttachmentId") Long
 				messageBoardAttachmentId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_messageBoardAttachmentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardAttachmentResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardAttachmentResource),
 			messageBoardAttachmentResource ->
 				messageBoardAttachmentResource.deleteMessageBoardAttachment(
 					messageBoardAttachmentId));
@@ -820,13 +917,15 @@ public class Mutation {
 		"postMessageBoardMessageMessageBoardAttachmentMessageBoardMessageIdMultipartBody"
 	)
 	public MessageBoardAttachment postMessageBoardMessageMessageBoardAttachment(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardMessageId") Long messageBoardMessageId,
 			@GraphQLName("multipartBody") MultipartBody multipartBody)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardAttachmentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardAttachmentResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardAttachmentResource),
 			messageBoardAttachmentResource ->
 				messageBoardAttachmentResource.
 					postMessageBoardMessageMessageBoardAttachment(
@@ -839,13 +938,15 @@ public class Mutation {
 		"postMessageBoardThreadMessageBoardAttachmentMessageBoardThreadIdMultipartBody"
 	)
 	public MessageBoardAttachment postMessageBoardThreadMessageBoardAttachment(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardThreadId") Long messageBoardThreadId,
 			@GraphQLName("multipartBody") MultipartBody multipartBody)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardAttachmentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardAttachmentResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardAttachmentResource),
 			messageBoardAttachmentResource ->
 				messageBoardAttachmentResource.
 					postMessageBoardThreadMessageBoardAttachment(
@@ -854,12 +955,14 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteMessageBoardMessage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardMessageId") Long messageBoardMessageId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardMessageResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardMessageResource),
 			messageBoardMessageResource ->
 				messageBoardMessageResource.deleteMessageBoardMessage(
 					messageBoardMessageId));
@@ -867,6 +970,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public MessageBoardMessage patchMessageBoardMessage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardMessageId") Long messageBoardMessageId,
 			@GraphQLName("messageBoardMessage") MessageBoardMessage
 				messageBoardMessage)
@@ -874,7 +978,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardMessageResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardMessageResource),
 			messageBoardMessageResource ->
 				messageBoardMessageResource.patchMessageBoardMessage(
 					messageBoardMessageId, messageBoardMessage));
@@ -882,6 +987,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public MessageBoardMessage putMessageBoardMessage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardMessageId") Long messageBoardMessageId,
 			@GraphQLName("messageBoardMessage") MessageBoardMessage
 				messageBoardMessage)
@@ -889,7 +995,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardMessageResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardMessageResource),
 			messageBoardMessageResource ->
 				messageBoardMessageResource.putMessageBoardMessage(
 					messageBoardMessageId, messageBoardMessage));
@@ -897,12 +1004,14 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteMessageBoardMessageMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardMessageId") Long messageBoardMessageId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardMessageResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardMessageResource),
 			messageBoardMessageResource ->
 				messageBoardMessageResource.deleteMessageBoardMessageMyRating(
 					messageBoardMessageId));
@@ -911,13 +1020,15 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Rating postMessageBoardMessageMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardMessageId") Long messageBoardMessageId,
 			@GraphQLName("rating") Rating rating)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardMessageResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardMessageResource),
 			messageBoardMessageResource ->
 				messageBoardMessageResource.postMessageBoardMessageMyRating(
 					messageBoardMessageId, rating));
@@ -925,13 +1036,15 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public Rating putMessageBoardMessageMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardMessageId") Long messageBoardMessageId,
 			@GraphQLName("rating") Rating rating)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardMessageResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardMessageResource),
 			messageBoardMessageResource ->
 				messageBoardMessageResource.putMessageBoardMessageMyRating(
 					messageBoardMessageId, rating));
@@ -940,6 +1053,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public MessageBoardMessage postMessageBoardMessageMessageBoardMessage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("parentMessageBoardMessageId") Long
 				parentMessageBoardMessageId,
 			@GraphQLName("messageBoardMessage") MessageBoardMessage
@@ -948,7 +1062,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardMessageResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardMessageResource),
 			messageBoardMessageResource ->
 				messageBoardMessageResource.
 					postMessageBoardMessageMessageBoardMessage(
@@ -958,6 +1073,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public MessageBoardMessage postMessageBoardThreadMessageBoardMessage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardThreadId") Long messageBoardThreadId,
 			@GraphQLName("messageBoardMessage") MessageBoardMessage
 				messageBoardMessage)
@@ -965,7 +1081,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardMessageResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardMessageResource),
 			messageBoardMessageResource ->
 				messageBoardMessageResource.
 					postMessageBoardThreadMessageBoardMessage(
@@ -974,12 +1091,14 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteMessageBoardSection(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardSectionId") Long messageBoardSectionId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_messageBoardSectionResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardSectionResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardSectionResource),
 			messageBoardSectionResource ->
 				messageBoardSectionResource.deleteMessageBoardSection(
 					messageBoardSectionId));
@@ -987,6 +1106,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public MessageBoardSection patchMessageBoardSection(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardSectionId") Long messageBoardSectionId,
 			@GraphQLName("messageBoardSection") MessageBoardSection
 				messageBoardSection)
@@ -994,7 +1114,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_messageBoardSectionResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardSectionResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardSectionResource),
 			messageBoardSectionResource ->
 				messageBoardSectionResource.patchMessageBoardSection(
 					messageBoardSectionId, messageBoardSection));
@@ -1002,6 +1123,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public MessageBoardSection putMessageBoardSection(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardSectionId") Long messageBoardSectionId,
 			@GraphQLName("messageBoardSection") MessageBoardSection
 				messageBoardSection)
@@ -1009,7 +1131,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_messageBoardSectionResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardSectionResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardSectionResource),
 			messageBoardSectionResource ->
 				messageBoardSectionResource.putMessageBoardSection(
 					messageBoardSectionId, messageBoardSection));
@@ -1018,6 +1141,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public MessageBoardSection postMessageBoardSectionMessageBoardSection(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("parentMessageBoardSectionId") Long
 				parentMessageBoardSectionId,
 			@GraphQLName("messageBoardSection") MessageBoardSection
@@ -1026,7 +1150,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_messageBoardSectionResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardSectionResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardSectionResource),
 			messageBoardSectionResource ->
 				messageBoardSectionResource.
 					postMessageBoardSectionMessageBoardSection(
@@ -1036,6 +1161,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public MessageBoardSection postSiteMessageBoardSection(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("messageBoardSection") MessageBoardSection
 				messageBoardSection)
@@ -1043,7 +1169,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_messageBoardSectionResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardSectionResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardSectionResource),
 			messageBoardSectionResource ->
 				messageBoardSectionResource.postSiteMessageBoardSection(
 					siteId, messageBoardSection));
@@ -1052,6 +1179,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public MessageBoardThread postMessageBoardSectionMessageBoardThread(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardSectionId") Long messageBoardSectionId,
 			@GraphQLName("messageBoardThread") MessageBoardThread
 				messageBoardThread)
@@ -1059,7 +1187,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardThreadResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardThreadResource),
 			messageBoardThreadResource ->
 				messageBoardThreadResource.
 					postMessageBoardSectionMessageBoardThread(
@@ -1068,12 +1197,14 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteMessageBoardThread(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardThreadId") Long messageBoardThreadId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardThreadResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardThreadResource),
 			messageBoardThreadResource ->
 				messageBoardThreadResource.deleteMessageBoardThread(
 					messageBoardThreadId));
@@ -1081,6 +1212,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public MessageBoardThread patchMessageBoardThread(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardThreadId") Long messageBoardThreadId,
 			@GraphQLName("messageBoardThread") MessageBoardThread
 				messageBoardThread)
@@ -1088,7 +1220,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardThreadResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardThreadResource),
 			messageBoardThreadResource ->
 				messageBoardThreadResource.patchMessageBoardThread(
 					messageBoardThreadId, messageBoardThread));
@@ -1096,6 +1229,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public MessageBoardThread putMessageBoardThread(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardThreadId") Long messageBoardThreadId,
 			@GraphQLName("messageBoardThread") MessageBoardThread
 				messageBoardThread)
@@ -1103,7 +1237,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardThreadResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardThreadResource),
 			messageBoardThreadResource ->
 				messageBoardThreadResource.putMessageBoardThread(
 					messageBoardThreadId, messageBoardThread));
@@ -1111,12 +1246,14 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteMessageBoardThreadMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardThreadId") Long messageBoardThreadId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardThreadResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardThreadResource),
 			messageBoardThreadResource ->
 				messageBoardThreadResource.deleteMessageBoardThreadMyRating(
 					messageBoardThreadId));
@@ -1125,13 +1262,15 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Rating postMessageBoardThreadMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardThreadId") Long messageBoardThreadId,
 			@GraphQLName("rating") Rating rating)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardThreadResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardThreadResource),
 			messageBoardThreadResource ->
 				messageBoardThreadResource.postMessageBoardThreadMyRating(
 					messageBoardThreadId, rating));
@@ -1139,13 +1278,15 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public Rating putMessageBoardThreadMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardThreadId") Long messageBoardThreadId,
 			@GraphQLName("rating") Rating rating)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardThreadResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardThreadResource),
 			messageBoardThreadResource ->
 				messageBoardThreadResource.putMessageBoardThreadMyRating(
 					messageBoardThreadId, rating));
@@ -1154,6 +1295,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public MessageBoardThread postSiteMessageBoardThread(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("messageBoardThread") MessageBoardThread
 				messageBoardThread)
@@ -1161,7 +1303,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardThreadResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardThreadResource),
 			messageBoardThreadResource ->
 				messageBoardThreadResource.postSiteMessageBoardThread(
 					siteId, messageBoardThread));
@@ -1170,6 +1313,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public StructuredContent postSiteStructuredContent(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("structuredContent") StructuredContent
 				structuredContent)
@@ -1177,7 +1321,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource ->
 				structuredContentResource.postSiteStructuredContent(
 					siteId, structuredContent));
@@ -1186,6 +1331,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public StructuredContent postStructuredContentFolderStructuredContent(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentFolderId") Long
 				structuredContentFolderId,
 			@GraphQLName("structuredContent") StructuredContent
@@ -1194,7 +1340,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource ->
 				structuredContentResource.
 					postStructuredContentFolderStructuredContent(
@@ -1203,12 +1350,14 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteStructuredContent(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentId") Long structuredContentId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource ->
 				structuredContentResource.deleteStructuredContent(
 					structuredContentId));
@@ -1216,6 +1365,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public StructuredContent patchStructuredContent(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentId") Long structuredContentId,
 			@GraphQLName("structuredContent") StructuredContent
 				structuredContent)
@@ -1223,7 +1373,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource ->
 				structuredContentResource.patchStructuredContent(
 					structuredContentId, structuredContent));
@@ -1231,6 +1382,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public StructuredContent putStructuredContent(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentId") Long structuredContentId,
 			@GraphQLName("structuredContent") StructuredContent
 				structuredContent)
@@ -1238,7 +1390,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource ->
 				structuredContentResource.putStructuredContent(
 					structuredContentId, structuredContent));
@@ -1246,12 +1399,14 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteStructuredContentMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentId") Long structuredContentId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource ->
 				structuredContentResource.deleteStructuredContentMyRating(
 					structuredContentId));
@@ -1260,13 +1415,15 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Rating postStructuredContentMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentId") Long structuredContentId,
 			@GraphQLName("rating") Rating rating)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource ->
 				structuredContentResource.postStructuredContentMyRating(
 					structuredContentId, rating));
@@ -1274,13 +1431,15 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public Rating putStructuredContentMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentId") Long structuredContentId,
 			@GraphQLName("rating") Rating rating)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource ->
 				structuredContentResource.putStructuredContentMyRating(
 					structuredContentId, rating));
@@ -1289,6 +1448,7 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public StructuredContentFolder postSiteStructuredContentFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("structuredContentFolder") StructuredContentFolder
 				structuredContentFolder)
@@ -1296,7 +1456,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_structuredContentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentFolderResource),
 			structuredContentFolderResource ->
 				structuredContentFolderResource.postSiteStructuredContentFolder(
 					siteId, structuredContentFolder));
@@ -1306,6 +1467,7 @@ public class Mutation {
 	@GraphQLInvokeDetached
 	public StructuredContentFolder
 			postStructuredContentFolderStructuredContentFolder(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("parentStructuredContentFolderId") Long
 					parentStructuredContentFolderId,
 				@GraphQLName("structuredContentFolder") StructuredContentFolder
@@ -1314,7 +1476,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_structuredContentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentFolderResource),
 			structuredContentFolderResource ->
 				structuredContentFolderResource.
 					postStructuredContentFolderStructuredContentFolder(
@@ -1324,13 +1487,15 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public void deleteStructuredContentFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentFolderId") Long
 				structuredContentFolderId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_structuredContentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentFolderResource),
 			structuredContentFolderResource ->
 				structuredContentFolderResource.deleteStructuredContentFolder(
 					structuredContentFolderId));
@@ -1338,6 +1503,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public StructuredContentFolder patchStructuredContentFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentFolderId") Long
 				structuredContentFolderId,
 			@GraphQLName("structuredContentFolder") StructuredContentFolder
@@ -1346,7 +1512,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_structuredContentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentFolderResource),
 			structuredContentFolderResource ->
 				structuredContentFolderResource.patchStructuredContentFolder(
 					structuredContentFolderId, structuredContentFolder));
@@ -1354,6 +1521,7 @@ public class Mutation {
 
 	@GraphQLInvokeDetached
 	public StructuredContentFolder putStructuredContentFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentFolderId") Long
 				structuredContentFolderId,
 			@GraphQLName("structuredContentFolder") StructuredContentFolder
@@ -1362,7 +1530,8 @@ public class Mutation {
 
 		return _applyComponentServiceObjects(
 			_structuredContentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentFolderResource),
 			structuredContentFolderResource ->
 				structuredContentFolderResource.putStructuredContentFolder(
 					structuredContentFolderId, structuredContentFolder));
@@ -1407,8 +1576,13 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			BlogPostingResource blogPostingResource)
 		throws Exception {
+
+		blogPostingResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		blogPostingResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1416,24 +1590,41 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			BlogPostingImageResource blogPostingImageResource)
 		throws Exception {
+
+		blogPostingImageResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		blogPostingImageResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
-	private void _populateResourceContext(CommentResource commentResource)
+	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			CommentResource commentResource)
 		throws Exception {
+
+		commentResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		commentResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
-	private void _populateResourceContext(DocumentResource documentResource)
+	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			DocumentResource documentResource)
 		throws Exception {
+
+		documentResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		documentResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1441,8 +1632,13 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			DocumentFolderResource documentFolderResource)
 		throws Exception {
+
+		documentFolderResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		documentFolderResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1450,8 +1646,13 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			KnowledgeBaseArticleResource knowledgeBaseArticleResource)
 		throws Exception {
+
+		knowledgeBaseArticleResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		knowledgeBaseArticleResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1459,8 +1660,13 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			KnowledgeBaseAttachmentResource knowledgeBaseAttachmentResource)
 		throws Exception {
+
+		knowledgeBaseAttachmentResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		knowledgeBaseAttachmentResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1468,8 +1674,13 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			KnowledgeBaseFolderResource knowledgeBaseFolderResource)
 		throws Exception {
+
+		knowledgeBaseFolderResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		knowledgeBaseFolderResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1477,8 +1688,13 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			MessageBoardAttachmentResource messageBoardAttachmentResource)
 		throws Exception {
+
+		messageBoardAttachmentResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		messageBoardAttachmentResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1486,8 +1702,13 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			MessageBoardMessageResource messageBoardMessageResource)
 		throws Exception {
+
+		messageBoardMessageResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		messageBoardMessageResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1495,8 +1716,13 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			MessageBoardSectionResource messageBoardSectionResource)
 		throws Exception {
+
+		messageBoardSectionResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		messageBoardSectionResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1504,8 +1730,13 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			MessageBoardThreadResource messageBoardThreadResource)
 		throws Exception {
+
+		messageBoardThreadResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		messageBoardThreadResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1513,8 +1744,13 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			StructuredContentResource structuredContentResource)
 		throws Exception {
+
+		structuredContentResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		structuredContentResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1522,14 +1758,26 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			StructuredContentFolderResource structuredContentFolderResource)
 		throws Exception {
+
+		structuredContentFolderResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		structuredContentFolderResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
+	public static void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		_acceptLanguageFunction = acceptLanguageFunction;
+	}
+
+	private static Function<Object, AcceptLanguage> _acceptLanguageFunction;
 	private static ComponentServiceObjects<BlogPostingResource>
 		_blogPostingResourceComponentServiceObjects;
 	private static ComponentServiceObjects<BlogPostingImageResource>

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -53,6 +53,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -60,7 +61,10 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
+import graphql.schema.DataFetchingEnvironment;
+
 import java.util.Collection;
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -206,12 +210,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public BlogPosting getBlogPosting(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("blogPostingId") Long blogPostingId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			blogPostingResource -> _populateResourceContext(
+				dataFetchingEnvironment, blogPostingResource),
 			blogPostingResource -> blogPostingResource.getBlogPosting(
 				blogPostingId));
 	}
@@ -219,12 +225,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Rating getBlogPostingMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("blogPostingId") Long blogPostingId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			blogPostingResource -> _populateResourceContext(
+				dataFetchingEnvironment, blogPostingResource),
 			blogPostingResource -> blogPostingResource.getBlogPostingMyRating(
 				blogPostingId));
 	}
@@ -232,6 +240,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<BlogPosting> getSiteBlogPostingsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -241,7 +250,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			blogPostingResource -> _populateResourceContext(
+				dataFetchingEnvironment, blogPostingResource),
 			blogPostingResource -> {
 				Page paginationPage =
 					blogPostingResource.getSiteBlogPostingsPage(
@@ -255,12 +265,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public BlogPostingImage getBlogPostingImage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("blogPostingImageId") Long blogPostingImageId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_blogPostingImageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			blogPostingImageResource -> _populateResourceContext(
+				dataFetchingEnvironment, blogPostingImageResource),
 			blogPostingImageResource ->
 				blogPostingImageResource.getBlogPostingImage(
 					blogPostingImageId));
@@ -269,6 +281,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<BlogPostingImage> getSiteBlogPostingImagesPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -278,7 +291,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_blogPostingImageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			blogPostingImageResource -> _populateResourceContext(
+				dataFetchingEnvironment, blogPostingImageResource),
 			blogPostingImageResource -> {
 				Page paginationPage =
 					blogPostingImageResource.getSiteBlogPostingImagesPage(
@@ -292,6 +306,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Comment> getBlogPostingCommentsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("blogPostingId") Long blogPostingId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -301,7 +316,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			commentResource -> _populateResourceContext(
+				dataFetchingEnvironment, commentResource),
 			commentResource -> {
 				Page paginationPage =
 					commentResource.getBlogPostingCommentsPage(
@@ -314,18 +330,22 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Comment getComment(@GraphQLName("commentId") Long commentId)
+	public Comment getComment(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			@GraphQLName("commentId") Long commentId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			commentResource -> _populateResourceContext(
+				dataFetchingEnvironment, commentResource),
 			commentResource -> commentResource.getComment(commentId));
 	}
 
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Comment> getCommentCommentsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("parentCommentId") Long parentCommentId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -335,7 +355,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			commentResource -> _populateResourceContext(
+				dataFetchingEnvironment, commentResource),
 			commentResource -> {
 				Page paginationPage = commentResource.getCommentCommentsPage(
 					parentCommentId, search, filter,
@@ -348,6 +369,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Comment> getDocumentCommentsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("documentId") Long documentId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -357,7 +379,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			commentResource -> _populateResourceContext(
+				dataFetchingEnvironment, commentResource),
 			commentResource -> {
 				Page paginationPage = commentResource.getDocumentCommentsPage(
 					documentId, search, filter, Pagination.of(pageSize, page),
@@ -370,6 +393,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Comment> getStructuredContentCommentsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentId") Long structuredContentId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -379,7 +403,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			commentResource -> _populateResourceContext(
+				dataFetchingEnvironment, commentResource),
 			commentResource -> {
 				Page paginationPage =
 					commentResource.getStructuredContentCommentsPage(
@@ -393,6 +418,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<ContentSetElement> getContentSetContentSetElementsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("contentSetId") Long contentSetId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -400,7 +426,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_contentSetElementResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			contentSetElementResource -> _populateResourceContext(
+				dataFetchingEnvironment, contentSetElementResource),
 			contentSetElementResource -> {
 				Page paginationPage =
 					contentSetElementResource.
@@ -415,6 +442,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<ContentSetElement>
 			getSiteContentSetByKeyContentSetElementsPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("siteId") Long siteId,
 				@GraphQLName("key") String key,
 				@GraphQLName("pageSize") int pageSize,
@@ -423,7 +451,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_contentSetElementResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			contentSetElementResource -> _populateResourceContext(
+				dataFetchingEnvironment, contentSetElementResource),
 			contentSetElementResource -> {
 				Page paginationPage =
 					contentSetElementResource.
@@ -438,6 +467,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<ContentSetElement>
 			getSiteContentSetByUuidContentSetElementsPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("siteId") Long siteId,
 				@GraphQLName("uuid") String uuid,
 				@GraphQLName("pageSize") int pageSize,
@@ -446,7 +476,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_contentSetElementResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			contentSetElementResource -> _populateResourceContext(
+				dataFetchingEnvironment, contentSetElementResource),
 			contentSetElementResource -> {
 				Page paginationPage =
 					contentSetElementResource.
@@ -460,12 +491,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public ContentStructure getContentStructure(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("contentStructureId") Long contentStructureId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_contentStructureResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			contentStructureResource -> _populateResourceContext(
+				dataFetchingEnvironment, contentStructureResource),
 			contentStructureResource ->
 				contentStructureResource.getContentStructure(
 					contentStructureId));
@@ -474,6 +507,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<ContentStructure> getSiteContentStructuresPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -483,7 +517,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_contentStructureResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			contentStructureResource -> _populateResourceContext(
+				dataFetchingEnvironment, contentStructureResource),
 			contentStructureResource -> {
 				Page paginationPage =
 					contentStructureResource.getSiteContentStructuresPage(
@@ -497,6 +532,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Document> getDocumentFolderDocumentsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("documentFolderId") Long documentFolderId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -506,7 +542,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentResource),
 			documentResource -> {
 				Page paginationPage =
 					documentResource.getDocumentFolderDocumentsPage(
@@ -519,24 +556,29 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Document getDocument(@GraphQLName("documentId") Long documentId)
+	public Document getDocument(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			@GraphQLName("documentId") Long documentId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentResource),
 			documentResource -> documentResource.getDocument(documentId));
 	}
 
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Rating getDocumentMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("documentId") Long documentId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentResource),
 			documentResource -> documentResource.getDocumentMyRating(
 				documentId));
 	}
@@ -544,6 +586,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Document> getSiteDocumentsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
@@ -554,7 +597,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentResource),
 			documentResource -> {
 				Page paginationPage = documentResource.getSiteDocumentsPage(
 					siteId, flatten, search, filter,
@@ -567,12 +611,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public DocumentFolder getDocumentFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("documentFolderId") Long documentFolderId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_documentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentFolderResource),
 			documentFolderResource -> documentFolderResource.getDocumentFolder(
 				documentFolderId));
 	}
@@ -580,6 +626,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<DocumentFolder> getDocumentFolderDocumentFoldersPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("parentDocumentFolderId") Long parentDocumentFolderId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -589,7 +636,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_documentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentFolderResource),
 			documentFolderResource -> {
 				Page paginationPage =
 					documentFolderResource.getDocumentFolderDocumentFoldersPage(
@@ -603,6 +651,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<DocumentFolder> getSiteDocumentFoldersPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
@@ -613,7 +662,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_documentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			documentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, documentFolderResource),
 			documentFolderResource -> {
 				Page paginationPage =
 					documentFolderResource.getSiteDocumentFoldersPage(
@@ -627,12 +677,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public KnowledgeBaseArticle getKnowledgeBaseArticle(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseArticleId") Long knowledgeBaseArticleId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseArticleResource),
 			knowledgeBaseArticleResource ->
 				knowledgeBaseArticleResource.getKnowledgeBaseArticle(
 					knowledgeBaseArticleId));
@@ -641,12 +693,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Rating getKnowledgeBaseArticleMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseArticleId") Long knowledgeBaseArticleId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseArticleResource),
 			knowledgeBaseArticleResource ->
 				knowledgeBaseArticleResource.getKnowledgeBaseArticleMyRating(
 					knowledgeBaseArticleId));
@@ -656,6 +710,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<KnowledgeBaseArticle>
 			getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("parentKnowledgeBaseArticleId") Long
 					parentKnowledgeBaseArticleId,
 				@GraphQLName("search") String search,
@@ -667,7 +722,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseArticleResource),
 			knowledgeBaseArticleResource -> {
 				Page paginationPage =
 					knowledgeBaseArticleResource.
@@ -683,6 +739,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<KnowledgeBaseArticle>
 			getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("knowledgeBaseFolderId") Long
 					knowledgeBaseFolderId,
 				@GraphQLName("flatten") Boolean flatten,
@@ -695,7 +752,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseArticleResource),
 			knowledgeBaseArticleResource -> {
 				Page paginationPage =
 					knowledgeBaseArticleResource.
@@ -710,6 +768,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<KnowledgeBaseArticle> getSiteKnowledgeBaseArticlesPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
@@ -720,7 +779,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseArticleResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseArticleResource),
 			knowledgeBaseArticleResource -> {
 				Page paginationPage =
 					knowledgeBaseArticleResource.
@@ -736,13 +796,15 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<KnowledgeBaseAttachment>
 			getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("knowledgeBaseArticleId") Long
 					knowledgeBaseArticleId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseAttachmentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseAttachmentResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseAttachmentResource),
 			knowledgeBaseAttachmentResource -> {
 				Page paginationPage =
 					knowledgeBaseAttachmentResource.
@@ -756,13 +818,15 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public KnowledgeBaseAttachment getKnowledgeBaseAttachment(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseAttachmentId") Long
 				knowledgeBaseAttachmentId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseAttachmentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseAttachmentResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseAttachmentResource),
 			knowledgeBaseAttachmentResource ->
 				knowledgeBaseAttachmentResource.getKnowledgeBaseAttachment(
 					knowledgeBaseAttachmentId));
@@ -771,12 +835,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public KnowledgeBaseFolder getKnowledgeBaseFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("knowledgeBaseFolderId") Long knowledgeBaseFolderId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseFolderResource),
 			knowledgeBaseFolderResource ->
 				knowledgeBaseFolderResource.getKnowledgeBaseFolder(
 					knowledgeBaseFolderId));
@@ -786,6 +852,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<KnowledgeBaseFolder>
 			getKnowledgeBaseFolderKnowledgeBaseFoldersPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("parentKnowledgeBaseFolderId") Long
 					parentKnowledgeBaseFolderId,
 				@GraphQLName("pageSize") int pageSize,
@@ -794,7 +861,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseFolderResource),
 			knowledgeBaseFolderResource -> {
 				Page paginationPage =
 					knowledgeBaseFolderResource.
@@ -809,6 +877,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<KnowledgeBaseFolder> getSiteKnowledgeBaseFoldersPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -816,7 +885,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			knowledgeBaseFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, knowledgeBaseFolderResource),
 			knowledgeBaseFolderResource -> {
 				Page paginationPage =
 					knowledgeBaseFolderResource.getSiteKnowledgeBaseFoldersPage(
@@ -829,13 +899,15 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public MessageBoardAttachment getMessageBoardAttachment(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardAttachmentId") Long
 				messageBoardAttachmentId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardAttachmentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardAttachmentResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardAttachmentResource),
 			messageBoardAttachmentResource ->
 				messageBoardAttachmentResource.getMessageBoardAttachment(
 					messageBoardAttachmentId));
@@ -845,13 +917,15 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<MessageBoardAttachment>
 			getMessageBoardMessageMessageBoardAttachmentsPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("messageBoardMessageId") Long
 					messageBoardMessageId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardAttachmentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardAttachmentResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardAttachmentResource),
 			messageBoardAttachmentResource -> {
 				Page paginationPage =
 					messageBoardAttachmentResource.
@@ -866,12 +940,14 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<MessageBoardAttachment>
 			getMessageBoardThreadMessageBoardAttachmentsPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("messageBoardThreadId") Long messageBoardThreadId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardAttachmentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardAttachmentResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardAttachmentResource),
 			messageBoardAttachmentResource -> {
 				Page paginationPage =
 					messageBoardAttachmentResource.
@@ -885,12 +961,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public MessageBoardMessage getMessageBoardMessage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardMessageId") Long messageBoardMessageId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardMessageResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardMessageResource),
 			messageBoardMessageResource ->
 				messageBoardMessageResource.getMessageBoardMessage(
 					messageBoardMessageId));
@@ -899,12 +977,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Rating getMessageBoardMessageMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardMessageId") Long messageBoardMessageId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardMessageResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardMessageResource),
 			messageBoardMessageResource ->
 				messageBoardMessageResource.getMessageBoardMessageMyRating(
 					messageBoardMessageId));
@@ -914,6 +994,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<MessageBoardMessage>
 			getMessageBoardMessageMessageBoardMessagesPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("parentMessageBoardMessageId") Long
 					parentMessageBoardMessageId,
 				@GraphQLName("search") String search,
@@ -925,7 +1006,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardMessageResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardMessageResource),
 			messageBoardMessageResource -> {
 				Page paginationPage =
 					messageBoardMessageResource.
@@ -941,6 +1023,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<MessageBoardMessage>
 			getMessageBoardThreadMessageBoardMessagesPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("messageBoardThreadId") Long messageBoardThreadId,
 				@GraphQLName("search") String search,
 				@GraphQLName("filter") Filter filter,
@@ -951,7 +1034,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardMessageResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardMessageResource),
 			messageBoardMessageResource -> {
 				Page paginationPage =
 					messageBoardMessageResource.
@@ -966,12 +1050,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public MessageBoardSection getMessageBoardSection(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardSectionId") Long messageBoardSectionId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardSectionResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardSectionResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardSectionResource),
 			messageBoardSectionResource ->
 				messageBoardSectionResource.getMessageBoardSection(
 					messageBoardSectionId));
@@ -981,6 +1067,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<MessageBoardSection>
 			getMessageBoardSectionMessageBoardSectionsPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("parentMessageBoardSectionId") Long
 					parentMessageBoardSectionId,
 				@GraphQLName("search") String search,
@@ -992,7 +1079,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_messageBoardSectionResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardSectionResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardSectionResource),
 			messageBoardSectionResource -> {
 				Page paginationPage =
 					messageBoardSectionResource.
@@ -1007,6 +1095,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<MessageBoardSection> getSiteMessageBoardSectionsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
@@ -1017,7 +1106,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_messageBoardSectionResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardSectionResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardSectionResource),
 			messageBoardSectionResource -> {
 				Page paginationPage =
 					messageBoardSectionResource.getSiteMessageBoardSectionsPage(
@@ -1032,6 +1122,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<MessageBoardThread>
 			getMessageBoardSectionMessageBoardThreadsPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("messageBoardSectionId") Long
 					messageBoardSectionId,
 				@GraphQLName("search") String search,
@@ -1043,7 +1134,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardThreadResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardThreadResource),
 			messageBoardThreadResource -> {
 				Page paginationPage =
 					messageBoardThreadResource.
@@ -1058,12 +1150,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public MessageBoardThread getMessageBoardThread(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardThreadId") Long messageBoardThreadId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardThreadResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardThreadResource),
 			messageBoardThreadResource ->
 				messageBoardThreadResource.getMessageBoardThread(
 					messageBoardThreadId));
@@ -1072,12 +1166,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Rating getMessageBoardThreadMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("messageBoardThreadId") Long messageBoardThreadId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardThreadResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardThreadResource),
 			messageBoardThreadResource ->
 				messageBoardThreadResource.getMessageBoardThreadMyRating(
 					messageBoardThreadId));
@@ -1086,6 +1182,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<MessageBoardThread> getSiteMessageBoardThreadsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
@@ -1096,7 +1193,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			messageBoardThreadResource -> _populateResourceContext(
+				dataFetchingEnvironment, messageBoardThreadResource),
 			messageBoardThreadResource -> {
 				Page paginationPage =
 					messageBoardThreadResource.getSiteMessageBoardThreadsPage(
@@ -1111,6 +1209,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<StructuredContent>
 			getContentStructureStructuredContentsPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("contentStructureId") Long contentStructureId,
 				@GraphQLName("search") String search,
 				@GraphQLName("filter") Filter filter,
@@ -1121,7 +1220,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource -> {
 				Page paginationPage =
 					structuredContentResource.
@@ -1136,6 +1236,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<StructuredContent> getSiteStructuredContentsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
@@ -1146,7 +1247,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource -> {
 				Page paginationPage =
 					structuredContentResource.getSiteStructuredContentsPage(
@@ -1160,12 +1262,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public StructuredContent getSiteStructuredContentByKey(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId, @GraphQLName("key") String key)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource ->
 				structuredContentResource.getSiteStructuredContentByKey(
 					siteId, key));
@@ -1174,13 +1278,15 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public StructuredContent getSiteStructuredContentByUuid(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("uuid") String uuid)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource ->
 				structuredContentResource.getSiteStructuredContentByUuid(
 					siteId, uuid));
@@ -1190,6 +1296,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<StructuredContent>
 			getStructuredContentFolderStructuredContentsPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("structuredContentFolderId") Long
 					structuredContentFolderId,
 				@GraphQLName("search") String search,
@@ -1201,7 +1308,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource -> {
 				Page paginationPage =
 					structuredContentResource.
@@ -1216,12 +1324,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public StructuredContent getStructuredContent(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentId") Long structuredContentId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource ->
 				structuredContentResource.getStructuredContent(
 					structuredContentId));
@@ -1230,12 +1340,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Rating getStructuredContentMyRating(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentId") Long structuredContentId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource ->
 				structuredContentResource.getStructuredContentMyRating(
 					structuredContentId));
@@ -1244,13 +1356,15 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public String getStructuredContentRenderedContentTemplate(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentId") Long structuredContentId,
 			@GraphQLName("templateId") Long templateId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentResource),
 			structuredContentResource ->
 				structuredContentResource.
 					getStructuredContentRenderedContentTemplate(
@@ -1261,6 +1375,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<StructuredContentFolder>
 			getSiteStructuredContentFoldersPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("siteId") Long siteId,
 				@GraphQLName("flatten") Boolean flatten,
 				@GraphQLName("search") String search,
@@ -1272,7 +1387,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_structuredContentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentFolderResource),
 			structuredContentFolderResource -> {
 				Page paginationPage =
 					structuredContentFolderResource.
@@ -1288,6 +1404,7 @@ public class Query {
 	@GraphQLInvokeDetached
 	public Collection<StructuredContentFolder>
 			getStructuredContentFolderStructuredContentFoldersPage(
+				DataFetchingEnvironment dataFetchingEnvironment,
 				@GraphQLName("parentStructuredContentFolderId") Long
 					parentStructuredContentFolderId,
 				@GraphQLName("search") String search,
@@ -1299,7 +1416,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_structuredContentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentFolderResource),
 			structuredContentFolderResource -> {
 				Page paginationPage =
 					structuredContentFolderResource.
@@ -1314,13 +1432,15 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public StructuredContentFolder getStructuredContentFolder(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("structuredContentFolderId") Long
 				structuredContentFolderId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_structuredContentFolderResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			structuredContentFolderResource -> _populateResourceContext(
+				dataFetchingEnvironment, structuredContentFolderResource),
 			structuredContentFolderResource ->
 				structuredContentFolderResource.getStructuredContentFolder(
 					structuredContentFolderId));
@@ -1346,8 +1466,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			BlogPostingResource blogPostingResource)
 		throws Exception {
+
+		blogPostingResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		blogPostingResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1355,16 +1480,27 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			BlogPostingImageResource blogPostingImageResource)
 		throws Exception {
+
+		blogPostingImageResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		blogPostingImageResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
-	private void _populateResourceContext(CommentResource commentResource)
+	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			CommentResource commentResource)
 		throws Exception {
+
+		commentResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		commentResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1372,8 +1508,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			ContentSetElementResource contentSetElementResource)
 		throws Exception {
+
+		contentSetElementResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		contentSetElementResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1381,16 +1522,27 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			ContentStructureResource contentStructureResource)
 		throws Exception {
+
+		contentStructureResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		contentStructureResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
-	private void _populateResourceContext(DocumentResource documentResource)
+	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			DocumentResource documentResource)
 		throws Exception {
+
+		documentResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		documentResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1398,8 +1550,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			DocumentFolderResource documentFolderResource)
 		throws Exception {
+
+		documentFolderResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		documentFolderResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1407,8 +1564,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			KnowledgeBaseArticleResource knowledgeBaseArticleResource)
 		throws Exception {
+
+		knowledgeBaseArticleResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		knowledgeBaseArticleResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1416,8 +1578,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			KnowledgeBaseAttachmentResource knowledgeBaseAttachmentResource)
 		throws Exception {
+
+		knowledgeBaseAttachmentResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		knowledgeBaseAttachmentResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1425,8 +1592,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			KnowledgeBaseFolderResource knowledgeBaseFolderResource)
 		throws Exception {
+
+		knowledgeBaseFolderResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		knowledgeBaseFolderResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1434,8 +1606,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			MessageBoardAttachmentResource messageBoardAttachmentResource)
 		throws Exception {
+
+		messageBoardAttachmentResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		messageBoardAttachmentResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1443,8 +1620,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			MessageBoardMessageResource messageBoardMessageResource)
 		throws Exception {
+
+		messageBoardMessageResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		messageBoardMessageResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1452,8 +1634,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			MessageBoardSectionResource messageBoardSectionResource)
 		throws Exception {
+
+		messageBoardSectionResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		messageBoardSectionResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1461,8 +1648,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			MessageBoardThreadResource messageBoardThreadResource)
 		throws Exception {
+
+		messageBoardThreadResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		messageBoardThreadResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1470,8 +1662,13 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			StructuredContentResource structuredContentResource)
 		throws Exception {
+
+		structuredContentResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		structuredContentResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -1479,14 +1676,26 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			StructuredContentFolderResource structuredContentFolderResource)
 		throws Exception {
+
+		structuredContentFolderResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		structuredContentFolderResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
+	public static void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		_acceptLanguageFunction = acceptLanguageFunction;
+	}
+
+	private static Function<Object, AcceptLanguage> _acceptLanguageFunction;
 	private static ComponentServiceObjects<BlogPostingResource>
 		_blogPostingResourceComponentServiceObjects;
 	private static ComponentServiceObjects<BlogPostingImageResource>

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -32,7 +32,10 @@ import com.liferay.headless.delivery.resource.v1_0.MessageBoardSectionResource;
 import com.liferay.headless.delivery.resource.v1_0.MessageBoardThreadResource;
 import com.liferay.headless.delivery.resource.v1_0.StructuredContentFolderResource;
 import com.liferay.headless.delivery.resource.v1_0.StructuredContentResource;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -129,6 +132,14 @@ public class ServletDataImpl implements ServletData {
 	@Override
 	public Query getQuery() {
 		return new Query();
+	}
+
+	@Override
+	public void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		Query.setAcceptLanguageFunction(acceptLanguageFunction);
+		Mutation.setAcceptLanguageFunction(acceptLanguageFunction);
 	}
 
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -141,6 +141,10 @@ public abstract class BaseBlogPostingImageResourceImpl
 		return new BlogPostingImage();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -327,6 +327,10 @@ public abstract class BaseBlogPostingResourceImpl
 		return new BlogPosting();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -305,6 +305,10 @@ public abstract class BaseCommentResourceImpl implements CommentResource {
 		return new Comment();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
@@ -131,6 +131,10 @@ public abstract class BaseContentSetElementResourceImpl
 		return Page.of(Collections.emptyList());
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -102,6 +102,10 @@ public abstract class BaseContentStructureResourceImpl
 		return Page.of(Collections.emptyList());
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -279,6 +279,10 @@ public abstract class BaseDocumentFolderResourceImpl
 		return new DocumentFolder();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -313,6 +313,10 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 		return new Document();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -474,6 +474,10 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 		return new KnowledgeBaseArticle();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
@@ -153,6 +153,10 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 		return new KnowledgeBaseAttachment();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -290,6 +290,10 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 		return new KnowledgeBaseFolder();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -195,6 +195,10 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 		return new MessageBoardAttachment();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -415,6 +415,10 @@ public abstract class BaseMessageBoardMessageResourceImpl
 		return new MessageBoardMessage();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -301,6 +301,10 @@ public abstract class BaseMessageBoardSectionResourceImpl
 		return new MessageBoardSection();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -398,6 +398,10 @@ public abstract class BaseMessageBoardThreadResourceImpl
 		return new MessageBoardThread();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -316,6 +316,10 @@ public abstract class BaseStructuredContentFolderResourceImpl
 		return new StructuredContentFolder();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -511,6 +511,10 @@ public abstract class BaseStructuredContentResourceImpl
 		return StringPool.BLANK;
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormDocumentResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormDocumentResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.form.resource.v1_0;
 
 import com.liferay.headless.form.dto.v1_0.FormDocument;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 
 import javax.annotation.Generated;
 
@@ -33,6 +34,8 @@ public interface FormDocumentResource {
 	public void deleteFormDocument(Long formDocumentId) throws Exception;
 
 	public FormDocument getFormDocument(Long formDocumentId) throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormRecordResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormRecordResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.form.resource.v1_0;
 
 import com.liferay.headless.form.dto.v1_0.FormRecord;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -46,6 +47,8 @@ public interface FormRecordResource {
 
 	public FormRecord getFormFormRecordByLatestDraft(Long formId)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormResource.java
@@ -18,6 +18,7 @@ import com.liferay.headless.form.dto.v1_0.Form;
 import com.liferay.headless.form.dto.v1_0.FormContext;
 import com.liferay.headless.form.dto.v1_0.FormDocument;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -47,6 +48,8 @@ public interface FormResource {
 
 	public Page<Form> getSiteFormsPage(Long siteId, Pagination pagination)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormStructureResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormStructureResource.java
@@ -16,6 +16,7 @@ package com.liferay.headless.form.resource.v1_0;
 
 import com.liferay.headless.form.dto.v1_0.FormStructure;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -38,6 +39,8 @@ public interface FormStructureResource {
 	public Page<FormStructure> getSiteFormStructuresPage(
 			Long siteId, Pagination pagination)
 		throws Exception;
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 

--- a/modules/apps/headless/headless-form/headless-form-impl/build.gradle
+++ b/modules/apps/headless/headless-form/headless-form-impl/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
+	compileOnly group: "com.graphql-java", name: "graphql-java", version: "8.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/mutation/v1_0/Mutation.java
@@ -24,11 +24,16 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
+
+import graphql.schema.DataFetchingEnvironment;
+
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -68,13 +73,15 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public FormContext postFormEvaluateContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("formId") Long formId,
 			@GraphQLName("formContext") FormContext formContext)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_formResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			formResource -> _populateResourceContext(
+				dataFetchingEnvironment, formResource),
 			formResource -> formResource.postFormEvaluateContext(
 				formId, formContext));
 	}
@@ -83,38 +90,44 @@ public class Mutation {
 	@GraphQLInvokeDetached
 	@GraphQLName("postFormFormDocumentFormIdMultipartBody")
 	public FormDocument postFormFormDocument(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("formId") Long formId,
 			@GraphQLName("multipartBody") MultipartBody multipartBody)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_formResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			formResource -> _populateResourceContext(
+				dataFetchingEnvironment, formResource),
 			formResource -> formResource.postFormFormDocument(
 				formId, multipartBody));
 	}
 
 	@GraphQLInvokeDetached
 	public void deleteFormDocument(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("formDocumentId") Long formDocumentId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
 			_formDocumentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			formDocumentResource -> _populateResourceContext(
+				dataFetchingEnvironment, formDocumentResource),
 			formDocumentResource -> formDocumentResource.deleteFormDocument(
 				formDocumentId));
 	}
 
 	@GraphQLInvokeDetached
 	public FormRecord putFormRecord(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("formRecordId") Long formRecordId,
 			@GraphQLName("formRecord") FormRecord formRecord)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_formRecordResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			formRecordResource -> _populateResourceContext(
+				dataFetchingEnvironment, formRecordResource),
 			formRecordResource -> formRecordResource.putFormRecord(
 				formRecordId, formRecord));
 	}
@@ -122,13 +135,15 @@ public class Mutation {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public FormRecord postFormFormRecord(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("formId") Long formId,
 			@GraphQLName("formRecord") FormRecord formRecord)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_formRecordResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			formRecordResource -> _populateResourceContext(
+				dataFetchingEnvironment, formRecordResource),
 			formRecordResource -> formRecordResource.postFormFormRecord(
 				formId, formRecord));
 	}
@@ -171,8 +186,14 @@ public class Mutation {
 		}
 	}
 
-	private void _populateResourceContext(FormResource formResource)
+	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			FormResource formResource)
 		throws Exception {
+
+		formResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		formResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -180,22 +201,40 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			FormDocumentResource formDocumentResource)
 		throws Exception {
+
+		formDocumentResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		formDocumentResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
-	private void _populateResourceContext(FormRecordResource formRecordResource)
+	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			FormRecordResource formRecordResource)
 		throws Exception {
+
+		formRecordResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		formRecordResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
+	public static void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		_acceptLanguageFunction = acceptLanguageFunction;
+	}
+
+	private static Function<Object, AcceptLanguage> _acceptLanguageFunction;
 	private static ComponentServiceObjects<FormResource>
 		_formResourceComponentServiceObjects;
 	private static ComponentServiceObjects<FormDocumentResource>

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/query/v1_0/Query.java
@@ -26,6 +26,7 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -33,7 +34,10 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLInvokeDetached;
 import graphql.annotations.annotationTypes.GraphQLName;
 
+import graphql.schema.DataFetchingEnvironment;
+
 import java.util.Collection;
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -80,16 +84,22 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public Form getForm(@GraphQLName("formId") Long formId) throws Exception {
+	public Form getForm(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			@GraphQLName("formId") Long formId)
+		throws Exception {
+
 		return _applyComponentServiceObjects(
 			_formResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			formResource -> _populateResourceContext(
+				dataFetchingEnvironment, formResource),
 			formResource -> formResource.getForm(formId));
 	}
 
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<Form> getSiteFormsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -97,7 +107,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_formResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			formResource -> _populateResourceContext(
+				dataFetchingEnvironment, formResource),
 			formResource -> {
 				Page paginationPage = formResource.getSiteFormsPage(
 					siteId, Pagination.of(pageSize, page));
@@ -109,12 +120,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public FormDocument getFormDocument(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("formDocumentId") Long formDocumentId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_formDocumentResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			formDocumentResource -> _populateResourceContext(
+				dataFetchingEnvironment, formDocumentResource),
 			formDocumentResource -> formDocumentResource.getFormDocument(
 				formDocumentId));
 	}
@@ -122,12 +135,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public FormRecord getFormRecord(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("formRecordId") Long formRecordId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_formRecordResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			formRecordResource -> _populateResourceContext(
+				dataFetchingEnvironment, formRecordResource),
 			formRecordResource -> formRecordResource.getFormRecord(
 				formRecordId));
 	}
@@ -135,6 +150,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<FormRecord> getFormFormRecordsPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("formId") Long formId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -142,7 +158,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_formRecordResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			formRecordResource -> _populateResourceContext(
+				dataFetchingEnvironment, formRecordResource),
 			formRecordResource -> {
 				Page paginationPage = formRecordResource.getFormFormRecordsPage(
 					formId, Pagination.of(pageSize, page));
@@ -154,12 +171,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public FormRecord getFormFormRecordByLatestDraft(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("formId") Long formId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_formRecordResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			formRecordResource -> _populateResourceContext(
+				dataFetchingEnvironment, formRecordResource),
 			formRecordResource ->
 				formRecordResource.getFormFormRecordByLatestDraft(formId));
 	}
@@ -167,12 +186,14 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public FormStructure getFormStructure(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("formStructureId") Long formStructureId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_formStructureResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			formStructureResource -> _populateResourceContext(
+				dataFetchingEnvironment, formStructureResource),
 			formStructureResource -> formStructureResource.getFormStructure(
 				formStructureId));
 	}
@@ -180,6 +201,7 @@ public class Query {
 	@GraphQLField
 	@GraphQLInvokeDetached
 	public Collection<FormStructure> getSiteFormStructuresPage(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -187,7 +209,8 @@ public class Query {
 
 		return _applyComponentServiceObjects(
 			_formStructureResourceComponentServiceObjects,
-			this::_populateResourceContext,
+			formStructureResource -> _populateResourceContext(
+				dataFetchingEnvironment, formStructureResource),
 			formStructureResource -> {
 				Page paginationPage =
 					formStructureResource.getSiteFormStructuresPage(
@@ -216,8 +239,14 @@ public class Query {
 		}
 	}
 
-	private void _populateResourceContext(FormResource formResource)
+	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			FormResource formResource)
 		throws Exception {
+
+		formResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		formResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -225,16 +254,27 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			FormDocumentResource formDocumentResource)
 		throws Exception {
+
+		formDocumentResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		formDocumentResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
-	private void _populateResourceContext(FormRecordResource formRecordResource)
+	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			FormRecordResource formRecordResource)
 		throws Exception {
+
+		formRecordResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		formRecordResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
@@ -242,14 +282,26 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			DataFetchingEnvironment dataFetchingEnvironment,
 			FormStructureResource formStructureResource)
 		throws Exception {
+
+		formStructureResource.setContextAcceptLanguage(
+			_acceptLanguageFunction.apply(
+				dataFetchingEnvironment.getContext()));
 
 		formStructureResource.setContextCompany(
 			CompanyLocalServiceUtil.getCompany(
 				CompanyThreadLocal.getCompanyId()));
 	}
 
+	public static void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		_acceptLanguageFunction = acceptLanguageFunction;
+	}
+
+	private static Function<Object, AcceptLanguage> _acceptLanguageFunction;
 	private static ComponentServiceObjects<FormResource>
 		_formResourceComponentServiceObjects;
 	private static ComponentServiceObjects<FormDocumentResource>

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -20,7 +20,10 @@ import com.liferay.headless.form.resource.v1_0.FormDocumentResource;
 import com.liferay.headless.form.resource.v1_0.FormRecordResource;
 import com.liferay.headless.form.resource.v1_0.FormResource;
 import com.liferay.headless.form.resource.v1_0.FormStructureResource;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -71,6 +74,14 @@ public class ServletDataImpl implements ServletData {
 	@Override
 	public Query getQuery() {
 		return new Query();
+	}
+
+	@Override
+	public void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+
+		Query.setAcceptLanguageFunction(acceptLanguageFunction);
+		Mutation.setAcceptLanguageFunction(acceptLanguageFunction);
 	}
 
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
@@ -81,6 +81,10 @@ public abstract class BaseFormDocumentResourceImpl
 		return new FormDocument();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
@@ -137,6 +137,10 @@ public abstract class BaseFormRecordResourceImpl implements FormRecordResource {
 		return new FormRecord();
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
@@ -120,6 +120,10 @@ public abstract class BaseFormResourceImpl implements FormResource {
 		return Page.of(Collections.emptyList());
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
@@ -89,6 +89,10 @@ public abstract class BaseFormStructureResourceImpl
 		return Page.of(Collections.emptyList());
 	}
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/apps/portal-security/portal-security-auth-verifier-test/src/testIntegration/java/com/liferay/portal/security/auth/verifier/test/AuthVerifierTest.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier-test/src/testIntegration/java/com/liferay/portal/security/auth/verifier/test/AuthVerifierTest.java
@@ -134,6 +134,7 @@ public class AuthVerifierTest {
 
 		properties.put(
 			"auth-verifier-tracker-test-servlet-context-helper", true);
+		properties.put("liferay.auth.verifier", false);
 
 		_registerServletContextHelper(
 			"auth-verifier-filter-tracker-disabled-test", properties);
@@ -269,7 +270,8 @@ public class AuthVerifierTest {
 				"test/remoteUser");
 
 		try (InputStream inputStream = url.openStream()) {
-			Assert.assertEquals("no-remote-user", StringUtil.read(inputStream));
+			Assert.assertEquals(
+				"remote-user-set", StringUtil.read(inputStream));
 		}
 	}
 

--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/tracker/AuthVerifierFilterTracker.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/tracker/AuthVerifierFilterTracker.java
@@ -64,7 +64,7 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 		"default.registration.property=filter.init.guest.allowed=true",
 		"default.remote.access.filter.service.ranking:Integer=-10",
 		"default.whiteboard.property=" + HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_SERVLET + "=cxf-servlet",
-		"servlet.context.helper.select.filter=(&(!(liferay.auth.verifier=false))(|(osgi.jaxrs.name=*)(liferay.graphql.auth=true)))"
+		"servlet.context.helper.select.filter=(!(liferay.auth.verifier=false))"
 	},
 	service = {}
 )

--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/tracker/AuthVerifierFilterTracker.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/tracker/AuthVerifierFilterTracker.java
@@ -64,7 +64,7 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 		"default.registration.property=filter.init.guest.allowed=true",
 		"default.remote.access.filter.service.ranking:Integer=-10",
 		"default.whiteboard.property=" + HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_SERVLET + "=cxf-servlet",
-		"servlet.context.helper.select.filter=(&(!(liferay.auth.verifier=false))(osgi.jaxrs.name=*))"
+		"servlet.context.helper.select.filter=(&(!(liferay.auth.verifier=false))(|(osgi.jaxrs.name=*)(liferay.graphql.auth=true)))"
 	},
 	service = {}
 )

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/servlet/ServletData.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/servlet/ServletData.java
@@ -14,6 +14,10 @@
 
 package com.liferay.portal.vulcan.graphql.servlet;
 
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import java.util.function.Function;
+
 /**
  * @author Preston Crary
  */
@@ -24,5 +28,9 @@ public interface ServletData {
 	public String getPath();
 
 	public Object getQuery();
+
+	public default void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+	}
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	compileOnly group: "org.apache.cxf", name: "cxf-core", version: "3.2.5"
 	compileOnly group: "org.apache.cxf", name: "cxf-rt-frontend-jaxrs", version: "3.2.5"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.http.whiteboard", version: "1.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.jaxrs", version: "1.0.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly group: "org.springframework", name: "spring-tx", version: "4.1.9.RELEASE"

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
@@ -15,7 +15,6 @@ dependencies {
 	compileInclude group: "com.fasterxml.jackson.jaxrs", name: "jackson-jaxrs-xml-provider", version: "2.9.8"
 	compileInclude group: "com.google.guava", name: "failureaccess", version: "1.0.1"
 	compileInclude group: "com.google.guava", name: "guava", version: "27.1-jre"
-	compileInclude group: "com.graphql-java", name: "graphql-java", version: "8.0"
 	compileInclude group: "com.graphql-java", name: "graphql-java-servlet", version: "6.1.3"
 	compileInclude group: "com.graphql-java", name: "java-dataloader", version: "2.1.1"
 	compileInclude group: "commons-codec", name: "commons-codec", version: "1.10"
@@ -35,6 +34,7 @@ dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.9.9"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.9"
 	compileOnly group: "com.fasterxml.jackson.jaxrs", name: "jackson-jaxrs-json-provider", version: "2.9.8"
+	compileOnly group: "com.graphql-java", name: "graphql-java", version: "8.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "commons-fileupload", name: "commons-fileupload", version: "1.3.3"
@@ -64,7 +64,11 @@ deployDependencies {
 	from configurations.compileOnly
 
 	include "swagger-annotations-*.jar"
+	include "java-dataloader-*.jar"
+	include "reactive-streams-*.jar"
 	include "validation-api-*.jar"
+	include "graphql-java-8.0.jar"
+	include "antlr4-runtime-*.jar"
 }
 
 jar {

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -14,8 +14,11 @@
 
 package com.liferay.portal.vulcan.internal.graphql.servlet;
 
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+import com.liferay.portal.vulcan.internal.accept.language.AcceptLanguageImpl;
 
 import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.graphQLProcessors.GraphQLInputProcessor;
@@ -32,13 +35,16 @@ import graphql.annotations.processor.typeFunctions.DefaultTypeFunction;
 
 import graphql.schema.GraphQLSchema;
 
+import graphql.servlet.GraphQLContext;
 import graphql.servlet.SimpleGraphQLHttpServlet;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Dictionary;
+import java.util.Optional;
 
 import javax.servlet.Servlet;
+import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -163,6 +169,18 @@ public class GraphQLServletExtender {
 			Dictionary<String, Object> properties = new HashMapDictionary<>();
 
 			Class<? extends ServletData> clazz = servletData.getClass();
+
+			servletData.setAcceptLanguageFunction(
+				object -> {
+					GraphQLContext graphQLContext = (GraphQLContext)object;
+
+					Optional<HttpServletRequest> httpServletRequestOptional =
+						graphQLContext.getHttpServletRequest();
+
+					return new AcceptLanguageImpl(
+						httpServletRequestOptional.orElse(null),
+						LanguageUtil.getLanguage(), PortalUtil.getPortal());
+				});
 
 			String path = servletData.getPath();
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -190,7 +190,6 @@ public class GraphQLServletExtender {
 			helperProperties.put(
 				HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_SERVLET,
 				clazz.getName());
-			helperProperties.put("liferay.graphql.auth", true);
 
 			Collection<ServiceRegistration<?>> serviceRegistrations =
 				new ArrayList<>();

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/validation/BeanValidationInterceptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/validation/BeanValidationInterceptor.java
@@ -30,6 +30,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.ext.Provider;
 
+import com.liferay.portal.kernel.util.ListUtil;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.interceptor.InterceptorChain;
 import org.apache.cxf.jaxrs.lifecycle.ResourceProvider;
@@ -118,7 +119,7 @@ public class BeanValidationInterceptor
 		Message message, Object resourceInstance, Method method,
 		List<Object> arguments) {
 
-		if (arguments.isEmpty()) {
+		if (ListUtil.isEmpty(arguments)) {
 			return;
 		}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/validation/BeanValidationInterceptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/validation/BeanValidationInterceptor.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.vulcan.internal.jaxrs.validation;
 
+import com.liferay.portal.kernel.util.ListUtil;
+
 import java.io.IOException;
 
 import java.lang.reflect.Method;
@@ -30,7 +32,6 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.ext.Provider;
 
-import com.liferay.portal.kernel.util.ListUtil;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.interceptor.InterceptorChain;
 import org.apache.cxf.jaxrs.lifecycle.ResourceProvider;

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -97,6 +97,10 @@ public abstract class Base${schemaName}ResourceImpl implements ${schemaName}Reso
 		}
 	</#list>
 
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
 	}

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_mutation.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_mutation.ftl
@@ -96,6 +96,7 @@ public class Mutation {
 
 	<#list schemaNames as schemaName>
 		private void _populateResourceContext(${schemaName}Resource ${freeMarkerTool.getSchemaVarName(schemaName)}Resource) throws Exception {
+			${freeMarkerTool.getSchemaVarName(schemaName)}Resource.setContextAcceptLanguage(LocaleThreadLocal.getDefaultLocale());
 			${freeMarkerTool.getSchemaVarName(schemaName)}Resource.setContextCompany(CompanyLocalServiceUtil.getCompany(CompanyThreadLocal.getCompanyId()));
 		}
 	</#list>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_servlet_data.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_servlet_data.ftl
@@ -7,7 +7,10 @@ package ${configYAML.apiPackagePath}.internal.graphql.servlet.${escapedVersion};
 import ${configYAML.apiPackagePath}.internal.graphql.mutation.${escapedVersion}.Mutation;
 import ${configYAML.apiPackagePath}.internal.graphql.query.${escapedVersion}.Query;
 
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+
+import java.util.function.Function;
 
 import javax.annotation.Generated;
 
@@ -55,6 +58,17 @@ public class ServletDataImpl implements ServletData {
 	@Override
 	public Query getQuery() {
 		return new Query();
+	}
+
+	@Override
+	public void setAcceptLanguageFunction(
+		Function<Object, AcceptLanguage> acceptLanguageFunction) {
+		<#if querySchemaNames?has_content>
+			Query.setAcceptLanguageFunction(acceptLanguageFunction);
+		</#if>
+		<#if mutationSchemaNames?has_content>
+			Mutation.setAcceptLanguageFunction(acceptLanguageFunction);
+		</#if>
 	}
 
 	<#assign schemaNames = mutationSchemaNames />

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/resource.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/resource.ftl
@@ -7,6 +7,7 @@ package ${configYAML.apiPackagePath}.resource.${escapedVersion};
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -31,6 +32,8 @@ public interface ${schemaName}Resource {
 	<#list freeMarkerTool.getResourceJavaMethodSignatures(configYAML, openAPIYAML, schemaName) as javaMethodSignature>
 		public ${javaMethodSignature.returnType} ${javaMethodSignature.methodName}(${freeMarkerTool.getResourceParameters(javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, false)}) throws Exception;
 	</#list>
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage);
 
 	public void setContextCompany(Company contextCompany);
 


### PR DESCRIPTION
This depends on #74188.

I'm using the function to avoid adding a dependency in the API projects (to be able to cast to GraphQLContext) and to not expose AcceptLanguage constructors.

I'm afraid adding graphl-java is needed to be able to inject the DataFetchingEnvironment with the HttpRequest (unless we provide our own graphql-servlet). A compileInclude can't work because the library is doing a instanceOf check inside (portal-vulcan-impl != headless-api modules, or we change the classLoader). I can add the dependencies to the static module if this solution is valid.