### PR TITLE
LPS-97221 Replace method instantiation in SPI*Resources for activate

### DIFF
--- a/modules/apps/headless/headless-common-spi/src/main/java/com/liferay/headless/common/spi/resource/SPICommentResource.java
+++ b/modules/apps/headless/headless-common-spi/src/main/java/com/liferay/headless/common/spi/resource/SPICommentResource.java
@@ -28,13 +28,13 @@ import com.liferay.portal.kernel.comment.Discussion;
 import com.liferay.portal.kernel.comment.DiscussionComment;
 import com.liferay.portal.kernel.comment.DiscussionPermission;
 import com.liferay.portal.kernel.comment.DuplicateCommentException;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.TermFilter;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -57,11 +57,10 @@ import javax.ws.rs.core.MultivaluedMap;
 public class SPICommentResource<T> {
 
 	public SPICommentResource(
-		CommentManager commentManager, Company company,
+		CommentManager commentManager,
 		UnsafeFunction<Comment, T, Exception> transformUnsafeFunction) {
 
 		_commentManager = commentManager;
-		_company = company;
 		_transformUnsafeFunction = transformUnsafeFunction;
 	}
 
@@ -166,7 +165,7 @@ public class SPICommentResource<T> {
 		DiscussionPermission discussionPermission = _getDiscussionPermission();
 
 		discussionPermission.checkViewPermission(
-			_company.getCompanyId(), comment.getGroupId(),
+			CompanyThreadLocal.getCompanyId(), comment.getGroupId(),
 			comment.getClassName(), comment.getClassPK());
 	}
 
@@ -202,7 +201,7 @@ public class SPICommentResource<T> {
 				searchContext.setAttribute("discussion", Boolean.TRUE);
 				searchContext.setAttribute(
 					"searchPermissionContext", StringPool.BLANK);
-				searchContext.setCompanyId(_company.getCompanyId());
+				searchContext.setCompanyId(CompanyThreadLocal.getCompanyId());
 			},
 			document -> _transformUnsafeFunction.apply(
 				_commentManager.fetchComment(
@@ -230,7 +229,7 @@ public class SPICommentResource<T> {
 		DiscussionPermission discussionPermission = _getDiscussionPermission();
 
 		discussionPermission.checkAddPermission(
-			_company.getCompanyId(), groupId, className, classPK);
+			CompanyThreadLocal.getCompanyId(), groupId, className, classPK);
 
 		try {
 			long commentId = addCommentUnsafeSupplier.get();
@@ -254,7 +253,6 @@ public class SPICommentResource<T> {
 	private static final EntityModel _entityModel = new CommentEntityModel();
 
 	private final CommentManager _commentManager;
-	private final Company _company;
 	private final UnsafeFunction<Comment, T, Exception>
 		_transformUnsafeFunction;
 

--- a/modules/apps/headless/headless-common-spi/src/main/java/com/liferay/headless/common/spi/resource/SPIRatingResource.java
+++ b/modules/apps/headless/headless-common-spi/src/main/java/com/liferay/headless/common/spi/resource/SPIRatingResource.java
@@ -17,6 +17,8 @@ package com.liferay.headless.common.spi.resource;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.ratings.kernel.model.RatingsEntry;
@@ -29,49 +31,59 @@ public class SPIRatingResource<T> {
 
 	public SPIRatingResource(
 		String className, RatingsEntryLocalService ratingsEntryLocalService,
-		UnsafeFunction<RatingsEntry, T, Exception> transformUnsafeFunction,
-		User user) {
+		UnsafeFunction<RatingsEntry, T, Exception> transformUnsafeFunction) {
 
 		_className = className;
 		_ratingsEntryLocalService = ratingsEntryLocalService;
 		_transformUnsafeFunction = transformUnsafeFunction;
-		_user = user;
 	}
 
 	public T addOrUpdateRating(Number ratingValue, long classPK)
 		throws Exception {
 
-		_checkPermission();
+		User user = _getUser();
+
+		_checkPermission(user);
 
 		return _transformUnsafeFunction.apply(
 			_ratingsEntryLocalService.updateEntry(
-				_user.getUserId(), _className, classPK,
+				user.getUserId(), _className, classPK,
 				GetterUtil.getDouble(ratingValue), new ServiceContext()));
 	}
 
 	public void deleteRating(Long classPK) throws Exception {
-		_checkPermission();
+		User user = _getUser();
+
+		_checkPermission(user);
 
 		_ratingsEntryLocalService.deleteEntry(
-			_user.getUserId(), _className, classPK);
+			user.getUserId(), _className, classPK);
 	}
 
 	public T getRating(Long classPK) throws Exception {
+		User user = _getUser();
+
 		return _transformUnsafeFunction.apply(
 			_ratingsEntryLocalService.getEntry(
-				_user.getUserId(), _className, classPK));
+				user.getUserId(), _className, classPK));
 	}
 
-	private void _checkPermission() throws Exception {
-		if (_user.isDefaultUser()) {
+	private void _checkPermission(User user) throws Exception {
+		if (user.isDefaultUser()) {
 			throw new PrincipalException();
 		}
+	}
+
+	private User _getUser() {
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		return permissionChecker.getUser();
 	}
 
 	private final String _className;
 	private final RatingsEntryLocalService _ratingsEntryLocalService;
 	private final UnsafeFunction<RatingsEntry, T, Exception>
 		_transformUnsafeFunction;
-	private final User _user;
 
 }

--- a/modules/apps/headless/headless-common-spi/src/main/resources/com/liferay/headless/common/spi/resource/packageinfo
+++ b/modules/apps/headless/headless-common-spi/src/main/resources/com/liferay/headless/common/spi/resource/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
@@ -32,7 +32,6 @@ import com.liferay.headless.delivery.internal.dto.v1_0.util.EntityFieldsUtil;
 import com.liferay.headless.delivery.internal.dto.v1_0.util.RatingUtil;
 import com.liferay.headless.delivery.internal.odata.entity.v1_0.BlogPostingEntityModel;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingResource;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
@@ -59,10 +58,11 @@ import java.util.Map;
 import java.util.Optional;
 
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
@@ -83,9 +83,7 @@ public class BlogPostingResourceImpl
 
 	@Override
 	public void deleteBlogPostingMyRating(Long blogPostingId) throws Exception {
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		spiRatingResource.deleteRating(blogPostingId);
+		_spiRatingResource.deleteRating(blogPostingId);
 	}
 
 	@Override
@@ -97,9 +95,7 @@ public class BlogPostingResourceImpl
 
 	@Override
 	public Rating getBlogPostingMyRating(Long blogPostingId) throws Exception {
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.getRating(blogPostingId);
+		return _spiRatingResource.getRating(blogPostingId);
 	}
 
 	@Override
@@ -139,9 +135,7 @@ public class BlogPostingResourceImpl
 	public Rating postBlogPostingMyRating(Long blogPostingId, Rating rating)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.addOrUpdateRating(
+		return _spiRatingResource.addOrUpdateRating(
 			rating.getRatingValue(), blogPostingId);
 	}
 
@@ -225,10 +219,21 @@ public class BlogPostingResourceImpl
 	public Rating putBlogPostingMyRating(Long blogPostingId, Rating rating)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.addOrUpdateRating(
+		return _spiRatingResource.addOrUpdateRating(
 			rating.getRatingValue(), blogPostingId);
+	}
+
+	@Activate
+	protected void activate() {
+		_spiRatingResource = new SPIRatingResource<>(
+			BlogsEntry.class.getName(), _ratingsEntryLocalService,
+			ratingsEntry -> RatingUtil.toRating(
+				_portal, ratingsEntry, _userLocalService));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_spiRatingResource = null;
 	}
 
 	@Override
@@ -286,14 +291,6 @@ public class BlogPostingResourceImpl
 		}
 	}
 
-	private SPIRatingResource<Rating> _getSPIRatingResource() {
-		return new SPIRatingResource<>(
-			BlogsEntry.class.getName(), _ratingsEntryLocalService,
-			ratingsEntry -> RatingUtil.toRating(
-				_portal, ratingsEntry, _userLocalService),
-			_user);
-	}
-
 	private BlogPosting _toBlogPosting(BlogsEntry blogsEntry) throws Exception {
 		return _blogPostingDTOConverter.toDTO(
 			new DefaultDTOConverterContext(
@@ -322,8 +319,7 @@ public class BlogPostingResourceImpl
 	@Reference
 	private RatingsEntryLocalService _ratingsEntryLocalService;
 
-	@Context
-	private User _user;
+	private SPIRatingResource<Rating> _spiRatingResource;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
@@ -36,7 +36,9 @@ import com.liferay.portal.vulcan.resource.EntityModelResource;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.MultivaluedMap;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
@@ -52,10 +54,7 @@ public class CommentResourceImpl
 
 	@Override
 	public void deleteComment(Long commentId) throws Exception {
-		SPICommentResource<Comment> spiCommentResource =
-			_getSPICommentResource();
-
-		spiCommentResource.deleteComment(commentId);
+		_spiCommentResource.deleteComment(commentId);
 	}
 
 	@Override
@@ -64,22 +63,16 @@ public class CommentResourceImpl
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		SPICommentResource<Comment> spiCommentResource =
-			_getSPICommentResource();
-
 		BlogsEntry blogsEntry = _blogsEntryService.getEntry(blogPostingId);
 
-		return spiCommentResource.getEntityCommentsPage(
+		return _spiCommentResource.getEntityCommentsPage(
 			blogsEntry.getGroupId(), BlogsEntry.class.getName(), blogPostingId,
 			search, filter, pagination, sorts);
 	}
 
 	@Override
 	public Comment getComment(Long commentId) throws Exception {
-		SPICommentResource<Comment> spiCommentResource =
-			_getSPICommentResource();
-
-		return spiCommentResource.getComment(commentId);
+		return _spiCommentResource.getComment(commentId);
 	}
 
 	@Override
@@ -88,10 +81,7 @@ public class CommentResourceImpl
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		SPICommentResource<Comment> spiCommentResource =
-			_getSPICommentResource();
-
-		return spiCommentResource.getCommentCommentsPage(
+		return _spiCommentResource.getCommentCommentsPage(
 			parentCommentId, search, filter, pagination, sorts);
 	}
 
@@ -101,22 +91,16 @@ public class CommentResourceImpl
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		SPICommentResource<Comment> spiCommentResource =
-			_getSPICommentResource();
-
 		DLFileEntry dlFileEntry = _dlFileEntryService.getFileEntry(documentId);
 
-		return spiCommentResource.getEntityCommentsPage(
+		return _spiCommentResource.getEntityCommentsPage(
 			dlFileEntry.getGroupId(), DLFileEntry.class.getName(), documentId,
 			search, filter, pagination, sorts);
 	}
 
 	@Override
 	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
-		SPICommentResource<Comment> spiCommentResource =
-			_getSPICommentResource();
-
-		return spiCommentResource.getEntityModel(multivaluedMap);
+		return _spiCommentResource.getEntityModel(multivaluedMap);
 	}
 
 	@Override
@@ -125,13 +109,10 @@ public class CommentResourceImpl
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		SPICommentResource<Comment> spiCommentResource =
-			_getSPICommentResource();
-
 		JournalArticle journalArticle = _journalArticleService.getLatestArticle(
 			structuredContentId);
 
-		return spiCommentResource.getEntityCommentsPage(
+		return _spiCommentResource.getEntityCommentsPage(
 			journalArticle.getGroupId(), JournalArticle.class.getName(),
 			structuredContentId, search, filter, pagination, sorts);
 	}
@@ -140,12 +121,9 @@ public class CommentResourceImpl
 	public Comment postBlogPostingComment(Long blogPostingId, Comment comment)
 		throws Exception {
 
-		SPICommentResource<Comment> spiCommentResource =
-			_getSPICommentResource();
-
 		BlogsEntry blogsEntry = _blogsEntryService.getEntry(blogPostingId);
 
-		return spiCommentResource.postEntityComment(
+		return _spiCommentResource.postEntityComment(
 			blogsEntry.getGroupId(), BlogsEntry.class.getName(), blogPostingId,
 			comment.getText());
 	}
@@ -161,10 +139,7 @@ public class CommentResourceImpl
 			throw new NotFoundException();
 		}
 
-		SPICommentResource<Comment> spiCommentResource =
-			_getSPICommentResource();
-
-		return spiCommentResource.postCommentComment(
+		return _spiCommentResource.postCommentComment(
 			parentComment, comment.getText());
 	}
 
@@ -172,12 +147,9 @@ public class CommentResourceImpl
 	public Comment postDocumentComment(Long documentId, Comment comment)
 		throws Exception {
 
-		SPICommentResource<Comment> spiCommentResource =
-			_getSPICommentResource();
-
 		DLFileEntry fileEntry = _dlFileEntryService.getFileEntry(documentId);
 
-		return spiCommentResource.postEntityComment(
+		return _spiCommentResource.postEntityComment(
 			fileEntry.getGroupId(), DLFileEntry.class.getName(), documentId,
 			comment.getText());
 	}
@@ -187,13 +159,10 @@ public class CommentResourceImpl
 			Long structuredContentId, Comment comment)
 		throws Exception {
 
-		SPICommentResource<Comment> spiCommentResource =
-			_getSPICommentResource();
-
 		JournalArticle journalArticle = _journalArticleService.getLatestArticle(
 			structuredContentId);
 
-		return spiCommentResource.postEntityComment(
+		return _spiCommentResource.postEntityComment(
 			journalArticle.getGroupId(), JournalArticle.class.getName(),
 			structuredContentId, comment.getText());
 	}
@@ -202,17 +171,20 @@ public class CommentResourceImpl
 	public Comment putComment(Long commentId, Comment comment)
 		throws Exception {
 
-		SPICommentResource<Comment> spiCommentResource =
-			_getSPICommentResource();
-
-		return spiCommentResource.putComment(commentId, comment.getText());
+		return _spiCommentResource.putComment(commentId, comment.getText());
 	}
 
-	private SPICommentResource<Comment> _getSPICommentResource() {
-		return new SPICommentResource<>(
-			_commentManager, contextCompany,
+	@Activate
+	protected void activate() {
+		_spiCommentResource = new SPICommentResource<>(
+			_commentManager,
 			comment -> CommentUtil.toComment(
 				comment, _commentManager, _portal));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_spiCommentResource = null;
 	}
 
 	@Reference
@@ -229,5 +201,7 @@ public class CommentResourceImpl
 
 	@Reference
 	private Portal _portal;
+
+	private SPICommentResource<Comment> _spiCommentResource;
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -35,7 +35,6 @@ import com.liferay.headless.delivery.internal.dto.v1_0.util.RatingUtil;
 import com.liferay.headless.delivery.internal.odata.entity.v1_0.DocumentEntityModel;
 import com.liferay.headless.delivery.resource.v1_0.DocumentResource;
 import com.liferay.petra.function.UnsafeConsumer;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
@@ -64,10 +63,11 @@ import java.util.Map;
 import java.util.Optional;
 
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
@@ -88,9 +88,7 @@ public class DocumentResourceImpl
 
 	@Override
 	public void deleteDocumentMyRating(Long documentId) throws Exception {
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		spiRatingResource.deleteRating(documentId);
+		_spiRatingResource.deleteRating(documentId);
 	}
 
 	@Override
@@ -122,9 +120,7 @@ public class DocumentResourceImpl
 	}
 
 	public Rating getDocumentMyRating(Long documentId) throws Exception {
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.getRating(documentId);
+		return _spiRatingResource.getRating(documentId);
 	}
 
 	@Override
@@ -244,9 +240,7 @@ public class DocumentResourceImpl
 	public Rating postDocumentMyRating(Long documentId, Rating rating)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.addOrUpdateRating(
+		return _spiRatingResource.addOrUpdateRating(
 			rating.getRatingValue(), documentId);
 	}
 
@@ -323,10 +317,21 @@ public class DocumentResourceImpl
 	public Rating putDocumentMyRating(Long documentId, Rating rating)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.addOrUpdateRating(
+		return _spiRatingResource.addOrUpdateRating(
 			rating.getRatingValue(), documentId);
+	}
+
+	@Activate
+	protected void activate() {
+		_spiRatingResource = new SPIRatingResource<>(
+			DLFileEntry.class.getName(), _ratingsEntryLocalService,
+			ratingsEntry -> RatingUtil.toRating(
+				_portal, ratingsEntry, _userLocalService));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_spiRatingResource = null;
 	}
 
 	private Document _addDocument(
@@ -415,14 +420,6 @@ public class DocumentResourceImpl
 			contextAcceptLanguage.getPreferredLocale());
 	}
 
-	private SPIRatingResource<Rating> _getSPIRatingResource() {
-		return new SPIRatingResource<>(
-			DLFileEntry.class.getName(), _ratingsEntryLocalService,
-			ratingsEntry -> RatingUtil.toRating(
-				_portal, ratingsEntry, _userLocalService),
-			_user);
-	}
-
 	private Document _toDocument(FileEntry fileEntry) throws Exception {
 		return _documentDTOConverter.toDTO(
 			new DefaultDTOConverterContext(null, fileEntry.getFileEntryId()));
@@ -452,8 +449,7 @@ public class DocumentResourceImpl
 	@Reference
 	private RatingsEntryLocalService _ratingsEntryLocalService;
 
-	@Context
-	private User _user;
+	private SPIRatingResource<Rating> _spiRatingResource;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseArticleResourceImpl.java
@@ -33,7 +33,6 @@ import com.liferay.knowledge.base.model.KBFolder;
 import com.liferay.knowledge.base.service.KBArticleService;
 import com.liferay.knowledge.base.service.KBFolderService;
 import com.liferay.petra.function.UnsafeConsumer;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
@@ -57,10 +56,11 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
@@ -86,9 +86,7 @@ public class KnowledgeBaseArticleResourceImpl
 	public void deleteKnowledgeBaseArticleMyRating(Long knowledgeBaseArticleId)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		spiRatingResource.deleteRating(knowledgeBaseArticleId);
+		_spiRatingResource.deleteRating(knowledgeBaseArticleId);
 	}
 
 	@Override
@@ -138,9 +136,7 @@ public class KnowledgeBaseArticleResourceImpl
 	public Rating getKnowledgeBaseArticleMyRating(Long knowledgeBaseArticleId)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.getRating(knowledgeBaseArticleId);
+		return _spiRatingResource.getRating(knowledgeBaseArticleId);
 	}
 
 	@Override
@@ -217,9 +213,7 @@ public class KnowledgeBaseArticleResourceImpl
 			Long knowledgeBaseArticleId, Rating rating)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.addOrUpdateRating(
+		return _spiRatingResource.addOrUpdateRating(
 			rating.getRatingValue(), knowledgeBaseArticleId);
 	}
 
@@ -279,10 +273,21 @@ public class KnowledgeBaseArticleResourceImpl
 			Long knowledgeBaseArticleId, Rating rating)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.addOrUpdateRating(
+		return _spiRatingResource.addOrUpdateRating(
 			rating.getRatingValue(), knowledgeBaseArticleId);
+	}
+
+	@Activate
+	protected void activate() {
+		_spiRatingResource = new SPIRatingResource<>(
+			KBArticle.class.getName(), _ratingsEntryLocalService,
+			ratingsEntry -> RatingUtil.toRating(
+				_portal, ratingsEntry, _userLocalService));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_spiRatingResource = null;
 	}
 
 	private Map<String, Serializable> _getExpandoBridgeAttributes(
@@ -340,14 +345,6 @@ public class KnowledgeBaseArticleResourceImpl
 			sorts);
 	}
 
-	private SPIRatingResource<Rating> _getSPIRatingResource() {
-		return new SPIRatingResource<>(
-			KBArticle.class.getName(), _ratingsEntryLocalService,
-			ratingsEntry -> RatingUtil.toRating(
-				_portal, ratingsEntry, _userLocalService),
-			_user);
-	}
-
 	private KnowledgeBaseArticle _toKBArticle(KBArticle kbArticle)
 		throws Exception {
 
@@ -389,8 +386,7 @@ public class KnowledgeBaseArticleResourceImpl
 	@Reference
 	private RatingsEntryLocalService _ratingsEntryLocalService;
 
-	@Context
-	private User _user;
+	private SPIRatingResource<Rating> _spiRatingResource;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
@@ -32,7 +32,6 @@ import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.model.MBThread;
 import com.liferay.message.boards.service.MBMessageService;
 import com.liferay.message.boards.service.MBThreadLocalService;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
@@ -55,10 +54,11 @@ import java.util.Collections;
 import java.util.Map;
 
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
@@ -82,9 +82,7 @@ public class MessageBoardMessageResourceImpl
 	public void deleteMessageBoardMessageMyRating(Long messageBoardMessageId)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		spiRatingResource.deleteRating(messageBoardMessageId);
+		_spiRatingResource.deleteRating(messageBoardMessageId);
 	}
 
 	@Override
@@ -120,9 +118,7 @@ public class MessageBoardMessageResourceImpl
 	public Rating getMessageBoardMessageMyRating(Long messageBoardMessageId)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.getRating(messageBoardMessageId);
+		return _spiRatingResource.getRating(messageBoardMessageId);
 	}
 
 	@Override
@@ -154,9 +150,7 @@ public class MessageBoardMessageResourceImpl
 			Long messageBoardMessageId, Rating rating)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.addOrUpdateRating(
+		return _spiRatingResource.addOrUpdateRating(
 			rating.getRatingValue(), messageBoardMessageId);
 	}
 
@@ -217,10 +211,21 @@ public class MessageBoardMessageResourceImpl
 			Long messageBoardMessageId, Rating rating)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.addOrUpdateRating(
+		return _spiRatingResource.addOrUpdateRating(
 			rating.getRatingValue(), messageBoardMessageId);
+	}
+
+	@Activate
+	protected void activate() {
+		_spiRatingResource = new SPIRatingResource<>(
+			MBMessage.class.getName(), _ratingsEntryLocalService,
+			ratingsEntry -> RatingUtil.toRating(
+				_portal, ratingsEntry, _userLocalService));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_spiRatingResource = null;
 	}
 
 	private MessageBoardMessage _addMessageBoardThread(
@@ -295,14 +300,6 @@ public class MessageBoardMessageResourceImpl
 			sorts);
 	}
 
-	private SPIRatingResource<Rating> _getSPIRatingResource() {
-		return new SPIRatingResource<>(
-			MBMessage.class.getName(), _ratingsEntryLocalService,
-			ratingsEntry -> RatingUtil.toRating(
-				_portal, ratingsEntry, _userLocalService),
-			_user);
-	}
-
 	private MessageBoardMessage _toMessageBoardMessage(MBMessage mbMessage)
 		throws Exception {
 
@@ -345,8 +342,7 @@ public class MessageBoardMessageResourceImpl
 	@Reference
 	private RatingsEntryLocalService _ratingsEntryLocalService;
 
-	@Context
-	private User _user;
+	private SPIRatingResource<Rating> _spiRatingResource;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
@@ -46,7 +46,6 @@ import com.liferay.message.boards.settings.MBGroupServiceSettings;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
@@ -78,10 +77,11 @@ import java.util.Map;
 import java.util.Optional;
 
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
@@ -106,12 +106,10 @@ public class MessageBoardThreadResourceImpl
 	public void deleteMessageBoardThreadMyRating(Long messageBoardThreadId)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
 		MBThread mbThread = _mbThreadLocalService.getMBThread(
 			messageBoardThreadId);
 
-		spiRatingResource.deleteRating(mbThread.getRootMessageId());
+		_spiRatingResource.deleteRating(mbThread.getRootMessageId());
 	}
 
 	@Override
@@ -163,12 +161,10 @@ public class MessageBoardThreadResourceImpl
 	public Rating getMessageBoardThreadMyRating(Long messageBoardThreadId)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
 		MBThread mbThread = _mbThreadLocalService.getMBThread(
 			messageBoardThreadId);
 
-		return spiRatingResource.getRating(mbThread.getRootMessageId());
+		return _spiRatingResource.getRating(mbThread.getRootMessageId());
 	}
 
 	@Override
@@ -212,12 +208,10 @@ public class MessageBoardThreadResourceImpl
 			Long messageBoardThreadId, Rating rating)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
 		MBThread mbThread = _mbThreadLocalService.getThread(
 			messageBoardThreadId);
 
-		return spiRatingResource.addOrUpdateRating(
+		return _spiRatingResource.addOrUpdateRating(
 			rating.getRatingValue(), mbThread.getRootMessageId());
 	}
 
@@ -266,13 +260,24 @@ public class MessageBoardThreadResourceImpl
 			Long messageBoardThreadId, Rating rating)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
 		MBThread mbThread = _mbThreadLocalService.getThread(
 			messageBoardThreadId);
 
-		return spiRatingResource.addOrUpdateRating(
+		return _spiRatingResource.addOrUpdateRating(
 			rating.getRatingValue(), mbThread.getRootMessageId());
+	}
+
+	@Activate
+	protected void activate() {
+		_spiRatingResource = new SPIRatingResource<>(
+			MBMessage.class.getName(), _ratingsEntryLocalService,
+			ratingsEntry -> RatingUtil.toRating(
+				_portal, ratingsEntry, _userLocalService));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_spiRatingResource = null;
 	}
 
 	private MessageBoardThread _addMessageBoardThread(
@@ -323,14 +328,6 @@ public class MessageBoardThreadResourceImpl
 				_mbMessageService.getMessage(
 					GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)))),
 			sorts);
-	}
-
-	private SPIRatingResource<Rating> _getSPIRatingResource() {
-		return new SPIRatingResource<>(
-			MBMessage.class.getName(), _ratingsEntryLocalService,
-			ratingsEntry -> RatingUtil.toRating(
-				_portal, ratingsEntry, _userLocalService),
-			_user);
 	}
 
 	private MessageBoardThread _toMessageBoardThread(MBMessage mbMessage)
@@ -495,8 +492,7 @@ public class MessageBoardThreadResourceImpl
 	@Reference
 	private RatingsStatsLocalService _ratingsStatsLocalService;
 
-	@Context
-	private User _user;
+	private SPIRatingResource<Rating> _spiRatingResource;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -61,7 +61,6 @@ import com.liferay.journal.util.JournalConverter;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Sort;
@@ -113,7 +112,9 @@ import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
@@ -143,9 +144,7 @@ public class StructuredContentResourceImpl
 	public void deleteStructuredContentMyRating(Long structuredContentId)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		spiRatingResource.deleteRating(structuredContentId);
+		_spiRatingResource.deleteRating(structuredContentId);
 	}
 
 	@Override
@@ -283,9 +282,7 @@ public class StructuredContentResourceImpl
 	public Rating getStructuredContentMyRating(Long structuredContentId)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.getRating(structuredContentId);
+		return _spiRatingResource.getRating(structuredContentId);
 	}
 
 	@Override
@@ -411,9 +408,7 @@ public class StructuredContentResourceImpl
 			Long structuredContentId, Rating rating)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.addOrUpdateRating(
+		return _spiRatingResource.addOrUpdateRating(
 			rating.getRatingValue(), structuredContentId);
 	}
 
@@ -478,10 +473,21 @@ public class StructuredContentResourceImpl
 			Long structuredContentId, Rating rating)
 		throws Exception {
 
-		SPIRatingResource<Rating> spiRatingResource = _getSPIRatingResource();
-
-		return spiRatingResource.addOrUpdateRating(
+		return _spiRatingResource.addOrUpdateRating(
 			rating.getRatingValue(), structuredContentId);
+	}
+
+	@Activate
+	protected void activate() {
+		_spiRatingResource = new SPIRatingResource<>(
+			JournalArticle.class.getName(), _ratingsEntryLocalService,
+			ratingsEntry -> RatingUtil.toRating(
+				_portal, ratingsEntry, _userLocalService));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_spiRatingResource = null;
 	}
 
 	private StructuredContent _addStructuredContent(
@@ -645,14 +651,6 @@ public class StructuredContentResourceImpl
 		return transform(
 			ddmStructure.getRootFieldNames(),
 			fieldName -> _getDDMFormField(ddmStructure, fieldName));
-	}
-
-	private SPIRatingResource<Rating> _getSPIRatingResource() {
-		return new SPIRatingResource<>(
-			JournalArticle.class.getName(), _ratingsEntryLocalService,
-			ratingsEntry -> RatingUtil.toRating(
-				_portal, ratingsEntry, _userLocalService),
-			_user);
 	}
 
 	private StructuredContent _getStructuredContent(
@@ -915,11 +913,10 @@ public class StructuredContentResourceImpl
 	@Reference
 	private RatingsEntryLocalService _ratingsEntryLocalService;
 
+	private SPIRatingResource<Rating> _spiRatingResource;
+
 	@Reference
 	private StructuredContentDTOConverter _structuredContentDTOConverter;
-
-	@Context
-	private User _user;
 
 	@Reference
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
We weren't using @activate because we need Company and User but we can extract it from the thread local. It means a version change (User and Company are not needed anymore) but if you are going to rename the module, it won't need it.