### PR TITLE
LPS-97193 Prevent clicking on Version tab from closing sidebar

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
@@ -209,10 +209,11 @@ function handleEvent(eventName, event) {
 }
 
 /**
- * Creates a delegated event listener for `eventName` events on `element`.
+ * Creates a delegated event listener for `eventName` events on
+ * `elementOrSelector`.
  */
-function subscribe(element, eventName, handler) {
-	if (element) {
+function subscribe(elementOrSelector, eventName, handler) {
+	if (elementOrSelector) {
 		// Add only one listener per `eventName`.
 		if (!eventNamesToSelectors[eventName]) {
 			eventNamesToSelectors[eventName] = {};
@@ -223,7 +224,10 @@ function subscribe(element, eventName, handler) {
 		}
 
 		const emitters = eventNamesToSelectors[eventName];
-		const selector = getUniqueSelector(element);
+		const selector =
+			typeof elementOrSelector === 'string'
+				? elementOrSelector
+				: getUniqueSelector(elementOrSelector);
 
 		if (!emitters[selector]) {
 			emitters[selector] = new EventEmitter();
@@ -876,12 +880,9 @@ SideNavigation.prototype = {
 		const containerSelector = options.container;
 
 		if (!instance._sidenavCloseSubscription) {
-			const closeButton = document.querySelector(
-				`${containerSelector} .sidenav-close`
-			);
-
+			const closeButtonSelector = `${containerSelector} .sidenav-close`;
 			instance._sidenavCloseSubscription = subscribe(
-				closeButton,
+				closeButtonSelector,
 				'click',
 				function handleSidenavClose(event) {
 					event.preventDefault();


### PR DESCRIPTION
Prior to this commit, we were finding all close buttons in a given container using the ".sidenav-close" class, and then calling `getUniqueSelector()` redundantly. Because `getUniqueSelector()` is very conservative about the selectors it generates (in order to avoid false positives during event delegation), we wind up with an insufficiently specific selector; ie. instead of something like:

    .image-viewer-sidenav .sidenav-close

we wind up with:

    #yui_patched_v3_18_1_1_1561468792477_1163 a

This leads to unwanted side effects, like clicking on tabs causing the sidenav to close, because the selector will match all "a" tags in the container.

The fix is to use an concrete selector if supplied, and only fall back to generating one with `getUniqueSelector()` if we have to.