### PR TITLE
LPS-97488 Remove unnecessary JSONPackageJSONCheck suppressions

### DIFF
--- a/modules/apps/frontend-js/frontend-js-node-shims/npmscripts.config.js
+++ b/modules/apps/frontend-js/frontend-js-node-shims/npmscripts.config.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+module.exports = {
+	check: [],
+	fix: [],
+	preset: 'liferay-npm-scripts/src/presets/standard'
+};

--- a/modules/apps/frontend-js/frontend-js-node-shims/package.json
+++ b/modules/apps/frontend-js/frontend-js-node-shims/package.json
@@ -20,7 +20,9 @@
 	},
 	"name": "frontend-js-node-shims",
 	"scripts": {
-		"build": "liferay-npm-scripts build"
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
 	},
 	"version": "4.0.0"
 }

--- a/modules/apps/frontend-js/frontend-js-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-web/package.json
@@ -21,9 +21,6 @@
 		"svg4everybody": "^2.1.8",
 		"uuid": "^3.3.2"
 	},
-	"devDependencies": {
-		"babel-loader": "^8.0.5"
-	},
 	"jest": {
 		"globals": {
 			"Liferay": {}

--- a/modules/apps/segments/segments-web/package.json
+++ b/modules/apps/segments/segments-web/package.json
@@ -51,6 +51,7 @@
 	"private": true,
 	"scripts": {
 		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
 		"csf": "liferay-npm-scripts fix",
 		"format": "liferay-npm-scripts fix",
 		"test": "env TZ=utc liferay-npm-scripts test",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -2060,7 +2060,7 @@ babel-jest@^24.5.0:
     chalk "^2.4.2"
     slash "^2.0.0"
 
-babel-loader@8.0.6, babel-loader@^8.0.5:
+babel-loader@8.0.6:
   version "8.0.6"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.6.tgz#e33bdb6f362b03f4bb141a0c21ab87c501b70dfb"
   integrity sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -118,8 +118,6 @@
 		<!-- Temporary suppressions for frontend build setup (Chema) -->
 
 		<suppress checks="JSONPackageJSONCheck" files="modules/apps/analytics/analytics-client-js/package\.json" />
-		<suppress checks="JSONPackageJSONCheck" files="modules/apps/frontend-js/frontend-js-node-shims/package\.json" />
-		<suppress checks="JSONPackageJSONCheck" files="modules/apps/frontend-js/frontend-js-web/package\.json" />
 		<suppress checks="JSONPackageJSONCheck" files="modules/apps/segments/segments-web/package\.json" />
 	</source-check>
 </suppressions>


### PR DESCRIPTION
- frontend-js-node-shims had a suppression because it didn't define "checkFormat" and "format" scripts; we didn't define them because there is nothing to check in this module. But still, we can remove the suppression by adding the scripts and specifying empty globs in the npmscripts.config.js file.
- frontend-js-web had a suppression because it defined "devDependencies", which we only allow at the top level; we can remove them because we have access to this package (and all the webpack-related packages) transitively via the presence of liferay-npm-scripts.

Also note:

- segments-web has a suppression because it defines "devDependencies" (which will take us a while to remove), and because it didn't define a "checkFormat" script; I added the latter, even though I can't remove the suppression yet due to the "devDependencies".
- analytics-client-js is effectively an independent project that happens to live inside this repo, so it will probably have "devDependencies" of its own for the foreseeable future, so I can't remove that one immediately either.