### PR TITLE
LPS-98235 Removing bad editable value propagation through Experiences

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/AddCommentForm.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/AddCommentForm.es.js
@@ -73,7 +73,7 @@ const AddCommentForm = props => {
 			</div>
 
 			{showButtons && (
-				<>
+				<React.Fragment>
 					<ClayButton
 						disabled={addingComment}
 						displayType='primary'
@@ -91,7 +91,7 @@ const AddCommentForm = props => {
 					>
 						{Liferay.Language.get('cancel')}
 					</ClayButton>
-				</>
+				</React.Fragment>
 			)}
 		</form>
 	);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/store/ConnectedComponent.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/store/ConnectedComponent.es.js
@@ -93,7 +93,7 @@ const getConnectedComponent = (Component, properties) => {
  * Second order function to produce a Connected Component Wrapper
  * @param {Function} mapStateToProps - Recieves the state and returns mapped version of it ready for consumption by the Wrapped Component
  * @param {Function} mapDispatchToProps - Recieves the dispatch and returns a set of component props that use it to call the modify the state tree
- * @returns
+ * @returns {object}
  */
 function getConnectedReactComponent(mapStateToProps, mapDispatchToProps) {
 	/**

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/store/ConnectedComponent.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/store/ConnectedComponent.es.js
@@ -125,9 +125,7 @@ function getConnectedReactComponent(mapStateToProps, mapDispatchToProps) {
 					{...mapStateToProps(storeState, props)}
 					{...mapDispatchToProps(store.dispatch, props)}
 				/>
-			) : (
-				<></>
-			);
+			) : null;
 		};
 	};
 }


### PR DESCRIPTION
@p2kmgcl @wincent

This pull also swaps `<>` for `<React.Fragment>` and adds a value to an empty `@returns` in the jsdocs.

Thanks!