### PR TITLE
LPS-96486 Add first of custom lints

### DIFF
--- a/modules/apps/document-library/document-library-preview-audio/test/AudioPreviewer.es.js
+++ b/modules/apps/document-library/document-library-preview-audio/test/AudioPreviewer.es.js
@@ -23,7 +23,7 @@ describe('document-library-preview-audio', () => {
 		}
 	});
 
-	it('should render an audio player', () => {
+	it('renders an audio player', () => {
 		component = new AudioPreviewer({
 			audioMaxWidth: 520,
 			audioSources: [

--- a/modules/apps/document-library/document-library-preview-audio/test/__snapshots__/AudioPreviewer.es.js.snap
+++ b/modules/apps/document-library/document-library-preview-audio/test/__snapshots__/AudioPreviewer.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`document-library-preview-audio should render an audio player 1`] = `
+exports[`document-library-preview-audio renders an audio player 1`] = `
 <div class="preview-file">
   <div class="preview-file-container"><audio class="preview-file-audio" controls="" controlslist="nodownload" style="max-width: 520px;">
       <source src="//audio.ogg" type="audio/ogg">

--- a/modules/apps/document-library/document-library-preview-document/test/DocumentPreviewer.es.js
+++ b/modules/apps/document-library/document-library-preview-document/test/DocumentPreviewer.es.js
@@ -28,7 +28,7 @@ describe('document-library-preview-document', () => {
 		}
 	});
 
-	it('should render a document previewer with ten pages and the first page rendered', () => {
+	it('renders a document previewer with ten pages and the first page rendered', () => {
 		component = new DocumentPreviewer({
 			...defaultDocumentPreviewerConfig,
 			currentPage: 1,
@@ -38,7 +38,7 @@ describe('document-library-preview-document', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render a document previewer with nineteen pages and the fifth page rendered', () => {
+	it('renders a document previewer with nineteen pages and the fifth page rendered', () => {
 		component = new DocumentPreviewer({
 			...defaultDocumentPreviewerConfig,
 			currentPage: 5,

--- a/modules/apps/document-library/document-library-preview-document/test/__snapshots__/DocumentPreviewer.es.js.snap
+++ b/modules/apps/document-library/document-library-preview-document/test/__snapshots__/DocumentPreviewer.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`document-library-preview-document should render a document previewer with nineteen pages and the fifth page rendered 1`] = `
+exports[`document-library-preview-document renders a document previewer with nineteen pages and the fifth page rendered 1`] = `
 <div class="preview-file">
   <div class="preview-file-container preview-file-max-height" ref="imageContainer"><img class=" preview-file-document  preview-file-document-fit" src="/document-images/5"></div>
   <div class="preview-toolbar-container">
@@ -18,7 +18,7 @@ exports[`document-library-preview-document should render a document previewer wi
 </div>
 `;
 
-exports[`document-library-preview-document should render a document previewer with ten pages and the first page rendered 1`] = `
+exports[`document-library-preview-document renders a document previewer with ten pages and the first page rendered 1`] = `
 <div class="preview-file">
   <div class="preview-file-container preview-file-max-height" ref="imageContainer"><img class=" preview-file-document  preview-file-document-fit" src="/document-images/1"></div>
   <div class="preview-toolbar-container">

--- a/modules/apps/document-library/document-library-preview-image/test/ImagePreviewer.es.js
+++ b/modules/apps/document-library/document-library-preview-image/test/ImagePreviewer.es.js
@@ -23,7 +23,7 @@ describe('document-library-preview-image', () => {
 		}
 	});
 
-	it('should render an image previewer', () => {
+	it('renders an image previewer', () => {
 		component = new ImagePreviewer({
 			imageURL: 'image.jpg',
 			spritemap: 'icons.svg'

--- a/modules/apps/document-library/document-library-preview-image/test/__snapshots__/ImagePreviewer.es.js.snap
+++ b/modules/apps/document-library/document-library-preview-image/test/__snapshots__/ImagePreviewer.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`document-library-preview-image should render an image previewer 1`] = `
+exports[`document-library-preview-image renders an image previewer 1`] = `
 <div class="preview-file">
   <div class="preview-file-container preview-file-max-height" ref="imageContainer"><img class="preview-file-image" ref="image" src="image.jpg" style=""></div>
   <div class="preview-toolbar-container">

--- a/modules/apps/document-library/document-library-preview-video/test/VideoPreviewer.es.js
+++ b/modules/apps/document-library/document-library-preview-video/test/VideoPreviewer.es.js
@@ -23,7 +23,7 @@ describe('document-library-preview-video', () => {
 		}
 	});
 
-	it('should render an video player', () => {
+	it('renders a video player', () => {
 		component = new VideoPreviewer({
 			videoPosterURL: 'poster.jpg',
 			videoSources: [

--- a/modules/apps/document-library/document-library-preview-video/test/__snapshots__/VideoPreviewer.es.js.snap
+++ b/modules/apps/document-library/document-library-preview-video/test/__snapshots__/VideoPreviewer.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`document-library-preview-video should render an video player 1`] = `
+exports[`document-library-preview-video renders a video player 1`] = `
 <div class="preview-file">
   <div class="preview-file-container preview-file-max-height"><video class="preview-file-video" controls="" controlslist="nodownload" poster="poster.jpg">
       <source src="//video.mp4" type="video/mp4">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/Calculator/Calculator.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/Calculator/Calculator.es.js
@@ -70,7 +70,7 @@ describe('Calculator', () => {
 		});
 
 		describe('addTokenToExpression(tokenType, tokenValue)', () => {
-			it('should add a token to an expression', () => {
+			it('adds a token to an expression', () => {
 				component.expression = '4*[Field1]+';
 
 				component.addTokenToExpression(Token.VARIABLE, 'Field2');
@@ -78,7 +78,7 @@ describe('Calculator', () => {
 				expect(component.expression).toEqual('4*[Field1]+[Field2]');
 			});
 
-			it('should add implicit multiplications to an expression when applicable', () => {
+			it('adds implicit multiplications to an expression when applicable', () => {
 				component.expression = '1+[Field1]';
 
 				component.addTokenToExpression(Token.VARIABLE, 'Field2');
@@ -88,7 +88,7 @@ describe('Calculator', () => {
 		});
 
 		describe('removeTokenFromExpression()', () => {
-			it('should remove the last token from the expression', () => {
+			it('removes the last token from the expression', () => {
 				component.expression = '4*[Field1]';
 
 				component.removeTokenFromExpression();
@@ -96,7 +96,7 @@ describe('Calculator', () => {
 				expect(component.expression).toEqual('4*');
 			});
 
-			it('should remove both the left parenthesis and the function when last tokens are an openning of a function', () => {
+			it('removes both the left parenthesis and the function when last tokens are an openning of a function', () => {
 				component.expression = '1+sum(';
 
 				component.removeTokenFromExpression();
@@ -106,7 +106,7 @@ describe('Calculator', () => {
 		});
 
 		describe('getStateBasedOnExpression(expression)', () => {
-			it('should disable functions, numbers and operators when last token is a sum function', () => {
+			it('disables functions, numbers and operators when last token is a sum function', () => {
 				const result = component.getStateBasedOnExpression('4*sum(');
 
 				expect(result.disableFunctions).toBe(true);
@@ -114,7 +114,7 @@ describe('Calculator', () => {
 				expect(result.disableOperators).toBe(true);
 			});
 
-			it('should not disable functions, numbers and operators when last token is not a sum function', () => {
+			it('does not disable functions, numbers and operators when last token is not a sum function', () => {
 				const result = component.getStateBasedOnExpression(
 					'4*sum(Field2)+4'
 				);
@@ -126,7 +126,7 @@ describe('Calculator', () => {
 		});
 
 		describe('shouldAddImplicitMultiplication(tokens, newToken)', () => {
-			it('should return true if new token is a Left Parenthesis and last token is a Literal', () => {
+			it('returns true if new token is a Left Parenthesis and last token is a Literal', () => {
 				const tokens = [new Token(Token.LITERAL, '5')];
 
 				const result = component.shouldAddImplicitMultiplication(
@@ -137,7 +137,7 @@ describe('Calculator', () => {
 				expect(result).toEqual(true);
 			});
 
-			it('should return true if new token is a Left Parenthesis and last token is a Variable', () => {
+			it('returns true if new token is a Left Parenthesis and last token is a Variable', () => {
 				const tokens = [new Token(Token.VARIABLE, 'Field1')];
 
 				const result = component.shouldAddImplicitMultiplication(
@@ -148,7 +148,7 @@ describe('Calculator', () => {
 				expect(result).toEqual(true);
 			});
 
-			it('should return true if new token is a Function and last token is a Variable', () => {
+			it('returns true if new token is a Function and last token is a Variable', () => {
 				const tokens = [new Token(Token.VARIABLE, 'Field1')];
 
 				const result = component.shouldAddImplicitMultiplication(
@@ -159,7 +159,7 @@ describe('Calculator', () => {
 				expect(result).toEqual(true);
 			});
 
-			it('should return true if new token is a Variable and last token is a Variable', () => {
+			it('returns true if new token is a Variable and last token is a Variable', () => {
 				const tokens = [new Token(Token.VARIABLE, 'Field1')];
 
 				const result = component.shouldAddImplicitMultiplication(
@@ -170,7 +170,7 @@ describe('Calculator', () => {
 				expect(result).toEqual(true);
 			});
 
-			it('should return true if new token is a Variable and last token is a Literal', () => {
+			it('returns true if new token is a Variable and last token is a Literal', () => {
 				const tokens = [new Token(Token.LITERAL, '345')];
 
 				const result = component.shouldAddImplicitMultiplication(
@@ -181,7 +181,7 @@ describe('Calculator', () => {
 				expect(result).toEqual(true);
 			});
 
-			it('should return true if new token is a Literal and last token is a Variable', () => {
+			it('returns true if new token is a Literal and last token is a Variable', () => {
 				const tokens = [new Token(Token.VARIABLE, 'Field1')];
 
 				const result = component.shouldAddImplicitMultiplication(
@@ -192,7 +192,7 @@ describe('Calculator', () => {
 				expect(result).toEqual(true);
 			});
 
-			it('should return true if new token is a Literal and last token is a Function', () => {
+			it('returns true if new token is a Literal and last token is a Function', () => {
 				const tokens = [new Token(Token.FUNCTION, 'sum')];
 
 				const result = component.shouldAddImplicitMultiplication(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/FormBuilder/FormBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/FormBuilder/FormBuilder.es.js
@@ -153,11 +153,11 @@ describe('Builder', () => {
 		jest.clearAllTimers();
 	});
 
-	it('should render the default markup', () => {
+	it('renders the default markup', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should continue to propagate the fieldAdded event', () => {
+	it('continues to propagate the fieldAdded event', () => {
 		const {sidebar} = component.refs;
 		const spy = jest.spyOn(component, 'emit');
 
@@ -184,7 +184,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalledWith('fieldAdded', expect.anything());
 	});
 
-	it('should continue to propagate the fieldBlurred event', () => {
+	it('continues to propagate the fieldBlurred event', () => {
 		const {sidebar} = component.refs;
 		const spy = jest.spyOn(component, 'emit');
 
@@ -195,7 +195,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalledWith('sidebarFieldBlurred');
 	});
 
-	it('should continue to propagate the fieldClicked event', () => {
+	it('continues to propagate the fieldClicked event', () => {
 		const {FormRenderer} = component.refs;
 		const spy = jest.spyOn(component, 'emit');
 
@@ -210,7 +210,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalled();
 	});
 
-	it('should open the sidebar when attached and there are no fields on the active page', () => {
+	it('opens the sidebar when attached and there are no fields on the active page', () => {
 		const spy = jest.spyOn(component, 'openSidebar');
 
 		component.props.pages = [{rows: [{columns: [{fields: []}]}]}];
@@ -220,7 +220,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalled();
 	});
 
-	it('should open the sidebar when a field is clicked', () => {
+	it('opens the sidebar when a field is clicked', () => {
 		const {FormRenderer} = component.refs;
 		const spy = jest.spyOn(component, 'openSidebar');
 
@@ -235,7 +235,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalled();
 	});
 
-	it('should continue to propagate the pageAdded event', () => {
+	it('continues to propagate the pageAdded event', () => {
 		const {FormRenderer} = component.refs;
 		const spy = jest.spyOn(component, 'emit');
 
@@ -246,7 +246,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalledWith('pageAdded');
 	});
 
-	it('should continue to propagate the pageDeleted event', () => {
+	it('continues to propagate the pageDeleted event', () => {
 		const {FormRenderer} = component.refs;
 		const spy = jest.spyOn(component, 'emit');
 
@@ -257,7 +257,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalledWith('pageDeleted', expect.anything());
 	});
 
-	it('should continue to propagate the pagesUpdated event', () => {
+	it('continues to propagate the pagesUpdated event', () => {
 		const {FormRenderer} = component.refs;
 		const spy = jest.spyOn(component, 'emit');
 
@@ -268,7 +268,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalledWith('pagesUpdated', expect.anything());
 	});
 
-	it('should continue to propagate the activePageUpdated event', () => {
+	it('continues to propagate the activePageUpdated event', () => {
 		const {FormRenderer} = component.refs;
 		const spy = jest.spyOn(component, 'emit');
 
@@ -282,7 +282,7 @@ describe('Builder', () => {
 		);
 	});
 
-	it('should continue to propagate the fieldDuplicated event', () => {
+	it('continues to propagate the fieldDuplicated event', () => {
 		const {FormRenderer} = component.refs;
 		const spy = jest.spyOn(component, 'emit');
 
@@ -293,7 +293,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalledWith('fieldDuplicated', expect.anything());
 	});
 
-	it('should continue to propagate the fieldEdited event', () => {
+	it('continues to propagate the fieldEdited event', () => {
 		const {sidebar} = component.refs;
 		const spy = jest.spyOn(component, 'emit');
 
@@ -312,7 +312,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalledWith('fieldEdited', expect.anything());
 	});
 
-	it('should continue to propagate the fieldEdited event when the edited field is predefined value', () => {
+	it('continues to propagate the fieldEdited event when the edited field is predefined value', () => {
 		const {sidebar} = component.refs;
 		const spy = jest.spyOn(component, 'emit');
 
@@ -330,7 +330,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalledWith('fieldEdited', expect.anything());
 	});
 
-	it('should continue to propagate the fieldMoved event', () => {
+	it('continues to propagate the fieldMoved event', () => {
 		const spy = jest.spyOn(component, 'emit');
 		const {FormRenderer} = component.refs;
 		const mockEvent = jest.fn();
@@ -341,7 +341,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalledWith('fieldMoved', expect.anything());
 	});
 
-	it('should open sidebar when the "pageReset" event is received', () => {
+	it('opens sidebar when the "pageReset" event is received', () => {
 		const {FormRenderer, sidebar} = component.refs;
 
 		FormRenderer.emit('pageReset');
@@ -351,7 +351,7 @@ describe('Builder', () => {
 		expect(sidebar.state.open).toBeTruthy();
 	});
 
-	it('should open sidebar when activePage changes and new page has no fields', () => {
+	it('opens sidebar when activePage changes and new page has no fields', () => {
 		const spy = jest.spyOn(component, 'openSidebar');
 
 		component.props.pages = [
@@ -367,7 +367,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalled();
 	});
 
-	it('should not open sidebar when activePage changes and new page has fields', () => {
+	it('does not open sidebar when activePage changes and new page has fields', () => {
 		const spy = jest.spyOn(component, 'openSidebar');
 
 		component.props.pages = [...pages, ...pages];
@@ -378,7 +378,7 @@ describe('Builder', () => {
 		expect(spy).not.toHaveBeenCalled();
 	});
 
-	it('should show modal when fieldChangesCanceled event is trigered from sidebar', () => {
+	it('shows modal when fieldChangesCanceled event is trigered from sidebar', () => {
 		const {cancelChangesModal, sidebar} = component.refs;
 
 		sidebar.emit('fieldChangesCanceled');
@@ -392,7 +392,7 @@ describe('Builder', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should emit fieldChangesCanceled event when yes is clicked in the modal', () => {
+	it('emits fieldChangesCanceled event when yes is clicked in the modal', () => {
 		const spy = jest.spyOn(component, 'emit');
 		const {cancelChangesModal, sidebar} = component.refs;
 		const mockEvent = jest.fn();
@@ -411,7 +411,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalledWith('fieldChangesCanceled', {});
 	});
 
-	it('should show modal when trash button gets clicked', () => {
+	it('shows modal when trash button gets clicked', () => {
 		const {FormRenderer} = component.refs;
 
 		FormRenderer.emit('fieldDeleted', {
@@ -429,7 +429,7 @@ describe('Builder', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should emit deleteField event when yes is clicked in the modal', () => {
+	it('emits deleteField event when yes is clicked in the modal', () => {
 		const spy = jest.spyOn(component, 'emit');
 		const {FormRenderer} = component.refs;
 		const mockEvent = jest.fn();
@@ -448,7 +448,7 @@ describe('Builder', () => {
 		expect(spy).toHaveBeenCalledWith('fieldDeleted', expect.anything());
 	});
 
-	it('should propagate successPageChanged event', () => {
+	it('propagates successPageChanged event', () => {
 		const spy = jest.spyOn(component, 'emit');
 		const {FormRenderer} = component.refs;
 		const mockEvent = jest.fn();
@@ -464,7 +464,7 @@ describe('Builder', () => {
 		);
 	});
 
-	it('should not open sidebar when the delete current page option item is clicked', () => {
+	it('does not open sidebar when the delete current page option item is clicked', () => {
 		const spy = jest.spyOn(component, 'openSidebar');
 
 		const componentPages = [...pages, ...pages];

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/LayoutProvider.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/LayoutProvider.es.js
@@ -89,7 +89,7 @@ describe('LayoutProvider', () => {
 		pages = null;
 	});
 
-	it('should receive pages through PROPS and move to the internal state', () => {
+	it('receives pages through PROPS and move to the internal state', () => {
 		component = new LayoutProvider({
 			initialPages: pages,
 			rules: []
@@ -98,7 +98,7 @@ describe('LayoutProvider', () => {
 		expect(component.state.pages).toEqual(component.props.initialPages);
 	});
 
-	it('should attach the events to the child component', () => {
+	it('attaches the events to the child component', () => {
 		component = new Parent();
 
 		const {provider} = component.refs;
@@ -112,7 +112,7 @@ describe('LayoutProvider', () => {
 		});
 	});
 
-	it('should pass to the child component the pages of the internal state', () => {
+	it('passes to the child component the pages of the internal state', () => {
 		component = new Parent();
 
 		const {child, provider} = component.refs;
@@ -120,7 +120,7 @@ describe('LayoutProvider', () => {
 		expect(child.props.pages).toEqual(provider.state.pages);
 	});
 
-	it('should pass to the child component the focusedField', () => {
+	it('passes to the child component the focusedField', () => {
 		component = new Parent();
 
 		const {child, provider} = component.refs;
@@ -141,7 +141,7 @@ describe('LayoutProvider', () => {
 		expect(child.props.focusedField).toEqual(provider.state.focusedField);
 	});
 
-	it('should receive ruleAdded event to save a rule', () => {
+	it('receives ruleAdded event to save a rule', () => {
 		component = new Parent();
 
 		jest.runAllTimers();
@@ -165,7 +165,7 @@ describe('LayoutProvider', () => {
 		expect([...oldRules, mockEvent]).toEqual(provider.state.rules);
 	});
 
-	it('should receive ruleSaved event to edit a rule', () => {
+	it('receives ruleSaved event to edit a rule', () => {
 		component = new Parent();
 
 		jest.runAllTimers();
@@ -200,7 +200,7 @@ describe('LayoutProvider', () => {
 		expect(originalRule[0]).not.toEqual(provider.state.rules[0]);
 	});
 
-	it('should pass to the child component the mode', () => {
+	it('passes to the child component the mode', () => {
 		component = new Parent();
 
 		const {child, provider} = component.refs;
@@ -216,7 +216,7 @@ describe('LayoutProvider', () => {
 
 	describe('Field events', () => {
 		describe('fieldMoved', () => {
-			it('should listen to the fieldMoved event and move the field to the row in pages', () => {
+			it('listens to the fieldMoved event and move the field to the row in pages', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -247,7 +247,7 @@ describe('LayoutProvider', () => {
 				expect(child.props.pages).toEqual(provider.state.pages);
 			});
 
-			it('should listen to the pagesUpdated event', () => {
+			it('listens to the pagesUpdated event', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -260,7 +260,7 @@ describe('LayoutProvider', () => {
 				expect(child.props.pages).toEqual(provider.state.pages);
 			});
 
-			it('should listen to the fieldMoved event and move the field to the column in pages', () => {
+			it('listens to the fieldMoved event and move the field to the column in pages', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -286,7 +286,7 @@ describe('LayoutProvider', () => {
 				expect(child.props.pages).toEqual(provider.state.pages);
 			});
 
-			it('should move the field to the column in pages and remove the row if there are no fields', () => {
+			it('moves the field to the column in pages and remove the row if there are no fields', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -312,7 +312,7 @@ describe('LayoutProvider', () => {
 				expect(child.props.pages).toEqual(provider.state.pages);
 			});
 
-			it('should move the field to the row in pages and remove the row if there are no fields', () => {
+			it('moves the field to the row in pages and remove the row if there are no fields', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -340,7 +340,7 @@ describe('LayoutProvider', () => {
 		});
 
 		describe('fieldAdded', () => {
-			it('should listen the fieldAdded event and add the field in the column to the pages', () => {
+			it('listens the fieldAdded event and add the field in the column to the pages', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -365,7 +365,7 @@ describe('LayoutProvider', () => {
 				expect(child.props.pages).toEqual(provider.state.pages);
 			});
 
-			it('should listen the fieldAdded event and add the field in the row to the pages', () => {
+			it('listen the fieldAdded event and add the field in the row to the pages', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -390,7 +390,7 @@ describe('LayoutProvider', () => {
 				expect(child.props.pages).toEqual(provider.state.pages);
 			});
 
-			it('should update the focusedField with the location of the new field when adding to the pages', () => {
+			it('updates the focusedField with the location of the new field when adding to the pages', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -419,7 +419,7 @@ describe('LayoutProvider', () => {
 		});
 
 		describe('fieldDeleted', () => {
-			it('should listen the fieldDeleted event and delete the field in the column to the pages', () => {
+			it('listens the fieldDeleted event and delete the field in the column to the pages', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -439,7 +439,7 @@ describe('LayoutProvider', () => {
 		});
 
 		describe('fieldDuplicated', () => {
-			it('should listen the duplicate field event and add this field in the pages', () => {
+			it('listens the duplicate field event and add this field in the pages', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -483,7 +483,7 @@ describe('LayoutProvider', () => {
 		});
 
 		describe('fieldClicked', () => {
-			it('should listen the fieldClicked event and change the state of the focusedField to the data receive', () => {
+			it('listens the fieldClicked event and change the state of the focusedField to the data receive', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -503,7 +503,7 @@ describe('LayoutProvider', () => {
 		});
 
 		describe('fieldBlurred', () => {
-			it('should listen the fieldBlurred event and change the state of the focusedField to the data receive', () => {
+			it('listens the fieldBlurred event and change the state of the focusedField to the data receive', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -518,7 +518,7 @@ describe('LayoutProvider', () => {
 		});
 
 		describe('fieldResized', () => {
-			it('should listen to the columnResized event and resize the field when the left arrow is pulled', () => {
+			it('listens to the columnResized event and resize the field when the left arrow is pulled', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -544,7 +544,7 @@ describe('LayoutProvider', () => {
 		});
 
 		xdescribe('fieldChangesCanceled', () => {
-			it('should listen the fieldChangesCanceled event and change the state of the focusedField and pages for the data wich was received', () => {
+			it('listens the fieldChangesCanceled event and change the state of the focusedField and pages for the data wich was received', () => {
 				component = new Parent({
 					initialPages: pages
 				});
@@ -583,7 +583,7 @@ describe('LayoutProvider', () => {
 		});
 
 		describe('focusedFieldUpdated', () => {
-			it('should listen the focusedFieldUpdated event and change the state of the focusedField and pages for the data wich was received', () => {
+			it('listens the focusedFieldUpdated event and change the state of the focusedField and pages for the data wich was received', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -604,7 +604,7 @@ describe('LayoutProvider', () => {
 		});
 
 		describe('pageDeleted', () => {
-			it('should listen the pageDeleted event and change the state of pages for the data wich was received', () => {
+			it('listens the pageDeleted event and change the state of pages for the data wich was received', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -622,7 +622,7 @@ describe('LayoutProvider', () => {
 		});
 
 		describe('pageAdded', () => {
-			it('should listen the pageAdded event and change the state of pages for the data wich was received', () => {
+			it('listens the pageAdded event and change the state of pages for the data wich was received', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -637,7 +637,7 @@ describe('LayoutProvider', () => {
 		});
 
 		describe('pageReset', () => {
-			it('should listen the pageReset event and change the state of pages for the data wich was received', () => {
+			it('listens the pageReset event and change the state of pages for the data wich was received', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -652,7 +652,7 @@ describe('LayoutProvider', () => {
 		});
 
 		describe('paginationModeUpdated', () => {
-			it('should listen the paginationModeUpdated event and change the state of pagination mode for the data wich was received', () => {
+			it('listens the paginationModeUpdated event and change the state of pagination mode for the data wich was received', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -665,7 +665,7 @@ describe('LayoutProvider', () => {
 				expect(provider.state.pages).toMatchSnapshot();
 			});
 
-			it('should listen the paginationModeUpdated event and change the state of pagination mode from pagination to wizard', () => {
+			it('listens the paginationModeUpdated event and change the state of pagination mode from pagination to wizard', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -686,7 +686,7 @@ describe('LayoutProvider', () => {
 		});
 
 		describe('successPageChanged', () => {
-			it('should listen the successPageChanged event and change the state of success page for the data wich was received', () => {
+			it('listens the successPageChanged event and change the state of success page for the data wich was received', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;
@@ -703,7 +703,7 @@ describe('LayoutProvider', () => {
 		});
 
 		describe('activePageUpdated', () => {
-			it('should listen the activePageUpdated event and change the state of the active page for the data wich was received', () => {
+			it('listens the activePageUpdated event and change the state of the active page for the data wich was received', () => {
 				component = new Parent();
 
 				const {child, provider} = component.refs;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/handlers/columnResizedHandler.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/handlers/columnResizedHandler.es.js
@@ -16,7 +16,7 @@ import * as columnResizedHandler from 'source/components/LayoutProvider/handlers
 
 describe('LayoutProvider/handlers/columnResized', () => {
 	describe('handleColumnResized(state, source, column, direction)', () => {
-		it('should resize columns when pulling with the left handle', () => {
+		it('resizes columns when pulling with the left handle', () => {
 			const source = {
 				dataset: {
 					ddmFieldColumn: 1,
@@ -56,7 +56,7 @@ describe('LayoutProvider/handlers/columnResized', () => {
 			expect(result.pages[0].rows[0].columns[1].size).toEqual(6);
 		});
 
-		it("should remove column to the left if it's empty and cornered", () => {
+		it("removes column to the left if it's empty and cornered", () => {
 			const source = {
 				dataset: {
 					ddmFieldColumn: 1,
@@ -95,7 +95,7 @@ describe('LayoutProvider/handlers/columnResized', () => {
 			expect(result.pages[0].rows[0].columns.length).toEqual(1);
 		});
 
-		it('should add a column when pulling to the right with the left handle', () => {
+		it('adds a column when pulling to the right with the left handle', () => {
 			const source = {
 				dataset: {
 					ddmFieldColumn: 0,
@@ -134,7 +134,7 @@ describe('LayoutProvider/handlers/columnResized', () => {
 			expect(result.pages[0].rows[0].columns.length).toEqual(3);
 		});
 
-		it('should remove column when pulling to the right edge with the right handle', () => {
+		it('removes column when pulling to the right edge with the right handle', () => {
 			const source = {
 				dataset: {
 					ddmFieldColumn: 0,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/handlers/fieldDeletedHandler.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/handlers/fieldDeletedHandler.es.js
@@ -19,7 +19,7 @@ import RulesSupport from 'source/components/RuleBuilder/RulesSupport.es';
 
 describe('LayoutProvider/handlers/fieldDeletedHandler', () => {
 	describe('handleFieldDeleted(state, event)', () => {
-		it('should call removeRow() when row is left with no fields after delete operation', () => {
+		it('calls removeRow() when row is left with no fields after delete operation', () => {
 			const event = {
 				columnIndex: 0,
 				pageIndex: 0,
@@ -41,7 +41,7 @@ describe('LayoutProvider/handlers/fieldDeletedHandler', () => {
 			removeRowSpy.mockRestore();
 		});
 
-		it('should call clearAllConditionFieldValues() when deleting a field used as the first operand of a condition', () => {
+		it('calls clearAllConditionFieldValues() when deleting a field used as the first operand of a condition', () => {
 			const event = {
 				columnIndex: 0,
 				pageIndex: 0,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/handlers/fieldEditedHandler.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/handlers/fieldEditedHandler.es.js
@@ -18,7 +18,7 @@ import mockPages from 'mock/mockPages.es';
 
 describe('LayoutProvider/handlers/fieldEditedHandler', () => {
 	describe('handleFieldEdited(state, event)', () => {
-		it('should call updateFocusedField()', () => {
+		it('calls updateFocusedField()', () => {
 			const event = {
 				propertyName: 'dataType',
 				propertyValue: 'string'
@@ -43,7 +43,7 @@ describe('LayoutProvider/handlers/fieldEditedHandler', () => {
 			updateFocusedFieldSpy.mockRestore();
 		});
 
-		it('should not call updateFocusedField() when changing name to an empty string', () => {
+		it('does not call updateFocusedField() when changing name to an empty string', () => {
 			const event = {
 				propertyName: 'name',
 				propertyValue: ''

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/handlers/fieldSetAddedHandler.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/handlers/fieldSetAddedHandler.es.js
@@ -17,7 +17,7 @@ import mockPages from 'mock/mockPages.es';
 
 describe('LayoutProvider/handlers/fieldSetAddedHandler', () => {
 	describe('handleFieldSetAdded(props, state, event)', () => {
-		it('should insert the fieldset page to the current page', () => {
+		it('inserts the fieldset page to the current page', () => {
 			const event = {
 				fieldSetPage: [
 					{

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/util/fields.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/util/fields.es.js
@@ -17,21 +17,21 @@ import {generateFieldName} from 'source/components/LayoutProvider/util/fields.es
 
 describe('LayoutProvider/util/fields', () => {
 	describe('generateFieldName(pages, desiredName, currentName)', () => {
-		it('should generate a name based on the desired name', () => {
+		it('generates a name based on the desired name', () => {
 			expect(generateFieldName(mockPages, 'New  Name!')).toEqual(
 				'NewName'
 			);
 		});
 
-		it('should generate an incremental name when desired name is already being used', () => {
+		it('generates an incremental name when desired name is already being used', () => {
 			expect(generateFieldName(mockPages, 'radio')).toEqual('radio1');
 		});
 
-		it('should generate an incremental name when changing desired name to an already used one', () => {
+		it('generates an incremental name when changing desired name to an already used one', () => {
 			expect(generateFieldName(mockPages, 'radio!!')).toEqual('radio1');
 		});
 
-		it('should fallback to currentName when generated name is invalid', () => {
+		it('fallbacks to currentName when generated name is invalid', () => {
 			expect(generateFieldName(mockPages, 'radio!', 'radio')).toEqual(
 				'radio'
 			);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/util/focusedField.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/util/focusedField.es.js
@@ -84,7 +84,7 @@ const focusedField = {
 
 describe('LayoutProvider/util/focusedField', () => {
 	describe('updateFocusedFieldLabel(state, focusedField, value)', () => {
-		it('should update the focused field "label" property', () => {
+		it('updates the focused field "label" property', () => {
 			const state = {
 				pages: mockPages
 			};
@@ -98,7 +98,7 @@ describe('LayoutProvider/util/focusedField', () => {
 			expect(newFocusedField.label).toEqual('New Label');
 		});
 
-		it('should update the settingsContext of the focused field with the new field label', () => {
+		it('updates the settingsContext of the focused field with the new field label', () => {
 			const state = {
 				pages: mockPages
 			};
@@ -114,7 +114,7 @@ describe('LayoutProvider/util/focusedField', () => {
 			).toEqual('New Label');
 		});
 
-		it('should automatically update the field name if it was auto generated from its label', () => {
+		it('automaticallys update the field name if it was auto generated from its label', () => {
 			const mockFocusedField = {
 				...focusedField,
 				fieldName: 'GeneratedFieldName',
@@ -137,7 +137,7 @@ describe('LayoutProvider/util/focusedField', () => {
 			).toEqual('NewLabel');
 		});
 
-		it('should not automatically update the field name if it was not auto generated from its label', () => {
+		it('does not automatically update the field name if it was not auto generated from its label', () => {
 			const state = {
 				pages: mockPages
 			};
@@ -156,7 +156,7 @@ describe('LayoutProvider/util/focusedField', () => {
 	});
 
 	describe('updateFocusedFieldName(state, focusedField, value)', () => {
-		it('should update the focused field "fieldName" property', () => {
+		it('updates the focused field "fieldName" property', () => {
 			const state = {
 				pages: mockPages
 			};
@@ -170,7 +170,7 @@ describe('LayoutProvider/util/focusedField', () => {
 			expect(newFocusedField.fieldName).toEqual('newName');
 		});
 
-		it('should update the settingsContext of the focused field with the new field name', () => {
+		it('updates the settingsContext of the focused field with the new field name', () => {
 			const state = {
 				pages: mockPages
 			};
@@ -186,7 +186,7 @@ describe('LayoutProvider/util/focusedField', () => {
 			).toEqual('newName');
 		});
 
-		it('should update the validation expression of the validation field of the settingsContext with the new field name', () => {
+		it('updates the validation expression of the validation field of the settingsContext with the new field name', () => {
 			const state = {
 				pages: mockPages
 			};
@@ -212,7 +212,7 @@ describe('LayoutProvider/util/focusedField', () => {
 			).toEqual('newName');
 		});
 
-		it('should fallback to the previous valid name when trying to change to an invalid one', () => {
+		it('falls back to the previous valid name when trying to change to an invalid one', () => {
 			const state = {
 				pages: mockPages
 			};
@@ -230,7 +230,7 @@ describe('LayoutProvider/util/focusedField', () => {
 	});
 
 	describe('updateFocusedFieldDataType(state, focusedField, value)', () => {
-		it('should update the focused field "dataType" property', () => {
+		it('updates the focused field "dataType" property', () => {
 			const state = {
 				pages: mockPages
 			};
@@ -244,7 +244,7 @@ describe('LayoutProvider/util/focusedField', () => {
 			expect(newFocusedField.dataType).toEqual('newDataType');
 		});
 
-		it('should update the settingsContext of the focused field with the new dataType', () => {
+		it('updates the settingsContext of the focused field with the new dataType', () => {
 			const state = {
 				pages: mockPages
 			};
@@ -260,7 +260,7 @@ describe('LayoutProvider/util/focusedField', () => {
 			).toEqual('newDataType');
 		});
 
-		it('should update the validation expression of the validation field of the settingsContext with the new dataType', () => {
+		it('updates the validation expression of the validation field of the settingsContext with the new dataType', () => {
 			const state = {
 				pages: mockPages
 			};
@@ -282,7 +282,7 @@ describe('LayoutProvider/util/focusedField', () => {
 	});
 
 	describe('updateFocusedFieldOptions(state, focusedField, options)', () => {
-		it('should update the focused field "options" property', () => {
+		it('updates the focused field "options" property', () => {
 			const newOptions = [
 				{
 					label: 'New Label',
@@ -304,7 +304,7 @@ describe('LayoutProvider/util/focusedField', () => {
 	});
 
 	describe('updateFocusedFieldProperty(state, focusedField, options)', () => {
-		it('should update the desired property', () => {
+		it('updates the desired property', () => {
 			const state = {
 				pages: mockPages
 			};

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/util/rules.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/util/rules.es.js
@@ -19,7 +19,7 @@ import {
 
 describe('LayoutProvider/util/rules', () => {
 	describe('renameFieldInsideExpression(expression, fieldName, newFieldName)', () => {
-		it('should rename a field name used inside an expression', () => {
+		it('renames a field name used inside an expression', () => {
 			const expression = '2*[FieldName1]+sum([FieldName2])';
 
 			expect(
@@ -40,7 +40,7 @@ describe('LayoutProvider/util/rules', () => {
 	});
 
 	describe('updateRulesFieldName(rules, fieldName, newFieldName)', () => {
-		it('should rename a field name used inside a rule condition operand of type "field"', () => {
+		it('renames a field name used inside a rule condition operand of type "field"', () => {
 			const rules = [
 				{
 					actions: [],
@@ -83,7 +83,7 @@ describe('LayoutProvider/util/rules', () => {
 			);
 		});
 
-		it('should rename a field name used inside a rule action target', () => {
+		it('renames a field name used inside a rule action target', () => {
 			const rules = [
 				{
 					actions: [
@@ -108,7 +108,7 @@ describe('LayoutProvider/util/rules', () => {
 			expect(updatedRules[0].actions[1].target).toEqual('FieldName2');
 		});
 
-		it('should rename a field name used inside an expression of rule of type "calculate"', () => {
+		it('renames a field name used inside an expression of rule of type "calculate"', () => {
 			const rules = [
 				{
 					actions: [

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/Page/PageRenderer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/Page/PageRenderer.es.js
@@ -39,7 +39,7 @@ describe('PageRenderer', () => {
 		jest.useFakeTimers();
 	});
 
-	it('should display empty drag message when there are rows with no columns specified', () => {
+	it('displays empty drag message when there are rows with no columns specified', () => {
 		component = new PageRenderer({
 			...componentProps,
 			page: {
@@ -49,7 +49,7 @@ describe('PageRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should change the page title', () => {
+	it('changes the page title', () => {
 		component = new PageRenderer({
 			...componentProps
 		});
@@ -70,7 +70,7 @@ describe('PageRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should change the page title', () => {
+	it('changes the page title', () => {
 		component = new PageRenderer({
 			...componentProps
 		});
@@ -91,7 +91,7 @@ describe('PageRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render a layout and emit an event when delete button is clicked', () => {
+	it('renders a layout and emit an event when delete button is clicked', () => {
 		component = new PageRenderer({
 			...componentProps
 		});
@@ -107,7 +107,7 @@ describe('PageRenderer', () => {
 		);
 	});
 
-	it('should render a layout and emit an event when duplicate button is clicked', () => {
+	it('renders a layout and emit an event when duplicate button is clicked', () => {
 		component = new PageRenderer({
 			...componentProps
 		});
@@ -123,7 +123,7 @@ describe('PageRenderer', () => {
 		);
 	});
 
-	it('should render a layout with emit an field clicked event', () => {
+	it('renders a layout with emit an field clicked event', () => {
 		component = new PageRenderer({
 			...componentProps
 		});
@@ -136,7 +136,7 @@ describe('PageRenderer', () => {
 		expect(spy).toHaveBeenCalledWith('fieldClicked', expect.any(Object));
 	});
 
-	it('should emit a fieldClicked event with the field location', () => {
+	it('emits a fieldClicked event with the field location', () => {
 		component = new PageRenderer({
 			...componentProps,
 			dragAndDropDisabled: true

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleBuilder/RuleBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleBuilder/RuleBuilder.es.js
@@ -212,7 +212,7 @@ describe('RuleBuilder', () => {
 
 		dom.exitDocument(addbutton);
 	});
-	it('should render the list of rules when mode is set to view', () => {
+	it('renders the list of rules when mode is set to view', () => {
 		component.setState({mode: 'view'});
 
 		jest.runAllTimers();
@@ -220,7 +220,7 @@ describe('RuleBuilder', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render rule screen creator when click add button', () => {
+	it('renders rule screen creator when click add button', () => {
 		const addbutton = document.querySelector('#addFieldButton');
 
 		dom.triggerEvent(addbutton, 'click', {});
@@ -230,7 +230,7 @@ describe('RuleBuilder', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should receive ruleAdded event to save a rule', () => {
+	it('receives ruleAdded event to save a rule', () => {
 		jest.runAllTimers();
 
 		const spy = jest.spyOn(component, 'emit');
@@ -248,7 +248,7 @@ describe('RuleBuilder', () => {
 		expect(spy).toHaveBeenCalledWith('ruleAdded', {});
 	});
 
-	it('should change the view mode from view to edit', () => {
+	it('changes the view mode from view to edit', () => {
 		jest.runAllTimers();
 
 		jest.useFakeTimers();
@@ -262,7 +262,7 @@ describe('RuleBuilder', () => {
 		expect(component.state.mode).toEqual('edit');
 	});
 
-	it('should receive ruleCancel event to discard a rule creation', () => {
+	it('receives ruleCancel event to discard a rule creation', () => {
 		jest.runAllTimers();
 
 		const totalRules = component.props.rules.length;
@@ -282,7 +282,7 @@ describe('RuleBuilder', () => {
 		expect(component.state.rules.length).toEqual(totalRules);
 	});
 
-	it('should fetch roles when rendered', () => {
+	it('fetchs roles when rendered', () => {
 		const spy = jest.spyOn(window, 'fetch');
 
 		component = new RuleBuilder(baseConfig);
@@ -295,7 +295,7 @@ describe('RuleBuilder', () => {
 		spy.mockRestore();
 	});
 
-	it('should be able to edit a rule when more than one is available in the Rules list', () => {
+	it('is able to edit a rule when more than one is available in the Rules list', () => {
 		component = new RuleBuilder(baseConfig);
 
 		jest.useFakeTimers();
@@ -309,7 +309,7 @@ describe('RuleBuilder', () => {
 		expect(component.state.mode).toEqual('edit');
 	});
 
-	it("should be able to edit a rule when there's only one rule available in the Rules list", () => {
+	it("is able to edit a rule when there's only one rule available in the Rules list", () => {
 		component = new RuleBuilder({
 			...baseConfig,
 			rules: [

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleBuilder/RulesSupport.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleBuilder/RulesSupport.es.js
@@ -42,7 +42,7 @@ const mockConditions = [
 ];
 
 describe('RulesSupport', () => {
-	it('should clear the action target value', () => {
+	it('clears the action target value', () => {
 		const mockArgument = [...mockActions];
 
 		const actions = RulesSupport.clearTargetValue(mockArgument, 0);
@@ -50,7 +50,7 @@ describe('RulesSupport', () => {
 		expect(actions[0].target).toEqual('');
 	});
 
-	it('should clear the first operand value', () => {
+	it('clears the first operand value', () => {
 		const mockArgument = [...mockConditions];
 
 		const condition = RulesSupport.clearFirstOperandValue(mockArgument[0]);
@@ -59,7 +59,7 @@ describe('RulesSupport', () => {
 		expect(condition.operands[0].value).toEqual('');
 	});
 
-	it('should clear the operator value', () => {
+	it('clears the operator value', () => {
 		const mockArgument = [...mockConditions];
 
 		const condition = RulesSupport.clearOperatorValue(mockArgument[0]);
@@ -67,7 +67,7 @@ describe('RulesSupport', () => {
 		expect(condition.operator).toEqual('');
 	});
 
-	it('should clear the second operand value', () => {
+	it('clears the second operand value', () => {
 		const mockArgument = [...mockConditions];
 
 		const condition = RulesSupport.clearSecondOperandValue(mockArgument[0]);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleEditor/RuleEditor.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleEditor/RuleEditor.es.js
@@ -142,7 +142,7 @@ describe('Rule Editor', () => {
 		});
 
 		describe("When a condition is added and there's more than one condition, there must be an option the delete the condition", () => {
-			it('should display a confirmation modal when trying to delete a condition', () => {
+			it('displays a confirmation modal when trying to delete a condition', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -170,7 +170,7 @@ describe('Rule Editor', () => {
 				expect(component).toMatchSnapshot();
 			});
 
-			it('should delete a condition of user accepts confirmation modal', () => {
+			it('deletes a condition of user accepts confirmation modal', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -206,7 +206,7 @@ describe('Rule Editor', () => {
 		});
 
 		describe('The OR select must be disabled by default', () => {
-			it('should disable the "AND" or "OR" selector when there\'s only one condtion', () => {
+			it('disables the "AND" or "OR" selector when there\'s only one condtion', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -222,7 +222,7 @@ describe('Rule Editor', () => {
 		});
 
 		describe('The OR select must be activated if the are more than one condition', () => {
-			it('should enable the "AND" or "OR" selector when there\'s more than one condtion', () => {
+			it('enables the "AND" or "OR" selector when there\'s more than one condtion', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -251,7 +251,7 @@ describe('Rule Editor', () => {
 		});
 
 		describe('Clear all fields when first operand is not selected', () => {
-			it('should make operators field "read only" when first operand is not selected', () => {
+			it('makes operators field "read only" when first operand is not selected', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -263,7 +263,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.conditionOperator0.readOnly).toBeTruthy();
 			});
 
-			it('should hide the second operand type selector when first operand is not selected', () => {
+			it('hides the second operand type selector when first operand is not selected', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -275,7 +275,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.secondOperandTypeSelector0).toBeFalsy();
 			});
 
-			it('should hide the second operand when first operand is not selected', () => {
+			it('hides the second operand when first operand is not selected', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -287,7 +287,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.secondOperand0).toBeFalsy();
 			});
 
-			it('should reset the operator, and hide the second operand type selector and second operand', () => {
+			it('resets the operator, and hide the second operand type selector and second operand', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -318,7 +318,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.secondOperand0).toBeFalsy();
 			});
 
-			it('should reset the operator, and hide the second operand type selector and second operand', () => {
+			it('resets the operator, and hide the second operand type selector and second operand', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -349,7 +349,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.secondOperand0).toBeFalsy();
 			});
 
-			it('should not reset second operand type selector nor second operand when operator changes from a binary type to another binary type', () => {
+			it('does not reset second operand type selector nor second operand when operator changes from a binary type to another binary type', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -384,7 +384,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.secondOperand0.value).toEqual(['123']);
 			});
 
-			it('should hide second operand type selector and hide second operand when operator changes from a binary type to an unary type', () => {
+			it('hides second operand type selector and hide second operand when operator changes from a binary type to an unary type', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -414,7 +414,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.secondOperand0).toBeFalsy();
 			});
 
-			it('should not make operators field "read only" when first operand is selected', () => {
+			it('does not make operators field "read only" when first operand is selected', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -427,8 +427,8 @@ describe('Rule Editor', () => {
 			});
 		});
 
-		describe('should configure the conditions according to the first operand type', () => {
-			it('should populate operators when the first selected operand is a field', () => {
+		describe('configuring the conditions according to the first operand type', () => {
+			it('populates operators when the first selected operand is a field', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -442,7 +442,7 @@ describe('Rule Editor', () => {
 				).toMatchSnapshot();
 			});
 
-			it('should populate operators when the first selected operand is an user', () => {
+			it('populates operators when the first selected operand is an user', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -456,7 +456,7 @@ describe('Rule Editor', () => {
 				).toMatchSnapshot();
 			});
 
-			it('should keep operator values the same when first operand changes to another value of the same type', () => {
+			it('keeps operator values the same when first operand changes to another value of the same type', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -477,7 +477,7 @@ describe('Rule Editor', () => {
 				);
 			});
 
-			it('should clear first operand when field is removed from pages', () => {
+			it('clears first operand when field is removed from pages', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -493,7 +493,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.firstOperand0.value).toEqual(['']);
 			});
 
-			it('should not clear first operand when pages are changed and first operand is User', () => {
+			it('does not clear first operand when pages are changed and first operand is User', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -509,7 +509,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.firstOperand0.value).toEqual(['user']);
 			});
 
-			it('should not clear first operand when pages were changed but selected field was not removed', () => {
+			it('does not clear first operand when pages were changed but selected field was not removed', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -544,7 +544,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.firstOperand0.value).toEqual(['radio']);
 			});
 
-			it('should not clear second operand value when pages were changed but selected field was not removed', () => {
+			it('does not clear second operand value when pages were changed but selected field was not removed', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -599,7 +599,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.secondOperand0.value).toEqual(['123']);
 			});
 
-			it('should not display second operand type selector ("Other Field" or "Value") when operator is empty', () => {
+			it('does not display second operand type selector ("Other Field" or "Value") when operator is empty', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -620,7 +620,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.secondOperandTypeSelector0).toBeFalsy();
 			});
 
-			it('should reset second operand type selector ("Other Field" or "Value") and hide second operand when selected field is removed', () => {
+			it('resets second operand type selector ("Other Field" or "Value") and hide second operand when selected field is removed', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -667,7 +667,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.secondOperand0).toBeFalsy();
 			});
 
-			it('should reset second operand type selector ("Other Field" or "Value") and hide second operand when first operand field is changed', () => {
+			it('resets second operand type selector ("Other Field" or "Value") and hide second operand when first operand field is changed', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -705,7 +705,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.secondOperand0).toBeFalsy();
 			});
 
-			it('should add a new condition to the conditions array', () => {
+			it('adds a new condition to the conditions array', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -730,7 +730,7 @@ describe('Rule Editor', () => {
 				expect(component).toMatchSnapshot();
 			});
 
-			it('should change all logical operators when changing it via the global logical operator selector', () => {
+			it('changes all logical operators when changing it via the global logical operator selector', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -759,7 +759,7 @@ describe('Rule Editor', () => {
 		});
 
 		describe('When the user choose any of the options of the action a select target should be displayed', () => {
-			it('should display the action target according to action type (Show, Enable or Required)', () => {
+			it('displays the action target according to action type (Show, Enable or Required)', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -771,7 +771,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.actionTarget0).toBeTruthy();
 			});
 
-			it('should add to the deletedField all the fields removed from the FormBuilder', () => {
+			it('adds to the deletedField all the fields removed from the FormBuilder', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -795,7 +795,7 @@ describe('Rule Editor', () => {
 				expect(notEquals).toEqual(false);
 			});
 
-			it('should not reset the target after setting a target to an action and click in the action selected without changing it', () => {
+			it('does not reset the target after setting a target to an action and click in the action selected without changing it', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -813,7 +813,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.actionTarget0.value).toEqual(['date']);
 			});
 
-			it('should show Result field when the action Calculate is selected', () => {
+			it('shows Result field when the action Calculate is selected', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -827,7 +827,7 @@ describe('Rule Editor', () => {
 				expect(resultField).toBe(true);
 			});
 
-			it('should show Result field when the action Calculate is selected', () => {
+			it('shows Result field when the action Calculate is selected', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -851,7 +851,7 @@ describe('Rule Editor', () => {
 				expect(resultField).toBe(false);
 			});
 
-			it('should refresh the target when the user changes any of the options of the first action select between (Show, Enable or Required)', () => {
+			it('refreshes the target when the user changes any of the options of the first action select between (Show, Enable or Required)', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -870,7 +870,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.actionTarget0.value).toEqual(['']);
 			});
 
-			it('should refresh the target when the user changes de Action from autofill to Show, Enable or Required', () => {
+			it('refreshes the target when the user changes de Action from autofill to Show, Enable or Required', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -890,7 +890,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.actionTarget0.value).toEqual(['']);
 			});
 
-			it('should display the action target according to action type (Autofill)', () => {
+			it('displays the action target according to action type (Autofill)', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -908,7 +908,7 @@ describe('Rule Editor', () => {
 				expect(labelVisible).toBeTruthy();
 			});
 
-			it('should display only one data-provider label everytime an autofill target is selected', () => {
+			it('displays only one data-provider label everytime an autofill target is selected', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -932,7 +932,7 @@ describe('Rule Editor', () => {
 				expect(labelQuantityAfter).toBe(1);
 			});
 
-			it('should duplicate an action when duplicate field is clicked', () => {
+			it('duplicates an action when duplicate field is clicked', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -1008,7 +1008,7 @@ describe('Rule Editor', () => {
 				expect(component.refs.cancel.disabled).toBe(false);
 			});
 
-			it('should be possible to save a rule', () => {
+			it('is possible to save a rule', () => {
 				jest.useFakeTimers();
 
 				component = new RuleEditor({
@@ -1078,7 +1078,7 @@ describe('Rule Editor', () => {
 				});
 			});
 
-			it('should be possible to cancel a rule', () => {
+			it('is possible to cancel a rule', () => {
 				component = new RuleEditor({
 					...getBaseConfig()
 				});
@@ -1121,7 +1121,7 @@ describe('Rule Editor', () => {
 				);
 			});
 
-			it('should edit an existent rule', () => {
+			it('edits an existent rule', () => {
 				component = new RuleEditor({
 					...getBaseConfig(),
 					rule: {
@@ -1187,7 +1187,7 @@ describe('Rule Editor', () => {
 
 describe('Regression', () => {
 	describe('LPS-86162 The filled value is being lost when re-selecting Value in the rule builder', () => {
-		it('should not clear second operand value when there were no changes on second oprand type', () => {
+		it('does not clear second operand value when there were no changes on second oprand type', () => {
 			component = new RuleEditor({
 				...getBaseConfig()
 			});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleList/RuleList.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/RuleList/RuleList.es.js
@@ -84,7 +84,7 @@ describe('RuleList', () => {
 		}
 	});
 
-	it('should return the field label for each action', () => {
+	it('returns the field label for each action', () => {
 		component = new RuleList(configDefault);
 
 		const contextLabel =
@@ -97,7 +97,7 @@ describe('RuleList', () => {
 		expect(actionLabel).toEqual(contextLabel);
 	});
 
-	it('should show message when rule list is empty', () => {
+	it('shows message when rule list is empty', () => {
 		component = new RuleList({
 			pages,
 			rules: [],

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/Sidebar/Sidebar.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/Sidebar/Sidebar.es.js
@@ -176,7 +176,7 @@ describe('Sidebar', () => {
 		}
 	});
 
-	it('should render the default markup', () => {
+	it('renders the default markup', () => {
 		component = new Sidebar({
 			fieldTypes,
 			spritemap
@@ -185,7 +185,7 @@ describe('Sidebar', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render a Sidebar open', () => {
+	it('renders a Sidebar open', () => {
 		component = new Sidebar({
 			fieldTypes,
 			spritemap
@@ -197,7 +197,7 @@ describe('Sidebar', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render a Sidebar closed', () => {
+	it('renders a Sidebar closed', () => {
 		component = new Sidebar({
 			fieldTypes,
 			spritemap
@@ -209,7 +209,7 @@ describe('Sidebar', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render a Sidebar with fieldTypes', () => {
+	it('renders a Sidebar with fieldTypes', () => {
 		component = new Sidebar({
 			fieldTypes,
 			spritemap
@@ -222,7 +222,7 @@ describe('Sidebar', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should close the sidebar when the mouse down event is not on it', () => {
+	it('closes the sidebar when the mouse down event is not on it', () => {
 		component = new Sidebar({
 			fieldTypes,
 			spritemap
@@ -239,7 +239,7 @@ describe('Sidebar', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should emit fieldMoved when the dragEnd method is called', () => {
+	it('emits fieldMoved when the dragEnd method is called', () => {
 		component = new Sidebar({
 			fieldTypes,
 			spritemap
@@ -281,7 +281,7 @@ describe('Sidebar', () => {
 		expect(spy).toHaveBeenCalledWith('fieldAdded', expect.anything());
 	});
 
-	it('should emit the fieldDuplicated event when the duplicate field option is clicked on the sidebar settings', () => {
+	it('emits the fieldDuplicated event when the duplicate field option is clicked on the sidebar settings', () => {
 		component = new Sidebar({
 			fieldTypes,
 			focusedField,
@@ -305,7 +305,7 @@ describe('Sidebar', () => {
 		expect(spy).toHaveBeenCalledWith('fieldDuplicated', expect.anything());
 	});
 
-	it('should emit the fieldDeleted event when the delete field option is clicked on the sidebar settings', () => {
+	it('emits the fieldDeleted event when the delete field option is clicked on the sidebar settings', () => {
 		component = new Sidebar({
 			fieldTypes,
 			focusedField,
@@ -329,7 +329,7 @@ describe('Sidebar', () => {
 		expect(spy).toHaveBeenCalled();
 	});
 
-	it('should emit the fieldChangesCanceled event when the cancel field chages option is clicked on the sidebar settings', () => {
+	it('emits the fieldChangesCanceled event when the cancel field chages option is clicked on the sidebar settings', () => {
 		component = new Sidebar({
 			fieldTypes,
 			focusedField,
@@ -353,7 +353,7 @@ describe('Sidebar', () => {
 		expect(spy).toHaveBeenCalled();
 	});
 
-	it('should render a Sidebar with spritemap', () => {
+	it('renders a Sidebar with spritemap', () => {
 		component = new Sidebar({
 			fieldTypes,
 			spritemap
@@ -366,7 +366,7 @@ describe('Sidebar', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should close the sidebar in edition mode', () => {
+	it('closes the sidebar in edition mode', () => {
 		const focusedField = mockFieldType;
 
 		component = new Sidebar({
@@ -382,7 +382,7 @@ describe('Sidebar', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should close the sidebar in edition mode', () => {
+	it('closes the sidebar in edition mode', () => {
 		const focusedField = mockFieldType;
 
 		component = new Sidebar({
@@ -407,7 +407,7 @@ describe('Sidebar', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should propagates evaluator changed event', () => {
+	it('propagates evaluator changed event', () => {
 		const focusedField = mockFieldType;
 
 		component = new Sidebar({
@@ -430,7 +430,7 @@ describe('Sidebar', () => {
 		expect(spy).toHaveBeenCalled();
 	});
 
-	it('should propagates field edited event', () => {
+	it('propagates field edited event', () => {
 		const focusedField = mockFieldType;
 
 		component = new Sidebar({
@@ -452,7 +452,7 @@ describe('Sidebar', () => {
 	});
 
 	describe('Interaction with markup', () => {
-		it('should close Sidebar when click the button close', () => {
+		it('closes Sidebar when click the button close', () => {
 			component = new Sidebar({
 				fieldTypes,
 				spritemap
@@ -475,7 +475,7 @@ describe('Sidebar', () => {
 	});
 
 	describe('Changing field type', () => {
-		it('should always be enabled', () => {
+		it('is always be enabled', () => {
 			component = new Sidebar({
 				fieldTypes,
 				focusedField: mockFieldType,
@@ -487,7 +487,7 @@ describe('Sidebar', () => {
 			expect(component.isChangeFieldTypeEnabled()).toBeTruthy();
 		});
 
-		it('should keep basic properties after changing field type', done => {
+		it('keeps basic properties after changing field type', done => {
 			const {settingsContext} = mockFieldType;
 			let {pages} = settingsContext;
 
@@ -526,7 +526,7 @@ describe('Sidebar', () => {
 			component.changeFieldType('checkbox');
 		});
 
-		it('should not keep validation settings between field type', done => {
+		it('does not keep validation settings between field type', done => {
 			const {settingsContext} = mockFieldType;
 			let {pages} = settingsContext;
 
@@ -559,7 +559,7 @@ describe('Sidebar', () => {
 			component.changeFieldType('checkbox');
 		});
 
-		it('should emit an event with new field type settings', done => {
+		it('emits an event with new field type settings', done => {
 			component = new Sidebar({
 				fieldTypes,
 				focusedField: mockFieldType,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/SuccessPage/SuccessPage.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/SuccessPage/SuccessPage.es.js
@@ -36,7 +36,7 @@ describe.only('SuccessPage', () => {
 		successPageSettings = null;
 	});
 
-	it('should render the default layour', () => {
+	it('renders the default layour', () => {
 		component = new SuccessPage({
 			contentLabel: 'Content',
 			successPageSettings,
@@ -48,7 +48,7 @@ describe.only('SuccessPage', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should emit success page changed when success page title is changed', () => {
+	it('emits success page changed when success page title is changed', () => {
 		const newPageSettings = {
 			...successPageSettings,
 			enabled: true
@@ -76,7 +76,7 @@ describe.only('SuccessPage', () => {
 		);
 	});
 
-	it('should emit success page changed when success page body is changed', () => {
+	it('emits success page changed when success page body is changed', () => {
 		const newPageSettings = {
 			...successPageSettings,
 			enabled: true

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/expressions/Tokenizer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/expressions/Tokenizer.es.js
@@ -16,7 +16,7 @@ import Token from 'source/expressions/Token.es';
 import Tokenizer from 'source/expressions/Tokenizer.es';
 
 describe('Tokenizer', () => {
-	it('should tokenize single digit expressions', () => {
+	it('tokenizes single digit expressions', () => {
 		expect(Tokenizer.tokenize('4[a] + 1')).toEqual([
 			new Token('Literal', '4'),
 			new Token('Operator', '*'),
@@ -26,7 +26,7 @@ describe('Tokenizer', () => {
 		]);
 	});
 
-	it('should tokenize multiple digit expressions', () => {
+	it('tokenizes multiple digit expressions', () => {
 		expect(Tokenizer.tokenize('456[a] + 125')).toEqual([
 			new Token('Literal', '456'),
 			new Token('Operator', '*'),
@@ -36,7 +36,7 @@ describe('Tokenizer', () => {
 		]);
 	});
 
-	it('should tokenize floating point expressions', () => {
+	it('tokenizes floating point expressions', () => {
 		expect(Tokenizer.tokenize('7.346 + 13.44 * 567')).toEqual([
 			new Token('Literal', '7.346'),
 			new Token('Operator', '+'),
@@ -46,7 +46,7 @@ describe('Tokenizer', () => {
 		]);
 	});
 
-	it('should tokenize multiple letter variables', () => {
+	it('tokenizes multiple letter variables', () => {
 		expect(Tokenizer.tokenize('[Field1] * [Field2] + [Field3]')).toEqual([
 			new Token('Variable', 'Field1'),
 			new Token('Operator', '*'),
@@ -56,7 +56,7 @@ describe('Tokenizer', () => {
 		]);
 	});
 
-	it('should tokenize expressions with functions', () => {
+	it('tokenizes expressions with functions', () => {
 		expect(Tokenizer.tokenize('2 * 5 + sum([Field2])')).toEqual([
 			new Token('Literal', '2'),
 			new Token('Operator', '*'),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/util/i18n.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/util/i18n.es.js
@@ -15,7 +15,7 @@
 import {setLocalizedValue} from 'source/util/i18n.es';
 
 describe('Internationlization', () => {
-	it('should create a localized property for a specific object string value', () => {
+	it('creates a localized property for a specific object string value', () => {
 		const obj = {
 			title: ''
 		};
@@ -31,7 +31,7 @@ describe('Internationlization', () => {
 		});
 	});
 
-	it('should replace a localized value for a specific object string', () => {
+	it('replaces a localized value for a specific object string', () => {
 		const obj = {
 			localizedTitle: {
 				en_US: ''

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Checkbox/Checkbox.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Checkbox/Checkbox.es.js
@@ -28,7 +28,7 @@ describe('Field Checkbox', () => {
 		}
 	});
 
-	it('should be not edidable', () => {
+	it('is not edidable', () => {
 		component = new Checkbox({
 			readOnly: false,
 			spritemap
@@ -37,7 +37,7 @@ describe('Field Checkbox', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a helptext', () => {
+	it('has a helptext', () => {
 		component = new Checkbox({
 			spritemap,
 			tip: 'Type something'
@@ -46,7 +46,7 @@ describe('Field Checkbox', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have an id', () => {
+	it('has an id', () => {
 		component = new Checkbox({
 			id: 'ID',
 			spritemap
@@ -55,7 +55,7 @@ describe('Field Checkbox', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a label', () => {
+	it('has a label', () => {
 		component = new Checkbox({
 			label: 'label',
 			spritemap
@@ -64,7 +64,7 @@ describe('Field Checkbox', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a predefined Value', () => {
+	it('has a predefined Value', () => {
 		component = new Checkbox({
 			placeholder: 'Option 1',
 			spritemap
@@ -73,7 +73,7 @@ describe('Field Checkbox', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should not be required', () => {
+	it('is not required', () => {
 		component = new Checkbox({
 			required: false,
 			spritemap
@@ -82,7 +82,7 @@ describe('Field Checkbox', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should be shown as a switcher', () => {
+	it('is shown as a switcher', () => {
 		component = new Checkbox({
 			showAsSwitcher: true,
 			spritemap
@@ -91,7 +91,7 @@ describe('Field Checkbox', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should be shown as checkbox', () => {
+	it('is shown as checkbox', () => {
 		component = new Checkbox({
 			showAsSwitcher: false,
 			spritemap
@@ -100,7 +100,7 @@ describe('Field Checkbox', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render Label if showLabel is true', () => {
+	it('renders Label if showLabel is true', () => {
 		component = new Checkbox({
 			label: 'text',
 			showLabel: true,
@@ -110,7 +110,7 @@ describe('Field Checkbox', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a spritemap', () => {
+	it('has a spritemap', () => {
 		component = new Checkbox({
 			spritemap
 		});
@@ -118,7 +118,7 @@ describe('Field Checkbox', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a value', () => {
+	it('has a value', () => {
 		component = new Checkbox({
 			spritemap,
 			value: true
@@ -127,7 +127,7 @@ describe('Field Checkbox', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a key', () => {
+	it('has a key', () => {
 		component = new Checkbox({
 			key: 'key',
 			spritemap
@@ -136,7 +136,7 @@ describe('Field Checkbox', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should emit field edit event on field change', done => {
+	it('emits field edit event on field change', done => {
 		const handleFieldEdited = jest.fn();
 
 		const events = {fieldEdited: handleFieldEdited};
@@ -161,7 +161,7 @@ describe('Field Checkbox', () => {
 		jest.runAllTimers();
 	});
 
-	it('should propagate the field edit event on field change', () => {
+	it('propagates the field edit event on field change', () => {
 		component = new Checkbox({
 			spritemap
 		});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/CheckboxMultiple/CheckboxMultiple.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/CheckboxMultiple/CheckboxMultiple.es.js
@@ -28,7 +28,7 @@ describe('Field Checkbox Multiple', () => {
 		}
 	});
 
-	it('should be not edidable', () => {
+	it('is not edidable', () => {
 		component = new CheckboxMultiple({
 			readOnly: false,
 			spritemap
@@ -37,7 +37,7 @@ describe('Field Checkbox Multiple', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a helptext', () => {
+	it('has a helptext', () => {
 		component = new CheckboxMultiple({
 			spritemap,
 			tip: 'Type something'
@@ -46,7 +46,7 @@ describe('Field Checkbox Multiple', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have an id', () => {
+	it('has an id', () => {
 		component = new CheckboxMultiple({
 			id: 'ID',
 			spritemap
@@ -55,7 +55,7 @@ describe('Field Checkbox Multiple', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a label', () => {
+	it('has a label', () => {
 		component = new CheckboxMultiple({
 			label: 'label',
 			spritemap
@@ -64,7 +64,7 @@ describe('Field Checkbox Multiple', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a predefined Value', () => {
+	it('has a predefined Value', () => {
 		component = new CheckboxMultiple({
 			placeholder: 'Option 1',
 			spritemap
@@ -73,7 +73,7 @@ describe('Field Checkbox Multiple', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should not be required', () => {
+	it('is not required', () => {
 		component = new CheckboxMultiple({
 			required: false,
 			spritemap
@@ -82,7 +82,7 @@ describe('Field Checkbox Multiple', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should be shown as a switcher', () => {
+	it('is shown as a switcher', () => {
 		component = new CheckboxMultiple({
 			showAsSwitcher: true,
 			spritemap
@@ -91,7 +91,7 @@ describe('Field Checkbox Multiple', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should be shown as checkbox', () => {
+	it('is shown as checkbox', () => {
 		component = new CheckboxMultiple({
 			showAsSwitcher: false,
 			spritemap
@@ -100,7 +100,7 @@ describe('Field Checkbox Multiple', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render Label if showLabel is true', () => {
+	it('renders Label if showLabel is true', () => {
 		component = new CheckboxMultiple({
 			label: 'text',
 			showLabel: true,
@@ -110,7 +110,7 @@ describe('Field Checkbox Multiple', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a spritemap', () => {
+	it('has a spritemap', () => {
 		component = new CheckboxMultiple({
 			spritemap
 		});
@@ -118,7 +118,7 @@ describe('Field Checkbox Multiple', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a value', () => {
+	it('has a value', () => {
 		component = new CheckboxMultiple({
 			spritemap,
 			value: true
@@ -127,7 +127,7 @@ describe('Field Checkbox Multiple', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a key', () => {
+	it('has a key', () => {
 		component = new CheckboxMultiple({
 			key: 'key',
 			spritemap
@@ -136,7 +136,7 @@ describe('Field Checkbox Multiple', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should emit field edit event on field change', done => {
+	it('emits field edit event on field change', done => {
 		const handleFieldEdited = jest.fn();
 
 		const events = {fieldEdited: handleFieldEdited};
@@ -161,7 +161,7 @@ describe('Field Checkbox Multiple', () => {
 		jest.runAllTimers();
 	});
 
-	it('should propagate the field edit event on field change', () => {
+	it('propagates the field edit event on field change', () => {
 		component = new CheckboxMultiple({
 			spritemap
 		});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/DatePicker.es.js
@@ -32,7 +32,7 @@ describe('DatePicker', () => {
 		jest.useFakeTimers();
 	});
 
-	it('should have a helptext', () => {
+	it('has a helptext', () => {
 		component = new DatePicker({
 			...defaultDatePickerConfig,
 			tip: 'Type something'
@@ -41,7 +41,7 @@ describe('DatePicker', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have an id', () => {
+	it('has an id', () => {
 		component = new DatePicker({
 			...defaultDatePickerConfig,
 			id: 'ID'
@@ -50,7 +50,7 @@ describe('DatePicker', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a label', () => {
+	it('has a label', () => {
 		component = new DatePicker({
 			...defaultDatePickerConfig,
 			label: 'label'
@@ -59,7 +59,7 @@ describe('DatePicker', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a predefinedValue', () => {
+	it('has a predefinedValue', () => {
 		component = new DatePicker({
 			...defaultDatePickerConfig,
 			predefinedValue: '05/05/2019'
@@ -68,7 +68,7 @@ describe('DatePicker', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should expand the datepicker when clicking the calendar icon', () => {
+	it('expands the datepicker when clicking the calendar icon', () => {
 		component = new DatePicker({
 			...defaultDatePickerConfig
 		});
@@ -87,7 +87,7 @@ describe('DatePicker', () => {
 		expect(spy).toBeCalled();
 	});
 
-	it('should fill the input with the current date selected on Date Picker', () => {
+	it('fills the input with the current date selected on Date Picker', () => {
 		component = new DatePicker({
 			...defaultDatePickerConfig
 		});
@@ -111,7 +111,7 @@ describe('DatePicker', () => {
 		expect(spy).toHaveBeenCalledWith('fieldEdited', expect.anything());
 	});
 
-	it('should decrease the current month when the back arrow is selected on Date Picker', () => {
+	it('decreases the current month when the back arrow is selected on Date Picker', () => {
 		component = new DatePicker({
 			...defaultDatePickerConfig
 		});
@@ -146,7 +146,7 @@ describe('DatePicker', () => {
 		}
 	});
 
-	it('should increase the current month when the forward arrow is selected on Date Picker', () => {
+	it('increases the current month when the forward arrow is selected on Date Picker', () => {
 		component = new DatePicker({
 			...defaultDatePickerConfig
 		});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
@@ -29,7 +29,7 @@ describe('Field DocumentLibrary', () => {
 		}
 	});
 
-	it('should not be readOnly', () => {
+	it('is not readOnly', () => {
 		component = new DocumentLibrary({
 			...defaultDocumentLibraryConfig,
 			readOnly: false
@@ -38,7 +38,7 @@ describe('Field DocumentLibrary', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a helptext', () => {
+	it('has a helptext', () => {
 		component = new DocumentLibrary({
 			...defaultDocumentLibraryConfig,
 			tip: 'Type something'
@@ -47,7 +47,7 @@ describe('Field DocumentLibrary', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have an id', () => {
+	it('has an id', () => {
 		component = new DocumentLibrary({
 			...defaultDocumentLibraryConfig,
 			id: 'ID'
@@ -56,7 +56,7 @@ describe('Field DocumentLibrary', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a label', () => {
+	it('has a label', () => {
 		component = new DocumentLibrary({
 			...defaultDocumentLibraryConfig,
 			label: 'label'
@@ -65,7 +65,7 @@ describe('Field DocumentLibrary', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a placeholder', () => {
+	it('has a placeholder', () => {
 		component = new DocumentLibrary({
 			...defaultDocumentLibraryConfig,
 			placeholder: 'Placeholder'
@@ -74,7 +74,7 @@ describe('Field DocumentLibrary', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should not be required', () => {
+	it('is not required', () => {
 		component = new DocumentLibrary({
 			...defaultDocumentLibraryConfig,
 			required: false
@@ -83,7 +83,7 @@ describe('Field DocumentLibrary', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render Label if showLabel is true', () => {
+	it('renders Label if showLabel is true', () => {
 		component = new DocumentLibrary({
 			...defaultDocumentLibraryConfig,
 			label: 'text',
@@ -93,13 +93,13 @@ describe('Field DocumentLibrary', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a spritemap', () => {
+	it('has a spritemap', () => {
 		component = new DocumentLibrary(defaultDocumentLibraryConfig);
 
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a value', () => {
+	it('has a value', () => {
 		component = new DocumentLibrary({
 			...defaultDocumentLibraryConfig,
 			value: {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/__snapshots__/DocumentLibrary.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/__snapshots__/DocumentLibrary.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Field DocumentLibrary should have a helptext 1`] = `
+exports[`Field DocumentLibrary has a helptext 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="liferay-ddm-form-field-document-library">
     <div class="input-group">
@@ -11,7 +11,7 @@ exports[`Field DocumentLibrary should have a helptext 1`] = `
 </div>
 `;
 
-exports[`Field DocumentLibrary should have a label 1`] = `
+exports[`Field DocumentLibrary has a label 1`] = `
 <div class="form-group" data-field-name="textField"><label>label </label>
   <div class="liferay-ddm-form-field-document-library">
     <div class="input-group">
@@ -22,7 +22,7 @@ exports[`Field DocumentLibrary should have a label 1`] = `
 </div>
 `;
 
-exports[`Field DocumentLibrary should have a placeholder 1`] = `
+exports[`Field DocumentLibrary has a placeholder 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="liferay-ddm-form-field-document-library">
     <div class="input-group">
@@ -33,7 +33,7 @@ exports[`Field DocumentLibrary should have a placeholder 1`] = `
 </div>
 `;
 
-exports[`Field DocumentLibrary should have a spritemap 1`] = `
+exports[`Field DocumentLibrary has a spritemap 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="liferay-ddm-form-field-document-library">
     <div class="input-group">
@@ -44,7 +44,7 @@ exports[`Field DocumentLibrary should have a spritemap 1`] = `
 </div>
 `;
 
-exports[`Field DocumentLibrary should have a value 1`] = `
+exports[`Field DocumentLibrary has a value 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="liferay-ddm-form-field-document-library">
     <div class="input-group">
@@ -55,7 +55,7 @@ exports[`Field DocumentLibrary should have a value 1`] = `
 </div>
 `;
 
-exports[`Field DocumentLibrary should have an id 1`] = `
+exports[`Field DocumentLibrary has an id 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="liferay-ddm-form-field-document-library">
     <div class="input-group">
@@ -66,7 +66,7 @@ exports[`Field DocumentLibrary should have an id 1`] = `
 </div>
 `;
 
-exports[`Field DocumentLibrary should not be readOnly 1`] = `
+exports[`Field DocumentLibrary is not readOnly 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="liferay-ddm-form-field-document-library">
     <div class="input-group">
@@ -77,7 +77,7 @@ exports[`Field DocumentLibrary should not be readOnly 1`] = `
 </div>
 `;
 
-exports[`Field DocumentLibrary should not be required 1`] = `
+exports[`Field DocumentLibrary is not required 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="liferay-ddm-form-field-document-library">
     <div class="input-group">
@@ -88,7 +88,7 @@ exports[`Field DocumentLibrary should not be required 1`] = `
 </div>
 `;
 
-exports[`Field DocumentLibrary should render Label if showLabel is true 1`] = `
+exports[`Field DocumentLibrary renders Label if showLabel is true 1`] = `
 <div class="form-group" data-field-name="textField"><label>text </label>
   <div class="liferay-ddm-form-field-document-library">
     <div class="input-group">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Editor/Editor.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Editor/Editor.es.js
@@ -29,7 +29,7 @@ describe('Field Editor', () => {
 		}
 	});
 
-	it('should be readOnly', () => {
+	it('is readOnly', () => {
 		component = new Editor({
 			...defaultEditorConfig,
 			readOnly: true
@@ -38,7 +38,7 @@ describe('Field Editor', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a helptext', () => {
+	it('has a helptext', () => {
 		component = new Editor({
 			...defaultEditorConfig,
 			tip: 'Type something'
@@ -47,7 +47,7 @@ describe('Field Editor', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have an id', () => {
+	it('has an id', () => {
 		component = new Editor({
 			...defaultEditorConfig,
 			id: 'ID'
@@ -56,7 +56,7 @@ describe('Field Editor', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a label', () => {
+	it('has a label', () => {
 		component = new Editor({
 			...defaultEditorConfig,
 			label: 'label'
@@ -65,7 +65,7 @@ describe('Field Editor', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a placeholder', () => {
+	it('has a placeholder', () => {
 		component = new Editor({
 			...defaultEditorConfig,
 			placeholder: 'Placeholder'
@@ -74,7 +74,7 @@ describe('Field Editor', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should not be required', () => {
+	it('is not required', () => {
 		component = new Editor({
 			...defaultEditorConfig,
 			required: false
@@ -83,7 +83,7 @@ describe('Field Editor', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render Label if showLabel is true', () => {
+	it('renders Label if showLabel is true', () => {
 		component = new Editor({
 			...defaultEditorConfig,
 			label: 'text',
@@ -93,13 +93,13 @@ describe('Field Editor', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a spritemap', () => {
+	it('has a spritemap', () => {
 		component = new Editor(defaultEditorConfig);
 
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a value', () => {
+	it('has a value', () => {
 		component = new Editor({
 			...defaultEditorConfig,
 			value: 'value'
@@ -108,7 +108,7 @@ describe('Field Editor', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a key', () => {
+	it('has a key', () => {
 		component = new Editor({
 			...defaultEditorConfig,
 			key: 'key'
@@ -117,7 +117,7 @@ describe('Field Editor', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should emit a change value when onChangeEditor method is triggered', () => {
+	it('emits a change value when onChangeEditor method is triggered', () => {
 		component = new Editor({
 			...defaultEditorConfig
 		});
@@ -129,7 +129,7 @@ describe('Field Editor', () => {
 		expect(spy).toBeCalled();
 	});
 
-	it('should trigger AlloyEditor actionPerformed method', () => {
+	it('triggers AlloyEditor actionPerformed method', () => {
 		component = new Editor({
 			...defaultEditorConfig
 		});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Editor/__snapshots__/Editor.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Editor/__snapshots__/Editor.es.js.snap
@@ -1,16 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Field Editor should be readOnly 1`] = `
-<div class="form-group" data-field-name="textField">
-  <div class="field-type-editor form-control input-group-container">
-    <div class="alloy-editor-container input-group" id="textFieldContainer">
-      <div class="alloy-editor alloy-editor-placeholder" contenteditable="false" id="textFieldEditorContainer" name="textFieldEditor"></div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Field Editor should have a helptext 1`] = `
+exports[`Field Editor has a helptext 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="field-type-editor form-control input-group-container">
     <div class="alloy-editor-container input-group" id="textFieldContainer">
@@ -20,7 +10,7 @@ exports[`Field Editor should have a helptext 1`] = `
 </div>
 `;
 
-exports[`Field Editor should have a key 1`] = `
+exports[`Field Editor has a key 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="field-type-editor form-control input-group-container">
     <div class="alloy-editor-container input-group" id="textFieldContainer">
@@ -30,7 +20,7 @@ exports[`Field Editor should have a key 1`] = `
 </div>
 `;
 
-exports[`Field Editor should have a label 1`] = `
+exports[`Field Editor has a label 1`] = `
 <div class="form-group" data-field-name="textField"><label>label </label>
   <div class="field-type-editor form-control input-group-container">
     <div class="alloy-editor-container input-group" id="textFieldContainer">
@@ -40,7 +30,7 @@ exports[`Field Editor should have a label 1`] = `
 </div>
 `;
 
-exports[`Field Editor should have a placeholder 1`] = `
+exports[`Field Editor has a placeholder 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="field-type-editor form-control input-group-container">
     <div class="alloy-editor-container input-group" id="textFieldContainer">
@@ -50,7 +40,7 @@ exports[`Field Editor should have a placeholder 1`] = `
 </div>
 `;
 
-exports[`Field Editor should have a spritemap 1`] = `
+exports[`Field Editor has a spritemap 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="field-type-editor form-control input-group-container">
     <div class="alloy-editor-container input-group" id="textFieldContainer">
@@ -60,7 +50,7 @@ exports[`Field Editor should have a spritemap 1`] = `
 </div>
 `;
 
-exports[`Field Editor should have a value 1`] = `
+exports[`Field Editor has a value 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="field-type-editor form-control input-group-container">
     <div class="alloy-editor-container input-group" id="textFieldContainer">
@@ -70,7 +60,7 @@ exports[`Field Editor should have a value 1`] = `
 </div>
 `;
 
-exports[`Field Editor should have an id 1`] = `
+exports[`Field Editor has an id 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="field-type-editor form-control input-group-container">
     <div class="alloy-editor-container input-group" id="textFieldContainer">
@@ -80,7 +70,7 @@ exports[`Field Editor should have an id 1`] = `
 </div>
 `;
 
-exports[`Field Editor should not be required 1`] = `
+exports[`Field Editor is not required 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="field-type-editor form-control input-group-container">
     <div class="alloy-editor-container input-group" id="textFieldContainer">
@@ -90,7 +80,17 @@ exports[`Field Editor should not be required 1`] = `
 </div>
 `;
 
-exports[`Field Editor should render Label if showLabel is true 1`] = `
+exports[`Field Editor is readOnly 1`] = `
+<div class="form-group" data-field-name="textField">
+  <div class="field-type-editor form-control input-group-container">
+    <div class="alloy-editor-container input-group" id="textFieldContainer">
+      <div class="alloy-editor alloy-editor-placeholder" contenteditable="false" id="textFieldEditorContainer" name="textFieldEditor"></div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Field Editor renders Label if showLabel is true 1`] = `
 <div class="form-group" data-field-name="textField"><label>text </label>
   <div class="field-type-editor form-control input-group-container">
     <div class="alloy-editor-container input-group" id="textFieldContainer">
@@ -100,7 +100,7 @@ exports[`Field Editor should render Label if showLabel is true 1`] = `
 </div>
 `;
 
-exports[`Field Editor should trigger AlloyEditor actionPerformed method 1`] = `
+exports[`Field Editor triggers AlloyEditor actionPerformed method 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="field-type-editor form-control input-group-container">
     <div class="alloy-editor-container input-group" id="textFieldContainer">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/FieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/FieldBase.es.js
@@ -24,7 +24,7 @@ describe('FieldBase', () => {
 		}
 	});
 
-	it('should render the default markup', () => {
+	it('renders the default markup', () => {
 		component = new FieldBase({
 			spritemap
 		});
@@ -32,7 +32,7 @@ describe('FieldBase', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render the FieldBase with required', () => {
+	it('renders the FieldBase with required', () => {
 		component = new FieldBase({
 			required: true,
 			spritemap
@@ -41,7 +41,7 @@ describe('FieldBase', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render the FieldBase with id', () => {
+	it('renders the FieldBase with id', () => {
 		component = new FieldBase({
 			id: 'Id',
 			spritemap
@@ -50,7 +50,7 @@ describe('FieldBase', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render the FieldBase with help text', () => {
+	it('renders the FieldBase with help text', () => {
 		component = new FieldBase({
 			spritemap,
 			tip: 'Type something!'
@@ -59,7 +59,7 @@ describe('FieldBase', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render the FieldBase with label', () => {
+	it('renders the FieldBase with label', () => {
 		component = new FieldBase({
 			label: 'Text',
 			spritemap
@@ -68,7 +68,7 @@ describe('FieldBase', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should not render the label if showLabel is false', () => {
+	it('does not render the label if showLabel is false', () => {
 		component = new FieldBase({
 			label: 'Text',
 			showLabel: false,
@@ -78,7 +78,7 @@ describe('FieldBase', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render the FieldBase with contentRenderer', () => {
+	it('renders the FieldBase with contentRenderer', () => {
 		component = new FieldBase({
 			contentRenderer: `
                 <div>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Grid/Grid.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Grid/Grid.es.js
@@ -24,7 +24,7 @@ describe('Grid', () => {
 		}
 	});
 
-	it('should render columns', () => {
+	it('renders columns', () => {
 		component = new Grid({
 			columns: [
 				{
@@ -42,7 +42,7 @@ describe('Grid', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render no columns when columns comes empty', () => {
+	it('renders no columns when columns comes empty', () => {
 		component = new Grid({
 			columns: [],
 			spritemap
@@ -51,7 +51,7 @@ describe('Grid', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should be not edidable', () => {
+	it('is not edidable', () => {
 		component = new Grid({
 			readOnly: false,
 			spritemap
@@ -60,7 +60,7 @@ describe('Grid', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a tip', () => {
+	it('has a tip', () => {
 		component = new Grid({
 			spritemap,
 			tip: 'Type something'
@@ -69,7 +69,7 @@ describe('Grid', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have an id', () => {
+	it('has an id', () => {
 		component = new Grid({
 			id: 'ID',
 			spritemap
@@ -78,7 +78,7 @@ describe('Grid', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a label', () => {
+	it('has a label', () => {
 		component = new Grid({
 			label: 'label',
 			spritemap
@@ -87,7 +87,7 @@ describe('Grid', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should not be required', () => {
+	it('is not required', () => {
 		component = new Grid({
 			required: false,
 			spritemap
@@ -96,7 +96,7 @@ describe('Grid', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render rows', () => {
+	it('renders rows', () => {
 		component = new Grid({
 			rows: [
 				{
@@ -114,7 +114,7 @@ describe('Grid', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render no rows when row comes empty', () => {
+	it('renders no rows when row comes empty', () => {
 		component = new Grid({
 			rows: [],
 			spritemap
@@ -123,7 +123,7 @@ describe('Grid', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render Label if showLabel is true', () => {
+	it('renders Label if showLabel is true', () => {
 		component = new Grid({
 			label: 'text',
 			showLabel: true,
@@ -133,7 +133,7 @@ describe('Grid', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a spritemap', () => {
+	it('has a spritemap', () => {
 		component = new Grid({
 			spritemap
 		});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/KeyValue/KeyValue.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/KeyValue/KeyValue.es.js
@@ -24,7 +24,7 @@ describe('KeyValue', () => {
 		}
 	});
 
-	it('should be not edidable', () => {
+	it('is not edidable', () => {
 		component = new KeyValue({
 			name: 'keyValue',
 			readOnly: false,
@@ -34,7 +34,7 @@ describe('KeyValue', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a helptext', () => {
+	it('has a helptext', () => {
 		component = new KeyValue({
 			name: 'keyValue',
 			spritemap,
@@ -44,7 +44,7 @@ describe('KeyValue', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have an id', () => {
+	it('has an id', () => {
 		component = new KeyValue({
 			id: 'ID',
 			name: 'keyValue',
@@ -54,7 +54,7 @@ describe('KeyValue', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a label', () => {
+	it('has a label', () => {
 		component = new KeyValue({
 			label: 'label',
 			name: 'keyValue',
@@ -64,7 +64,7 @@ describe('KeyValue', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a predefined Value', () => {
+	it('has a predefined Value', () => {
 		component = new KeyValue({
 			name: 'keyValue',
 			placeholder: 'Option 1',
@@ -74,7 +74,7 @@ describe('KeyValue', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should not be required', () => {
+	it('is not required', () => {
 		component = new KeyValue({
 			name: 'keyValue',
 			required: false,
@@ -84,7 +84,7 @@ describe('KeyValue', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render Label if showLabel is true', () => {
+	it('renders Label if showLabel is true', () => {
 		component = new KeyValue({
 			label: 'text',
 			name: 'keyValue',
@@ -95,7 +95,7 @@ describe('KeyValue', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a spritemap', () => {
+	it('has a spritemap', () => {
 		component = new KeyValue({
 			name: 'keyValue',
 			spritemap
@@ -104,7 +104,7 @@ describe('KeyValue', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a value', () => {
+	it('has a value', () => {
 		component = new KeyValue({
 			name: 'keyValue',
 			spritemap,
@@ -114,7 +114,7 @@ describe('KeyValue', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render component with a key', () => {
+	it('renders component with a key', () => {
 		component = new KeyValue({
 			keyword: 'key',
 			name: 'keyValue',

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/KeyValue/__snapshots__/KeyValue.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/KeyValue/__snapshots__/KeyValue.es.js.snap
@@ -1,69 +1,69 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KeyValue should be not edidable 1`] = `
-<div class="form-group" data-field-name="keyValue">
-  <div class="form-group" data-field-name="keyValueLabelkeyValue"><input class="ddm-field-text form-control" name="keyValueLabelkeyValue" type="text" value=""></div>
-  <div class="active form-text key-value-editor"><label class="control-label key-value-label">field-name:</label><input class="key-value-input" type="text"></div>
-</div>
-`;
-
-exports[`KeyValue should have a helptext 1`] = `
+exports[`KeyValue has a helptext 1`] = `
 <div class="form-group" data-field-name="keyValue">
   <div class="form-group" data-field-name="keyValueLabelkeyValue"><input class="ddm-field-text form-control" name="keyValueLabelkeyValue" type="text" value=""></div>
   <div class="active form-text key-value-editor"><label class="control-label key-value-label">field-name:</label><input class="key-value-input" type="text"></div><span class="form-text">Type something</span>
 </div>
 `;
 
-exports[`KeyValue should have a label 1`] = `
+exports[`KeyValue has a label 1`] = `
 <div class="form-group" data-field-name="keyValue"><label>label </label>
   <div class="form-group" data-field-name="keyValueLabelkeyValue"><input class="ddm-field-text form-control" name="keyValueLabelkeyValue" type="text" value=""></div>
   <div class="active form-text key-value-editor"><label class="control-label key-value-label">field-name:</label><input class="key-value-input" type="text"></div>
 </div>
 `;
 
-exports[`KeyValue should have a predefined Value 1`] = `
+exports[`KeyValue has a predefined Value 1`] = `
 <div class="form-group" data-field-name="keyValue">
   <div class="form-group" data-field-name="keyValueLabelkeyValue"><input class="ddm-field-text form-control" name="keyValueLabelkeyValue" type="text" placeholder="Option 1" value=""></div>
   <div class="active form-text key-value-editor"><label class="control-label key-value-label">field-name:</label><input class="key-value-input" type="text"></div>
 </div>
 `;
 
-exports[`KeyValue should have a spritemap 1`] = `
+exports[`KeyValue has a spritemap 1`] = `
 <div class="form-group" data-field-name="keyValue">
   <div class="form-group" data-field-name="keyValueLabelkeyValue"><input class="ddm-field-text form-control" name="keyValueLabelkeyValue" type="text" value=""></div>
   <div class="active form-text key-value-editor"><label class="control-label key-value-label">field-name:</label><input class="key-value-input" type="text"></div>
 </div>
 `;
 
-exports[`KeyValue should have a value 1`] = `
+exports[`KeyValue has a value 1`] = `
 <div class="form-group" data-field-name="keyValue">
   <div class="form-group" data-field-name="keyValueLabelkeyValue"><input class="ddm-field-text form-control" name="keyValueLabelkeyValue" type="text" value="value"></div>
   <div class="active form-text key-value-editor"><label class="control-label key-value-label">field-name:</label><input class="key-value-input" type="text"></div>
 </div>
 `;
 
-exports[`KeyValue should have an id 1`] = `
+exports[`KeyValue has an id 1`] = `
 <div class="form-group" data-field-name="keyValue">
   <div class="form-group" data-field-name="keyValueLabelkeyValue"><input class="ddm-field-text form-control" name="keyValueLabelkeyValue" type="text" value=""></div>
   <div class="active form-text key-value-editor"><label class="control-label key-value-label">field-name:</label><input class="key-value-input" type="text"></div>
 </div>
 `;
 
-exports[`KeyValue should not be required 1`] = `
+exports[`KeyValue is not edidable 1`] = `
 <div class="form-group" data-field-name="keyValue">
   <div class="form-group" data-field-name="keyValueLabelkeyValue"><input class="ddm-field-text form-control" name="keyValueLabelkeyValue" type="text" value=""></div>
   <div class="active form-text key-value-editor"><label class="control-label key-value-label">field-name:</label><input class="key-value-input" type="text"></div>
 </div>
 `;
 
-exports[`KeyValue should render Label if showLabel is true 1`] = `
+exports[`KeyValue is not required 1`] = `
+<div class="form-group" data-field-name="keyValue">
+  <div class="form-group" data-field-name="keyValueLabelkeyValue"><input class="ddm-field-text form-control" name="keyValueLabelkeyValue" type="text" value=""></div>
+  <div class="active form-text key-value-editor"><label class="control-label key-value-label">field-name:</label><input class="key-value-input" type="text"></div>
+</div>
+`;
+
+exports[`KeyValue renders Label if showLabel is true 1`] = `
 <div class="form-group" data-field-name="keyValue"><label>text </label>
   <div class="form-group" data-field-name="keyValueLabelkeyValue"><input class="ddm-field-text form-control" name="keyValueLabelkeyValue" type="text" value=""></div>
   <div class="active form-text key-value-editor"><label class="control-label key-value-label">field-name:</label><input class="key-value-input" type="text"></div>
 </div>
 `;
 
-exports[`KeyValue should render component with a key 1`] = `
+exports[`KeyValue renders component with a key 1`] = `
 <div class="form-group" data-field-name="keyValue">
   <div class="form-group" data-field-name="keyValueLabelkeyValue"><input class="ddm-field-text form-control" name="keyValueLabelkeyValue" type="text" value=""></div>
   <div class="active form-text key-value-editor"><label class="control-label key-value-label">field-name:</label><input class="key-value-input" type="text" value="key"></div>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Numeric/Numeric.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Numeric/Numeric.es.js
@@ -34,7 +34,7 @@ describe('Field Numeric', () => {
 		}
 	});
 
-	it('should render the default markup', () => {
+	it('renders the default markup', () => {
 		component = new Numeric({
 			...defaultNumericConfig,
 			readOnly: false
@@ -43,7 +43,7 @@ describe('Field Numeric', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should not be readOnly', () => {
+	it('is not readOnly', () => {
 		component = new Numeric({
 			...defaultNumericConfig,
 			readOnly: false
@@ -52,7 +52,7 @@ describe('Field Numeric', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a helptext', () => {
+	it('has a helptext', () => {
 		component = new Numeric({
 			...defaultNumericConfig,
 			tip: 'Type something'
@@ -61,7 +61,7 @@ describe('Field Numeric', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have an id', () => {
+	it('has an id', () => {
 		component = new Numeric({
 			...defaultNumericConfig,
 			id: 'ID'
@@ -70,7 +70,7 @@ describe('Field Numeric', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a label', () => {
+	it('has a label', () => {
 		component = new Numeric({
 			...defaultNumericConfig,
 			label: 'label'
@@ -79,7 +79,7 @@ describe('Field Numeric', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a placeholder', () => {
+	it('has a placeholder', () => {
 		component = new Numeric({
 			...defaultNumericConfig,
 			placeholder: 'Placeholder'
@@ -88,7 +88,7 @@ describe('Field Numeric', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should not be required', () => {
+	it('is not required', () => {
 		component = new Numeric({
 			...defaultNumericConfig,
 			required: false
@@ -97,7 +97,7 @@ describe('Field Numeric', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render Label if showLabel is true', () => {
+	it('renders Label if showLabel is true', () => {
 		component = new Numeric({
 			...defaultNumericConfig,
 			label: 'Numeric Field',
@@ -107,13 +107,13 @@ describe('Field Numeric', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a spritemap', () => {
+	it('has a spritemap', () => {
 		component = new Numeric(defaultNumericConfig);
 
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a value', () => {
+	it('has a value', () => {
 		component = new Numeric({
 			...defaultNumericConfig,
 			value: '123'
@@ -122,7 +122,7 @@ describe('Field Numeric', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a key', () => {
+	it('has a key', () => {
 		component = new Numeric({
 			...defaultNumericConfig,
 			key: 'key'
@@ -131,7 +131,7 @@ describe('Field Numeric', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should emit a field edit event on field value change', () => {
+	it('emits a field edit event on field value change', () => {
 		jest.useFakeTimers();
 
 		const handleFieldEdited = jest.fn();
@@ -150,7 +150,7 @@ describe('Field Numeric', () => {
 		expect(handleFieldEdited).toHaveBeenCalled();
 	});
 
-	it('should propagate the field edit event', () => {
+	it('propagates the field edit event', () => {
 		jest.useFakeTimers();
 
 		component = new Numeric({
@@ -168,7 +168,7 @@ describe('Field Numeric', () => {
 		expect(spy).toHaveBeenCalledWith('fieldEdited', expect.any(Object));
 	});
 
-	it('should change the mask type', () => {
+	it('changes the mask type', () => {
 		component = new Numeric({
 			...defaultNumericConfig
 		});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Options/Options.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Options/Options.es.js
@@ -39,7 +39,7 @@ describe('Options', () => {
 		}
 	});
 
-	it('should show the options', () => {
+	it('shows the options', () => {
 		component = new Options({
 			spritemap,
 			value: optionsValue
@@ -48,7 +48,7 @@ describe('Options', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should delete an option when delete button is clicked', () => {
+	it('deletes an option when delete button is clicked', () => {
 		component = new Options({
 			spritemap,
 			value: optionsValue
@@ -61,7 +61,7 @@ describe('Options', () => {
 		expect(component.items.length).toEqual(before - 1);
 	});
 
-	it('.normalizeValue() should not allow options with the same value', () => {
+	it('.normalizeValue() does not allow options with the same value', () => {
 		component = new Options({
 			spritemap
 		});
@@ -93,7 +93,7 @@ describe('Options', () => {
 		});
 	});
 
-	it('should allow the user to order the fieldName options by dragging and dropping the options', () => {
+	it('allows the user to order the fieldName options by dragging and dropping the options', () => {
 		component = new Options({
 			spritemap,
 			value: optionsValue

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Paragraph/Paragraph.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Paragraph/Paragraph.es.js
@@ -29,7 +29,7 @@ describe('Field Paragraph', () => {
 		}
 	});
 
-	it('should be readOnly', () => {
+	it('is readOnly', () => {
 		component = new Paragraph({
 			...defaultParagraphConfig,
 			readOnly: true
@@ -38,7 +38,7 @@ describe('Field Paragraph', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have an id', () => {
+	it('has an id', () => {
 		component = new Paragraph({
 			...defaultParagraphConfig,
 			id: 'ID'
@@ -47,7 +47,7 @@ describe('Field Paragraph', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a label', () => {
+	it('has a label', () => {
 		component = new Paragraph({
 			...defaultParagraphConfig,
 			label: 'label'
@@ -56,7 +56,7 @@ describe('Field Paragraph', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a placeholder', () => {
+	it('has a placeholder', () => {
 		component = new Paragraph({
 			...defaultParagraphConfig,
 			placeholder: 'Placeholder'
@@ -65,7 +65,7 @@ describe('Field Paragraph', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should not be required', () => {
+	it('is not required', () => {
 		component = new Paragraph({
 			...defaultParagraphConfig,
 			required: false
@@ -74,7 +74,7 @@ describe('Field Paragraph', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render Label if showLabel is true', () => {
+	it('renders Label if showLabel is true', () => {
 		component = new Paragraph({
 			...defaultParagraphConfig,
 			label: 'text',
@@ -84,13 +84,13 @@ describe('Field Paragraph', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a spritemap', () => {
+	it('has a spritemap', () => {
 		component = new Paragraph(defaultParagraphConfig);
 
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a value', () => {
+	it('has a value', () => {
 		component = new Paragraph({
 			...defaultParagraphConfig,
 			value: 'value'
@@ -99,7 +99,7 @@ describe('Field Paragraph', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a key', () => {
+	it('has a key', () => {
 		component = new Paragraph({
 			...defaultParagraphConfig,
 			key: 'key'

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Paragraph/__snapshots__/Paragraph.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Paragraph/__snapshots__/Paragraph.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Field Paragraph should be readOnly 1`] = `
+exports[`Field Paragraph has a key 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="form-group liferay-ddm-form-field-paragraph" data-fieldname="textField">
     <div class="liferay-ddm-form-field-paragraph-text"></div>
@@ -8,15 +8,7 @@ exports[`Field Paragraph should be readOnly 1`] = `
 </div>
 `;
 
-exports[`Field Paragraph should have a key 1`] = `
-<div class="form-group" data-field-name="textField">
-  <div class="form-group liferay-ddm-form-field-paragraph" data-fieldname="textField">
-    <div class="liferay-ddm-form-field-paragraph-text"></div>
-  </div>
-</div>
-`;
-
-exports[`Field Paragraph should have a label 1`] = `
+exports[`Field Paragraph has a label 1`] = `
 <div class="form-group" data-field-name="textField"><label>label </label>
   <div class="form-group liferay-ddm-form-field-paragraph" data-fieldname="textField">
     <div class="liferay-ddm-form-field-paragraph-text"></div>
@@ -24,7 +16,7 @@ exports[`Field Paragraph should have a label 1`] = `
 </div>
 `;
 
-exports[`Field Paragraph should have a placeholder 1`] = `
+exports[`Field Paragraph has a placeholder 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="form-group liferay-ddm-form-field-paragraph" data-fieldname="textField">
     <div class="liferay-ddm-form-field-paragraph-text"></div>
@@ -32,7 +24,7 @@ exports[`Field Paragraph should have a placeholder 1`] = `
 </div>
 `;
 
-exports[`Field Paragraph should have a spritemap 1`] = `
+exports[`Field Paragraph has a spritemap 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="form-group liferay-ddm-form-field-paragraph" data-fieldname="textField">
     <div class="liferay-ddm-form-field-paragraph-text"></div>
@@ -40,7 +32,7 @@ exports[`Field Paragraph should have a spritemap 1`] = `
 </div>
 `;
 
-exports[`Field Paragraph should have a value 1`] = `
+exports[`Field Paragraph has a value 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="form-group liferay-ddm-form-field-paragraph" data-fieldname="textField">
     <div class="liferay-ddm-form-field-paragraph-text"></div>
@@ -48,7 +40,7 @@ exports[`Field Paragraph should have a value 1`] = `
 </div>
 `;
 
-exports[`Field Paragraph should have an id 1`] = `
+exports[`Field Paragraph has an id 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="form-group liferay-ddm-form-field-paragraph" data-fieldname="textField">
     <div class="liferay-ddm-form-field-paragraph-text"></div>
@@ -56,7 +48,7 @@ exports[`Field Paragraph should have an id 1`] = `
 </div>
 `;
 
-exports[`Field Paragraph should not be required 1`] = `
+exports[`Field Paragraph is not required 1`] = `
 <div class="form-group" data-field-name="textField">
   <div class="form-group liferay-ddm-form-field-paragraph" data-fieldname="textField">
     <div class="liferay-ddm-form-field-paragraph-text"></div>
@@ -64,7 +56,15 @@ exports[`Field Paragraph should not be required 1`] = `
 </div>
 `;
 
-exports[`Field Paragraph should render Label if showLabel is true 1`] = `
+exports[`Field Paragraph is readOnly 1`] = `
+<div class="form-group" data-field-name="textField">
+  <div class="form-group liferay-ddm-form-field-paragraph" data-fieldname="textField">
+    <div class="liferay-ddm-form-field-paragraph-text"></div>
+  </div>
+</div>
+`;
+
+exports[`Field Paragraph renders Label if showLabel is true 1`] = `
 <div class="form-group" data-field-name="textField"><label>text </label>
   <div class="form-group liferay-ddm-form-field-paragraph" data-fieldname="textField">
     <div class="liferay-ddm-form-field-paragraph-text"></div>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Radio/Radio.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Radio/Radio.es.js
@@ -29,7 +29,7 @@ describe('Field Radio', () => {
 		}
 	});
 
-	it('should be not edidable', () => {
+	it('is not edidable', () => {
 		component = new Radio({
 			...defaultRadioConfig,
 			readOnly: false
@@ -38,7 +38,7 @@ describe('Field Radio', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a helptext', () => {
+	it('has a helptext', () => {
 		component = new Radio({
 			...defaultRadioConfig,
 			tip: 'Type something'
@@ -47,7 +47,7 @@ describe('Field Radio', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render options', () => {
+	it('renders options', () => {
 		component = new Radio({
 			...defaultRadioConfig,
 			options: [
@@ -77,7 +77,7 @@ describe('Field Radio', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render no options when options is empty', () => {
+	it('renders no options when options is empty', () => {
 		component = new Radio({
 			...defaultRadioConfig,
 			options: []
@@ -86,7 +86,7 @@ describe('Field Radio', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have an id', () => {
+	it('has an id', () => {
 		component = new Radio({
 			...defaultRadioConfig,
 			id: 'ID'
@@ -95,7 +95,7 @@ describe('Field Radio', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a label', () => {
+	it('has a label', () => {
 		component = new Radio({
 			...defaultRadioConfig,
 			label: 'label'
@@ -104,7 +104,7 @@ describe('Field Radio', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a predefined Value', () => {
+	it('has a predefined Value', () => {
 		component = new Radio({
 			...defaultRadioConfig,
 			placeholder: 'Option 1'
@@ -113,7 +113,7 @@ describe('Field Radio', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should not be required', () => {
+	it('is not required', () => {
 		component = new Radio({
 			...defaultRadioConfig,
 			required: false
@@ -122,7 +122,7 @@ describe('Field Radio', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render Label if showLabel is true', () => {
+	it('renders Label if showLabel is true', () => {
 		component = new Radio({
 			...defaultRadioConfig,
 			label: 'text',
@@ -132,13 +132,13 @@ describe('Field Radio', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a spritemap', () => {
+	it('has a spritemap', () => {
 		component = new Radio(defaultRadioConfig);
 
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a value', () => {
+	it('has a value', () => {
 		component = new Radio({
 			...defaultRadioConfig,
 			value: 'value'

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Radio/__snapshots__/Radio.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Radio/__snapshots__/Radio.es.js.snap
@@ -1,15 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Field Radio should be not edidable 1`] = `
-<div class="form-group" data-field-name="radioField">
-  <div class="ddm-radio">
-    <div class="custom-control custom-radio"><label><input class="custom-control-input" name="radioField" ref="input" type="radio" role="radio"><span class="custom-control-label"><span class="custom-control-label-text">Option 1</span></span></label></div>
-    <div class="custom-control custom-radio"><label><input class="custom-control-input" name="radioField" ref="input" type="radio" role="radio"><span class="custom-control-label"><span class="custom-control-label-text">Option 2</span></span></label></div>
-  </div>
-</div>
-`;
-
-exports[`Field Radio should have a helptext 1`] = `
+exports[`Field Radio has a helptext 1`] = `
 <div class="form-group" data-field-name="radioField">
   <div class="ddm-radio">
     <div class="custom-control custom-radio"><label><input class="custom-control-input" name="radioField" ref="input" type="radio" role="radio"><span class="custom-control-label"><span class="custom-control-label-text">Option 1</span></span></label></div>
@@ -18,7 +9,7 @@ exports[`Field Radio should have a helptext 1`] = `
 </div>
 `;
 
-exports[`Field Radio should have a label 1`] = `
+exports[`Field Radio has a label 1`] = `
 <div class="form-group" data-field-name="radioField"><label>label </label>
   <div class="ddm-radio">
     <div class="custom-control custom-radio"><label><input class="custom-control-input" name="radioField" ref="input" type="radio" role="radio"><span class="custom-control-label"><span class="custom-control-label-text">Option 1</span></span></label></div>
@@ -27,7 +18,7 @@ exports[`Field Radio should have a label 1`] = `
 </div>
 `;
 
-exports[`Field Radio should have a predefined Value 1`] = `
+exports[`Field Radio has a predefined Value 1`] = `
 <div class="form-group" data-field-name="radioField">
   <div class="ddm-radio">
     <div class="custom-control custom-radio"><label><input class="custom-control-input" name="radioField" ref="input" type="radio" role="radio"><span class="custom-control-label"><span class="custom-control-label-text">Option 1</span></span></label></div>
@@ -36,7 +27,7 @@ exports[`Field Radio should have a predefined Value 1`] = `
 </div>
 `;
 
-exports[`Field Radio should have a spritemap 1`] = `
+exports[`Field Radio has a spritemap 1`] = `
 <div class="form-group" data-field-name="radioField">
   <div class="ddm-radio">
     <div class="custom-control custom-radio"><label><input class="custom-control-input" name="radioField" ref="input" type="radio" role="radio"><span class="custom-control-label"><span class="custom-control-label-text">Option 1</span></span></label></div>
@@ -45,7 +36,7 @@ exports[`Field Radio should have a spritemap 1`] = `
 </div>
 `;
 
-exports[`Field Radio should have a value 1`] = `
+exports[`Field Radio has a value 1`] = `
 <div class="form-group" data-field-name="radioField">
   <div class="ddm-radio">
     <div class="custom-control custom-radio"><label><input class="custom-control-input" name="radioField" ref="input" type="radio" role="radio"><span class="custom-control-label"><span class="custom-control-label-text">Option 1</span></span></label></div>
@@ -54,7 +45,7 @@ exports[`Field Radio should have a value 1`] = `
 </div>
 `;
 
-exports[`Field Radio should have an id 1`] = `
+exports[`Field Radio has an id 1`] = `
 <div class="form-group" data-field-name="radioField">
   <div class="ddm-radio">
     <div class="custom-control custom-radio"><label><input class="custom-control-input" name="radioField" ref="input" type="radio" role="radio"><span class="custom-control-label"><span class="custom-control-label-text">Option 1</span></span></label></div>
@@ -63,7 +54,7 @@ exports[`Field Radio should have an id 1`] = `
 </div>
 `;
 
-exports[`Field Radio should not be required 1`] = `
+exports[`Field Radio is not edidable 1`] = `
 <div class="form-group" data-field-name="radioField">
   <div class="ddm-radio">
     <div class="custom-control custom-radio"><label><input class="custom-control-input" name="radioField" ref="input" type="radio" role="radio"><span class="custom-control-label"><span class="custom-control-label-text">Option 1</span></span></label></div>
@@ -72,7 +63,16 @@ exports[`Field Radio should not be required 1`] = `
 </div>
 `;
 
-exports[`Field Radio should render Label if showLabel is true 1`] = `
+exports[`Field Radio is not required 1`] = `
+<div class="form-group" data-field-name="radioField">
+  <div class="ddm-radio">
+    <div class="custom-control custom-radio"><label><input class="custom-control-input" name="radioField" ref="input" type="radio" role="radio"><span class="custom-control-label"><span class="custom-control-label-text">Option 1</span></span></label></div>
+    <div class="custom-control custom-radio"><label><input class="custom-control-input" name="radioField" ref="input" type="radio" role="radio"><span class="custom-control-label"><span class="custom-control-label-text">Option 2</span></span></label></div>
+  </div>
+</div>
+`;
+
+exports[`Field Radio renders Label if showLabel is true 1`] = `
 <div class="form-group" data-field-name="radioField"><label>text </label>
   <div class="ddm-radio">
     <div class="custom-control custom-radio"><label><input class="custom-control-input" name="radioField" ref="input" type="radio" role="radio"><span class="custom-control-label"><span class="custom-control-label-text">Option 1</span></span></label></div>
@@ -81,13 +81,13 @@ exports[`Field Radio should render Label if showLabel is true 1`] = `
 </div>
 `;
 
-exports[`Field Radio should render no options when options is empty 1`] = `
+exports[`Field Radio renders no options when options is empty 1`] = `
 <div class="form-group" data-field-name="radioField">
   <div class="ddm-radio"></div>
 </div>
 `;
 
-exports[`Field Radio should render options 1`] = `
+exports[`Field Radio renders options 1`] = `
 <div class="form-group" data-field-name="radioField">
   <div class="ddm-radio">
     <div class="custom-control custom-radio" id="id"><label><input class="custom-control-input" name="radioField" value="item" ref="input" type="radio" role="radio"><span class="custom-control-label"><span class="custom-control-label-text">label</span></span></label></div>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Select/Select.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Select/Select.es.js
@@ -28,7 +28,7 @@ describe('Select', () => {
 		}
 	});
 
-	it('should be not edidable', () => {
+	it('is not editable', () => {
 		component = new Select({
 			readOnly: false,
 			spritemap
@@ -37,7 +37,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a helptext', () => {
+	it('has a helptext', () => {
 		component = new Select({
 			spritemap,
 			tip: 'Type something'
@@ -46,7 +46,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have an id', () => {
+	it('has an id', () => {
 		component = new Select({
 			id: 'ID',
 			spritemap
@@ -55,7 +55,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render options', () => {
+	it('renders options', () => {
 		component = new Select({
 			options: [
 				{
@@ -75,7 +75,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render no options when options come empty', () => {
+	it('renders no options when options come empty', () => {
 		component = new Select({
 			options: [],
 			spritemap
@@ -84,7 +84,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a label', () => {
+	it('has a label', () => {
 		component = new Select({
 			label: 'label',
 			spritemap
@@ -93,7 +93,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should be closed by default', () => {
+	it('is closed by default', () => {
 		component = new Select({
 			open: false,
 			spritemap
@@ -102,7 +102,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it("should have class dropdown-opened when it's opened", () => {
+	it("has class dropdown-opened when it's opened", () => {
 		component = new Select({
 			open: true,
 			spritemap
@@ -111,7 +111,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a placeholder', () => {
+	it('has a placeholder', () => {
 		component = new Select({
 			placeholder: 'Placeholder',
 			spritemap
@@ -120,7 +120,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a predefinedValue', () => {
+	it('has a predefinedValue', () => {
 		component = new Select({
 			predefinedValue: ['Select'],
 			spritemap
@@ -129,7 +129,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should not be required', () => {
+	it('is not required', () => {
 		component = new Select({
 			required: false,
 			spritemap
@@ -138,7 +138,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should put an asterisk when field is required', () => {
+	it('puts an asterisk when field is required', () => {
 		component = new Select({
 			label: 'This is the label',
 			required: true,
@@ -148,7 +148,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render Label if showLabel is true', () => {
+	it('renders Label if showLabel is true', () => {
 		component = new Select({
 			label: 'text',
 			showLabel: true,
@@ -158,7 +158,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a spritemap', () => {
+	it('has a spritemap', () => {
 		component = new Select({
 			spritemap
 		});
@@ -166,7 +166,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a value', () => {
+	it('has a value', () => {
 		component = new Select({
 			spritemap,
 			value: ['value']
@@ -175,7 +175,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a key', () => {
+	it('has a key', () => {
 		component = new Select({
 			key: 'key',
 			spritemap
@@ -184,7 +184,7 @@ describe('Select', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should emit a field edit event when an item is selected', () => {
+	it('emits a field edit event when an item is selected', () => {
 		const handleFieldEdited = jest.fn();
 
 		const events = {fieldEdited: handleFieldEdited};
@@ -225,7 +225,7 @@ describe('Select', () => {
 		expect(spy).toHaveBeenCalled();
 	});
 
-	it('should render the dropdown with search when there are more than six options', () => {
+	it('renders the dropdown with search when there are more than six options', () => {
 		component = new Select({
 			dataSourceType: 'manual',
 			options: [

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Text/Text.es.js
@@ -29,7 +29,7 @@ describe('Field Text', () => {
 		}
 	});
 
-	it('should not be readOnly', () => {
+	it('is not readOnly', () => {
 		component = new Text({
 			...defaultTextConfig,
 			readOnly: false
@@ -38,7 +38,7 @@ describe('Field Text', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a helptext', () => {
+	it('has a helptext', () => {
 		component = new Text({
 			...defaultTextConfig,
 			tip: 'Type something'
@@ -47,7 +47,7 @@ describe('Field Text', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have an id', () => {
+	it('has an id', () => {
 		component = new Text({
 			...defaultTextConfig,
 			id: 'ID'
@@ -56,7 +56,7 @@ describe('Field Text', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a label', () => {
+	it('has a label', () => {
 		component = new Text({
 			...defaultTextConfig,
 			label: 'label'
@@ -65,7 +65,7 @@ describe('Field Text', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a placeholder', () => {
+	it('has a placeholder', () => {
 		component = new Text({
 			...defaultTextConfig,
 			placeholder: 'Placeholder'
@@ -74,7 +74,7 @@ describe('Field Text', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should not be required', () => {
+	it('is not required', () => {
 		component = new Text({
 			...defaultTextConfig,
 			required: false
@@ -83,7 +83,7 @@ describe('Field Text', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render Label if showLabel is true', () => {
+	it('renders Label if showLabel is true', () => {
 		component = new Text({
 			...defaultTextConfig,
 			label: 'text',
@@ -93,13 +93,13 @@ describe('Field Text', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a spritemap', () => {
+	it('has a spritemap', () => {
 		component = new Text(defaultTextConfig);
 
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should have a value', () => {
+	it('has a value', () => {
 		component = new Text({
 			...defaultTextConfig,
 			value: 'value'
@@ -108,7 +108,7 @@ describe('Field Text', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should emit a field edit with correct parameters', done => {
+	it('emits a field edit with correct parameters', done => {
 		const handleFieldEdited = data => {
 			expect(data).toEqual(
 				expect.objectContaining({

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Text/__snapshots__/Text.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Text/__snapshots__/Text.es.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Field Text should have a helptext 1`] = `<div class="form-group" data-field-name="textField"><input class="ddm-field-text form-control" name="textField" type="text" value=""><span class="form-text">Type something</span></div>`;
+exports[`Field Text has a helptext 1`] = `<div class="form-group" data-field-name="textField"><input class="ddm-field-text form-control" name="textField" type="text" value=""><span class="form-text">Type something</span></div>`;
 
-exports[`Field Text should have a label 1`] = `<div class="form-group" data-field-name="textField"><label>label </label><input class="ddm-field-text form-control" name="textField" type="text" value=""></div>`;
+exports[`Field Text has a label 1`] = `<div class="form-group" data-field-name="textField"><label>label </label><input class="ddm-field-text form-control" name="textField" type="text" value=""></div>`;
 
-exports[`Field Text should have a placeholder 1`] = `<div class="form-group" data-field-name="textField"><input class="ddm-field-text form-control" name="textField" type="text" placeholder="Placeholder" value=""></div>`;
+exports[`Field Text has a placeholder 1`] = `<div class="form-group" data-field-name="textField"><input class="ddm-field-text form-control" name="textField" type="text" placeholder="Placeholder" value=""></div>`;
 
-exports[`Field Text should have a spritemap 1`] = `<div class="form-group" data-field-name="textField"><input class="ddm-field-text form-control" name="textField" type="text" value=""></div>`;
+exports[`Field Text has a spritemap 1`] = `<div class="form-group" data-field-name="textField"><input class="ddm-field-text form-control" name="textField" type="text" value=""></div>`;
 
-exports[`Field Text should have a value 1`] = `<div class="form-group" data-field-name="textField"><input class="ddm-field-text form-control" name="textField" type="text" value="value"></div>`;
+exports[`Field Text has a value 1`] = `<div class="form-group" data-field-name="textField"><input class="ddm-field-text form-control" name="textField" type="text" value="value"></div>`;
 
-exports[`Field Text should have an id 1`] = `<div class="form-group" data-field-name="textField"><input class="ddm-field-text form-control" name="textField" type="text" id="ID" value=""></div>`;
+exports[`Field Text has an id 1`] = `<div class="form-group" data-field-name="textField"><input class="ddm-field-text form-control" name="textField" type="text" id="ID" value=""></div>`;
 
-exports[`Field Text should not be readOnly 1`] = `<div class="form-group" data-field-name="textField"><input class="ddm-field-text form-control" name="textField" type="text" value=""></div>`;
+exports[`Field Text is not readOnly 1`] = `<div class="form-group" data-field-name="textField"><input class="ddm-field-text form-control" name="textField" type="text" value=""></div>`;
 
-exports[`Field Text should not be required 1`] = `<div class="form-group" data-field-name="textField"><input class="ddm-field-text form-control" name="textField" type="text" value=""></div>`;
+exports[`Field Text is not required 1`] = `<div class="form-group" data-field-name="textField"><input class="ddm-field-text form-control" name="textField" type="text" value=""></div>`;
 
-exports[`Field Text should render Label if showLabel is true 1`] = `<div class="form-group" data-field-name="textField"><label>text </label><input class="ddm-field-text form-control" name="textField" type="text" value=""></div>`;
+exports[`Field Text renders Label if showLabel is true 1`] = `<div class="form-group" data-field-name="textField"><label>text </label><input class="ddm-field-text form-control" name="textField" type="text" value=""></div>`;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Validation/Validation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Validation/Validation.es.js
@@ -24,7 +24,7 @@ describe('Validation', () => {
 		}
 	});
 
-	it('should render checkbox to enable Validation', () => {
+	it('renders checkbox to enable Validation', () => {
 		component = new Validation({
 			dataType: 'string',
 			label: 'Validator',
@@ -35,7 +35,7 @@ describe('Validation', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should enable validation after click on toogle', done => {
+	it('enables validation after click on toogle', done => {
 		jest.useFakeTimers();
 
 		component = new Validation({
@@ -61,7 +61,7 @@ describe('Validation', () => {
 		jest.runAllTimers();
 	});
 
-	it('should render parameter field with TextField element', done => {
+	it('renders parameter field with TextField element', done => {
 		jest.useFakeTimers();
 
 		component = new Validation({
@@ -87,7 +87,7 @@ describe('Validation', () => {
 		jest.runAllTimers();
 	});
 
-	it('should render parameter field with Numeric element', done => {
+	it('renders parameter field with Numeric element', done => {
 		jest.useFakeTimers();
 
 		component = new Validation({
@@ -114,7 +114,7 @@ describe('Validation', () => {
 		jest.runAllTimers();
 	});
 
-	it('should render parameter field with Text element and then with Numeric after update dataType', done => {
+	it('renders parameter field with Text element and then with Numeric after update dataType', done => {
 		jest.useFakeTimers();
 
 		component = new Validation({
@@ -145,7 +145,7 @@ describe('Validation', () => {
 
 	describe('Regression Tests', () => {
 		describe('LPS-88007', () => {
-			it('should not render "Show Error Message" and "The Value" as required fields', () => {
+			it('does not render "Show Error Message" and "The Value" as required fields', () => {
 				jest.useFakeTimers();
 
 				component = new Validation({

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/components/Tooltip/Tooltip.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/components/Tooltip/Tooltip.es.js
@@ -29,7 +29,7 @@ describe('Field Tooltip', () => {
 		}
 	});
 
-	it('should render the default markup', () => {
+	it('renders the default markup', () => {
 		component = new Tooltip({
 			icon: 'question-circle-full',
 			spritemap,
@@ -39,7 +39,7 @@ describe('Field Tooltip', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should update the tooltip visible state when the mouse is over the tooltip target', () => {
+	it('updates the tooltip visible state when the mouse is over the tooltip target', () => {
 		component = new Tooltip({
 			icon: 'question-circle-full',
 			spritemap,
@@ -56,7 +56,7 @@ describe('Field Tooltip', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should update the tooltip visible state when the mouse leaved the tooltip target', () => {
+	it('updates the tooltip visible state when the mouse leaved the tooltip target', () => {
 		component = new Tooltip({
 			icon: 'question-circle-full',
 			spritemap,
@@ -70,7 +70,7 @@ describe('Field Tooltip', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should update the tooltip visible state when the mouse is over the tooltip target', () => {
+	it('updates the tooltip visible state when the mouse is over the tooltip target', () => {
 		component = new Tooltip({
 			icon: 'question-circle-full',
 			spritemap,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/components/FormRenderer/Evaluator.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/components/FormRenderer/Evaluator.es.js
@@ -40,7 +40,7 @@ describe('Evaluator', () => {
 		}
 	});
 
-	it('should render default markup', () => {
+	it('renders default markup', () => {
 		component = new EvaluatorComponent({
 			fieldType,
 			formContext: {}
@@ -49,7 +49,7 @@ describe('Evaluator', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should continue propagating the fieldEdited event', () => {
+	it('continues propagating the fieldEdited event', () => {
 		component = new EvaluatorComponent({
 			fieldType,
 			formContext: {}
@@ -73,7 +73,7 @@ describe('Evaluator', () => {
 		expect(spy).toHaveBeenCalledWith('fieldEdited', event);
 	});
 
-	it('should continue propagating the fieldEdited event when it is evaluable', () => {
+	it('continues propagating the fieldEdited event when it is evaluable', () => {
 		component = new EvaluatorComponent({
 			fieldType,
 			formContext: {
@@ -100,7 +100,7 @@ describe('Evaluator', () => {
 		expect(spy).toHaveBeenCalledWith('fieldEdited', event);
 	});
 
-	it("should update the state of the evaluator's pages when it receives a new page as it props", () => {
+	it("updates the state of the evaluator's pages when it receives a new page as it props", () => {
 		const newPages = [
 			{
 				rows: [
@@ -150,7 +150,7 @@ describe('Evaluator', () => {
 		expect(component.state.pages).toEqual(newPages);
 	});
 
-	it("should not update the state of the evaluator's pages when it receives any property which is not pages", () => {
+	it("does not update the state of the evaluator's pages when it receives any property which is not pages", () => {
 		component = new EvaluatorComponent({
 			fieldType,
 			formContext: {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/components/FormRenderer/FormRenderer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/components/FormRenderer/FormRenderer.es.js
@@ -39,7 +39,7 @@ describe('FormRenderer', () => {
 		pages = null;
 	});
 
-	it('should render default markup', () => {
+	it('renders default markup', () => {
 		component = new FormRenderer({
 			pages,
 			spritemap,
@@ -49,7 +49,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render a layout in wizard mode', () => {
+	it('renders a layout in wizard mode', () => {
 		component = new FormRenderer({
 			pages,
 			paginationMode: 'wizard',
@@ -60,7 +60,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render a layout in pagination mode', () => {
+	it('renders a layout in pagination mode', () => {
 		component = new FormRenderer({
 			pages,
 			paginationMode: 'pagination',
@@ -71,7 +71,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render a layout with pages in mode of list', () => {
+	it('renders a layout with pages in mode of list', () => {
 		component = new FormRenderer({
 			modeRenderer: 'list',
 			pages,
@@ -82,7 +82,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render a layout in editable mode', () => {
+	it('renders a layout in editable mode', () => {
 		component = new FormRenderer({
 			editable: true,
 			pages,
@@ -94,7 +94,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render a layout with disabled drag and drop', () => {
+	it('renders a layout with disabled drag and drop', () => {
 		component = new FormRenderer({
 			dragAndDropDisabled: true,
 			editable: true,
@@ -107,7 +107,7 @@ describe('FormRenderer', () => {
 		expect(component._dragAndDrop).toBeUndefined();
 	});
 
-	it('should receive an update page event and propage it', () => {
+	it('receives an update page event and propage it', () => {
 		component = new FormRenderer({
 			dragAndDropDisabled: true,
 			editable: true,
@@ -129,7 +129,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should receive a delete button event and propage it', () => {
+	it('receives a delete button event and propage it', () => {
 		component = new FormRenderer({
 			dragAndDropDisabled: true,
 			editable: true,
@@ -151,7 +151,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should receive a duplicate button event and propage it', () => {
+	it('receives a duplicate button event and propage it', () => {
 		component = new FormRenderer({
 			dragAndDropDisabled: true,
 			editable: true,
@@ -173,7 +173,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should continue to propagate the fieldEdited event', () => {
+	it('continues to propagate the fieldEdited event', () => {
 		component = new FormRenderer({
 			dragAndDropDisabled: true,
 			editable: true,
@@ -193,7 +193,7 @@ describe('FormRenderer', () => {
 		expect(spy).toHaveBeenCalledWith('fieldEdited', expect.anything());
 	});
 
-	it('should continue to propagate the fieldClicked event', () => {
+	it('continues to propagate the fieldClicked event', () => {
 		component = new FormRenderer({
 			dragAndDropDisabled: true,
 			editable: true,
@@ -213,7 +213,7 @@ describe('FormRenderer', () => {
 		expect(spy).toHaveBeenCalledWith('fieldClicked', expect.anything());
 	});
 
-	it('should change the active page', () => {
+	it('changes the active page', () => {
 		const newPages = [...pages, ...pages];
 
 		component = new FormRenderer({
@@ -236,7 +236,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should change the pagination mode when switch pagination mode is clicked', () => {
+	it('changes the pagination mode when switch pagination mode is clicked', () => {
 		const newPages = [...pages, ...pages];
 
 		component = new FormRenderer({
@@ -263,7 +263,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should back the pagination mode to wizard mode when user clicks in switch page on the settings menu', () => {
+	it('backs the pagination mode to wizard mode when user clicks in switch page on the settings menu', () => {
 		const newPages = [...pages, ...pages];
 
 		component = new FormRenderer({
@@ -304,7 +304,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should change the active page for a empty page', () => {
+	it('changes the active page for a empty page', () => {
 		const newPages = [...pages, ...pages];
 
 		newPages[1].rows = [
@@ -338,7 +338,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should change the active by clicking on the pagination when the page mode is in pagination mode', () => {
+	it('changes the active by clicking on the pagination when the page mode is in pagination mode', () => {
 		const newPages = [...pages, ...pages];
 
 		component = new FormRenderer({
@@ -365,7 +365,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should change the active page by clicking on the arrow right icon in the pagination button', () => {
+	it('changes the active page by clicking on the arrow right icon in the pagination button', () => {
 		const newPages = [...pages, ...pages];
 
 		component = new FormRenderer({
@@ -387,7 +387,7 @@ describe('FormRenderer', () => {
 		expect(spy).toHaveBeenCalledWith('activePageUpdated', 1);
 	});
 
-	it('should change the page from a normal page to a success page by clicking on the arrow right', () => {
+	it('changes the page from a normal page to a success page by clicking on the arrow right', () => {
 		const newPages = [...pages];
 
 		component = new FormRenderer({
@@ -412,7 +412,7 @@ describe('FormRenderer', () => {
 		expect(spy).toHaveBeenCalledWith('activePageUpdated', -1);
 	});
 
-	it('should change the page from a success page to a normal page by clicking on the arrow left', () => {
+	it('changes the page from a success page to a normal page by clicking on the arrow left', () => {
 		const newPages = [...pages];
 
 		component = new FormRenderer({
@@ -439,7 +439,7 @@ describe('FormRenderer', () => {
 		expect(spy).toHaveBeenCalledWith('activePageUpdated', 0);
 	});
 
-	it('should change the active by clicking on the arrow left icon in the pagination button', () => {
+	it('changes the active by clicking on the arrow left icon in the pagination button', () => {
 		const newPages = [...pages, ...pages];
 
 		component = new FormRenderer({
@@ -461,7 +461,7 @@ describe('FormRenderer', () => {
 		expect(spy).toHaveBeenCalledWith('activePageUpdated', 0);
 	});
 
-	it('should propagate field edit event', () => {
+	it('propagates field edit event', () => {
 		component = new FormRenderer({
 			editable: true,
 			pages,
@@ -477,7 +477,7 @@ describe('FormRenderer', () => {
 		expect(spy).toHaveBeenCalled();
 	});
 
-	it('should render a layout and emit the field move event', () => {
+	it('renders a layout and emit the field move event', () => {
 		component = new FormRenderer({
 			editable: true,
 			pages,
@@ -514,7 +514,7 @@ describe('FormRenderer', () => {
 		});
 	});
 
-	it('should render a layout and ignore the field move when there is no target', () => {
+	it('renders a layout and ignore the field move when there is no target', () => {
 		component = new FormRenderer({
 			editable: true,
 			pages,
@@ -538,7 +538,7 @@ describe('FormRenderer', () => {
 		expect(spy).not.toHaveBeenCalledWith('fieldMoved', expect.any(Object));
 	});
 
-	it('should render a layout and reset drag and drop to every change of API pages when editable is true', () => {
+	it('renders a layout and reset drag and drop to every change of API pages when editable is true', () => {
 		component = new FormRenderer({
 			editable: true,
 			pages,
@@ -561,7 +561,7 @@ describe('FormRenderer', () => {
 		expect(spyDragAndDrop).toHaveBeenCalled();
 	});
 
-	it('should render a layout and if it is not editable should not reset the drag-and-drop feature for all API page changes', () => {
+	it('renders a layout and if it is not editable should not reset the drag-and-drop feature for all API page changes', () => {
 		component = new FormRenderer({
 			editable: false,
 			pages,
@@ -584,7 +584,7 @@ describe('FormRenderer', () => {
 		expect(spy).not.toHaveBeenCalled();
 	});
 
-	it('should render a layout and if it is disabled should not reset the drag-and-drop feature for all API page changes', () => {
+	it('renders a layout and if it is disabled should not reset the drag-and-drop feature for all API page changes', () => {
 		component = new FormRenderer({
 			dragAndDropDisabled: true,
 			editable: true,
@@ -608,7 +608,7 @@ describe('FormRenderer', () => {
 		expect(spy).not.toHaveBeenCalled();
 	});
 
-	it('should render a layout with an empty field only in editable mode', () => {
+	it('renders a layout with an empty field only in editable mode', () => {
 		const columnIndex = 2;
 		const fields = [
 			{
@@ -638,7 +638,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should not render the layout with the field empty in non-editable mode', () => {
+	it('does not render the layout with the field empty in non-editable mode', () => {
 		const columnIndex = 2;
 		const fields = [
 			{
@@ -668,7 +668,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should change the form page title', () => {
+	it('changes the form page title', () => {
 		component = new FormRenderer({
 			editable: true,
 			pages,
@@ -692,7 +692,7 @@ describe('FormRenderer', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should change the form page description', () => {
+	it('changes the form page description', () => {
 		component = new FormRenderer({
 			editable: true,
 			pages,
@@ -717,7 +717,7 @@ describe('FormRenderer', () => {
 	});
 
 	describe('PagesSettings', () => {
-		it('should add a new page on the layout render', () => {
+		it('adds a new page on the layout render', () => {
 			component = new FormRenderer({
 				editable: true,
 				pages,
@@ -739,7 +739,7 @@ describe('FormRenderer', () => {
 			expect(component).toMatchSnapshot();
 		});
 
-		it('should reset the current page on layout render', () => {
+		it('resets the current page on layout render', () => {
 			component = new FormRenderer({
 				editable: true,
 				pages,
@@ -761,7 +761,7 @@ describe('FormRenderer', () => {
 			expect(component).toMatchSnapshot();
 		});
 
-		it('should add a success page', () => {
+		it('adds a success page', () => {
 			component = new FormRenderer({
 				editable: true,
 				pages,
@@ -783,7 +783,7 @@ describe('FormRenderer', () => {
 			expect(component).toMatchSnapshot();
 		});
 
-		it('should delete the success page', () => {
+		it('deletes the success page', () => {
 			component = new FormRenderer({
 				editable: true,
 				pages,
@@ -817,7 +817,7 @@ describe('FormRenderer', () => {
 			expect(component).toMatchSnapshot();
 		});
 
-		it('should propagate success page changed when some success page field is changed', () => {
+		it('propagates success page changed when some success page field is changed', () => {
 			component = new FormRenderer({
 				dragAndDropDisabled: true,
 				editable: true,
@@ -844,7 +844,7 @@ describe('FormRenderer', () => {
 			);
 		});
 
-		it('should show delete-field option, when the form builder has more than one page', () => {
+		it('shows delete-field option, when the form builder has more than one page', () => {
 			const pagesTemp = [...pages, ...pages];
 
 			component = new FormRenderer({
@@ -880,7 +880,7 @@ describe('FormRenderer', () => {
 			expect(component).toMatchSnapshot();
 		});
 
-		it('should show reset-field option, when the form builder has only one page', () => {
+		it('shows reset-field option, when the form builder has only one page', () => {
 			component = new FormRenderer({
 				editable: true,
 				pages,
@@ -910,7 +910,7 @@ describe('FormRenderer', () => {
 			expect(component).toMatchSnapshot();
 		});
 
-		it('should delete the current page on layout render', () => {
+		it('deletes the current page on layout render', () => {
 			const newPages = [...pages, ...pages];
 
 			component = new FormRenderer({

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/components/FormRenderer/FormSupport.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/components/FormRenderer/FormSupport.es.js
@@ -41,7 +41,7 @@ describe('FormSupport', () => {
 		).toMatchSnapshot();
 	});
 
-	it('should return an implementation of a row for the pages', () => {
+	it('returns an implementation of a row for the pages', () => {
 		const row = [
 			{
 				spritemap: 'icons.svg',
@@ -65,7 +65,7 @@ describe('FormSupport', () => {
 		});
 	});
 
-	it('should get a specific field through the pages', () => {
+	it('gets a specific field through the pages', () => {
 		const indexColumn = 0;
 		const indexPage = 0;
 		const indexRow = 0;
@@ -95,7 +95,7 @@ describe('FormSupport', () => {
 		).toMatchSnapshot();
 	});
 
-	it('should add a new fields to column void', () => {
+	it('adds a new fields to column void', () => {
 		const columnIndex = 2;
 		const fields = [
 			{
@@ -117,7 +117,7 @@ describe('FormSupport', () => {
 		).toMatchSnapshot();
 	});
 
-	it('should remove a column from pages and reorder', () => {
+	it('removes a column from pages and reorder', () => {
 		const columnIndex = 1;
 		const pageIndex = 0;
 		const rowIndex = 1;
@@ -127,7 +127,7 @@ describe('FormSupport', () => {
 		).toMatchSnapshot();
 	});
 
-	it('should remove a fields to column from pages', () => {
+	it('removes a fields to column from pages', () => {
 		const columnIndex = 1;
 		const pageIndex = 0;
 		const rowIndex = 1;
@@ -137,7 +137,7 @@ describe('FormSupport', () => {
 		).toMatchSnapshot();
 	});
 
-	it('should remove a row from pages and reorder', () => {
+	it('removes a row from pages and reorder', () => {
 		const pageIndex = 0;
 		const rowIndex = 1;
 
@@ -146,7 +146,7 @@ describe('FormSupport', () => {
 		).toMatchSnapshot();
 	});
 
-	it('should get a column from pages', () => {
+	it('gets a column from pages', () => {
 		const columnIndex = 1;
 		const pageIndex = 0;
 		const rowIndex = 1;
@@ -156,7 +156,7 @@ describe('FormSupport', () => {
 		).toMatchSnapshot();
 	});
 
-	it('should get a row from pages', () => {
+	it('gets a row from pages', () => {
 		const pageIndex = 0;
 		const rowIndex = 1;
 
@@ -165,7 +165,7 @@ describe('FormSupport', () => {
 		).toMatchSnapshot();
 	});
 
-	it('should return true if there are fields in a row', () => {
+	it('returns true if there are fields in a row', () => {
 		const pageIndex = 0;
 		const rowIndex = 0;
 
@@ -174,7 +174,7 @@ describe('FormSupport', () => {
 		).toBeTruthy();
 	});
 
-	it('should return false if there are fields in a row', () => {
+	it('returns false if there are fields in a row', () => {
 		const pageIndex = 0;
 		const rowIndex = 0;
 
@@ -187,7 +187,7 @@ describe('FormSupport', () => {
 		).toBeFalsy();
 	});
 
-	it('should extract the location of the field through the element', () => {
+	it('extracts the location of the field through the element', () => {
 		const element = createElement({
 			attributes: [
 				{
@@ -213,7 +213,7 @@ describe('FormSupport', () => {
 		});
 	});
 
-	it('should extract the location of the row through the element', () => {
+	it('extracts the location of the row through the element', () => {
 		const element = createElement({
 			attributes: [
 				{
@@ -239,7 +239,7 @@ describe('FormSupport', () => {
 		});
 	});
 
-	it('should update a field', () => {
+	it('updates a field', () => {
 		const properties = {
 			label: 'Foo',
 			type: 'radio'

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/util/__snapshots__/visitors.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/util/__snapshots__/visitors.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PagesVisitor should be able to change columns 1`] = `
+exports[`PagesVisitor is able to change columns 1`] = `
 Array [
   Object {
     "rows": Array [
@@ -170,7 +170,7 @@ Array [
 ]
 `;
 
-exports[`PagesVisitor should be able to change fields 1`] = `
+exports[`PagesVisitor is able to change fields 1`] = `
 Array [
   Object {
     "rows": Array [
@@ -340,7 +340,7 @@ Array [
 ]
 `;
 
-exports[`PagesVisitor should be able to change pages 1`] = `
+exports[`PagesVisitor is able to change pages 1`] = `
 Array [
   Object {
     "rows": Array [
@@ -510,7 +510,7 @@ Array [
 ]
 `;
 
-exports[`PagesVisitor should be able to change rows 1`] = `
+exports[`PagesVisitor is able to change rows 1`] = `
 Array [
   Object {
     "rows": Array [

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/util/visitors.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/util/visitors.es.js
@@ -30,7 +30,7 @@ describe('PagesVisitor', () => {
 		}
 	});
 
-	it('should not multate the fields of the original array', () => {
+	it('does not multate the fields of the original array', () => {
 		const newPages = visitor.mapFields((field, index) => {
 			if (field.fieldName == 'radio') {
 				field.fieldName = 'liferay';
@@ -42,7 +42,7 @@ describe('PagesVisitor', () => {
 		expect(mockPages).not.toBe(newPages);
 	});
 
-	it('should be able to change pages', () => {
+	it('is able to change pages', () => {
 		expect(
 			visitor.mapPages((page, index) => ({
 				...page,
@@ -51,7 +51,7 @@ describe('PagesVisitor', () => {
 		).toMatchSnapshot();
 	});
 
-	it('should be able to change rows', () => {
+	it('is able to change rows', () => {
 		expect(
 			visitor.mapRows(row => ({
 				...row,
@@ -60,7 +60,7 @@ describe('PagesVisitor', () => {
 		).toMatchSnapshot();
 	});
 
-	it('should be able to change columns', () => {
+	it('is able to change columns', () => {
 		expect(
 			visitor.mapColumns(column => ({
 				...column,
@@ -69,7 +69,7 @@ describe('PagesVisitor', () => {
 		).toMatchSnapshot();
 	});
 
-	it('should be able to change fields', () => {
+	it('is able to change fields', () => {
 		expect(
 			visitor.mapFields((field, index) => ({
 				...field,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/Popover/Popover.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/Popover/Popover.es.js
@@ -45,12 +45,12 @@ describe('Popover', () => {
 		fetch.resetMocks();
 	});
 
-	it('should render the default markup', () => {
+	it('renders the default markup', () => {
 		component = new Popover(props);
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render popover opened', () => {
+	it('renders popover opened', () => {
 		component = new Popover({
 			...props,
 			visible: true
@@ -59,7 +59,7 @@ describe('Popover', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should open when the visible property changes', () => {
+	it('opens when the visible property changes', () => {
 		component = new Popover(props);
 
 		jest.runAllTimers();
@@ -78,7 +78,7 @@ describe('Popover', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should open when alignedElement is clicked', () => {
+	it('opens when alignedElement is clicked', () => {
 		component = new Popover(props);
 
 		jest.runAllTimers();
@@ -89,7 +89,7 @@ describe('Popover', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should close when it is already opened and the alignedElement is clicked', () => {
+	it('closes when it is already opened and the alignedElement is clicked', () => {
 		component = new Popover({
 			...props,
 			visible: true
@@ -103,7 +103,7 @@ describe('Popover', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should close when document has mousedown event', () => {
+	it('closes when document has mousedown event', () => {
 		component = new Popover({
 			...props,
 			visible: true

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/Popover/__snapshots__/Popover.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/Popover/__snapshots__/Popover.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Popover should close when document has mousedown event 1`] = `
+exports[`Popover closes when document has mousedown event 1`] = `
 <div class="popover clay-popover-top hide ddm-share-url-popover" style="visibility: visible; display: none; top: 0px; left: 0px;">
   <div class="arrow"></div>
   <div class="popover-header">Liferay</div>
@@ -8,7 +8,7 @@ exports[`Popover should close when document has mousedown event 1`] = `
 </div>
 `;
 
-exports[`Popover should close when it is already opened and the alignedElement is clicked 1`] = `
+exports[`Popover closes when it is already opened and the alignedElement is clicked 1`] = `
 <div class="popover clay-popover-top ddm-share-url-popover" style="visibility: visible; display: none; top: 0px; left: 0px;">
   <div class="arrow"></div>
   <div class="popover-header">Liferay</div>
@@ -16,14 +16,14 @@ exports[`Popover should close when it is already opened and the alignedElement i
 </div>
 `;
 
-exports[`Popover should open when alignedElement is clicked 1`] = `
+exports[`Popover opens when alignedElement is clicked 1`] = `
 <div class="popover clay-popover-none hide ddm-share-url-popover" style="display: none; visibility: visible;">
   <div class="popover-header">Liferay</div>
   <div class="popover-body"><span class="text-secondary">This content will be displayed when popover appears</span>0</div>
 </div>
 `;
 
-exports[`Popover should open when the visible property changes 1`] = `
+exports[`Popover opens when the visible property changes 1`] = `
 <div class="popover clay-popover-top ddm-share-url-popover" style="visibility: visible; top: 0px; left: 0px;">
   <div class="arrow"></div>
   <div class="popover-header">Liferay</div>
@@ -31,14 +31,14 @@ exports[`Popover should open when the visible property changes 1`] = `
 </div>
 `;
 
-exports[`Popover should render popover opened 1`] = `
+exports[`Popover renders popover opened 1`] = `
 <div class="popover clay-popover-none ddm-share-url-popover" style="visibility: visible; display: none;">
   <div class="popover-header">Liferay</div>
   <div class="popover-body"><span class="text-secondary">This content will be displayed when popover appears</span>0</div>
 </div>
 `;
 
-exports[`Popover should render the default markup 1`] = `
+exports[`Popover renders the default markup 1`] = `
 <div class="popover clay-popover-none hide ddm-share-url-popover" style="display: none; visibility: visible;">
   <div class="popover-header">Liferay</div>
   <div class="popover-body"><span class="text-secondary">This content will be displayed when popover appears</span>0</div>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/PreviewButton/PreviewButton.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/PreviewButton/PreviewButton.es.js
@@ -37,14 +37,14 @@ describe('PreviewButton', () => {
 		fetch.resetMocks();
 	});
 
-	it('should render', () => {
+	it('renders', () => {
 		component = new PreviewButton(props);
 
 		expect(component).toMatchSnapshot();
 	});
 
 	describe('preview()', () => {
-		it('should call fetch with published=true', () => {
+		it('calls fetch with published=true', () => {
 			component = new PreviewButton(props);
 
 			const windowOpenSpy = jest.spyOn(window, 'open');
@@ -61,7 +61,7 @@ describe('PreviewButton', () => {
 				);
 		});
 
-		it('should be called when button is clicked', () => {
+		it('is called when button is clicked', () => {
 			component = new PreviewButton(props);
 
 			const previewSpy = jest.spyOn(component, 'preview');
@@ -73,7 +73,7 @@ describe('PreviewButton', () => {
 			expect(previewSpy).toHaveBeenCalled();
 		});
 
-		it('should show error notification when resolvePreviewURL fails', () => {
+		it('shows error notification when resolvePreviewURL fails', () => {
 			component = new PreviewButton({
 				...props,
 				resolvePreviewURL: () => Promise.reject()

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/PreviewButton/__snapshots__/PreviewButton.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/PreviewButton/__snapshots__/PreviewButton.es.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PreviewButton should render 1`] = `<button class="btn btn-default btn-link" type="button"></button>`;
+exports[`PreviewButton renders 1`] = `<button class="btn btn-default btn-link" type="button"></button>`;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/PublishButton/PublishButton.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/PublishButton/PublishButton.es.js
@@ -51,13 +51,13 @@ describe('PublishButton', () => {
 		fetch.resetMocks();
 	});
 
-	it('should render published', () => {
+	it('renders published', () => {
 		component = new PublishButton(props);
 
 		expect(component).toMatchSnapshot();
 	});
 
-	it('should render unpublished', () => {
+	it('renders unpublished', () => {
 		component = new PublishButton({
 			...props,
 			published: false
@@ -67,7 +67,7 @@ describe('PublishButton', () => {
 	});
 
 	describe('publish()', () => {
-		it('should call submitForm()', () => {
+		it('calls submitForm()', () => {
 			const submitForm = jest.fn();
 
 			component = new PublishButton({
@@ -82,7 +82,7 @@ describe('PublishButton', () => {
 	});
 
 	describe('unpublish()', () => {
-		it('should call submitForm()', () => {
+		it('calls submitForm()', () => {
 			const submitForm = jest.fn();
 
 			component = new PublishButton({
@@ -97,7 +97,7 @@ describe('PublishButton', () => {
 	});
 
 	describe('toggle()', () => {
-		it('should call publish() when props.published=false', () => {
+		it('calls publish() when props.published=false', () => {
 			component = new PublishButton({
 				...props,
 				published: false
@@ -112,7 +112,7 @@ describe('PublishButton', () => {
 				.then(() => expect(publishSpy).toHaveBeenCalled());
 		});
 
-		it('should call unpublish() when props.published=true', () => {
+		it('calls unpublish() when props.published=true', () => {
 			component = new PublishButton({
 				...props,
 				published: true
@@ -127,7 +127,7 @@ describe('PublishButton', () => {
 				.then(() => expect(unpublishSpy).toHaveBeenCalled());
 		});
 
-		it('should be called when button is clicked', () => {
+		it('is called when button is clicked', () => {
 			component = new PublishButton({
 				...props,
 				published: true

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/PublishButton/__snapshots__/PublishButton.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/PublishButton/__snapshots__/PublishButton.es.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PublishButton should render published 1`] = `<button class="btn btn-default btn-primary" type="button">Unpublish Form</button>`;
+exports[`PublishButton renders published 1`] = `<button class="btn btn-default btn-primary" type="button">Unpublish Form</button>`;
 
-exports[`PublishButton should render unpublished 1`] = `<button class="btn btn-default btn-primary" type="button">Publish Form</button>`;
+exports[`PublishButton renders unpublished 1`] = `<button class="btn btn-default btn-primary" type="button">Publish Form</button>`;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/ShareFormPopover/ShareFormPopover.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/components/ShareFormPopover/ShareFormPopover.es.js
@@ -46,12 +46,12 @@ describe('ShareFormPopover', () => {
 		fetch.resetMocks();
 	});
 
-	it('should render the default markup', () => {
+	it('renders the default markup', () => {
 		component = new ShareFormPopover(props);
 		expect(component).toMatchSnapshot();
 	});
 
-	it("should copy the sharable URL to user's clipboard", () => {
+	it("copies the sharable URL to user's clipboard", () => {
 		component = new ShareFormPopover(props);
 		component._clipboard.emit('success');
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/util/AutoSave.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/util/AutoSave.es.js
@@ -71,7 +71,7 @@ describe('AutoSave', () => {
 		});
 	});
 
-	it('should call the saveIfNeeded function every given interval', () => {
+	it('calls the saveIfNeeded function every given interval', () => {
 		const saveIfNeededMock = jest.spyOn(component, 'saveIfNeeded');
 
 		saveIfNeededMock.mockImplementation(() => null);
@@ -83,7 +83,7 @@ describe('AutoSave', () => {
 		saveIfNeededMock.mockRestore();
 	});
 
-	it('should call save function only once when time has passed but state has not changed', () => {
+	it('calls save function only once when time has passed but state has not changed', () => {
 		const saveSpy = jest.spyOn(component, 'save');
 
 		stateSyncronizer.getState = () => {
@@ -104,7 +104,7 @@ describe('AutoSave', () => {
 		saveSpy.mockRestore();
 	});
 
-	it('should save current state hash if request is successful', () => {
+	it('saves current state hash if request is successful', () => {
 		const spy = jest.spyOn(component, 'saveStateHash');
 
 		const modifiedDate = 'date-1';
@@ -122,7 +122,7 @@ describe('AutoSave', () => {
 			.then(() => expect(spy).toHaveBeenCalledTimes(1));
 	});
 
-	it('should reload the page when session has expired', () => {
+	it('reloads the page when session has expired', () => {
 		const reloadMock = jest.spyOn(window.location, 'reload');
 
 		reloadMock.mockImplementation(() => null);
@@ -135,7 +135,7 @@ describe('AutoSave', () => {
 		});
 	});
 
-	it('should not reload the page when request failed for other reasons', () => {
+	it('does not reload the page when request failed for other reasons', () => {
 		const reloadMock = jest.spyOn(window.location, 'reload');
 
 		reloadMock.mockImplementation(() => null);
@@ -148,7 +148,7 @@ describe('AutoSave', () => {
 		});
 	});
 
-	it('should emit the "autosaved" event if request is successful', () => {
+	it('emits the "autosaved" event if request is successful', () => {
 		const spy = jest.spyOn(component, 'emit');
 
 		const modifiedDate = 'date-1';
@@ -169,7 +169,7 @@ describe('AutoSave', () => {
 		});
 	});
 
-	it('should define input ids after form is saved for the first time', () => {
+	it('defines input ids after form is saved for the first time', () => {
 		const ddmStructureIdInput = createInput('ddmStructureId');
 		const formInstanceIdInput = createInput('formInstanceId');
 

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/CompatibilityEventProxy.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/CompatibilityEventProxy.es.js
@@ -61,7 +61,7 @@ describe('CompatibilityEventProxy', () => {
 
 	const namespace = 'namespace';
 
-	it('should not emit any event when no targets have been added', done => {
+	it('does not emit any event when no targets have been added', done => {
 		const component = new CompatibilityEventProxy({
 			host
 		});
@@ -78,7 +78,7 @@ describe('CompatibilityEventProxy', () => {
 		done();
 	});
 
-	it('should not crash if target has no method fire', done => {
+	it('does not crash if target has no method fire', done => {
 		const mockedTarget = {};
 
 		const component = new CompatibilityEventProxy({
@@ -103,7 +103,7 @@ describe('CompatibilityEventProxy', () => {
 		done();
 	});
 
-	it('should emit adapted event with event name and event params to given targets when no namespace is specified', done => {
+	it('emits adapted event with event name and event params to given targets when no namespace is specified', done => {
 		const mockedTarget = createMockedTarget(eventNameToEmit);
 
 		const spy = jest.spyOn(mockedTarget, 'fire');
@@ -124,7 +124,7 @@ describe('CompatibilityEventProxy', () => {
 		done();
 	});
 
-	it('should emit adapted event with event name and event params to given targets when namespace is specified', done => {
+	it('emits adapted event with event name and event params to given targets when namespace is specified', done => {
 		const namespacedEventNameToEmit = namespace + ':' + eventNameToEmit;
 
 		const mockedTarget = createMockedTarget(namespacedEventNameToEmit);
@@ -148,7 +148,7 @@ describe('CompatibilityEventProxy', () => {
 		done();
 	});
 
-	it('should emit adapted event to given targets when target is not listening', done => {
+	it('emits adapted event to given targets when target is not listening', done => {
 		const mockedTarget = createMockedTarget();
 
 		const spy = jest.spyOn(mockedTarget, 'fire');
@@ -166,7 +166,7 @@ describe('CompatibilityEventProxy', () => {
 		done();
 	});
 
-	it('should emit adapted event to given targets when target is listening', done => {
+	it('emits adapted event to given targets when target is listening', done => {
 		const mockedTarget = createMockedTarget(eventNameToEmit);
 
 		const spy = jest.spyOn(mockedTarget, 'fire');
@@ -184,7 +184,7 @@ describe('CompatibilityEventProxy', () => {
 		done();
 	});
 
-	it('should maintain target original state of emitFacade after emiting events', done => {
+	it('maintains target original state of emitFacade after emiting events', done => {
 		const emitFacade = false;
 
 		const mockedTarget = createMockedTarget(eventNameToEmit, emitFacade);
@@ -207,7 +207,7 @@ describe('CompatibilityEventProxy', () => {
 		done();
 	});
 
-	it('should maintain target original state of emitFacade after emiting events when component emitFacade is true', done => {
+	it('maintains target original state of emitFacade after emiting events when component emitFacade is true', done => {
 		const emitFacade = false;
 
 		const mockedTarget = createMockedTarget(eventNameToEmit, emitFacade);
@@ -231,7 +231,7 @@ describe('CompatibilityEventProxy', () => {
 		done();
 	});
 
-	it('should adapt the events according to specified RegExp', done => {
+	it('adapts the events according to specified RegExp', done => {
 		const eventNameToEmit = 'eventChanged';
 
 		const eventObjectToEmit = {
@@ -265,7 +265,7 @@ describe('CompatibilityEventProxy', () => {
 		done();
 	});
 
-	it('should emit events even if the event does not have a key property', done => {
+	it('emits events even if the event does not have a key property', done => {
 		const eventObjectToEmit = {};
 
 		const mockedTarget = createMockedTarget(eventNameToEmit);

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/PortletBase.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/PortletBase.es.js
@@ -50,14 +50,14 @@ describe('PortletBase', () => {
 	});
 
 	describe('PortletBase.all', () => {
-		it('should return an empty list if no elements are found', () => {
+		it('returns an empty list if no elements are found', () => {
 			const elements = portletBase.all('.bar');
 
 			expect(elements).not.toBeNull();
 			expect(elements.length).toEqual(0);
 		});
 
-		it('should get all matching nodes within the root node tree', () => {
+		it('gets all matching nodes within the root node tree', () => {
 			expect(portletBase.all('.foo').length).toEqual(2);
 			expect(
 				portletBase.all(
@@ -67,7 +67,7 @@ describe('PortletBase', () => {
 			).toEqual(1);
 		});
 
-		it('should use the document as root node if one has not been specified or the default has not been found', () => {
+		it('uses the document as root node if one has not been specified or the default has not been found', () => {
 			portletBase = new PortletBase({
 				namespace: '_com_liferay_unknown_portlet'
 			});
@@ -90,7 +90,7 @@ describe('PortletBase', () => {
 			global.fetch = globalFetch;
 		});
 
-		it('should make the request to the given url', done => {
+		it('makes the request to the given url', done => {
 			global.fetch = jest.fn(url => {
 				expect(url).toBe(sampleUrl);
 				done();
@@ -99,7 +99,7 @@ describe('PortletBase', () => {
 			portletBase.fetch(sampleUrl, sampleBody);
 		});
 
-		it('should add credentials option to the request', done => {
+		it('adds credentials option to the request', done => {
 			global.fetch = jest.fn((url, options) => {
 				expect(options.credentials).toBe('include');
 				done();
@@ -108,7 +108,7 @@ describe('PortletBase', () => {
 			portletBase.fetch(sampleUrl, sampleBody);
 		});
 
-		it('should add the POST method option to the request', done => {
+		it('adds the POST method option to the request', done => {
 			global.fetch = jest.fn((url, options) => {
 				expect(options.method).toBe('POST');
 				done();
@@ -117,7 +117,7 @@ describe('PortletBase', () => {
 			portletBase.fetch(sampleUrl, sampleBody);
 		});
 
-		it('should add the given body to the request', done => {
+		it('adds the given body to the request', done => {
 			global.fetch = jest.fn((url, options) => {
 				expect(options.body).toBe(sampleBody);
 				done();
@@ -127,7 +127,7 @@ describe('PortletBase', () => {
 			portletBase.fetch(sampleUrl, sampleBody);
 		});
 
-		it('should transform the given body using getRequestBody_', done => {
+		it('transforms the given body using getRequestBody_', done => {
 			portletBase.getRequestBody_ = jest.fn();
 
 			global.fetch = jest.fn((url, options) => {
@@ -144,7 +144,7 @@ describe('PortletBase', () => {
 	});
 
 	describe('PortletBase.getRequestBody_', () => {
-		it('should keep body intact if it is already a FormData instance', () => {
+		it('keeps body intact if it is already a FormData instance', () => {
 			const sampleFormData = new FormData();
 
 			expect(portletBase.getRequestBody_(sampleFormData)).toBe(
@@ -152,7 +152,7 @@ describe('PortletBase', () => {
 			);
 		});
 
-		it('should create a FormData instance from a given HTMLFormElement', () => {
+		it('creates a FormData instance from a given HTMLFormElement', () => {
 			const sampleFormElement = document.createElement('form');
 
 			sampleFormElement.innerHTML = `
@@ -174,7 +174,7 @@ describe('PortletBase', () => {
 			);
 		});
 
-		it('should append all object keys inside a new FormData element', () => {
+		it('appends all object keys inside a new FormData element', () => {
 			portletBase.ns = obj => obj;
 
 			const sampleBody = {
@@ -190,7 +190,7 @@ describe('PortletBase', () => {
 	});
 
 	describe('PortletBase.ns', () => {
-		it('should namespace objects with the portlet namespace using the provided Liferay.Util.ns helper', () => {
+		it('namespaces objects with the portlet namespace using the provided Liferay.Util.ns helper', () => {
 			portletBase.ns('test');
 
 			expect(Liferay.Util.ns.mock.calls.length).toBe(1);
@@ -198,11 +198,11 @@ describe('PortletBase', () => {
 	});
 
 	describe('PortletBase.one', () => {
-		it('should return null if no element is found', () => {
+		it('returns null if no element is found', () => {
 			expect(portletBase.one('.bar')).toBeNull();
 		});
 
-		it('should get the first matching node within the root node tree', () => {
+		it('gets the first matching node within the root node tree', () => {
 			expect(portletBase.one('.foo')).toEqual(
 				document.getElementById(
 					'_com_liferay_test_portlet_child_container'
@@ -221,7 +221,7 @@ describe('PortletBase', () => {
 			);
 		});
 
-		it('should use the document as root node if one has not been specified or the default has not been found', () => {
+		it('uses the document as root node if one has not been specified or the default has not been found', () => {
 			portletBase = new PortletBase({
 				namespace: '_com_liferay_unknown_portlet'
 			});
@@ -233,13 +233,13 @@ describe('PortletBase', () => {
 	});
 
 	describe('PortletBase.rootNode', () => {
-		it('should set the root node by default', () => {
+		it('sets the root node by default', () => {
 			expect(portletBase.rootNode).toEqual(
 				document.getElementById('p_p_id' + namespace)
 			);
 		});
 
-		it('should use a specified root node', () => {
+		it('uses a specified root node', () => {
 			portletBase.rootNode = '#' + namespace + 'child_container';
 
 			expect(portletBase.rootNode).toEqual(
@@ -247,7 +247,7 @@ describe('PortletBase', () => {
 			);
 		});
 
-		it('should override the default root node if specified', () => {
+		it('overrides the default root node if specified', () => {
 			portletBase = new PortletBase({
 				namespace,
 				rootNode: '#' + namespace + 'child_container'

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/aop/AOP.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/aop/AOP.es.js
@@ -28,7 +28,7 @@ describe('Ajax', function() {
 		callOrder = [];
 	});
 
-	it('should call listener before original method', function() {
+	it('calls listener before original method', function() {
 		const obj = new MyClass();
 
 		AOP.before(spy1, obj, 'add');
@@ -42,7 +42,7 @@ describe('Ajax', function() {
 		expect(retVal).toEqual(3);
 	});
 
-	it('should call listener after original method', function() {
+	it('calls listener after original method', function() {
 		const obj = new MyClass();
 
 		AOP.after(spy1, obj, 'add');
@@ -56,7 +56,7 @@ describe('Ajax', function() {
 		expect(retVal).toEqual(3);
 	});
 
-	it('should call multiple listeners in correct order', function() {
+	it('calls multiple listeners in correct order', function() {
 		const obj = new MyClass();
 
 		AOP.before(spy1, obj, 'add');
@@ -73,7 +73,7 @@ describe('Ajax', function() {
 		expect(retVal).toEqual(3);
 	});
 
-	it('should not call listener if returned handle is removed', function() {
+	it('does not call listener if returned handle is removed', function() {
 		const obj = new MyClass();
 
 		const handle = AOP.before(spy1, obj, 'add');
@@ -91,7 +91,7 @@ describe('Ajax', function() {
 		expect(spy1).toHaveBeenCalledTimes(1);
 	});
 
-	it('should only remove listeners that are detached', function() {
+	it('only removes listeners that are detached', function() {
 		const obj = new MyClass();
 
 		const handle1 = AOP.before(spy1, obj, 'add');
@@ -112,7 +112,7 @@ describe('Ajax', function() {
 		expect(spy2).toHaveBeenCalledTimes(2);
 	});
 
-	it('should prevent wrapped function from firing when AOP.prevent is returned by listener', function() {
+	it('prevents wrapped function from firing when AOP.prevent is returned by listener', function() {
 		const obj = new MyClass();
 
 		AOP.before(
@@ -128,7 +128,7 @@ describe('Ajax', function() {
 		expect(addSpy).not.toHaveBeenCalled();
 	});
 
-	it('should prevent wrapped function and all further before subscribers from firing when AOP.halt is returned by listener', function() {
+	it('prevents wrapped function and all further before subscribers from firing when AOP.halt is returned by listener', function() {
 		const obj = new MyClass();
 
 		AOP.before(
@@ -147,7 +147,7 @@ describe('Ajax', function() {
 		expect(retVal).toEqual('new value');
 	});
 
-	it('should prevent all further after subscribers from firing when AOP.halt is returned by listener', function() {
+	it('prevents all further after subscribers from firing when AOP.halt is returned by listener', function() {
 		const obj = new MyClass();
 
 		AOP.after(
@@ -165,7 +165,7 @@ describe('Ajax', function() {
 		expect(retVal).toEqual('new value');
 	});
 
-	it('should modify return value when AOP.alterReturn is returned by `after` listener', function() {
+	it('modifies return value when AOP.alterReturn is returned by `after` listener', function() {
 		const obj = new MyClass();
 
 		AOP.after(
@@ -182,7 +182,7 @@ describe('Ajax', function() {
 		expect(retVal).toEqual(4);
 	});
 
-	it('should track changes made to return value with subsequent changes made by AOP.alterReturn', function() {
+	it('tracks changes made to return value with subsequent changes made by AOP.alterReturn', function() {
 		const obj = new MyClass();
 
 		AOP.after(
@@ -219,7 +219,7 @@ describe('Ajax', function() {
 		expect(retVal).toEqual('now a string:');
 	});
 
-	it('should track original return value when changes are made by AOP.alterReturn', function() {
+	it('tracks original return value when changes are made by AOP.alterReturn', function() {
 		const obj = new MyClass();
 
 		AOP.after(

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/component.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/component.es.js
@@ -37,7 +37,7 @@ describe('Liferay', () => {
 	});
 
 	describe('Liferay.component', () => {
-		it('should store function inputs and invoke them lazily on component retrieval', () => {
+		it('stores function inputs and invoke them lazily on component retrieval', () => {
 			const myButton = {myButton: 'myButton'};
 			const spy = jest.fn(x => myButton);
 
@@ -48,7 +48,7 @@ describe('Liferay', () => {
 			expect(component('myButton')).toEqual(myButton);
 		});
 
-		it('should warn through console when a component is registered twice', () => {
+		it('warns through console when a component is registered twice', () => {
 			let msg = '';
 
 			console.warn = function() {
@@ -68,7 +68,7 @@ describe('Liferay', () => {
 	});
 
 	describe('Liferay.componentReady', () => {
-		it('should return a single component if called before it is registered', () => {
+		it('returns a single component if called before it is registered', () => {
 			const myButton = {myButton: 'myButton'};
 
 			const promise = componentReady('myButton').then(component => {
@@ -80,7 +80,7 @@ describe('Liferay', () => {
 			return promise;
 		});
 
-		it('should return a single component if called after it is registered', () => {
+		it('returns a single component if called after it is registered', () => {
 			const myButton = {myButton: 'myButton'};
 
 			component('myButton', myButton);
@@ -90,7 +90,7 @@ describe('Liferay', () => {
 			});
 		});
 
-		it('should return an array of components if called before they are registered', () => {
+		it('returns an array of components if called before they are registered', () => {
 			const myButton1 = {myButton1: 'myButton1'};
 			const myButton2 = {myButton2: 'myButton2'};
 
@@ -107,7 +107,7 @@ describe('Liferay', () => {
 			return promise;
 		});
 
-		it('should return an array of components if called after they are registered', () => {
+		it('returns an array of components if called after they are registered', () => {
 			const myButton1 = {myButton1: 'myButton1'};
 			const myButton2 = {myButton2: 'myButton2'};
 
@@ -124,7 +124,7 @@ describe('Liferay', () => {
 	});
 
 	describe('Liferay.destroyComponent', () => {
-		it('should destroy a registered component', () => {
+		it('destroys a registered component', () => {
 			const componentId = 'myComponent';
 
 			component(componentId, {});
@@ -134,7 +134,7 @@ describe('Liferay', () => {
 			expect(component(componentId)).toBeUndefined();
 		});
 
-		it('should ignore non registered components', () => {
+		it('ignores non registered components', () => {
 			component('componentId', {});
 
 			expect(() => {
@@ -142,7 +142,7 @@ describe('Liferay', () => {
 			}).not.toThrow();
 		});
 
-		it("should invoke a component's lifecyle destroy method if present when destroying it", () => {
+		it("invokes a component's lifecyle destroy method if present when destroying it", () => {
 			const componentId = 'myComponent';
 			const destroyFn = jest.fn();
 
@@ -155,7 +155,7 @@ describe('Liferay', () => {
 			expect(destroyFn).toHaveBeenCalled();
 		});
 
-		it("should invoke a component's lifecyle dispose method if present when destroying it", () => {
+		it("invokes a component's lifecyle dispose method if present when destroying it", () => {
 			const componentId = 'myComponent';
 			const disposeFn = jest.fn();
 
@@ -170,7 +170,7 @@ describe('Liferay', () => {
 	});
 
 	describe('Liferay.destroyComponents', () => {
-		it('should destroy all registered components if no filter function is provided', () => {
+		it('destroys all registered components if no filter function is provided', () => {
 			component('component1', 1);
 			component('component2', 2);
 			component('component3', 3);
@@ -182,7 +182,7 @@ describe('Liferay', () => {
 			expect(component('component3')).toBeUndefined();
 		});
 
-		it('should invoke the provided filter function for every component with the registered component and destroy config as params', () => {
+		it('invokes the provided filter function for every component with the registered component and destroy config as params', () => {
 			const filterFn = jest.fn();
 
 			const componentConfig = {destroy: true};
@@ -200,7 +200,7 @@ describe('Liferay', () => {
 			expect(filterFn.mock.calls[2]).toEqual([3, {}]);
 		});
 
-		it('should only destoy the components matched by the provided filter function', () => {
+		it('only destroys the components matched by the provided filter function', () => {
 			const filterFn = jest.fn(
 				(component, componentConfig) => componentConfig.destroy
 			);
@@ -220,7 +220,7 @@ describe('Liferay', () => {
 	});
 
 	describe('Liferay.destroyUnfulfilledPromises', () => {
-		it('should clean up all pending invocations of componentReady', () => {
+		it('cleans up all pending invocations of componentReady', () => {
 			const spy = jest.fn();
 
 			componentReady('component').then(spy);

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/portlet/__snapshots__/events.es.js.snap
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/portlet/__snapshots__/events.es.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PortletHub should throw error if dispatchClientEvent is called with invalid args 1`] = `"Too many arguments provided: 1, 2, 3"`;
+exports[`PortletHub throws error if dispatchClientEvent is called with invalid args 1`] = `"Too many arguments provided: 1, 2, 3"`;
 
-exports[`PortletHub should throw error if dispatchClientEvent is called with invalid args 2`] = `"Too few arguments provided: Number of arguments: 1"`;
+exports[`PortletHub throws error if dispatchClientEvent is called with invalid args 2`] = `"Too few arguments provided: Number of arguments: 1"`;
 
-exports[`PortletHub should throw error when attempting to dispatch event with protected name 1`] = `"Too few arguments provided: Number of arguments: 1"`;
+exports[`PortletHub throws error when attempting to dispatch event with protected name 1`] = `"Too few arguments provided: Number of arguments: 1"`;

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/portlet/events.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/portlet/events.es.js
@@ -18,7 +18,7 @@
 import register from '../../../src/main/resources/META-INF/resources/liferay/portlet/register.es';
 
 describe('PortletHub', () => {
-	it('should add client event listener', () => {
+	it('adds client event listener', () => {
 		const stub = jest.fn();
 
 		return register('PortletA').then(hub => {
@@ -29,7 +29,7 @@ describe('PortletHub', () => {
 		});
 	});
 
-	it('should return number of listeners', () => {
+	it('returns number of listeners', () => {
 		const stub = jest.fn();
 
 		return register('PortletA').then(hub => {
@@ -46,7 +46,7 @@ describe('PortletHub', () => {
 		});
 	});
 
-	it('should throw error if addEventListener is called with invalid args', () => {
+	it('throws error if addEventListener is called with invalid args', () => {
 		return register('PortletA').then(hub => {
 			expect(() => {
 				hub.addEventListener(1, 2, 3);
@@ -62,7 +62,7 @@ describe('PortletHub', () => {
 		});
 	});
 
-	it('should not call listener if it is removed', () => {
+	it('does not call listener if it is removed', () => {
 		const stub = jest.fn();
 
 		return register('PortletA').then(hub => {
@@ -79,7 +79,7 @@ describe('PortletHub', () => {
 		});
 	});
 
-	it('should throw error if dispatchClientEvent is called with invalid args', () => {
+	it('throws error if dispatchClientEvent is called with invalid args', () => {
 		const stub = jest.fn();
 
 		return register('PortletA').then(hub => {
@@ -93,7 +93,7 @@ describe('PortletHub', () => {
 		});
 	});
 
-	it('should throw error when attempting to dispatch event with protected name', () => {
+	it('throws error when attempting to dispatch event with protected name', () => {
 		return register('PortletA').then(hub => {
 			expect(() => {
 				hub.dispatchClientEvent('portlet.clientEvent');
@@ -101,7 +101,7 @@ describe('PortletHub', () => {
 		});
 	});
 
-	it('should throw error if removeEventListener is called with invalid args', () => {
+	it('throws error if removeEventListener is called with invalid args', () => {
 		return register('PortletA').then(hub => {
 			expect(() => {
 				hub.removeEventListener(1, 2);
@@ -119,7 +119,7 @@ describe('PortletHub', () => {
 		});
 	});
 
-	it('should call listener with matching wildcard event types', () => {
+	it('calls listener with matching wildcard event types', () => {
 		const stub = jest.fn();
 
 		return register('PortletA').then(hub => {

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/portlet/register.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/portlet/register.es.js
@@ -17,7 +17,7 @@ import register from '../../../src/main/resources/META-INF/resources/liferay/por
 
 describe('PortletHub', () => {
 	describe('register', () => {
-		it('should throw error if called without portletId', () => {
+		it('throws error if called without portletId', () => {
 			expect.assertions(1);
 
 			const testFn = () => register();
@@ -25,7 +25,7 @@ describe('PortletHub', () => {
 			expect(testFn).toThrow();
 		});
 
-		it('should return an instance of PortletInit', () => {
+		it('returns an instance of PortletInit', () => {
 			return register('PortletA').then(hub => {
 				expect(hub).toBeInstanceOf(PortletInit);
 			});

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/portlet/state.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/portlet/state.es.js
@@ -18,7 +18,7 @@ import register from '../../../src/main/resources/META-INF/resources/liferay/por
 
 describe('PortletHub', () => {
 	describe('newState', () => {
-		it('should return a new RenderState object', () => {
+		it('returns a new RenderState object', () => {
 			expect.assertions(3);
 
 			return register('PortletB').then(hub => {
@@ -45,7 +45,7 @@ describe('PortletHub', () => {
 	});
 
 	describe('newParameters', () => {
-		it('should return new parameters according to the data passed', () => {
+		it('returns new parameters according to the data passed', () => {
 			expect.assertions(4);
 
 			return register('PortletC').then(hub => {
@@ -74,7 +74,7 @@ describe('PortletHub', () => {
 
 	describe('RenderState', () => {
 		describe('constructor', () => {
-			it('should create a RenderState object according to the data passed to the constructor', () => {
+			it('creates a RenderState object according to the data passed to the constructor', () => {
 				const mockData = {
 					parameters: {
 						a: [null],
@@ -106,7 +106,7 @@ describe('PortletHub', () => {
 		});
 
 		describe('clone', () => {
-			it('should return a new RenderState instance with the same properties', () => {
+			it('returns a new RenderState instance with the same properties', () => {
 				const renderState1 = new RenderState({
 					parameters: {
 						a: [1, 2, 3],
@@ -151,7 +151,7 @@ describe('PortletHub', () => {
 		});
 
 		describe('getValue', () => {
-			it('should throw an error if specified parameter is not a string', () => {
+			it('throws an error if specified parameter is not a string', () => {
 				const renderState = new RenderState({
 					parameters: {
 						a: [1, 2, 3]
@@ -167,7 +167,7 @@ describe('PortletHub', () => {
 				expect(testFn).toThrow();
 			});
 
-			it('should return a value if specified parameter is undefined and default value is specified', () => {
+			it('returns a value if specified parameter is undefined and default value is specified', () => {
 				const renderState = new RenderState();
 
 				const defaultValue = [1, 2, 3];
@@ -177,7 +177,7 @@ describe('PortletHub', () => {
 				expect(value).toEqual(expect.arrayContaining(defaultValue));
 			});
 
-			it('should return a parameter value if it is defined', () => {
+			it('returns a parameter value if it is defined', () => {
 				const renderState = new RenderState({
 					parameters: {
 						a: ['foo']
@@ -193,7 +193,7 @@ describe('PortletHub', () => {
 		});
 
 		describe('getValues', () => {
-			it('should throw an error if the specified parameter is not a string', () => {
+			it('throws an error if the specified parameter is not a string', () => {
 				const renderState = new RenderState();
 
 				const testFn = () => {
@@ -203,7 +203,7 @@ describe('PortletHub', () => {
 				expect(testFn).toThrow();
 			});
 
-			it('should return a value if the specified parameter is undefined and a default value is provided', () => {
+			it('returns a value if the specified parameter is undefined and a default value is provided', () => {
 				const renderState = new RenderState();
 
 				const values = renderState.getValues('foo', 'bar');
@@ -211,7 +211,7 @@ describe('PortletHub', () => {
 				expect(values).toEqual('bar');
 			});
 
-			it("should return a parameter's value if it is defined", () => {
+			it("returns a parameter's value if it is defined", () => {
 				const renderState = new RenderState({
 					parameters: {
 						data: ['something', 'here']
@@ -229,7 +229,7 @@ describe('PortletHub', () => {
 		});
 
 		describe('remove', () => {
-			it('should throw an error if the speficied parameter is not a string', () => {
+			it('throws an error if the speficied parameter is not a string', () => {
 				const renderState = new RenderState();
 
 				const testFn = () => {
@@ -239,7 +239,7 @@ describe('PortletHub', () => {
 				expect(testFn).toThrow();
 			});
 
-			it('should not remove a existing parameter', () => {
+			it('does not remove a existing parameter', () => {
 				const renderState = new RenderState({
 					parameters: {
 						data: [1, 2, 3]
@@ -259,7 +259,7 @@ describe('PortletHub', () => {
 		});
 
 		describe('setValue', () => {
-			it('should throw an error if `name` is not a string', () => {
+			it('throws an error if `name` is not a string', () => {
 				const renderState = new RenderState();
 
 				const testFn = () => {
@@ -269,7 +269,7 @@ describe('PortletHub', () => {
 				expect(testFn).toThrow();
 			});
 
-			it('should throw an error if `value` is not a string', () => {
+			it('throws an error if `value` is not a string', () => {
 				const renderState = new RenderState();
 
 				const testFn = () => {
@@ -279,7 +279,7 @@ describe('PortletHub', () => {
 				expect(testFn).toThrow();
 			});
 
-			it('should throw an error if `value` is not a array', () => {
+			it('throws an error if `value` is not a array', () => {
 				const renderState = new RenderState();
 
 				const testFn = () => {
@@ -291,7 +291,7 @@ describe('PortletHub', () => {
 				expect(testFn).toThrow();
 			});
 
-			it('should throw an error if `value` is not null', () => {
+			it('throws an error if `value` is not null', () => {
 				const renderState = new RenderState();
 
 				const testFn = () => {
@@ -301,7 +301,7 @@ describe('PortletHub', () => {
 				expect(testFn).toThrow();
 			});
 
-			it('should set a parameter if `value` is a string', () => {
+			it('sets a parameter if `value` is a string', () => {
 				const renderState = new RenderState();
 
 				renderState.setValue('a', 'foo');
@@ -309,7 +309,7 @@ describe('PortletHub', () => {
 				expect(renderState.getValue('a')).toEqual('foo');
 			});
 
-			it('should set a parameter if `value` is null', () => {
+			it('sets a parameter if `value` is null', () => {
 				const renderState = new RenderState();
 
 				renderState.setValue('b', null);
@@ -319,7 +319,7 @@ describe('PortletHub', () => {
 				expect(value).toEqual(null);
 			});
 
-			it('should set a parameter if `value` is an array', () => {
+			it('sets a parameter if `value` is an array', () => {
 				const renderState = new RenderState();
 
 				renderState.setValue('c', [4, 5, 6]);
@@ -335,7 +335,7 @@ describe('PortletHub', () => {
 		});
 
 		describe('setValues', () => {
-			it('should throw an error if `value` is not a string', () => {
+			it('throws an error if `value` is not a string', () => {
 				const renderState = new RenderState();
 
 				const testFn = () => {
@@ -345,7 +345,7 @@ describe('PortletHub', () => {
 				expect(testFn).toThrow();
 			});
 
-			it('should throw an error if `value` is not null', () => {
+			it('throws an error if `value` is not null', () => {
 				const renderState = new RenderState();
 
 				const testFn = () => {
@@ -355,7 +355,7 @@ describe('PortletHub', () => {
 				expect(testFn).toThrow();
 			});
 
-			it('should throw an error if `value` is not an array', () => {
+			it('throws an error if `value` is not an array', () => {
 				const renderState = new RenderState();
 
 				const testFn = () => {
@@ -367,7 +367,7 @@ describe('PortletHub', () => {
 				expect(testFn).toThrow();
 			});
 
-			it('should set a parameter value if `value` is a string', () => {
+			it('sets a parameter value if `value` is a string', () => {
 				const renderState = new RenderState();
 
 				renderState.setValues('data', 'hello');
@@ -381,7 +381,7 @@ describe('PortletHub', () => {
 				expect(value).toEqual('hello');
 			});
 
-			it('should set a parameter value if `value` is null', () => {
+			it('sets a parameter value if `value` is null', () => {
 				const renderState = new RenderState();
 
 				renderState.setValues('data', null);
@@ -395,7 +395,7 @@ describe('PortletHub', () => {
 				expect(value).toEqual(null);
 			});
 
-			it('should set a parameter value if `value` is an array', () => {
+			it('sets a parameter value if `value` is an array', () => {
 				const renderState = new RenderState();
 
 				renderState.setValues('url', ['one', 'two', 'three']);

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/__snapshots__/ns.es.js.snap
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/__snapshots__/ns.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Liferay.Util.ns should return an object 1`] = `
+exports[`Liferay.Util.ns returns an object 1`] = `
 Object {
   "_ns_arr1": Array [
     1,

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/__snapshots__/to_char_code.es.js.snap
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/__snapshots__/to_char_code.es.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Liferay.Util.toCharCode should return string 1`] = `"10810510210111497121"`;
+exports[`Liferay.Util.toCharCode returns string 1`] = `"10810510210111497121"`;

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/address/get_countries.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/address/get_countries.es.js
@@ -17,7 +17,7 @@
 import getCountries from '../../../../src/main/resources/META-INF/resources/liferay/util/address/get_countries.es';
 
 describe('Liferay.Address.getCountries', () => {
-	it('should throw an error if the callback parameter is not a function', () => {
+	it('throws an error if the callback parameter is not a function', () => {
 		expect(() => getCountries('')).toThrow('must be a function');
 	});
 });

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/address/get_regions.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/address/get_regions.es.js
@@ -17,11 +17,11 @@
 import getRegions from '../../../../src/main/resources/META-INF/resources/liferay/util/address/get_regions.es';
 
 describe('Liferay.Address.getRegions', () => {
-	it('should throw an error if the callback parameter is not a function', () => {
+	it('throws an error if the callback parameter is not a function', () => {
 		expect(() => getRegions('')).toThrow('must be a function');
 	});
 
-	it('should throw an error if the selectKey parameter is not a string', () => {
+	it('throws an error if the selectKey parameter is not a string', () => {
 		expect(() => getRegions(() => {}, {})).toThrow('must be a string');
 	});
 });

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/fetch.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/fetch.es.js
@@ -21,7 +21,7 @@ import fetch from '../../../src/main/resources/META-INF/resources/liferay/util/f
 describe('Liferay.Util.fetch', () => {
 	const sampleUrl = 'http://sampleurl.com';
 
-	it('should apply default settings if none are given', () => {
+	it('applies default settings if none are given', () => {
 		global.fetch = jest.fn((resource, init) => {
 			expect(init).toEqual({
 				credentials: 'include'
@@ -33,7 +33,7 @@ describe('Liferay.Util.fetch', () => {
 		global.fetch.mockRestore();
 	});
 
-	it('should override a default setting with given setting', () => {
+	it('overrides a default setting with given setting', () => {
 		global.fetch = jest.fn((resource, init) => {
 			expect(init).toEqual({
 				credentials: 'omit'
@@ -47,7 +47,7 @@ describe('Liferay.Util.fetch', () => {
 		global.fetch.mockRestore();
 	});
 
-	it('should merge default settings with given different settings', () => {
+	it('merges default settings with given different settings', () => {
 		global.fetch = jest.fn((resource, init) => {
 			expect(init).toEqual({
 				credentials: 'include',

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/get_form_element.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/get_form_element.es.js
@@ -18,7 +18,7 @@ import dom from 'metal-dom';
 import getFormElement from '../../../../src/main/resources/META-INF/resources/liferay/util/form/get_form_element.es';
 
 describe('Liferay.Util.getFormElement', () => {
-	it('should return null if the form parameter is not a form node', () => {
+	it('returns null if the form parameter is not a form node', () => {
 		const fragment = dom.buildFragment('<div />');
 
 		const form = fragment.firstElementChild;
@@ -27,7 +27,7 @@ describe('Liferay.Util.getFormElement', () => {
 		expect(getFormElement(form, 'foo')).toEqual(null);
 	});
 
-	it('should return null if the elementName parameter is not a string', () => {
+	it('returns null if the elementName parameter is not a string', () => {
 		const fragment = dom.buildFragment('<form />');
 
 		const form = fragment.firstElementChild;
@@ -36,7 +36,7 @@ describe('Liferay.Util.getFormElement', () => {
 		expect(getFormElement(form, {})).toEqual(null);
 	});
 
-	it('should return null if the element does not exist withing the form', () => {
+	it('returns null if the element does not exist withing the form', () => {
 		const fragment = dom.buildFragment(`
 					<form data-fm-namespace="_com_liferay_test_portlet_" id="fm">
 						<input name="_com_liferay_test_portlet_foo" type="text" value="abc">
@@ -48,7 +48,7 @@ describe('Liferay.Util.getFormElement', () => {
 		expect(getFormElement(form, 'bar')).toEqual(null);
 	});
 
-	it('should return element value if the element does exist withing the form', () => {
+	it('returns element value if the element does exist withing the form', () => {
 		const fragment = dom.buildFragment(`
 					<form data-fm-namespace="_com_liferay_test_portlet_" id="fm">
 						<input name="_com_liferay_test_portlet_foo" type="text" value="abc">

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/object_to_form_data.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/object_to_form_data.es.js
@@ -18,7 +18,7 @@ import objectToFormData from '../../../../src/main/resources/META-INF/resources/
 
 describe('Liferay.Util.objectToFormData', () => {
 	describe('for plain objects', () => {
-		it('should convert the object string entries into string FormData entries', () => {
+		it('converts the object string entries into string FormData entries', () => {
 			const body = {
 				value1: 'value1',
 				value2: 'value2'
@@ -30,7 +30,7 @@ describe('Liferay.Util.objectToFormData', () => {
 			expect(formData.get('value2')).toEqual('value2');
 		});
 
-		it('should convert the object boolean entries into string FormData entries', () => {
+		it('converts the object boolean entries into string FormData entries', () => {
 			const body = {
 				value1: true,
 				value2: false
@@ -42,7 +42,7 @@ describe('Liferay.Util.objectToFormData', () => {
 			expect(formData.get('value2')).toEqual('false');
 		});
 
-		it('should convert the object number entries into string FormData entries', () => {
+		it('converts the object number entries into string FormData entries', () => {
 			const body = {
 				value1: 1,
 				value2: -1
@@ -54,7 +54,7 @@ describe('Liferay.Util.objectToFormData', () => {
 			expect(formData.get('value2')).toEqual('-1');
 		});
 
-		it('should convert the object File entries into File FormData entries', () => {
+		it('converts the object File entries into File FormData entries', () => {
 			const body = {
 				value1: new File([''], '')
 			};
@@ -66,7 +66,7 @@ describe('Liferay.Util.objectToFormData', () => {
 	});
 
 	describe('for objects with array values', () => {
-		it('should generate a grouped field matching the key of the array', () => {
+		it('generates a grouped field matching the key of the array', () => {
 			const body = {
 				array: ['value1', 'value2']
 			};
@@ -80,7 +80,7 @@ describe('Liferay.Util.objectToFormData', () => {
 	});
 
 	describe('for objects with object values', () => {
-		it('should transform an object with complex values into a FormData element', () => {
+		it('transforms an object with complex values into a FormData element', () => {
 			const body = {
 				objectValue: {
 					arrayValue: ['arrayValue1', 'arrayValue2'],

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/post_form.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/post_form.es.js
@@ -29,7 +29,7 @@ describe('Liferay.Util.postForm', () => {
 		global.submitForm = jest.fn();
 	});
 
-	it('should do nothing if the form parameter is not a form node', () => {
+	it('does nothing if the form parameter is not a form node', () => {
 		const fragment = dom.buildFragment('<div />');
 
 		postForm(undefined);
@@ -38,7 +38,7 @@ describe('Liferay.Util.postForm', () => {
 		expect(global.submitForm.mock.calls.length).toBe(0);
 	});
 
-	it('should submit form even if options parameter is not set', () => {
+	it('submits form even if options parameter is not set', () => {
 		const fragment = dom.buildFragment('<form />');
 
 		const form = fragment.firstElementChild;
@@ -48,7 +48,7 @@ describe('Liferay.Util.postForm', () => {
 		expect(global.submitForm.mock.calls.length).toBe(1);
 	});
 
-	it('should do nothing if the url optional parameter is not a string', () => {
+	it('does nothing if the url optional parameter is not a string', () => {
 		const fragment = dom.buildFragment('<form />');
 
 		const form = fragment.firstElementChild;
@@ -59,7 +59,7 @@ describe('Liferay.Util.postForm', () => {
 		expect(global.submitForm.mock.calls.length).toBe(0);
 	});
 
-	it('should do nothing if the data optional parameter is not an object', () => {
+	it('does nothing if the data optional parameter is not an object', () => {
 		const fragment = dom.buildFragment('<form />');
 
 		const form = fragment.firstElementChild;
@@ -70,7 +70,7 @@ describe('Liferay.Util.postForm', () => {
 		expect(global.submitForm.mock.calls.length).toBe(0);
 	});
 
-	it('should set given element values in data parameter, and submit form to a given url', () => {
+	it('sets given element values in data parameter, and submit form to a given url', () => {
 		const fragment = dom.buildFragment(`
 					<form data-fm-namespace="_com_liferay_test_portlet_" id="fm">
 						<input name="_com_liferay_test_portlet_foo" type="text" value="abc">

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/set_form_values.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/form/set_form_values.es.js
@@ -19,7 +19,7 @@ import getFormElement from '../../../../src/main/resources/META-INF/resources/li
 import setFormValues from '../../../../src/main/resources/META-INF/resources/liferay/util/form/set_form_values.es';
 
 describe('Liferay.Util.setFormValues', () => {
-	it('should set the given values of form elements', () => {
+	it('sets the given values of form elements', () => {
 		const fragment = dom.buildFragment(`
 					<form data-fm-namespace="_com_liferay_test_portlet_" id="fm">
 						<input name="_com_liferay_test_portlet_foo" type="text" value="abc">

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_crop_region.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_crop_region.es.js
@@ -18,7 +18,7 @@ import dom from 'metal-dom';
 import getCropRegion from '../../../src/main/resources/META-INF/resources/liferay/util/get_crop_region.es';
 
 describe('Liferay.Util.getCropRegion', () => {
-	it('should return an object with original image height and width if region is an empty object', () => {
+	it('returns an object with original image height and width if region is an empty object', () => {
 		const image = {
 			naturalHeight: 438,
 			naturalWidth: 558,
@@ -37,7 +37,7 @@ describe('Liferay.Util.getCropRegion', () => {
 		});
 	});
 
-	it('should throw an error if image parameter is not an image element', () => {
+	it('throws an error if image parameter is not an image element', () => {
 		const image = dom.buildFragment('<div />');
 
 		const region = {
@@ -54,7 +54,7 @@ describe('Liferay.Util.getCropRegion', () => {
 		expect(testFn).toThrow();
 	});
 
-	it('should throw an error if region parameter is not an object', () => {
+	it('throws an error if region parameter is not an object', () => {
 		const image = {
 			naturalHeight: 438,
 			naturalWidth: 558,
@@ -72,7 +72,7 @@ describe('Liferay.Util.getCropRegion', () => {
 		expect(testFn).toThrow();
 	});
 
-	it('should return an object with coordinates set to 0 if region coordinates are negative values', () => {
+	it('returns an object with coordinates set to 0 if region coordinates are negative values', () => {
 		const image = {
 			naturalHeight: 438,
 			naturalWidth: 558,
@@ -96,7 +96,7 @@ describe('Liferay.Util.getCropRegion', () => {
 		});
 	});
 
-	it('should return an object if imagePreview parameter is an image and region parameter is an object', () => {
+	it('returns an object if imagePreview parameter is an image and region parameter is an object', () => {
 		const image = {
 			naturalHeight: 438,
 			naturalWidth: 558,

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/navigate.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/navigate.es.js
@@ -34,13 +34,13 @@ describe('Liferay.Util.navigate', () => {
 			};
 		});
 
-		it('should navigate to the given url using the provided Liferay.SPA.app.navigate helper', () => {
+		it('navigates to the given url using the provided Liferay.SPA.app.navigate helper', () => {
 			navigate(sampleUrl);
 
 			expect(Liferay.SPA.app.navigate).toBeCalledWith(sampleUrl);
 		});
 
-		it('should setup one-time-only global listeners in the Liferay object if specified', () => {
+		it('setups one-time-only global listeners in the Liferay object if specified', () => {
 			const listenerFn = jest.fn();
 
 			navigate(sampleUrl, {
@@ -63,7 +63,7 @@ describe('Liferay.Util.navigate', () => {
 	});
 
 	describe('when SPA is disabled', () => {
-		it('should navigate to the given url using window.location.assign', () => {
+		it('navigates to the given url using window.location.assign', () => {
 			const spy = jest
 				.spyOn(console, 'error')
 				.mockImplementation(() => undefined);

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/ns.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/ns.es.js
@@ -17,7 +17,7 @@
 import ns from '../../../src/main/resources/META-INF/resources/liferay/util/ns.es';
 
 describe('Liferay.Util.ns', () => {
-	it('should return an object', () => {
+	it('returns an object', () => {
 		const namespace = '_ns_';
 
 		const payload = {

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/to_char_code.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/to_char_code.es.js
@@ -17,7 +17,7 @@
 import toCharCode from '../../../src/main/resources/META-INF/resources/liferay/util/to_char_code.es';
 
 describe('Liferay.Util.toCharCode', () => {
-	it('should return string', () => {
+	it('returns string', () => {
 		const result = toCharCode('liferay');
 
 		expect(typeof result).toBe('string');

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/test/management_toolbar/ManagementToolbar.es.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/test/management_toolbar/ManagementToolbar.es.js
@@ -57,13 +57,13 @@ describe('ManagementToolbar', () => {
 		});
 	});
 
-	it('should listen to the rowToggled event from the registered search container', () => {
+	it('listens to the rowToggled event from the registered search container', () => {
 		searchContainer.fire('rowToggled');
 
 		expect(searchContainerCallbacks.rowToggled).toHaveBeenCalled();
 	});
 
-	it('should deselect all searchContainer rows', () => {
+	it('deselects all searchContainer rows', () => {
 		managementToolbar._handleClearSelectionButtonClicked();
 
 		expect(searchContainer.select.toggleAllRows).toHaveBeenCalledWith(
@@ -72,7 +72,7 @@ describe('ManagementToolbar', () => {
 		);
 	});
 
-	it('should select all searchContainer rows', () => {
+	it('selects all searchContainer rows', () => {
 		managementToolbar._handleSelectAllButtonClicked();
 
 		expect(searchContainer.select.toggleAllRows).toHaveBeenCalledWith(
@@ -81,7 +81,7 @@ describe('ManagementToolbar', () => {
 		);
 	});
 
-	it('should toggle the searchContainer selected rows', () => {
+	it('toggles the searchContainer selected rows', () => {
 		managementToolbar._handleSelectPageCheckboxChanged({
 			data: {
 				checked: true

--- a/modules/apps/map/map-common/test/liferay/GeoJSONBase.es.js
+++ b/modules/apps/map/map-common/test/liferay/GeoJSONBase.es.js
@@ -47,7 +47,7 @@ describe('GeoJSONBase', () => {
 	});
 
 	describe('addData()', () => {
-		it('should apply _getNativeFeatures() to the given parameter', () => {
+		it('applies _getNativeFeatures() to the given parameter', () => {
 			geoJSONChild.addData('some data to be parsed');
 
 			expect(geoJSONChild._getNativeFeatures).toHaveBeenCalledTimes(1);
@@ -56,20 +56,20 @@ describe('GeoJSONBase', () => {
 			);
 		});
 
-		it('should emit a featuresAdded event after adding data', () => {
+		it('emits a featuresAdded event after adding data', () => {
 			geoJSONChild.addData('more data');
 
 			expect(geoJSONChild.emit).toHaveBeenCalledTimes(1);
 			expect(geoJSONChild.emit.mock.calls[0][0]).toBe('featuresAdded');
 		});
 
-		it('should not emit a featuresAdded event with no features', () => {
+		it('does not emit a featuresAdded event with no features', () => {
 			geoJSONChild.addData();
 
 			expect(geoJSONChild.emit).not.toHaveBeenCalled();
 		});
 
-		it('should wrap every feature with _wrapNativeFeature()', () => {
+		it('wraps every feature with _wrapNativeFeature()', () => {
 			geoJSONChild.addData('even more stuff');
 
 			expect(geoJSONChild.emit).toHaveBeenCalledTimes(1);
@@ -84,14 +84,14 @@ describe('GeoJSONBase', () => {
 	});
 
 	describe('_handleFeatureClicked()', () => {
-		it('should emit a featureClick event', () => {
+		it('emits a featureClick event', () => {
 			geoJSONChild._handleFeatureClicked();
 
 			expect(geoJSONChild.emit).toHaveBeenCalledTimes(1);
 			expect(geoJSONChild.emit.mock.calls[0][0]).toBe('featureClick');
 		});
 
-		it('should wrap the given feature with _wrapNativeFeature()', () => {
+		it('wraps the given feature with _wrapNativeFeature()', () => {
 			geoJSONChild._handleFeatureClicked('Nice feature baby');
 
 			expect(geoJSONChild.emit).toHaveBeenCalledTimes(1);
@@ -106,7 +106,7 @@ describe('GeoJSONBase', () => {
 	});
 
 	describe('_getNativeFeatures()', () => {
-		it('should throw a not implemented error', () => {
+		it('throws a not implemented error', () => {
 			expect(() => {
 				geoJSONBase._getNativeFeatures();
 			}).toThrow();
@@ -114,7 +114,7 @@ describe('GeoJSONBase', () => {
 	});
 
 	describe('_wrapNativeFeature()', () => {
-		it('should throw a not implemented error', () => {
+		it('throws a not implemented error', () => {
 			expect(() => {
 				geoJSONBase._wrapNativeFeature();
 			}).toThrow();

--- a/modules/apps/map/map-common/test/liferay/MapBase.es.js
+++ b/modules/apps/map/map-common/test/liferay/MapBase.es.js
@@ -97,7 +97,7 @@ describe('MapBase', () => {
 	});
 
 	describe('addMarker()', () => {
-		it('should pass the given location object to the constructor', () => {
+		it('passes the given location object to the constructor', () => {
 			const location = getLocation();
 
 			mapImpl._map = 'map';
@@ -107,7 +107,7 @@ describe('MapBase', () => {
 			expect(MapImpl.MarkerImpl.mock.calls[0][0].location).toBe(location);
 		});
 
-		it('should pass the existing _map to the constructor', () => {
+		it('passes the existing _map to the constructor', () => {
 			const location = getLocation();
 
 			mapImpl._map = 'map';
@@ -117,7 +117,7 @@ describe('MapBase', () => {
 			expect(MapImpl.MarkerImpl.mock.calls[0][0].map).toBe('map');
 		});
 
-		it('should do nothing is MarkerImpl is not implemented', () => {
+		it('does nothing if MarkerImpl is not implemented', () => {
 			MapImpl.MarkerImpl = null;
 
 			const result = mapImpl.addMarker();
@@ -128,7 +128,7 @@ describe('MapBase', () => {
 	});
 
 	describe('constructor()', () => {
-		it('should call _initializeMap as a fallback', () => {
+		it('calls _initializeMap as a fallback', () => {
 			window.Liferay = {
 				Util: {
 					getGeolocation: jest.fn((success, fallback) => fallback())
@@ -148,7 +148,7 @@ describe('MapBase', () => {
 	});
 
 	describe('destructor()', () => {
-		it('should dispose existing _geoJSONLayer', () => {
+		it('disposes existing _geoJSONLayer', () => {
 			const layer = {dispose: jest.fn()};
 
 			mapImpl._geoJSONLayer = layer;
@@ -161,7 +161,7 @@ describe('MapBase', () => {
 			expect(layer.dispose).toHaveBeenCalledTimes(1);
 		});
 
-		it('should dispose existing search custom control', () => {
+		it('disposes existing search custom control', () => {
 			const control = {dispose: jest.fn()};
 
 			mapImpl._customControls = {[MapImpl.CONTROLS.SEARCH]: control};
@@ -178,7 +178,7 @@ describe('MapBase', () => {
 	});
 
 	describe('getNativeMap()', () => {
-		it('should return the _map property', () => {
+		it('returns the _map property', () => {
 			mapImpl._map = {name: 'map'};
 
 			expect(mapImpl.getNativeMap()).toBe(mapImpl._map);
@@ -186,7 +186,7 @@ describe('MapBase', () => {
 	});
 
 	describe('openDialog()', () => {
-		it('should call _getDialog() method', () => {
+		it('calls _getDialog() method', () => {
 			mapImpl._getDialog = jest.fn(() => null);
 
 			mapImpl.openDialog();
@@ -194,7 +194,7 @@ describe('MapBase', () => {
 			expect(mapImpl._getDialog).toHaveBeenCalledTimes(1);
 		});
 
-		it('should call dialog.open() with the given dialog config', () => {
+		it('calls dialog.open() with the given dialog config', () => {
 			const dialog = {open: jest.fn()};
 			const dialogConfig = {opt1: 'asd'};
 
@@ -208,7 +208,7 @@ describe('MapBase', () => {
 	});
 
 	describe('_bindUIMB()', () => {
-		it('should bind handlers to featuresAdded and featureClick events on geoJSONLayer', () => {
+		it('binds handlers to featuresAdded and featureClick events on geoJSONLayer', () => {
 			mapImpl._handleGeoJSONLayerFeatureClicked = jest.fn();
 			mapImpl._handleGeoJSONLayerFeaturesAdded = jest.fn();
 
@@ -222,7 +222,7 @@ describe('MapBase', () => {
 			]);
 		});
 
-		it('should bind handlers to dragend event on geolocationMarker', () => {
+		it('binds handlers to dragend event on geolocationMarker', () => {
 			mapImpl._geolocationMarker = {on: jest.fn()};
 			mapImpl._handleGeoLocationMarkerDragended = jest.fn();
 
@@ -234,7 +234,7 @@ describe('MapBase', () => {
 			]);
 		});
 
-		it('should bind handlers to click event on customControls[HOME]', () => {
+		it('binds handlers to click event on customControls[HOME]', () => {
 			mapImpl._handleHomeButtonClicked = jest.fn();
 
 			mapImpl._customControls = {
@@ -249,7 +249,7 @@ describe('MapBase', () => {
 			).toEqual(['click', mapImpl._handleHomeButtonClicked]);
 		});
 
-		it('should bind handlers to search event on customControls[SEARCH]', () => {
+		it('binds handlers to search event on customControls[SEARCH]', () => {
 			mapImpl._handleSearchButtonClicked = jest.fn();
 			mapImpl._customControls = {
 				[MapImpl.CONTROLS.SEARCH]: {on: jest.fn()}
@@ -265,13 +265,13 @@ describe('MapBase', () => {
 	});
 
 	describe('_getDialog()', () => {
-		it('should do nothing if there is no MapBase.DialogImpl', () => {
+		it('does nothing if there is no MapBase.DialogImpl', () => {
 			MapImpl.DialogImpl = null;
 
 			expect(mapImpl._getDialog()).toBe(null);
 		});
 
-		it('should pass the existing map to the dialog constructor', () => {
+		it('passes the existing map to the dialog constructor', () => {
 			mapImpl._map = Math.random();
 
 			const dialog = mapImpl._getDialog();
@@ -279,7 +279,7 @@ describe('MapBase', () => {
 			expect(MapImpl.DialogImpl.mock.calls[0][0].map).toBe(mapImpl._map);
 		});
 
-		it('should reuse the existing dialog instance', () => {
+		it('reuses the existing dialog instance', () => {
 			const dialog1 = mapImpl._getDialog();
 			const dialog2 = mapImpl._getDialog();
 
@@ -288,13 +288,13 @@ describe('MapBase', () => {
 	});
 
 	describe('_getGeoCoder()', () => {
-		it('should do nothing if there is no MapBase.GeocoderImpl', () => {
+		it('does nothing if there is no MapBase.GeocoderImpl', () => {
 			MapImpl.GeocoderImpl = null;
 
 			expect(mapImpl._getGeocoder()).toBe(null);
 		});
 
-		it('should reuse the existing geocoder instance', () => {
+		it('reuses the existing geocoder instance', () => {
 			const geocoder1 = mapImpl._getGeocoder();
 			const geocoder2 = mapImpl._getGeocoder();
 
@@ -303,7 +303,7 @@ describe('MapBase', () => {
 	});
 
 	describe('_initializeGeoJSONData()', () => {
-		it('should do nothing if there is no data attribute', () => {
+		it('does nothing if there is no data attribute', () => {
 			mapImpl._geoJSONLayer = {addData: jest.fn()};
 
 			mapImpl.data = null;
@@ -313,7 +313,7 @@ describe('MapBase', () => {
 			expect(mapImpl._geoJSONLayer.addData).not.toHaveBeenCalled();
 		});
 
-		it('should call geoJSONLayer.addData with data attribute', () => {
+		it('calls geoJSONLayer.addData with data attribute', () => {
 			mapImpl._geoJSONLayer = {addData: jest.fn()};
 
 			mapImpl.data = {name: 'more data'};
@@ -327,7 +327,7 @@ describe('MapBase', () => {
 	});
 
 	describe('_initializeLocation()', () => {
-		it('should directly call initializeMap with the given location if geolocation is false', () => {
+		it('directly calls initializeMap with the given location if geolocation is false', () => {
 			const location = getLocation();
 
 			mapImpl._initializeMap = jest.fn();
@@ -347,26 +347,26 @@ describe('MapBase', () => {
 			position = {location: getLocation()};
 		});
 
-		it('should store the given position as position', () => {
+		it('stores the given position as position', () => {
 			mapImpl._initializeMap(position);
 
 			expect(position).toBe(mapImpl.position);
 		});
 
-		it('should store the given position as originalPosition', () => {
+		it('stores the given position as originalPosition', () => {
 			mapImpl._initializeMap(position);
 
 			expect(position).toBe(mapImpl._originalPosition);
 		});
 
-		it('should create a new map and store it as _map', () => {
+		it('creates a new map and store it as _map', () => {
 			mapImpl._initializeMap(position);
 
 			expect(mapImpl._map.name).toBe('map');
 			expect(mapImpl._map.location).toBe(position.location);
 		});
 
-		it('should call _getControlsConfig()', () => {
+		it('calls _getControlsConfig()', () => {
 			jest.spyOn(mapImpl, '_getControlsConfig');
 
 			mapImpl._initializeMap(position);
@@ -374,7 +374,7 @@ describe('MapBase', () => {
 			expect(mapImpl._getControlsConfig).toHaveBeenCalledTimes(1);
 		});
 
-		it('should call _createCustomControls()', () => {
+		it('calls _createCustomControls()', () => {
 			jest.spyOn(mapImpl, '_createCustomControls');
 
 			mapImpl._initializeMap(position);
@@ -382,7 +382,7 @@ describe('MapBase', () => {
 			expect(mapImpl._createCustomControls).toHaveBeenCalledTimes(1);
 		});
 
-		it('should call _bindUIMB()', () => {
+		it('calls _bindUIMB()', () => {
 			jest.spyOn(mapImpl, '_bindUIMB');
 
 			mapImpl._initializeMap(position);
@@ -390,7 +390,7 @@ describe('MapBase', () => {
 			expect(mapImpl._bindUIMB).toHaveBeenCalledTimes(1);
 		});
 
-		it('should call _initializeGeoJSONData()', () => {
+		it('calls _initializeGeoJSONData()', () => {
 			jest.spyOn(mapImpl, '_initializeGeoJSONData');
 
 			mapImpl._initializeMap(position);
@@ -424,13 +424,13 @@ describe('MapBase', () => {
 			}
 		}
 
-		it('should get the map bounds using getBounds()', () => {
+		it('gets the map bounds using getBounds()', () => {
 			mapImpl._handleGeoJSONLayerFeaturesAdded({features: []});
 
 			expect(mapImpl.getBounds).toHaveBeenCalledTimes(1);
 		});
 
-		it('should get the feature geometry for each feature', () => {
+		it('gets the feature geometry for each feature', () => {
 			const feature = new Feature();
 
 			mapImpl._handleGeoJSONLayerFeaturesAdded({features: [feature]});
@@ -439,7 +439,7 @@ describe('MapBase', () => {
 			expect(feature.geometry.get).toHaveBeenCalledTimes(1);
 		});
 
-		it('should update the map position when there is a single feature', () => {
+		it('updates the map position when there is a single feature', () => {
 			const feature = new Feature();
 
 			mapImpl._handleGeoJSONLayerFeaturesAdded({features: [feature]});
@@ -447,7 +447,7 @@ describe('MapBase', () => {
 			expect(mapImpl.position.location).toBe(feature.geometry.location);
 		});
 
-		it('should add the features locations to the map bounds when there are multiple features', () => {
+		it('adds the features locations to the map bounds when there are multiple features', () => {
 			const featureA = new Feature();
 			const featureB = new Feature();
 
@@ -463,13 +463,13 @@ describe('MapBase', () => {
 	});
 
 	describe('_handleGeoJSONLayerFeatureClicked()', () => {
-		it('should emit a featureClick event', () => {
+		it('emits a featureClick event', () => {
 			mapImpl._handleGeoJSONLayerFeatureClicked({});
 
 			expect(mapImpl.emit.mock.calls[0][0]).toBe('featureClick');
 		});
 
-		it('should send the given feature as event data', () => {
+		it('sends the given feature as event data', () => {
 			mapImpl._handleGeoJSONLayerFeatureClicked({feature: 'feature'});
 
 			expect(mapImpl.emit.mock.calls[0][1]).toEqual({feature: 'feature'});
@@ -477,7 +477,7 @@ describe('MapBase', () => {
 	});
 
 	describe('_handleGeoLocationMarkerDragended()', () => {
-		it('should get the location position with geocoder.reverse()', () => {
+		it('gets the location position with geocoder.reverse()', () => {
 			const location = getLocation();
 
 			jest.spyOn(mapImpl._getGeocoder(), 'reverse');
@@ -489,7 +489,7 @@ describe('MapBase', () => {
 			);
 		});
 
-		it('should update the instance position', () => {
+		it('updates the instance position', () => {
 			const location = getLocation();
 
 			mapImpl._handleGeoLocationMarkerDragended({location});
@@ -499,7 +499,7 @@ describe('MapBase', () => {
 	});
 
 	describe('_handleHomeButtonClicked()', () => {
-		it('should call preventDefault on the given event', () => {
+		it('calls preventDefault on the given event', () => {
 			const event = {preventDefault: jest.fn()};
 			const position = {location: getLocation()};
 
@@ -510,7 +510,7 @@ describe('MapBase', () => {
 			expect(event.preventDefault).toHaveBeenCalledTimes(1);
 		});
 
-		it('should set the instance position to _originalPosition', () => {
+		it('sets the instance position to _originalPosition', () => {
 			const event = {preventDefault: jest.fn()};
 			const position = {location: getLocation()};
 
@@ -523,7 +523,7 @@ describe('MapBase', () => {
 	});
 
 	describe('_handlePositionChanged()', () => {
-		it('should call setCenter with the given location', () => {
+		it('calls setCenter with the given location', () => {
 			const location = getLocation();
 
 			mapImpl._handlePositionChanged({location});
@@ -531,7 +531,7 @@ describe('MapBase', () => {
 			expect(mapImpl.setCenter.mock.calls[0]).toEqual([location]);
 		});
 
-		it('should update the geolocationMarker position if present', () => {
+		it('updates the geolocationMarker position if present', () => {
 			const locationA = getLocation();
 			const locationB = getLocation();
 
@@ -548,7 +548,7 @@ describe('MapBase', () => {
 	});
 
 	describe('_handleSearchButtonClicked()', () => {
-		it('should update the instance position', () => {
+		it('updates the instance position', () => {
 			const position = {location: getLocation()};
 
 			mapImpl._handleSearchButtonClicked({position});
@@ -558,7 +558,7 @@ describe('MapBase', () => {
 	});
 
 	describe('getBounds()', () => {
-		it('should throw a not implemented Error', () => {
+		it('throws a not implemented Error', () => {
 			expect(() => {
 				new MapBase().getBounds();
 			}).toThrow();
@@ -566,7 +566,7 @@ describe('MapBase', () => {
 	});
 
 	describe('setCenter()', () => {
-		it('should throw a not implemented Error', () => {
+		it('throws a not implemented Error', () => {
 			expect(() => {
 				new MapBase().setCenter();
 			}).toThrow();
@@ -574,7 +574,7 @@ describe('MapBase', () => {
 	});
 
 	describe('_createMap()', () => {
-		it('should throw a not implemented Error', () => {
+		it('throws a not implemented Error', () => {
 			expect(() => {
 				new MapBase()._createMap();
 			}).toThrow();

--- a/modules/apps/map/map-common/test/liferay/MarkerBase.es.js
+++ b/modules/apps/map/map-common/test/liferay/MarkerBase.es.js
@@ -37,7 +37,7 @@ describe('MarkerBase', () => {
 	});
 
 	describe('_handleNativeEvent', () => {
-		it('should call _getNormalizedEventData with the given event', () => {
+		it('calls _getNormalizedEventData with the given event', () => {
 			markerChild._handleNativeEvent(
 				{name: 'NativeEvent'},
 				'NonNativeEvent'
@@ -51,7 +51,7 @@ describe('MarkerBase', () => {
 			]);
 		});
 
-		it('should emit an event with the given event type', () => {
+		it('emits an event with the given event type', () => {
 			markerChild._handleNativeEvent(
 				{name: 'NativeEvent'},
 				'NonNativeEvent'
@@ -61,7 +61,7 @@ describe('MarkerBase', () => {
 			expect(markerChild.emit.mock.calls[0][0]).toBe('NonNativeEvent');
 		});
 
-		it('should add the normalized event data', () => {
+		it('adds the normalized event data', () => {
 			markerChild._handleNativeEvent(
 				{name: 'NativeEvent'},
 				'NonNativeEvent'
@@ -114,7 +114,7 @@ describe('MarkerBase', () => {
 	});
 
 	describe('_getNativeMarker', () => {
-		it('should throw a not implemented error', () => {
+		it('throws a not implemented error', () => {
 			expect(() => {
 				new MarkerBase()._getNativeMarker();
 			}).toThrow();
@@ -122,7 +122,7 @@ describe('MarkerBase', () => {
 	});
 
 	describe('_getNormalizedEventData', () => {
-		it('should throw a not implemented error', () => {
+		it('throws a not implemented error', () => {
 			expect(() => {
 				new MarkerBase()._getNormalizedEventData();
 			}).toThrow();

--- a/modules/apps/map/map-common/test/liferay/validators.es.js
+++ b/modules/apps/map/map-common/test/liferay/validators.es.js
@@ -16,7 +16,7 @@ import {isSubsetOf} from '../../src/main/resources/META-INF/resources/js/validat
 
 describe('validators', () => {
 	describe('isSubsetOf()', () => {
-		it('should return true if a set is subset of a superset', () => {
+		it('returns true if a set is subset of a superset', () => {
 			const superset = ['a', 'b', 'c'];
 			const checker = isSubsetOf(superset);
 

--- a/modules/apps/segments/segments-web/.eslintrc.js
+++ b/modules/apps/segments/segments-web/.eslintrc.js
@@ -13,5 +13,5 @@
  */
 
 module.exports = {
-	extends: ['liferay/react']
+	extends: ['liferay/portal', 'liferay/react']
 };

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/ContributorsBuilder.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/ContributorsBuilder.es.js
@@ -182,7 +182,7 @@ const propertyGroups = [
 describe('ContributorsBuilder', () => {
 	afterEach(cleanup);
 
-	it('should render builder with sidebar', () => {
+	it('renders builder with sidebar', () => {
 		const editing = true;
 
 		const {asFragment} = render(
@@ -200,7 +200,7 @@ describe('ContributorsBuilder', () => {
 		expect(asFragment()).toMatchSnapshot('initialRenderEditing');
 	});
 
-	it('should render builder without sidebar', () => {
+	it('renders builder without sidebar', () => {
 		const editing = false;
 
 		const {asFragment} = render(

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaBuilder.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaBuilder.es.js
@@ -19,7 +19,7 @@ import {cleanup, render} from 'react-testing-library';
 describe('CriteriaBuilder', () => {
 	afterEach(cleanup);
 
-	it('should render', () => {
+	it('renders', () => {
 		const {asFragment} = render(
 			<CriteriaBuilder
 				editing={false}

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaGroup.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaGroup.es.js
@@ -21,7 +21,7 @@ const connectDnd = jest.fn(el => el);
 describe('CriteriaGroup', () => {
 	afterEach(cleanup);
 
-	it('should render', () => {
+	it('renders', () => {
 		const OriginalCriteriaGroup = CriteriaGroup.DecoratedComponent;
 
 		const {asFragment} = render(

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaRow.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaRow.es.js
@@ -22,7 +22,7 @@ const connectDnd = jest.fn(el => el);
 describe('CriteriaRow', () => {
 	afterEach(cleanup);
 
-	it('should render', () => {
+	it('renders', () => {
 		const OriginalCriteriaRow = CriteriaRow.DecoratedComponent;
 
 		const {asFragment} = render(
@@ -55,7 +55,7 @@ describe('CriteriaRow', () => {
 		expect(asFragment()).toMatchSnapshot();
 	});
 
-	it('should render and inform there is an unknown property', () => {
+	it('renders and inform there is an unknown property', () => {
 		const OriginalCriteriaRow = CriteriaRow.DecoratedComponent;
 
 		const {asFragment} = render(

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/DropZone.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/DropZone.es.js
@@ -21,7 +21,7 @@ const connectDnd = jest.fn(el => el);
 describe('DropZone', () => {
 	afterEach(cleanup);
 
-	it('should render', () => {
+	it('renders', () => {
 		const OriginalDropZone = DropZone.DecoratedComponent;
 
 		const {asFragment} = render(

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/EmptyDropZone.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/EmptyDropZone.es.js
@@ -21,7 +21,7 @@ const connectDnd = jest.fn(el => el);
 describe('EmptyDropZone', () => {
 	afterEach(cleanup);
 
-	it('should render', () => {
+	it('renders', () => {
 		const OriginalEmptyDropZone = EmptyDropZone.DecoratedComponent;
 
 		const {asFragment} = render(
@@ -36,7 +36,7 @@ describe('EmptyDropZone', () => {
 		expect(asFragment()).toMatchSnapshot();
 	});
 
-	it('should render illustration when empty contributors', () => {
+	it('renders illustration when empty contributors', () => {
 		const OriginalEmptyDropZone = EmptyDropZone.DecoratedComponent;
 
 		const {asFragment} = render(

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/ContributorsBuilder.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/ContributorsBuilder.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ContributorsBuilder should render builder with sidebar: initialRenderEditing 1`] = `
+exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 1`] = `
 <DocumentFragment>
   <div
     class="contributor-builder-root editing"
@@ -793,7 +793,7 @@ exports[`ContributorsBuilder should render builder with sidebar: initialRenderEd
 </DocumentFragment>
 `;
 
-exports[`ContributorsBuilder should render builder without sidebar: initialRenderNotEditing 1`] = `
+exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEditing 1`] = `
 <DocumentFragment>
   <div
     class="contributor-builder-root"

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/CriteriaBuilder.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/CriteriaBuilder.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CriteriaBuilder should render 1`] = `
+exports[`CriteriaBuilder renders 1`] = `
 <DocumentFragment>
   <div
     class="criteria-builder-root"

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/CriteriaGroup.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/CriteriaGroup.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CriteriaGroup should render 1`] = `
+exports[`CriteriaGroup renders 1`] = `
 <DocumentFragment>
   <div
     class="criteria-group-item color--user"

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/CriteriaRow.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/CriteriaRow.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CriteriaRow should render 1`] = `
+exports[`CriteriaRow renders 1`] = `
 <DocumentFragment>
   <div
     class="criterion-row-root"
@@ -67,7 +67,7 @@ exports[`CriteriaRow should render 1`] = `
 </DocumentFragment>
 `;
 
-exports[`CriteriaRow should render and inform there is an unknown property 1`] = `
+exports[`CriteriaRow renders and inform there is an unknown property 1`] = `
 <DocumentFragment>
   <div
     class="criterion-row-root criterion-row-root-error"

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/DropZone.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/DropZone.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DropZone should render 1`] = `
+exports[`DropZone renders 1`] = `
 <DocumentFragment>
   <div
     class="drop-zone-root"

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/EmptyDropZone.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/EmptyDropZone.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EmptyDropZone should render 1`] = `
+exports[`EmptyDropZone renders 1`] = `
 <DocumentFragment>
   <div
     class="empty-drop-zone-root empty-drop-zone-dashed border-primary rounded"
@@ -16,7 +16,7 @@ exports[`EmptyDropZone should render 1`] = `
 </DocumentFragment>
 `;
 
-exports[`EmptyDropZone should render illustration when empty contributors 1`] = `
+exports[`EmptyDropZone renders illustration when empty contributors 1`] = `
 <DocumentFragment>
   <div
     class="empty-drop-zone-root"

--- a/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/CriteriaSidebar.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/CriteriaSidebar.es.js
@@ -19,7 +19,7 @@ import {cleanup, render} from 'react-testing-library';
 describe('CriteriaSidebar', () => {
 	afterEach(cleanup);
 
-	it('should render', () => {
+	it('renders', () => {
 		const {asFragment} = render(<CriteriaSidebar propertyGroups={[]} />);
 
 		expect(asFragment()).toMatchSnapshot();

--- a/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/CriteriaSidebarItem.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/CriteriaSidebarItem.es.js
@@ -21,7 +21,7 @@ const connectDnd = jest.fn(el => el);
 describe('CriteriaSidebarItem', () => {
 	afterEach(cleanup);
 
-	it('should render', () => {
+	it('renders', () => {
 		const OriginalCriteriaSidebarItem =
 			CriteriaSidebarItem.DecoratedComponent;
 

--- a/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/CriteriaSidebarSearchBar.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/CriteriaSidebarSearchBar.es.js
@@ -52,7 +52,7 @@ class TestComponent extends Component {
 describe('CriteriaSidebarSearchBar', () => {
 	afterEach(cleanup);
 
-	it('should render', () => {
+	it('renders', () => {
 		const {asFragment} = render(
 			<CriteriaSidebarSearchBar onChange={jest.fn()} />
 		);
@@ -60,7 +60,7 @@ describe('CriteriaSidebarSearchBar', () => {
 		expect(asFragment()).toMatchSnapshot();
 	});
 
-	it('should render with a blank search input with no search value', () => {
+	it('renders with a blank search input with no search value', () => {
 		const {getByTestId} = render(
 			<CriteriaSidebarSearchBar onChange={jest.fn()} />
 		);
@@ -70,7 +70,7 @@ describe('CriteriaSidebarSearchBar', () => {
 		expect(searchInput.value).toEqual('');
 	});
 
-	it('should render with the value in the search input', () => {
+	it('renders with the value in the search input', () => {
 		const {getByTestId} = render(
 			<CriteriaSidebarSearchBar
 				onChange={jest.fn()}
@@ -83,7 +83,7 @@ describe('CriteriaSidebarSearchBar', () => {
 		expect(searchInput.value).toEqual('test');
 	});
 
-	it('should render a button with a times icon when an input is entered', () => {
+	it('renders a button with a times icon when an input is entered', () => {
 		const {getByTestId} = render(
 			<CriteriaSidebarSearchBar
 				onChange={jest.fn()}
@@ -96,7 +96,7 @@ describe('CriteriaSidebarSearchBar', () => {
 		expect(searchButton).toMatchSnapshot();
 	});
 
-	it('should clear the input when the times icon is clicked', () => {
+	it('clears the input when the times icon is clicked', () => {
 		const {getByTestId} = render(<TestComponent initialValue='test' />);
 
 		const searchButton = getByTestId(SEARCH_BUTTON_TESTID);

--- a/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebar.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebar.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CriteriaSidebar should render 1`] = `
+exports[`CriteriaSidebar renders 1`] = `
 <DocumentFragment>
   <div
     class="criteria-sidebar-root"

--- a/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebarItem.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebarItem.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CriteriaSidebarItem should render 1`] = `
+exports[`CriteriaSidebarItem renders 1`] = `
 <DocumentFragment>
   <li
     class="criteria-sidebar-item-root"

--- a/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebarSearchBar.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebarSearchBar.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CriteriaSidebarSearchBar should render 1`] = `
+exports[`CriteriaSidebarSearchBar renders 1`] = `
 <DocumentFragment>
   <div
     class="input-group"
@@ -38,7 +38,7 @@ exports[`CriteriaSidebarSearchBar should render 1`] = `
 </DocumentFragment>
 `;
 
-exports[`CriteriaSidebarSearchBar should render a button with a times icon when an input is entered 1`] = `
+exports[`CriteriaSidebarSearchBar renders a button with a times icon when an input is entered 1`] = `
 <button
   class="btn btn-unstyled"
   data-testid="search-button"

--- a/modules/apps/segments/segments-web/test/js/components/inputs/BooleanInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/BooleanInput.es.js
@@ -22,7 +22,7 @@ const OPTIONS_BOOLEAN_INPUT_TESTID = 'options-boolean';
 describe('BooleanInput', () => {
 	afterEach(cleanup);
 
-	it('should render type boolean', () => {
+	it('renders type boolean', () => {
 		const mockOnChange = jest.fn();
 
 		const defaultBoolValue = 'true';

--- a/modules/apps/segments/segments-web/test/js/components/inputs/CollectionInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/CollectionInput.es.js
@@ -24,7 +24,7 @@ const COLLECTION_VALUE_INPUT_TESTID = 'collection-value-input';
 describe('CollectionInput', () => {
 	afterEach(cleanup);
 
-	it('should render collection type', () => {
+	it('renders collection type', () => {
 		const mockOnChange = jest.fn();
 
 		const startingKey = 'testKey';
@@ -40,7 +40,7 @@ describe('CollectionInput', () => {
 		expect(asFragment()).toMatchSnapshot();
 	});
 
-	it('should render a key input with the right-side value of the equal character', () => {
+	it('renders a key input with the right-side value of the equal character', () => {
 		const mockOnChange = jest.fn();
 
 		const startingKey = 'testKey';
@@ -58,7 +58,7 @@ describe('CollectionInput', () => {
 		expect(keyInputElement.value).toBe(startingKey);
 	});
 
-	it('should render a value input with the left-side value of the equal character', () => {
+	it('renders a value input with the left-side value of the equal character', () => {
 		const mockOnChange = jest.fn();
 
 		const startingKey = 'testKey';
@@ -76,7 +76,7 @@ describe('CollectionInput', () => {
 		expect(valueInputElement.value).toBe(startingValue);
 	});
 
-	it('should have a changeable key input', () => {
+	it('has a changeable key input', () => {
 		const mockOnChange = jest.fn();
 
 		const startingKey = 'testKey';
@@ -100,7 +100,7 @@ describe('CollectionInput', () => {
 		});
 	});
 
-	it('should have a changeable value input', () => {
+	it('has a changeable value input', () => {
 		const mockOnChange = jest.fn();
 
 		const startingKey = 'testKey';

--- a/modules/apps/segments/segments-web/test/js/components/inputs/DateInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/DateInput.es.js
@@ -23,7 +23,7 @@ const DATE_INPUT_TESTID = 'date-input';
 describe('DateInput', () => {
 	afterEach(cleanup);
 
-	it('should render type date', () => {
+	it('renders type date', () => {
 		const mockOnChange = jest.fn();
 
 		const defaultNumberValue = '2019-01-23';
@@ -46,7 +46,7 @@ describe('DateInput', () => {
 		});
 	});
 
-	it('should render now with wrong date', () => {
+	it('renders now with wrong date', () => {
 		const mockOnChange = jest.fn();
 
 		const defaultNumberValue = '2019-01-23';

--- a/modules/apps/segments/segments-web/test/js/components/inputs/DateTimeInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/DateTimeInput.es.js
@@ -23,7 +23,7 @@ const DATE_INPUT_TESTID = 'date-input';
 describe('DateTimeInput', () => {
 	afterEach(cleanup);
 
-	it('should render type date', () => {
+	it('renders type date', () => {
 		const mockOnChange = jest.fn();
 
 		const defaultValue = '2019-01-23';
@@ -47,7 +47,7 @@ describe('DateTimeInput', () => {
 		});
 	});
 
-	it('should render now with wrong date', () => {
+	it('renders now with wrong date', () => {
 		const mockOnChange = jest.fn();
 
 		const defaultValue = '2019-01-23';

--- a/modules/apps/segments/segments-web/test/js/components/inputs/DecimalInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/DecimalInput.es.js
@@ -22,7 +22,7 @@ const DECIMAL_NUMBER_INPUT_TESTID = 'decimal-number';
 describe('DecimalInput', () => {
 	afterEach(cleanup);
 
-	it('should render type decimal number', () => {
+	it('renders type decimal number', () => {
 		const mockOnChange = jest.fn();
 
 		const defaultNumberValue = '1.23';
@@ -44,7 +44,7 @@ describe('DecimalInput', () => {
 		});
 	});
 
-	it('should format the value after blur', () => {
+	it('formats the value after blur', () => {
 		const mockOnChange = jest.fn();
 
 		const {getByTestId} = render(<DecimalInput onChange={mockOnChange} />);

--- a/modules/apps/segments/segments-web/test/js/components/inputs/IntegerInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/IntegerInput.es.js
@@ -22,7 +22,7 @@ const INTEGER_NUMBER_INPUT_TESTID = 'integer-number';
 describe('IntegerInput', () => {
 	afterEach(cleanup);
 
-	it('should render type integer number', () => {
+	it('renders type integer number', () => {
 		const mockOnChange = jest.fn();
 
 		const defaultNumberValue = '1';

--- a/modules/apps/segments/segments-web/test/js/components/inputs/SelectEntityInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/SelectEntityInput.es.js
@@ -21,7 +21,7 @@ const ENTITY_SELECT_INPUT_TESTID = 'entity-select-input';
 describe('SelectEntityInput', () => {
 	afterEach(cleanup);
 
-	it('should render type id', () => {
+	it('renders type id', () => {
 		const mockOnChange = jest.fn();
 
 		const defaultNumberValue = '12345';

--- a/modules/apps/segments/segments-web/test/js/components/inputs/StringInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/StringInput.es.js
@@ -26,13 +26,13 @@ const defaultValue = 'defaultValue';
 describe('StringInput', () => {
 	afterEach(cleanup);
 
-	it('should render with type string', () => {
+	it('renders with type string', () => {
 		const {asFragment} = render(<StringInput onChange={jest.fn()} />);
 
 		expect(asFragment()).toMatchSnapshot();
 	});
 
-	it('should render type string with value', () => {
+	it('renders type string with value', () => {
 		const mockOnChange = jest.fn();
 
 		const {asFragment, getByTestId} = render(
@@ -50,7 +50,7 @@ describe('StringInput', () => {
 		});
 	});
 
-	it('should render type string with options', () => {
+	it('renders type string with options', () => {
 		const mockOnChange = jest.fn();
 
 		const options = [

--- a/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/BooleanInput.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/BooleanInput.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BooleanInput should render type boolean 1`] = `
+exports[`BooleanInput renders type boolean 1`] = `
 <DocumentFragment>
   <select
     class="form-control criterion-input form-control"

--- a/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/CollectionInput.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/CollectionInput.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CollectionInput should render collection type 1`] = `
+exports[`CollectionInput renders collection type 1`] = `
 <DocumentFragment>
   <input
     class="criterion-input form-control"

--- a/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/DateInput.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/DateInput.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DateInput should render now with wrong date 1`] = `
+exports[`DateInput renders now with wrong date 1`] = `
 <DocumentFragment>
   <div
     class="criterion-input date-input"
@@ -15,7 +15,7 @@ exports[`DateInput should render now with wrong date 1`] = `
 </DocumentFragment>
 `;
 
-exports[`DateInput should render type date 1`] = `
+exports[`DateInput renders type date 1`] = `
 <DocumentFragment>
   <div
     class="criterion-input date-input"

--- a/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/DateTimeInput.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/DateTimeInput.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DateTimeInput should render now with wrong date 1`] = `
+exports[`DateTimeInput renders now with wrong date 1`] = `
 <DocumentFragment>
   <div
     class="criterion-input date-input"
@@ -15,7 +15,7 @@ exports[`DateTimeInput should render now with wrong date 1`] = `
 </DocumentFragment>
 `;
 
-exports[`DateTimeInput should render type date 1`] = `
+exports[`DateTimeInput renders type date 1`] = `
 <DocumentFragment>
   <div
     class="criterion-input date-input"

--- a/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/DecimalInput.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/DecimalInput.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DecimalInput should render type decimal number 1`] = `
+exports[`DecimalInput renders type decimal number 1`] = `
 <DocumentFragment>
   <input
     class="criterion-input form-control"

--- a/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/IntegerInput.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/IntegerInput.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IntegerInput should render type integer number 1`] = `
+exports[`IntegerInput renders type integer number 1`] = `
 <DocumentFragment>
   <input
     class="criterion-input form-control"

--- a/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/StringInput.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/StringInput.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StringInput should render type string with options 1`] = `
+exports[`StringInput renders type string with options 1`] = `
 <DocumentFragment>
   <select
     class="form-control criterion-input form-control"
@@ -20,7 +20,7 @@ exports[`StringInput should render type string with options 1`] = `
 </DocumentFragment>
 `;
 
-exports[`StringInput should render type string with value 1`] = `
+exports[`StringInput renders type string with value 1`] = `
 <DocumentFragment>
   <input
     class="criterion-input form-control"
@@ -31,7 +31,7 @@ exports[`StringInput should render type string with value 1`] = `
 </DocumentFragment>
 `;
 
-exports[`StringInput should render with type string 1`] = `
+exports[`StringInput renders with type string 1`] = `
 <DocumentFragment>
   <input
     class="criterion-input form-control"

--- a/modules/apps/segments/segments-web/test/js/components/segment_edit/SegmentEdit.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/segment_edit/SegmentEdit.es.js
@@ -23,7 +23,7 @@ const SOURCE_ICON_TESTID = 'source-icon';
 describe('SegmentEdit', () => {
 	afterEach(cleanup);
 
-	it('should render', () => {
+	it('renders', () => {
 		const {asFragment} = render(
 			<SegmentEdit
 				availableLocales={{
@@ -41,7 +41,7 @@ describe('SegmentEdit', () => {
 		expect(asFragment()).toMatchSnapshot();
 	});
 
-	it('should render with an analytics cloud icon', () => {
+	it('renders with an analytics cloud icon', () => {
 		const {icon, name} = SOURCES.ASAH_FARO_BACKEND;
 
 		const {getByTestId} = render(
@@ -64,7 +64,7 @@ describe('SegmentEdit', () => {
 		expect(image).toHaveAttribute('src', icon);
 	});
 
-	it('should render with a dxp icon', () => {
+	it('renders with a dxp icon', () => {
 		const {icon, name} = SOURCES.DEFAULT;
 
 		const {getByTestId} = render(
@@ -87,7 +87,7 @@ describe('SegmentEdit', () => {
 		expect(image).toHaveAttribute('src', icon);
 	});
 
-	it('should render with edit buttons if the user has update permissions', () => {
+	it('renders with edit buttons if the user has update permissions', () => {
 		const hasUpdatePermission = true;
 
 		const {asFragment} = render(
@@ -108,7 +108,7 @@ describe('SegmentEdit', () => {
 		expect(asFragment()).toMatchSnapshot();
 	});
 
-	it('should render without edit buttons if the user does not have update permissions', () => {
+	it('renders without edit buttons if the user does not have update permissions', () => {
 		const hasUpdatePermission = false;
 
 		const {asFragment} = render(
@@ -129,7 +129,7 @@ describe('SegmentEdit', () => {
 		expect(asFragment()).toMatchSnapshot();
 	});
 
-	it('should render with given values', () => {
+	it('renders with given values', () => {
 		const contributors = [
 			{
 				conjunctionId: 'and',

--- a/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SegmentEdit should render 1`] = `
+exports[`SegmentEdit renders 1`] = `
 <DocumentFragment>
   <div
     class="segment-edit-page-root"
@@ -99,7 +99,7 @@ exports[`SegmentEdit should render 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SegmentEdit should render with edit buttons if the user has update permissions 1`] = `
+exports[`SegmentEdit renders with edit buttons if the user has update permissions 1`] = `
 <DocumentFragment>
   <div
     class="segment-edit-page-root"
@@ -278,7 +278,7 @@ exports[`SegmentEdit should render with edit buttons if the user has update perm
 </DocumentFragment>
 `;
 
-exports[`SegmentEdit should render with given values 1`] = `
+exports[`SegmentEdit renders with given values 1`] = `
 <DocumentFragment>
   <div
     class="segment-edit-page-root"
@@ -770,7 +770,7 @@ exports[`SegmentEdit should render with given values 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SegmentEdit should render without edit buttons if the user does not have update permissions 1`] = `
+exports[`SegmentEdit renders without edit buttons if the user does not have update permissions 1`] = `
 <DocumentFragment>
   <div
     class="segment-edit-page-root"

--- a/modules/apps/segments/segments-web/test/js/components/shared/ClayToggle.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/shared/ClayToggle.es.js
@@ -19,7 +19,7 @@ import {cleanup, render} from 'react-testing-library';
 describe('ClayToggle', () => {
 	afterEach(cleanup);
 
-	it('should render', () => {
+	it('renders', () => {
 		const {asFragment} = render(<ClayToggle onChange={jest.fn()} />);
 
 		expect(asFragment()).toMatchSnapshot();

--- a/modules/apps/segments/segments-web/test/js/components/shared/__snapshots__/ClayToggle.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/shared/__snapshots__/ClayToggle.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ClayToggle should render 1`] = `
+exports[`ClayToggle renders 1`] = `
 <DocumentFragment>
   <label
     class="toggle-switch"

--- a/modules/apps/segments/segments-web/test/js/components/title_editor/LocalizedInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/title_editor/LocalizedInput.es.js
@@ -28,12 +28,12 @@ describe('LocalizedInput', () => {
 	describe('with minimal configuration', () => {
 		afterEach(cleanup);
 
-		it('should render', () => {
+		it('renders', () => {
 			const {asFragment} = setUpComponent();
 			expect(asFragment()).toMatchSnapshot();
 		});
 
-		it('should have main input with empty value', () => {
+		it('has main input with empty value', () => {
 			const {getByTestId} = setUpComponent();
 			const mainInput = getByTestId(LOCALIZED_MAIN_INPUT_ID);
 
@@ -54,21 +54,21 @@ describe('LocalizedInput', () => {
 		}
 	});
 
-	describe('should render with pre-existing value', () => {
+	describe('rendering with pre-existing value', () => {
 		afterEach(cleanup);
 
-		it('should render', () => {
+		it('renders', () => {
 			const {asFragment} = setUpComponent();
 			expect(asFragment()).toMatchSnapshot();
 		});
 
-		it('should have main input with value', () => {
+		it('has main input with value', () => {
 			const {getByTestId} = setUpComponent();
 			const mainInput = getByTestId(LOCALIZED_MAIN_INPUT_ID);
 			expect(mainInput.value).toBe(PRE_EXISTING_VALUE);
 		});
 
-		it('should have dropdown with options', () => {
+		it('has dropdown with options', () => {
 			const {asFragment, getByTestId} = setUpComponent();
 			const dropdownButton = getByTestId(LOCALIZED_DROPDOWN_BUTTON);
 			fireEvent.click(dropdownButton);
@@ -76,7 +76,7 @@ describe('LocalizedInput', () => {
 			expect(asFragment()).toMatchSnapshot();
 		});
 
-		it('should switch main input value on language selection', () => {
+		it('switches main input value on language selection', () => {
 			const {getByTestId, getByText} = setUpComponent();
 			const dropdownButton = getByTestId(LOCALIZED_DROPDOWN_BUTTON);
 			const mainInput = getByTestId(LOCALIZED_MAIN_INPUT_ID);

--- a/modules/apps/segments/segments-web/test/js/components/title_editor/__snapshots__/LocalizedInput.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/title_editor/__snapshots__/LocalizedInput.es.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LocalizedInput should render with pre-existing value should have dropdown with options 1`] = `
+exports[`LocalizedInput rendering with pre-existing value has dropdown with options 1`] = `
 <DocumentFragment>
   <div
     class="input-group input-localized input-localized-input"
@@ -122,7 +122,7 @@ exports[`LocalizedInput should render with pre-existing value should have dropdo
 </DocumentFragment>
 `;
 
-exports[`LocalizedInput should render with pre-existing value should render 1`] = `
+exports[`LocalizedInput rendering with pre-existing value renders 1`] = `
 <DocumentFragment>
   <div
     class="input-group input-localized input-localized-input"
@@ -173,7 +173,7 @@ exports[`LocalizedInput should render with pre-existing value should render 1`] 
 </DocumentFragment>
 `;
 
-exports[`LocalizedInput with minimal configuration should render 1`] = `
+exports[`LocalizedInput with minimal configuration renders 1`] = `
 <DocumentFragment>
   <div
     class="input-group input-localized input-localized-input"

--- a/modules/apps/segments/segments-web/test/js/utils/odata.es.js
+++ b/modules/apps/segments/segments-web/test/js/utils/odata.es.js
@@ -43,7 +43,7 @@ describe('odata-util', () => {
 	});
 
 	describe('buildQueryString', () => {
-		it('should build a query string from a flat criteria map', () => {
+		it('builds a query string from a flat criteria map', () => {
 			expect(ODataUtil.buildQueryString([mockCriteria(1)])).toEqual(
 				"(firstName eq 'test')"
 			);
@@ -52,7 +52,7 @@ describe('odata-util', () => {
 			);
 		});
 
-		it('should build a query string from a criteria map with nested items', () => {
+		it('builds a query string from a criteria map with nested items', () => {
 			expect(ODataUtil.buildQueryString([mockCriteriaNested()])).toEqual(
 				"((((firstName eq 'test' or firstName eq 'test') and firstName eq 'test') or firstName eq 'test') and firstName eq 'test')"
 			);
@@ -60,7 +60,7 @@ describe('odata-util', () => {
 	});
 
 	describe('translateQueryToCriteria', () => {
-		it('should translate a query string into a criteria map', () => {
+		it('translates a query string into a criteria map', () => {
 			expect(
 				ODataUtil.translateQueryToCriteria("(firstName eq 'test')")
 			).toEqual({
@@ -76,7 +76,7 @@ describe('odata-util', () => {
 			});
 		});
 
-		it('should handle a query string with empty groups', () => {
+		it('handles a query string with empty groups', () => {
 			expect(
 				ODataUtil.translateQueryToCriteria("(((firstName eq 'test')))")
 			).toEqual({
@@ -92,7 +92,7 @@ describe('odata-util', () => {
 			});
 		});
 
-		it('should handle a query string with "not" operator', () => {
+		it('handles a query string with "not" operator', () => {
 			expect(
 				ODataUtil.translateQueryToCriteria(
 					"(not (firstName eq 'test'))"
@@ -110,7 +110,7 @@ describe('odata-util', () => {
 			});
 		});
 
-		it('should handle a query string with "contains" operator', () => {
+		it('handles a query string with "contains" operator', () => {
 			expect(
 				ODataUtil.translateQueryToCriteria(
 					"contains(firstName, 'test')"
@@ -128,7 +128,7 @@ describe('odata-util', () => {
 			});
 		});
 
-		it('should return null if the query is empty or invalid', () => {
+		it('returns null if the query is empty or invalid', () => {
 			expect(ODataUtil.translateQueryToCriteria()).toEqual(null);
 			expect(ODataUtil.translateQueryToCriteria('()')).toEqual(null);
 			expect(
@@ -143,20 +143,20 @@ describe('odata-util', () => {
 	});
 
 	describe('conversion to and from', () => {
-		it('should be able to translate a query string to map and back to string', () => {
+		it('is able to translate a query string to map and back to string', () => {
 			const testQuery = "(firstName eq 'test')";
 
 			testConversionToAndFrom(testQuery, {properties});
 		});
 
-		it('should be able to translate a complex query string to map and back to string', () => {
+		it('is able to translate a complex query string to map and back to string', () => {
 			const testQuery =
 				"((firstName eq 'test' or firstName eq 'test') and firstName eq 'test')";
 
 			testConversionToAndFrom(testQuery, {properties});
 		});
 
-		it('should be able to translate a query string with "not" to map and back to string', () => {
+		it('is able to translate a query string with "not" to map and back to string', () => {
 			const testQuery = "((not (firstName eq 'test')))";
 
 			const translatedMap = ODataUtil.translateQueryToCriteria(testQuery);
@@ -168,60 +168,60 @@ describe('odata-util', () => {
 			expect(translatedString).toEqual(testQuery);
 		});
 
-		it('should be able to translate a complex query string with "not" to map and back to string', () => {
+		it('is able to translate a complex query string with "not" to map and back to string', () => {
 			const testQuery =
 				"(firstName eq 'test' and ((not (lastName eq 'foo')) or (not (lastName eq 'bar'))))";
 
 			testConversionToAndFrom(testQuery, {properties});
 		});
 
-		it('should be able to translate a query string with "contains" to map and back to string', () => {
+		it('is able to translate a query string with "contains" to map and back to string', () => {
 			const testQuery = "(contains(firstName, 'test'))";
 
 			testConversionToAndFrom(testQuery, {properties});
 		});
 
-		it('should be able to translate a query string with "contains" to map and back to string', () => {
+		it('is able to translate a query string with "contains" to map and back to string', () => {
 			const testQuery =
 				"(firstName eq 'test' and (contains(lastName, 'foo') or contains(lastName, 'bar')))";
 
 			testConversionToAndFrom(testQuery, {properties});
 		});
 
-		it('should be able to translate a query string with "not contains" to map and back to string', () => {
+		it('is able to translate a query string with "not contains" to map and back to string', () => {
 			const testQuery = "((not (contains(firstName, 'test'))))";
 
 			testConversionToAndFrom(testQuery, {properties});
 		});
 
-		it('should be able to translate a collection type query string with "contains" to map and back to string', () => {
+		it('is able to translate a collection type query string with "contains" to map and back to string', () => {
 			const testQuery =
 				"(cookies/any(c:contains(c, 'keyTest=valueTest')))";
 
 			testConversionToAndFrom(testQuery, {properties});
 		});
 
-		it('should be able to translate a collection type query string with "not contains" to map and back to string', () => {
+		it('is able to translate a collection type query string with "not contains" to map and back to string', () => {
 			const testQuery =
 				"((not (cookies/any(c:contains(c, 'keyTest=valueTest')))))";
 
 			testConversionToAndFrom(testQuery, {properties});
 		});
 
-		it('should be able to translate a collection type query string with "eq" to map and back to string', () => {
+		it('is able to translate a collection type query string with "eq" to map and back to string', () => {
 			const testQuery = "(cookies/any(c:c eq 'keyTest=valueTest'))";
 
 			testConversionToAndFrom(testQuery, {properties});
 		});
 
-		it('should be able to translate a collection type query string with "not" to map and back to string', () => {
+		it('is able to translate a collection type query string with "not" to map and back to string', () => {
 			const testQuery =
 				"((not (cookies/any(c:c eq 'keyTest=valueTest'))))";
 
 			testConversionToAndFrom(testQuery, {properties});
 		});
 
-		it('should be able to translate a nested and complex collection type query string to map and back to string', () => {
+		it('is able to translate a nested and complex collection type query string to map and back to string', () => {
 			const testQuery =
 				"((not (cookies/any(c:c eq 'keyTest1=valueTest1'))) and ((not (cookies/any(c:c eq 'keyTest2=valueTest2'))) or (cookies/any(c:c eq 'keyTest3=valueTest3') and cookies/any(c:c eq 'keyTest4=valueTest4'))) and name eq 'test')";
 

--- a/modules/apps/segments/segments-web/test/js/utils/utils.es.js
+++ b/modules/apps/segments/segments-web/test/js/utils/utils.es.js
@@ -20,7 +20,7 @@ const GROUP_ID = 'group_1';
 
 describe('utils', () => {
 	describe('createNewGroup', () => {
-		it('should return a new group object with the passed in items', () => {
+		it('returns a new group object with the passed in items', () => {
 			expect(Utils.createNewGroup([])).toEqual({
 				conjunctionName: CONJUNCTIONS.AND,
 				groupId: GROUP_ID,
@@ -30,12 +30,12 @@ describe('utils', () => {
 	});
 
 	describe('getChildGroupIds', () => {
-		it('should return an empty array if there are no child groups', () => {
+		it('returns an empty array if there are no child groups', () => {
 			expect(Utils.getChildGroupIds(mockCriteria(1))).toEqual([]);
 			expect(Utils.getChildGroupIds(mockCriteria(3))).toEqual([]);
 		});
 
-		it('should return the child group ids', () => {
+		it('returns the child group ids', () => {
 			expect(Utils.getChildGroupIds(mockCriteriaNested())).toEqual([
 				'group_02',
 				'group_03',
@@ -45,7 +45,7 @@ describe('utils', () => {
 	});
 
 	describe('getSupportedOperatorsFromType', () => {
-		it('should return an array of supported operators', () => {
+		it('returns an array of supported operators', () => {
 			const operators = [
 				{
 					label: Liferay.Language.get('equals'),
@@ -89,7 +89,7 @@ describe('utils', () => {
 	});
 
 	describe('insertAtIndex', () => {
-		it('should insert an item at the beginning', () => {
+		it('inserts an item at the beginning', () => {
 			expect(Utils.insertAtIndex('c', ['a', 'b'], 0)).toEqual([
 				'c',
 				'a',
@@ -97,7 +97,7 @@ describe('utils', () => {
 			]);
 		});
 
-		it('should insert an item at the middle', () => {
+		it('inserts an item at the middle', () => {
 			expect(Utils.insertAtIndex('c', ['a', 'b'], 1)).toEqual([
 				'a',
 				'c',
@@ -105,7 +105,7 @@ describe('utils', () => {
 			]);
 		});
 
-		it('should insert an item at the end', () => {
+		it('inserts an item at the end', () => {
 			expect(Utils.insertAtIndex('c', ['a', 'b'], 2)).toEqual([
 				'a',
 				'b',
@@ -115,7 +115,7 @@ describe('utils', () => {
 	});
 
 	describe('objectToFormData', () => {
-		it('should take an object of key value pairs and return a form data object with the same values', () => {
+		it('takes an object of key value pairs and return a form data object with the same values', () => {
 			const testData = {
 				bar: 'bar',
 				foo: 'foo'
@@ -129,21 +129,21 @@ describe('utils', () => {
 	});
 
 	describe('removeAtIndex', () => {
-		it('should remove the item at the beginning', () => {
+		it('removes the item at the beginning', () => {
 			expect(Utils.removeAtIndex(['a', 'b', 'c'], 0)).toEqual(['b', 'c']);
 		});
 
-		it('should remove the item at the middle', () => {
+		it('removes the item at the middle', () => {
 			expect(Utils.removeAtIndex(['a', 'b', 'c'], 1)).toEqual(['a', 'c']);
 		});
 
-		it('should remove the item at the end', () => {
+		it('removes the item at the end', () => {
 			expect(Utils.removeAtIndex(['a', 'b', 'c'], 2)).toEqual(['a', 'b']);
 		});
 	});
 
 	describe('replaceAtIndex', () => {
-		it('should replace the item at the beginning', () => {
+		it('replaces the item at the beginning', () => {
 			expect(Utils.replaceAtIndex('x', ['a', 'b', 'c'], 0)).toEqual([
 				'x',
 				'b',
@@ -151,7 +151,7 @@ describe('utils', () => {
 			]);
 		});
 
-		it('should replace the item at the middle', () => {
+		it('replaces the item at the middle', () => {
 			expect(Utils.replaceAtIndex('x', ['a', 'b', 'c'], 1)).toEqual([
 				'a',
 				'x',
@@ -159,7 +159,7 @@ describe('utils', () => {
 			]);
 		});
 
-		it('should replace the item at the end', () => {
+		it('replaces the item at the end', () => {
 			expect(Utils.replaceAtIndex('x', ['a', 'b', 'c'], 2)).toEqual([
 				'a',
 				'b',
@@ -169,25 +169,25 @@ describe('utils', () => {
 	});
 
 	describe('sub', () => {
-		it('should return an array', () => {
+		it('returns an array', () => {
 			const res = Utils.sub('hello world', [''], false);
 
 			expect(res).toEqual(['hello world']);
 		});
 
-		it('should return a string', () => {
+		it('returns a string', () => {
 			const res = Utils.sub('hello world', ['']);
 
 			expect(res).toEqual('hello world');
 		});
 
-		it('should return with a subbed value for {0}', () => {
+		it('returns with a subbed value for {0}', () => {
 			const res = Utils.sub('hello {0}', ['world']);
 
 			expect(res).toEqual('hello world');
 		});
 
-		it('should return with multiple subbed values', () => {
+		it('returns with multiple subbed values', () => {
 			const res = Utils.sub('My name is {0} {1}', ['hello', 'world']);
 
 			expect(res).toEqual('My name is hello world');

--- a/modules/package.json
+++ b/modules/package.json
@@ -16,7 +16,7 @@
 		"liferay-npm-bridge-generator": "2.7.1",
 		"liferay-npm-bundler": "2.7.1",
 		"liferay-npm-bundler-preset-standard": "2.7.1",
-		"liferay-npm-scripts": "4.1.0",
+		"liferay-npm-scripts": "4.2.1",
 		"liferay-theme-es2015-hook": "8.0.0-rc.2",
 		"metal-jest-serializer": "2.0.0"
 	},

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -5464,10 +5464,10 @@ escodegen@^1.6.1, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-4.0.0.tgz#8e52878d7cba62a99d9974ee3172546898504e67"
-  integrity sha512-mgSrQLbU4QtmNSWxry/4TMOMfGynLbz+PD3ae0wTw0pIlEBCXfxtnkLnoR5OfWtnZpuiMyFBQo89PTR3WoGfrA==
+eslint-config-liferay@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-4.1.1.tgz#865bcc24b472a6cd2a268f0e0464cb411ee585ff"
+  integrity sha512-nxdticVkSLsJwtvmQuEGY+zEB8F/lfViKKMYuusrynyvV9XUhSVfzHhH2bbsjxyjbV/dL+YRP0WsHL6DiIGytA==
   dependencies:
     eslint-config-prettier "5.0.0"
     eslint-plugin-no-for-of-loops "^1.0.0"
@@ -9642,10 +9642,10 @@ liferay-npm-bundler@2.7.1:
     semver "^5.5.0"
     xml-js "^1.6.8"
 
-liferay-npm-scripts@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-4.1.0.tgz#d6c4ea767ce16f40b982421d091e7daa6e9a1d03"
-  integrity sha512-U+vtE0w5xXgyoONRIcKz+mv471nwIDbGJtzh7ykdyIF2fOrbXlMFlf1pC4XqKTZJ/CF6sC8eiBzKfQm9yQohsQ==
+liferay-npm-scripts@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-4.2.1.tgz#b780e31a2b5f089122b01dc206699d35d0c45ccf"
+  integrity sha512-Oo3ohNIjNKyIzlMW1lMkWPbD1MkP05x9hTzdUIVmMIJhVvV81urjx06sl+Nlgobx4OyTe22hYxvbEcSjauPZhA==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/plugin-proposal-class-properties" "7.4.4"
@@ -9658,7 +9658,7 @@ liferay-npm-scripts@4.1.0:
     cross-spawn "^6.0.5"
     deepmerge "^3.0.0"
     eslint "5.16.0"
-    eslint-config-liferay "^4.0.0"
+    eslint-config-liferay "^4.1.1"
     glob "^7.1.3"
     jest "^24.5.0"
     liferay-jest-junit-reporter "1.0.1"


### PR DESCRIPTION
We wanted to provide examples of two different kinds of custom lint rules that run on the new ESLint-powered tooling:

- "liferay/no-it-should": This is an example of a lint rule that we can apply to all of our frontend code, inside and outside of liferay-portal (eg. in the other GitHub hosted projects). As per [the guidance here](https://github.com/liferay/liferay-frontend-guidelines/blob/master/guidelines/general/testing.md), this enforces the recommendation to not start `it()` descriptions with the word "should", and instead use a verb.

  To keep all the lints green, I updated all the places identified by the lint, and updated the corresponding snapshot files, where applicable, to keep the tests passing.

- "liferay-portal/side-navigation": This is an example of a lint that is specific to liferay-portal; it guards against the use of the legacy jQuery-based `sideNavigation()` API and tells people to use `Liferay.SideNavigation()` instead.

With these two examples we now have a pattern that we can replicate for all the other frontend things we want to lint inside and outside of this repo.

The rules themselves live in eslint-config-liferay, which we apply via liferay-npm-scripts. So this commit updates the dependency and changes the configuration in one place (segments/segments-web) so that it knows about the new liferay-portal-specific lint preset.