### PR TITLE
LPS-97498 Add full-sentence descriptions to frontend ignore files

### DIFF
--- a/modules/.eslintignore
+++ b/modules/.eslintignore
@@ -1,24 +1,65 @@
+##
+## Base patterns
+##
+
+#
+# Target "modern" JavaScript files only by first ignoring all ".js"
+# files and then un-ignoring the ".es.js" subset.
+#
 **/*.js
 !**/*.es.js
 
-!.eslintrc.js
+##
+## Configuration files
+##
+
+#
+# Un-ignore configuration files because they should be treated as "modern"
+# despite not having an ".es.js" extension.
+#
+!**/*/.eslintrc.js
+!**/*/npmscripts.config.js
+
+#
+# Unlike the other configuration files (which can appear inside project
+# subdirectories), there should only ever be one global Prettier configuration
+# file at the top-level, so we do not use a recursive ("**/*") glob here.
+#
 !.prettierrc.js
-!npmscripts.config.js
+
+##
+## Generated files
+##
 
 #
-# Generated files.
+# For the most part, these are artifacts of our installation and build
+# processes and exist only as untracked files. A small number are committed
+# to the repository, but as they are generated files the linter should
+# not touch them.
 #
-
 **/*.soy.js
 **/build/**/*
 **/classes/**/*
 **/css/clay/**/*
 **/node_modules/**/*
-**/sdk/**/*
 **/zippableResources/**/*
 
-#
-# Restricted paths.
-#
+##
+## Sample files
+##
 
+#
+# The few files here are provided for example purposes and are not actively
+# changed, so we exclude them from linting.
+#
+**/sdk/**/*
+
+##
+## Restricted paths
+##
+
+#
+# Any pull request that touches files under this path will be immediately closed
+# by the bot.
+#
 modules/tests/poshi-runner/**/*

--- a/modules/.prettierignore
+++ b/modules/.prettierignore
@@ -1,34 +1,57 @@
-#
-# Generated files.
-#
+##
+## Generated files
+##
 
+#
+# For the most part, these are artifacts of our installation and build
+# processes and exist only as untracked files. A small number are committed
+# to the repository, but as they are generated files the linter should
+# not touch them.
+#
 **/*.soy.js
 **/build/**/*
 **/classes/**/*
 **/css/clay/**/*
 
-#
-# Template file that needs trailing blank line.
-#
+##
+## Template files
+##
 
+#
+# This file defines the copyright headers the linter should add to any file
+# that does not have them. In order to produce the desired result when
+# prepended, it must have a trailing blank line. Prettier would remove the blank
+# line if we did not ignore it here.
+#
 /copyright.js
 
-#
-# Restricted paths.
-#
+##
+## Restricted paths
+##
 
+#
+# Any pull request that touches files under this path will be immediately closed
+# by the bot.
+#
 /modules/tests/poshi-runner/**/*
 
-#
-# Sample files.
-#
+##
+## Sample files
+##
 
+#
+# These files are empty, apart from copyright headers, which means that we need
+# to ignore them to prevent Prettier from stripping off the trailing blank line.
+#
 apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/test/resources/com/liferay/portal/portlet/bridge/soy/internal/dependencies/**/*.js
 apps/fragment/fragment-demo-data-creator-impl/src/main/resources/com/liferay/fragment/demo/data/creator/internal/dependencies/**/*.js
 apps/fragment/fragment-test/src/testIntegration/resources/com/liferay/fragment/dependencies/**/*.js
 
-#
-# Third-party.
-#
+##
+## Third-party
+##
 
+#
+# This is a generated third-party file, not intended for editing or inspection.
+#
 /yarn-*.js


### PR DESCRIPTION
This commit fleshes out the comments in the .eslintignore and .prettierignore files.

I tried to model it on the portal.properties style, with one notable difference: we cannot indent the lines to make the sections stand out because both Prettier and ESLint are whitespaces-sensitive, treating any leading whitespace as part of the glob patterns (which doesn't make any sense, but it's not something we can realistically change).