### PR TITLE
LPS-97680 Streamline linting in layout-content-page-editor-web

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/.eslintrc.js
+++ b/modules/apps/layout/layout-content-page-editor-web/.eslintrc.js
@@ -13,8 +13,12 @@
  */
 
 module.exports = {
+	extends: ['liferay/portal', 'liferay/react'],
 	globals: {
 		AlloyEditor: true,
 		process: true
+	},
+	rules: {
+		'react/no-string-refs': 'off',
 	}
 };

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/NoCommentsMessage.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/NoCommentsMessage.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import React from 'react';
 
 import {NoCommentsMessageIcon} from './NoCommentsMessageIcon.es';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/NoCommentsMessageIcon.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/NoCommentsMessageIcon.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import React from 'react';
 
 const NoCommentsMessageIcon = () => (

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/SidebarComments.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/SidebarComments.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import React from 'react';
 import {NoCommentsMessage} from './NoCommentsMessage.es';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/SidebarCommentsPanel.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/SidebarCommentsPanel.es.js
@@ -21,8 +21,6 @@ import {getConnectedComponent} from '../../../store/ConnectedComponent.es';
 import {SidebarComments} from './SidebarComments.es';
 import templates from './SidebarCommentsPanel.soy';
 
-/* eslint no-unused-vars: "warn" */
-
 class SidebarCommentsPanel extends Component {
 	disposed() {
 		ReactDOM.unmountComponentAtNode(this.refs.app);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/toolbar/Experiments.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/toolbar/Experiments.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: ["error", { "varsIgnorePattern": "^React$|^ClayIconSpriteContext$|^PageEditorContext$|^ConnectedExperiments$" }]*/
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Component from 'metal-component';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/toolbar/Experiments/CreateExperimentModal.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/toolbar/Experiments/CreateExperimentModal.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import React, {useState, useContext} from 'react';
 import PropTypes from 'prop-types';
 import ClayButton from '@clayui/button';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/toolbar/Experiments/ExperimentsDropdown.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/toolbar/Experiments/ExperimentsDropdown.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import ClayDropDown from '@clayui/drop-down';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/store/ConnectedComponent.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/store/ConnectedComponent.es.js
@@ -17,8 +17,6 @@ import {Config} from 'metal-state';
 import {connect, disconnect, Store} from './store.es';
 import INITIAL_STATE from './state.es';
 
-/* eslint no-unused-vars: "warn" */
-
 /**
  * HOC that returns a component that connects automatically
  * to a Store parameter.

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/store/store.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/store/store.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-undef: "warn" */
-
 import State, {Config} from 'metal-state';
 import {DEFAULT_INITIAL_STATE} from './state.es';
 


### PR DESCRIPTION
This commit removes the last of the lint suppressions in this project. This module is a bit different because it has a mix of React and metal-jsx. That means we can either:

- Use the "liferay/metal" preset, which means we'll miss out on React-specific lints, and we'll see some spurious warnings about `React` being an unused variable.
- Use the "liferay/react" preset, which means we'll see errors about using deprecated string refs (undesirable in React, but literally the only way refs work in metal-jsx).

I went with the latter because it requires the smallest configuration override to get rid of the spurious lints (that is, turning off the "react/no-string-refs" rule). Additionally, I think this is the right call because:

- We should be skating towards where the puck is going (majority React usage) and not towards where it is at the moment (majority metal-jsx usage in this module).
- Undesired string ref usage in React is actually very rare because of our dominant use of functional components.