### PR TITLE
LPS-95231 use provided javax.validation

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7719,8 +7719,6 @@
         com.sun.tools.*,\
         com.sun.xml.*,\
         com.yourkit.*,\
-        javax.validation,\
-        javax.validation.*,\
         jdk.*,\
         sun.*,\
         weblogic.jndi,\


### PR DESCRIPTION
Solve issue with websphere due to their classloader prioritizing system classes instead of provided ones.