### PR TITLE
LPS-96029 remove properties that are replaced by file values

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/KnowledgeBaseAttachmentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/KnowledgeBaseAttachmentResourceTest.java
@@ -68,11 +68,6 @@ public class KnowledgeBaseAttachmentResourceTest
 	}
 
 	@Override
-	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {"contentUrl", "encodingFormat", "title"};
-	}
-
-	@Override
 	protected Map<String, File> getMultipartFiles() throws Exception {
 		Map<String, File> files = new HashMap<>();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardAttachmentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardAttachmentResourceTest.java
@@ -67,11 +67,6 @@ public class MessageBoardAttachmentResourceTest
 	}
 
 	@Override
-	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {"contentUrl", "encodingFormat", "title"};
-	}
-
-	@Override
 	protected Map<String, File> getMultipartFiles() throws Exception {
 		Map<String, File> files = new HashMap<>();
 


### PR DESCRIPTION
These properties can't be validated by comparing randomMessageBoardAttachment and the received value because are override by getMultipartFiles()... those should be checked in the assertValid method that @ruben-pulido has to implement.