### PR TITLE
LPS-96632 Allow filtering and sorting in graphQL

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
@@ -31,6 +31,8 @@ import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.function.BiFunction;
+
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -80,9 +82,9 @@ public class Query {
 	public KeywordPage getSiteKeywordsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -90,8 +92,10 @@ public class Query {
 			this::_populateResourceContext,
 			keywordResource -> new KeywordPage(
 				keywordResource.getSiteKeywordsPage(
-					siteId, search, filter, Pagination.of(page, pageSize),
-					sorts)));
+					siteId, search,
+					_filterBiFunction.apply(keywordResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(keywordResource, sort))));
 	}
 
 	@GraphQLField
@@ -99,9 +103,9 @@ public class Query {
 			@GraphQLName("parentTaxonomyCategoryId") Long
 				parentTaxonomyCategoryId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -110,8 +114,12 @@ public class Query {
 			taxonomyCategoryResource -> new TaxonomyCategoryPage(
 				taxonomyCategoryResource.
 					getTaxonomyCategoryTaxonomyCategoriesPage(
-						parentTaxonomyCategoryId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						parentTaxonomyCategoryId, search,
+						_filterBiFunction.apply(
+							taxonomyCategoryResource, filter),
+						Pagination.of(page, pageSize),
+						_sortBiFunction.apply(
+							taxonomyCategoryResource, sort))));
 	}
 
 	@GraphQLField
@@ -131,9 +139,9 @@ public class Query {
 	public TaxonomyCategoryPage getTaxonomyVocabularyTaxonomyCategoriesPage(
 			@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -142,17 +150,21 @@ public class Query {
 			taxonomyCategoryResource -> new TaxonomyCategoryPage(
 				taxonomyCategoryResource.
 					getTaxonomyVocabularyTaxonomyCategoriesPage(
-						taxonomyVocabularyId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						taxonomyVocabularyId, search,
+						_filterBiFunction.apply(
+							taxonomyCategoryResource, filter),
+						Pagination.of(page, pageSize),
+						_sortBiFunction.apply(
+							taxonomyCategoryResource, sort))));
 	}
 
 	@GraphQLField
 	public TaxonomyVocabularyPage getSiteTaxonomyVocabulariesPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -160,8 +172,10 @@ public class Query {
 			this::_populateResourceContext,
 			taxonomyVocabularyResource -> new TaxonomyVocabularyPage(
 				taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
-					siteId, search, filter, Pagination.of(page, pageSize),
-					sorts)));
+					siteId, search,
+					_filterBiFunction.apply(taxonomyVocabularyResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(taxonomyVocabularyResource, sort))));
 	}
 
 	@GraphQLField
@@ -299,6 +313,8 @@ public class Query {
 		_taxonomyVocabularyResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
+	private BiFunction<Object, String, Filter> _filterBiFunction;
+	private BiFunction<Object, String, Sort[]> _sortBiFunction;
 	private Company _company;
 
 }

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
@@ -43,6 +43,8 @@ import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.function.BiFunction;
+
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -167,9 +169,9 @@ public class Query {
 	@GraphQLField
 	public OrganizationPage getOrganizationsPage(
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -177,7 +179,10 @@ public class Query {
 			this::_populateResourceContext,
 			organizationResource -> new OrganizationPage(
 				organizationResource.getOrganizationsPage(
-					search, filter, Pagination.of(page, pageSize), sorts)));
+					search,
+					_filterBiFunction.apply(organizationResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(organizationResource, sort))));
 	}
 
 	@GraphQLField
@@ -196,9 +201,9 @@ public class Query {
 	public OrganizationPage getOrganizationOrganizationsPage(
 			@GraphQLName("parentOrganizationId") Long parentOrganizationId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -206,8 +211,10 @@ public class Query {
 			this::_populateResourceContext,
 			organizationResource -> new OrganizationPage(
 				organizationResource.getOrganizationOrganizationsPage(
-					parentOrganizationId, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					parentOrganizationId, search,
+					_filterBiFunction.apply(organizationResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(organizationResource, sort))));
 	}
 
 	@GraphQLField
@@ -359,9 +366,9 @@ public class Query {
 	public UserAccountPage getOrganizationUserAccountsPage(
 			@GraphQLName("organizationId") Long organizationId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -369,16 +376,18 @@ public class Query {
 			this::_populateResourceContext,
 			userAccountResource -> new UserAccountPage(
 				userAccountResource.getOrganizationUserAccountsPage(
-					organizationId, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					organizationId, search,
+					_filterBiFunction.apply(userAccountResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(userAccountResource, sort))));
 	}
 
 	@GraphQLField
 	public UserAccountPage getUserAccountsPage(
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -386,7 +395,10 @@ public class Query {
 			this::_populateResourceContext,
 			userAccountResource -> new UserAccountPage(
 				userAccountResource.getUserAccountsPage(
-					search, filter, Pagination.of(page, pageSize), sorts)));
+					search,
+					_filterBiFunction.apply(userAccountResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(userAccountResource, sort))));
 	}
 
 	@GraphQLField
@@ -405,9 +417,9 @@ public class Query {
 	public UserAccountPage getWebSiteUserAccountsPage(
 			@GraphQLName("webSiteId") Long webSiteId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -415,8 +427,10 @@ public class Query {
 			this::_populateResourceContext,
 			userAccountResource -> new UserAccountPage(
 				userAccountResource.getWebSiteUserAccountsPage(
-					webSiteId, search, filter, Pagination.of(page, pageSize),
-					sorts)));
+					webSiteId, search,
+					_filterBiFunction.apply(userAccountResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(userAccountResource, sort))));
 	}
 
 	@GraphQLField
@@ -776,6 +790,8 @@ public class Query {
 		_webUrlResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
+	private BiFunction<Object, String, Filter> _filterBiFunction;
+	private BiFunction<Object, String, Sort[]> _sortBiFunction;
 	private Company _company;
 
 }

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/query/v1_0/Query.java
@@ -21,11 +21,15 @@ import com.liferay.headless.admin.workflow.resource.v1_0.WorkflowTaskResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.function.BiFunction;
 
 import javax.annotation.Generated;
 
@@ -225,6 +229,8 @@ public class Query {
 		_workflowTaskResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
+	private BiFunction<Object, String, Filter> _filterBiFunction;
+	private BiFunction<Object, String, Sort[]> _sortBiFunction;
 	private Company _company;
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -58,6 +58,8 @@ import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.function.BiFunction;
+
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -227,9 +229,9 @@ public class Query {
 	public BlogPostingPage getSiteBlogPostingsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -237,8 +239,10 @@ public class Query {
 			this::_populateResourceContext,
 			blogPostingResource -> new BlogPostingPage(
 				blogPostingResource.getSiteBlogPostingsPage(
-					siteId, search, filter, Pagination.of(page, pageSize),
-					sorts)));
+					siteId, search,
+					_filterBiFunction.apply(blogPostingResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(blogPostingResource, sort))));
 	}
 
 	@GraphQLField
@@ -258,9 +262,9 @@ public class Query {
 	public BlogPostingImagePage getSiteBlogPostingImagesPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -268,17 +272,19 @@ public class Query {
 			this::_populateResourceContext,
 			blogPostingImageResource -> new BlogPostingImagePage(
 				blogPostingImageResource.getSiteBlogPostingImagesPage(
-					siteId, search, filter, Pagination.of(page, pageSize),
-					sorts)));
+					siteId, search,
+					_filterBiFunction.apply(blogPostingImageResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(blogPostingImageResource, sort))));
 	}
 
 	@GraphQLField
 	public CommentPage getBlogPostingCommentsPage(
 			@GraphQLName("blogPostingId") Long blogPostingId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -286,8 +292,10 @@ public class Query {
 			this::_populateResourceContext,
 			commentResource -> new CommentPage(
 				commentResource.getBlogPostingCommentsPage(
-					blogPostingId, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					blogPostingId, search,
+					_filterBiFunction.apply(commentResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(commentResource, sort))));
 	}
 
 	@GraphQLField
@@ -304,9 +312,9 @@ public class Query {
 	public CommentPage getCommentCommentsPage(
 			@GraphQLName("parentCommentId") Long parentCommentId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -314,17 +322,19 @@ public class Query {
 			this::_populateResourceContext,
 			commentResource -> new CommentPage(
 				commentResource.getCommentCommentsPage(
-					parentCommentId, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					parentCommentId, search,
+					_filterBiFunction.apply(commentResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(commentResource, sort))));
 	}
 
 	@GraphQLField
 	public CommentPage getDocumentCommentsPage(
 			@GraphQLName("documentId") Long documentId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -332,17 +342,19 @@ public class Query {
 			this::_populateResourceContext,
 			commentResource -> new CommentPage(
 				commentResource.getDocumentCommentsPage(
-					documentId, search, filter, Pagination.of(page, pageSize),
-					sorts)));
+					documentId, search,
+					_filterBiFunction.apply(commentResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(commentResource, sort))));
 	}
 
 	@GraphQLField
 	public CommentPage getStructuredContentCommentsPage(
 			@GraphQLName("structuredContentId") Long structuredContentId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -350,8 +362,10 @@ public class Query {
 			this::_populateResourceContext,
 			commentResource -> new CommentPage(
 				commentResource.getStructuredContentCommentsPage(
-					structuredContentId, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					structuredContentId, search,
+					_filterBiFunction.apply(commentResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(commentResource, sort))));
 	}
 
 	@GraphQLField
@@ -419,9 +433,9 @@ public class Query {
 	public ContentStructurePage getSiteContentStructuresPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -429,17 +443,19 @@ public class Query {
 			this::_populateResourceContext,
 			contentStructureResource -> new ContentStructurePage(
 				contentStructureResource.getSiteContentStructuresPage(
-					siteId, search, filter, Pagination.of(page, pageSize),
-					sorts)));
+					siteId, search,
+					_filterBiFunction.apply(contentStructureResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(contentStructureResource, sort))));
 	}
 
 	@GraphQLField
 	public DocumentPage getDocumentFolderDocumentsPage(
 			@GraphQLName("documentFolderId") Long documentFolderId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -447,8 +463,10 @@ public class Query {
 			this::_populateResourceContext,
 			documentResource -> new DocumentPage(
 				documentResource.getDocumentFolderDocumentsPage(
-					documentFolderId, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					documentFolderId, search,
+					_filterBiFunction.apply(documentResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(documentResource, sort))));
 	}
 
 	@GraphQLField
@@ -478,9 +496,9 @@ public class Query {
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -488,8 +506,10 @@ public class Query {
 			this::_populateResourceContext,
 			documentResource -> new DocumentPage(
 				documentResource.getSiteDocumentsPage(
-					siteId, flatten, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					siteId, flatten, search,
+					_filterBiFunction.apply(documentResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(documentResource, sort))));
 	}
 
 	@GraphQLField
@@ -508,9 +528,9 @@ public class Query {
 	public DocumentFolderPage getDocumentFolderDocumentFoldersPage(
 			@GraphQLName("parentDocumentFolderId") Long parentDocumentFolderId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -518,8 +538,10 @@ public class Query {
 			this::_populateResourceContext,
 			documentFolderResource -> new DocumentFolderPage(
 				documentFolderResource.getDocumentFolderDocumentFoldersPage(
-					parentDocumentFolderId, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					parentDocumentFolderId, search,
+					_filterBiFunction.apply(documentFolderResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(documentFolderResource, sort))));
 	}
 
 	@GraphQLField
@@ -527,9 +549,9 @@ public class Query {
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -537,8 +559,10 @@ public class Query {
 			this::_populateResourceContext,
 			documentFolderResource -> new DocumentFolderPage(
 				documentFolderResource.getSiteDocumentFoldersPage(
-					siteId, flatten, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					siteId, flatten, search,
+					_filterBiFunction.apply(documentFolderResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(documentFolderResource, sort))));
 	}
 
 	@GraphQLField
@@ -573,10 +597,10 @@ public class Query {
 				@GraphQLName("parentKnowledgeBaseArticleId") Long
 					parentKnowledgeBaseArticleId,
 				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
+				@GraphQLName("filter") String filter,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+				@GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -585,8 +609,12 @@ public class Query {
 			knowledgeBaseArticleResource -> new KnowledgeBaseArticlePage(
 				knowledgeBaseArticleResource.
 					getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
-						parentKnowledgeBaseArticleId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						parentKnowledgeBaseArticleId, search,
+						_filterBiFunction.apply(
+							knowledgeBaseArticleResource, filter),
+						Pagination.of(page, pageSize),
+						_sortBiFunction.apply(
+							knowledgeBaseArticleResource, sort))));
 	}
 
 	@GraphQLField
@@ -596,10 +624,10 @@ public class Query {
 					knowledgeBaseFolderId,
 				@GraphQLName("flatten") Boolean flatten,
 				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
+				@GraphQLName("filter") String filter,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+				@GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -608,8 +636,12 @@ public class Query {
 			knowledgeBaseArticleResource -> new KnowledgeBaseArticlePage(
 				knowledgeBaseArticleResource.
 					getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
-						knowledgeBaseFolderId, flatten, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						knowledgeBaseFolderId, flatten, search,
+						_filterBiFunction.apply(
+							knowledgeBaseArticleResource, filter),
+						Pagination.of(page, pageSize),
+						_sortBiFunction.apply(
+							knowledgeBaseArticleResource, sort))));
 	}
 
 	@GraphQLField
@@ -617,9 +649,9 @@ public class Query {
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -627,8 +659,12 @@ public class Query {
 			this::_populateResourceContext,
 			knowledgeBaseArticleResource -> new KnowledgeBaseArticlePage(
 				knowledgeBaseArticleResource.getSiteKnowledgeBaseArticlesPage(
-					siteId, flatten, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					siteId, flatten, search,
+					_filterBiFunction.apply(
+						knowledgeBaseArticleResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(
+						knowledgeBaseArticleResource, sort))));
 	}
 
 	@GraphQLField
@@ -785,10 +821,10 @@ public class Query {
 				@GraphQLName("parentMessageBoardMessageId") Long
 					parentMessageBoardMessageId,
 				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
+				@GraphQLName("filter") String filter,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+				@GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -797,8 +833,12 @@ public class Query {
 			messageBoardMessageResource -> new MessageBoardMessagePage(
 				messageBoardMessageResource.
 					getMessageBoardMessageMessageBoardMessagesPage(
-						parentMessageBoardMessageId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						parentMessageBoardMessageId, search,
+						_filterBiFunction.apply(
+							messageBoardMessageResource, filter),
+						Pagination.of(page, pageSize),
+						_sortBiFunction.apply(
+							messageBoardMessageResource, sort))));
 	}
 
 	@GraphQLField
@@ -806,10 +846,10 @@ public class Query {
 			getMessageBoardThreadMessageBoardMessagesPage(
 				@GraphQLName("messageBoardThreadId") Long messageBoardThreadId,
 				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
+				@GraphQLName("filter") String filter,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+				@GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -818,8 +858,12 @@ public class Query {
 			messageBoardMessageResource -> new MessageBoardMessagePage(
 				messageBoardMessageResource.
 					getMessageBoardThreadMessageBoardMessagesPage(
-						messageBoardThreadId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						messageBoardThreadId, search,
+						_filterBiFunction.apply(
+							messageBoardMessageResource, filter),
+						Pagination.of(page, pageSize),
+						_sortBiFunction.apply(
+							messageBoardMessageResource, sort))));
 	}
 
 	@GraphQLField
@@ -841,10 +885,10 @@ public class Query {
 				@GraphQLName("parentMessageBoardSectionId") Long
 					parentMessageBoardSectionId,
 				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
+				@GraphQLName("filter") String filter,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+				@GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -853,8 +897,12 @@ public class Query {
 			messageBoardSectionResource -> new MessageBoardSectionPage(
 				messageBoardSectionResource.
 					getMessageBoardSectionMessageBoardSectionsPage(
-						parentMessageBoardSectionId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						parentMessageBoardSectionId, search,
+						_filterBiFunction.apply(
+							messageBoardSectionResource, filter),
+						Pagination.of(page, pageSize),
+						_sortBiFunction.apply(
+							messageBoardSectionResource, sort))));
 	}
 
 	@GraphQLField
@@ -862,9 +910,9 @@ public class Query {
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -872,17 +920,20 @@ public class Query {
 			this::_populateResourceContext,
 			messageBoardSectionResource -> new MessageBoardSectionPage(
 				messageBoardSectionResource.getSiteMessageBoardSectionsPage(
-					siteId, flatten, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					siteId, flatten, search,
+					_filterBiFunction.apply(
+						messageBoardSectionResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(messageBoardSectionResource, sort))));
 	}
 
 	@GraphQLField
 	public MessageBoardThreadPage getMessageBoardSectionMessageBoardThreadsPage(
 			@GraphQLName("messageBoardSectionId") Long messageBoardSectionId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -891,8 +942,12 @@ public class Query {
 			messageBoardThreadResource -> new MessageBoardThreadPage(
 				messageBoardThreadResource.
 					getMessageBoardSectionMessageBoardThreadsPage(
-						messageBoardSectionId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						messageBoardSectionId, search,
+						_filterBiFunction.apply(
+							messageBoardThreadResource, filter),
+						Pagination.of(page, pageSize),
+						_sortBiFunction.apply(
+							messageBoardThreadResource, sort))));
 	}
 
 	@GraphQLField
@@ -926,9 +981,9 @@ public class Query {
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -936,17 +991,19 @@ public class Query {
 			this::_populateResourceContext,
 			messageBoardThreadResource -> new MessageBoardThreadPage(
 				messageBoardThreadResource.getSiteMessageBoardThreadsPage(
-					siteId, flatten, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					siteId, flatten, search,
+					_filterBiFunction.apply(messageBoardThreadResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(messageBoardThreadResource, sort))));
 	}
 
 	@GraphQLField
 	public StructuredContentPage getContentStructureStructuredContentsPage(
 			@GraphQLName("contentStructureId") Long contentStructureId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -955,8 +1012,12 @@ public class Query {
 			structuredContentResource -> new StructuredContentPage(
 				structuredContentResource.
 					getContentStructureStructuredContentsPage(
-						contentStructureId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						contentStructureId, search,
+						_filterBiFunction.apply(
+							structuredContentResource, filter),
+						Pagination.of(page, pageSize),
+						_sortBiFunction.apply(
+							structuredContentResource, sort))));
 	}
 
 	@GraphQLField
@@ -964,9 +1025,9 @@ public class Query {
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -974,8 +1035,10 @@ public class Query {
 			this::_populateResourceContext,
 			structuredContentResource -> new StructuredContentPage(
 				structuredContentResource.getSiteStructuredContentsPage(
-					siteId, flatten, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					siteId, flatten, search,
+					_filterBiFunction.apply(structuredContentResource, filter),
+					Pagination.of(page, pageSize),
+					_sortBiFunction.apply(structuredContentResource, sort))));
 	}
 
 	@GraphQLField
@@ -1011,10 +1074,10 @@ public class Query {
 				@GraphQLName("structuredContentFolderId") Long
 					structuredContentFolderId,
 				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
+				@GraphQLName("filter") String filter,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+				@GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -1023,8 +1086,12 @@ public class Query {
 			structuredContentResource -> new StructuredContentPage(
 				structuredContentResource.
 					getStructuredContentFolderStructuredContentsPage(
-						structuredContentFolderId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						structuredContentFolderId, search,
+						_filterBiFunction.apply(
+							structuredContentResource, filter),
+						Pagination.of(page, pageSize),
+						_sortBiFunction.apply(
+							structuredContentResource, sort))));
 	}
 
 	@GraphQLField
@@ -1073,9 +1140,9 @@ public class Query {
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filter,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page, @GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -1084,8 +1151,12 @@ public class Query {
 			structuredContentFolderResource -> new StructuredContentFolderPage(
 				structuredContentFolderResource.
 					getSiteStructuredContentFoldersPage(
-						siteId, flatten, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						siteId, flatten, search,
+						_filterBiFunction.apply(
+							structuredContentFolderResource, filter),
+						Pagination.of(page, pageSize),
+						_sortBiFunction.apply(
+							structuredContentFolderResource, sort))));
 	}
 
 	@GraphQLField
@@ -1094,10 +1165,10 @@ public class Query {
 				@GraphQLName("parentStructuredContentFolderId") Long
 					parentStructuredContentFolderId,
 				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
+				@GraphQLName("filter") String filter,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+				@GraphQLName("sorts") String sort)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -1106,8 +1177,12 @@ public class Query {
 			structuredContentFolderResource -> new StructuredContentFolderPage(
 				structuredContentFolderResource.
 					getStructuredContentFolderStructuredContentFoldersPage(
-						parentStructuredContentFolderId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						parentStructuredContentFolderId, search,
+						_filterBiFunction.apply(
+							structuredContentFolderResource, filter),
+						Pagination.of(page, pageSize),
+						_sortBiFunction.apply(
+							structuredContentFolderResource, sort))));
 	}
 
 	@GraphQLField
@@ -1690,6 +1765,8 @@ public class Query {
 		_structuredContentFolderResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
+	private BiFunction<Object, String, Filter> _filterBiFunction;
+	private BiFunction<Object, String, Sort[]> _sortBiFunction;
 	private Company _company;
 
 }

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/query/v1_0/Query.java
@@ -26,11 +26,15 @@ import com.liferay.headless.form.resource.v1_0.FormStructureResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.function.BiFunction;
 
 import javax.annotation.Generated;
 
@@ -331,6 +335,8 @@ public class Query {
 		_formStructureResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
+	private BiFunction<Object, String, Filter> _filterBiFunction;
+	private BiFunction<Object, String, Sort[]> _sortBiFunction;
 	private Company _company;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/ContextProviderUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/ContextProviderUtil.java
@@ -17,11 +17,14 @@ package com.liferay.portal.vulcan.internal.jaxrs.context.provider;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
 import javax.ws.rs.container.ResourceContext;
+import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
 
@@ -58,6 +61,18 @@ public class ContextProviderUtil {
 	public static HttpServletRequest getHttpServletRequest(Message message) {
 		return (HttpServletRequest)message.getContextualProperty(
 			"HTTP.REQUEST");
+	}
+
+	public static MultivaluedHashMap<String, String> getMultivaluedHashMap(
+		Map<String, String[]> parameterMap) {
+
+		return new MultivaluedHashMap<String, String>() {
+			{
+				for (Entry<String, String[]> entry : parameterMap.entrySet()) {
+					put(entry.getKey(), Arrays.asList(entry.getValue()));
+				}
+			}
+		};
 	}
 
 	private static Object _getMatchedResource(Message message) {

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/SortContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/SortContextProvider.java
@@ -54,24 +54,9 @@ public class SortContextProvider implements ContextProvider<Sort[]> {
 		_sortParserProvider = sortParserProvider;
 	}
 
-	@Override
-	public Sort[] createContext(Message message) {
-		try {
-			return _createContext(message);
-		}
-		catch (InvalidSortException ise) {
-			throw ise;
-		}
-		catch (Exception e) {
-			throw new ServerErrorException(500, e);
-		}
-	}
-
-	private Sort[] _createContext(Message message) throws Exception {
-		HttpServletRequest httpServletRequest =
-			ContextProviderUtil.getHttpServletRequest(message);
-
-		String sortString = ParamUtil.getString(httpServletRequest, "sort");
+	public Sort[] createContext(
+		AcceptLanguage acceptLanguage, EntityModel entityModel,
+		String sortString) {
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("Sort parameter value: " + sortString);
@@ -80,8 +65,6 @@ public class SortContextProvider implements ContextProvider<Sort[]> {
 		if (Validator.isNull(sortString)) {
 			return null;
 		}
-
-		EntityModel entityModel = ContextProviderUtil.getEntityModel(message);
 
 		if (_log.isDebugEnabled()) {
 			if (entityModel != null) {
@@ -107,9 +90,6 @@ public class SortContextProvider implements ContextProvider<Sort[]> {
 			_log.debug("OData sort: " + oDataSort);
 		}
 
-		AcceptLanguage acceptLanguage = new AcceptLanguageImpl(
-			httpServletRequest, _language, _portal);
-
 		List<SortField> sortFields = oDataSort.getSortFields();
 
 		Sort[] sorts = new Sort[sortFields.size()];
@@ -124,6 +104,25 @@ public class SortContextProvider implements ContextProvider<Sort[]> {
 		}
 
 		return sorts;
+	}
+
+	@Override
+	public Sort[] createContext(Message message) {
+		try {
+			HttpServletRequest httpServletRequest =
+				ContextProviderUtil.getHttpServletRequest(message);
+
+			return createContext(
+				new AcceptLanguageImpl(httpServletRequest, _language, _portal),
+				ContextProviderUtil.getEntityModel(message),
+				ParamUtil.getString(httpServletRequest, "sort"));
+		}
+		catch (InvalidSortException ise) {
+			throw ise;
+		}
+		catch (Exception e) {
+			throw new ServerErrorException(500, e);
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_query.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_query.ftl
@@ -20,6 +20,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.Date;
+import java.util.function.BiFunction;
 
 import javax.annotation.Generated;
 
@@ -56,7 +57,7 @@ public class Query {
 			${javaMethodSignature.returnType}
 		</#if>
 
-		${javaMethodSignature.methodName}(${freeMarkerTool.getGraphQLParameters(javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, true)}) throws Exception {
+		${javaMethodSignature.methodName}(${freeMarkerTool.getGraphQLParameters(javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, true)?replace("com.liferay.portal.kernel.search.filter.Filter filter", "String filter")?replace("com.liferay.portal.kernel.search.Sort[] sorts", "String sort")}) throws Exception {
 			<#assign arguments = freeMarkerTool.getGraphQLArguments(javaMethodSignature.javaMethodParameters) />
 
 			<#if javaMethodSignature.returnType?contains("Collection<")>
@@ -65,7 +66,7 @@ public class Query {
 					this::_populateResourceContext,
 					${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource ->
 						new ${javaMethodSignature.schemaName}Page(
-							${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource.${javaMethodSignature.methodName}(${arguments?replace("pageSize,page", "Pagination.of(page, pageSize)")}))
+							${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource.${javaMethodSignature.methodName}(${arguments?replace("pageSize,page", "Pagination.of(page, pageSize)")?replace("filter", "_filterBiFunction.apply(${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource, filter)")?replace("sorts", "_sortBiFunction.apply(${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource, sort)")}))
 					);
 			<#else>
 				return _applyComponentServiceObjects(_${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}ResourceComponentServiceObjects, this::_populateResourceContext, ${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource -> ${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource.${javaMethodSignature.methodName}(${arguments?replace("pageSize,page", "Pagination.of(page, pageSize)")}));
@@ -124,6 +125,8 @@ public class Query {
 	</#list>
 
 	private AcceptLanguage _acceptLanguage;
+	private BiFunction<Object, String, Filter> _filterBiFunction;
+	private BiFunction<Object, String, Sort[]> _sortBiFunction;
 	private Company _company;
 
 }


### PR DESCRIPTION
We need both httpRequest (inside GraphQLExtender) and the resource (inside each Query) and that's why we need a function, to propagate everything. 

GraphQL types aren't useful because they can't depend on the HTTPRequest.