### PR TITLE
LPS-97205 Add "liferay/portal" to the list of extended configs

### DIFF
--- a/modules/apps/app-builder/app-builder-web/.eslintrc.js
+++ b/modules/apps/app-builder/app-builder-web/.eslintrc.js
@@ -13,5 +13,5 @@
  */
 
 module.exports = {
-	extends: ['liferay/react']
+	extends: ['liferay/portal', 'liferay/react']
 };


### PR DESCRIPTION
In liferay-portal, we should always include "liferay/portal" in the list of extended configs, as per the README:

https://github.com/liferay/eslint-config-liferay#react

This activates some additional checks specifically for liferay-portal (only a couple for now, but probably more in the future).

In a separate PR I'll add enforcement that extension list is always correct, but that will require an update to liferay-npm-scripts.