### PR TITLE
LPS-97465 Remove lint suppressions in DDM

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/.eslintrc.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/.eslintrc.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+module.exports = {
+	extends: ['liferay/portal', 'liferay/metal']
+};

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Calculator/Calculator.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Calculator/Calculator.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-useless-escape: "warn" */
-
 import 'clay-dropdown';
 import Component from 'metal-component';
 import Soy from 'metal-soy';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilder.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import '../SuccessPage/SuccessPage.es';
 import ClayModal from 'clay-modal';
 import Component from 'metal-jsx';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withActionableFields.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withActionableFields.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import * as FormSupport from 'dynamic-data-mapping-form-renderer/js/components/FormRenderer/FormSupport.es';
 import ClayButton from 'clay-button';
 import ClayModal from 'clay-modal';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withEditablePageHeader.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withEditablePageHeader.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import './EditablePageHeader.soy.js';
 import Component from 'metal-jsx';
 import {Config} from 'metal-state';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withMoveableFields.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withMoveableFields.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import * as FormSupport from 'dynamic-data-mapping-form-renderer/js/components/FormRenderer/FormSupport.es';
 import Component from 'metal-jsx';
 import {Config} from 'metal-state';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withMultiplePages.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withMultiplePages.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import '../SuccessPage/SuccessPagePaginationItem.soy.js';
 import '../SuccessPage/SuccessPageRenderer.soy.js';
 import '../SuccessPage/SuccessPageWizardItem.soy.js';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withResizeableColumns.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withResizeableColumns.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import Component from 'metal-jsx';
 import Position from 'metal-position';
 import {Config} from 'metal-state';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleBuilder/RuleBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleBuilder/RuleBuilder.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import Component from 'metal-jsx';
 import dom from 'metal-dom';
 import RuleEditor from '../../components/RuleEditor/RuleEditor.es';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleEditor/RuleEditor.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleEditor/RuleEditor.es.js
@@ -12,9 +12,6 @@
  * details.
  */
 
-/* eslint no-for-of-loops/no-for-of-loops: "warn" */
-/* eslint no-unused-vars: "warn" */
-
 import '../Calculator/Calculator.es';
 import 'clay-alert';
 import 'clay-button';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import * as FormSupport from 'dynamic-data-mapping-form-renderer/js/components/FormRenderer/FormSupport.es';
 import classnames from 'classnames';
 import ClayButton from 'clay-button';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/LayoutProvider.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/LayoutProvider.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import LayoutProvider from 'source/components/LayoutProvider/LayoutProvider.es';
 import mockPages from 'mock/mockPages.es';
 import {JSXComponent} from 'metal-jsx';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/SuccessPage/SuccessPage.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/SuccessPage/SuccessPage.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-only-tests/no-only-tests: "warn" */
-
 import SuccessPage from 'source/components/SuccessPage/SuccessPage.es';
 import SucessPageSettings from 'mock/mockSuccessPage.es';
 import dom from 'metal-dom';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import '../FieldBase/FieldBase.es';
 import './DocumentLibraryRegister.soy.js';
 import Component from 'metal-component';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/validations.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/validations.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-useless-escape: "warn" */
-
 export const VALIDATIONS = {
 	numeric: [
 		{

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/util/visitors.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/js/util/visitors.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import mockPages from 'mock/mockPages.es';
 import {PagesVisitor} from 'source/util/visitors.es';
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/.eslintrc.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/.eslintrc.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+module.exports = {
+	extends: ['liferay/portal', 'liferay/metal']
+};

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/Popover/Popover.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/Popover/Popover.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import Component, {Config} from 'metal-jsx';
 import dom from 'metal-dom';
 import getCN from 'classnames';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/PreviewButton/PreviewButton.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/PreviewButton/PreviewButton.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import ClayButton from 'clay-button';
 import Component from 'metal-jsx';
 import Notifications from '../../util/Notifications.es';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/PublishButton/PublishButton.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/PublishButton/PublishButton.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import ClayButton from 'clay-button';
 import Component from 'metal-jsx';
 import {Config} from 'metal-state';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/ShareFormPopover/ShareFormPopover.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/ShareFormPopover/ShareFormPopover.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import ClipboardJS from 'clipboard';
 import Component, {Config} from 'metal-jsx';
 import getCN from 'classnames';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/ShareFormPopover/ShareFormPopover.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/ShareFormPopover/ShareFormPopover.es.js
@@ -19,7 +19,6 @@ import Component, {Config} from 'metal-jsx';
 import getCN from 'classnames';
 import Popover from '../Popover/Popover.es';
 import {Align} from 'metal-position';
-import {EventHandler} from 'metal-events';
 import {selectText} from 'dynamic-data-mapping-form-builder/js/util/dom.es';
 
 class ShareFormPopover extends Component {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import AutoSave from './util/AutoSave.es';
 import ClayModal from 'clay-modal';
 import Component from 'metal-jsx';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/util/AutoSave.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/util/AutoSave.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-spaced-func: 0 */
-
 import Component from 'metal-jsx';
 import objectHash from 'object-hash';
 import {Config} from 'metal-state';

--- a/modules/package.json
+++ b/modules/package.json
@@ -16,7 +16,7 @@
 		"liferay-npm-bridge-generator": "2.7.1",
 		"liferay-npm-bundler": "2.7.1",
 		"liferay-npm-bundler-preset-standard": "2.7.1",
-		"liferay-npm-scripts": "4.5.0",
+		"liferay-npm-scripts": "4.6.0",
 		"liferay-theme-es2015-hook": "8.0.0-rc.2",
 		"metal-jest-serializer": "2.0.0"
 	},

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -5494,10 +5494,10 @@ escodegen@^1.6.1, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-4.2.0.tgz#bc46c27cf1e1a12b500fc82ccfd1403eac237567"
-  integrity sha512-Rn1EA8QBQWvwr2A+PuzA2M5RsZNzqGs00AJAMcAWcn+0c4juuxiFnC3CWmUqajyCjaQbSBilXTtgLbJ5yEDs6A==
+eslint-config-liferay@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-4.3.0.tgz#b7b50748ca974c4e096907e14a80cb8a706f6b2c"
+  integrity sha512-1tTZFojMC654FGgQy5HlI7CLvX/GXSTASOWcuXntYC3zbwsjYLLi0WkcOPJhOO/ORbtO6fPFb7ZXJX9zDOr/dA==
   dependencies:
     eslint-config-prettier "5.0.0"
     eslint-plugin-no-for-of-loops "^1.0.0"
@@ -9703,10 +9703,10 @@ liferay-npm-bundler@2.7.1:
     semver "^5.5.0"
     xml-js "^1.6.8"
 
-liferay-npm-scripts@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-4.5.0.tgz#b538953ce78c177cb74266e68f2e3016d620a0cf"
-  integrity sha512-/HmlJmvpdEKPk7Lt90gHD6yF5kjDFQmLWZL1CyNtiTHESZJvNmwDN8Pnawxb2YrWc/XNnk6MPR/+tPLxIRw3Fg==
+liferay-npm-scripts@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-4.6.0.tgz#74c6265db71b124770061d70bcda589e23a6a244"
+  integrity sha512-VP660T5cr/E/tm5gviSkApluAnrbjFZVQ2n3V8SOyHupaWWgAC7pjS4/fIzNPooDbB7C0/015p6YuYexFzEoXg==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/plugin-proposal-class-properties" "7.4.4"
@@ -9720,7 +9720,7 @@ liferay-npm-scripts@4.5.0:
     cross-spawn "^6.0.5"
     deepmerge "^3.0.0"
     eslint "5.16.0"
-    eslint-config-liferay "^4.2.0"
+    eslint-config-liferay "^4.3.0"
     glob "^7.1.3"
     jest "^24.5.0"
     liferay-jest-junit-reporter "1.0.1"


### PR DESCRIPTION
Main mechanism is updating to liferay-npm-scripts v4.6.0, which includes a "liferay/metal" preset for dealing with portions of the codebase that use metal-jsx rather than React. This allows us to remove suppressions for 34 problems.

Other suppressions were already addressed in prior commits (eg. 84ea82e), but we forgot to remove the suppression comments.