### PR TITLE
LPS-96700 Unique endpoint graphql

### DIFF
--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/tracker/AuthVerifierFilterTracker.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/tracker/AuthVerifierFilterTracker.java
@@ -58,9 +58,9 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 @Component(
 	immediate = true,
 	property = {
-		"default.registration.property=filter.init.auth.verifier.BasicAuthHeaderAuthVerifier.urls.includes=/*",
+		"default.registration.property=filter.init.auth.verifier.BasicAuthHeaderAuthVerifier.urls.includes=*",
 		"default.registration.property=filter.init.auth.verifier.OAuth2RESTAuthVerifier.urls.includes=*",
-		"default.registration.property=filter.init.auth.verifier.PortalSessionAuthVerifier.urls.includes=/*",
+		"default.registration.property=filter.init.auth.verifier.PortalSessionAuthVerifier.urls.includes=*",
 		"default.registration.property=filter.init.guest.allowed=true",
 		"default.remote.access.filter.service.ranking:Integer=-10",
 		"default.whiteboard.property=" + HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_SERVLET + "=cxf-servlet",

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.internal.accept.language.AcceptLanguageImpl;
@@ -53,16 +54,20 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 
+import java.util.Dictionary;
 import java.util.Map;
 import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.http.context.ServletContextHelper;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 
 /**
  * @author Preston Crary
@@ -123,6 +128,22 @@ public class GraphQLServletExtender {
 		// GraphQLTypeRetriever
 
 		graphQLInterfaceRetriever.setGraphQLTypeRetriever(graphQLTypeRetriever);
+
+		Dictionary<String, Object> helperProperties = new HashMapDictionary<>();
+
+		helperProperties.put(
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME, "GraphQL");
+		helperProperties.put(
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_PATH, "/graphql");
+		helperProperties.put(
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_SERVLET, "GraphQL");
+
+		_servletContextHelperServiceRegistration =
+			bundleContext.registerService(
+				ServletContextHelper.class,
+				new ServletContextHelper(bundleContext.getBundle()) {
+				},
+				helperProperties);
 	}
 
 	@Deactivate
@@ -271,4 +292,6 @@ public class GraphQLServletExtender {
 
 	}
 
+	private ServiceRegistration<ServletContextHelper>
+		_servletContextHelperServiceRegistration;
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -23,14 +23,18 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 import com.liferay.portal.vulcan.internal.accept.language.AcceptLanguageImpl;
 
 import graphql.annotations.GraphQLFieldDefinitionWrapper;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.processor.ProcessingElementsContainer;
+import graphql.annotations.processor.graphQLProcessors.GraphQLInputProcessor;
+import graphql.annotations.processor.graphQLProcessors.GraphQLOutputProcessor;
 import graphql.annotations.processor.retrievers.GraphQLExtensionsHandler;
 import graphql.annotations.processor.retrievers.GraphQLFieldRetriever;
 import graphql.annotations.processor.retrievers.GraphQLInterfaceRetriever;
+import graphql.annotations.processor.retrievers.GraphQLObjectHandler;
 import graphql.annotations.processor.retrievers.GraphQLObjectInfoRetriever;
 import graphql.annotations.processor.retrievers.GraphQLTypeRetriever;
 import graphql.annotations.processor.retrievers.fieldBuilders.ArgumentBuilder;
@@ -40,24 +44,32 @@ import graphql.annotations.processor.retrievers.fieldBuilders.method.MethodNameB
 import graphql.annotations.processor.retrievers.fieldBuilders.method.MethodTypeBuilder;
 import graphql.annotations.processor.searchAlgorithms.BreadthFirstSearch;
 import graphql.annotations.processor.searchAlgorithms.ParentalSearch;
+import graphql.annotations.processor.typeFunctions.DefaultTypeFunction;
 import graphql.annotations.processor.util.NamingKit;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.StaticDataFetcher;
 
 import graphql.servlet.GraphQLContext;
+import graphql.servlet.SimpleGraphQLHttpServlet;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 
+import java.util.ArrayList;
 import java.util.Dictionary;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.framework.BundleContext;
@@ -66,6 +78,9 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.http.context.ServletContextHelper;
 import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 
@@ -77,6 +92,8 @@ public class GraphQLServletExtender {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+
 		GraphQLFieldRetriever graphQLFieldRetriever =
 			new LiferayGraphQLFieldRetriever();
 		GraphQLInterfaceRetriever graphQLInterfaceRetriever =
@@ -129,6 +146,23 @@ public class GraphQLServletExtender {
 
 		graphQLInterfaceRetriever.setGraphQLTypeRetriever(graphQLTypeRetriever);
 
+		_defaultTypeFunction = new DefaultTypeFunction(
+			new GraphQLInputProcessor() {
+				{
+					setGraphQLTypeRetriever(graphQLTypeRetriever);
+				}
+			},
+			new GraphQLOutputProcessor() {
+				{
+					setGraphQLTypeRetriever(graphQLTypeRetriever);
+				}
+			});
+		_graphQLObjectHandler = new GraphQLObjectHandler() {
+			{
+				setTypeRetriever(graphQLTypeRetriever);
+			}
+		};
+
 		Dictionary<String, Object> helperProperties = new HashMapDictionary<>();
 
 		helperProperties.put(
@@ -144,10 +178,138 @@ public class GraphQLServletExtender {
 				new ServletContextHelper(bundleContext.getBundle()) {
 				},
 				helperProperties);
+
+		_activated = true;
+
+		rewire();
+	}
+
+	@Reference(
+		cardinality = ReferenceCardinality.MULTIPLE,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
+	protected synchronized void addServletData(ServletData servletData) {
+		_servletDataList.add(servletData);
+
+		rewire();
 	}
 
 	@Deactivate
 	protected void deactivate() {
+		_activated = false;
+
+		if (_servletServiceRegistration != null) {
+			try {
+				_servletServiceRegistration.unregister();
+			}
+			catch (Exception e) {
+			}
+		}
+
+		try {
+			_servletContextHelperServiceRegistration.unregister();
+		}
+		catch (Exception e) {
+		}
+	}
+
+	protected void registerServlet(GraphQLSchema.Builder schemaBuilder) {
+		Dictionary<String, Object> properties = new HashMapDictionary<>();
+
+		properties.put(
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME, "GraphQL");
+
+		properties.put(
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN, "/*");
+
+		properties.put(
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT, "GraphQL");
+
+		// Servlet
+
+		SimpleGraphQLHttpServlet.Builder servletBuilder =
+			SimpleGraphQLHttpServlet.newBuilder(schemaBuilder.build());
+
+		Servlet servlet = servletBuilder.build();
+
+		if (_servletServiceRegistration != null) {
+			try {
+				_servletServiceRegistration.unregister();
+			}
+			catch (Exception e) {
+			}
+		}
+
+		_servletServiceRegistration = _bundleContext.registerService(
+			Servlet.class, servlet, properties);
+	}
+
+	protected synchronized void removeServletData(ServletData servletData) {
+		_servletDataList.remove(servletData);
+
+		rewire();
+	}
+
+	protected synchronized void rewire() {
+		if (!_activated) {
+			return;
+		}
+
+		ProcessingElementsContainer processingElementsContainer =
+			new ProcessingElementsContainer(_defaultTypeFunction);
+
+		GraphQLSchema.Builder schemaBuilder = GraphQLSchema.newSchema();
+
+		GraphQLObjectType.Builder mutationBuilder =
+			GraphQLObjectType.newObject();
+
+		mutationBuilder = mutationBuilder.name("mutation");
+
+		GraphQLObjectType.Builder queryBuilder = GraphQLObjectType.newObject();
+
+		queryBuilder = queryBuilder.name("query");
+
+		for (ServletData servletData : _servletDataList) {
+			Object mutation = servletData.getMutation();
+
+			GraphQLObjectType mutationGraphQLObjectType =
+				_graphQLObjectHandler.getObject(
+					mutation.getClass(), processingElementsContainer);
+
+			mutationBuilder.field(
+				GraphQLFieldDefinition.newFieldDefinition(
+				).name(
+					servletData.getPath()
+				).type(
+					mutationGraphQLObjectType
+				).dataFetcherFactory(
+					StaticDataFetcher::new
+				)
+			).build();
+
+			Object query = servletData.getQuery();
+
+			GraphQLObjectType queryGraphQLObjectType =
+				_graphQLObjectHandler.getObject(
+					query.getClass(), processingElementsContainer);
+
+			queryBuilder.field(
+				GraphQLFieldDefinition.newFieldDefinition(
+				).name(
+					servletData.getPath()
+				).type(
+					queryGraphQLObjectType
+				).dataFetcherFactory(
+					StaticDataFetcher::new
+				)
+			).build();
+		}
+
+		schemaBuilder.mutation(mutationBuilder.build());
+		schemaBuilder.query(queryBuilder.build());
+
+		registerServlet(schemaBuilder);
 	}
 
 	private Object _get(
@@ -218,14 +380,25 @@ public class GraphQLServletExtender {
 		return method.invoke(instance, args);
 	}
 
+	private volatile boolean _activated;
+	private BundleContext _bundleContext;
+
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	private DefaultTypeFunction _defaultTypeFunction;
+	private GraphQLObjectHandler _graphQLObjectHandler;
 
 	@Reference
 	private Language _language;
 
 	@Reference
 	private Portal _portal;
+
+	private ServiceRegistration<ServletContextHelper>
+		_servletContextHelperServiceRegistration;
+	private final List<ServletData> _servletDataList = new ArrayList<>();
+	private volatile ServiceRegistration<Servlet> _servletServiceRegistration;
 
 	private class LiferayGraphQLFieldRetriever extends GraphQLFieldRetriever {
 
@@ -292,6 +465,4 @@ public class GraphQLServletExtender {
 
 	}
 
-	private ServiceRegistration<ServletContextHelper>
-		_servletContextHelperServiceRegistration;
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.vulcan.internal.graphql.servlet;
 
+import static graphql.annotations.processor.util.NamingKit.toGraphqlName;
+
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
@@ -94,7 +96,21 @@ public class GraphQLServletExtender {
 			new GraphQLInterfaceRetriever();
 
 		GraphQLObjectInfoRetriever graphQLObjectInfoRetriever =
-			new GraphQLObjectInfoRetriever();
+			new GraphQLObjectInfoRetriever() {
+
+				@Override
+				public String getTypeName(Class<?> objectClass) {
+					GraphQLName name = objectClass.getAnnotation(
+						GraphQLName.class);
+
+					if (name == null) {
+						return toGraphqlName(objectClass.getName());
+					}
+
+					return toGraphqlName(name.value());
+				}
+
+			};
 
 		BreadthFirstSearch breadthFirstSearch = new BreadthFirstSearch(
 			graphQLObjectInfoRetriever);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -106,14 +106,14 @@ public class GraphQLServletExtender {
 
 				@Override
 				public String getTypeName(Class<?> objectClass) {
-					GraphQLName name = objectClass.getAnnotation(
+					GraphQLName graphQLName = objectClass.getAnnotation(
 						GraphQLName.class);
 
-					if (name == null) {
+					if (graphQLName == null) {
 						return toGraphqlName(objectClass.getName());
 					}
 
-					return toGraphqlName(name.value());
+					return toGraphqlName(graphQLName.value());
 				}
 
 			};
@@ -160,13 +160,13 @@ public class GraphQLServletExtender {
 				}
 			});
 
-		Dictionary<String, Object> helperProperties = new HashMapDictionary<>();
+		Dictionary<String, Object> properties = new HashMapDictionary<>();
 
-		helperProperties.put(
+		properties.put(
 			HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME, "GraphQL");
-		helperProperties.put(
+		properties.put(
 			HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_PATH, "/graphql");
-		helperProperties.put(
+		properties.put(
 			HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_SERVLET, "GraphQL");
 
 		_servletContextHelperServiceRegistration =
@@ -174,7 +174,7 @@ public class GraphQLServletExtender {
 				ServletContextHelper.class,
 				new ServletContextHelper(bundleContext.getBundle()) {
 				},
-				helperProperties);
+				properties);
 
 		_activated = true;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -27,6 +27,7 @@ import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 import com.liferay.portal.vulcan.internal.accept.language.AcceptLanguageImpl;
 
 import graphql.annotations.GraphQLFieldDefinitionWrapper;
+import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.graphQLProcessors.GraphQLInputProcessor;
@@ -34,7 +35,6 @@ import graphql.annotations.processor.graphQLProcessors.GraphQLOutputProcessor;
 import graphql.annotations.processor.retrievers.GraphQLExtensionsHandler;
 import graphql.annotations.processor.retrievers.GraphQLFieldRetriever;
 import graphql.annotations.processor.retrievers.GraphQLInterfaceRetriever;
-import graphql.annotations.processor.retrievers.GraphQLObjectHandler;
 import graphql.annotations.processor.retrievers.GraphQLObjectInfoRetriever;
 import graphql.annotations.processor.retrievers.GraphQLTypeRetriever;
 import graphql.annotations.processor.retrievers.fieldBuilders.ArgumentBuilder;
@@ -53,7 +53,6 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
-import graphql.schema.StaticDataFetcher;
 
 import graphql.servlet.GraphQLContext;
 import graphql.servlet.SimpleGraphQLHttpServlet;
@@ -64,10 +63,13 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletRequest;
@@ -157,11 +159,6 @@ public class GraphQLServletExtender {
 					setGraphQLTypeRetriever(graphQLTypeRetriever);
 				}
 			});
-		_graphQLObjectHandler = new GraphQLObjectHandler() {
-			{
-				setTypeRetriever(graphQLTypeRetriever);
-			}
-		};
 
 		Dictionary<String, Object> helperProperties = new HashMapDictionary<>();
 
@@ -259,6 +256,9 @@ public class GraphQLServletExtender {
 		ProcessingElementsContainer processingElementsContainer =
 			new ProcessingElementsContainer(_defaultTypeFunction);
 
+		GraphQLFieldRetriever graphQLFieldRetriever =
+			new GraphQLFieldRetriever();
+
 		GraphQLSchema.Builder schemaBuilder = GraphQLSchema.newSchema();
 
 		GraphQLObjectType.Builder mutationBuilder =
@@ -266,47 +266,24 @@ public class GraphQLServletExtender {
 
 		mutationBuilder = mutationBuilder.name("mutation");
 
+		mutationBuilder.fields(
+			_getGraphQLFieldDefinitions(
+				processingElementsContainer, graphQLFieldRetriever,
+				ServletData::getMutation)
+		).build();
+
+		schemaBuilder.mutation(mutationBuilder.build());
+
 		GraphQLObjectType.Builder queryBuilder = GraphQLObjectType.newObject();
 
 		queryBuilder = queryBuilder.name("query");
 
-		for (ServletData servletData : _servletDataList) {
-			Object mutation = servletData.getMutation();
+		queryBuilder.fields(
+			_getGraphQLFieldDefinitions(
+				processingElementsContainer, graphQLFieldRetriever,
+				ServletData::getQuery)
+		).build();
 
-			GraphQLObjectType mutationGraphQLObjectType =
-				_graphQLObjectHandler.getObject(
-					mutation.getClass(), processingElementsContainer);
-
-			mutationBuilder.field(
-				GraphQLFieldDefinition.newFieldDefinition(
-				).name(
-					servletData.getPath()
-				).type(
-					mutationGraphQLObjectType
-				).dataFetcherFactory(
-					StaticDataFetcher::new
-				)
-			).build();
-
-			Object query = servletData.getQuery();
-
-			GraphQLObjectType queryGraphQLObjectType =
-				_graphQLObjectHandler.getObject(
-					query.getClass(), processingElementsContainer);
-
-			queryBuilder.field(
-				GraphQLFieldDefinition.newFieldDefinition(
-				).name(
-					servletData.getPath()
-				).type(
-					queryGraphQLObjectType
-				).dataFetcherFactory(
-					StaticDataFetcher::new
-				)
-			).build();
-		}
-
-		schemaBuilder.mutation(mutationBuilder.build());
 		schemaBuilder.query(queryBuilder.build());
 
 		registerServlet(schemaBuilder);
@@ -380,6 +357,30 @@ public class GraphQLServletExtender {
 		return method.invoke(instance, args);
 	}
 
+	private List<GraphQLFieldDefinition> _getGraphQLFieldDefinitions(
+		ProcessingElementsContainer processingElementsContainer,
+		GraphQLFieldRetriever graphQLFieldRetriever,
+		Function<ServletData, Object> objectClassFunction) {
+
+		return _servletDataList.stream(
+		).map(
+			objectClassFunction
+		).map(
+			Object::getClass
+		).map(
+			Class::getMethods
+		).flatMap(
+			Arrays::stream
+		).filter(
+			method -> method.isAnnotationPresent(GraphQLField.class)
+		).map(
+			method -> graphQLFieldRetriever.getField(
+				method, processingElementsContainer)
+		).collect(
+			Collectors.toList()
+		);
+	}
+
 	private volatile boolean _activated;
 	private BundleContext _bundleContext;
 
@@ -387,7 +388,6 @@ public class GraphQLServletExtender {
 	private CompanyLocalService _companyLocalService;
 
 	private DefaultTypeFunction _defaultTypeFunction;
-	private GraphQLObjectHandler _graphQLObjectHandler;
 
 	@Reference
 	private Language _language;


### PR DESCRIPTION
Rebased :)

Use only one GraphQL endpoint for all the APIs. @pablo-agulla is thinking about how it makes more sense to version it (if URL, inside as a property...). That's why I haven't removed the path method in ServletData (it looks like it will be transformed in getVersion()).