### PR TITLE
LPS-97401 Update to liferay-npm-scripts v4.0.0

### DIFF
--- a/modules/apps/frontend-js/frontend-js-react-web/npmscripts.config.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/npmscripts.config.js
@@ -1,3 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 module.exports = {
 	check: [],
 	fix: [],

--- a/modules/package.json
+++ b/modules/package.json
@@ -16,7 +16,7 @@
 		"liferay-npm-bridge-generator": "2.7.1",
 		"liferay-npm-bundler": "2.7.1",
 		"liferay-npm-bundler-preset-standard": "2.7.1",
-		"liferay-npm-scripts": "3.3.0",
+		"liferay-npm-scripts": "4.0.0",
 		"liferay-theme-es2015-hook": "8.0.0-rc.2",
 		"metal-jest-serializer": "2.0.0"
 	},

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -9642,10 +9642,10 @@ liferay-npm-bundler@2.7.1:
     semver "^5.5.0"
     xml-js "^1.6.8"
 
-liferay-npm-scripts@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-3.3.0.tgz#7f23265fca8832fa45560934484429ab7f0a5bc5"
-  integrity sha512-3zDmiFv+JKkK4lEb/Qc1uMjNOtWtVJCEPivLoiS4O2UJzX77RyqaL8S/KgT6MRf4KyXTvsDQldj3I3vx5wQXSw==
+liferay-npm-scripts@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-4.0.0.tgz#70024178a198e2d3dbf1f0307f3ebfd486601ebf"
+  integrity sha512-wmOcLRFm9LhjGL+NAHD/HOsFUsEZ7vSqCNrkM8spY8zlf1FwmwPqpLwiJtsFKJaUcThl84LEYuplKnHdF8eNTw==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/plugin-proposal-class-properties" "7.4.4"


### PR DESCRIPTION
Major version bump because this one does linting and formatting (previously it only did linting), so is technically a "breaking change" in the sense that a run of `yarn checkFormat` that previously passed could fail now. (Having said that, it doesn't actually fail because we previously dealt with pre-existing lints in LPS-97079).