### PR TITLE
LPS-96628 pageinfo

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
@@ -31,6 +31,8 @@ import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.Collection;
+
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -66,6 +68,78 @@ public class Query {
 			taxonomyVocabularyResourceComponentServiceObjects;
 	}
 
+	@GraphQLName("KeywordPage")
+	public class KeywordPage {
+
+		public KeywordPage(Page keywordPage) {
+			items = keywordPage.getItems();
+			page = keywordPage.getPage();
+			pageSize = keywordPage.getPageSize();
+			totalCount = keywordPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<Keyword> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("TaxonomyCategoryPage")
+	public class TaxonomyCategoryPage {
+
+		public TaxonomyCategoryPage(Page taxonomyCategoryPage) {
+			items = taxonomyCategoryPage.getItems();
+			page = taxonomyCategoryPage.getPage();
+			pageSize = taxonomyCategoryPage.getPageSize();
+			totalCount = taxonomyCategoryPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<TaxonomyCategory> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("TaxonomyVocabularyPage")
+	public class TaxonomyVocabularyPage {
+
+		public TaxonomyVocabularyPage(Page taxonomyVocabularyPage) {
+			items = taxonomyVocabularyPage.getItems();
+			page = taxonomyVocabularyPage.getPage();
+			pageSize = taxonomyVocabularyPage.getPageSize();
+			totalCount = taxonomyVocabularyPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<TaxonomyVocabulary> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
 	@GraphQLField
 	public Keyword getKeyword(@GraphQLName("keywordId") Long keywordId)
 		throws Exception {
@@ -77,7 +151,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<Keyword> getSiteKeywordsPage(
+	public KeywordPage getSiteKeywordsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -88,39 +162,30 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_keywordResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			keywordResource -> {
-				Page paginationPage = keywordResource.getSiteKeywordsPage(
+			keywordResource -> new KeywordPage(
+				keywordResource.getSiteKeywordsPage(
 					siteId, search, filter, Pagination.of(page, pageSize),
-					sorts);
-
-				return paginationPage.getItems();
-			});
+					sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<TaxonomyCategory>
-			getTaxonomyCategoryTaxonomyCategoriesPage(
-				@GraphQLName("parentTaxonomyCategoryId") Long
-					parentTaxonomyCategoryId,
-				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+	public TaxonomyCategoryPage getTaxonomyCategoryTaxonomyCategoriesPage(
+			@GraphQLName("parentTaxonomyCategoryId") Long
+				parentTaxonomyCategoryId,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") Filter filter,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_taxonomyCategoryResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			taxonomyCategoryResource -> {
-				Page paginationPage =
-					taxonomyCategoryResource.
-						getTaxonomyCategoryTaxonomyCategoriesPage(
-							parentTaxonomyCategoryId, search, filter,
-							Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			taxonomyCategoryResource -> new TaxonomyCategoryPage(
+				taxonomyCategoryResource.
+					getTaxonomyCategoryTaxonomyCategoriesPage(
+						parentTaxonomyCategoryId, search, filter,
+						Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
@@ -137,52 +202,40 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<TaxonomyCategory>
-			getTaxonomyVocabularyTaxonomyCategoriesPage(
-				@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId,
-				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+	public TaxonomyCategoryPage getTaxonomyVocabularyTaxonomyCategoriesPage(
+			@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") Filter filter,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_taxonomyCategoryResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			taxonomyCategoryResource -> {
-				Page paginationPage =
-					taxonomyCategoryResource.
-						getTaxonomyVocabularyTaxonomyCategoriesPage(
-							taxonomyVocabularyId, search, filter,
-							Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			taxonomyCategoryResource -> new TaxonomyCategoryPage(
+				taxonomyCategoryResource.
+					getTaxonomyVocabularyTaxonomyCategoriesPage(
+						taxonomyVocabularyId, search, filter,
+						Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<TaxonomyVocabulary>
-			getSiteTaxonomyVocabulariesPage(
-				@GraphQLName("siteId") Long siteId,
-				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+	public TaxonomyVocabularyPage getSiteTaxonomyVocabulariesPage(
+			@GraphQLName("siteId") Long siteId,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") Filter filter,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_taxonomyVocabularyResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			taxonomyVocabularyResource -> {
-				Page paginationPage =
-					taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
-						siteId, search, filter, Pagination.of(page, pageSize),
-						sorts);
-
-				return paginationPage.getItems();
-			});
+			taxonomyVocabularyResource -> new TaxonomyVocabularyPage(
+				taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
+					siteId, search, filter, Pagination.of(page, pageSize),
+					sorts)));
 	}
 
 	@GraphQLField

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
@@ -43,6 +43,8 @@ import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.Collection;
+
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -126,6 +128,222 @@ public class Query {
 			webUrlResourceComponentServiceObjects;
 	}
 
+	@GraphQLName("EmailAddressPage")
+	public class EmailAddressPage {
+
+		public EmailAddressPage(Page emailAddressPage) {
+			items = emailAddressPage.getItems();
+			page = emailAddressPage.getPage();
+			pageSize = emailAddressPage.getPageSize();
+			totalCount = emailAddressPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<EmailAddress> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("OrganizationPage")
+	public class OrganizationPage {
+
+		public OrganizationPage(Page organizationPage) {
+			items = organizationPage.getItems();
+			page = organizationPage.getPage();
+			pageSize = organizationPage.getPageSize();
+			totalCount = organizationPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<Organization> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("PhonePage")
+	public class PhonePage {
+
+		public PhonePage(Page phonePage) {
+			items = phonePage.getItems();
+			page = phonePage.getPage();
+			pageSize = phonePage.getPageSize();
+			totalCount = phonePage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<Phone> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("PostalAddressPage")
+	public class PostalAddressPage {
+
+		public PostalAddressPage(Page postalAddressPage) {
+			items = postalAddressPage.getItems();
+			page = postalAddressPage.getPage();
+			pageSize = postalAddressPage.getPageSize();
+			totalCount = postalAddressPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<PostalAddress> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("RolePage")
+	public class RolePage {
+
+		public RolePage(Page rolePage) {
+			items = rolePage.getItems();
+			page = rolePage.getPage();
+			pageSize = rolePage.getPageSize();
+			totalCount = rolePage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<Role> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("SegmentPage")
+	public class SegmentPage {
+
+		public SegmentPage(Page segmentPage) {
+			items = segmentPage.getItems();
+			page = segmentPage.getPage();
+			pageSize = segmentPage.getPageSize();
+			totalCount = segmentPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<Segment> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("SegmentUserPage")
+	public class SegmentUserPage {
+
+		public SegmentUserPage(Page segmentUserPage) {
+			items = segmentUserPage.getItems();
+			page = segmentUserPage.getPage();
+			pageSize = segmentUserPage.getPageSize();
+			totalCount = segmentUserPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<SegmentUser> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("UserAccountPage")
+	public class UserAccountPage {
+
+		public UserAccountPage(Page userAccountPage) {
+			items = userAccountPage.getItems();
+			page = userAccountPage.getPage();
+			pageSize = userAccountPage.getPageSize();
+			totalCount = userAccountPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<UserAccount> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("WebUrlPage")
+	public class WebUrlPage {
+
+		public WebUrlPage(Page webUrlPage) {
+			items = webUrlPage.getItems();
+			page = webUrlPage.getPage();
+			pageSize = webUrlPage.getPageSize();
+			totalCount = webUrlPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<WebUrl> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
 	@GraphQLField
 	public EmailAddress getEmailAddress(
 			@GraphQLName("emailAddressId") Long emailAddressId)
@@ -139,41 +357,33 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<EmailAddress> getOrganizationEmailAddressesPage(
+	public EmailAddressPage getOrganizationEmailAddressesPage(
 			@GraphQLName("organizationId") Long organizationId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_emailAddressResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			emailAddressResource -> {
-				Page paginationPage =
-					emailAddressResource.getOrganizationEmailAddressesPage(
-						organizationId);
-
-				return paginationPage.getItems();
-			});
+			emailAddressResource -> new EmailAddressPage(
+				emailAddressResource.getOrganizationEmailAddressesPage(
+					organizationId)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<EmailAddress> getUserAccountEmailAddressesPage(
+	public EmailAddressPage getUserAccountEmailAddressesPage(
 			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_emailAddressResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			emailAddressResource -> {
-				Page paginationPage =
-					emailAddressResource.getUserAccountEmailAddressesPage(
-						userAccountId);
-
-				return paginationPage.getItems();
-			});
+			emailAddressResource -> new EmailAddressPage(
+				emailAddressResource.getUserAccountEmailAddressesPage(
+					userAccountId)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<Organization> getOrganizationsPage(
+	public OrganizationPage getOrganizationsPage(
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
 			@GraphQLName("pageSize") int pageSize,
@@ -183,12 +393,9 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_organizationResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			organizationResource -> {
-				Page paginationPage = organizationResource.getOrganizationsPage(
-					search, filter, Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			organizationResource -> new OrganizationPage(
+				organizationResource.getOrganizationsPage(
+					search, filter, Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
@@ -204,7 +411,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<Organization> getOrganizationOrganizationsPage(
+	public OrganizationPage getOrganizationOrganizationsPage(
 			@GraphQLName("parentOrganizationId") Long parentOrganizationId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -215,30 +422,22 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_organizationResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			organizationResource -> {
-				Page paginationPage =
-					organizationResource.getOrganizationOrganizationsPage(
-						parentOrganizationId, search, filter,
-						Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			organizationResource -> new OrganizationPage(
+				organizationResource.getOrganizationOrganizationsPage(
+					parentOrganizationId, search, filter,
+					Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<Phone> getOrganizationPhonesPage(
+	public PhonePage getOrganizationPhonesPage(
 			@GraphQLName("organizationId") Long organizationId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_phoneResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			phoneResource -> {
-				Page paginationPage = phoneResource.getOrganizationPhonesPage(
-					organizationId);
-
-				return paginationPage.getItems();
-			});
+			phoneResource -> new PhonePage(
+				phoneResource.getOrganizationPhonesPage(organizationId)));
 	}
 
 	@GraphQLField
@@ -252,37 +451,28 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<Phone> getUserAccountPhonesPage(
+	public PhonePage getUserAccountPhonesPage(
 			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_phoneResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			phoneResource -> {
-				Page paginationPage = phoneResource.getUserAccountPhonesPage(
-					userAccountId);
-
-				return paginationPage.getItems();
-			});
+			phoneResource -> new PhonePage(
+				phoneResource.getUserAccountPhonesPage(userAccountId)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<PostalAddress>
-			getOrganizationPostalAddressesPage(
-				@GraphQLName("organizationId") Long organizationId)
+	public PostalAddressPage getOrganizationPostalAddressesPage(
+			@GraphQLName("organizationId") Long organizationId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_postalAddressResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			postalAddressResource -> {
-				Page paginationPage =
-					postalAddressResource.getOrganizationPostalAddressesPage(
-						organizationId);
-
-				return paginationPage.getItems();
-			});
+			postalAddressResource -> new PostalAddressPage(
+				postalAddressResource.getOrganizationPostalAddressesPage(
+					organizationId)));
 	}
 
 	@GraphQLField
@@ -298,25 +488,20 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<PostalAddress>
-			getUserAccountPostalAddressesPage(
-				@GraphQLName("userAccountId") Long userAccountId)
+	public PostalAddressPage getUserAccountPostalAddressesPage(
+			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_postalAddressResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			postalAddressResource -> {
-				Page paginationPage =
-					postalAddressResource.getUserAccountPostalAddressesPage(
-						userAccountId);
-
-				return paginationPage.getItems();
-			});
+			postalAddressResource -> new PostalAddressPage(
+				postalAddressResource.getUserAccountPostalAddressesPage(
+					userAccountId)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<Role> getRolesPage(
+	public RolePage getRolesPage(
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
 		throws Exception {
@@ -324,12 +509,8 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_roleResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			roleResource -> {
-				Page paginationPage = roleResource.getRolesPage(
-					Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			roleResource -> new RolePage(
+				roleResource.getRolesPage(Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLField
@@ -341,7 +522,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<Segment> getSiteSegmentsPage(
+	public SegmentPage getSiteSegmentsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -350,16 +531,13 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_segmentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			segmentResource -> {
-				Page paginationPage = segmentResource.getSiteSegmentsPage(
-					siteId, Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			segmentResource -> new SegmentPage(
+				segmentResource.getSiteSegmentsPage(
+					siteId, Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLField
-	public java.util.Collection<Segment> getSiteUserAccountSegmentsPage(
+	public SegmentPage getSiteUserAccountSegmentsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
@@ -367,17 +545,13 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_segmentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			segmentResource -> {
-				Page paginationPage =
-					segmentResource.getSiteUserAccountSegmentsPage(
-						siteId, userAccountId);
-
-				return paginationPage.getItems();
-			});
+			segmentResource -> new SegmentPage(
+				segmentResource.getSiteUserAccountSegmentsPage(
+					siteId, userAccountId)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<SegmentUser> getSegmentUserAccountsPage(
+	public SegmentUserPage getSegmentUserAccountsPage(
 			@GraphQLName("segmentId") Long segmentId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -386,13 +560,9 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_segmentUserResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			segmentUserResource -> {
-				Page paginationPage =
-					segmentUserResource.getSegmentUserAccountsPage(
-						segmentId, Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			segmentUserResource -> new SegmentUserPage(
+				segmentUserResource.getSegmentUserAccountsPage(
+					segmentId, Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLField
@@ -404,7 +574,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<UserAccount> getOrganizationUserAccountsPage(
+	public UserAccountPage getOrganizationUserAccountsPage(
 			@GraphQLName("organizationId") Long organizationId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -415,18 +585,14 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_userAccountResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			userAccountResource -> {
-				Page paginationPage =
-					userAccountResource.getOrganizationUserAccountsPage(
-						organizationId, search, filter,
-						Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			userAccountResource -> new UserAccountPage(
+				userAccountResource.getOrganizationUserAccountsPage(
+					organizationId, search, filter,
+					Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<UserAccount> getUserAccountsPage(
+	public UserAccountPage getUserAccountsPage(
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
 			@GraphQLName("pageSize") int pageSize,
@@ -436,12 +602,9 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_userAccountResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			userAccountResource -> {
-				Page paginationPage = userAccountResource.getUserAccountsPage(
-					search, filter, Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			userAccountResource -> new UserAccountPage(
+				userAccountResource.getUserAccountsPage(
+					search, filter, Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
@@ -457,7 +620,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<UserAccount> getWebSiteUserAccountsPage(
+	public UserAccountPage getWebSiteUserAccountsPage(
 			@GraphQLName("webSiteId") Long webSiteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -468,46 +631,34 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_userAccountResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			userAccountResource -> {
-				Page paginationPage =
-					userAccountResource.getWebSiteUserAccountsPage(
-						webSiteId, search, filter,
-						Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			userAccountResource -> new UserAccountPage(
+				userAccountResource.getWebSiteUserAccountsPage(
+					webSiteId, search, filter, Pagination.of(page, pageSize),
+					sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<WebUrl> getOrganizationWebUrlsPage(
+	public WebUrlPage getOrganizationWebUrlsPage(
 			@GraphQLName("organizationId") Long organizationId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_webUrlResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			webUrlResource -> {
-				Page paginationPage = webUrlResource.getOrganizationWebUrlsPage(
-					organizationId);
-
-				return paginationPage.getItems();
-			});
+			webUrlResource -> new WebUrlPage(
+				webUrlResource.getOrganizationWebUrlsPage(organizationId)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<WebUrl> getUserAccountWebUrlsPage(
+	public WebUrlPage getUserAccountWebUrlsPage(
 			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_webUrlResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			webUrlResource -> {
-				Page paginationPage = webUrlResource.getUserAccountWebUrlsPage(
-					userAccountId);
-
-				return paginationPage.getItems();
-			});
+			webUrlResource -> new WebUrlPage(
+				webUrlResource.getUserAccountWebUrlsPage(userAccountId)));
 	}
 
 	@GraphQLField

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailAddressResourceTestCase.java
@@ -202,6 +202,12 @@ public abstract class BaseEmailAddressResourceTestCase {
 
 	@Test
 	public void testGetOrganizationEmailAddressesPage() throws Exception {
+		Page<EmailAddress> page =
+			emailAddressResource.getOrganizationEmailAddressesPage(
+				testGetOrganizationEmailAddressesPage_getOrganizationId());
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long organizationId =
 			testGetOrganizationEmailAddressesPage_getOrganizationId();
 		Long irrelevantOrganizationId =
@@ -212,9 +218,8 @@ public abstract class BaseEmailAddressResourceTestCase {
 				testGetOrganizationEmailAddressesPage_addEmailAddress(
 					irrelevantOrganizationId, randomIrrelevantEmailAddress());
 
-			Page<EmailAddress> page =
-				emailAddressResource.getOrganizationEmailAddressesPage(
-					irrelevantOrganizationId);
+			page = emailAddressResource.getOrganizationEmailAddressesPage(
+				irrelevantOrganizationId);
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -232,9 +237,8 @@ public abstract class BaseEmailAddressResourceTestCase {
 			testGetOrganizationEmailAddressesPage_addEmailAddress(
 				organizationId, randomEmailAddress());
 
-		Page<EmailAddress> page =
-			emailAddressResource.getOrganizationEmailAddressesPage(
-				organizationId);
+		page = emailAddressResource.getOrganizationEmailAddressesPage(
+			organizationId);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -269,6 +273,12 @@ public abstract class BaseEmailAddressResourceTestCase {
 
 	@Test
 	public void testGetUserAccountEmailAddressesPage() throws Exception {
+		Page<EmailAddress> page =
+			emailAddressResource.getUserAccountEmailAddressesPage(
+				testGetUserAccountEmailAddressesPage_getUserAccountId());
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long userAccountId =
 			testGetUserAccountEmailAddressesPage_getUserAccountId();
 		Long irrelevantUserAccountId =
@@ -279,9 +289,8 @@ public abstract class BaseEmailAddressResourceTestCase {
 				testGetUserAccountEmailAddressesPage_addEmailAddress(
 					irrelevantUserAccountId, randomIrrelevantEmailAddress());
 
-			Page<EmailAddress> page =
-				emailAddressResource.getUserAccountEmailAddressesPage(
-					irrelevantUserAccountId);
+			page = emailAddressResource.getUserAccountEmailAddressesPage(
+				irrelevantUserAccountId);
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -299,9 +308,8 @@ public abstract class BaseEmailAddressResourceTestCase {
 			testGetUserAccountEmailAddressesPage_addEmailAddress(
 				userAccountId, randomEmailAddress());
 
-		Page<EmailAddress> page =
-			emailAddressResource.getUserAccountEmailAddressesPage(
-				userAccountId);
+		page = emailAddressResource.getUserAccountEmailAddressesPage(
+			userAccountId);
 
 		Assert.assertEquals(2, page.getTotalCount());
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
@@ -186,6 +186,11 @@ public abstract class BasePhoneResourceTestCase {
 
 	@Test
 	public void testGetOrganizationPhonesPage() throws Exception {
+		Page<Phone> page = phoneResource.getOrganizationPhonesPage(
+			testGetOrganizationPhonesPage_getOrganizationId());
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long organizationId = testGetOrganizationPhonesPage_getOrganizationId();
 		Long irrelevantOrganizationId =
 			testGetOrganizationPhonesPage_getIrrelevantOrganizationId();
@@ -194,7 +199,7 @@ public abstract class BasePhoneResourceTestCase {
 			Phone irrelevantPhone = testGetOrganizationPhonesPage_addPhone(
 				irrelevantOrganizationId, randomIrrelevantPhone());
 
-			Page<Phone> page = phoneResource.getOrganizationPhonesPage(
+			page = phoneResource.getOrganizationPhonesPage(
 				irrelevantOrganizationId);
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -210,8 +215,7 @@ public abstract class BasePhoneResourceTestCase {
 		Phone phone2 = testGetOrganizationPhonesPage_addPhone(
 			organizationId, randomPhone());
 
-		Page<Phone> page = phoneResource.getOrganizationPhonesPage(
-			organizationId);
+		page = phoneResource.getOrganizationPhonesPage(organizationId);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -258,6 +262,11 @@ public abstract class BasePhoneResourceTestCase {
 
 	@Test
 	public void testGetUserAccountPhonesPage() throws Exception {
+		Page<Phone> page = phoneResource.getUserAccountPhonesPage(
+			testGetUserAccountPhonesPage_getUserAccountId());
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long userAccountId = testGetUserAccountPhonesPage_getUserAccountId();
 		Long irrelevantUserAccountId =
 			testGetUserAccountPhonesPage_getIrrelevantUserAccountId();
@@ -266,7 +275,7 @@ public abstract class BasePhoneResourceTestCase {
 			Phone irrelevantPhone = testGetUserAccountPhonesPage_addPhone(
 				irrelevantUserAccountId, randomIrrelevantPhone());
 
-			Page<Phone> page = phoneResource.getUserAccountPhonesPage(
+			page = phoneResource.getUserAccountPhonesPage(
 				irrelevantUserAccountId);
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -282,8 +291,7 @@ public abstract class BasePhoneResourceTestCase {
 		Phone phone2 = testGetUserAccountPhonesPage_addPhone(
 			userAccountId, randomPhone());
 
-		Page<Phone> page = phoneResource.getUserAccountPhonesPage(
-			userAccountId);
+		page = phoneResource.getUserAccountPhonesPage(userAccountId);
 
 		Assert.assertEquals(2, page.getTotalCount());
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
@@ -196,6 +196,12 @@ public abstract class BasePostalAddressResourceTestCase {
 
 	@Test
 	public void testGetOrganizationPostalAddressesPage() throws Exception {
+		Page<PostalAddress> page =
+			postalAddressResource.getOrganizationPostalAddressesPage(
+				testGetOrganizationPostalAddressesPage_getOrganizationId());
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long organizationId =
 			testGetOrganizationPostalAddressesPage_getOrganizationId();
 		Long irrelevantOrganizationId =
@@ -206,9 +212,8 @@ public abstract class BasePostalAddressResourceTestCase {
 				testGetOrganizationPostalAddressesPage_addPostalAddress(
 					irrelevantOrganizationId, randomIrrelevantPostalAddress());
 
-			Page<PostalAddress> page =
-				postalAddressResource.getOrganizationPostalAddressesPage(
-					irrelevantOrganizationId);
+			page = postalAddressResource.getOrganizationPostalAddressesPage(
+				irrelevantOrganizationId);
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -226,9 +231,8 @@ public abstract class BasePostalAddressResourceTestCase {
 			testGetOrganizationPostalAddressesPage_addPostalAddress(
 				organizationId, randomPostalAddress());
 
-		Page<PostalAddress> page =
-			postalAddressResource.getOrganizationPostalAddressesPage(
-				organizationId);
+		page = postalAddressResource.getOrganizationPostalAddressesPage(
+			organizationId);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -282,6 +286,12 @@ public abstract class BasePostalAddressResourceTestCase {
 
 	@Test
 	public void testGetUserAccountPostalAddressesPage() throws Exception {
+		Page<PostalAddress> page =
+			postalAddressResource.getUserAccountPostalAddressesPage(
+				testGetUserAccountPostalAddressesPage_getUserAccountId());
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long userAccountId =
 			testGetUserAccountPostalAddressesPage_getUserAccountId();
 		Long irrelevantUserAccountId =
@@ -292,9 +302,8 @@ public abstract class BasePostalAddressResourceTestCase {
 				testGetUserAccountPostalAddressesPage_addPostalAddress(
 					irrelevantUserAccountId, randomIrrelevantPostalAddress());
 
-			Page<PostalAddress> page =
-				postalAddressResource.getUserAccountPostalAddressesPage(
-					irrelevantUserAccountId);
+			page = postalAddressResource.getUserAccountPostalAddressesPage(
+				irrelevantUserAccountId);
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -312,9 +321,8 @@ public abstract class BasePostalAddressResourceTestCase {
 			testGetUserAccountPostalAddressesPage_addPostalAddress(
 				userAccountId, randomPostalAddress());
 
-		Page<PostalAddress> page =
-			postalAddressResource.getUserAccountPostalAddressesPage(
-				userAccountId);
+		page = postalAddressResource.getUserAccountPostalAddressesPage(
+			userAccountId);
 
 		Assert.assertEquals(2, page.getTotalCount());
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
@@ -188,6 +188,11 @@ public abstract class BaseSegmentResourceTestCase {
 
 	@Test
 	public void testGetSiteSegmentsPage() throws Exception {
+		Page<Segment> page = segmentResource.getSiteSegmentsPage(
+			testGetSiteSegmentsPage_getSiteId(), Pagination.of(1, 2));
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long siteId = testGetSiteSegmentsPage_getSiteId();
 		Long irrelevantSiteId = testGetSiteSegmentsPage_getIrrelevantSiteId();
 
@@ -195,7 +200,7 @@ public abstract class BaseSegmentResourceTestCase {
 			Segment irrelevantSegment = testGetSiteSegmentsPage_addSegment(
 				irrelevantSiteId, randomIrrelevantSegment());
 
-			Page<Segment> page = segmentResource.getSiteSegmentsPage(
+			page = segmentResource.getSiteSegmentsPage(
 				irrelevantSiteId, Pagination.of(1, 2));
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -212,8 +217,7 @@ public abstract class BaseSegmentResourceTestCase {
 		Segment segment2 = testGetSiteSegmentsPage_addSegment(
 			siteId, randomSegment());
 
-		Page<Segment> page = segmentResource.getSiteSegmentsPage(
-			siteId, Pagination.of(1, 2));
+		page = segmentResource.getSiteSegmentsPage(siteId, Pagination.of(1, 2));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -279,6 +283,12 @@ public abstract class BaseSegmentResourceTestCase {
 
 	@Test
 	public void testGetSiteUserAccountSegmentsPage() throws Exception {
+		Page<Segment> page = segmentResource.getSiteUserAccountSegmentsPage(
+			testGetSiteUserAccountSegmentsPage_getSiteId(),
+			testGetSiteUserAccountSegmentsPage_getUserAccountId());
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long siteId = testGetSiteUserAccountSegmentsPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteUserAccountSegmentsPage_getIrrelevantSiteId();
@@ -293,7 +303,7 @@ public abstract class BaseSegmentResourceTestCase {
 					irrelevantSiteId, irrelevantUserAccountId,
 					randomIrrelevantSegment());
 
-			Page<Segment> page = segmentResource.getSiteUserAccountSegmentsPage(
+			page = segmentResource.getSiteUserAccountSegmentsPage(
 				irrelevantSiteId, irrelevantUserAccountId);
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -310,7 +320,7 @@ public abstract class BaseSegmentResourceTestCase {
 		Segment segment2 = testGetSiteUserAccountSegmentsPage_addSegment(
 			siteId, userAccountId, randomSegment());
 
-		Page<Segment> page = segmentResource.getSiteUserAccountSegmentsPage(
+		page = segmentResource.getSiteUserAccountSegmentsPage(
 			siteId, userAccountId);
 
 		Assert.assertEquals(2, page.getTotalCount());

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
@@ -185,6 +185,11 @@ public abstract class BaseSegmentUserResourceTestCase {
 
 	@Test
 	public void testGetSegmentUserAccountsPage() throws Exception {
+		Page<SegmentUser> page = segmentUserResource.getSegmentUserAccountsPage(
+			testGetSegmentUserAccountsPage_getSegmentId(), Pagination.of(1, 2));
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long segmentId = testGetSegmentUserAccountsPage_getSegmentId();
 		Long irrelevantSegmentId =
 			testGetSegmentUserAccountsPage_getIrrelevantSegmentId();
@@ -194,9 +199,8 @@ public abstract class BaseSegmentUserResourceTestCase {
 				testGetSegmentUserAccountsPage_addSegmentUser(
 					irrelevantSegmentId, randomIrrelevantSegmentUser());
 
-			Page<SegmentUser> page =
-				segmentUserResource.getSegmentUserAccountsPage(
-					irrelevantSegmentId, Pagination.of(1, 2));
+			page = segmentUserResource.getSegmentUserAccountsPage(
+				irrelevantSegmentId, Pagination.of(1, 2));
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -214,7 +218,7 @@ public abstract class BaseSegmentUserResourceTestCase {
 			testGetSegmentUserAccountsPage_addSegmentUser(
 				segmentId, randomSegmentUser());
 
-		Page<SegmentUser> page = segmentUserResource.getSegmentUserAccountsPage(
+		page = segmentUserResource.getSegmentUserAccountsPage(
 			segmentId, Pagination.of(1, 2));
 
 		Assert.assertEquals(2, page.getTotalCount());

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
@@ -184,6 +184,11 @@ public abstract class BaseWebUrlResourceTestCase {
 
 	@Test
 	public void testGetOrganizationWebUrlsPage() throws Exception {
+		Page<WebUrl> page = webUrlResource.getOrganizationWebUrlsPage(
+			testGetOrganizationWebUrlsPage_getOrganizationId());
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long organizationId =
 			testGetOrganizationWebUrlsPage_getOrganizationId();
 		Long irrelevantOrganizationId =
@@ -193,7 +198,7 @@ public abstract class BaseWebUrlResourceTestCase {
 			WebUrl irrelevantWebUrl = testGetOrganizationWebUrlsPage_addWebUrl(
 				irrelevantOrganizationId, randomIrrelevantWebUrl());
 
-			Page<WebUrl> page = webUrlResource.getOrganizationWebUrlsPage(
+			page = webUrlResource.getOrganizationWebUrlsPage(
 				irrelevantOrganizationId);
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -209,8 +214,7 @@ public abstract class BaseWebUrlResourceTestCase {
 		WebUrl webUrl2 = testGetOrganizationWebUrlsPage_addWebUrl(
 			organizationId, randomWebUrl());
 
-		Page<WebUrl> page = webUrlResource.getOrganizationWebUrlsPage(
-			organizationId);
+		page = webUrlResource.getOrganizationWebUrlsPage(organizationId);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -242,6 +246,11 @@ public abstract class BaseWebUrlResourceTestCase {
 
 	@Test
 	public void testGetUserAccountWebUrlsPage() throws Exception {
+		Page<WebUrl> page = webUrlResource.getUserAccountWebUrlsPage(
+			testGetUserAccountWebUrlsPage_getUserAccountId());
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long userAccountId = testGetUserAccountWebUrlsPage_getUserAccountId();
 		Long irrelevantUserAccountId =
 			testGetUserAccountWebUrlsPage_getIrrelevantUserAccountId();
@@ -250,7 +259,7 @@ public abstract class BaseWebUrlResourceTestCase {
 			WebUrl irrelevantWebUrl = testGetUserAccountWebUrlsPage_addWebUrl(
 				irrelevantUserAccountId, randomIrrelevantWebUrl());
 
-			Page<WebUrl> page = webUrlResource.getUserAccountWebUrlsPage(
+			page = webUrlResource.getUserAccountWebUrlsPage(
 				irrelevantUserAccountId);
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -266,8 +275,7 @@ public abstract class BaseWebUrlResourceTestCase {
 		WebUrl webUrl2 = testGetUserAccountWebUrlsPage_addWebUrl(
 			userAccountId, randomWebUrl());
 
-		Page<WebUrl> page = webUrlResource.getUserAccountWebUrlsPage(
-			userAccountId);
+		page = webUrlResource.getUserAccountWebUrlsPage(userAccountId);
 
 		Assert.assertEquals(2, page.getTotalCount());
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/query/v1_0/Query.java
@@ -27,6 +27,8 @@ import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.Collection;
+
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -54,6 +56,54 @@ public class Query {
 			workflowTaskResourceComponentServiceObjects;
 	}
 
+	@GraphQLName("WorkflowLogPage")
+	public class WorkflowLogPage {
+
+		public WorkflowLogPage(Page workflowLogPage) {
+			items = workflowLogPage.getItems();
+			page = workflowLogPage.getPage();
+			pageSize = workflowLogPage.getPageSize();
+			totalCount = workflowLogPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<WorkflowLog> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("WorkflowTaskPage")
+	public class WorkflowTaskPage {
+
+		public WorkflowTaskPage(Page workflowTaskPage) {
+			items = workflowTaskPage.getItems();
+			page = workflowTaskPage.getPage();
+			pageSize = workflowTaskPage.getPageSize();
+			totalCount = workflowTaskPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<WorkflowTask> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
 	@GraphQLField
 	public WorkflowLog getWorkflowLog(
 			@GraphQLName("workflowLogId") Long workflowLogId)
@@ -67,7 +117,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<WorkflowLog> getWorkflowTaskWorkflowLogsPage(
+	public WorkflowLogPage getWorkflowTaskWorkflowLogsPage(
 			@GraphQLName("workflowTaskId") Long workflowTaskId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -76,17 +126,13 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_workflowLogResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			workflowLogResource -> {
-				Page paginationPage =
-					workflowLogResource.getWorkflowTaskWorkflowLogsPage(
-						workflowTaskId, Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			workflowLogResource -> new WorkflowLogPage(
+				workflowLogResource.getWorkflowTaskWorkflowLogsPage(
+					workflowTaskId, Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLField
-	public java.util.Collection<WorkflowTask> getRoleWorkflowTasksPage(
+	public WorkflowTaskPage getRoleWorkflowTasksPage(
 			@GraphQLName("roleId") Long roleId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -95,17 +141,13 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_workflowTaskResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			workflowTaskResource -> {
-				Page paginationPage =
-					workflowTaskResource.getRoleWorkflowTasksPage(
-						roleId, Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			workflowTaskResource -> new WorkflowTaskPage(
+				workflowTaskResource.getRoleWorkflowTasksPage(
+					roleId, Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLField
-	public java.util.Collection<WorkflowTask> getWorkflowTasksAssignedToMePage(
+	public WorkflowTaskPage getWorkflowTasksAssignedToMePage(
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
 		throws Exception {
@@ -113,32 +155,23 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_workflowTaskResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			workflowTaskResource -> {
-				Page paginationPage =
-					workflowTaskResource.getWorkflowTasksAssignedToMePage(
-						Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			workflowTaskResource -> new WorkflowTaskPage(
+				workflowTaskResource.getWorkflowTasksAssignedToMePage(
+					Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLField
-	public java.util.Collection<WorkflowTask>
-			getWorkflowTasksAssignedToMyRolesPage(
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page)
+	public WorkflowTaskPage getWorkflowTasksAssignedToMyRolesPage(
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_workflowTaskResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			workflowTaskResource -> {
-				Page paginationPage =
-					workflowTaskResource.getWorkflowTasksAssignedToMyRolesPage(
-						Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			workflowTaskResource -> new WorkflowTaskPage(
+				workflowTaskResource.getWorkflowTasksAssignedToMyRolesPage(
+					Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLField

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
@@ -206,6 +206,13 @@ public abstract class BaseWorkflowLogResourceTestCase {
 
 	@Test
 	public void testGetWorkflowTaskWorkflowLogsPage() throws Exception {
+		Page<WorkflowLog> page =
+			workflowLogResource.getWorkflowTaskWorkflowLogsPage(
+				testGetWorkflowTaskWorkflowLogsPage_getWorkflowTaskId(),
+				Pagination.of(1, 2));
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long workflowTaskId =
 			testGetWorkflowTaskWorkflowLogsPage_getWorkflowTaskId();
 		Long irrelevantWorkflowTaskId =
@@ -216,9 +223,8 @@ public abstract class BaseWorkflowLogResourceTestCase {
 				testGetWorkflowTaskWorkflowLogsPage_addWorkflowLog(
 					irrelevantWorkflowTaskId, randomIrrelevantWorkflowLog());
 
-			Page<WorkflowLog> page =
-				workflowLogResource.getWorkflowTaskWorkflowLogsPage(
-					irrelevantWorkflowTaskId, Pagination.of(1, 2));
+			page = workflowLogResource.getWorkflowTaskWorkflowLogsPage(
+				irrelevantWorkflowTaskId, Pagination.of(1, 2));
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -236,9 +242,8 @@ public abstract class BaseWorkflowLogResourceTestCase {
 			testGetWorkflowTaskWorkflowLogsPage_addWorkflowLog(
 				workflowTaskId, randomWorkflowLog());
 
-		Page<WorkflowLog> page =
-			workflowLogResource.getWorkflowTaskWorkflowLogsPage(
-				workflowTaskId, Pagination.of(1, 2));
+		page = workflowLogResource.getWorkflowTaskWorkflowLogsPage(
+			workflowTaskId, Pagination.of(1, 2));
 
 		Assert.assertEquals(2, page.getTotalCount());
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
@@ -188,6 +188,11 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 	@Test
 	public void testGetRoleWorkflowTasksPage() throws Exception {
+		Page<WorkflowTask> page = workflowTaskResource.getRoleWorkflowTasksPage(
+			testGetRoleWorkflowTasksPage_getRoleId(), Pagination.of(1, 2));
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long roleId = testGetRoleWorkflowTasksPage_getRoleId();
 		Long irrelevantRoleId =
 			testGetRoleWorkflowTasksPage_getIrrelevantRoleId();
@@ -197,9 +202,8 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 				testGetRoleWorkflowTasksPage_addWorkflowTask(
 					irrelevantRoleId, randomIrrelevantWorkflowTask());
 
-			Page<WorkflowTask> page =
-				workflowTaskResource.getRoleWorkflowTasksPage(
-					irrelevantRoleId, Pagination.of(1, 2));
+			page = workflowTaskResource.getRoleWorkflowTasksPage(
+				irrelevantRoleId, Pagination.of(1, 2));
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -217,7 +221,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 			testGetRoleWorkflowTasksPage_addWorkflowTask(
 				roleId, randomWorkflowTask());
 
-		Page<WorkflowTask> page = workflowTaskResource.getRoleWorkflowTasksPage(
+		page = workflowTaskResource.getRoleWorkflowTasksPage(
 			roleId, Pagination.of(1, 2));
 
 		Assert.assertEquals(2, page.getTotalCount());

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -58,6 +58,8 @@ import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.Collection;
+
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -199,6 +201,390 @@ public class Query {
 			structuredContentFolderResourceComponentServiceObjects;
 	}
 
+	@GraphQLName("BlogPostingPage")
+	public class BlogPostingPage {
+
+		public BlogPostingPage(Page blogPostingPage) {
+			items = blogPostingPage.getItems();
+			page = blogPostingPage.getPage();
+			pageSize = blogPostingPage.getPageSize();
+			totalCount = blogPostingPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<BlogPosting> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("BlogPostingImagePage")
+	public class BlogPostingImagePage {
+
+		public BlogPostingImagePage(Page blogPostingImagePage) {
+			items = blogPostingImagePage.getItems();
+			page = blogPostingImagePage.getPage();
+			pageSize = blogPostingImagePage.getPageSize();
+			totalCount = blogPostingImagePage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<BlogPostingImage> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("CommentPage")
+	public class CommentPage {
+
+		public CommentPage(Page commentPage) {
+			items = commentPage.getItems();
+			page = commentPage.getPage();
+			pageSize = commentPage.getPageSize();
+			totalCount = commentPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<Comment> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("ContentSetElementPage")
+	public class ContentSetElementPage {
+
+		public ContentSetElementPage(Page contentSetElementPage) {
+			items = contentSetElementPage.getItems();
+			page = contentSetElementPage.getPage();
+			pageSize = contentSetElementPage.getPageSize();
+			totalCount = contentSetElementPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<ContentSetElement> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("ContentStructurePage")
+	public class ContentStructurePage {
+
+		public ContentStructurePage(Page contentStructurePage) {
+			items = contentStructurePage.getItems();
+			page = contentStructurePage.getPage();
+			pageSize = contentStructurePage.getPageSize();
+			totalCount = contentStructurePage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<ContentStructure> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("DocumentPage")
+	public class DocumentPage {
+
+		public DocumentPage(Page documentPage) {
+			items = documentPage.getItems();
+			page = documentPage.getPage();
+			pageSize = documentPage.getPageSize();
+			totalCount = documentPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<Document> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("DocumentFolderPage")
+	public class DocumentFolderPage {
+
+		public DocumentFolderPage(Page documentFolderPage) {
+			items = documentFolderPage.getItems();
+			page = documentFolderPage.getPage();
+			pageSize = documentFolderPage.getPageSize();
+			totalCount = documentFolderPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<DocumentFolder> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("KnowledgeBaseArticlePage")
+	public class KnowledgeBaseArticlePage {
+
+		public KnowledgeBaseArticlePage(Page knowledgeBaseArticlePage) {
+			items = knowledgeBaseArticlePage.getItems();
+			page = knowledgeBaseArticlePage.getPage();
+			pageSize = knowledgeBaseArticlePage.getPageSize();
+			totalCount = knowledgeBaseArticlePage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<KnowledgeBaseArticle> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("KnowledgeBaseAttachmentPage")
+	public class KnowledgeBaseAttachmentPage {
+
+		public KnowledgeBaseAttachmentPage(Page knowledgeBaseAttachmentPage) {
+			items = knowledgeBaseAttachmentPage.getItems();
+			page = knowledgeBaseAttachmentPage.getPage();
+			pageSize = knowledgeBaseAttachmentPage.getPageSize();
+			totalCount = knowledgeBaseAttachmentPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<KnowledgeBaseAttachment> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("KnowledgeBaseFolderPage")
+	public class KnowledgeBaseFolderPage {
+
+		public KnowledgeBaseFolderPage(Page knowledgeBaseFolderPage) {
+			items = knowledgeBaseFolderPage.getItems();
+			page = knowledgeBaseFolderPage.getPage();
+			pageSize = knowledgeBaseFolderPage.getPageSize();
+			totalCount = knowledgeBaseFolderPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<KnowledgeBaseFolder> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("MessageBoardAttachmentPage")
+	public class MessageBoardAttachmentPage {
+
+		public MessageBoardAttachmentPage(Page messageBoardAttachmentPage) {
+			items = messageBoardAttachmentPage.getItems();
+			page = messageBoardAttachmentPage.getPage();
+			pageSize = messageBoardAttachmentPage.getPageSize();
+			totalCount = messageBoardAttachmentPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<MessageBoardAttachment> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("MessageBoardMessagePage")
+	public class MessageBoardMessagePage {
+
+		public MessageBoardMessagePage(Page messageBoardMessagePage) {
+			items = messageBoardMessagePage.getItems();
+			page = messageBoardMessagePage.getPage();
+			pageSize = messageBoardMessagePage.getPageSize();
+			totalCount = messageBoardMessagePage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<MessageBoardMessage> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("MessageBoardSectionPage")
+	public class MessageBoardSectionPage {
+
+		public MessageBoardSectionPage(Page messageBoardSectionPage) {
+			items = messageBoardSectionPage.getItems();
+			page = messageBoardSectionPage.getPage();
+			pageSize = messageBoardSectionPage.getPageSize();
+			totalCount = messageBoardSectionPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<MessageBoardSection> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("MessageBoardThreadPage")
+	public class MessageBoardThreadPage {
+
+		public MessageBoardThreadPage(Page messageBoardThreadPage) {
+			items = messageBoardThreadPage.getItems();
+			page = messageBoardThreadPage.getPage();
+			pageSize = messageBoardThreadPage.getPageSize();
+			totalCount = messageBoardThreadPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<MessageBoardThread> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("StructuredContentPage")
+	public class StructuredContentPage {
+
+		public StructuredContentPage(Page structuredContentPage) {
+			items = structuredContentPage.getItems();
+			page = structuredContentPage.getPage();
+			pageSize = structuredContentPage.getPageSize();
+			totalCount = structuredContentPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<StructuredContent> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("StructuredContentFolderPage")
+	public class StructuredContentFolderPage {
+
+		public StructuredContentFolderPage(Page structuredContentFolderPage) {
+			items = structuredContentFolderPage.getItems();
+			page = structuredContentFolderPage.getPage();
+			pageSize = structuredContentFolderPage.getPageSize();
+			totalCount = structuredContentFolderPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<StructuredContentFolder> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
 	@GraphQLField
 	public BlogPosting getBlogPosting(
 			@GraphQLName("blogPostingId") Long blogPostingId)
@@ -224,7 +610,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<BlogPosting> getSiteBlogPostingsPage(
+	public BlogPostingPage getSiteBlogPostingsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -235,14 +621,10 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			blogPostingResource -> {
-				Page paginationPage =
-					blogPostingResource.getSiteBlogPostingsPage(
-						siteId, search, filter, Pagination.of(page, pageSize),
-						sorts);
-
-				return paginationPage.getItems();
-			});
+			blogPostingResource -> new BlogPostingPage(
+				blogPostingResource.getSiteBlogPostingsPage(
+					siteId, search, filter, Pagination.of(page, pageSize),
+					sorts)));
 	}
 
 	@GraphQLField
@@ -259,7 +641,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<BlogPostingImage> getSiteBlogPostingImagesPage(
+	public BlogPostingImagePage getSiteBlogPostingImagesPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -270,18 +652,14 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_blogPostingImageResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			blogPostingImageResource -> {
-				Page paginationPage =
-					blogPostingImageResource.getSiteBlogPostingImagesPage(
-						siteId, search, filter, Pagination.of(page, pageSize),
-						sorts);
-
-				return paginationPage.getItems();
-			});
+			blogPostingImageResource -> new BlogPostingImagePage(
+				blogPostingImageResource.getSiteBlogPostingImagesPage(
+					siteId, search, filter, Pagination.of(page, pageSize),
+					sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<Comment> getBlogPostingCommentsPage(
+	public CommentPage getBlogPostingCommentsPage(
 			@GraphQLName("blogPostingId") Long blogPostingId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -292,14 +670,10 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			commentResource -> {
-				Page paginationPage =
-					commentResource.getBlogPostingCommentsPage(
-						blogPostingId, search, filter,
-						Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			commentResource -> new CommentPage(
+				commentResource.getBlogPostingCommentsPage(
+					blogPostingId, search, filter,
+					Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
@@ -313,7 +687,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<Comment> getCommentCommentsPage(
+	public CommentPage getCommentCommentsPage(
 			@GraphQLName("parentCommentId") Long parentCommentId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -324,17 +698,14 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			commentResource -> {
-				Page paginationPage = commentResource.getCommentCommentsPage(
+			commentResource -> new CommentPage(
+				commentResource.getCommentCommentsPage(
 					parentCommentId, search, filter,
-					Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+					Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<Comment> getDocumentCommentsPage(
+	public CommentPage getDocumentCommentsPage(
 			@GraphQLName("documentId") Long documentId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -345,17 +716,14 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			commentResource -> {
-				Page paginationPage = commentResource.getDocumentCommentsPage(
+			commentResource -> new CommentPage(
+				commentResource.getDocumentCommentsPage(
 					documentId, search, filter, Pagination.of(page, pageSize),
-					sorts);
-
-				return paginationPage.getItems();
-			});
+					sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<Comment> getStructuredContentCommentsPage(
+	public CommentPage getStructuredContentCommentsPage(
 			@GraphQLName("structuredContentId") Long structuredContentId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -366,79 +734,58 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_commentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			commentResource -> {
-				Page paginationPage =
-					commentResource.getStructuredContentCommentsPage(
-						structuredContentId, search, filter,
-						Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			commentResource -> new CommentPage(
+				commentResource.getStructuredContentCommentsPage(
+					structuredContentId, search, filter,
+					Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<ContentSetElement>
-			getContentSetContentSetElementsPage(
-				@GraphQLName("contentSetId") Long contentSetId,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page)
+	public ContentSetElementPage getContentSetContentSetElementsPage(
+			@GraphQLName("contentSetId") Long contentSetId,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_contentSetElementResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			contentSetElementResource -> {
-				Page paginationPage =
-					contentSetElementResource.
-						getContentSetContentSetElementsPage(
-							contentSetId, Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			contentSetElementResource -> new ContentSetElementPage(
+				contentSetElementResource.getContentSetContentSetElementsPage(
+					contentSetId, Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLField
-	public java.util.Collection<ContentSetElement>
-			getSiteContentSetByKeyContentSetElementsPage(
-				@GraphQLName("siteId") Long siteId,
-				@GraphQLName("key") String key,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page)
+	public ContentSetElementPage getSiteContentSetByKeyContentSetElementsPage(
+			@GraphQLName("siteId") Long siteId, @GraphQLName("key") String key,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_contentSetElementResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			contentSetElementResource -> {
-				Page paginationPage =
-					contentSetElementResource.
-						getSiteContentSetByKeyContentSetElementsPage(
-							siteId, key, Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			contentSetElementResource -> new ContentSetElementPage(
+				contentSetElementResource.
+					getSiteContentSetByKeyContentSetElementsPage(
+						siteId, key, Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLField
-	public java.util.Collection<ContentSetElement>
-			getSiteContentSetByUuidContentSetElementsPage(
-				@GraphQLName("siteId") Long siteId,
-				@GraphQLName("uuid") String uuid,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page)
+	public ContentSetElementPage getSiteContentSetByUuidContentSetElementsPage(
+			@GraphQLName("siteId") Long siteId,
+			@GraphQLName("uuid") String uuid,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_contentSetElementResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			contentSetElementResource -> {
-				Page paginationPage =
-					contentSetElementResource.
-						getSiteContentSetByUuidContentSetElementsPage(
-							siteId, uuid, Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			contentSetElementResource -> new ContentSetElementPage(
+				contentSetElementResource.
+					getSiteContentSetByUuidContentSetElementsPage(
+						siteId, uuid, Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLField
@@ -455,7 +802,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<ContentStructure> getSiteContentStructuresPage(
+	public ContentStructurePage getSiteContentStructuresPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -466,18 +813,14 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_contentStructureResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			contentStructureResource -> {
-				Page paginationPage =
-					contentStructureResource.getSiteContentStructuresPage(
-						siteId, search, filter, Pagination.of(page, pageSize),
-						sorts);
-
-				return paginationPage.getItems();
-			});
+			contentStructureResource -> new ContentStructurePage(
+				contentStructureResource.getSiteContentStructuresPage(
+					siteId, search, filter, Pagination.of(page, pageSize),
+					sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<Document> getDocumentFolderDocumentsPage(
+	public DocumentPage getDocumentFolderDocumentsPage(
 			@GraphQLName("documentFolderId") Long documentFolderId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") Filter filter,
@@ -488,14 +831,10 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			documentResource -> {
-				Page paginationPage =
-					documentResource.getDocumentFolderDocumentsPage(
-						documentFolderId, search, filter,
-						Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			documentResource -> new DocumentPage(
+				documentResource.getDocumentFolderDocumentsPage(
+					documentFolderId, search, filter,
+					Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
@@ -521,7 +860,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<Document> getSiteDocumentsPage(
+	public DocumentPage getSiteDocumentsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
@@ -533,13 +872,10 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_documentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			documentResource -> {
-				Page paginationPage = documentResource.getSiteDocumentsPage(
+			documentResource -> new DocumentPage(
+				documentResource.getSiteDocumentsPage(
 					siteId, flatten, search, filter,
-					Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+					Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
@@ -555,32 +891,25 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<DocumentFolder>
-			getDocumentFolderDocumentFoldersPage(
-				@GraphQLName("parentDocumentFolderId") Long
-					parentDocumentFolderId,
-				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+	public DocumentFolderPage getDocumentFolderDocumentFoldersPage(
+			@GraphQLName("parentDocumentFolderId") Long parentDocumentFolderId,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") Filter filter,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_documentFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			documentFolderResource -> {
-				Page paginationPage =
-					documentFolderResource.getDocumentFolderDocumentFoldersPage(
-						parentDocumentFolderId, search, filter,
-						Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			documentFolderResource -> new DocumentFolderPage(
+				documentFolderResource.getDocumentFolderDocumentFoldersPage(
+					parentDocumentFolderId, search, filter,
+					Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<DocumentFolder> getSiteDocumentFoldersPage(
+	public DocumentFolderPage getSiteDocumentFoldersPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
@@ -592,14 +921,10 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_documentFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			documentFolderResource -> {
-				Page paginationPage =
-					documentFolderResource.getSiteDocumentFoldersPage(
-						siteId, flatten, search, filter,
-						Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			documentFolderResource -> new DocumentFolderPage(
+				documentFolderResource.getSiteDocumentFoldersPage(
+					siteId, flatten, search, filter,
+					Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
@@ -629,7 +954,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<KnowledgeBaseArticle>
+	public KnowledgeBaseArticlePage
 			getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
 				@GraphQLName("parentKnowledgeBaseArticleId") Long
 					parentKnowledgeBaseArticleId,
@@ -643,19 +968,15 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			knowledgeBaseArticleResource -> {
-				Page paginationPage =
-					knowledgeBaseArticleResource.
-						getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
-							parentKnowledgeBaseArticleId, search, filter,
-							Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			knowledgeBaseArticleResource -> new KnowledgeBaseArticlePage(
+				knowledgeBaseArticleResource.
+					getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
+						parentKnowledgeBaseArticleId, search, filter,
+						Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<KnowledgeBaseArticle>
+	public KnowledgeBaseArticlePage
 			getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
 				@GraphQLName("knowledgeBaseFolderId") Long
 					knowledgeBaseFolderId,
@@ -670,45 +991,34 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			knowledgeBaseArticleResource -> {
-				Page paginationPage =
-					knowledgeBaseArticleResource.
-						getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
-							knowledgeBaseFolderId, flatten, search, filter,
-							Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			knowledgeBaseArticleResource -> new KnowledgeBaseArticlePage(
+				knowledgeBaseArticleResource.
+					getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
+						knowledgeBaseFolderId, flatten, search, filter,
+						Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<KnowledgeBaseArticle>
-			getSiteKnowledgeBaseArticlesPage(
-				@GraphQLName("siteId") Long siteId,
-				@GraphQLName("flatten") Boolean flatten,
-				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+	public KnowledgeBaseArticlePage getSiteKnowledgeBaseArticlesPage(
+			@GraphQLName("siteId") Long siteId,
+			@GraphQLName("flatten") Boolean flatten,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") Filter filter,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseArticleResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			knowledgeBaseArticleResource -> {
-				Page paginationPage =
-					knowledgeBaseArticleResource.
-						getSiteKnowledgeBaseArticlesPage(
-							siteId, flatten, search, filter,
-							Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			knowledgeBaseArticleResource -> new KnowledgeBaseArticlePage(
+				knowledgeBaseArticleResource.getSiteKnowledgeBaseArticlesPage(
+					siteId, flatten, search, filter,
+					Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<KnowledgeBaseAttachment>
+	public KnowledgeBaseAttachmentPage
 			getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
 				@GraphQLName("knowledgeBaseArticleId") Long
 					knowledgeBaseArticleId)
@@ -717,14 +1027,10 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_knowledgeBaseAttachmentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			knowledgeBaseAttachmentResource -> {
-				Page paginationPage =
-					knowledgeBaseAttachmentResource.
-						getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
-							knowledgeBaseArticleId);
-
-				return paginationPage.getItems();
-			});
+			knowledgeBaseAttachmentResource -> new KnowledgeBaseAttachmentPage(
+				knowledgeBaseAttachmentResource.
+					getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
+						knowledgeBaseArticleId)));
 	}
 
 	@GraphQLField
@@ -755,7 +1061,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<KnowledgeBaseFolder>
+	public KnowledgeBaseFolderPage
 			getKnowledgeBaseFolderKnowledgeBaseFoldersPage(
 				@GraphQLName("parentKnowledgeBaseFolderId") Long
 					parentKnowledgeBaseFolderId,
@@ -766,35 +1072,26 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_knowledgeBaseFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			knowledgeBaseFolderResource -> {
-				Page paginationPage =
-					knowledgeBaseFolderResource.
-						getKnowledgeBaseFolderKnowledgeBaseFoldersPage(
-							parentKnowledgeBaseFolderId,
-							Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			knowledgeBaseFolderResource -> new KnowledgeBaseFolderPage(
+				knowledgeBaseFolderResource.
+					getKnowledgeBaseFolderKnowledgeBaseFoldersPage(
+						parentKnowledgeBaseFolderId,
+						Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLField
-	public java.util.Collection<KnowledgeBaseFolder>
-			getSiteKnowledgeBaseFoldersPage(
-				@GraphQLName("siteId") Long siteId,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page)
+	public KnowledgeBaseFolderPage getSiteKnowledgeBaseFoldersPage(
+			@GraphQLName("siteId") Long siteId,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_knowledgeBaseFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			knowledgeBaseFolderResource -> {
-				Page paginationPage =
-					knowledgeBaseFolderResource.getSiteKnowledgeBaseFoldersPage(
-						siteId, Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			knowledgeBaseFolderResource -> new KnowledgeBaseFolderPage(
+				knowledgeBaseFolderResource.getSiteKnowledgeBaseFoldersPage(
+					siteId, Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLField
@@ -812,7 +1109,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<MessageBoardAttachment>
+	public MessageBoardAttachmentPage
 			getMessageBoardMessageMessageBoardAttachmentsPage(
 				@GraphQLName("messageBoardMessageId") Long
 					messageBoardMessageId)
@@ -821,18 +1118,14 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_messageBoardAttachmentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			messageBoardAttachmentResource -> {
-				Page paginationPage =
-					messageBoardAttachmentResource.
-						getMessageBoardMessageMessageBoardAttachmentsPage(
-							messageBoardMessageId);
-
-				return paginationPage.getItems();
-			});
+			messageBoardAttachmentResource -> new MessageBoardAttachmentPage(
+				messageBoardAttachmentResource.
+					getMessageBoardMessageMessageBoardAttachmentsPage(
+						messageBoardMessageId)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<MessageBoardAttachment>
+	public MessageBoardAttachmentPage
 			getMessageBoardThreadMessageBoardAttachmentsPage(
 				@GraphQLName("messageBoardThreadId") Long messageBoardThreadId)
 		throws Exception {
@@ -840,14 +1133,10 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_messageBoardAttachmentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			messageBoardAttachmentResource -> {
-				Page paginationPage =
-					messageBoardAttachmentResource.
-						getMessageBoardThreadMessageBoardAttachmentsPage(
-							messageBoardThreadId);
-
-				return paginationPage.getItems();
-			});
+			messageBoardAttachmentResource -> new MessageBoardAttachmentPage(
+				messageBoardAttachmentResource.
+					getMessageBoardThreadMessageBoardAttachmentsPage(
+						messageBoardThreadId)));
 	}
 
 	@GraphQLField
@@ -877,7 +1166,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<MessageBoardMessage>
+	public MessageBoardMessagePage
 			getMessageBoardMessageMessageBoardMessagesPage(
 				@GraphQLName("parentMessageBoardMessageId") Long
 					parentMessageBoardMessageId,
@@ -891,19 +1180,15 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			messageBoardMessageResource -> {
-				Page paginationPage =
-					messageBoardMessageResource.
-						getMessageBoardMessageMessageBoardMessagesPage(
-							parentMessageBoardMessageId, search, filter,
-							Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			messageBoardMessageResource -> new MessageBoardMessagePage(
+				messageBoardMessageResource.
+					getMessageBoardMessageMessageBoardMessagesPage(
+						parentMessageBoardMessageId, search, filter,
+						Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<MessageBoardMessage>
+	public MessageBoardMessagePage
 			getMessageBoardThreadMessageBoardMessagesPage(
 				@GraphQLName("messageBoardThreadId") Long messageBoardThreadId,
 				@GraphQLName("search") String search,
@@ -916,15 +1201,11 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_messageBoardMessageResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			messageBoardMessageResource -> {
-				Page paginationPage =
-					messageBoardMessageResource.
-						getMessageBoardThreadMessageBoardMessagesPage(
-							messageBoardThreadId, search, filter,
-							Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			messageBoardMessageResource -> new MessageBoardMessagePage(
+				messageBoardMessageResource.
+					getMessageBoardThreadMessageBoardMessagesPage(
+						messageBoardThreadId, search, filter,
+						Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
@@ -941,7 +1222,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<MessageBoardSection>
+	public MessageBoardSectionPage
 			getMessageBoardSectionMessageBoardSectionsPage(
 				@GraphQLName("parentMessageBoardSectionId") Long
 					parentMessageBoardSectionId,
@@ -955,66 +1236,49 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_messageBoardSectionResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			messageBoardSectionResource -> {
-				Page paginationPage =
-					messageBoardSectionResource.
-						getMessageBoardSectionMessageBoardSectionsPage(
-							parentMessageBoardSectionId, search, filter,
-							Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			messageBoardSectionResource -> new MessageBoardSectionPage(
+				messageBoardSectionResource.
+					getMessageBoardSectionMessageBoardSectionsPage(
+						parentMessageBoardSectionId, search, filter,
+						Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<MessageBoardSection>
-			getSiteMessageBoardSectionsPage(
-				@GraphQLName("siteId") Long siteId,
-				@GraphQLName("flatten") Boolean flatten,
-				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+	public MessageBoardSectionPage getSiteMessageBoardSectionsPage(
+			@GraphQLName("siteId") Long siteId,
+			@GraphQLName("flatten") Boolean flatten,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") Filter filter,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardSectionResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			messageBoardSectionResource -> {
-				Page paginationPage =
-					messageBoardSectionResource.getSiteMessageBoardSectionsPage(
-						siteId, flatten, search, filter,
-						Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			messageBoardSectionResource -> new MessageBoardSectionPage(
+				messageBoardSectionResource.getSiteMessageBoardSectionsPage(
+					siteId, flatten, search, filter,
+					Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<MessageBoardThread>
-			getMessageBoardSectionMessageBoardThreadsPage(
-				@GraphQLName("messageBoardSectionId") Long
-					messageBoardSectionId,
-				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+	public MessageBoardThreadPage getMessageBoardSectionMessageBoardThreadsPage(
+			@GraphQLName("messageBoardSectionId") Long messageBoardSectionId,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") Filter filter,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			messageBoardThreadResource -> {
-				Page paginationPage =
-					messageBoardThreadResource.
-						getMessageBoardSectionMessageBoardThreadsPage(
-							messageBoardSectionId, search, filter,
-							Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			messageBoardThreadResource -> new MessageBoardThreadPage(
+				messageBoardThreadResource.
+					getMessageBoardSectionMessageBoardThreadsPage(
+						messageBoardSectionId, search, filter,
+						Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
@@ -1044,78 +1308,60 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<MessageBoardThread>
-			getSiteMessageBoardThreadsPage(
-				@GraphQLName("siteId") Long siteId,
-				@GraphQLName("flatten") Boolean flatten,
-				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+	public MessageBoardThreadPage getSiteMessageBoardThreadsPage(
+			@GraphQLName("siteId") Long siteId,
+			@GraphQLName("flatten") Boolean flatten,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") Filter filter,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_messageBoardThreadResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			messageBoardThreadResource -> {
-				Page paginationPage =
-					messageBoardThreadResource.getSiteMessageBoardThreadsPage(
-						siteId, flatten, search, filter,
-						Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			messageBoardThreadResource -> new MessageBoardThreadPage(
+				messageBoardThreadResource.getSiteMessageBoardThreadsPage(
+					siteId, flatten, search, filter,
+					Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<StructuredContent>
-			getContentStructureStructuredContentsPage(
-				@GraphQLName("contentStructureId") Long contentStructureId,
-				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+	public StructuredContentPage getContentStructureStructuredContentsPage(
+			@GraphQLName("contentStructureId") Long contentStructureId,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") Filter filter,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			structuredContentResource -> {
-				Page paginationPage =
-					structuredContentResource.
-						getContentStructureStructuredContentsPage(
-							contentStructureId, search, filter,
-							Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			structuredContentResource -> new StructuredContentPage(
+				structuredContentResource.
+					getContentStructureStructuredContentsPage(
+						contentStructureId, search, filter,
+						Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<StructuredContent>
-			getSiteStructuredContentsPage(
-				@GraphQLName("siteId") Long siteId,
-				@GraphQLName("flatten") Boolean flatten,
-				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+	public StructuredContentPage getSiteStructuredContentsPage(
+			@GraphQLName("siteId") Long siteId,
+			@GraphQLName("flatten") Boolean flatten,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") Filter filter,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			structuredContentResource -> {
-				Page paginationPage =
-					structuredContentResource.getSiteStructuredContentsPage(
-						siteId, flatten, search, filter,
-						Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			structuredContentResource -> new StructuredContentPage(
+				structuredContentResource.getSiteStructuredContentsPage(
+					siteId, flatten, search, filter,
+					Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
@@ -1146,7 +1392,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<StructuredContent>
+	public StructuredContentPage
 			getStructuredContentFolderStructuredContentsPage(
 				@GraphQLName("structuredContentFolderId") Long
 					structuredContentFolderId,
@@ -1160,15 +1406,11 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_structuredContentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			structuredContentResource -> {
-				Page paginationPage =
-					structuredContentResource.
-						getStructuredContentFolderStructuredContentsPage(
-							structuredContentFolderId, search, filter,
-							Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			structuredContentResource -> new StructuredContentPage(
+				structuredContentResource.
+					getStructuredContentFolderStructuredContentsPage(
+						structuredContentFolderId, search, filter,
+						Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
@@ -1213,33 +1455,27 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<StructuredContentFolder>
-			getSiteStructuredContentFoldersPage(
-				@GraphQLName("siteId") Long siteId,
-				@GraphQLName("flatten") Boolean flatten,
-				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+	public StructuredContentFolderPage getSiteStructuredContentFoldersPage(
+			@GraphQLName("siteId") Long siteId,
+			@GraphQLName("flatten") Boolean flatten,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") Filter filter,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_structuredContentFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			structuredContentFolderResource -> {
-				Page paginationPage =
-					structuredContentFolderResource.
-						getSiteStructuredContentFoldersPage(
-							siteId, flatten, search, filter,
-							Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			structuredContentFolderResource -> new StructuredContentFolderPage(
+				structuredContentFolderResource.
+					getSiteStructuredContentFoldersPage(
+						siteId, flatten, search, filter,
+						Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField
-	public java.util.Collection<StructuredContentFolder>
+	public StructuredContentFolderPage
 			getStructuredContentFolderStructuredContentFoldersPage(
 				@GraphQLName("parentStructuredContentFolderId") Long
 					parentStructuredContentFolderId,
@@ -1253,15 +1489,11 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_structuredContentFolderResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			structuredContentFolderResource -> {
-				Page paginationPage =
-					structuredContentFolderResource.
-						getStructuredContentFolderStructuredContentFoldersPage(
-							parentStructuredContentFolderId, search, filter,
-							Pagination.of(page, pageSize), sorts);
-
-				return paginationPage.getItems();
-			});
+			structuredContentFolderResource -> new StructuredContentFolderPage(
+				structuredContentFolderResource.
+					getStructuredContentFolderStructuredContentFoldersPage(
+						parentStructuredContentFolderId, search, filter,
+						Pagination.of(page, pageSize), sorts)));
 	}
 
 	@GraphQLField

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
@@ -187,6 +187,13 @@ public abstract class BaseContentSetElementResourceTestCase {
 
 	@Test
 	public void testGetContentSetContentSetElementsPage() throws Exception {
+		Page<ContentSetElement> page =
+			contentSetElementResource.getContentSetContentSetElementsPage(
+				testGetContentSetContentSetElementsPage_getContentSetId(),
+				Pagination.of(1, 2));
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long contentSetId =
 			testGetContentSetContentSetElementsPage_getContentSetId();
 		Long irrelevantContentSetId =
@@ -198,7 +205,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 					irrelevantContentSetId,
 					randomIrrelevantContentSetElement());
 
-			Page<ContentSetElement> page =
+			page =
 				contentSetElementResource.getContentSetContentSetElementsPage(
 					irrelevantContentSetId, Pagination.of(1, 2));
 
@@ -218,9 +225,8 @@ public abstract class BaseContentSetElementResourceTestCase {
 			testGetContentSetContentSetElementsPage_addContentSetElement(
 				contentSetId, randomContentSetElement());
 
-		Page<ContentSetElement> page =
-			contentSetElementResource.getContentSetContentSetElementsPage(
-				contentSetId, Pagination.of(1, 2));
+		page = contentSetElementResource.getContentSetContentSetElementsPage(
+			contentSetId, Pagination.of(1, 2));
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -308,6 +314,15 @@ public abstract class BaseContentSetElementResourceTestCase {
 	public void testGetSiteContentSetByKeyContentSetElementsPage()
 		throws Exception {
 
+		Page<ContentSetElement> page =
+			contentSetElementResource.
+				getSiteContentSetByKeyContentSetElementsPage(
+					testGetSiteContentSetByKeyContentSetElementsPage_getSiteId(),
+					testGetSiteContentSetByKeyContentSetElementsPage_getKey(),
+					Pagination.of(1, 2));
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long siteId =
 			testGetSiteContentSetByKeyContentSetElementsPage_getSiteId();
 		Long irrelevantSiteId =
@@ -322,7 +337,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 					irrelevantSiteId, irrelevantKey,
 					randomIrrelevantContentSetElement());
 
-			Page<ContentSetElement> page =
+			page =
 				contentSetElementResource.
 					getSiteContentSetByKeyContentSetElementsPage(
 						irrelevantSiteId, irrelevantKey, Pagination.of(1, 2));
@@ -343,7 +358,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 			testGetSiteContentSetByKeyContentSetElementsPage_addContentSetElement(
 				siteId, key, randomContentSetElement());
 
-		Page<ContentSetElement> page =
+		page =
 			contentSetElementResource.
 				getSiteContentSetByKeyContentSetElementsPage(
 					siteId, key, Pagination.of(1, 2));
@@ -451,6 +466,15 @@ public abstract class BaseContentSetElementResourceTestCase {
 	public void testGetSiteContentSetByUuidContentSetElementsPage()
 		throws Exception {
 
+		Page<ContentSetElement> page =
+			contentSetElementResource.
+				getSiteContentSetByUuidContentSetElementsPage(
+					testGetSiteContentSetByUuidContentSetElementsPage_getSiteId(),
+					testGetSiteContentSetByUuidContentSetElementsPage_getUuid(),
+					Pagination.of(1, 2));
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long siteId =
 			testGetSiteContentSetByUuidContentSetElementsPage_getSiteId();
 		Long irrelevantSiteId =
@@ -466,7 +490,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 					irrelevantSiteId, irrelevantUuid,
 					randomIrrelevantContentSetElement());
 
-			Page<ContentSetElement> page =
+			page =
 				contentSetElementResource.
 					getSiteContentSetByUuidContentSetElementsPage(
 						irrelevantSiteId, irrelevantUuid, Pagination.of(1, 2));
@@ -487,7 +511,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 			testGetSiteContentSetByUuidContentSetElementsPage_addContentSetElement(
 				siteId, uuid, randomContentSetElement());
 
-		Page<ContentSetElement> page =
+		page =
 			contentSetElementResource.
 				getSiteContentSetByUuidContentSetElementsPage(
 					siteId, uuid, Pagination.of(1, 2));

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
@@ -200,6 +200,13 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 	public void testGetKnowledgeBaseArticleKnowledgeBaseAttachmentsPage()
 		throws Exception {
 
+		Page<KnowledgeBaseAttachment> page =
+			knowledgeBaseAttachmentResource.
+				getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
+					testGetKnowledgeBaseArticleKnowledgeBaseAttachmentsPage_getKnowledgeBaseArticleId());
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long knowledgeBaseArticleId =
 			testGetKnowledgeBaseArticleKnowledgeBaseAttachmentsPage_getKnowledgeBaseArticleId();
 		Long irrelevantKnowledgeBaseArticleId =
@@ -211,7 +218,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 					irrelevantKnowledgeBaseArticleId,
 					randomIrrelevantKnowledgeBaseAttachment());
 
-			Page<KnowledgeBaseAttachment> page =
+			page =
 				knowledgeBaseAttachmentResource.
 					getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
 						irrelevantKnowledgeBaseArticleId);
@@ -232,7 +239,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 			testGetKnowledgeBaseArticleKnowledgeBaseAttachmentsPage_addKnowledgeBaseAttachment(
 				knowledgeBaseArticleId, randomKnowledgeBaseAttachment());
 
-		Page<KnowledgeBaseAttachment> page =
+		page =
 			knowledgeBaseAttachmentResource.
 				getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
 					knowledgeBaseArticleId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -306,6 +306,14 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	public void testGetKnowledgeBaseFolderKnowledgeBaseFoldersPage()
 		throws Exception {
 
+		Page<KnowledgeBaseFolder> page =
+			knowledgeBaseFolderResource.
+				getKnowledgeBaseFolderKnowledgeBaseFoldersPage(
+					testGetKnowledgeBaseFolderKnowledgeBaseFoldersPage_getParentKnowledgeBaseFolderId(),
+					Pagination.of(1, 2));
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long parentKnowledgeBaseFolderId =
 			testGetKnowledgeBaseFolderKnowledgeBaseFoldersPage_getParentKnowledgeBaseFolderId();
 		Long irrelevantParentKnowledgeBaseFolderId =
@@ -317,7 +325,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 					irrelevantParentKnowledgeBaseFolderId,
 					randomIrrelevantKnowledgeBaseFolder());
 
-			Page<KnowledgeBaseFolder> page =
+			page =
 				knowledgeBaseFolderResource.
 					getKnowledgeBaseFolderKnowledgeBaseFoldersPage(
 						irrelevantParentKnowledgeBaseFolderId,
@@ -339,7 +347,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			testGetKnowledgeBaseFolderKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
 				parentKnowledgeBaseFolderId, randomKnowledgeBaseFolder());
 
-		Page<KnowledgeBaseFolder> page =
+		page =
 			knowledgeBaseFolderResource.
 				getKnowledgeBaseFolderKnowledgeBaseFoldersPage(
 					parentKnowledgeBaseFolderId, Pagination.of(1, 2));
@@ -461,6 +469,13 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 
 	@Test
 	public void testGetSiteKnowledgeBaseFoldersPage() throws Exception {
+		Page<KnowledgeBaseFolder> page =
+			knowledgeBaseFolderResource.getSiteKnowledgeBaseFoldersPage(
+				testGetSiteKnowledgeBaseFoldersPage_getSiteId(),
+				Pagination.of(1, 2));
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long siteId = testGetSiteKnowledgeBaseFoldersPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteKnowledgeBaseFoldersPage_getIrrelevantSiteId();
@@ -470,9 +485,8 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 				testGetSiteKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
 					irrelevantSiteId, randomIrrelevantKnowledgeBaseFolder());
 
-			Page<KnowledgeBaseFolder> page =
-				knowledgeBaseFolderResource.getSiteKnowledgeBaseFoldersPage(
-					irrelevantSiteId, Pagination.of(1, 2));
+			page = knowledgeBaseFolderResource.getSiteKnowledgeBaseFoldersPage(
+				irrelevantSiteId, Pagination.of(1, 2));
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -490,9 +504,8 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			testGetSiteKnowledgeBaseFoldersPage_addKnowledgeBaseFolder(
 				siteId, randomKnowledgeBaseFolder());
 
-		Page<KnowledgeBaseFolder> page =
-			knowledgeBaseFolderResource.getSiteKnowledgeBaseFoldersPage(
-				siteId, Pagination.of(1, 2));
+		page = knowledgeBaseFolderResource.getSiteKnowledgeBaseFoldersPage(
+			siteId, Pagination.of(1, 2));
 
 		Assert.assertEquals(2, page.getTotalCount());
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -252,6 +252,13 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 	public void testGetMessageBoardMessageMessageBoardAttachmentsPage()
 		throws Exception {
 
+		Page<MessageBoardAttachment> page =
+			messageBoardAttachmentResource.
+				getMessageBoardMessageMessageBoardAttachmentsPage(
+					testGetMessageBoardMessageMessageBoardAttachmentsPage_getMessageBoardMessageId());
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long messageBoardMessageId =
 			testGetMessageBoardMessageMessageBoardAttachmentsPage_getMessageBoardMessageId();
 		Long irrelevantMessageBoardMessageId =
@@ -263,7 +270,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 					irrelevantMessageBoardMessageId,
 					randomIrrelevantMessageBoardAttachment());
 
-			Page<MessageBoardAttachment> page =
+			page =
 				messageBoardAttachmentResource.
 					getMessageBoardMessageMessageBoardAttachmentsPage(
 						irrelevantMessageBoardMessageId);
@@ -284,7 +291,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 			testGetMessageBoardMessageMessageBoardAttachmentsPage_addMessageBoardAttachment(
 				messageBoardMessageId, randomMessageBoardAttachment());
 
-		Page<MessageBoardAttachment> page =
+		page =
 			messageBoardAttachmentResource.
 				getMessageBoardMessageMessageBoardAttachmentsPage(
 					messageBoardMessageId);
@@ -359,6 +366,13 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 	public void testGetMessageBoardThreadMessageBoardAttachmentsPage()
 		throws Exception {
 
+		Page<MessageBoardAttachment> page =
+			messageBoardAttachmentResource.
+				getMessageBoardThreadMessageBoardAttachmentsPage(
+					testGetMessageBoardThreadMessageBoardAttachmentsPage_getMessageBoardThreadId());
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long messageBoardThreadId =
 			testGetMessageBoardThreadMessageBoardAttachmentsPage_getMessageBoardThreadId();
 		Long irrelevantMessageBoardThreadId =
@@ -370,7 +384,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 					irrelevantMessageBoardThreadId,
 					randomIrrelevantMessageBoardAttachment());
 
-			Page<MessageBoardAttachment> page =
+			page =
 				messageBoardAttachmentResource.
 					getMessageBoardThreadMessageBoardAttachmentsPage(
 						irrelevantMessageBoardThreadId);
@@ -391,7 +405,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 			testGetMessageBoardThreadMessageBoardAttachmentsPage_addMessageBoardAttachment(
 				messageBoardThreadId, randomMessageBoardAttachment());
 
-		Page<MessageBoardAttachment> page =
+		page =
 			messageBoardAttachmentResource.
 				getMessageBoardThreadMessageBoardAttachmentsPage(
 					messageBoardThreadId);

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/query/v1_0/Query.java
@@ -16,6 +16,7 @@ package com.liferay.headless.form.internal.graphql.query.v1_0;
 
 import com.liferay.headless.form.dto.v1_0.Form;
 import com.liferay.headless.form.dto.v1_0.FormDocument;
+import com.liferay.headless.form.dto.v1_0.FormPage;
 import com.liferay.headless.form.dto.v1_0.FormRecord;
 import com.liferay.headless.form.dto.v1_0.FormStructure;
 import com.liferay.headless.form.resource.v1_0.FormDocumentResource;
@@ -30,6 +31,8 @@ import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.Collection;
 
 import javax.annotation.Generated;
 
@@ -74,6 +77,102 @@ public class Query {
 			formStructureResourceComponentServiceObjects;
 	}
 
+	@GraphQLName("FormPage")
+	public class FormPage {
+
+		public FormPage(Page formPage) {
+			items = formPage.getItems();
+			page = formPage.getPage();
+			pageSize = formPage.getPageSize();
+			totalCount = formPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<Form> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("FormDocumentPage")
+	public class FormDocumentPage {
+
+		public FormDocumentPage(Page formDocumentPage) {
+			items = formDocumentPage.getItems();
+			page = formDocumentPage.getPage();
+			pageSize = formDocumentPage.getPageSize();
+			totalCount = formDocumentPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<FormDocument> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("FormRecordPage")
+	public class FormRecordPage {
+
+		public FormRecordPage(Page formRecordPage) {
+			items = formRecordPage.getItems();
+			page = formRecordPage.getPage();
+			pageSize = formRecordPage.getPageSize();
+			totalCount = formRecordPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<FormRecord> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("FormStructurePage")
+	public class FormStructurePage {
+
+		public FormStructurePage(Page formStructurePage) {
+			items = formStructurePage.getItems();
+			page = formStructurePage.getPage();
+			pageSize = formStructurePage.getPageSize();
+			totalCount = formStructurePage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Collection<FormStructure> items;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
 	@GraphQLField
 	public Form getForm(@GraphQLName("formId") Long formId) throws Exception {
 		return _applyComponentServiceObjects(
@@ -83,7 +182,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<Form> getSiteFormsPage(
+	public FormPage getSiteFormsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -92,12 +191,9 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_formResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			formResource -> {
-				Page paginationPage = formResource.getSiteFormsPage(
-					siteId, Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			formResource -> new FormPage(
+				formResource.getSiteFormsPage(
+					siteId, Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLField
@@ -125,7 +221,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<FormRecord> getFormFormRecordsPage(
+	public FormRecordPage getFormFormRecordsPage(
 			@GraphQLName("formId") Long formId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -134,12 +230,9 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_formRecordResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			formRecordResource -> {
-				Page paginationPage = formRecordResource.getFormFormRecordsPage(
-					formId, Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			formRecordResource -> new FormRecordPage(
+				formRecordResource.getFormFormRecordsPage(
+					formId, Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLField
@@ -167,7 +260,7 @@ public class Query {
 	}
 
 	@GraphQLField
-	public java.util.Collection<FormStructure> getSiteFormStructuresPage(
+	public FormStructurePage getSiteFormStructuresPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("pageSize") int pageSize,
 			@GraphQLName("page") int page)
@@ -176,13 +269,9 @@ public class Query {
 		return _applyComponentServiceObjects(
 			_formStructureResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			formStructureResource -> {
-				Page paginationPage =
-					formStructureResource.getSiteFormStructuresPage(
-						siteId, Pagination.of(page, pageSize));
-
-				return paginationPage.getItems();
-			});
+			formStructureResource -> new FormStructurePage(
+				formStructureResource.getSiteFormStructuresPage(
+					siteId, Pagination.of(page, pageSize))));
 	}
 
 	private <T, R, E1 extends Throwable, E2 extends Throwable> R

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
@@ -220,6 +220,11 @@ public abstract class BaseFormRecordResourceTestCase {
 
 	@Test
 	public void testGetFormFormRecordsPage() throws Exception {
+		Page<FormRecord> page = formRecordResource.getFormFormRecordsPage(
+			testGetFormFormRecordsPage_getFormId(), Pagination.of(1, 2));
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long formId = testGetFormFormRecordsPage_getFormId();
 		Long irrelevantFormId =
 			testGetFormFormRecordsPage_getIrrelevantFormId();
@@ -229,7 +234,7 @@ public abstract class BaseFormRecordResourceTestCase {
 				testGetFormFormRecordsPage_addFormRecord(
 					irrelevantFormId, randomIrrelevantFormRecord());
 
-			Page<FormRecord> page = formRecordResource.getFormFormRecordsPage(
+			page = formRecordResource.getFormFormRecordsPage(
 				irrelevantFormId, Pagination.of(1, 2));
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -246,7 +251,7 @@ public abstract class BaseFormRecordResourceTestCase {
 		FormRecord formRecord2 = testGetFormFormRecordsPage_addFormRecord(
 			formId, randomFormRecord());
 
-		Page<FormRecord> page = formRecordResource.getFormFormRecordsPage(
+		page = formRecordResource.getFormFormRecordsPage(
 			formId, Pagination.of(1, 2));
 
 		Assert.assertEquals(2, page.getTotalCount());

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
@@ -213,6 +213,11 @@ public abstract class BaseFormResourceTestCase {
 
 	@Test
 	public void testGetSiteFormsPage() throws Exception {
+		Page<Form> page = formResource.getSiteFormsPage(
+			testGetSiteFormsPage_getSiteId(), Pagination.of(1, 2));
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long siteId = testGetSiteFormsPage_getSiteId();
 		Long irrelevantSiteId = testGetSiteFormsPage_getIrrelevantSiteId();
 
@@ -220,7 +225,7 @@ public abstract class BaseFormResourceTestCase {
 			Form irrelevantForm = testGetSiteFormsPage_addForm(
 				irrelevantSiteId, randomIrrelevantForm());
 
-			Page<Form> page = formResource.getSiteFormsPage(
+			page = formResource.getSiteFormsPage(
 				irrelevantSiteId, Pagination.of(1, 2));
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -234,8 +239,7 @@ public abstract class BaseFormResourceTestCase {
 
 		Form form2 = testGetSiteFormsPage_addForm(siteId, randomForm());
 
-		Page<Form> page = formResource.getSiteFormsPage(
-			siteId, Pagination.of(1, 2));
+		page = formResource.getSiteFormsPage(siteId, Pagination.of(1, 2));
 
 		Assert.assertEquals(2, page.getTotalCount());
 

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
@@ -205,6 +205,12 @@ public abstract class BaseFormStructureResourceTestCase {
 
 	@Test
 	public void testGetSiteFormStructuresPage() throws Exception {
+		Page<FormStructure> page =
+			formStructureResource.getSiteFormStructuresPage(
+				testGetSiteFormStructuresPage_getSiteId(), Pagination.of(1, 2));
+
+		Assert.assertEquals(0, page.getTotalCount());
+
 		Long siteId = testGetSiteFormStructuresPage_getSiteId();
 		Long irrelevantSiteId =
 			testGetSiteFormStructuresPage_getIrrelevantSiteId();
@@ -214,9 +220,8 @@ public abstract class BaseFormStructureResourceTestCase {
 				testGetSiteFormStructuresPage_addFormStructure(
 					irrelevantSiteId, randomIrrelevantFormStructure());
 
-			Page<FormStructure> page =
-				formStructureResource.getSiteFormStructuresPage(
-					irrelevantSiteId, Pagination.of(1, 2));
+			page = formStructureResource.getSiteFormStructuresPage(
+				irrelevantSiteId, Pagination.of(1, 2));
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -234,9 +239,8 @@ public abstract class BaseFormStructureResourceTestCase {
 			testGetSiteFormStructuresPage_addFormStructure(
 				siteId, randomFormStructure());
 
-		Page<FormStructure> page =
-			formStructureResource.getSiteFormStructuresPage(
-				siteId, Pagination.of(1, 2));
+		page = formStructureResource.getSiteFormStructuresPage(
+			siteId, Pagination.of(1, 2));
 
 		Assert.assertEquals(2, page.getTotalCount());
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_query.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_query.ftl
@@ -19,6 +19,7 @@ import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.Collection;
 import java.util.Date;
 
 import javax.annotation.Generated;
@@ -46,20 +47,49 @@ public class Query {
 		}
 	</#list>
 
+	<#list schemaNames as schemaName>
+		@GraphQLName("${schemaName}Page")
+		public class ${schemaName}Page {
+
+			public ${schemaName}Page(Page ${freeMarkerTool.getSchemaVarName(schemaName)}Page) {
+				items = ${freeMarkerTool.getSchemaVarName(schemaName)}Page.getItems();
+				page = ${freeMarkerTool.getSchemaVarName(schemaName)}Page.getPage();
+				pageSize = ${freeMarkerTool.getSchemaVarName(schemaName)}Page.getPageSize();
+				totalCount = ${freeMarkerTool.getSchemaVarName(schemaName)}Page.getTotalCount();
+			}
+
+			@GraphQLField
+			protected Collection<${schemaName}> items;
+			@GraphQLField
+			protected long page;
+			@GraphQLField
+			protected long pageSize;
+			@GraphQLField
+			protected long totalCount;
+		}
+	</#list>
+
 	<#list javaMethodSignatures as javaMethodSignature>
 		${freeMarkerTool.getGraphQLMethodAnnotations(javaMethodSignature)}
-		public ${javaMethodSignature.returnType} ${javaMethodSignature.methodName}(${freeMarkerTool.getGraphQLParameters(javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, true)}) throws Exception {
+		public
+
+		<#if javaMethodSignature.returnType?contains("Collection<")>
+			${javaMethodSignature.schemaName}Page
+		<#else>
+			${javaMethodSignature.returnType}
+		</#if>
+
+		${javaMethodSignature.methodName}(${freeMarkerTool.getGraphQLParameters(javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, true)}) throws Exception {
 			<#assign arguments = freeMarkerTool.getGraphQLArguments(javaMethodSignature.javaMethodParameters) />
 
 			<#if javaMethodSignature.returnType?contains("Collection<")>
 				return _applyComponentServiceObjects(
 					_${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}ResourceComponentServiceObjects,
 					this::_populateResourceContext,
-					${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource -> {
-						Page paginationPage = ${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource.${javaMethodSignature.methodName}(${arguments?replace("pageSize,page", "Pagination.of(page, pageSize)")});
-
-						return paginationPage.getItems();
-					});
+					${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource ->
+						new ${javaMethodSignature.schemaName}Page(
+							${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource.${javaMethodSignature.methodName}(${arguments?replace("pageSize,page", "Pagination.of(page, pageSize)")}))
+					);
 			<#else>
 				return _applyComponentServiceObjects(_${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}ResourceComponentServiceObjects, this::_populateResourceContext, ${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource -> ${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource.${javaMethodSignature.methodName}(${arguments?replace("pageSize,page", "Pagination.of(page, pageSize)")}));
 			</#if>


### PR DESCRIPTION
This is for returning the page information (page number, totalCount...). 

I tried to modify the library because it can't infer the generics of Page to the right type... but it would mean to override too much code (the method that tries to infer the type doesn't have the context of the parent class so we would have to propagate that information). Generating concrete classes does the job.

Fields have to be protected to allow the library to pick the right name (instead of _totalCount).