### PR TITLE
LPS-92841 portal-search-admin-web: Remove h5 tag from search list

### DIFF
--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/css/main.scss
@@ -46,4 +46,11 @@
 			padding: 0.625rem 1rem;
 		}
 	}
+
+	.search-admin-actions-panel {
+		.pull-left {
+			color: #272833;
+		}
+
+	}
 }

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/index_actions.jsp
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/index_actions.jsp
@@ -116,7 +116,7 @@ portletURL.setParameter("mvcRenderCommandName", "/search_admin/view");
 			<ul class="list-group system-action-group">
 				<li class="clearfix list-group-item">
 					<div class="pull-left">
-						<h5><liferay-ui:message key="reindex-all-search-indexes" /></h5>
+						<liferay-ui:message key="reindex-all-search-indexes" />
 					</div>
 
 					<%
@@ -148,7 +148,7 @@ portletURL.setParameter("mvcRenderCommandName", "/search_admin/view");
 				</li>
 				<li class="clearfix list-group-item">
 					<div class="pull-left">
-						<h5><liferay-ui:message key="reindex-all-spell-check-indexes" /></h5>
+						<liferay-ui:message key="reindex-all-spell-check-indexes" />
 					</div>
 
 					<div class="pull-right">
@@ -167,7 +167,7 @@ portletURL.setParameter("mvcRenderCommandName", "/search_admin/view");
 
 					<li class="clearfix list-group-item">
 						<div class="pull-left">
-							<h5><liferay-ui:message arguments="<%= indexer.getClassName() %>" key="reindex-x" /></h5>
+							<liferay-ui:message arguments="<%= indexer.getClassName() %>" key="reindex-x" />
 						</div>
 
 						<div class="index-action-wrapper pull-right" data-type="<%= indexer.getClassName() %>">


### PR DESCRIPTION
<h3>:x: ci:test:search - 19 out of 21 jobs passed in 1 hour 22 minutes 767 ms</h3>

https://github.com/brandizzi/liferay-portal/pull/783#issuecomment-506384763

Only unique failure is broken semantic versioning in portal-kerrnel, which is unrelated.

Author: @foshiro
Reviewer: @brandizzi

[Bug] list items title should not be h5
https://issues.liferay.com/browse/LPS-92841