### PR TITLE
LPS-96832 Disable ImageIO disk cache by default to reduce IO operations.

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5395,7 +5395,7 @@
     #
     # Env: LIFERAY_IMAGE_PERIOD_IO_PERIOD_USE_PERIOD_DISK_PERIOD_CACHE
     #
-    image.io.use.disk.cache=true
+    image.io.use.disk.cache=false
 
     #
     # Set the maximum image height and width in pixels that can be read by the


### PR DESCRIPTION
@slnn this should reduce some file creation.