### PR TITLE
LPS-98334 Remove redundant ESLint extensions

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/.eslintrc.js
+++ b/modules/apps/data-engine/data-engine-taglib/.eslintrc.js
@@ -13,5 +13,5 @@
  */
 
 module.exports = {
-	extends: ['liferay/portal', 'liferay/metal']
+	extends: ['liferay/metal']
 };

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/.eslintrc.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/.eslintrc.js
@@ -13,5 +13,5 @@
  */
 
 module.exports = {
-	extends: ['liferay/portal', 'liferay/metal']
+	extends: ['liferay/metal']
 };

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/.eslintrc.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/.eslintrc.js
@@ -13,5 +13,5 @@
  */
 
 module.exports = {
-	extends: ['liferay/portal', 'liferay/metal']
+	extends: ['liferay/metal']
 };

--- a/modules/apps/layout/layout-content-page-editor-web/.eslintrc.js
+++ b/modules/apps/layout/layout-content-page-editor-web/.eslintrc.js
@@ -13,7 +13,7 @@
  */
 
 module.exports = {
-	extends: ['liferay/portal', 'liferay/react'],
+	extends: ['liferay/react'],
 	globals: {
 		AlloyEditor: true,
 		process: true

--- a/modules/apps/segments/segments-web/.eslintrc.js
+++ b/modules/apps/segments/segments-web/.eslintrc.js
@@ -13,5 +13,5 @@
  */
 
 module.exports = {
-	extends: ['liferay/portal', 'liferay/react']
+	extends: ['liferay/react']
 };


### PR DESCRIPTION
As described [here](https://github.com/liferay/eslint-config-liferay/pull/53), I realized that we don't need to include "liferay/portal" explicitly because it already has effect everywhere, automatically, thanks to liferay-npm-scripts.

I'll make the next version of liferay-npm-scripts detect and report this kind of redundancy to stop these sneaking in again.