### PR TITLE
LPS-96700 unique endpoint for graphql

### DIFF
--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/tracker/AuthVerifierFilterTracker.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/tracker/AuthVerifierFilterTracker.java
@@ -58,9 +58,9 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 @Component(
 	immediate = true,
 	property = {
-		"default.registration.property=filter.init.auth.verifier.BasicAuthHeaderAuthVerifier.urls.includes=/*",
+		"default.registration.property=filter.init.auth.verifier.BasicAuthHeaderAuthVerifier.urls.includes=*",
 		"default.registration.property=filter.init.auth.verifier.OAuth2RESTAuthVerifier.urls.includes=*",
-		"default.registration.property=filter.init.auth.verifier.PortalSessionAuthVerifier.urls.includes=/*",
+		"default.registration.property=filter.init.auth.verifier.PortalSessionAuthVerifier.urls.includes=*",
 		"default.registration.property=filter.init.guest.allowed=true",
 		"default.remote.access.filter.service.ranking:Integer=-10",
 		"default.whiteboard.property=" + HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_SERVLET + "=cxf-servlet",

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -14,7 +14,10 @@
 
 package com.liferay.portal.vulcan.internal.graphql.servlet;
 
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.graphQLProcessors.GraphQLInputProcessor;
 import graphql.annotations.processor.graphQLProcessors.GraphQLOutputProcessor;
 import graphql.annotations.processor.retrievers.GraphQLExtensionsHandler;
@@ -26,10 +29,27 @@ import graphql.annotations.processor.retrievers.GraphQLTypeRetriever;
 import graphql.annotations.processor.searchAlgorithms.BreadthFirstSearch;
 import graphql.annotations.processor.searchAlgorithms.ParentalSearch;
 import graphql.annotations.processor.typeFunctions.DefaultTypeFunction;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.StaticDataFetcher;
+import graphql.servlet.SimpleGraphQLHttpServlet;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.osgi.service.http.context.ServletContextHelper;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
+
+import javax.servlet.Servlet;
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.List;
 
 import static graphql.annotations.processor.util.NamingKit.toGraphqlName;
 
@@ -41,6 +61,8 @@ public class GraphQLServletExtender {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+
 		GraphQLFieldRetriever graphQLFieldRetriever =
 			new GraphQLFieldRetriever();
 		GraphQLInterfaceRetriever graphQLInterfaceRetriever =
@@ -126,15 +148,148 @@ public class GraphQLServletExtender {
 				},
 				helperProperties);
 
+		_activated = true;
+
+		rewire();
+	}
+
+	@Reference(
+		cardinality = ReferenceCardinality.MULTIPLE,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
+	protected synchronized void addServletData(ServletData servletData) {
+		_servletDataList.add(servletData);
+
+		rewire();
 	}
 
 	@Deactivate
 	protected void deactivate() {
+		_activated = false;
+
+		if (_servletServiceRegistration != null) {
+			try {
+				_servletServiceRegistration.unregister();
+			}
+			catch (Exception e) {
+			}
+		}
+
+		try {
+			_servletContextHelperServiceRegistration.unregister();
+		}
+		catch (Exception e) {
+		}
 	}
 
+	protected void registerServlet(GraphQLSchema.Builder schemaBuilder) {
+		Dictionary<String, Object> properties = new HashMapDictionary<>();
+
+		properties.put(
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME, "GraphQL");
+
+		properties.put(
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN, "/*");
+
+		properties.put(
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT, "GraphQL");
+
+		// Servlet
+
+		SimpleGraphQLHttpServlet.Builder servletBuilder =
+			SimpleGraphQLHttpServlet.newBuilder(schemaBuilder.build());
+
+		Servlet servlet = servletBuilder.build();
+
+		if (_servletServiceRegistration != null) {
+			try {
+				_servletServiceRegistration.unregister();
+			}
+			catch (Exception e) {
+			}
+		}
+
+		_servletServiceRegistration = _bundleContext.registerService(
+			Servlet.class, servlet, properties);
+	}
+
+	protected synchronized void removeServletData(ServletData servletData) {
+		_servletDataList.remove(servletData);
+
+		rewire();
+	}
+
+	protected synchronized void rewire() {
+		if (!_activated) {
+			return;
+		}
+
+		ProcessingElementsContainer processingElementsContainer =
+			new ProcessingElementsContainer(_defaultTypeFunction);
+
+		GraphQLSchema.Builder schemaBuilder = GraphQLSchema.newSchema();
+
+		GraphQLObjectType.Builder mutationBuilder =
+			GraphQLObjectType.newObject();
+
+		mutationBuilder = mutationBuilder.name("mutation");
+
+		GraphQLObjectType.Builder queryBuilder = GraphQLObjectType.newObject();
+
+		queryBuilder = queryBuilder.name("query");
+
+		for (ServletData servletData : _servletDataList) {
+
+			Object mutation = servletData.getMutation();
+
+			GraphQLObjectType mutationGraphQLObjectType =
+				_graphQLObjectHandler.getObject(
+					mutation.getClass(), processingElementsContainer);
+
+			mutationBuilder.field(
+				GraphQLFieldDefinition.newFieldDefinition(
+				).name(
+					servletData.getPath()
+				).type(
+					mutationGraphQLObjectType
+				).dataFetcherFactory(
+					StaticDataFetcher::new
+				)
+			).build();
+
+			Object query = servletData.getQuery();
+
+			GraphQLObjectType queryGraphQLObjectType =
+				_graphQLObjectHandler.getObject(
+					query.getClass(), processingElementsContainer);
+
+			queryBuilder.field(
+				GraphQLFieldDefinition.newFieldDefinition(
+				).name(
+					servletData.getPath()
+				).type(
+					queryGraphQLObjectType
+				).dataFetcherFactory(
+					StaticDataFetcher::new
+				)
+			).build();
+		}
+
+		schemaBuilder.mutation(mutationBuilder.build());
+		schemaBuilder.query(queryBuilder.build());
+
+		registerServlet(schemaBuilder);
+	}
+
+	private volatile boolean _activated;
+	private BundleContext _bundleContext;
 	private DefaultTypeFunction _defaultTypeFunction;
 	private GraphQLObjectHandler _graphQLObjectHandler;
 
 	private ServiceRegistration<ServletContextHelper>
 		_servletContextHelperServiceRegistration;
+	private final List<ServletData> _servletDataList = new ArrayList<>();
+	private volatile ServiceRegistration<Servlet> _servletServiceRegistration;
+
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -110,6 +110,21 @@ public class GraphQLServletExtender {
 			}
 		};
 
+		Dictionary<String, Object> helperProperties = new HashMapDictionary<>();
+
+		helperProperties.put(
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME, "GraphQL");
+		helperProperties.put(
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_PATH, "/graphql");
+		helperProperties.put(
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_SERVLET, "GraphQL");
+
+		_servletContextHelperServiceRegistration =
+			bundleContext.registerService(
+				ServletContextHelper.class,
+				new ServletContextHelper(bundleContext.getBundle()) {
+				},
+				helperProperties);
 
 	}
 
@@ -120,4 +135,6 @@ public class GraphQLServletExtender {
 	private DefaultTypeFunction _defaultTypeFunction;
 	private GraphQLObjectHandler _graphQLObjectHandler;
 
+	private ServiceRegistration<ServletContextHelper>
+		_servletContextHelperServiceRegistration;
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -80,14 +80,14 @@ public class GraphQLServletExtender {
 
 				@Override
 				public String getTypeName(Class<?> objectClass) {
-					GraphQLName name = objectClass.getAnnotation(
+					GraphQLName graphQLName = objectClass.getAnnotation(
 						GraphQLName.class);
 
-					if (name == null) {
+					if (graphQLName == null) {
 						return toGraphqlName(objectClass.getName());
 					}
 
-					return toGraphqlName(name.value());
+					return toGraphqlName(graphQLName.value());
 				}
 
 			};
@@ -134,13 +134,13 @@ public class GraphQLServletExtender {
 				}
 			});
 
-		Dictionary<String, Object> helperProperties = new HashMapDictionary<>();
+		Dictionary<String, Object> properties = new HashMapDictionary<>();
 
-		helperProperties.put(
+		properties.put(
 			HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME, "GraphQL");
-		helperProperties.put(
+		properties.put(
 			HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_PATH, "/graphql");
-		helperProperties.put(
+		properties.put(
 			HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_SERVLET, "GraphQL");
 
 		_servletContextHelperServiceRegistration =
@@ -148,7 +148,7 @@ public class GraphQLServletExtender {
 				ServletContextHelper.class,
 				new ServletContextHelper(bundleContext.getBundle()) {
 				},
-				helperProperties);
+				properties);
 
 		_activated = true;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -14,9 +14,12 @@
 
 package com.liferay.portal.vulcan.internal.graphql.servlet;
 
+import static graphql.annotations.processor.util.NamingKit.toGraphqlName;
+
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 
+import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.graphQLProcessors.GraphQLInputProcessor;
 import graphql.annotations.processor.graphQLProcessors.GraphQLOutputProcessor;
@@ -65,7 +68,21 @@ public class GraphQLServletExtender {
 			new GraphQLInterfaceRetriever();
 
 		GraphQLObjectInfoRetriever graphQLObjectInfoRetriever =
-			new GraphQLObjectInfoRetriever();
+			new GraphQLObjectInfoRetriever() {
+
+				@Override
+				public String getTypeName(Class<?> objectClass) {
+					GraphQLName name = objectClass.getAnnotation(
+						GraphQLName.class);
+
+					if (name == null) {
+						return toGraphqlName(objectClass.getName());
+					}
+
+					return toGraphqlName(name.value());
+				}
+
+			};
 
 		BreadthFirstSearch breadthFirstSearch = new BreadthFirstSearch(
 			graphQLObjectInfoRetriever);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -14,13 +14,7 @@
 
 package com.liferay.portal.vulcan.internal.graphql.servlet;
 
-import static graphql.annotations.processor.util.NamingKit.toGraphqlName;
-
-import com.liferay.portal.kernel.util.HashMapDictionary;
-import com.liferay.portal.vulcan.graphql.servlet.ServletData;
-
 import graphql.annotations.annotationTypes.GraphQLName;
-import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.graphQLProcessors.GraphQLInputProcessor;
 import graphql.annotations.processor.graphQLProcessors.GraphQLOutputProcessor;
 import graphql.annotations.processor.retrievers.GraphQLExtensionsHandler;
@@ -32,27 +26,12 @@ import graphql.annotations.processor.retrievers.GraphQLTypeRetriever;
 import graphql.annotations.processor.searchAlgorithms.BreadthFirstSearch;
 import graphql.annotations.processor.searchAlgorithms.ParentalSearch;
 import graphql.annotations.processor.typeFunctions.DefaultTypeFunction;
-
-import graphql.schema.GraphQLSchema;
-
-import graphql.servlet.SimpleGraphQLHttpServlet;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Dictionary;
-
-import javax.servlet.Servlet;
-
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceReference;
-import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.http.context.ServletContextHelper;
-import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
-import org.osgi.util.tracker.ServiceTracker;
-import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+import static graphql.annotations.processor.util.NamingKit.toGraphqlName;
 
 /**
  * @author Preston Crary
@@ -131,135 +110,14 @@ public class GraphQLServletExtender {
 			}
 		};
 
-		_serviceTracker = new ServiceTracker<>(
-			bundleContext, ServletData.class,
-			new ServletDataServiceTrackerCustomizer(bundleContext));
 
-		_serviceTracker.open();
 	}
 
 	@Deactivate
 	protected void deactivate() {
-		_serviceTracker.close();
 	}
 
 	private DefaultTypeFunction _defaultTypeFunction;
 	private GraphQLObjectHandler _graphQLObjectHandler;
-	private ServiceTracker<?, ?> _serviceTracker;
-
-	private class ServletDataServiceTrackerCustomizer
-		implements ServiceTrackerCustomizer
-			<ServletData, Collection<ServiceRegistration<?>>> {
-
-		@Override
-		public Collection<ServiceRegistration<?>> addingService(
-			ServiceReference<ServletData> serviceReference) {
-
-			// Schema
-
-			GraphQLSchema.Builder schemaBuilder = GraphQLSchema.newSchema();
-
-			ServletData servletData = _bundleContext.getService(
-				serviceReference);
-
-			Object mutation = servletData.getMutation();
-
-			ProcessingElementsContainer processingElementsContainer =
-				new ProcessingElementsContainer(_defaultTypeFunction);
-
-			schemaBuilder.mutation(
-				_graphQLObjectHandler.getObject(
-					mutation.getClass(), processingElementsContainer));
-
-			Object query = servletData.getQuery();
-
-			schemaBuilder.query(
-				_graphQLObjectHandler.getObject(
-					query.getClass(), processingElementsContainer));
-
-			Dictionary<String, Object> properties = new HashMapDictionary<>();
-
-			Class<? extends ServletData> clazz = servletData.getClass();
-
-			String path = servletData.getPath();
-
-			String servletContextName = path.split("/")[1];
-
-			properties.put(
-				HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME,
-				clazz.getName());
-
-			properties.put(
-				HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN, "/*");
-
-			properties.put(
-				HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT,
-				servletContextName);
-
-			Dictionary<String, Object> helperProperties =
-				new HashMapDictionary<>();
-
-			helperProperties.put(
-				HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME,
-				servletContextName);
-			helperProperties.put(
-				HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_PATH, path);
-			helperProperties.put(
-				HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_SERVLET,
-				clazz.getName());
-
-			Collection<ServiceRegistration<?>> serviceRegistrations =
-				new ArrayList<>();
-
-			serviceRegistrations.add(
-				_bundleContext.registerService(
-					ServletContextHelper.class,
-					new ServletContextHelper(_bundleContext.getBundle()) {
-					},
-					helperProperties));
-
-			// Servlet
-
-			SimpleGraphQLHttpServlet.Builder servletBuilder =
-				SimpleGraphQLHttpServlet.newBuilder(schemaBuilder.build());
-
-			Servlet servlet = servletBuilder.build();
-
-			serviceRegistrations.add(
-				_bundleContext.registerService(
-					Servlet.class, servlet, properties));
-
-			return serviceRegistrations;
-		}
-
-		@Override
-		public void modifiedService(
-			ServiceReference<ServletData> serviceReference,
-			Collection<ServiceRegistration<?>> serviceRegistrations) {
-		}
-
-		@Override
-		public void removedService(
-			ServiceReference<ServletData> serviceReference,
-			Collection<ServiceRegistration<?>> serviceRegistrations) {
-
-			for (ServiceRegistration<?> serviceRegistration :
-					serviceRegistrations) {
-
-				serviceRegistration.unregister();
-			}
-
-			_bundleContext.ungetService(serviceReference);
-		}
-
-		private ServletDataServiceTrackerCustomizer(
-			BundleContext bundleContext) {
-
-			_bundleContext = bundleContext;
-		}
-
-		private final BundleContext _bundleContext;
-
-	}
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -14,8 +14,12 @@
 
 package com.liferay.portal.vulcan.internal.graphql.servlet;
 
+import static graphql.annotations.processor.util.NamingKit.toGraphqlName;
+
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+
+import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.graphQLProcessors.GraphQLInputProcessor;
@@ -23,17 +27,27 @@ import graphql.annotations.processor.graphQLProcessors.GraphQLOutputProcessor;
 import graphql.annotations.processor.retrievers.GraphQLExtensionsHandler;
 import graphql.annotations.processor.retrievers.GraphQLFieldRetriever;
 import graphql.annotations.processor.retrievers.GraphQLInterfaceRetriever;
-import graphql.annotations.processor.retrievers.GraphQLObjectHandler;
 import graphql.annotations.processor.retrievers.GraphQLObjectInfoRetriever;
 import graphql.annotations.processor.retrievers.GraphQLTypeRetriever;
 import graphql.annotations.processor.searchAlgorithms.BreadthFirstSearch;
 import graphql.annotations.processor.searchAlgorithms.ParentalSearch;
 import graphql.annotations.processor.typeFunctions.DefaultTypeFunction;
+
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
-import graphql.schema.StaticDataFetcher;
+
 import graphql.servlet.SimpleGraphQLHttpServlet;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.servlet.Servlet;
+
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
@@ -45,13 +59,6 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.http.context.ServletContextHelper;
 import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
-
-import javax.servlet.Servlet;
-import java.util.ArrayList;
-import java.util.Dictionary;
-import java.util.List;
-
-import static graphql.annotations.processor.util.NamingKit.toGraphqlName;
 
 /**
  * @author Preston Crary
@@ -126,11 +133,6 @@ public class GraphQLServletExtender {
 					setGraphQLTypeRetriever(graphQLTypeRetriever);
 				}
 			});
-		_graphQLObjectHandler = new GraphQLObjectHandler() {
-			{
-				setTypeRetriever(graphQLTypeRetriever);
-			}
-		};
 
 		Dictionary<String, Object> helperProperties = new HashMapDictionary<>();
 
@@ -228,6 +230,9 @@ public class GraphQLServletExtender {
 		ProcessingElementsContainer processingElementsContainer =
 			new ProcessingElementsContainer(_defaultTypeFunction);
 
+		GraphQLFieldRetriever graphQLFieldRetriever =
+			new GraphQLFieldRetriever();
+
 		GraphQLSchema.Builder schemaBuilder = GraphQLSchema.newSchema();
 
 		GraphQLObjectType.Builder mutationBuilder =
@@ -235,58 +240,56 @@ public class GraphQLServletExtender {
 
 		mutationBuilder = mutationBuilder.name("mutation");
 
+		mutationBuilder.fields(
+			_getGraphQLFieldDefinitions(
+				processingElementsContainer, graphQLFieldRetriever,
+				ServletData::getMutation)
+		).build();
+
+		schemaBuilder.mutation(mutationBuilder.build());
+
 		GraphQLObjectType.Builder queryBuilder = GraphQLObjectType.newObject();
 
 		queryBuilder = queryBuilder.name("query");
 
-		for (ServletData servletData : _servletDataList) {
+		queryBuilder.fields(
+			_getGraphQLFieldDefinitions(
+				processingElementsContainer, graphQLFieldRetriever,
+				ServletData::getQuery)
+		).build();
 
-			Object mutation = servletData.getMutation();
-
-			GraphQLObjectType mutationGraphQLObjectType =
-				_graphQLObjectHandler.getObject(
-					mutation.getClass(), processingElementsContainer);
-
-			mutationBuilder.field(
-				GraphQLFieldDefinition.newFieldDefinition(
-				).name(
-					servletData.getPath()
-				).type(
-					mutationGraphQLObjectType
-				).dataFetcherFactory(
-					StaticDataFetcher::new
-				)
-			).build();
-
-			Object query = servletData.getQuery();
-
-			GraphQLObjectType queryGraphQLObjectType =
-				_graphQLObjectHandler.getObject(
-					query.getClass(), processingElementsContainer);
-
-			queryBuilder.field(
-				GraphQLFieldDefinition.newFieldDefinition(
-				).name(
-					servletData.getPath()
-				).type(
-					queryGraphQLObjectType
-				).dataFetcherFactory(
-					StaticDataFetcher::new
-				)
-			).build();
-		}
-
-		schemaBuilder.mutation(mutationBuilder.build());
 		schemaBuilder.query(queryBuilder.build());
 
 		registerServlet(schemaBuilder);
 	}
 
+	private List<GraphQLFieldDefinition> _getGraphQLFieldDefinitions(
+		ProcessingElementsContainer processingElementsContainer,
+		GraphQLFieldRetriever graphQLFieldRetriever,
+		Function<ServletData, Object> objectClassFunction) {
+
+		return _servletDataList.stream(
+		).map(
+			objectClassFunction
+		).map(
+			Object::getClass
+		).map(
+			Class::getMethods
+		).flatMap(
+			Arrays::stream
+		).filter(
+			method -> method.isAnnotationPresent(GraphQLField.class)
+		).map(
+			method -> graphQLFieldRetriever.getField(
+				method, processingElementsContainer)
+		).collect(
+			Collectors.toList()
+		);
+	}
+
 	private volatile boolean _activated;
 	private BundleContext _bundleContext;
 	private DefaultTypeFunction _defaultTypeFunction;
-	private GraphQLObjectHandler _graphQLObjectHandler;
-
 	private ServiceRegistration<ServletContextHelper>
 		_servletContextHelperServiceRegistration;
 	private final List<ServletData> _servletDataList = new ArrayList<>();


### PR DESCRIPTION
Use only one GraphQL endpoint for all the APIs. @pablo-agulla is thinking about how it makes more sense to version it (if URL, inside as a property...). That's why I haven't removed the path method in ServletData (it looks like it will be transformed in getVersion()).

/cc @csierra