### PR TITLE
LPS-97526 Fix errors

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/toolbar/Experiments/CreateExperimentModal.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/toolbar/Experiments/CreateExperimentModal.es.js
@@ -35,11 +35,11 @@ function CreateExperimentModal({setVisible, visible, onCreateExperiment}) {
 	const formId = `${portletNamespace}_createExperiement`;
 
 	return (
-		<>
+		<React.Fragment>
 			{visible && (
 				<ClayModal onClose={_closeModal} size='lg'>
 					{onClose => (
-						<>
+						<React.Fragment>
 							<ClayModal.Header>
 								{Liferay.Language.get('test-settings')}
 							</ClayModal.Header>
@@ -98,11 +98,11 @@ function CreateExperimentModal({setVisible, visible, onCreateExperiment}) {
 									</ClayButton>
 								}
 							/>
-						</>
+						</React.Fragment>
 					)}
 				</ClayModal>
 			)}
-		</>
+		</React.Fragment>
 	);
 
 	function _closeModal() {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/toolbar/Experiments/ExperimentsDropdown.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/toolbar/Experiments/ExperimentsDropdown.es.js
@@ -38,7 +38,7 @@ function ExperimentsDropdown({
 	);
 
 	return (
-		<>
+		<React.Fragment>
 			<ClayDropDown
 				className='ml-2'
 				trigger={
@@ -51,7 +51,7 @@ function ExperimentsDropdown({
 				onActiveChange={setActive}
 			>
 				{filteredExperiments.length > 0 ? (
-					<>
+					<React.Fragment>
 						<div className='px-3 pt-2'>
 							<h6 className='text-uppercase'>
 								{Liferay.Language.get(
@@ -78,7 +78,7 @@ function ExperimentsDropdown({
 								);
 							})}
 						</ClayDropDown.ItemList>
-					</>
+					</React.Fragment>
 				) : (
 					<div className='px-3 pt-3'>
 						<h2>
@@ -112,7 +112,7 @@ function ExperimentsDropdown({
 					setVisible={setModalShown}
 				/>
 			)}
-		</>
+		</React.Fragment>
 	);
 }
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/reducers/segmentsExperiments.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/reducers/segmentsExperiments.es.js
@@ -27,7 +27,7 @@ const CREATE_SEGMENTS_EXPERIMENT_URL =
  * @param {object} action.payload
  * @param {string} action.payload.name
  * @param {string} action.payload.description
- * @returns
+ * @returns {Promise}
  */
 export function createSegmentsExperimentsReducer(state, action) {
 	return new Promise((resolve, reject) => {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/store/ConnectedComponent.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/store/ConnectedComponent.es.js
@@ -91,10 +91,10 @@ const getConnectedComponent = (Component, properties) => {
 /**
  * Second order function to produce a Connected Component Wrapper
  *
- * @param {Function} mapStateToProps - Recieves the state and returns mapped version of it ready for consumption by the Wrapped Component
- * @param {Function} mapDispatchToProps - Recieves the dispatch and returns a set of component props that use it to call the modify the state tree
+ * @param {Function} mapStateToProps - Receives the state and returns mapped version of it ready for consumption by the Wrapped Component
+ * @param {Function} mapDispatchToProps - Receives the dispatch and returns a set of component props that use it to call the modify the state tree
  * @param {Store} store
- * @returns
+ * @returns {Function}
  */
 function getConnectedReactComponent(
 	mapStateToProps,


### PR DESCRIPTION
Fixes the errors reported here:

https://github.com/brianchandotcom/liferay-portal/pull/75660#issuecomment-511035136

Specifically:

- Missing `@returns` tag values.
- `<>`/`</>` shorthand syntax for `<React.Fragment>`/`</React.Fragment>` which is causing some as-yet-undetermined tool to choke.

I'm trying to identify the tool which isn't happy with the shorthand and if I can't find or upgrade it I'll add a lint to prevent shorthand usage.