### PR TITLE
LPS-97016 Update Liferay.Language.get regex to tolerate line breaks

### DIFF
--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -1974,7 +1974,8 @@ public class LanguageImpl implements Language, Serializable {
 	private static PortalCache<Long, Serializable> _groupLocalesPortalCache;
 	private static volatile long _lastModified = System.currentTimeMillis();
 	private static final Pattern _pattern = Pattern.compile(
-		"Liferay\\s*\\.\\s*Language\\s*\\.\\s*get\\s*\\(\\s*[\"']([^)]+)[\"']\\s*\\)",
+		"Liferay\\s*\\.\\s*Language\\s*\\.\\s*get\\s*" +
+			"\\(\\s*[\"']([^)]+)[\"']\\s*\\)",
 		Pattern.MULTILINE);
 
 	private static final Synchronizer<Long, Serializable> _removeSynchronizer =

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -1974,7 +1974,8 @@ public class LanguageImpl implements Language, Serializable {
 	private static PortalCache<Long, Serializable> _groupLocalesPortalCache;
 	private static volatile long _lastModified = System.currentTimeMillis();
 	private static final Pattern _pattern = Pattern.compile(
-		"Liferay\\.Language\\.get\\([\"']([^)]+)[\"']\\)");
+		"Liferay\\s*\\.\\s*Language\\s*\\.\\s*get\\s*\\(\\s*[\"']([^)]+)[\"']\\s*\\)",
+		Pattern.MULTILINE);
 
 	private static final Synchronizer<Long, Serializable> _removeSynchronizer =
 		new Synchronizer<Long, Serializable>() {


### PR DESCRIPTION
This addresses the problem raised [here](https://github.com/brianchandotcom/liferay-portal/pull/74563#issuecomment-502770104).

Prettier will break long lines, so the cleanest way to avoid conflict with our `Liferay.Language.get()` substitution is to make it tolerate the line breaks.

Browser network tab shows that the substitution is working even in a file where the call to `Liferay.Language.get()` is split over multiple lines:

<img width="626" alt="Web_Content_-_Liferay_and_liferay-portal___nvim" src="https://user-images.githubusercontent.com/7074/59682054-b0b19380-91d5-11e9-8f99-70b6fd798881.png">