### PR TITLE
LPS-97378 | master

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/details.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/details.jsp
@@ -47,8 +47,10 @@ StringBuilder friendlyURLBase = new StringBuilder();
 	String virtualHostname = layoutSet.getVirtualHostname();
 
 	if (Validator.isNull(virtualHostname) || (friendlyURLBase.indexOf(virtualHostname) == -1)) {
+		String groupFriendlyURL = HttpUtil.decodeURL(group.getFriendlyURL());
+
 		friendlyURLBase.append(group.getPathFriendlyURL(layoutsAdminDisplayContext.isPrivateLayout(), themeDisplay));
-		friendlyURLBase.append(group.getFriendlyURL());
+		friendlyURLBase.append(groupFriendlyURL);
 	}
 	%>
 

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/SiteAdminPortlet.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/SiteAdminPortlet.java
@@ -700,7 +700,8 @@ public class SiteAdminPortlet extends MVCPortlet {
 				actionRequest, "description");
 			type = ParamUtil.getInteger(
 				actionRequest, "type", GroupConstants.TYPE_SITE_OPEN);
-			friendlyURL = ParamUtil.getString(actionRequest, "friendlyURL");
+			friendlyURL = ParamUtil.getString(
+				actionRequest, "groupFriendlyURL");
 			manualMembership = ParamUtil.getBoolean(
 				actionRequest, "manualMembership", true);
 			inheritContent = ParamUtil.getBoolean(
@@ -736,7 +737,7 @@ public class SiteAdminPortlet extends MVCPortlet {
 				actionRequest, "manualMembership",
 				liveGroup.isManualMembership());
 			friendlyURL = ParamUtil.getString(
-				actionRequest, "friendlyURL", liveGroup.getFriendlyURL());
+				actionRequest, "groupFriendlyURL", liveGroup.getFriendlyURL());
 			inheritContent = ParamUtil.getBoolean(
 				actionRequest, "inheritContent", liveGroup.isInheritContent());
 			active = ParamUtil.getBoolean(

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/site_url.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/site_url.jsp
@@ -115,7 +115,7 @@ String privateVirtualHost = ParamUtil.getString(request, "privateVirtualHost", B
 		<liferay-ui:message arguments="<%= new Object[] {themeDisplay.getPortalURL() + themeDisplay.getPathFriendlyURLPublic(), themeDisplay.getPortalURL() + themeDisplay.getPathFriendlyURLPrivateGroup()} %>" key="the-friendly-url-is-appended-to-x-for-public-pages-and-x-for-private-pages" translateArguments="<%= false %>" />
 	</p>
 
-	<aui:input label="friendly-url" name="friendlyURL" />
+	<aui:input label="friendly-url" name="friendlyURL" value="<%= HttpUtil.decodeURL(liveGroup.getFriendlyURL()) %>" />
 
 	<c:if test="<%= liveGroup.hasStagingGroup() %>">
 		<aui:input bean="<%= stagingGroup %>" field="friendlyURL" fieldParam="stagingFriendlyURL" label="staging-friendly-url" model="<%= Group.class %>" name="stagingFriendlyURL" />

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/site_url.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/site_url.jsp
@@ -115,10 +115,10 @@ String privateVirtualHost = ParamUtil.getString(request, "privateVirtualHost", B
 		<liferay-ui:message arguments="<%= new Object[] {themeDisplay.getPortalURL() + themeDisplay.getPathFriendlyURLPublic(), themeDisplay.getPortalURL() + themeDisplay.getPathFriendlyURLPrivateGroup()} %>" key="the-friendly-url-is-appended-to-x-for-public-pages-and-x-for-private-pages" translateArguments="<%= false %>" />
 	</p>
 
-	<aui:input label="friendly-url" name="friendlyURL" value="<%= HttpUtil.decodeURL(liveGroup.getFriendlyURL()) %>" />
+	<aui:input label="friendly-url" name="groupFriendlyURL" type="text" value="<%= HttpUtil.decodeURL(liveGroup.getFriendlyURL()) %>" />
 
 	<c:if test="<%= liveGroup.hasStagingGroup() %>">
-		<aui:input bean="<%= stagingGroup %>" field="friendlyURL" fieldParam="stagingFriendlyURL" label="staging-friendly-url" model="<%= Group.class %>" name="stagingFriendlyURL" />
+		<aui:input label="staging-friendly-url" name="stagingFriendlyURL" type="text" value="<%= HttpUtil.decodeURL(stagingGroup.getFriendlyURL()) %>" />
 	</c:if>
 
 	<p class="text-muted">
@@ -164,7 +164,7 @@ String privateVirtualHost = ParamUtil.getString(request, "privateVirtualHost", B
 </aui:fieldset>
 
 <script>
-	var friendlyURL = document.getElementById('<portlet:namespace />friendlyURL');
+	var friendlyURL = document.getElementById('<portlet:namespace />groupFriendlyURL');
 
 	if (friendlyURL) {
 		friendlyURL.addEventListener(

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupServiceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupServiceTest.java
@@ -58,6 +58,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
+import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
@@ -1143,6 +1144,19 @@ public class GroupServiceTest {
 		Assert.assertEquals(
 			LocaleUtil.SPAIN,
 			_portal.getSiteDefaultLocale(_group.getGroupId()));
+	}
+
+	@Test
+	public void testUpdateFriendlyURLWithJapaneseCharacters() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		String friendlyURL = "/平仮名片仮名漢字";
+
+		_group = _groupService.updateFriendlyURL(
+			_group.getGroupId(), friendlyURL);
+
+		Assert.assertEquals(
+			friendlyURL, HttpUtil.decodeURL(_group.getFriendlyURL()));
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -4432,7 +4432,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 	}
 
 	protected String getFriendlyURL(String friendlyURL) {
-		return FriendlyURLNormalizerUtil.normalize(friendlyURL);
+		return FriendlyURLNormalizerUtil.normalizeWithEncoding(friendlyURL);
 	}
 
 	protected String getOrgGroupName(String name) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-97378
cc: @jkappler I checked to make sure that updateFriendlyUrl will not fail validation on Japanese characters(used hirigana/katakana/kanji to be safe) and then made sure if a user properly use HttpUtil.decodeURL, they should expect the friendly url to be correct in japanese locale