### PR TITLE
LPS-97142 Disable Sprite by default

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -818,7 +818,9 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 			// Sprite images
 
-			setSpriteImages(servletContext, portletApp, "/html/icons/");
+			if (PropsValues.SPRITE_ENABLED) {
+				setSpriteImages(servletContext, portletApp, "/html/icons/");
+			}
 		}
 		catch (Exception e) {
 			_log.error(e, e);
@@ -926,7 +928,9 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 			// Sprite images
 
-			setSpriteImages(servletContext, portletApp, "/icons/");
+			if (PropsValues.SPRITE_ENABLED) {
+				setSpriteImages(servletContext, portletApp, "/icons/");
+			}
 
 			return ListUtil.fromMapValues(portletsMap);
 		}

--- a/portal-impl/src/com/liferay/portal/service/impl/ThemeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ThemeLocalServiceImpl.java
@@ -848,7 +848,9 @@ public class ThemeLocalServiceImpl extends ThemeLocalServiceBaseImpl {
 				}
 			}
 
-			_setSpriteImages(servletContext, theme, imagesPath);
+			if (PropsValues.SPRITE_ENABLED) {
+				_setSpriteImages(servletContext, theme, imagesPath);
+			}
 
 			if (!_themes.containsKey(themeId)) {
 				_themes.put(themeId, theme);

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2957,6 +2957,9 @@ public class PropsValues {
 	public static final String[] SPRING_PORTLET_CONFIGS = PropsUtil.getArray(
 		PropsKeys.SPRING_PORTLET_CONFIGS);
 
+	public static final boolean SPRITE_ENABLED = GetterUtil.getBoolean(
+		PropsUtil.get(PropsKeys.SPRITE_ENABLED));
+
 	public static final String SPRITE_FILE_NAME = PropsUtil.get(
 		PropsKeys.SPRITE_FILE_NAME);
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8605,6 +8605,13 @@
 ##
 
     #
+    # Set this property to true to enable sprite.
+    #
+    # Env: LIFERAY_SPRITE_PERIOD_ENABLED
+    #
+    sprite.enabled=false
+
+    #
     # Set the file names used for the auto generated sprites. The default file
     # name used to be ".sprite.png" but is now "_sprite.png" because SiteMinder
     # does not allow file names to start with a period. This property will not

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -3364,6 +3364,8 @@ public interface PropsKeys {
 	public static final String SPRING_PORTLET_CONFIGS =
 		"spring.portlet.configs";
 
+	public static final String SPRITE_ENABLED = "sprite.enabled";
+
 	public static final String SPRITE_FILE_NAME = "sprite.file.name";
 
 	public static final String SPRITE_PROPERTIES_FILE_NAME =


### PR DESCRIPTION
@dantewang this removes tons of file reads, it should save about a half sec. And more noticeable on the first bootup.