### PR TITLE
LPS-97760 | master

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/convert/test/DocumentLibraryConvertProcessTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/convert/test/DocumentLibraryConvertProcessTest.java
@@ -73,6 +73,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -82,6 +83,7 @@ import org.junit.runner.RunWith;
  * @author Sergio González
  * @author Manuel de la Peña
  */
+@Ignore
 @RunWith(Arquillian.class)
 public class DocumentLibraryConvertProcessTest {
 


### PR DESCRIPTION
frontport of https://github.com/brianchandotcom/liferay-portal-ee/pull/25256 cc/ @adolfopa

@timpak I think confusion as to what branches this affected occured since the description of [LPS-97173](https://issues.liferay.com/browse/LPS-97173) only includes 7.2.x. In the future, I think it would be helpful to make sure the description matches the affects version and comments.

I am involving myself because CI seems backed up. This test is still aborting in PRs and upstream acceptance runs (times out at 2 hours), so that could be part of the cause. I noticed the slowness because some high-priority stable testsuite jobs are waiting for over 20 minutes for an available slave cc/@reizero00