### PR TITLE
LPS-97858 Fix order of polyfills

### DIFF
--- a/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/java/com/liferay/frontend/compatibility/ie/internal/servlet/taglib/IETopHeadDynamicInclude.java
+++ b/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/java/com/liferay/frontend/compatibility/ie/internal/servlet/taglib/IETopHeadDynamicInclude.java
@@ -83,10 +83,10 @@ public class IETopHeadDynamicInclude extends BaseDynamicInclude {
 	private static final String[] _FILE_NAMES = {
 		"/array.fill.js", "/array.find.js", "/array.findindex.js",
 		"/array.from.js", "/array.includes.js", "/array.of.js",
-		"/element.classlist.js", "/fetch.js", "/formdata.js",
-		"/nodelist.foreach.js", "/object.assign.js", "/object.entries.js",
-		"/object.values.js", "/promise.js", "/string.endswith.js",
-		"/string.includes.js", "/uint16array.slice.js", "/url.search.params.js"
+		"/element.classlist.js", "/url.search.params.js", "/fetch.js",
+		"/formdata.js", "/nodelist.foreach.js", "/object.assign.js",
+		"/object.entries.js", "/object.values.js", "/promise.js",
+		"/string.endswith.js", "/string.includes.js", "/uint16array.slice.js"
 	};
 
 	@Reference


### PR DESCRIPTION
Before this change these files were sorted alphabetically by name,
but since fetch.js depends on url.search.params.js being loaded the
order was changed.