### PR TITLE
LPS-98169 Remove unnecessary lint suppressions

### DIFF
--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-resize/src/main/resources/META-INF/resources/ResizeComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-resize/src/main/resources/META-INF/resources/ResizeComponent.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import {core} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/debounce/debounce.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/debounce/debounce.es.js
@@ -48,7 +48,7 @@ describe('debounce', function() {
 		let context;
 
 		const fn = function() {
-			context = this; /* eslint-disable-line */
+			context = this;
 		};
 
 		const debounced = debounce(fn.bind(expectedContext), 200);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/AddCommentForm.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/AddCommentForm.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import ClayButton from '@clayui/button';
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/FragmentComments.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/FragmentComments.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/SidebarComments.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/SidebarComments.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/GeoJSONBase.es.js
+++ b/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/GeoJSONBase.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import State, {Config} from 'metal-state';
 
 /**


### PR DESCRIPTION
(Split up into two commits because I suspect the layout-page-content-editor-web changes may not cherry-pick cleanly to 7.2.x, but the others should.)

This PR removes some unnecessary lint suppressions that probably got copy-pasted from some older branch when https://github.com/brianchandotcom/liferay-portal/pull/75756 was prepared. But they are no longer necessary thanks to https://github.com/brianchandotcom/liferay-portal/pull/75651.

The other ones were just left over from [the sweep we did (LPS-97459)](https://issues.liferay.com/browse/LPS-97459) which dropped us from around 300 warnings to 0. I searched for all lint suppressions with this and removed the ones that aren't required:

    git grep -l '/\*\s*eslint\b' | grep -v yarn-1