### PR TITLE
LPS-97498 Ignore generated *.soy.js files

### DIFF
--- a/modules/.eslintignore
+++ b/modules/.eslintignore
@@ -5,10 +5,14 @@
 !.prettierrc.js
 !npmscripts.config.js
 
+# Generated files.
+**/*.soy.js
 **/build/**/*
 **/classes/**/*
 **/css/clay/**/*
 **/node_modules/**/*
 **/sdk/**/*
 **/zippableResources/**/*
+
+# Restricted paths.
 modules/tests/poshi-runner/**/*

--- a/modules/.prettierignore
+++ b/modules/.prettierignore
@@ -1,3 +1,5 @@
+# Generated files.
+**/*.soy.js
 **/build/**/*
 **/classes/**/*
 **/css/clay/**/*


### PR DESCRIPTION
Follow-up to:

https://github.com/brianchandotcom/liferay-portal/pull/75011

I don't believe the globs we're using will cause us to format any generated `*.soy.js` files. But in the name of robustness, this commit explicitly prevents Prettier and ESLint from *ever* considering such files, just in case future changes ever wind up putting some in places identified by globs.