### PR TITLE
LPS-90011 portal-search-web: Add test to check the removed stagingGroup validation.

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/portlet/CategoryFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/portlet/CategoryFacetPortlet.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.search.web.internal.category.facet.portlet;
 
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -128,6 +129,15 @@ public class CategoryFacetPortlet extends MVCPortlet {
 
 		ThemeDisplay themeDisplay = portletSharedSearchResponse.getThemeDisplay(
 			renderRequest);
+
+		Group group = themeDisplay.getScopeGroup();
+
+		Group stagingGroup = group.getStagingGroup();
+
+		if (stagingGroup != null) {
+			assetCategoriesSearchFacetDisplayBuilder.setExcludedGroupId(
+				stagingGroup.getGroupId());
+		}
 
 		assetCategoriesSearchFacetDisplayBuilder.setLocale(
 			themeDisplay.getLocale());

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/builder/AssetCategoriesSearchFacetDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/builder/AssetCategoriesSearchFacetDisplayBuilder.java
@@ -65,6 +65,10 @@ public class AssetCategoriesSearchFacetDisplayBuilder implements Serializable {
 		return assetCategoriesSearchFacetDisplayContext;
 	}
 
+	public long getExcludedGroupId() {
+		return _excludedGroupId;
+	}
+
 	public void setAssetCategoryLocalService(
 		AssetCategoryLocalService assetCategoryLocalService) {
 
@@ -79,6 +83,10 @@ public class AssetCategoriesSearchFacetDisplayBuilder implements Serializable {
 
 	public void setDisplayStyle(String displayStyle) {
 		_displayStyle = displayStyle;
+	}
+
+	public void setExcludedGroupId(long excludedGroupId) {
+		_excludedGroupId = excludedGroupId;
 	}
 
 	public void setFacet(Facet facet) {
@@ -149,6 +157,8 @@ public class AssetCategoriesSearchFacetDisplayBuilder implements Serializable {
 		if (_buckets.isEmpty()) {
 			return getEmptyTermDisplayContexts();
 		}
+
+		_removeExcludedGroup();
 
 		List<AssetCategoriesSearchFacetTermDisplayContext>
 			assetCategoriesSearchFacetTermDisplayContexts = new ArrayList<>(
@@ -339,10 +349,33 @@ public class AssetCategoriesSearchFacetDisplayBuilder implements Serializable {
 		return null;
 	}
 
+	private void _removeExcludedGroup() {
+		Stream<Tuple> stream = _buckets.stream();
+
+		_buckets = stream.filter(
+			tuple -> {
+				if (_excludedGroupId == 0) {
+					return true;
+				}
+
+				AssetCategory assetCategory = (AssetCategory)tuple.getObject(0);
+
+				if (assetCategory.getGroupId() == _excludedGroupId) {
+					return false;
+				}
+
+				return true;
+			}
+		).collect(
+			Collectors.toList()
+		);
+	}
+
 	private AssetCategoryLocalService _assetCategoryLocalService;
 	private AssetCategoryPermissionChecker _assetCategoryPermissionChecker;
 	private List<Tuple> _buckets;
 	private String _displayStyle;
+	private long _excludedGroupId;
 	private Facet _facet;
 	private boolean _frequenciesVisible;
 	private int _frequencyThreshold;


### PR DESCRIPTION
<h3>:x: ci:test:search - 18 out of 21 jobs passed in 1 hour 17 minutes 27 seconds 380 ms</h3>

https://github.com/brandizzi/liferay-portal/pull/791#issuecomment-507404202

Only unique failure is in unrelated module.

Author: @luanmaoski
Reviewer: @brandizzi

[Bug] Search facets don't take into account the groupId in empty searches
https://issues.liferay.com/browse/LPS-90011