### PR TITLE
LPS-97686 Remove remaining lint suppressions from frontend-image-editor

### DIFF
--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-brightness/src/main/resources/META-INF/resources/BrightnessComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-brightness/src/main/resources/META-INF/resources/BrightnessComponent.es.js
@@ -12,16 +12,14 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
-import Component from 'metal-component';
-import {Slider} from 'frontend-js-web';
-import Soy from 'metal-soy';
 import {debounce} from 'frontend-js-web';
+import 'frontend-js-web/liferay/compat/slider/Slider.es';
 import {core} from 'metal';
+import Component from 'metal-component';
+import Soy from 'metal-soy';
 
 import componentTemplates from './BrightnessComponent.soy';
-import controlsTemplates from './BrightnessControls.soy';
+import './BrightnessControls.soy';
 
 /**
  * Creates a Brightness component.
@@ -97,7 +95,7 @@ class BrightnessComponent extends Component {
 	 * finishes processing the image.
 	 */
 	spawnWorker_(message) {
-		return new Promise((resolve, reject) => {
+		return new Promise(resolve => {
 			const workerURI = this.modulePath + '/BrightnessWorker.js';
 			const processWorker = new Worker(workerURI);
 			processWorker.onmessage = event => resolve(event.data);

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-contrast/src/main/resources/META-INF/resources/ContrastComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-contrast/src/main/resources/META-INF/resources/ContrastComponent.es.js
@@ -12,16 +12,14 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
-import Component from 'metal-component';
-import {Slider} from 'frontend-js-web';
-import Soy from 'metal-soy';
 import {debounce} from 'frontend-js-web';
+import 'frontend-js-web/liferay/compat/slider/Slider.es';
 import {core} from 'metal';
+import Component from 'metal-component';
+import Soy from 'metal-soy';
 
 import componentTemplates from './ContrastComponent.soy';
-import controlsTemplates from './ContrastControls.soy';
+import './ContrastControls.soy';
 
 /**
  * Creates a Contrast component.
@@ -96,7 +94,7 @@ class ContrastComponent extends Component {
 	 * finishes processing the image.
 	 */
 	spawnWorker_(message) {
-		return new Promise((resolve, reject) => {
+		return new Promise(resolve => {
 			const workerURI = this.modulePath + '/ContrastWorker.js';
 			const processWorker = new Worker(workerURI);
 			processWorker.onmessage = event => resolve(event.data);

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-crop/src/main/resources/META-INF/resources/CropComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-crop/src/main/resources/META-INF/resources/CropComponent.es.js
@@ -12,14 +12,12 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
+import {core} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
-import {core} from 'metal';
 
 import componentTemplates from './CropComponent.soy';
-import controlsTemplates from './CropControls.soy';
+import './CropControls.soy';
 
 /**
  * Creates a Crop component.

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-crop/src/main/resources/META-INF/resources/CropHandles.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-crop/src/main/resources/META-INF/resources/CropHandles.es.js
@@ -12,14 +12,12 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
+import {async, core} from 'metal';
 import Component from 'metal-component';
-import Position from 'metal-position';
-import Soy from 'metal-soy';
 import dom from 'metal-dom';
 import {Drag} from 'metal-drag-drop';
-import {async, core} from 'metal';
+import Position from 'metal-position';
+import Soy from 'metal-soy';
 
 import handlesTemplates from './CropHandles.soy';
 
@@ -89,7 +87,7 @@ class CropHandles extends Component {
 	bindSelectionDrag_() {
 		const canvas = this.getImageEditorCanvas();
 
-		this.selectionDrag_.on(Drag.Events.DRAG, (data, event) => {
+		this.selectionDrag_.on(Drag.Events.DRAG, data => {
 			const left =
 				data.relativeX - canvas.offsetLeft + this.selectionBorderWidth_;
 			const top =
@@ -120,7 +118,7 @@ class CropHandles extends Component {
 	bindSizeDrag_() {
 		const canvas = this.getImageEditorCanvas();
 
-		this.sizeDrag_.on(Drag.Events.DRAG, (data, event) => {
+		this.sizeDrag_.on(Drag.Events.DRAG, data => {
 			const width = data.relativeX + this.resizer.offsetWidth / 2;
 			const height = data.relativeY + this.resizer.offsetHeight / 2;
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.es.js
@@ -12,14 +12,12 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
+import {async, core} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
-import {async, core} from 'metal';
 
 import componentTemplates from './EffectsComponent.soy';
-import controlsTemplates from './EffectsControls.soy';
+import './EffectsControls.soy';
 
 /**
  * Creates an Effects component.
@@ -152,7 +150,7 @@ class EffectsComponent extends Component {
 	 * are prefetched.
 	 */
 	prefetchEffects_() {
-		return new Promise((resolve, reject) => {
+		return new Promise(resolve => {
 			if (!this.isDisposed()) {
 				const missingEffects = this.effects.filter(
 					effect => !this.cache_[effect]
@@ -258,7 +256,7 @@ class EffectsComponent extends Component {
 	 * finishes processing the image.
 	 */
 	spawnWorker_(message) {
-		return new Promise((resolve, reject) => {
+		return new Promise(resolve => {
 			const processWorker = new Worker(
 				this.modulePath + '/EffectsWorker.js'
 			);

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-resize/src/main/resources/META-INF/resources/ResizeComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-resize/src/main/resources/META-INF/resources/ResizeComponent.es.js
@@ -14,12 +14,12 @@
 
 /* eslint no-unused-vars: "warn" */
 
+import {core} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
-import {core} from 'metal';
 
 import componentTemplates from './ResizeComponent.soy';
-import controlsTemplates from './ResizeControls.soy';
+import './ResizeControls.soy';
 
 /**
  * Creates a Resize component.
@@ -111,10 +111,8 @@ class ResizeComponent extends Component {
 	 * Toggles the value of the <code>lockProportions</code> attribute. When
 	 * enabled, changes in one of the dimensions cascades changes to the other
 	 * to keep the original image ratio.
-	 *
-	 * @param  {MouseEvent} event
 	 */
-	toggleLockProportions(event) {
+	toggleLockProportions() {
 		this.lockProportions = !this.lockProportions;
 	}
 }

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-rotate/src/main/resources/META-INF/resources/RotateComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-rotate/src/main/resources/META-INF/resources/RotateComponent.es.js
@@ -12,14 +12,12 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
+import {core} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
-import {core} from 'metal';
 
 import componentTemplates from './RotateComponent.soy';
-import controlsTemplates from './RotateControls.soy';
+import './RotateControls.soy';
 
 /**
  * Creates a Rotate component.
@@ -81,7 +79,7 @@ class RotateComponent extends Component {
 	 * rotated.
 	 */
 	rotate_(imageData, rotationAngle) {
-		const cancellablePromise = new Promise((resolve, reject) => {
+		const cancellablePromise = new Promise(resolve => {
 			const imageWidth = imageData.width;
 			const imageHeight = imageData.height;
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-saturation/src/main/resources/META-INF/resources/SaturationComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-saturation/src/main/resources/META-INF/resources/SaturationComponent.es.js
@@ -12,16 +12,14 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
-import Component from 'metal-component';
-import {Slider} from 'frontend-js-web';
-import Soy from 'metal-soy';
 import {debounce} from 'frontend-js-web';
+import 'frontend-js-web/liferay/compat/slider/Slider.es';
 import {core} from 'metal';
+import Component from 'metal-component';
+import Soy from 'metal-soy';
 
 import componentTemplates from './SaturationComponent.soy';
-import controlsTemplates from './SaturationControls.soy';
+import './SaturationControls.soy';
 
 /**
  * Creates a Saturation component.
@@ -96,7 +94,7 @@ class SaturationComponent extends Component {
 	 * finishes processing the image.
 	 */
 	spawnWorker_(message) {
-		return new Promise((resolve, reject) => {
+		return new Promise(resolve => {
 			const workerURI = this.modulePath + '/SaturationWorker.js';
 			const processWorker = new Worker(workerURI);
 


### PR DESCRIPTION
These were missed in the initial pass, and drop the lint warning count by about 19.

The "controls" imports are all just for side-effects (they register delegate templates with `deltemplate`), so they all became `import './SomeSoyFile.soy'`.

Likewise, `Slider.es` is only imported for its side-effect (a call to `Soy.register`).