### PR TITLE
LPS-95798 portal-search-web: Remove portlet id parameter on search

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/search_bar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/search_bar.js
@@ -1,8 +1,6 @@
 AUI.add(
 	'liferay-search-bar',
 	function(A) {
-		var FacetUtil = Liferay.Search.FacetUtil;
-
 		var SearchBar = function(form) {
 			var instance = this;
 
@@ -16,7 +14,8 @@ AUI.add(
 
 			if (emptySearchInput.val() === 'true') {
 				instance.emptySearchEnabled = true;
-			} else {
+			}
+			else {
 				instance.emptySearchEnabled = false;
 			}
 
@@ -71,59 +70,34 @@ AUI.add(
 			updateQueryString: function(queryString) {
 				var instance = this;
 
-				var hasQuestionMark = false;
+				var searchParams = new URLSearchParams(queryString);
 
-				if (queryString[0] === '?') {
-					hasQuestionMark = true;
-				}
-
-				queryString = FacetUtil.updateQueryString(
+				searchParams.set(
 					instance.keywordsInput.get('name'),
-					[instance.getKeywords()],
-					queryString
+					instance.getKeywords()
 				);
+				searchParams.delete('p_p_id');
+				searchParams.delete('p_p_state');
+
 
 				if (instance.scopeSelect) {
-					queryString = FacetUtil.updateQueryString(
+					searchParams.set(
 						instance.scopeSelect.get('name'),
-						[instance.scopeSelect.val()],
-						queryString
+						instance.scopeSelect.val(),
 					);
 				}
 
-				if (hasQuestionMark) {
-					var parts = queryString.split('?');
-
-					queryString = parts[1];
-
-					hasQuestionMark = false;
-				}
-
-				var parameterArray = queryString.split('&');
-
-				parameterArray = FacetUtil.removeURLParameters(
-					'start',
-					parameterArray
-				);
+				searchParams.delete('start');
 
 				if (instance.resetStartPage) {
 					var resetStartPageName = instance.resetStartPage.get(
 						'name'
 					);
 
-					parameterArray = FacetUtil.removeURLParameters(
-						resetStartPageName,
-						parameterArray
-					);
+					searchParams.delete(resetStartPageName);
 				}
 
-				queryString = parameterArray.join('&');
-
-				if (!hasQuestionMark) {
-					queryString = '?' + queryString;
-				}
-
-				return queryString;
+				return '?' + searchParams.toString();
 			},
 
 			_onClick: function(event) {
@@ -143,8 +117,5 @@ AUI.add(
 
 		Liferay.namespace('Search').SearchBar = SearchBar;
 	},
-	'',
-	{
-		requires: ['liferay-search-facet-util']
-	}
+	''
 );

--- a/modules/apps/portal-search/portal-search-web/test/search_bar_test.js
+++ b/modules/apps/portal-search/portal-search-web/test/search_bar_test.js
@@ -90,4 +90,30 @@ describe('Liferay.Search.SearchBar', function() {
 			)
 		);
 	});
+
+	describe(
+		'.updateQueryString',
+		function() {
+			it(
+				'should remove p_p_id, p_p_state, start and add query keyword',
+				withAlloyUI(
+					function (done, A) {
+						var form = A.Node.create(getFormTemplate('example'));
+
+						var searchBar = new Liferay.Search.SearchBar(form);
+
+						var queryString = '?p_p_lifecycle=0&p_p_mode=view&p_p_id=com_liferay_portal_search_web_search_bar_portlet_SearchBarPortlet&p_p_state=maximized&start=1';
+
+						queryString = searchBar.updateQueryString(queryString);
+
+						assert.equal(queryString, '?p_p_lifecycle=0&p_p_mode=view&q=example');
+
+						done();
+
+					},
+					['aui-node', 'liferay-search-bar']
+				)
+			);
+		}
+	);
 });


### PR DESCRIPTION
<h3>:x: ci:test:search - 18 out of 21 jobs passed in 1 hour 18 minutes 17 seconds 619 ms</h3>

https://github.com/brandizzi/liferay-portal/pull/765#issuecomment-502867270

Only unique failure is happening in other, unrelated pull requests, and is a rebase problem. It is reasonable to think it is unrelated then.

Author: @lipusz
Reviewer: @foshiro

[Bug] Search bar doesn't work after opening a element from a previous search