### PR TITLE
LPS-96558 Reduce heap usage of JspCompiler. Set -XDuseUnsharedTable o…

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspCompiler.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspCompiler.java
@@ -161,6 +161,8 @@ public class JspCompiler extends Jsr199JavaCompiler {
 		JspCompilationContext jspCompilationContext,
 		ErrorDispatcher errorDispatcher, boolean suppressLogging) {
 
+		options.add("-XDuseUnsharedTable");
+
 		Options options = jspCompilationContext.getOptions();
 
 		_classPath.add(options.getScratchDir());


### PR DESCRIPTION
…ption for jspc, since this creates a large soft reference cache that does not gets collected unless the system is close the OOM. This comes should make jspc slightly slower but frees up a considerable amount of memory afterwards.