### PR TITLE
LPS-96638 Fully support mutations (missing type conversion and validation)

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -39,6 +39,7 @@ import com.liferay.portal.vulcan.internal.accept.language.AcceptLanguageImpl;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.ContextProviderUtil;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.FilterContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.SortContextProvider;
+import com.liferay.portal.vulcan.internal.jaxrs.validation.ValidationUtil;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 
@@ -488,10 +489,14 @@ public class GraphQLServletExtender {
 
 				argument = _objectMapper.convertValue(
 					argument, parameter.getType());
+
+				ValidationUtil.validate(argument);
 			}
 
 			args[i] = argument;
 		}
+
+		ValidationUtil.validateArguments(instance, method, args);
 
 		return method.invoke(instance, args);
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.vulcan.internal.graphql.servlet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Company;
@@ -479,6 +481,15 @@ public class GraphQLServletExtender {
 				throw new ValidationException(parameterName + " is null");
 			}
 
+			Class<? extends Parameter> parameterClass = parameter.getClass();
+
+			if ((argument instanceof Map) &&
+				!parameterClass.isAssignableFrom(Map.class)) {
+
+				argument = _objectMapper.convertValue(
+					argument, parameter.getType());
+			}
+
 			args[i] = argument;
 		}
 
@@ -765,6 +776,8 @@ public class GraphQLServletExtender {
 				}
 
 			});
+
+	private static final ObjectMapper _objectMapper = new ObjectMapper();
 
 	private BundleContext _bundleContext;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/BaseMessageBodyReader.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/BaseMessageBodyReader.java
@@ -17,10 +17,8 @@ package com.liferay.portal.vulcan.internal.jaxrs.message.body;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.vulcan.internal.jaxrs.validation.ValidatorFactory;
+import com.liferay.portal.vulcan.internal.jaxrs.validation.ValidationUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,13 +27,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
 import java.util.Optional;
-import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
-
-import javax.validation.ConstraintViolation;
-import javax.validation.ValidationException;
-import javax.validation.Validator;
 
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.InternalServerErrorException;
@@ -83,7 +76,7 @@ public abstract class BaseMessageBodyReader implements MessageBodyReader {
 		if (!StringUtil.equals(
 				_httpServletRequest.getMethod(), HttpMethod.PATCH)) {
 
-			_validate(value);
+			ValidationUtil.validate(value);
 		}
 
 		return value;
@@ -98,30 +91,6 @@ public abstract class BaseMessageBodyReader implements MessageBodyReader {
 			() -> new InternalServerErrorException(
 				"Unable to generate object mapper for class " + clazz)
 		);
-	}
-
-	private void _validate(Object value) {
-		Validator validator = ValidatorFactory.getValidator();
-
-		Set<ConstraintViolation<Object>> constraintViolations =
-			validator.validate(value);
-
-		if (constraintViolations.isEmpty()) {
-			return;
-		}
-
-		StringBundler sb = new StringBundler(constraintViolations.size() * 4);
-
-		for (ConstraintViolation<Object> constraintViolation :
-				constraintViolations) {
-
-			sb.append(constraintViolation.getPropertyPath());
-			sb.append(StringPool.SPACE);
-			sb.append(constraintViolation.getMessage());
-			sb.append(StringPool.NEW_LINE);
-		}
-
-		throw new ValidationException(sb.toString());
 	}
 
 	private final Class<? extends ObjectMapper> _contextType;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/validation/BeanValidationInterceptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/validation/BeanValidationInterceptor.java
@@ -21,12 +21,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 
 import java.util.List;
-import java.util.Set;
-
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.validation.Validator;
-import javax.validation.executable.ExecutableValidator;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -124,17 +118,7 @@ public class BeanValidationInterceptor
 			return;
 		}
 
-		Validator validator = ValidatorFactory.getValidator();
-
-		ExecutableValidator executableValidator = validator.forExecutables();
-
-		Set<ConstraintViolation<Object>> constraintViolations =
-			executableValidator.validateParameters(
-				resource, method, arguments.toArray());
-
-		if (!constraintViolations.isEmpty()) {
-			throw new ConstraintViolationException(constraintViolations);
-		}
+		ValidationUtil.validateArguments(resource, method, arguments.toArray());
 	}
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/validation/ValidationUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/validation/ValidationUtil.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.validation;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+
+import java.lang.reflect.Method;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ValidationException;
+import javax.validation.Validator;
+import javax.validation.executable.ExecutableValidator;
+
+/**
+ * @author Javier Gamarra
+ */
+public class ValidationUtil {
+
+	public static void validate(Object value) {
+		Validator validator = ValidatorFactory.getValidator();
+
+		Set<ConstraintViolation<Object>> constraintViolations =
+			validator.validate(value);
+
+		if (!constraintViolations.isEmpty()) {
+			_throwValidationException(constraintViolations);
+		}
+	}
+
+	public static void validateArguments(
+		Object resource, Method method, Object[] arguments) {
+
+		Validator validator = ValidatorFactory.getValidator();
+
+		ExecutableValidator executableValidator = validator.forExecutables();
+
+		Set<ConstraintViolation<Object>> constraintViolations =
+			executableValidator.validateParameters(resource, method, arguments);
+
+		if (!constraintViolations.isEmpty()) {
+			_throwValidationException(constraintViolations);
+		}
+	}
+
+	private static void _throwValidationException(
+		Set<ConstraintViolation<Object>> constraintViolations) {
+
+		StringBundler sb = new StringBundler(constraintViolations.size() * 4);
+
+		for (ConstraintViolation<Object> constraintViolation :
+				constraintViolations) {
+
+			sb.append(constraintViolation.getPropertyPath());
+			sb.append(StringPool.SPACE);
+			sb.append(constraintViolation.getMessage());
+			sb.append(StringPool.NEW_LINE);
+		}
+
+		throw new ValidationException(sb.toString());
+	}
+
+}


### PR DESCRIPTION
I tried to modify the library (graphql-java, not annotations) but is not prepared to be extended/modified. The map behaviour is part of the GraphQL spec (https://graphql.github.io/graphql-spec/June2018/#sec-Input-Objects). The official recomendation is to convert manually or with jackson.