### PR TITLE
LPS-96569 Provide top-level ESLint configuration

### DIFF
--- a/modules/.eslintrc.js
+++ b/modules/.eslintrc.js
@@ -12,6 +12,18 @@
  * details.
  */
 
-module.exports = {
-	root: true
-};
+/**
+ * We use liferay-npm-scripts to perform linting in a controlled way, but we
+ * also try to expose its configuration here so it can be picked up by editors.
+ */
+let config = {};
+
+try {
+	config = require('liferay-npm-scripts/src/config/eslint.config');
+} catch (error) {
+	throw new Error(
+		'liferay-npm-scripts is not installed; please run "ant setup-sdk"'
+	);
+}
+
+module.exports = config;

--- a/modules/package.json
+++ b/modules/package.json
@@ -16,7 +16,7 @@
 		"liferay-npm-bridge-generator": "2.7.1",
 		"liferay-npm-bundler": "2.7.1",
 		"liferay-npm-bundler-preset-standard": "2.7.1",
-		"liferay-npm-scripts": "4.0.0",
+		"liferay-npm-scripts": "4.1.0",
 		"liferay-theme-es2015-hook": "8.0.0-rc.2",
 		"metal-jest-serializer": "2.0.0"
 	},

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -9642,10 +9642,10 @@ liferay-npm-bundler@2.7.1:
     semver "^5.5.0"
     xml-js "^1.6.8"
 
-liferay-npm-scripts@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-4.0.0.tgz#70024178a198e2d3dbf1f0307f3ebfd486601ebf"
-  integrity sha512-wmOcLRFm9LhjGL+NAHD/HOsFUsEZ7vSqCNrkM8spY8zlf1FwmwPqpLwiJtsFKJaUcThl84LEYuplKnHdF8eNTw==
+liferay-npm-scripts@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-4.1.0.tgz#d6c4ea767ce16f40b982421d091e7daa6e9a1d03"
+  integrity sha512-U+vtE0w5xXgyoONRIcKz+mv471nwIDbGJtzh7ykdyIF2fOrbXlMFlf1pC4XqKTZJ/CF6sC8eiBzKfQm9yQohsQ==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/plugin-proposal-class-properties" "7.4.4"


### PR DESCRIPTION
This will allow editors such as VSCode to pick up the ESLint config and show lint problems inline in the IDE.

Unlike the Prettier config (which is static), our ESLint config depends on installed code (because some of the rules are defined in plugins that live inside node_modules). This required some refactoring, the details of which are all described in:

https://github.com/liferay/liferay-npm-tools/pull/130

The short version is that we moved the `root: true` config from this repo into liferay-npm-scripts, we grab the base configuration using `require()`, and if the user hasn't run "ant setup-sdk" (or "ant all") yet, we throw a helpful error message that IDEs will show.

Example from VSCode:

![error](https://user-images.githubusercontent.com/7074/60187584-2056fc80-982e-11e9-9359-7477ec7f84be.png)
