### PR TITLE
LPS-97470 frontend-taglib-clay - Remove lint suppressions, fix lint errors

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/test/management_toolbar/ManagementToolbar.es.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/test/management_toolbar/ManagementToolbar.es.js
@@ -12,8 +12,7 @@
  * details.
  */
 
-/* eslint no-undef: "warn" */
-/* eslint no-unused-vars: "warn" */
+/* global global */
 
 import ManagementToolbar from '../../src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.es';
 
@@ -43,7 +42,7 @@ describe('ManagementToolbar', () => {
 			fire: jest.fn(eventName =>
 				searchContainerCallbacks[eventName].apply(this)
 			),
-			on: jest.fn((eventName, cb) => {
+			on: jest.fn(eventName => {
 				searchContainerCallbacks[eventName] = jest.fn();
 				return searchContainerHandle;
 			}),

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/test/management_toolbar/ManagementToolbar.es.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/test/management_toolbar/ManagementToolbar.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* global global */
-
 import ManagementToolbar from '../../src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.es';
 
 describe('ManagementToolbar', () => {

--- a/modules/package.json
+++ b/modules/package.json
@@ -17,7 +17,7 @@
 		"liferay-npm-bridge-generator": "2.7.1",
 		"liferay-npm-bundler": "2.7.1",
 		"liferay-npm-bundler-preset-standard": "2.7.1",
-		"liferay-npm-scripts": "4.3.0",
+		"liferay-npm-scripts": "4.4.0",
 		"liferay-theme-es2015-hook": "8.0.0-rc.2",
 		"metal-jest-serializer": "2.0.0"
 	},

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -9684,10 +9684,10 @@ liferay-npm-bundler@2.7.1:
     semver "^5.5.0"
     xml-js "^1.6.8"
 
-liferay-npm-scripts@4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-4.3.0.tgz#31ba1cd4bc0a62bba3d14db8725fe661c766f5d2"
-  integrity sha512-H/iUk22rvn2bSok2gty59OW2O6TVIMkbfz4gnJQ4HGAzS5b+5tjMbNgNGOfiYgBsdCb7EPJkHFcIbeRw2Gn/zQ==
+liferay-npm-scripts@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-4.4.0.tgz#a750b55c6edccc1b8c8df4bc397a1f5e4227a7ff"
+  integrity sha512-RdOLipFgIa6Xr3uTLeQUWImwExi7HYsOyOvRLqS9kNkIlN3Zj+8vp6udLvFaO+mXH3bOfmS9SuAzNEySMcUq9g==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/plugin-proposal-class-properties" "7.4.4"


### PR DESCRIPTION
Originally reviewed at: https://github.com/wincent/liferay-portal/pull/13

- Fixes one lint warning by removing an unused parameter.
- Makes another lint suppression unnecessary by changing the global config in liferay-npm-scripts.