### PR TITLE
LPS-97982 Discourage use of local ESLint overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@
 *~
 .ant-targets-build.xml
 .ant_targets
-.eslintrc
 .gh.json
 .sass-cache
 .sass_cache_*.css


### PR DESCRIPTION
Was just troubleshooting an issue with @p2kmgcl where he was seeing unwanted changes applied whenever he ran `gradlew formatSource`. Turns out the culprit was a pair of local ".estlintrc" files that he had on his machine but which were effectively invisible because of the .gitignore configuration.

Because we want to control linting totally uniformly across all of the liferay-portal, let's remove ".eslintrc" from the .gitignore, so that people don't unknowingly deviate from the universal config that we control. If people want to override, they can work with Frontend Infrastructure to identify and address the cause of their discrepancy.