### PR TITLE
LPS-98111 Fix tests

### DIFF
--- a/modules/apps/document-library/document-library-preview-document/package.json
+++ b/modules/apps/document-library/document-library-preview-document/package.json
@@ -15,7 +15,7 @@
 			"Liferay": {}
 		},
 		"moduleNameMapper": {
-			"(.*)\\.soy": "$1.soy.js"
+			"(.+/DocumentPreviewer\\.soy)": "$1.js"
 		},
 		"setupFilesAfterEnv": [
 			"<rootDir>/test/setup/index.js"

--- a/modules/apps/document-library/document-library-preview-image/package.json
+++ b/modules/apps/document-library/document-library-preview-image/package.json
@@ -14,7 +14,7 @@
 			"Liferay": {}
 		},
 		"moduleNameMapper": {
-			"(.*)\\.soy": "$1.soy.js"
+			"(.+/ImagePreviewer\\.soy)": "$1.js"
 		},
 		"setupFilesAfterEnv": [
 			"<rootDir>/test/setup/index.js"

--- a/modules/apps/document-library/document-library-preview-video/package.json
+++ b/modules/apps/document-library/document-library-preview-video/package.json
@@ -10,7 +10,7 @@
 			"Liferay": {}
 		},
 		"moduleNameMapper": {
-			"(.*)\\.soy": "$1.soy.js"
+			"(.+/VideoPreviewer\\.soy)": "$1.js"
 		},
 		"setupFilesAfterEnv": [
 			"<rootDir>/test/setup/index.js"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/jest-workspaces-transform.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/jest-workspaces-transform.js
@@ -1,3 +1,0 @@
-module.exports = require('babel-jest').createTransformer({
-	presets: ['@babel/preset-env']
-});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
@@ -17,8 +17,6 @@
 	"jest": {
 		"moduleNameMapper": {
 			"(.*)\\.soy$": "$1.soy.js",
-			"dynamic-data-mapping-form-builder/(.*)": "<rootDir>/../dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/$1",
-			"dynamic-data-mapping-form-renderer/(.*)": "<rootDir>/../dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/$1",
 			"source/(.*)": "<rootDir>/src/main/resources/META-INF/resources/$1.js"
 		},
 		"modulePathIgnorePatterns": [
@@ -41,10 +39,7 @@
 			"Select",
 			"Tooltip",
 			"Validation"
-		],
-		"transform": {
-			".+": "./jest-workspaces-transform.js"
-		}
+		]
 	},
 	"main": "./",
 	"name": "dynamic-data-mapping-form-field-type",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/jest-workspaces-transform.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/jest-workspaces-transform.js
@@ -1,3 +1,0 @@
-module.exports = require('babel-jest').createTransformer({
-	presets: ['@babel/preset-env']
-});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/package.json
@@ -55,10 +55,7 @@
 		],
 		"testPathIgnorePatterns": [
 			"FormRenderer"
-		],
-		"transform": {
-			".+": "./jest-workspaces-transform.js"
-		}
+		]
 	},
 	"main": "./",
 	"name": "dynamic-data-mapping-form-renderer",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/jest-workspaces-transform.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/jest-workspaces-transform.js
@@ -1,3 +1,0 @@
-module.exports = require('babel-jest').createTransformer({
-	presets: ['@babel/preset-env']
-});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/package.json
@@ -21,8 +21,6 @@
 	"jest": {
 		"moduleNameMapper": {
 			"(.*)\\.soy$": "$1.soy.js",
-			"dynamic-data-mapping-form-builder/(.*)": "<rootDir>/../dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/$1",
-			"dynamic-data-mapping-form-renderer/(.*)": "<rootDir>/../dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/$1",
 			"source/(.*)": "<rootDir>/src/main/resources/META-INF/resources/admin/js/$1.js"
 		},
 		"modulePathIgnorePatterns": [
@@ -42,10 +40,7 @@
 		],
 		"testPathIgnorePatterns": [
 			"ShareFormPopover"
-		],
-		"transform": {
-			".+": "./jest-workspaces-transform.js"
-		}
+		]
 	},
 	"main": "admin/js/main.es.js",
 	"name": "dynamic-data-mapping-form-web",

--- a/modules/apps/frontend-js/frontend-js-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-web/package.json
@@ -28,9 +28,6 @@
 		"setupFiles": [
 			"<rootDir>/test/liferay/portlet/mock/setup.es.js"
 		],
-		"testMatch": [
-			"**/test/**/*.js"
-		],
 		"testPathIgnorePatterns": [
 			"<rootDir>/node_modules/",
 			"<rootDir>/test/liferay/portlet/mock/portlet_data.es.js",

--- a/modules/package.json
+++ b/modules/package.json
@@ -16,7 +16,7 @@
 		"liferay-npm-bridge-generator": "2.7.1",
 		"liferay-npm-bundler": "2.7.1",
 		"liferay-npm-bundler-preset-standard": "2.7.1",
-		"liferay-npm-scripts": "4.6.0",
+		"liferay-npm-scripts": "4.8.0",
 		"liferay-theme-es2015-hook": "8.0.0-rc.2",
 		"metal-jest-serializer": "2.0.0"
 	},
@@ -27,8 +27,8 @@
 	},
 	"workspaces": {
 		"packages": [
-			"apps/**/*-taglib",
-			"apps/**/*-web",
+			"apps/*/*-taglib",
+			"apps/*/*-web",
 			"apps/analytics/analytics-client-js",
 			"apps/data-engine/data-engine-rest-impl",
 			"apps/document-library/document-library-preview-audio",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -4181,7 +4181,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.2.0, core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.5, core-js@^2.5.6:
+core-js@^2.2.0, core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.6:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
@@ -9696,10 +9696,10 @@ liferay-npm-bundler@2.7.1:
     semver "^5.5.0"
     xml-js "^1.6.8"
 
-liferay-npm-scripts@4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-4.6.0.tgz#74c6265db71b124770061d70bcda589e23a6a244"
-  integrity sha512-VP660T5cr/E/tm5gviSkApluAnrbjFZVQ2n3V8SOyHupaWWgAC7pjS4/fIzNPooDbB7C0/015p6YuYexFzEoXg==
+liferay-npm-scripts@4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-4.8.0.tgz#c69222b45ee529006a3d5678f7fe7d8c7ded7219"
+  integrity sha512-SeRrPmlGfFCgae7GUYZsg8nxjnaV0753RTfk0aw/7DNhtAp3Igjc46wmM0I6HccuRQVnJtu7Cfld8BXAv0hoiA==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/plugin-proposal-class-properties" "7.4.4"
@@ -12948,11 +12948,6 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
-
-regenerator-runtime@^0.12.0:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
-  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
 regenerator-runtime@^0.13.2:
   version "0.13.2"


### PR DESCRIPTION
Update to liferay-npm-scripts v4.8.0, which fixes the test failures caused by the move of `debounce()` to frontend-js-web. Basically, before this version, we weren't able to do cross-project imports in the test suite, and now we can.

In the process of preparing the update I was able to standardize things a little and remove some redundant config as a result.

I updated the workspace globs in the top-level "package.json" because liferay-npm-scripts uses those globs to produce the mapping that allows us to do cross-project imports: we don't actually need or want an arbitrarily deep match there.

Also tested against "master-private" so will prepare a corresponding PR for that.