### PR TITLE
LPS-98264

### DIFF
--- a/portal-kernel/src/com/liferay/exportimport/kernel/configuration/packageinfo
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.1
+version 2.1.0


### PR DESCRIPTION
Yesterday CI failed on semver tests because the ProviderType annotation change would have require a minor version change, however today after ant all the it seems it needs to be changed back, because baseline warns with an "excessive version increase". But if I change it back, CI fails again, base on the test results of this PR. 

thanks,
Daniel