### PR TITLE
LPS-96949 Generated

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/AffectedEntryResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/AffectedEntryResource.java
@@ -36,7 +36,7 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface AffectedEntryResource {
 
-	public Page<AffectedEntry> getAffectedEntry(
+	public Page<AffectedEntry> getEntryAffectedEntriesPage(
 			Long entryId, String keywords, Pagination pagination)
 		throws Exception;
 

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/resource/v1_0/AffectedEntryResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/resource/v1_0/AffectedEntryResource.java
@@ -36,11 +36,11 @@ public interface AffectedEntryResource {
 		return new Builder();
 	}
 
-	public Page<AffectedEntry> getAffectedEntry(
+	public Page<AffectedEntry> getEntryAffectedEntriesPage(
 			Long entryId, String keywords, Pagination pagination)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse getAffectedEntryHttpResponse(
+	public HttpInvoker.HttpResponse getEntryAffectedEntriesPageHttpResponse(
 			Long entryId, String keywords, Pagination pagination)
 		throws Exception;
 
@@ -86,12 +86,13 @@ public interface AffectedEntryResource {
 	public static class AffectedEntryResourceImpl
 		implements AffectedEntryResource {
 
-		public Page<AffectedEntry> getAffectedEntry(
+		public Page<AffectedEntry> getEntryAffectedEntriesPage(
 				Long entryId, String keywords, Pagination pagination)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getAffectedEntryHttpResponse(entryId, keywords, pagination);
+				getEntryAffectedEntriesPageHttpResponse(
+					entryId, keywords, pagination);
 
 			String content = httpResponse.getContent();
 
@@ -104,7 +105,7 @@ public interface AffectedEntryResource {
 			return Page.of(content, AffectedEntrySerDes::toDTO);
 		}
 
-		public HttpInvoker.HttpResponse getAffectedEntryHttpResponse(
+		public HttpInvoker.HttpResponse getEntryAffectedEntriesPageHttpResponse(
 				Long entryId, String keywords, Pagination pagination)
 			throws Exception {
 
@@ -131,7 +132,7 @@ public interface AffectedEntryResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/change-tracking/v1.0/affected-entries/{entryId}",
+						"/o/change-tracking/v1.0/entries/{entryId}/affected-entries",
 				entryId);
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
@@ -148,46 +148,6 @@ info:
     version: v1.0
 openapi: 3.0.1
 paths:
-    "/affected-entries/{entryId}":
-        get:
-            operationId: getAffectedEntry
-            parameters:
-                - in: path
-                  name: entryId
-                  required: true
-                  schema:
-                      format: int64
-                      type: integer
-                - in: query
-                  name: keywords
-                  required: false
-                  schema:
-                      type: string
-                - in: query
-                  name: page
-                  required: false
-                  schema:
-                      type: integer
-                - in: query
-                  name: pageSize
-                  required: false
-                  schema:
-                      type: integer
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/AffectedEntry"
-                                type: array
-                        application/xml:
-                            schema:
-                                items:
-                                    $ref: "#/components/schemas/AffectedEntry"
-                                type: array
-                    description: ""
-            tags: ["AffectedEntry"]
     "/collections":
         get:
             operationId: getCollectionsPage
@@ -487,6 +447,46 @@ paths:
                                 $ref: "#/components/schemas/Entry"
                     description: ""
             tags: ["Entry"]
+    "/entries/{entryId}/affected-entries":
+        get:
+            operationId: getEntryAffectedEntriesPage
+            parameters:
+                - in: path
+                  name: entryId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: query
+                  name: keywords
+                  required: false
+                  schema:
+                      type: string
+                - in: query
+                  name: page
+                  required: false
+                  schema:
+                      type: integer
+                - in: query
+                  name: pageSize
+                  required: false
+                  schema:
+                      type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/AffectedEntry"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/AffectedEntry"
+                                type: array
+                    description: ""
+            tags: ["AffectedEntry"]
     "/processes":
         get:
             operationId: getProcessesPage

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/graphql/query/v1_0/Query.java
@@ -99,7 +99,7 @@ public class Query {
 
 	@GraphQLField
 	@GraphQLInvokeDetached
-	public java.util.Collection<AffectedEntry> getAffectedEntry(
+	public java.util.Collection<AffectedEntry> getEntryAffectedEntriesPage(
 			@GraphQLName("entryId") Long entryId,
 			@GraphQLName("keywords") String keywords,
 			@GraphQLName("pageSize") int pageSize,
@@ -110,8 +110,9 @@ public class Query {
 			_affectedEntryResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			affectedEntryResource -> {
-				Page paginationPage = affectedEntryResource.getAffectedEntry(
-					entryId, keywords, Pagination.of(pageSize, page));
+				Page paginationPage =
+					affectedEntryResource.getEntryAffectedEntriesPage(
+						entryId, keywords, Pagination.of(pageSize, page));
 
 				return paginationPage.getItems();
 			});

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseAffectedEntryResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseAffectedEntryResourceImpl.java
@@ -64,10 +64,10 @@ public abstract class BaseAffectedEntryResourceImpl
 			@Parameter(in = ParameterIn.QUERY, name = "pageSize")
 		}
 	)
-	@Path("/affected-entries/{entryId}")
+	@Path("/entries/{entryId}/affected-entries")
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AffectedEntry")})
-	public Page<AffectedEntry> getAffectedEntry(
+	public Page<AffectedEntry> getEntryAffectedEntriesPage(
 			@NotNull @Parameter(hidden = true) @PathParam("entryId") Long
 				entryId,
 			@Parameter(hidden = true) @QueryParam("keywords") String keywords,

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseAffectedEntryResourceTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseAffectedEntryResourceTestCase.java
@@ -185,22 +185,24 @@ public abstract class BaseAffectedEntryResourceTestCase {
 	}
 
 	@Test
-	public void testGetAffectedEntry() throws Exception {
-		Page<AffectedEntry> page = affectedEntryResource.getAffectedEntry(
-			testGetAffectedEntry_getEntryId(), RandomTestUtil.randomString(),
-			Pagination.of(1, 2));
+	public void testGetEntryAffectedEntriesPage() throws Exception {
+		Page<AffectedEntry> page =
+			affectedEntryResource.getEntryAffectedEntriesPage(
+				testGetEntryAffectedEntriesPage_getEntryId(),
+				RandomTestUtil.randomString(), Pagination.of(1, 2));
 
 		Assert.assertEquals(0, page.getTotalCount());
 
-		Long entryId = testGetAffectedEntry_getEntryId();
-		Long irrelevantEntryId = testGetAffectedEntry_getIrrelevantEntryId();
+		Long entryId = testGetEntryAffectedEntriesPage_getEntryId();
+		Long irrelevantEntryId =
+			testGetEntryAffectedEntriesPage_getIrrelevantEntryId();
 
 		if ((irrelevantEntryId != null)) {
 			AffectedEntry irrelevantAffectedEntry =
-				testGetAffectedEntry_addAffectedEntry(
+				testGetEntryAffectedEntriesPage_addAffectedEntry(
 					irrelevantEntryId, randomIrrelevantAffectedEntry());
 
-			page = affectedEntryResource.getAffectedEntry(
+			page = affectedEntryResource.getEntryAffectedEntriesPage(
 				irrelevantEntryId, null, Pagination.of(1, 2));
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -211,13 +213,15 @@ public abstract class BaseAffectedEntryResourceTestCase {
 			assertValid(page);
 		}
 
-		AffectedEntry affectedEntry1 = testGetAffectedEntry_addAffectedEntry(
-			entryId, randomAffectedEntry());
+		AffectedEntry affectedEntry1 =
+			testGetEntryAffectedEntriesPage_addAffectedEntry(
+				entryId, randomAffectedEntry());
 
-		AffectedEntry affectedEntry2 = testGetAffectedEntry_addAffectedEntry(
-			entryId, randomAffectedEntry());
+		AffectedEntry affectedEntry2 =
+			testGetEntryAffectedEntriesPage_addAffectedEntry(
+				entryId, randomAffectedEntry());
 
-		page = affectedEntryResource.getAffectedEntry(
+		page = affectedEntryResource.getEntryAffectedEntriesPage(
 			entryId, null, Pagination.of(1, 2));
 
 		Assert.assertEquals(2, page.getTotalCount());
@@ -229,20 +233,26 @@ public abstract class BaseAffectedEntryResourceTestCase {
 	}
 
 	@Test
-	public void testGetAffectedEntryWithPagination() throws Exception {
-		Long entryId = testGetAffectedEntry_getEntryId();
+	public void testGetEntryAffectedEntriesPageWithPagination()
+		throws Exception {
 
-		AffectedEntry affectedEntry1 = testGetAffectedEntry_addAffectedEntry(
-			entryId, randomAffectedEntry());
+		Long entryId = testGetEntryAffectedEntriesPage_getEntryId();
 
-		AffectedEntry affectedEntry2 = testGetAffectedEntry_addAffectedEntry(
-			entryId, randomAffectedEntry());
+		AffectedEntry affectedEntry1 =
+			testGetEntryAffectedEntriesPage_addAffectedEntry(
+				entryId, randomAffectedEntry());
 
-		AffectedEntry affectedEntry3 = testGetAffectedEntry_addAffectedEntry(
-			entryId, randomAffectedEntry());
+		AffectedEntry affectedEntry2 =
+			testGetEntryAffectedEntriesPage_addAffectedEntry(
+				entryId, randomAffectedEntry());
 
-		Page<AffectedEntry> page1 = affectedEntryResource.getAffectedEntry(
-			entryId, null, Pagination.of(1, 2));
+		AffectedEntry affectedEntry3 =
+			testGetEntryAffectedEntriesPage_addAffectedEntry(
+				entryId, randomAffectedEntry());
+
+		Page<AffectedEntry> page1 =
+			affectedEntryResource.getEntryAffectedEntriesPage(
+				entryId, null, Pagination.of(1, 2));
 
 		List<AffectedEntry> affectedEntries1 =
 			(List<AffectedEntry>)page1.getItems();
@@ -250,8 +260,9 @@ public abstract class BaseAffectedEntryResourceTestCase {
 		Assert.assertEquals(
 			affectedEntries1.toString(), 2, affectedEntries1.size());
 
-		Page<AffectedEntry> page2 = affectedEntryResource.getAffectedEntry(
-			entryId, null, Pagination.of(2, 2));
+		Page<AffectedEntry> page2 =
+			affectedEntryResource.getEntryAffectedEntriesPage(
+				entryId, null, Pagination.of(2, 2));
 
 		Assert.assertEquals(3, page2.getTotalCount());
 
@@ -261,15 +272,16 @@ public abstract class BaseAffectedEntryResourceTestCase {
 		Assert.assertEquals(
 			affectedEntries2.toString(), 1, affectedEntries2.size());
 
-		Page<AffectedEntry> page3 = affectedEntryResource.getAffectedEntry(
-			entryId, null, Pagination.of(1, 3));
+		Page<AffectedEntry> page3 =
+			affectedEntryResource.getEntryAffectedEntriesPage(
+				entryId, null, Pagination.of(1, 3));
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(affectedEntry1, affectedEntry2, affectedEntry3),
 			(List<AffectedEntry>)page3.getItems());
 	}
 
-	protected AffectedEntry testGetAffectedEntry_addAffectedEntry(
+	protected AffectedEntry testGetEntryAffectedEntriesPage_addAffectedEntry(
 			Long entryId, AffectedEntry affectedEntry)
 		throws Exception {
 
@@ -277,12 +289,14 @@ public abstract class BaseAffectedEntryResourceTestCase {
 			"This method needs to be implemented");
 	}
 
-	protected Long testGetAffectedEntry_getEntryId() throws Exception {
+	protected Long testGetEntryAffectedEntriesPage_getEntryId()
+		throws Exception {
+
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
 	}
 
-	protected Long testGetAffectedEntry_getIrrelevantEntryId()
+	protected Long testGetEntryAffectedEntriesPage_getIrrelevantEntryId()
 		throws Exception {
 
 		return null;


### PR DESCRIPTION
hey @brianchandotcom I've renamed the endpoint because in the current state it doesn't make sense. In our application `/affected-entries` is not a resource on it's own like `/collections` or even `/entries`. Affected entries are always related to the entries similarly to `/document-folders/{documentFolderId}/documents` - documents are related to document folders. The endpoint for this reason is not `/documents/{documentFolderId}` as this is not reflecting the actual relationship between the resources.

I've discussed this with @nhpatt, he agreed.