### PR TITLE
LPS-96632 Support sort and filter in GraphQL

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
@@ -32,6 +32,8 @@ import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.function.BiFunction;
+
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -81,9 +83,10 @@ public class Query {
 	public KeywordPage getSiteKeywordsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -91,8 +94,10 @@ public class Query {
 			this::_populateResourceContext,
 			keywordResource -> new KeywordPage(
 				keywordResource.getSiteKeywordsPage(
-					siteId, search, filter, Pagination.of(page, pageSize),
-					sorts)));
+					siteId, search,
+					_filterByFunction.apply(keywordResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(keywordResource, sortString))));
 	}
 
 	@GraphQLField
@@ -100,9 +105,10 @@ public class Query {
 			@GraphQLName("parentTaxonomyCategoryId") Long
 				parentTaxonomyCategoryId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -111,8 +117,12 @@ public class Query {
 			taxonomyCategoryResource -> new TaxonomyCategoryPage(
 				taxonomyCategoryResource.
 					getTaxonomyCategoryTaxonomyCategoriesPage(
-						parentTaxonomyCategoryId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						parentTaxonomyCategoryId, search,
+						_filterByFunction.apply(
+							taxonomyCategoryResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortByFunction.apply(
+							taxonomyCategoryResource, sortString))));
 	}
 
 	@GraphQLField
@@ -132,9 +142,10 @@ public class Query {
 	public TaxonomyCategoryPage getTaxonomyVocabularyTaxonomyCategoriesPage(
 			@GraphQLName("taxonomyVocabularyId") Long taxonomyVocabularyId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -143,17 +154,22 @@ public class Query {
 			taxonomyCategoryResource -> new TaxonomyCategoryPage(
 				taxonomyCategoryResource.
 					getTaxonomyVocabularyTaxonomyCategoriesPage(
-						taxonomyVocabularyId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						taxonomyVocabularyId, search,
+						_filterByFunction.apply(
+							taxonomyCategoryResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortByFunction.apply(
+							taxonomyCategoryResource, sortString))));
 	}
 
 	@GraphQLField
 	public TaxonomyVocabularyPage getSiteTaxonomyVocabulariesPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -161,8 +177,12 @@ public class Query {
 			this::_populateResourceContext,
 			taxonomyVocabularyResource -> new TaxonomyVocabularyPage(
 				taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
-					siteId, search, filter, Pagination.of(page, pageSize),
-					sorts)));
+					siteId, search,
+					_filterByFunction.apply(
+						taxonomyVocabularyResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(
+						taxonomyVocabularyResource, sortString))));
 	}
 
 	@GraphQLField
@@ -303,6 +323,8 @@ public class Query {
 		_taxonomyVocabularyResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
+	private BiFunction<Object, String, Filter> _filterByFunction;
+	private BiFunction<Object, String, Sort[]> _sortByFunction;
 	private Company _company;
 	private User _user;
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
@@ -44,6 +44,8 @@ import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.function.BiFunction;
+
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -168,9 +170,10 @@ public class Query {
 	@GraphQLField
 	public OrganizationPage getOrganizationsPage(
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -178,7 +181,10 @@ public class Query {
 			this::_populateResourceContext,
 			organizationResource -> new OrganizationPage(
 				organizationResource.getOrganizationsPage(
-					search, filter, Pagination.of(page, pageSize), sorts)));
+					search,
+					_filterByFunction.apply(organizationResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(organizationResource, sortString))));
 	}
 
 	@GraphQLField
@@ -197,9 +203,10 @@ public class Query {
 	public OrganizationPage getOrganizationOrganizationsPage(
 			@GraphQLName("parentOrganizationId") Long parentOrganizationId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -207,8 +214,10 @@ public class Query {
 			this::_populateResourceContext,
 			organizationResource -> new OrganizationPage(
 				organizationResource.getOrganizationOrganizationsPage(
-					parentOrganizationId, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					parentOrganizationId, search,
+					_filterByFunction.apply(organizationResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(organizationResource, sortString))));
 	}
 
 	@GraphQLField
@@ -360,9 +369,10 @@ public class Query {
 	public UserAccountPage getOrganizationUserAccountsPage(
 			@GraphQLName("organizationId") Long organizationId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -370,16 +380,19 @@ public class Query {
 			this::_populateResourceContext,
 			userAccountResource -> new UserAccountPage(
 				userAccountResource.getOrganizationUserAccountsPage(
-					organizationId, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					organizationId, search,
+					_filterByFunction.apply(userAccountResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(userAccountResource, sortString))));
 	}
 
 	@GraphQLField
 	public UserAccountPage getUserAccountsPage(
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -387,7 +400,10 @@ public class Query {
 			this::_populateResourceContext,
 			userAccountResource -> new UserAccountPage(
 				userAccountResource.getUserAccountsPage(
-					search, filter, Pagination.of(page, pageSize), sorts)));
+					search,
+					_filterByFunction.apply(userAccountResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(userAccountResource, sortString))));
 	}
 
 	@GraphQLField
@@ -406,9 +422,10 @@ public class Query {
 	public UserAccountPage getWebSiteUserAccountsPage(
 			@GraphQLName("webSiteId") Long webSiteId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -416,8 +433,10 @@ public class Query {
 			this::_populateResourceContext,
 			userAccountResource -> new UserAccountPage(
 				userAccountResource.getWebSiteUserAccountsPage(
-					webSiteId, search, filter, Pagination.of(page, pageSize),
-					sorts)));
+					webSiteId, search,
+					_filterByFunction.apply(userAccountResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(userAccountResource, sortString))));
 	}
 
 	@GraphQLField
@@ -786,6 +805,8 @@ public class Query {
 		_webUrlResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
+	private BiFunction<Object, String, Filter> _filterByFunction;
+	private BiFunction<Object, String, Sort[]> _sortByFunction;
 	private Company _company;
 	private User _user;
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/query/v1_0/Query.java
@@ -22,11 +22,15 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.function.BiFunction;
 
 import javax.annotation.Generated;
 
@@ -228,6 +232,8 @@ public class Query {
 		_workflowTaskResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
+	private BiFunction<Object, String, Filter> _filterByFunction;
+	private BiFunction<Object, String, Sort[]> _sortByFunction;
 	private Company _company;
 	private User _user;
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -59,6 +59,8 @@ import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.function.BiFunction;
+
 import javax.annotation.Generated;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -228,9 +230,10 @@ public class Query {
 	public BlogPostingPage getSiteBlogPostingsPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -238,8 +241,10 @@ public class Query {
 			this::_populateResourceContext,
 			blogPostingResource -> new BlogPostingPage(
 				blogPostingResource.getSiteBlogPostingsPage(
-					siteId, search, filter, Pagination.of(page, pageSize),
-					sorts)));
+					siteId, search,
+					_filterByFunction.apply(blogPostingResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(blogPostingResource, sortString))));
 	}
 
 	@GraphQLField
@@ -259,9 +264,10 @@ public class Query {
 	public BlogPostingImagePage getSiteBlogPostingImagesPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -269,17 +275,22 @@ public class Query {
 			this::_populateResourceContext,
 			blogPostingImageResource -> new BlogPostingImagePage(
 				blogPostingImageResource.getSiteBlogPostingImagesPage(
-					siteId, search, filter, Pagination.of(page, pageSize),
-					sorts)));
+					siteId, search,
+					_filterByFunction.apply(
+						blogPostingImageResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(
+						blogPostingImageResource, sortString))));
 	}
 
 	@GraphQLField
 	public CommentPage getBlogPostingCommentsPage(
 			@GraphQLName("blogPostingId") Long blogPostingId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -287,8 +298,10 @@ public class Query {
 			this::_populateResourceContext,
 			commentResource -> new CommentPage(
 				commentResource.getBlogPostingCommentsPage(
-					blogPostingId, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					blogPostingId, search,
+					_filterByFunction.apply(commentResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(commentResource, sortString))));
 	}
 
 	@GraphQLField
@@ -305,9 +318,10 @@ public class Query {
 	public CommentPage getCommentCommentsPage(
 			@GraphQLName("parentCommentId") Long parentCommentId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -315,17 +329,20 @@ public class Query {
 			this::_populateResourceContext,
 			commentResource -> new CommentPage(
 				commentResource.getCommentCommentsPage(
-					parentCommentId, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					parentCommentId, search,
+					_filterByFunction.apply(commentResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(commentResource, sortString))));
 	}
 
 	@GraphQLField
 	public CommentPage getDocumentCommentsPage(
 			@GraphQLName("documentId") Long documentId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -333,17 +350,20 @@ public class Query {
 			this::_populateResourceContext,
 			commentResource -> new CommentPage(
 				commentResource.getDocumentCommentsPage(
-					documentId, search, filter, Pagination.of(page, pageSize),
-					sorts)));
+					documentId, search,
+					_filterByFunction.apply(commentResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(commentResource, sortString))));
 	}
 
 	@GraphQLField
 	public CommentPage getStructuredContentCommentsPage(
 			@GraphQLName("structuredContentId") Long structuredContentId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -351,8 +371,10 @@ public class Query {
 			this::_populateResourceContext,
 			commentResource -> new CommentPage(
 				commentResource.getStructuredContentCommentsPage(
-					structuredContentId, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					structuredContentId, search,
+					_filterByFunction.apply(commentResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(commentResource, sortString))));
 	}
 
 	@GraphQLField
@@ -420,9 +442,10 @@ public class Query {
 	public ContentStructurePage getSiteContentStructuresPage(
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -430,17 +453,22 @@ public class Query {
 			this::_populateResourceContext,
 			contentStructureResource -> new ContentStructurePage(
 				contentStructureResource.getSiteContentStructuresPage(
-					siteId, search, filter, Pagination.of(page, pageSize),
-					sorts)));
+					siteId, search,
+					_filterByFunction.apply(
+						contentStructureResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(
+						contentStructureResource, sortString))));
 	}
 
 	@GraphQLField
 	public DocumentPage getDocumentFolderDocumentsPage(
 			@GraphQLName("documentFolderId") Long documentFolderId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -448,8 +476,10 @@ public class Query {
 			this::_populateResourceContext,
 			documentResource -> new DocumentPage(
 				documentResource.getDocumentFolderDocumentsPage(
-					documentFolderId, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					documentFolderId, search,
+					_filterByFunction.apply(documentResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(documentResource, sortString))));
 	}
 
 	@GraphQLField
@@ -479,9 +509,10 @@ public class Query {
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -489,8 +520,10 @@ public class Query {
 			this::_populateResourceContext,
 			documentResource -> new DocumentPage(
 				documentResource.getSiteDocumentsPage(
-					siteId, flatten, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					siteId, flatten, search,
+					_filterByFunction.apply(documentResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(documentResource, sortString))));
 	}
 
 	@GraphQLField
@@ -509,9 +542,10 @@ public class Query {
 	public DocumentFolderPage getDocumentFolderDocumentFoldersPage(
 			@GraphQLName("parentDocumentFolderId") Long parentDocumentFolderId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -519,8 +553,12 @@ public class Query {
 			this::_populateResourceContext,
 			documentFolderResource -> new DocumentFolderPage(
 				documentFolderResource.getDocumentFolderDocumentFoldersPage(
-					parentDocumentFolderId, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					parentDocumentFolderId, search,
+					_filterByFunction.apply(
+						documentFolderResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(
+						documentFolderResource, sortString))));
 	}
 
 	@GraphQLField
@@ -528,9 +566,10 @@ public class Query {
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -538,8 +577,12 @@ public class Query {
 			this::_populateResourceContext,
 			documentFolderResource -> new DocumentFolderPage(
 				documentFolderResource.getSiteDocumentFoldersPage(
-					siteId, flatten, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					siteId, flatten, search,
+					_filterByFunction.apply(
+						documentFolderResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(
+						documentFolderResource, sortString))));
 	}
 
 	@GraphQLField
@@ -574,10 +617,10 @@ public class Query {
 				@GraphQLName("parentKnowledgeBaseArticleId") Long
 					parentKnowledgeBaseArticleId,
 				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
+				@GraphQLName("filter") String filterString,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+				@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -586,8 +629,12 @@ public class Query {
 			knowledgeBaseArticleResource -> new KnowledgeBaseArticlePage(
 				knowledgeBaseArticleResource.
 					getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
-						parentKnowledgeBaseArticleId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						parentKnowledgeBaseArticleId, search,
+						_filterByFunction.apply(
+							knowledgeBaseArticleResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortByFunction.apply(
+							knowledgeBaseArticleResource, sortString))));
 	}
 
 	@GraphQLField
@@ -597,10 +644,10 @@ public class Query {
 					knowledgeBaseFolderId,
 				@GraphQLName("flatten") Boolean flatten,
 				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
+				@GraphQLName("filter") String filterString,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+				@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -609,8 +656,12 @@ public class Query {
 			knowledgeBaseArticleResource -> new KnowledgeBaseArticlePage(
 				knowledgeBaseArticleResource.
 					getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
-						knowledgeBaseFolderId, flatten, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						knowledgeBaseFolderId, flatten, search,
+						_filterByFunction.apply(
+							knowledgeBaseArticleResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortByFunction.apply(
+							knowledgeBaseArticleResource, sortString))));
 	}
 
 	@GraphQLField
@@ -618,9 +669,10 @@ public class Query {
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -628,8 +680,12 @@ public class Query {
 			this::_populateResourceContext,
 			knowledgeBaseArticleResource -> new KnowledgeBaseArticlePage(
 				knowledgeBaseArticleResource.getSiteKnowledgeBaseArticlesPage(
-					siteId, flatten, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					siteId, flatten, search,
+					_filterByFunction.apply(
+						knowledgeBaseArticleResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(
+						knowledgeBaseArticleResource, sortString))));
 	}
 
 	@GraphQLField
@@ -786,10 +842,10 @@ public class Query {
 				@GraphQLName("parentMessageBoardMessageId") Long
 					parentMessageBoardMessageId,
 				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
+				@GraphQLName("filter") String filterString,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+				@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -798,8 +854,12 @@ public class Query {
 			messageBoardMessageResource -> new MessageBoardMessagePage(
 				messageBoardMessageResource.
 					getMessageBoardMessageMessageBoardMessagesPage(
-						parentMessageBoardMessageId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						parentMessageBoardMessageId, search,
+						_filterByFunction.apply(
+							messageBoardMessageResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortByFunction.apply(
+							messageBoardMessageResource, sortString))));
 	}
 
 	@GraphQLField
@@ -807,10 +867,10 @@ public class Query {
 			getMessageBoardThreadMessageBoardMessagesPage(
 				@GraphQLName("messageBoardThreadId") Long messageBoardThreadId,
 				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
+				@GraphQLName("filter") String filterString,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+				@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -819,8 +879,12 @@ public class Query {
 			messageBoardMessageResource -> new MessageBoardMessagePage(
 				messageBoardMessageResource.
 					getMessageBoardThreadMessageBoardMessagesPage(
-						messageBoardThreadId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						messageBoardThreadId, search,
+						_filterByFunction.apply(
+							messageBoardMessageResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortByFunction.apply(
+							messageBoardMessageResource, sortString))));
 	}
 
 	@GraphQLField
@@ -842,10 +906,10 @@ public class Query {
 				@GraphQLName("parentMessageBoardSectionId") Long
 					parentMessageBoardSectionId,
 				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
+				@GraphQLName("filter") String filterString,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+				@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -854,8 +918,12 @@ public class Query {
 			messageBoardSectionResource -> new MessageBoardSectionPage(
 				messageBoardSectionResource.
 					getMessageBoardSectionMessageBoardSectionsPage(
-						parentMessageBoardSectionId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						parentMessageBoardSectionId, search,
+						_filterByFunction.apply(
+							messageBoardSectionResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortByFunction.apply(
+							messageBoardSectionResource, sortString))));
 	}
 
 	@GraphQLField
@@ -863,9 +931,10 @@ public class Query {
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -873,17 +942,22 @@ public class Query {
 			this::_populateResourceContext,
 			messageBoardSectionResource -> new MessageBoardSectionPage(
 				messageBoardSectionResource.getSiteMessageBoardSectionsPage(
-					siteId, flatten, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					siteId, flatten, search,
+					_filterByFunction.apply(
+						messageBoardSectionResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(
+						messageBoardSectionResource, sortString))));
 	}
 
 	@GraphQLField
 	public MessageBoardThreadPage getMessageBoardSectionMessageBoardThreadsPage(
 			@GraphQLName("messageBoardSectionId") Long messageBoardSectionId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -892,8 +966,12 @@ public class Query {
 			messageBoardThreadResource -> new MessageBoardThreadPage(
 				messageBoardThreadResource.
 					getMessageBoardSectionMessageBoardThreadsPage(
-						messageBoardSectionId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						messageBoardSectionId, search,
+						_filterByFunction.apply(
+							messageBoardThreadResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortByFunction.apply(
+							messageBoardThreadResource, sortString))));
 	}
 
 	@GraphQLField
@@ -927,9 +1005,10 @@ public class Query {
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -937,17 +1016,22 @@ public class Query {
 			this::_populateResourceContext,
 			messageBoardThreadResource -> new MessageBoardThreadPage(
 				messageBoardThreadResource.getSiteMessageBoardThreadsPage(
-					siteId, flatten, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					siteId, flatten, search,
+					_filterByFunction.apply(
+						messageBoardThreadResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(
+						messageBoardThreadResource, sortString))));
 	}
 
 	@GraphQLField
 	public StructuredContentPage getContentStructureStructuredContentsPage(
 			@GraphQLName("contentStructureId") Long contentStructureId,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -956,8 +1040,12 @@ public class Query {
 			structuredContentResource -> new StructuredContentPage(
 				structuredContentResource.
 					getContentStructureStructuredContentsPage(
-						contentStructureId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						contentStructureId, search,
+						_filterByFunction.apply(
+							structuredContentResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortByFunction.apply(
+							structuredContentResource, sortString))));
 	}
 
 	@GraphQLField
@@ -965,9 +1053,10 @@ public class Query {
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -975,8 +1064,12 @@ public class Query {
 			this::_populateResourceContext,
 			structuredContentResource -> new StructuredContentPage(
 				structuredContentResource.getSiteStructuredContentsPage(
-					siteId, flatten, search, filter,
-					Pagination.of(page, pageSize), sorts)));
+					siteId, flatten, search,
+					_filterByFunction.apply(
+						structuredContentResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortByFunction.apply(
+						structuredContentResource, sortString))));
 	}
 
 	@GraphQLField
@@ -1012,10 +1105,10 @@ public class Query {
 				@GraphQLName("structuredContentFolderId") Long
 					structuredContentFolderId,
 				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
+				@GraphQLName("filter") String filterString,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+				@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -1024,8 +1117,12 @@ public class Query {
 			structuredContentResource -> new StructuredContentPage(
 				structuredContentResource.
 					getStructuredContentFolderStructuredContentsPage(
-						structuredContentFolderId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						structuredContentFolderId, search,
+						_filterByFunction.apply(
+							structuredContentResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortByFunction.apply(
+							structuredContentResource, sortString))));
 	}
 
 	@GraphQLField
@@ -1074,9 +1171,10 @@ public class Query {
 			@GraphQLName("siteId") Long siteId,
 			@GraphQLName("flatten") Boolean flatten,
 			@GraphQLName("search") String search,
-			@GraphQLName("filter") Filter filter,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page, @GraphQLName("sorts") Sort[] sorts)
+			@GraphQLName("page") int page,
+			@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -1085,8 +1183,12 @@ public class Query {
 			structuredContentFolderResource -> new StructuredContentFolderPage(
 				structuredContentFolderResource.
 					getSiteStructuredContentFoldersPage(
-						siteId, flatten, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						siteId, flatten, search,
+						_filterByFunction.apply(
+							structuredContentFolderResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortByFunction.apply(
+							structuredContentFolderResource, sortString))));
 	}
 
 	@GraphQLField
@@ -1095,10 +1197,10 @@ public class Query {
 				@GraphQLName("parentStructuredContentFolderId") Long
 					parentStructuredContentFolderId,
 				@GraphQLName("search") String search,
-				@GraphQLName("filter") Filter filter,
+				@GraphQLName("filter") String filterString,
 				@GraphQLName("pageSize") int pageSize,
 				@GraphQLName("page") int page,
-				@GraphQLName("sorts") Sort[] sorts)
+				@GraphQLName("sorts") String sortString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -1107,8 +1209,12 @@ public class Query {
 			structuredContentFolderResource -> new StructuredContentFolderPage(
 				structuredContentFolderResource.
 					getStructuredContentFolderStructuredContentFoldersPage(
-						parentStructuredContentFolderId, search, filter,
-						Pagination.of(page, pageSize), sorts)));
+						parentStructuredContentFolderId, search,
+						_filterByFunction.apply(
+							structuredContentFolderResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortByFunction.apply(
+							structuredContentFolderResource, sortString))));
 	}
 
 	@GraphQLField
@@ -1707,6 +1813,8 @@ public class Query {
 		_structuredContentFolderResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
+	private BiFunction<Object, String, Filter> _filterByFunction;
+	private BiFunction<Object, String, Sort[]> _sortByFunction;
 	private Company _company;
 	private User _user;
 

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/query/v1_0/Query.java
@@ -27,11 +27,15 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.function.BiFunction;
 
 import javax.annotation.Generated;
 
@@ -336,6 +340,8 @@ public class Query {
 		_formStructureResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
+	private BiFunction<Object, String, Filter> _filterByFunction;
+	private BiFunction<Object, String, Sort[]> _sortByFunction;
 	private Company _company;
 	private User _user;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/ContextProviderUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/ContextProviderUtil.java
@@ -17,11 +17,14 @@ package com.liferay.portal.vulcan.internal.jaxrs.context.provider;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
 import javax.ws.rs.container.ResourceContext;
+import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
 
@@ -58,6 +61,18 @@ public class ContextProviderUtil {
 	public static HttpServletRequest getHttpServletRequest(Message message) {
 		return (HttpServletRequest)message.getContextualProperty(
 			"HTTP.REQUEST");
+	}
+
+	public static MultivaluedHashMap<String, String> getMultivaluedHashMap(
+		Map<String, String[]> parameterMap) {
+
+		return new MultivaluedHashMap<String, String>() {
+			{
+				for (Entry<String, String[]> entry : parameterMap.entrySet()) {
+					put(entry.getKey(), Arrays.asList(entry.getValue()));
+				}
+			}
+		};
 	}
 
 	private static Object _getMatchedResource(Message message) {

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/FilterContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/FilterContextProvider.java
@@ -112,14 +112,10 @@ public class FilterContextProvider implements ContextProvider<Filter> {
 			HttpServletRequest httpServletRequest =
 				ContextProviderUtil.getHttpServletRequest(message);
 
-			AcceptLanguage acceptLanguage = new AcceptLanguageImpl(
-				httpServletRequest, _language, _portal);
-			EntityModel entityModel = ContextProviderUtil.getEntityModel(
-				message);
-			String filterString = ParamUtil.getString(
-				httpServletRequest, "filter");
-
-			return createContext(acceptLanguage, entityModel, filterString);
+			return createContext(
+				new AcceptLanguageImpl(httpServletRequest, _language, _portal),
+				ContextProviderUtil.getEntityModel(message),
+				ParamUtil.getString(httpServletRequest, "filter"));
 		}
 		catch (ExpressionVisitException eve) {
 			throw new BadRequestException(eve.getMessage(), eve);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/FilterContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/FilterContextProvider.java
@@ -114,12 +114,10 @@ public class FilterContextProvider implements ContextProvider<Filter> {
 
 			AcceptLanguage acceptLanguage = new AcceptLanguageImpl(
 				httpServletRequest, _language, _portal);
-
-			String filterString = ParamUtil.getString(
-				httpServletRequest, "filter");
-
 			EntityModel entityModel = ContextProviderUtil.getEntityModel(
 				message);
+			String filterString = ParamUtil.getString(
+				httpServletRequest, "filter");
 
 			return createContext(acceptLanguage, entityModel, filterString);
 		}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/validation/BeanValidationInterceptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/validation/BeanValidationInterceptor.java
@@ -117,7 +117,7 @@ public class BeanValidationInterceptor
 
 	@Override
 	protected void handleValidation(
-		Message message, Object resourceInstance, Method method,
+		Message message, Object resource, Method method,
 		List<Object> arguments) {
 
 		if (ListUtil.isEmpty(arguments)) {
@@ -130,7 +130,7 @@ public class BeanValidationInterceptor
 
 		Set<ConstraintViolation<Object>> constraintViolations =
 			executableValidator.validateParameters(
-				resourceInstance, method, arguments.toArray());
+				resource, method, arguments.toArray());
 
 		if (!constraintViolations.isEmpty()) {
 			throw new ConstraintViolationException(constraintViolations);

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_query.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_query.ftl
@@ -21,6 +21,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.Date;
+import java.util.function.BiFunction;
 
 import javax.annotation.Generated;
 
@@ -57,7 +58,7 @@ public class Query {
 			${javaMethodSignature.returnType}
 		</#if>
 
-		${javaMethodSignature.methodName}(${freeMarkerTool.getGraphQLParameters(javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, true)}) throws Exception {
+		${javaMethodSignature.methodName}(${freeMarkerTool.getGraphQLParameters(javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, true)?replace("com.liferay.portal.kernel.search.filter.Filter filter", "String filterString")?replace("com.liferay.portal.kernel.search.Sort[] sorts", "String sortString")}) throws Exception {
 			<#assign arguments = freeMarkerTool.getGraphQLArguments(javaMethodSignature.javaMethodParameters) />
 
 			<#if javaMethodSignature.returnType?contains("Collection<")>
@@ -66,7 +67,7 @@ public class Query {
 					this::_populateResourceContext,
 					${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource ->
 						new ${javaMethodSignature.schemaName}Page(
-							${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource.${javaMethodSignature.methodName}(${arguments?replace("pageSize,page", "Pagination.of(page, pageSize)")}))
+							${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource.${javaMethodSignature.methodName}(${arguments?replace("pageSize,page", "Pagination.of(page, pageSize)")?replace("filter", "_filterByFunction.apply(${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource, filterString)")?replace("sorts", "_sortByFunction.apply(${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource, sortString)")}))
 					);
 			<#else>
 				return _applyComponentServiceObjects(_${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}ResourceComponentServiceObjects, this::_populateResourceContext, ${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource -> ${freeMarkerTool.getSchemaVarName(javaMethodSignature.schemaName)}Resource.${javaMethodSignature.methodName}(${arguments?replace("pageSize,page", "Pagination.of(page, pageSize)")}));
@@ -126,6 +127,8 @@ public class Query {
 	</#list>
 
 	private AcceptLanguage _acceptLanguage;
+	private BiFunction<Object, String, Filter> _filterByFunction;
+	private BiFunction<Object, String, Sort[]> _sortByFunction;
 	private Company _company;
 	private User _user;
 


### PR DESCRIPTION
Renamed to filterByFunction and filterString.

We shouldn't use filter/sort in mutations (insert/update), I don't see a real use case right now, that's why I didn't change it there. If a use case appears I can move the logic to the java class.

Thanks!