### PR TITLE
LPS-98291 Bump bundle major version to 5 to allow backporting of module

### DIFF
--- a/modules/apps/login/login-authentication-opensso-web/bnd.bnd
+++ b/modules/apps/login/login-authentication-opensso-web/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Login Authentication OpenSSO Web
 Bundle-SymbolicName: com.liferay.login.authentication.opensso.web
-Bundle-Version: 2.0.0
+Bundle-Version: 5.0.0
 Web-ContextPath: /login-authentication-opensso-web


### PR DESCRIPTION
Hi Brian.
This is a pre-requisite to backporting [LPS-86003](https://issues.liferay.com/browse/LPS-86003) to 7.1.x (see [liferay-portal-ee/pull/15125](https://github.com/liferay/liferay-portal-ee/pull/15125)) and then 7.0.x.

/cc @topolik @lipusz @djavorszky @MichaelPrigge