### PR TITLE
LPS-96881 Add support for sort fields when entityModel is not provided

### DIFF
--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/sort/SortField.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/sort/SortField.java
@@ -40,8 +40,22 @@ public class SortField implements Serializable {
 			throw new IllegalArgumentException("Entity field is null");
 		}
 
-		_asc = asc;
 		_entityField = entityField;
+		_asc = asc;
+		_fieldName = entityField.getName();
+	}
+
+	/**
+	 * Creates a new sort field not linked to a entityField
+	 *
+	 * @param  fieldName the entity field name
+	 * @param  asc whether the sort should be ascending
+	 * @review
+	 */
+	public SortField(String fieldName, boolean asc) {
+		_fieldName = fieldName;
+		_asc = asc;
+		_entityField = null;
 	}
 
 	/**
@@ -52,6 +66,10 @@ public class SortField implements Serializable {
 	 * @review
 	 */
 	public String getSortableFieldName(Locale locale) {
+		if (_entityField == null) {
+			return _fieldName;
+		}
+
 		return _entityField.getSortableName(locale);
 	}
 
@@ -68,5 +86,6 @@ public class SortField implements Serializable {
 
 	private final boolean _asc;
 	private final EntityField _entityField;
+	private final String _fieldName;
 
 }

--- a/modules/apps/portal-odata/portal-odata-api/src/main/resources/com/liferay/portal/odata/sort/packageinfo
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/resources/com/liferay/portal/odata/sort/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/sort/SortParserImpl.java
+++ b/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/sort/SortParserImpl.java
@@ -146,6 +146,10 @@ public class SortParserImpl implements SortParser {
 			ascending = _ASC_DEFAULT;
 		}
 
+		if (_entityModel == null) {
+			return Optional.of(new SortField(fieldName, ascending));
+		}
+
 		Optional<EntityField> entityFieldOptional = getEntityFieldOptional(
 			_entityModel.getEntityFieldsMap(), fieldName);
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/SortContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/SortContextProvider.java
@@ -83,12 +83,10 @@ public class SortContextProvider implements ContextProvider<Sort[]> {
 
 		EntityModel entityModel = ContextProviderUtil.getEntityModel(message);
 
-		if (entityModel == null) {
-			return null;
-		}
-
 		if (_log.isDebugEnabled()) {
-			_log.debug("OData entity model name: " + entityModel.getName());
+			if (entityModel != null) {
+				_log.debug("OData entity model name: " + entityModel.getName());
+			}
 		}
 
 		SortParser sortParser = _sortParserProvider.provide(entityModel);


### PR DESCRIPTION
This way all APIs can use the sort parameter instead of inventing a new one.