### PR TITLE
LPS-97586 Update liferay-npm-scripts to v4.9.0

### DIFF
--- a/modules/apps/segments/segments-web/package.json
+++ b/modules/apps/segments/segments-web/package.json
@@ -25,11 +25,9 @@
 		"css-loader": "^2.0.1",
 		"html-webpack-plugin": "^3.2.0",
 		"html-webpack-template": "^6.2.0",
-		"jest-dom": "^3.0.0",
 		"liferay-lang-key-dev-loader": "^1.0.3",
 		"node-sass": "^4.11.0",
 		"odata-v4-parser": "^0.1.29",
-		"react-testing-library": "^5.3.2",
 		"sass-loader": "^7.1.0",
 		"snapshot-diff": "^0.4.1",
 		"style-loader": "^0.23.1"

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/ContributorsBuilder.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/ContributorsBuilder.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {cleanup, render} from '@testing-library/react';
 import ContributorsBuilder from 'components/criteria_builder/ContributorsBuilder.es';
 import React from 'react';
-import {cleanup, render} from 'react-testing-library';
 import {
 	CONJUNCTIONS,
 	SUPPORTED_CONJUNCTIONS,

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaBuilder.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaBuilder.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {cleanup, render} from '@testing-library/react';
 import CriteriaBuilder from 'components/criteria_builder/CriteriaBuilder.es';
 import React from 'react';
-import {cleanup, render} from 'react-testing-library';
 
 describe('CriteriaBuilder', () => {
 	afterEach(cleanup);

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaGroup.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaGroup.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {cleanup, render} from '@testing-library/react';
 import CriteriaGroup from 'components/criteria_builder/CriteriaGroup.es';
 import React from 'react';
-import {cleanup, render} from 'react-testing-library';
 
 const connectDnd = jest.fn(el => el);
 

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaRow.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaRow.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {cleanup, render} from '@testing-library/react';
 import CriteriaRow from 'components/criteria_builder/CriteriaRow.es';
 import React from 'react';
-import {cleanup, render} from 'react-testing-library';
 import {PROPERTY_TYPES} from 'utils/constants.es';
 
 const connectDnd = jest.fn(el => el);

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/DropZone.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/DropZone.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {cleanup, render} from '@testing-library/react';
 import DropZone from 'components/criteria_builder/DropZone.es';
 import React from 'react';
-import {cleanup, render} from 'react-testing-library';
 
 const connectDnd = jest.fn(el => el);
 

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/EmptyDropZone.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/EmptyDropZone.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {cleanup, render} from '@testing-library/react';
 import EmptyDropZone from 'components/criteria_builder/EmptyDropZone.es';
 import React from 'react';
-import {cleanup, render} from 'react-testing-library';
 
 const connectDnd = jest.fn(el => el);
 

--- a/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/CriteriaSidebar.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/CriteriaSidebar.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {cleanup, render} from '@testing-library/react';
 import CriteriaSidebar from 'components/criteria_sidebar/CriteriaSidebar.es';
 import React from 'react';
-import {cleanup, render} from 'react-testing-library';
 
 describe('CriteriaSidebar', () => {
 	afterEach(cleanup);

--- a/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/CriteriaSidebarItem.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/CriteriaSidebarItem.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {cleanup, render} from '@testing-library/react';
 import CriteriaSidebarItem from 'components/criteria_sidebar/CriteriaSidebarItem.es';
 import React from 'react';
-import {cleanup, render} from 'react-testing-library';
 
 const connectDnd = jest.fn(el => el);
 

--- a/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/CriteriaSidebarSearchBar.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/CriteriaSidebarSearchBar.es.js
@@ -12,10 +12,10 @@
  * details.
  */
 
+import {cleanup, fireEvent, render} from '@testing-library/react';
 import CriteriaSidebarSearchBar from 'components/criteria_sidebar/CriteriaSidebarSearchBar.es';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import {cleanup, fireEvent, render} from 'react-testing-library';
 
 const SEARCH_BUTTON_TESTID = 'search-button';
 

--- a/modules/apps/segments/segments-web/test/js/components/inputs/BooleanInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/BooleanInput.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {cleanup, render} from '@testing-library/react';
 import BooleanInput from 'components/inputs/BooleanInput.es';
 import React from 'react';
-import {cleanup, render} from 'react-testing-library';
 import {testControlledInput} from 'test/utils';
 
 const OPTIONS_BOOLEAN_INPUT_TESTID = 'options-boolean';

--- a/modules/apps/segments/segments-web/test/js/components/inputs/CollectionInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/CollectionInput.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {cleanup, render} from '@testing-library/react';
 import CollectionInput from 'components/inputs/CollectionInput.es';
 import React from 'react';
-import {cleanup, render} from 'react-testing-library';
 import {testControlledInput} from 'test/utils';
 
 const COLLECTION_KEY_INPUT_TESTID = 'collection-key-input';

--- a/modules/apps/segments/segments-web/test/js/components/inputs/DateInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/DateInput.es.js
@@ -12,10 +12,10 @@
  * details.
  */
 
-import dateFns from 'date-fns';
+import {cleanup, render} from '@testing-library/react';
 import DateInput from 'components/inputs/DateInput.es';
+import dateFns from 'date-fns';
 import React from 'react';
-import {cleanup, render} from 'react-testing-library';
 import {testControlledDateInput} from 'test/utils';
 
 const DATE_INPUT_TESTID = 'date-input';

--- a/modules/apps/segments/segments-web/test/js/components/inputs/DateTimeInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/DateTimeInput.es.js
@@ -12,10 +12,10 @@
  * details.
  */
 
-import dateFns from 'date-fns';
+import {cleanup, render} from '@testing-library/react';
 import DateTimeInput from 'components/inputs/DateTimeInput.es';
+import dateFns from 'date-fns';
 import React from 'react';
-import {cleanup, render} from 'react-testing-library';
 import {testControlledDateInput} from 'test/utils';
 
 const DATE_INPUT_TESTID = 'date-input';

--- a/modules/apps/segments/segments-web/test/js/components/inputs/DecimalInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/DecimalInput.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {cleanup, fireEvent, render} from '@testing-library/react';
 import DecimalInput from 'components/inputs/DecimalInput.es';
 import React from 'react';
-import {cleanup, fireEvent, render} from 'react-testing-library';
 import {testControlledInput} from 'test/utils';
 
 const DECIMAL_NUMBER_INPUT_TESTID = 'decimal-number';

--- a/modules/apps/segments/segments-web/test/js/components/inputs/IntegerInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/IntegerInput.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {cleanup, render} from '@testing-library/react';
 import IntegerInput from 'components/inputs/IntegerInput.es';
 import React from 'react';
-import {cleanup, render} from 'react-testing-library';
 import {testControlledInput} from 'test/utils';
 
 const INTEGER_NUMBER_INPUT_TESTID = 'integer-number';

--- a/modules/apps/segments/segments-web/test/js/components/inputs/SelectEntityInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/SelectEntityInput.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
-import React from 'react';
+import {cleanup, render} from '@testing-library/react';
 import SelectEntityInput from 'components/inputs/SelectEntityInput.es';
-import {cleanup, render} from 'react-testing-library';
+import React from 'react';
 
 const ENTITY_SELECT_INPUT_TESTID = 'entity-select-input';
 

--- a/modules/apps/segments/segments-web/test/js/components/inputs/StringInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/StringInput.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
-import React from 'react';
+import {cleanup, render} from '@testing-library/react';
 import StringInput from 'components/inputs/StringInput.es';
-import {cleanup, render} from 'react-testing-library';
+import React from 'react';
 import {testControlledInput} from 'test/utils';
 
 const OPTIONS_STRING_INPUT_TESTID = 'options-string';

--- a/modules/apps/segments/segments-web/test/js/components/segment_edit/SegmentEdit.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/segment_edit/SegmentEdit.es.js
@@ -12,10 +12,10 @@
  * details.
  */
 
-import 'jest-dom/extend-expect';
-import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import {cleanup, render} from '@testing-library/react';
 import SegmentEdit from 'components/segment_edit/SegmentEdit.es';
-import {cleanup, render} from 'react-testing-library';
+import React from 'react';
 import {SOURCES} from 'utils/constants.es';
 
 const SOURCE_ICON_TESTID = 'source-icon';

--- a/modules/apps/segments/segments-web/test/js/components/shared/ClayToggle.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/shared/ClayToggle.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {cleanup, render} from '@testing-library/react';
 import ClayToggle from 'components/shared/ClayToggle.es';
 import React from 'react';
-import {cleanup, render} from 'react-testing-library';
 
 describe('ClayToggle', () => {
 	afterEach(cleanup);

--- a/modules/apps/segments/segments-web/test/js/components/title_editor/LocalizedInput.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/title_editor/LocalizedInput.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {cleanup, fireEvent, render} from '@testing-library/react';
 import LocalizedInput from 'components/title_editor/LocalizedInput.es';
 import React from 'react';
-import {cleanup, fireEvent, render} from 'react-testing-library';
 
 const LOCALIZED_DROPDOWN_BUTTON = 'localized-dropdown-button';
 

--- a/modules/apps/segments/segments-web/test/js/utils.js
+++ b/modules/apps/segments/segments-web/test/js/utils.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {fireEvent} from 'react-testing-library';
+import {fireEvent} from '@testing-library/react';
 
 export function testControlledInput({
 	element,

--- a/modules/package.json
+++ b/modules/package.json
@@ -16,7 +16,7 @@
 		"liferay-npm-bridge-generator": "2.7.1",
 		"liferay-npm-bundler": "2.7.1",
 		"liferay-npm-bundler-preset-standard": "2.7.1",
-		"liferay-npm-scripts": "4.8.0",
+		"liferay-npm-scripts": "4.9.0",
 		"liferay-theme-es2015-hook": "8.0.0-rc.2",
 		"metal-jest-serializer": "2.0.0"
 	},

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -645,7 +645,7 @@
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
 
-"@babel/preset-react@7.0.0":
+"@babel/preset-react@7.0.0", "@babel/preset-react@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.0.0.tgz#e86b4b3d99433c7b3e9e91747e2653958bc6b3c0"
   integrity sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==
@@ -656,10 +656,10 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.1.5", "@babel/runtime@^7.4.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.0.tgz#49dcbcd637099a55d3a61e590a00d6861393b1b5"
-  integrity sha512-2xsuyZ0R0RBFwjgae5NpXk8FcfH4qovj5cEM5VEeB7KXnKqzaisIu2HSV/mCEISolJJuR4wkViUGYujA8MH9tw==
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.4":
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.4.tgz#cb7d1ad7c6d65676e66b47186577930465b5271b"
+  integrity sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -847,7 +847,7 @@
   dependencies:
     classnames "^2.2.6"
 
-"@clayui/modal@3.0.0-milestone.1":
+"@clayui/modal@3.0.0-milestone.1", "@clayui/modal@^3.0.0-milestone.1":
   version "3.0.0-milestone.1"
   resolved "https://registry.yarnpkg.com/@clayui/modal/-/modal-3.0.0-milestone.1.tgz#519f155d4d763abbcfe30a5d1cef39640722f5ae"
   integrity sha512-n1pKrC5ipGAeBB1BYueZ44NBZdO95K3J+4q/UbA7LB1LczvACzGTeD+Bvu8YF9NrdF+KuRrUZzYOLbvBiwtYTg==
@@ -1072,12 +1072,13 @@
     source-map "^0.6.1"
     write-file-atomic "2.4.1"
 
-"@jest/types@^24.5.0":
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.5.0.tgz#feee214a4d0167b0ca447284e95a57aa10b3ee95"
-  integrity sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==
+"@jest/types@^24.5.0", "@jest/types@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.8.0.tgz#f31e25948c58f0abd8c845ae26fcea1491dea7ad"
+  integrity sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==
   dependencies:
-    "@types/istanbul-lib-coverage" "^1.1.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
@@ -1133,6 +1134,40 @@
     array-from "^2.1.1"
     lodash.get "^4.4.2"
 
+"@testing-library/dom@^5.5.4":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-5.6.0.tgz#18a7c162a6a79964e731ad7b810022a28218047c"
+  integrity sha512-nAsRvQLr/b6TGNjuHMEbWXCNPLrQYnzqa/KKQZL7wBOtfptUxsa4Ah9aqkHW0ZmCSFmUDj4nFUxWPVTeMu0iCw==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    aria-query "3.0.0"
+    pretty-format "^24.8.0"
+    wait-for-expect "^1.2.0"
+
+"@testing-library/jest-dom@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-4.0.0.tgz#56eee8dd183fe14a682fda7aca6413ec4e5303d2"
+  integrity sha512-YQA/LnRRfqHV5YRauawOGgMDgq43XfyqCz3whmxIPyrfvTdjLCNyY/BseGaa48y54yb3oiRo/NZT0oXNMQdkTA==
+  dependencies:
+    "@babel/runtime" "^7.5.1"
+    chalk "^2.4.1"
+    css "^2.2.3"
+    css.escape "^1.5.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    lodash "^4.17.11"
+    pretty-format "^24.0.0"
+    redent "^3.0.0"
+
+"@testing-library/react@8.0.5":
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-8.0.5.tgz#2301011a8c5567eba59691860df19a3cfc9d7425"
+  integrity sha512-2EzVi7HjUUF8gKzB4s+oCJ1+F4VOrphO+DlUO6Ptgtcz1ko4J2zqnr0t7g+T7uedXXjJ0wdq70zQMhJXP3w37A==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@testing-library/dom" "^5.5.4"
+
 "@types/babel__core@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.0.tgz#710f2487dda4dcfd010ca6abb2b4dc7394365c51"
@@ -1180,10 +1215,30 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
+  integrity sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==
+
 "@types/istanbul-lib-coverage@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#2cc2ca41051498382b43157c8227fea60363f94a"
   integrity sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==
+
+"@types/istanbul-lib-report@*":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#e5471e7fa33c61358dd38426189c037a58433b8c"
+  integrity sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz#7a8cbf6a406f36c8add871625b278eaf0b0d255a"
+  integrity sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
 
 "@types/minimatch@*":
   version "3.0.3"
@@ -1629,6 +1684,14 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
+  integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
+  dependencies:
+    ast-types-flow "0.0.7"
+    commander "^2.11.0"
+
 arr-diff@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-1.1.0.tgz#687c32758163588fef7de7b36fabe495eb1a399a"
@@ -1796,6 +1859,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+ast-types-flow@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
 ast-types@0.10.1:
   version "0.10.1"
@@ -3949,10 +4017,10 @@ commander@0.6.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-0.6.1.tgz#fa68a14f6a945d54dbbe50d8cdb3320e9e3b1a06"
   integrity sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=
 
-commander@2, commander@^2.19.0, commander@^2.8.1, commander@^2.9.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
-  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.8.1, commander@^2.9.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
 commander@2.11.0:
   version "2.11.0"
@@ -4387,6 +4455,11 @@ css-what@2.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.2.tgz#c0876d9d0480927d7d4920dcd72af3595649554d"
   integrity sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
 
 css@^2.2.3:
   version "2.2.4"
@@ -5112,16 +5185,6 @@ dom-serializer@0:
   dependencies:
     domelementtype "^1.3.0"
     entities "^1.1.1"
-
-dom-testing-library@^3.13.1:
-  version "3.16.5"
-  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-3.16.5.tgz#8c71f127c6b4ee48115660798040291b59dfc894"
-  integrity sha512-t3OaTcDdsAqtAZNeZ13KnOJmt+2HaDJqYWyf0iBRzbG6GwrNtpF0122Ygu/qkerIwcnHMX1ihwZVx/DhaLpmTw==
-  dependencies:
-    "@babel/runtime" "^7.1.5"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    pretty-format "^24.0.0"
-    wait-for-expect "^1.1.0"
 
 domain-browser@1.1.7:
   version "1.1.7"
@@ -7705,10 +7768,10 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
-indent-string@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
-  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
 indexof@0.0.1:
   version "0.0.1"
@@ -8571,19 +8634,6 @@ jest-docblock@^24.3.0:
   integrity sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==
   dependencies:
     detect-newline "^2.1.0"
-
-jest-dom@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jest-dom/-/jest-dom-3.0.1.tgz#88ea2e9c919000431b9d1c09f97adf5364eac103"
-  integrity sha512-wkRQ3UHZhQ9e1v5StJo/pZzH08ywQ0FFVQMmiehJQwWSUeB2D5k37A5rQOS/tRZC/ETRQOxT05JtxWr/w1xUMQ==
-  dependencies:
-    chalk "^2.4.1"
-    css "^2.2.3"
-    jest-diff "^24.0.0"
-    jest-matcher-utils "^24.0.0"
-    lodash "^4.17.11"
-    pretty-format "^24.0.0"
-    redent "^2.0.0"
 
 jest-each@^24.5.0:
   version "24.5.0"
@@ -9696,16 +9746,18 @@ liferay-npm-bundler@2.7.1:
     semver "^5.5.0"
     xml-js "^1.6.8"
 
-liferay-npm-scripts@4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-4.8.0.tgz#c69222b45ee529006a3d5678f7fe7d8c7ded7219"
-  integrity sha512-SeRrPmlGfFCgae7GUYZsg8nxjnaV0753RTfk0aw/7DNhtAp3Igjc46wmM0I6HccuRQVnJtu7Cfld8BXAv0hoiA==
+liferay-npm-scripts@4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-4.9.0.tgz#b814d52e69fedd8597042b88d70f427cb9094824"
+  integrity sha512-nllVR078EqXq92QUcARcQXP3FjD8H3oi7crdP35NyK+ni739dHy8jIECpTVa0tCdowlJyJ1UkiqrWUKqWgThnw==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/plugin-proposal-class-properties" "7.4.4"
     "@babel/plugin-proposal-object-rest-spread" "7.4.4"
     "@babel/preset-env" "^7.4.2"
     "@babel/preset-react" "7.0.0"
+    "@testing-library/jest-dom" "4.0.0"
+    "@testing-library/react" "8.0.5"
     babel-eslint "^10.0.2"
     babel-loader "8.0.6"
     cosmiconfig "^5.2.1"
@@ -10898,6 +10950,11 @@ mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+
+min-indent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.0.tgz#cfc45c37e9ec0d8f0a0ec3dd4ef7f7c3abe39256"
+  integrity sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=
 
 mini-create-react-context@^0.3.0:
   version "0.3.2"
@@ -12349,12 +12406,12 @@ pretty-format@^23.0.1, pretty-format@^23.6.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^24.0.0, pretty-format@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.5.0.tgz#cc69a0281a62cd7242633fc135d6930cd889822d"
-  integrity sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==
+pretty-format@^24.0.0, pretty-format@^24.5.0, pretty-format@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.8.0.tgz#8dae7044f58db7cb8be245383b565a963e3c27f2"
+  integrity sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==
   dependencies:
-    "@jest/types" "^24.5.0"
+    "@jest/types" "^24.8.0"
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
@@ -12711,13 +12768,6 @@ react-router@5.0.1:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-testing-library@^5.3.2:
-  version "5.4.4"
-  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-5.4.4.tgz#3fa787999492be94b228e4540a7211556bf4fd94"
-  integrity sha512-/TiERZ+URSNhZQfjrUXh0VLsiLSmhqP1WP+2e2wWqWqrRIWpcAxrfuBxzlT75LYMDNmicEikaXJqRDi/pqCEDg==
-  dependencies:
-    dom-testing-library "^3.13.1"
-
 react@16.8.6, react@^16.6.3, react@^16.8.3, react@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
@@ -12916,13 +12966,13 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-redent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
-  integrity sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
   dependencies:
-    indent-string "^3.0.0"
-    strip-indent "^2.0.0"
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 redux@^4.0.1:
   version "4.0.1"
@@ -14343,10 +14393,12 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-indent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
-  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -15316,10 +15368,10 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
-wait-for-expect@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.1.0.tgz#6607375c3f79d32add35cd2c87ce13f351a3d453"
-  integrity sha512-vQDokqxyMyknfX3luCDn16bSaRcOyH6gGuUXMIbxBLeTo6nWuEWYqMTT9a+44FmW8c2m6TRWBdNvBBjA1hwEKg==
+wait-for-expect@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.2.0.tgz#fdab6a26e87d2039101db88bff3d8158e5c3e13f"
+  integrity sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q==
 
 walk@^2.3.9:
   version "2.3.14"

--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -715,13 +715,21 @@ Please run the following command from ${source.formatter.modules.dir.absolute.pa
 		<delete file="ServiceBuilder.temp" />
 
 		<if>
-			<resourcecount count="0" when="greater">
-				<fileset
-					dir="${project.dir}/modules"
-					excludes="**/.gradle/,**/bin/,**/build/,**/classes/,**/node_modules/,**/tmp/"
-					includes="**/yarn-*.js"
-				/>
-			</resourcecount>
+			<and>
+				<not>
+					<or>
+						<isset property="source.file.extensions" />
+						<isset property="source.files" />
+					</or>
+				</not>
+				<resourcecount count="0" when="greater">
+					<fileset
+						dir="${project.dir}/modules"
+						excludes="**/.gradle/,**/bin/,**/build/,**/classes/,**/node_modules/,**/tmp/"
+						includes="**/yarn-*.js"
+					/>
+				</resourcecount>
+			</and>
 			<then>
 				<if>
 					<and>

--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -739,11 +739,13 @@ Please run the following command from ${source.formatter.modules.dir.absolute.pa
 					<then>
 						<gradle-execute dir="${project.dir}/modules" task="yarnCheckFormat">
 							<arg value="--build-file=${project.dir}/modules/util.gradle" />
+							<env key="LIFERAY_NPM_SCRIPTS_WORKING_BRANCH_NAME" value="${git.working.branch.name}" />
 						</gradle-execute>
 					</then>
 					<else>
 						<gradle-execute dir="${project.dir}/modules" task="yarnFormat">
 							<arg value="--build-file=${project.dir}/modules/util.gradle" />
+							<env key="LIFERAY_NPM_SCRIPTS_WORKING_BRANCH_NAME" value="${git.working.branch.name}" />
 						</gradle-execute>
 					</else>
 				</if>

--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -714,6 +714,34 @@ Please run the following command from ${source.formatter.modules.dir.absolute.pa
 
 		<delete file="ServiceBuilder.temp" />
 
+		<if>
+			<resourcecount count="0" when="greater">
+				<fileset
+					dir="${project.dir}/modules"
+					excludes="**/.gradle/,**/bin/,**/build/,**/classes/,**/node_modules/,**/tmp/"
+					includes="**/yarn-*.js"
+				/>
+			</resourcecount>
+			<then>
+				<if>
+					<and>
+						<isset property="source.auto.fix" />
+						<isfalse value="${source.auto.fix}" />
+					</and>
+					<then>
+						<gradle-execute dir="${project.dir}/modules" task="yarnCheckFormat">
+							<arg value="--build-file=${project.dir}/modules/util.gradle" />
+						</gradle-execute>
+					</then>
+					<else>
+						<gradle-execute dir="${project.dir}/modules" task="yarnFormat">
+							<arg value="--build-file=${project.dir}/modules/util.gradle" />
+						</gradle-execute>
+					</else>
+				</if>
+			</then>
+		</if>
+
 		<var name="source.formatter.js.script" value="format" />
 		<var name="source.formatter.js.task" value="npmRunFormat" />
 


### PR DESCRIPTION
Two changes of note here:

1. We've bundled some common testing libraries with liferay-npm-scripts that means we can use them across all of our React projects. At the same time we updated from the versions of the libraries that we were already using in segments-web.

2. We turn automated source formatting back on for frontend files.

Tested like this:

On this branch, see that `ant format-source-current-branch` only checks the changed files:

     [exec] > Task :yarnFormatModules
     [exec] yarn run v1.13.0
     [exec] $ liferay-npm-scripts fix --production false
     [exec] Prettier checked 21 files, found 0 files with problems
     [exec]
     [exec] ESLint checked 20 files, found 0 errors, found 0 warnings
     [exec] Done in 6.27s.
     [exec]
     [exec] BUILD SUCCESSFUL in 10s
     [exec] 1 actionable task: 1 executed

See that `ant format-source-all` checks everything:

     [exec] $ liferay-npm-scripts fix --production false
     [exec] Prettier checked 1450 files, found 0 files with problems
     [exec]
     [exec] /Users/greghurrell/code/portal/liferay-portal/modules/apps/hello-soy/hello-soy-navigation-web/src/main/resources/META-INF/resources/Navigation.es.js
     [exec]   18:8  warning  'Footer' is defined but never used  no-unused-vars
     [exec]   19:8  warning  'Header' is defined but never used  no-unused-vars
     [exec]
     [exec] /Users/greghurrell/code/portal/liferay-portal/modules/apps/hello-soy/hello-soy-web/src/main/resources/META-INF/resources/View.es.js
     [exec]   18:8  warning  'Footer' is defined but never used  no-unused-vars
     [exec]   19:8  warning  'Header' is defined but never used  no-unused-vars
     [exec]
     [exec] ✖ 4 problems (0 errors, 4 warnings)
     [exec]
     [exec] ESLint checked 551 files, found 0 errors, found 4 warnings
     [exec] Done in 24.10s.

Note that there is a file on "master" which currently has a formatting error, so expect CI to complain about that. The fix is currently at:

https://github.com/brianchandotcom/liferay-portal/pull/75689

Also, the fix for those last 4 (non-fatal) warnings is at:

https://github.com/brianchandotcom/liferay-portal/pull/75696

How the partial formatting works: we pass an environment variable containing the upstream branch name (called "git.working.branch.name" in portal-impl/build.xml) so that `liferay-npm-scripts` can compute the merge base and get the changed file list. I initially was going to take the file list in via an environment variable, but I suspect that the maximum size limits on Windows (a little over 8k characters) would be insufficient in this repo where we have many files and the average path length is 120 characters, which would mean we could run out of space after only around 68 files). The alternative version is described in detail at:

https://github.com/liferay/liferay-npm-tools/pull/165