### PR TITLE
LPS-96637 Full support for relations in GraphQL

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-api/build.gradle
+++ b/modules/apps/change-tracking/change-tracking-rest-api/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/dto/v1_0/Collection.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/dto/v1_0/Collection.java
@@ -77,34 +77,6 @@ public class Collection {
 	protected Long additionCount;
 
 	@Schema
-	public Long getCollectionId() {
-		return collectionId;
-	}
-
-	public void setCollectionId(Long collectionId) {
-		this.collectionId = collectionId;
-	}
-
-	@JsonIgnore
-	public void setCollectionId(
-		UnsafeSupplier<Long, Exception> collectionIdUnsafeSupplier) {
-
-		try {
-			collectionId = collectionIdUnsafeSupplier.get();
-		}
-		catch (RuntimeException re) {
-			throw re;
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected Long collectionId;
-
-	@Schema
 	public Long getCompanyId() {
 		return companyId;
 	}
@@ -215,6 +187,32 @@ public class Collection {
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String description;
+
+	@Schema
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long id;
 
 	@Schema
 	public Long getModificationCount() {
@@ -338,16 +336,6 @@ public class Collection {
 			sb.append(additionCount);
 		}
 
-		if (collectionId != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"collectionId\": ");
-
-			sb.append(collectionId);
-		}
-
 		if (companyId != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -394,6 +382,16 @@ public class Collection {
 			sb.append(_escape(description));
 
 			sb.append("\"");
+		}
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
 		}
 
 		if (modificationCount != null) {

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/dto/v1_0/Entry.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/dto/v1_0/Entry.java
@@ -246,20 +246,18 @@ public class Entry {
 	protected Date dateModified;
 
 	@Schema
-	public Long getEntryId() {
-		return entryId;
+	public Long getId() {
+		return id;
 	}
 
-	public void setEntryId(Long entryId) {
-		this.entryId = entryId;
+	public void setId(Long id) {
+		this.id = id;
 	}
 
 	@JsonIgnore
-	public void setEntryId(
-		UnsafeSupplier<Long, Exception> entryIdUnsafeSupplier) {
-
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
 		try {
-			entryId = entryIdUnsafeSupplier.get();
+			id = idUnsafeSupplier.get();
 		}
 		catch (RuntimeException re) {
 			throw re;
@@ -271,7 +269,7 @@ public class Entry {
 
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected Long entryId;
+	protected Long id;
 
 	@Schema
 	public Long getKey() {
@@ -519,14 +517,14 @@ public class Entry {
 			sb.append("\"");
 		}
 
-		if (entryId != null) {
+		if (id != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
-			sb.append("\"entryId\": ");
+			sb.append("\"id\": ");
 
-			sb.append(entryId);
+			sb.append(id);
 		}
 
 		if (key != null) {

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/dto/v1_0/Process.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/dto/v1_0/Process.java
@@ -133,6 +133,32 @@ public class Process {
 	protected Date dateCreated;
 
 	@Schema
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long id;
+
+	@Schema
 	public Integer getPercentage() {
 		return percentage;
 	}
@@ -159,34 +185,6 @@ public class Process {
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer percentage;
-
-	@Schema
-	public Long getProcessId() {
-		return processId;
-	}
-
-	public void setProcessId(Long processId) {
-		this.processId = processId;
-	}
-
-	@JsonIgnore
-	public void setProcessId(
-		UnsafeSupplier<Long, Exception> processIdUnsafeSupplier) {
-
-		try {
-			processId = processIdUnsafeSupplier.get();
-		}
-		catch (RuntimeException re) {
-			throw re;
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected Long processId;
 
 	@Schema
 	public ProcessUser getProcessUser() {
@@ -308,6 +306,16 @@ public class Process {
 			sb.append("\"");
 		}
 
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
 		if (percentage != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -316,16 +324,6 @@ public class Process {
 			sb.append("\"percentage\": ");
 
 			sb.append(percentage);
-		}
-
-		if (processId != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"processId\": ");
-
-			sb.append(processId);
 		}
 
 		if (processUser != null) {

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/AffectedEntryResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/AffectedEntryResource.java
@@ -23,6 +23,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -47,6 +52,17 @@ public interface AffectedEntryResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/CollectionResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/CollectionResource.java
@@ -26,7 +26,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -69,6 +73,17 @@ public interface CollectionResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/EntryResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/EntryResource.java
@@ -24,6 +24,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -52,6 +57,17 @@ public interface EntryResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/ProcessResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/ProcessResource.java
@@ -25,6 +25,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -51,6 +56,17 @@ public interface ProcessResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/ProcessUserResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/ProcessUserResource.java
@@ -24,6 +24,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -48,6 +53,17 @@ public interface ProcessUserResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/SettingsResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest-api/src/main/java/com/liferay/change/tracking/rest/resource/v1_0/SettingsResource.java
@@ -23,6 +23,11 @@ import com.liferay.portal.vulcan.pagination.Page;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -49,6 +54,17 @@ public interface SettingsResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/dto/v1_0/Collection.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/dto/v1_0/Collection.java
@@ -50,27 +50,6 @@ public class Collection {
 
 	protected Long additionCount;
 
-	public Long getCollectionId() {
-		return collectionId;
-	}
-
-	public void setCollectionId(Long collectionId) {
-		this.collectionId = collectionId;
-	}
-
-	public void setCollectionId(
-		UnsafeSupplier<Long, Exception> collectionIdUnsafeSupplier) {
-
-		try {
-			collectionId = collectionIdUnsafeSupplier.get();
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	protected Long collectionId;
-
 	public Long getCompanyId() {
 		return companyId;
 	}
@@ -154,6 +133,25 @@ public class Collection {
 	}
 
 	protected String description;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
 
 	public Long getModificationCount() {
 		return modificationCount;

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/dto/v1_0/Entry.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/dto/v1_0/Entry.java
@@ -177,26 +177,24 @@ public class Entry {
 
 	protected Date dateModified;
 
-	public Long getEntryId() {
-		return entryId;
+	public Long getId() {
+		return id;
 	}
 
-	public void setEntryId(Long entryId) {
-		this.entryId = entryId;
+	public void setId(Long id) {
+		this.id = id;
 	}
 
-	public void setEntryId(
-		UnsafeSupplier<Long, Exception> entryIdUnsafeSupplier) {
-
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
 		try {
-			entryId = entryIdUnsafeSupplier.get();
+			id = idUnsafeSupplier.get();
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);
 		}
 	}
 
-	protected Long entryId;
+	protected Long id;
 
 	public Long getKey() {
 		return key;

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/dto/v1_0/Process.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/dto/v1_0/Process.java
@@ -92,6 +92,25 @@ public class Process {
 
 	protected Date dateCreated;
 
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
 	public Integer getPercentage() {
 		return percentage;
 	}
@@ -112,27 +131,6 @@ public class Process {
 	}
 
 	protected Integer percentage;
-
-	public Long getProcessId() {
-		return processId;
-	}
-
-	public void setProcessId(Long processId) {
-		this.processId = processId;
-	}
-
-	public void setProcessId(
-		UnsafeSupplier<Long, Exception> processIdUnsafeSupplier) {
-
-		try {
-			processId = processIdUnsafeSupplier.get();
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	protected Long processId;
 
 	public ProcessUser getProcessUser() {
 		return processUser;

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/serdes/v1_0/CollectionSerDes.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/serdes/v1_0/CollectionSerDes.java
@@ -70,16 +70,6 @@ public class CollectionSerDes {
 			sb.append(collection.getAdditionCount());
 		}
 
-		if (collection.getCollectionId() != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"collectionId\": ");
-
-			sb.append(collection.getCollectionId());
-		}
-
 		if (collection.getCompanyId() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -127,6 +117,16 @@ public class CollectionSerDes {
 			sb.append(_escape(collection.getDescription()));
 
 			sb.append("\"");
+		}
+
+		if (collection.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(collection.getId());
 		}
 
 		if (collection.getModificationCount() != null) {
@@ -196,14 +196,6 @@ public class CollectionSerDes {
 				"additionCount", String.valueOf(collection.getAdditionCount()));
 		}
 
-		if (collection.getCollectionId() == null) {
-			map.put("collectionId", null);
-		}
-		else {
-			map.put(
-				"collectionId", String.valueOf(collection.getCollectionId()));
-		}
-
 		if (collection.getCompanyId() == null) {
 			map.put("companyId", null);
 		}
@@ -228,6 +220,13 @@ public class CollectionSerDes {
 		}
 		else {
 			map.put("description", String.valueOf(collection.getDescription()));
+		}
+
+		if (collection.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(collection.getId()));
 		}
 
 		if (collection.getModificationCount() == null) {
@@ -319,12 +318,6 @@ public class CollectionSerDes {
 						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
-			else if (Objects.equals(jsonParserFieldName, "collectionId")) {
-				if (jsonParserFieldValue != null) {
-					collection.setCollectionId(
-						Long.valueOf((String)jsonParserFieldValue));
-				}
-			}
 			else if (Objects.equals(jsonParserFieldName, "companyId")) {
 				if (jsonParserFieldValue != null) {
 					collection.setCompanyId(
@@ -346,6 +339,12 @@ public class CollectionSerDes {
 			else if (Objects.equals(jsonParserFieldName, "description")) {
 				if (jsonParserFieldValue != null) {
 					collection.setDescription((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					collection.setId(
+						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "modificationCount")) {

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/serdes/v1_0/EntrySerDes.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/serdes/v1_0/EntrySerDes.java
@@ -137,14 +137,14 @@ public class EntrySerDes {
 			sb.append("\"");
 		}
 
-		if (entry.getEntryId() != null) {
+		if (entry.getId() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
-			sb.append("\"entryId\": ");
+			sb.append("\"id\": ");
 
-			sb.append(entry.getEntryId());
+			sb.append(entry.getId());
 		}
 
 		if (entry.getKey() != null) {
@@ -282,11 +282,11 @@ public class EntrySerDes {
 			"dateModified",
 			liferayToJSONDateFormat.format(entry.getDateModified()));
 
-		if (entry.getEntryId() == null) {
-			map.put("entryId", null);
+		if (entry.getId() == null) {
+			map.put("id", null);
 		}
 		else {
-			map.put("entryId", String.valueOf(entry.getEntryId()));
+			map.put("id", String.valueOf(entry.getId()));
 		}
 
 		if (entry.getKey() == null) {
@@ -420,10 +420,9 @@ public class EntrySerDes {
 					entry.setDateModified(toDate((String)jsonParserFieldValue));
 				}
 			}
-			else if (Objects.equals(jsonParserFieldName, "entryId")) {
+			else if (Objects.equals(jsonParserFieldName, "id")) {
 				if (jsonParserFieldValue != null) {
-					entry.setEntryId(
-						Long.valueOf((String)jsonParserFieldValue));
+					entry.setId(Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "key")) {

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/serdes/v1_0/ProcessSerDes.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/serdes/v1_0/ProcessSerDes.java
@@ -94,6 +94,16 @@ public class ProcessSerDes {
 			sb.append("\"");
 		}
 
+		if (process.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(process.getId());
+		}
+
 		if (process.getPercentage() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -102,16 +112,6 @@ public class ProcessSerDes {
 			sb.append("\"percentage\": ");
 
 			sb.append(process.getPercentage());
-		}
-
-		if (process.getProcessId() != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"processId\": ");
-
-			sb.append(process.getProcessId());
 		}
 
 		if (process.getProcessUser() != null) {
@@ -177,18 +177,18 @@ public class ProcessSerDes {
 			"dateCreated",
 			liferayToJSONDateFormat.format(process.getDateCreated()));
 
+		if (process.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(process.getId()));
+		}
+
 		if (process.getPercentage() == null) {
 			map.put("percentage", null);
 		}
 		else {
 			map.put("percentage", String.valueOf(process.getPercentage()));
-		}
-
-		if (process.getProcessId() == null) {
-			map.put("processId", null);
-		}
-		else {
-			map.put("processId", String.valueOf(process.getProcessId()));
 		}
 
 		if (process.getProcessUser() == null) {
@@ -280,16 +280,15 @@ public class ProcessSerDes {
 						toDate((String)jsonParserFieldValue));
 				}
 			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					process.setId(Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
 			else if (Objects.equals(jsonParserFieldName, "percentage")) {
 				if (jsonParserFieldValue != null) {
 					process.setPercentage(
 						Integer.valueOf((String)jsonParserFieldValue));
-				}
-			}
-			else if (Objects.equals(jsonParserFieldName, "processId")) {
-				if (jsonParserFieldValue != null) {
-					process.setProcessId(
-						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "processUser")) {

--- a/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
@@ -12,9 +12,6 @@ components:
                 additionCount:
                     format: int64
                     type: integer
-                collectionId:
-                    format: int64
-                    type: integer
                 companyId:
                     format: int64
                     type: integer
@@ -26,6 +23,9 @@ components:
                     type: integer
                 description:
                     type: string
+                id:
+                    format: int64
+                    type: integer
                 modificationCount:
                     format: int64
                     type: integer
@@ -65,7 +65,7 @@ components:
                     format: date-time
                     readOnly: true
                     type: string
-                entryId:
+                id:
                     format: int64
                     type: integer
                 key:
@@ -90,10 +90,10 @@ components:
                 dateCreated:
                     format: date-time
                     type: string
-                percentage:
-                    type: integer
-                processId:
+                id:
                     format: int64
+                    type: integer
+                percentage:
                     type: integer
                 processUser:
                     $ref: "#/components/schemas/ProcessUser"

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/util/CollectionUtil.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/util/CollectionUtil.java
@@ -37,12 +37,12 @@ public class CollectionUtil {
 			{
 				additionCount = ctCollectionChangeTypeCounts.getOrDefault(
 					CTConstants.CT_CHANGE_TYPE_ADDITION, 0L);
-				collectionId = ctCollection.getCtCollectionId();
 				companyId = ctCollection.getCompanyId();
 				dateStatus = ctCollection.getStatusDate();
 				deletionCount = ctCollectionChangeTypeCounts.getOrDefault(
 					CTConstants.CT_CHANGE_TYPE_DELETION, 0L);
 				description = ctCollection.getDescription();
+				id = ctCollection.getCtCollectionId();
 				modificationCount = ctCollectionChangeTypeCounts.getOrDefault(
 					CTConstants.CT_CHANGE_TYPE_MODIFICATION, 0L);
 				name = ctCollection.getName();

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/graphql/query/v1_0/Query.java
@@ -42,6 +42,9 @@ import java.util.function.BiFunction;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.osgi.service.component.ComponentServiceObjects;
 
 /**
@@ -422,6 +425,9 @@ public class Query {
 
 		affectedEntryResource.setContextAcceptLanguage(_acceptLanguage);
 		affectedEntryResource.setContextCompany(_company);
+		affectedEntryResource.setContextHttpServletRequest(_httpServletRequest);
+		affectedEntryResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		affectedEntryResource.setContextUser(_user);
 	}
 
@@ -430,6 +436,8 @@ public class Query {
 
 		collectionResource.setContextAcceptLanguage(_acceptLanguage);
 		collectionResource.setContextCompany(_company);
+		collectionResource.setContextHttpServletRequest(_httpServletRequest);
+		collectionResource.setContextHttpServletResponse(_httpServletResponse);
 		collectionResource.setContextUser(_user);
 	}
 
@@ -438,6 +446,8 @@ public class Query {
 
 		entryResource.setContextAcceptLanguage(_acceptLanguage);
 		entryResource.setContextCompany(_company);
+		entryResource.setContextHttpServletRequest(_httpServletRequest);
+		entryResource.setContextHttpServletResponse(_httpServletResponse);
 		entryResource.setContextUser(_user);
 	}
 
@@ -446,6 +456,8 @@ public class Query {
 
 		processResource.setContextAcceptLanguage(_acceptLanguage);
 		processResource.setContextCompany(_company);
+		processResource.setContextHttpServletRequest(_httpServletRequest);
+		processResource.setContextHttpServletResponse(_httpServletResponse);
 		processResource.setContextUser(_user);
 	}
 
@@ -455,6 +467,8 @@ public class Query {
 
 		processUserResource.setContextAcceptLanguage(_acceptLanguage);
 		processUserResource.setContextCompany(_company);
+		processUserResource.setContextHttpServletRequest(_httpServletRequest);
+		processUserResource.setContextHttpServletResponse(_httpServletResponse);
 		processUserResource.setContextUser(_user);
 	}
 
@@ -463,6 +477,8 @@ public class Query {
 
 		settingsResource.setContextAcceptLanguage(_acceptLanguage);
 		settingsResource.setContextCompany(_company);
+		settingsResource.setContextHttpServletRequest(_httpServletRequest);
+		settingsResource.setContextHttpServletResponse(_httpServletResponse);
 		settingsResource.setContextUser(_user);
 	}
 
@@ -483,6 +499,8 @@ public class Query {
 	private BiFunction<Object, String, Filter> _filterBiFunction;
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private Company _company;
+	private HttpServletRequest _httpServletRequest;
+	private HttpServletResponse _httpServletResponse;
 	private User _user;
 
 }

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseAffectedEntryResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseAffectedEntryResourceImpl.java
@@ -92,6 +92,22 @@ public abstract class BaseAffectedEntryResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseCollectionResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseCollectionResourceImpl.java
@@ -214,6 +214,22 @@ public abstract class BaseCollectionResourceImpl implements CollectionResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseEntryResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseEntryResourceImpl.java
@@ -121,6 +121,22 @@ public abstract class BaseEntryResourceImpl implements EntryResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
@@ -112,6 +112,22 @@ public abstract class BaseProcessResourceImpl implements ProcessResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseProcessUserResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseProcessUserResourceImpl.java
@@ -94,6 +94,22 @@ public abstract class BaseProcessUserResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseSettingsResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseSettingsResourceImpl.java
@@ -107,6 +107,22 @@ public abstract class BaseSettingsResourceImpl implements SettingsResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/EntryResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/EntryResourceImpl.java
@@ -102,7 +102,7 @@ public class EntryResourceImpl extends BaseEntryResourceImpl {
 						getVersionEntityContentTypeLanguageKey(
 							ctEntry.getModelClassNameId());
 				dateModified = ctEntry.getModifiedDate();
-				entryId = ctEntry.getCtEntryId();
+				id = ctEntry.getCtEntryId();
 				key = ctEntry.getModelResourcePrimKey();
 				siteName = CTDefinitionRegistryUtil.getVersionEntitySiteName(
 					ctEntry.getModelClassNameId(), ctEntry.getModelClassPK());

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/ProcessResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/ProcessResourceImpl.java
@@ -155,8 +155,8 @@ public class ProcessResourceImpl extends BaseProcessResourceImpl {
 				collection = CollectionUtil.toCollection(
 					ctCollection, _ctEngineManager);
 				companyId = ctProcess.getCompanyId();
-				processId = ctProcess.getCtProcessId();
 				dateCreated = ctProcess.getCreateDate();
+				id = ctProcess.getCtProcessId();
 
 				percentage = backgroundTaskOptional.flatMap(
 					ProcessResourceImpl.this::

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/graphql/v1_0/test/BaseCollectionGraphQLTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/graphql/v1_0/test/BaseCollectionGraphQLTestCase.java
@@ -17,6 +17,7 @@ package com.liferay.change.tracking.rest.graphql.v1_0.test;
 import com.liferay.change.tracking.rest.client.dto.v1_0.Collection;
 import com.liferay.change.tracking.rest.client.dto.v1_0.Entry;
 import com.liferay.change.tracking.rest.client.http.HttpInvoker;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -69,7 +70,42 @@ public abstract class BaseCollectionGraphQLTestCase {
 
 	@Test
 	public void testGetCollection() throws Exception {
-		Assert.assertTrue(true);
+		Collection postCollection = testGetCollection_addCollection();
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		graphQLFields.add(new GraphQLField("id"));
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			graphQLFields.add(new GraphQLField(additionalAssertFieldName));
+		}
+
+		GraphQLField graphQLField = new GraphQLField(
+			"query",
+			new GraphQLField(
+				"getCollection",
+				new HashMap<String, Object>() {
+					{
+						put("collectionId", postCollection.getId());
+					}
+				},
+				graphQLFields.toArray(new GraphQLField[0])));
+
+		JSONObject responseJSONObject = JSONFactoryUtil.createJSONObject(
+			_invoke(graphQLField.toString()));
+
+		JSONObject dataJSONObject = responseJSONObject.getJSONObject("data");
+
+		Assert.assertTrue(
+			equals(
+				postCollection, dataJSONObject.getJSONObject("getCollection")));
+	}
+
+	protected Collection testGetCollection_addCollection() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected boolean equals(Collection collection, JSONObject jsonObject) {
@@ -83,17 +119,6 @@ public abstract class BaseCollectionGraphQLTestCase {
 				if (!Objects.equals(
 						collection.getAdditionCount(),
 						(Long)jsonObject.getLong("additionCount"))) {
-
-					return false;
-				}
-
-				continue;
-			}
-
-			if (Objects.equals("collectionId", fieldName)) {
-				if (!Objects.equals(
-						collection.getCollectionId(),
-						(Long)jsonObject.getLong("collectionId"))) {
 
 					return false;
 				}
@@ -127,6 +152,16 @@ public abstract class BaseCollectionGraphQLTestCase {
 				if (!Objects.equals(
 						collection.getDescription(),
 						(String)jsonObject.getString("description"))) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("id", fieldName)) {
+				if (!Objects.equals(
+						collection.getId(), (Long)jsonObject.getLong("id"))) {
 
 					return false;
 				}
@@ -182,11 +217,11 @@ public abstract class BaseCollectionGraphQLTestCase {
 		return new Collection() {
 			{
 				additionCount = RandomTestUtil.randomLong();
-				collectionId = RandomTestUtil.randomLong();
 				companyId = RandomTestUtil.randomLong();
 				dateStatus = RandomTestUtil.nextDate();
 				deletionCount = RandomTestUtil.randomLong();
 				description = RandomTestUtil.randomString();
+				id = RandomTestUtil.randomLong();
 				modificationCount = RandomTestUtil.randomLong();
 				name = RandomTestUtil.randomString();
 				statusByUserName = RandomTestUtil.randomString();

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/graphql/v1_0/test/BaseEntryGraphQLTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/graphql/v1_0/test/BaseEntryGraphQLTestCase.java
@@ -16,6 +16,7 @@ package com.liferay.change.tracking.rest.graphql.v1_0.test;
 
 import com.liferay.change.tracking.rest.client.dto.v1_0.Entry;
 import com.liferay.change.tracking.rest.client.http.HttpInvoker;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -68,7 +69,41 @@ public abstract class BaseEntryGraphQLTestCase {
 
 	@Test
 	public void testGetEntry() throws Exception {
-		Assert.assertTrue(true);
+		Entry postEntry = testGetEntry_addEntry();
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		graphQLFields.add(new GraphQLField("id"));
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			graphQLFields.add(new GraphQLField(additionalAssertFieldName));
+		}
+
+		GraphQLField graphQLField = new GraphQLField(
+			"query",
+			new GraphQLField(
+				"getEntry",
+				new HashMap<String, Object>() {
+					{
+						put("entryId", postEntry.getId());
+					}
+				},
+				graphQLFields.toArray(new GraphQLField[0])));
+
+		JSONObject responseJSONObject = JSONFactoryUtil.createJSONObject(
+			_invoke(graphQLField.toString()));
+
+		JSONObject dataJSONObject = responseJSONObject.getJSONObject("data");
+
+		Assert.assertTrue(
+			equals(postEntry, dataJSONObject.getJSONObject("getEntry")));
+	}
+
+	protected Entry testGetEntry_addEntry() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected boolean equals(Entry entry, JSONObject jsonObject) {
@@ -122,10 +157,9 @@ public abstract class BaseEntryGraphQLTestCase {
 				continue;
 			}
 
-			if (Objects.equals("entryId", fieldName)) {
+			if (Objects.equals("id", fieldName)) {
 				if (!Objects.equals(
-						entry.getEntryId(),
-						(Long)jsonObject.getLong("entryId"))) {
+						entry.getId(), (Long)jsonObject.getLong("id"))) {
 
 					return false;
 				}
@@ -206,7 +240,7 @@ public abstract class BaseEntryGraphQLTestCase {
 				collision = RandomTestUtil.randomBoolean();
 				contentType = RandomTestUtil.randomString();
 				dateModified = RandomTestUtil.nextDate();
-				entryId = RandomTestUtil.randomLong();
+				id = RandomTestUtil.randomLong();
 				key = RandomTestUtil.randomLong();
 				siteName = RandomTestUtil.randomString();
 				title = RandomTestUtil.randomString();

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/graphql/v1_0/test/BaseProcessGraphQLTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/graphql/v1_0/test/BaseProcessGraphQLTestCase.java
@@ -17,6 +17,7 @@ package com.liferay.change.tracking.rest.graphql.v1_0.test;
 import com.liferay.change.tracking.rest.client.dto.v1_0.Entry;
 import com.liferay.change.tracking.rest.client.dto.v1_0.Process;
 import com.liferay.change.tracking.rest.client.http.HttpInvoker;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -69,7 +70,41 @@ public abstract class BaseProcessGraphQLTestCase {
 
 	@Test
 	public void testGetProcess() throws Exception {
-		Assert.assertTrue(true);
+		Process postProcess = testGetProcess_addProcess();
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		graphQLFields.add(new GraphQLField("id"));
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			graphQLFields.add(new GraphQLField(additionalAssertFieldName));
+		}
+
+		GraphQLField graphQLField = new GraphQLField(
+			"query",
+			new GraphQLField(
+				"getProcess",
+				new HashMap<String, Object>() {
+					{
+						put("processId", postProcess.getId());
+					}
+				},
+				graphQLFields.toArray(new GraphQLField[0])));
+
+		JSONObject responseJSONObject = JSONFactoryUtil.createJSONObject(
+			_invoke(graphQLField.toString()));
+
+		JSONObject dataJSONObject = responseJSONObject.getJSONObject("data");
+
+		Assert.assertTrue(
+			equals(postProcess, dataJSONObject.getJSONObject("getProcess")));
+	}
+
+	protected Process testGetProcess_addProcess() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected boolean equals(Process process, JSONObject jsonObject) {
@@ -90,10 +125,9 @@ public abstract class BaseProcessGraphQLTestCase {
 				continue;
 			}
 
-			if (Objects.equals("processId", fieldName)) {
+			if (Objects.equals("id", fieldName)) {
 				if (!Objects.equals(
-						process.getProcessId(),
-						(Long)jsonObject.getLong("processId"))) {
+						process.getId(), (Long)jsonObject.getLong("id"))) {
 
 					return false;
 				}
@@ -128,7 +162,7 @@ public abstract class BaseProcessGraphQLTestCase {
 			{
 				companyId = RandomTestUtil.randomLong();
 				dateCreated = RandomTestUtil.nextDate();
-				processId = RandomTestUtil.randomLong();
+				id = RandomTestUtil.randomLong();
 				status = RandomTestUtil.randomString();
 			}
 		};

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCollectionResourceTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCollectionResourceTestCase.java
@@ -214,6 +214,9 @@ public abstract class BaseCollectionResourceTestCase {
 			Arrays.asList(collection1, collection2),
 			(List<Collection>)page.getItems());
 		assertValid(page);
+
+		collectionResource.deleteCollection(collection1.getId());
+		collectionResource.deleteCollection(collection2.getId());
 	}
 
 	@Test
@@ -372,12 +375,40 @@ public abstract class BaseCollectionResourceTestCase {
 
 	@Test
 	public void testDeleteCollection() throws Exception {
-		Assert.assertTrue(true);
+		Collection collection = testDeleteCollection_addCollection();
+
+		assertHttpResponseStatusCode(
+			204,
+			collectionResource.deleteCollectionHttpResponse(
+				collection.getId(), null));
+
+		assertHttpResponseStatusCode(
+			404,
+			collectionResource.getCollectionHttpResponse(collection.getId()));
+
+		assertHttpResponseStatusCode(
+			404, collectionResource.getCollectionHttpResponse(0L));
+	}
+
+	protected Collection testDeleteCollection_addCollection() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
 	public void testGetCollection() throws Exception {
-		Assert.assertTrue(true);
+		Collection postCollection = testGetCollection_addCollection();
+
+		Collection getCollection = collectionResource.getCollection(
+			postCollection.getId(), null);
+
+		assertEquals(postCollection, getCollection);
+		assertValid(getCollection);
+	}
+
+	protected Collection testGetCollection_addCollection() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -443,19 +474,15 @@ public abstract class BaseCollectionResourceTestCase {
 	protected void assertValid(Collection collection) {
 		boolean valid = true;
 
+		if (collection.getId() == null) {
+			valid = false;
+		}
+
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
 			if (Objects.equals("additionCount", additionalAssertFieldName)) {
 				if (collection.getAdditionCount() == null) {
-					valid = false;
-				}
-
-				continue;
-			}
-
-			if (Objects.equals("collectionId", additionalAssertFieldName)) {
-				if (collection.getCollectionId() == null) {
 					valid = false;
 				}
 
@@ -572,17 +599,6 @@ public abstract class BaseCollectionResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals("collectionId", additionalAssertFieldName)) {
-				if (!Objects.deepEquals(
-						collection1.getCollectionId(),
-						collection2.getCollectionId())) {
-
-					return false;
-				}
-
-				continue;
-			}
-
 			if (Objects.equals("companyId", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						collection1.getCompanyId(),
@@ -620,6 +636,16 @@ public abstract class BaseCollectionResourceTestCase {
 				if (!Objects.deepEquals(
 						collection1.getDescription(),
 						collection2.getDescription())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("id", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collection1.getId(), collection2.getId())) {
 
 					return false;
 				}
@@ -724,11 +750,6 @@ public abstract class BaseCollectionResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
-		if (entityFieldName.equals("collectionId")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
-		}
-
 		if (entityFieldName.equals("companyId")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -778,6 +799,11 @@ public abstract class BaseCollectionResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("id")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("modificationCount")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -807,11 +833,11 @@ public abstract class BaseCollectionResourceTestCase {
 		return new Collection() {
 			{
 				additionCount = RandomTestUtil.randomLong();
-				collectionId = RandomTestUtil.randomLong();
 				companyId = RandomTestUtil.randomLong();
 				dateStatus = RandomTestUtil.nextDate();
 				deletionCount = RandomTestUtil.randomLong();
 				description = RandomTestUtil.randomString();
+				id = RandomTestUtil.randomLong();
 				modificationCount = RandomTestUtil.randomLong();
 				name = RandomTestUtil.randomString();
 				statusByUserName = RandomTestUtil.randomString();

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseEntryResourceTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseEntryResourceTestCase.java
@@ -398,7 +398,17 @@ public abstract class BaseEntryResourceTestCase {
 
 	@Test
 	public void testGetEntry() throws Exception {
-		Assert.assertTrue(true);
+		Entry postEntry = testGetEntry_addEntry();
+
+		Entry getEntry = entryResource.getEntry(postEntry.getId());
+
+		assertEquals(postEntry, getEntry);
+		assertValid(getEntry);
+	}
+
+	protected Entry testGetEntry_addEntry() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected void assertHttpResponseStatusCode(
@@ -453,6 +463,10 @@ public abstract class BaseEntryResourceTestCase {
 			valid = false;
 		}
 
+		if (entry.getId() == null) {
+			valid = false;
+		}
+
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
@@ -500,14 +514,6 @@ public abstract class BaseEntryResourceTestCase {
 
 			if (Objects.equals("contentType", additionalAssertFieldName)) {
 				if (entry.getContentType() == null) {
-					valid = false;
-				}
-
-				continue;
-			}
-
-			if (Objects.equals("entryId", additionalAssertFieldName)) {
-				if (entry.getEntryId() == null) {
 					valid = false;
 				}
 
@@ -668,10 +674,8 @@ public abstract class BaseEntryResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals("entryId", additionalAssertFieldName)) {
-				if (!Objects.deepEquals(
-						entry1.getEntryId(), entry2.getEntryId())) {
-
+			if (Objects.equals("id", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(entry1.getId(), entry2.getId())) {
 					return false;
 				}
 
@@ -846,7 +850,7 @@ public abstract class BaseEntryResourceTestCase {
 			return sb.toString();
 		}
 
-		if (entityFieldName.equals("entryId")) {
+		if (entityFieldName.equals("id")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
 		}
@@ -900,7 +904,7 @@ public abstract class BaseEntryResourceTestCase {
 				collision = RandomTestUtil.randomBoolean();
 				contentType = RandomTestUtil.randomString();
 				dateModified = RandomTestUtil.nextDate();
-				entryId = RandomTestUtil.randomLong();
+				id = RandomTestUtil.randomLong();
 				key = RandomTestUtil.randomLong();
 				siteName = RandomTestUtil.randomString();
 				title = RandomTestUtil.randomString();

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseProcessResourceTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseProcessResourceTestCase.java
@@ -345,7 +345,17 @@ public abstract class BaseProcessResourceTestCase {
 
 	@Test
 	public void testGetProcess() throws Exception {
-		Assert.assertTrue(true);
+		Process postProcess = testGetProcess_addProcess();
+
+		Process getProcess = processResource.getProcess(postProcess.getId());
+
+		assertEquals(postProcess, getProcess);
+		assertValid(getProcess);
+	}
+
+	protected Process testGetProcess_addProcess() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected void assertHttpResponseStatusCode(
@@ -403,6 +413,10 @@ public abstract class BaseProcessResourceTestCase {
 			valid = false;
 		}
 
+		if (process.getId() == null) {
+			valid = false;
+		}
+
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
@@ -424,14 +438,6 @@ public abstract class BaseProcessResourceTestCase {
 
 			if (Objects.equals("percentage", additionalAssertFieldName)) {
 				if (process.getPercentage() == null) {
-					valid = false;
-				}
-
-				continue;
-			}
-
-			if (Objects.equals("processId", additionalAssertFieldName)) {
-				if (process.getProcessId() == null) {
 					valid = false;
 				}
 
@@ -525,19 +531,17 @@ public abstract class BaseProcessResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals("percentage", additionalAssertFieldName)) {
-				if (!Objects.deepEquals(
-						process1.getPercentage(), process2.getPercentage())) {
-
+			if (Objects.equals("id", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(process1.getId(), process2.getId())) {
 					return false;
 				}
 
 				continue;
 			}
 
-			if (Objects.equals("processId", additionalAssertFieldName)) {
+			if (Objects.equals("percentage", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
-						process1.getProcessId(), process2.getProcessId())) {
+						process1.getPercentage(), process2.getPercentage())) {
 
 					return false;
 				}
@@ -664,12 +668,12 @@ public abstract class BaseProcessResourceTestCase {
 			return sb.toString();
 		}
 
-		if (entityFieldName.equals("percentage")) {
+		if (entityFieldName.equals("id")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
 		}
 
-		if (entityFieldName.equals("processId")) {
+		if (entityFieldName.equals("percentage")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
 		}
@@ -696,7 +700,7 @@ public abstract class BaseProcessResourceTestCase {
 			{
 				companyId = RandomTestUtil.randomLong();
 				dateCreated = RandomTestUtil.nextDate();
-				processId = RandomTestUtil.randomLong();
+				id = RandomTestUtil.randomLong();
 				status = RandomTestUtil.randomString();
 			}
 		};

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/build.gradle
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/build.gradle
@@ -2,7 +2,9 @@ dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
+	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/KeywordResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/KeywordResource.java
@@ -25,6 +25,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -58,6 +63,17 @@ public interface KeywordResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyCategoryResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyCategoryResource.java
@@ -25,6 +25,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -76,6 +81,17 @@ public interface TaxonomyCategoryResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyVocabularyResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyVocabularyResource.java
@@ -25,6 +25,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -67,6 +72,17 @@ public interface TaxonomyVocabularyResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
@@ -29,12 +29,16 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.function.BiFunction;
 
 import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.ComponentServiceObjects;
 
@@ -198,6 +202,78 @@ public class Query {
 					taxonomyVocabularyId));
 	}
 
+	@GraphQLTypeExtension(TaxonomyVocabulary.class)
+	public class GetTaxonomyVocabularyTaxonomyCategoriesPageTypeExtension {
+
+		private TaxonomyVocabulary _taxonomyVocabulary;
+
+		public GetTaxonomyVocabularyTaxonomyCategoriesPageTypeExtension(
+			TaxonomyVocabulary taxonomyVocabulary) {
+
+			_taxonomyVocabulary = taxonomyVocabulary;
+		}
+
+		@GraphQLField
+		public TaxonomyCategoryPage getTaxonomyVocabularyTaxonomyCategoriesPage(
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") String filterString,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_taxonomyCategoryResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				taxonomyCategoryResource -> new TaxonomyCategoryPage(
+					taxonomyCategoryResource.
+						getTaxonomyVocabularyTaxonomyCategoriesPage(
+							_taxonomyVocabulary.getId(), search,
+							_filterBiFunction.apply(
+								taxonomyCategoryResource, filterString),
+							Pagination.of(page, pageSize),
+							_sortsBiFunction.apply(
+								taxonomyCategoryResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(TaxonomyCategory.class)
+	public class GetTaxonomyCategoryTaxonomyCategoriesPageTypeExtension {
+
+		private TaxonomyCategory _taxonomyCategory;
+
+		public GetTaxonomyCategoryTaxonomyCategoriesPageTypeExtension(
+			TaxonomyCategory taxonomyCategory) {
+
+			_taxonomyCategory = taxonomyCategory;
+		}
+
+		@GraphQLField
+		public TaxonomyCategoryPage getTaxonomyCategoryTaxonomyCategoriesPage(
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") String filterString,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_taxonomyCategoryResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				taxonomyCategoryResource -> new TaxonomyCategoryPage(
+					taxonomyCategoryResource.
+						getTaxonomyCategoryTaxonomyCategoriesPage(
+							_taxonomyCategory.getId(), search,
+							_filterBiFunction.apply(
+								taxonomyCategoryResource, filterString),
+							Pagination.of(page, pageSize),
+							_sortsBiFunction.apply(
+								taxonomyCategoryResource, sortsString))));
+		}
+
+	}
+
 	@GraphQLName("KeywordPage")
 	public class KeywordPage {
 
@@ -294,6 +370,8 @@ public class Query {
 
 		keywordResource.setContextAcceptLanguage(_acceptLanguage);
 		keywordResource.setContextCompany(_company);
+		keywordResource.setContextHttpServletRequest(_httpServletRequest);
+		keywordResource.setContextHttpServletResponse(_httpServletResponse);
 		keywordResource.setContextUser(_user);
 	}
 
@@ -303,6 +381,10 @@ public class Query {
 
 		taxonomyCategoryResource.setContextAcceptLanguage(_acceptLanguage);
 		taxonomyCategoryResource.setContextCompany(_company);
+		taxonomyCategoryResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		taxonomyCategoryResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		taxonomyCategoryResource.setContextUser(_user);
 	}
 
@@ -312,6 +394,10 @@ public class Query {
 
 		taxonomyVocabularyResource.setContextAcceptLanguage(_acceptLanguage);
 		taxonomyVocabularyResource.setContextCompany(_company);
+		taxonomyVocabularyResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		taxonomyVocabularyResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		taxonomyVocabularyResource.setContextUser(_user);
 	}
 
@@ -326,6 +412,8 @@ public class Query {
 	private BiFunction<Object, String, Filter> _filterBiFunction;
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private Company _company;
+	private HttpServletRequest _httpServletRequest;
+	private HttpServletResponse _httpServletResponse;
 	private User _user;
 
 }

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -164,6 +164,22 @@ public abstract class BaseKeywordResourceImpl implements KeywordResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -295,6 +295,22 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -246,6 +246,22 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/build.gradle
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/build.gradle
@@ -2,7 +2,9 @@ dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
+	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/EmailAddressResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/EmailAddressResource.java
@@ -22,6 +22,11 @@ import com.liferay.portal.vulcan.pagination.Page;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -51,6 +56,17 @@ public interface EmailAddressResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/OrganizationResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/OrganizationResource.java
@@ -25,6 +25,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -55,6 +60,17 @@ public interface OrganizationResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/PhoneResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/PhoneResource.java
@@ -22,6 +22,11 @@ import com.liferay.portal.vulcan.pagination.Page;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -49,6 +54,17 @@ public interface PhoneResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/PostalAddressResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/PostalAddressResource.java
@@ -22,6 +22,11 @@ import com.liferay.portal.vulcan.pagination.Page;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -52,6 +57,17 @@ public interface PostalAddressResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/RoleResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/RoleResource.java
@@ -23,6 +23,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -46,6 +51,17 @@ public interface RoleResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SegmentResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SegmentResource.java
@@ -23,6 +23,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -49,6 +54,17 @@ public interface SegmentResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SegmentUserResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SegmentUserResource.java
@@ -23,6 +23,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -46,6 +51,17 @@ public interface SegmentUserResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserAccountResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserAccountResource.java
@@ -25,6 +25,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -62,6 +67,17 @@ public interface UserAccountResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/WebUrlResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/WebUrlResource.java
@@ -22,6 +22,11 @@ import com.liferay.portal.vulcan.pagination.Page;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -49,6 +54,17 @@ public interface WebUrlResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
@@ -41,12 +41,16 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.function.BiFunction;
 
 import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.ComponentServiceObjects;
 
@@ -475,6 +479,262 @@ public class Query {
 			webUrlResource -> webUrlResource.getWebUrl(webUrlId));
 	}
 
+	@GraphQLTypeExtension(UserAccount.class)
+	public class GetUserAccountEmailAddressesPageTypeExtension {
+
+		private UserAccount _userAccount;
+
+		public GetUserAccountEmailAddressesPageTypeExtension(
+			UserAccount userAccount) {
+
+			_userAccount = userAccount;
+		}
+
+		@GraphQLField
+		public EmailAddressPage getUserAccountEmailAddressesPage()
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_emailAddressResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				emailAddressResource -> new EmailAddressPage(
+					emailAddressResource.getUserAccountEmailAddressesPage(
+						_userAccount.getId())));
+		}
+
+	}
+
+	@GraphQLTypeExtension(Organization.class)
+	public class GetOrganizationWebUrlsPageTypeExtension {
+
+		private Organization _organization;
+
+		public GetOrganizationWebUrlsPageTypeExtension(
+			Organization organization) {
+
+			_organization = organization;
+		}
+
+		@GraphQLField
+		public WebUrlPage getOrganizationWebUrlsPage() throws Exception {
+			return _applyComponentServiceObjects(
+				_webUrlResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				webUrlResource -> new WebUrlPage(
+					webUrlResource.getOrganizationWebUrlsPage(
+						_organization.getId())));
+		}
+
+	}
+
+	@GraphQLTypeExtension(UserAccount.class)
+	public class GetUserAccountPhonesPageTypeExtension {
+
+		private UserAccount _userAccount;
+
+		public GetUserAccountPhonesPageTypeExtension(UserAccount userAccount) {
+			_userAccount = userAccount;
+		}
+
+		@GraphQLField
+		public PhonePage getUserAccountPhonesPage() throws Exception {
+			return _applyComponentServiceObjects(
+				_phoneResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				phoneResource -> new PhonePage(
+					phoneResource.getUserAccountPhonesPage(
+						_userAccount.getId())));
+		}
+
+	}
+
+	@GraphQLTypeExtension(Organization.class)
+	public class GetOrganizationUserAccountsPageTypeExtension {
+
+		private Organization _organization;
+
+		public GetOrganizationUserAccountsPageTypeExtension(
+			Organization organization) {
+
+			_organization = organization;
+		}
+
+		@GraphQLField
+		public UserAccountPage getOrganizationUserAccountsPage(
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") String filterString,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_userAccountResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				userAccountResource -> new UserAccountPage(
+					userAccountResource.getOrganizationUserAccountsPage(
+						_organization.getId(), search,
+						_filterBiFunction.apply(
+							userAccountResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(
+							userAccountResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(Organization.class)
+	public class GetOrganizationPostalAddressesPageTypeExtension {
+
+		private Organization _organization;
+
+		public GetOrganizationPostalAddressesPageTypeExtension(
+			Organization organization) {
+
+			_organization = organization;
+		}
+
+		@GraphQLField
+		public PostalAddressPage getOrganizationPostalAddressesPage()
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_postalAddressResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				postalAddressResource -> new PostalAddressPage(
+					postalAddressResource.getOrganizationPostalAddressesPage(
+						_organization.getId())));
+		}
+
+	}
+
+	@GraphQLTypeExtension(WebUrl.class)
+	public class GetOrganizationOrganizationsPageTypeExtension {
+
+		private WebUrl _webUrl;
+
+		public GetOrganizationOrganizationsPageTypeExtension(WebUrl webUrl) {
+			_webUrl = webUrl;
+		}
+
+		@GraphQLField
+		public OrganizationPage getOrganizationOrganizationsPage(
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") String filterString,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_organizationResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				organizationResource -> new OrganizationPage(
+					organizationResource.getOrganizationOrganizationsPage(
+						_webUrl.getId(), search,
+						_filterBiFunction.apply(
+							organizationResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(
+							organizationResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(UserAccount.class)
+	public class GetUserAccountWebUrlsPageTypeExtension {
+
+		private UserAccount _userAccount;
+
+		public GetUserAccountWebUrlsPageTypeExtension(UserAccount userAccount) {
+			_userAccount = userAccount;
+		}
+
+		@GraphQLField
+		public WebUrlPage getUserAccountWebUrlsPage() throws Exception {
+			return _applyComponentServiceObjects(
+				_webUrlResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				webUrlResource -> new WebUrlPage(
+					webUrlResource.getUserAccountWebUrlsPage(
+						_userAccount.getId())));
+		}
+
+	}
+
+	@GraphQLTypeExtension(Organization.class)
+	public class GetOrganizationEmailAddressesPageTypeExtension {
+
+		private Organization _organization;
+
+		public GetOrganizationEmailAddressesPageTypeExtension(
+			Organization organization) {
+
+			_organization = organization;
+		}
+
+		@GraphQLField
+		public EmailAddressPage getOrganizationEmailAddressesPage()
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_emailAddressResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				emailAddressResource -> new EmailAddressPage(
+					emailAddressResource.getOrganizationEmailAddressesPage(
+						_organization.getId())));
+		}
+
+	}
+
+	@GraphQLTypeExtension(Organization.class)
+	public class GetOrganizationPhonesPageTypeExtension {
+
+		private Organization _organization;
+
+		public GetOrganizationPhonesPageTypeExtension(
+			Organization organization) {
+
+			_organization = organization;
+		}
+
+		@GraphQLField
+		public PhonePage getOrganizationPhonesPage() throws Exception {
+			return _applyComponentServiceObjects(
+				_phoneResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				phoneResource -> new PhonePage(
+					phoneResource.getOrganizationPhonesPage(
+						_organization.getId())));
+		}
+
+	}
+
+	@GraphQLTypeExtension(UserAccount.class)
+	public class GetUserAccountPostalAddressesPageTypeExtension {
+
+		private UserAccount _userAccount;
+
+		public GetUserAccountPostalAddressesPageTypeExtension(
+			UserAccount userAccount) {
+
+			_userAccount = userAccount;
+		}
+
+		@GraphQLField
+		public PostalAddressPage getUserAccountPostalAddressesPage()
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_postalAddressResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				postalAddressResource -> new PostalAddressPage(
+					postalAddressResource.getUserAccountPostalAddressesPage(
+						_userAccount.getId())));
+		}
+
+	}
+
 	@GraphQLName("EmailAddressPage")
 	public class EmailAddressPage {
 
@@ -716,6 +976,9 @@ public class Query {
 
 		emailAddressResource.setContextAcceptLanguage(_acceptLanguage);
 		emailAddressResource.setContextCompany(_company);
+		emailAddressResource.setContextHttpServletRequest(_httpServletRequest);
+		emailAddressResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		emailAddressResource.setContextUser(_user);
 	}
 
@@ -725,6 +988,9 @@ public class Query {
 
 		organizationResource.setContextAcceptLanguage(_acceptLanguage);
 		organizationResource.setContextCompany(_company);
+		organizationResource.setContextHttpServletRequest(_httpServletRequest);
+		organizationResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		organizationResource.setContextUser(_user);
 	}
 
@@ -733,6 +999,8 @@ public class Query {
 
 		phoneResource.setContextAcceptLanguage(_acceptLanguage);
 		phoneResource.setContextCompany(_company);
+		phoneResource.setContextHttpServletRequest(_httpServletRequest);
+		phoneResource.setContextHttpServletResponse(_httpServletResponse);
 		phoneResource.setContextUser(_user);
 	}
 
@@ -742,6 +1010,9 @@ public class Query {
 
 		postalAddressResource.setContextAcceptLanguage(_acceptLanguage);
 		postalAddressResource.setContextCompany(_company);
+		postalAddressResource.setContextHttpServletRequest(_httpServletRequest);
+		postalAddressResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		postalAddressResource.setContextUser(_user);
 	}
 
@@ -750,6 +1021,8 @@ public class Query {
 
 		roleResource.setContextAcceptLanguage(_acceptLanguage);
 		roleResource.setContextCompany(_company);
+		roleResource.setContextHttpServletRequest(_httpServletRequest);
+		roleResource.setContextHttpServletResponse(_httpServletResponse);
 		roleResource.setContextUser(_user);
 	}
 
@@ -758,6 +1031,8 @@ public class Query {
 
 		segmentResource.setContextAcceptLanguage(_acceptLanguage);
 		segmentResource.setContextCompany(_company);
+		segmentResource.setContextHttpServletRequest(_httpServletRequest);
+		segmentResource.setContextHttpServletResponse(_httpServletResponse);
 		segmentResource.setContextUser(_user);
 	}
 
@@ -767,6 +1042,8 @@ public class Query {
 
 		segmentUserResource.setContextAcceptLanguage(_acceptLanguage);
 		segmentUserResource.setContextCompany(_company);
+		segmentUserResource.setContextHttpServletRequest(_httpServletRequest);
+		segmentUserResource.setContextHttpServletResponse(_httpServletResponse);
 		segmentUserResource.setContextUser(_user);
 	}
 
@@ -776,6 +1053,8 @@ public class Query {
 
 		userAccountResource.setContextAcceptLanguage(_acceptLanguage);
 		userAccountResource.setContextCompany(_company);
+		userAccountResource.setContextHttpServletRequest(_httpServletRequest);
+		userAccountResource.setContextHttpServletResponse(_httpServletResponse);
 		userAccountResource.setContextUser(_user);
 	}
 
@@ -784,6 +1063,8 @@ public class Query {
 
 		webUrlResource.setContextAcceptLanguage(_acceptLanguage);
 		webUrlResource.setContextCompany(_company);
+		webUrlResource.setContextHttpServletRequest(_httpServletRequest);
+		webUrlResource.setContextHttpServletResponse(_httpServletResponse);
 		webUrlResource.setContextUser(_user);
 	}
 
@@ -810,6 +1091,8 @@ public class Query {
 	private BiFunction<Object, String, Filter> _filterBiFunction;
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private Company _company;
+	private HttpServletRequest _httpServletRequest;
+	private HttpServletResponse _httpServletResponse;
 	private User _user;
 
 }

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
@@ -114,6 +114,22 @@ public abstract class BaseEmailAddressResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -140,6 +140,22 @@ public abstract class BaseOrganizationResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
@@ -111,6 +111,22 @@ public abstract class BasePhoneResourceImpl implements PhoneResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
@@ -114,6 +114,22 @@ public abstract class BasePostalAddressResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -98,6 +98,22 @@ public abstract class BaseRoleResourceImpl implements RoleResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
@@ -106,6 +106,22 @@ public abstract class BaseSegmentResourceImpl implements SegmentResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
@@ -87,6 +87,22 @@ public abstract class BaseSegmentUserResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -181,6 +181,22 @@ public abstract class BaseUserAccountResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
@@ -111,6 +111,22 @@ public abstract class BaseWebUrlResourceImpl implements WebUrlResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/build.gradle
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/build.gradle
@@ -2,6 +2,8 @@ dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/resource/v1_0/WorkflowLogResource.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/resource/v1_0/WorkflowLogResource.java
@@ -23,6 +23,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -48,6 +53,17 @@ public interface WorkflowLogResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/resource/v1_0/WorkflowTaskResource.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/resource/v1_0/WorkflowTaskResource.java
@@ -26,6 +26,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -76,6 +81,17 @@ public interface WorkflowTaskResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/resources/com/liferay/headless/admin/workflow/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/resources/com/liferay/headless/admin/workflow/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/query/v1_0/Query.java
@@ -27,12 +27,16 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.function.BiFunction;
 
 import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.ComponentServiceObjects;
 
@@ -141,6 +145,33 @@ public class Query {
 				workflowTaskId));
 	}
 
+	@GraphQLTypeExtension(WorkflowTask.class)
+	public class GetWorkflowTaskWorkflowLogsPageTypeExtension {
+
+		private WorkflowTask _workflowTask;
+
+		public GetWorkflowTaskWorkflowLogsPageTypeExtension(
+			WorkflowTask workflowTask) {
+
+			_workflowTask = workflowTask;
+		}
+
+		@GraphQLField
+		public WorkflowLogPage getWorkflowTaskWorkflowLogsPage(
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_workflowLogResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				workflowLogResource -> new WorkflowLogPage(
+					workflowLogResource.getWorkflowTaskWorkflowLogsPage(
+						_workflowTask.getId(), Pagination.of(page, pageSize))));
+		}
+
+	}
+
 	@GraphQLName("WorkflowLogPage")
 	public class WorkflowLogPage {
 
@@ -214,6 +245,8 @@ public class Query {
 
 		workflowLogResource.setContextAcceptLanguage(_acceptLanguage);
 		workflowLogResource.setContextCompany(_company);
+		workflowLogResource.setContextHttpServletRequest(_httpServletRequest);
+		workflowLogResource.setContextHttpServletResponse(_httpServletResponse);
 		workflowLogResource.setContextUser(_user);
 	}
 
@@ -223,6 +256,9 @@ public class Query {
 
 		workflowTaskResource.setContextAcceptLanguage(_acceptLanguage);
 		workflowTaskResource.setContextCompany(_company);
+		workflowTaskResource.setContextHttpServletRequest(_httpServletRequest);
+		workflowTaskResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		workflowTaskResource.setContextUser(_user);
 	}
 
@@ -235,6 +271,8 @@ public class Query {
 	private BiFunction<Object, String, Filter> _filterBiFunction;
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private Company _company;
+	private HttpServletRequest _httpServletRequest;
+	private HttpServletResponse _httpServletResponse;
 	private User _user;
 
 }

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
@@ -101,6 +101,22 @@ public abstract class BaseWorkflowLogResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskResourceImpl.java
@@ -213,6 +213,22 @@ public abstract class BaseWorkflowTaskResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/build.gradle
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/MessageBoardMessage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/MessageBoardMessage.java
@@ -396,6 +396,36 @@ public class MessageBoardMessage {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String[] keywords;
 
+	@Schema(
+		description = "The ID of the Message Board Thread to which this message is scoped."
+	)
+	public Long getMessageBoardThreadId() {
+		return messageBoardThreadId;
+	}
+
+	public void setMessageBoardThreadId(Long messageBoardThreadId) {
+		this.messageBoardThreadId = messageBoardThreadId;
+	}
+
+	@JsonIgnore
+	public void setMessageBoardThreadId(
+		UnsafeSupplier<Long, Exception> messageBoardThreadIdUnsafeSupplier) {
+
+		try {
+			messageBoardThreadId = messageBoardThreadIdUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long messageBoardThreadId;
+
 	@Schema(description = "The number of the message's attachments.")
 	public Integer getNumberOfMessageBoardAttachments() {
 		return numberOfMessageBoardAttachments;
@@ -768,6 +798,16 @@ public class MessageBoardMessage {
 			}
 
 			sb.append("]");
+		}
+
+		if (messageBoardThreadId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"messageBoardThreadId\": ");
+
+			sb.append(messageBoardThreadId);
 		}
 
 		if (numberOfMessageBoardAttachments != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingImageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingImageResource.java
@@ -26,6 +26,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -60,6 +65,17 @@ public interface BlogPostingImageResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingResource.java
@@ -26,6 +26,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -75,6 +80,17 @@ public interface BlogPostingResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/CommentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/CommentResource.java
@@ -25,6 +25,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -83,6 +88,17 @@ public interface CommentResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentSetElementResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentSetElementResource.java
@@ -23,6 +23,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -55,6 +60,17 @@ public interface ContentSetElementResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentStructureResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentStructureResource.java
@@ -25,6 +25,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -52,6 +57,17 @@ public interface ContentStructureResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentFolderResource.java
@@ -25,6 +25,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -75,6 +80,17 @@ public interface DocumentFolderResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentResource.java
@@ -27,6 +27,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -83,6 +88,17 @@ public interface DocumentResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseArticleResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseArticleResource.java
@@ -26,6 +26,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -107,6 +112,17 @@ public interface KnowledgeBaseArticleResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseAttachmentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseAttachmentResource.java
@@ -23,6 +23,11 @@ import com.liferay.portal.vulcan.pagination.Page;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -59,6 +64,17 @@ public interface KnowledgeBaseAttachmentResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseFolderResource.java
@@ -23,6 +23,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -75,6 +80,17 @@ public interface KnowledgeBaseFolderResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardAttachmentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardAttachmentResource.java
@@ -23,6 +23,11 @@ import com.liferay.portal.vulcan.pagination.Page;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -67,6 +72,17 @@ public interface MessageBoardAttachmentResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardMessageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardMessageResource.java
@@ -26,6 +26,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -95,6 +100,17 @@ public interface MessageBoardMessageResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardSectionResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardSectionResource.java
@@ -25,6 +25,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -79,6 +84,17 @@ public interface MessageBoardSectionResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardThreadResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardThreadResource.java
@@ -26,6 +26,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -92,6 +97,17 @@ public interface MessageBoardThreadResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentFolderResource.java
@@ -25,6 +25,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -82,6 +87,17 @@ public interface StructuredContentFolderResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentResource.java
@@ -26,6 +26,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -109,6 +114,17 @@ public interface StructuredContentResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiNodeResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiNodeResource.java
@@ -25,6 +25,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -59,6 +64,17 @@ public interface WikiNodeResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiPageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiPageResource.java
@@ -25,6 +25,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -59,6 +64,17 @@ public interface WikiPageResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/MessageBoardMessage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/MessageBoardMessage.java
@@ -290,6 +290,27 @@ public class MessageBoardMessage {
 
 	protected String[] keywords;
 
+	public Long getMessageBoardThreadId() {
+		return messageBoardThreadId;
+	}
+
+	public void setMessageBoardThreadId(Long messageBoardThreadId) {
+		this.messageBoardThreadId = messageBoardThreadId;
+	}
+
+	public void setMessageBoardThreadId(
+		UnsafeSupplier<Long, Exception> messageBoardThreadIdUnsafeSupplier) {
+
+		try {
+			messageBoardThreadId = messageBoardThreadIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long messageBoardThreadId;
+
 	public Integer getNumberOfMessageBoardAttachments() {
 		return numberOfMessageBoardAttachments;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardMessageSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardMessageSerDes.java
@@ -225,6 +225,16 @@ public class MessageBoardMessageSerDes {
 			sb.append("]");
 		}
 
+		if (messageBoardMessage.getMessageBoardThreadId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"messageBoardThreadId\": ");
+
+			sb.append(messageBoardMessage.getMessageBoardThreadId());
+		}
+
 		if (messageBoardMessage.getNumberOfMessageBoardAttachments() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -413,6 +423,15 @@ public class MessageBoardMessageSerDes {
 				"keywords", String.valueOf(messageBoardMessage.getKeywords()));
 		}
 
+		if (messageBoardMessage.getMessageBoardThreadId() == null) {
+			map.put("messageBoardThreadId", null);
+		}
+		else {
+			map.put(
+				"messageBoardThreadId",
+				String.valueOf(messageBoardMessage.getMessageBoardThreadId()));
+		}
+
 		if (messageBoardMessage.getNumberOfMessageBoardAttachments() == null) {
 			map.put("numberOfMessageBoardAttachments", null);
 		}
@@ -596,6 +615,14 @@ public class MessageBoardMessageSerDes {
 				if (jsonParserFieldValue != null) {
 					messageBoardMessage.setKeywords(
 						toStrings((Object[])jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "messageBoardThreadId")) {
+
+				if (jsonParserFieldValue != null) {
+					messageBoardMessage.setMessageBoardThreadId(
+						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -981,6 +981,12 @@ components:
                     items:
                         type: string
                     type: array
+                messageBoardThreadId:
+                    # @review
+                    description: The ID of the Message Board Thread to which this message is scoped.
+                    format: int64
+                    readOnly: true
+                    type: integer
                 numberOfMessageBoardAttachments:
                     description: The number of the message's attachments.
                     readOnly: true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -60,12 +60,16 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.function.BiFunction;
 
 import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.ComponentServiceObjects;
 
@@ -1313,6 +1317,916 @@ public class Query {
 			wikiPageResource -> wikiPageResource.getWikiPage(wikiPageId));
 	}
 
+	@GraphQLTypeExtension(KnowledgeBaseAttachment.class)
+	public class GetKnowledgeBaseArticleKnowledgeBaseArticlesPageTypeExtension {
+
+		private KnowledgeBaseAttachment _knowledgeBaseAttachment;
+
+		public GetKnowledgeBaseArticleKnowledgeBaseArticlesPageTypeExtension(
+			KnowledgeBaseAttachment knowledgeBaseAttachment) {
+
+			_knowledgeBaseAttachment = knowledgeBaseAttachment;
+		}
+
+		@GraphQLField
+		public KnowledgeBaseArticlePage
+				getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
+					@GraphQLName("search") String search,
+					@GraphQLName("filter") String filterString,
+					@GraphQLName("pageSize") int pageSize,
+					@GraphQLName("page") int page,
+					@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_knowledgeBaseArticleResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				knowledgeBaseArticleResource -> new KnowledgeBaseArticlePage(
+					knowledgeBaseArticleResource.
+						getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
+							_knowledgeBaseAttachment.getId(), search,
+							_filterBiFunction.apply(
+								knowledgeBaseArticleResource, filterString),
+							Pagination.of(page, pageSize),
+							_sortsBiFunction.apply(
+								knowledgeBaseArticleResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(Document.class)
+	public class GetDocumentFolderTypeExtension {
+
+		private Document _document;
+
+		public GetDocumentFolderTypeExtension(Document document) {
+			_document = document;
+		}
+
+		@GraphQLField
+		public DocumentFolder getDocumentFolder() throws Exception {
+			return _applyComponentServiceObjects(
+				_documentFolderResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				documentFolderResource ->
+					documentFolderResource.getDocumentFolder(
+						_document.getId()));
+		}
+
+	}
+
+	@GraphQLTypeExtension(MessageBoardThread.class)
+	public class GetMessageBoardThreadMessageBoardAttachmentsPageTypeExtension {
+
+		private MessageBoardThread _messageBoardThread;
+
+		public GetMessageBoardThreadMessageBoardAttachmentsPageTypeExtension(
+			MessageBoardThread messageBoardThread) {
+
+			_messageBoardThread = messageBoardThread;
+		}
+
+		@GraphQLField
+		public MessageBoardAttachmentPage
+				getMessageBoardThreadMessageBoardAttachmentsPage()
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_messageBoardAttachmentResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				messageBoardAttachmentResource ->
+					new MessageBoardAttachmentPage(
+						messageBoardAttachmentResource.
+							getMessageBoardThreadMessageBoardAttachmentsPage(
+								_messageBoardThread.getId())));
+		}
+
+	}
+
+	@GraphQLTypeExtension(StructuredContent.class)
+	public class GetStructuredContentRenderedContentTemplateTypeExtension {
+
+		private StructuredContent _structuredContent;
+
+		public GetStructuredContentRenderedContentTemplateTypeExtension(
+			StructuredContent structuredContent) {
+
+			_structuredContent = structuredContent;
+		}
+
+		@GraphQLField
+		public String getStructuredContentRenderedContentTemplate(
+				@GraphQLName("templateId") Long templateId)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_structuredContentResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				structuredContentResource ->
+					structuredContentResource.
+						getStructuredContentRenderedContentTemplate(
+							_structuredContent.getId(), templateId));
+		}
+
+	}
+
+	@GraphQLTypeExtension(KnowledgeBaseFolder.class)
+	public class GetKnowledgeBaseFolderKnowledgeBaseFoldersPageTypeExtension {
+
+		private KnowledgeBaseFolder _knowledgeBaseFolder;
+
+		public GetKnowledgeBaseFolderKnowledgeBaseFoldersPageTypeExtension(
+			KnowledgeBaseFolder knowledgeBaseFolder) {
+
+			_knowledgeBaseFolder = knowledgeBaseFolder;
+		}
+
+		@GraphQLField
+		public KnowledgeBaseFolderPage
+				getKnowledgeBaseFolderKnowledgeBaseFoldersPage(
+					@GraphQLName("pageSize") int pageSize,
+					@GraphQLName("page") int page)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_knowledgeBaseFolderResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				knowledgeBaseFolderResource -> new KnowledgeBaseFolderPage(
+					knowledgeBaseFolderResource.
+						getKnowledgeBaseFolderKnowledgeBaseFoldersPage(
+							_knowledgeBaseFolder.getId(),
+							Pagination.of(page, pageSize))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(Document.class)
+	public class GetDocumentMyRatingTypeExtension {
+
+		private Document _document;
+
+		public GetDocumentMyRatingTypeExtension(Document document) {
+			_document = document;
+		}
+
+		@GraphQLField
+		public Rating getDocumentMyRating() throws Exception {
+			return _applyComponentServiceObjects(
+				_documentResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				documentResource -> documentResource.getDocumentMyRating(
+					_document.getId()));
+		}
+
+	}
+
+	@GraphQLTypeExtension(ContentStructure.class)
+	public class GetContentStructureStructuredContentsPageTypeExtension {
+
+		private ContentStructure _contentStructure;
+
+		public GetContentStructureStructuredContentsPageTypeExtension(
+			ContentStructure contentStructure) {
+
+			_contentStructure = contentStructure;
+		}
+
+		@GraphQLField
+		public StructuredContentPage getContentStructureStructuredContentsPage(
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") String filterString,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_structuredContentResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				structuredContentResource -> new StructuredContentPage(
+					structuredContentResource.
+						getContentStructureStructuredContentsPage(
+							_contentStructure.getId(), search,
+							_filterBiFunction.apply(
+								structuredContentResource, filterString),
+							Pagination.of(page, pageSize),
+							_sortsBiFunction.apply(
+								structuredContentResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(MessageBoardMessage.class)
+	public class
+		GetMessageBoardMessageMessageBoardAttachmentsPageTypeExtension {
+
+		private MessageBoardMessage _messageBoardMessage;
+
+		public GetMessageBoardMessageMessageBoardAttachmentsPageTypeExtension(
+			MessageBoardMessage messageBoardMessage) {
+
+			_messageBoardMessage = messageBoardMessage;
+		}
+
+		@GraphQLField
+		public MessageBoardAttachmentPage
+				getMessageBoardMessageMessageBoardAttachmentsPage()
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_messageBoardAttachmentResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				messageBoardAttachmentResource ->
+					new MessageBoardAttachmentPage(
+						messageBoardAttachmentResource.
+							getMessageBoardMessageMessageBoardAttachmentsPage(
+								_messageBoardMessage.getId())));
+		}
+
+	}
+
+	@GraphQLTypeExtension(BlogPosting.class)
+	public class GetBlogPostingCommentsPageTypeExtension {
+
+		private BlogPosting _blogPosting;
+
+		public GetBlogPostingCommentsPageTypeExtension(
+			BlogPosting blogPosting) {
+
+			_blogPosting = blogPosting;
+		}
+
+		@GraphQLField
+		public CommentPage getBlogPostingCommentsPage(
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") String filterString,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_commentResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				commentResource -> new CommentPage(
+					commentResource.getBlogPostingCommentsPage(
+						_blogPosting.getId(), search,
+						_filterBiFunction.apply(commentResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(commentResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(DocumentFolder.class)
+	public class GetDocumentFolderDocumentsPageTypeExtension {
+
+		private DocumentFolder _documentFolder;
+
+		public GetDocumentFolderDocumentsPageTypeExtension(
+			DocumentFolder documentFolder) {
+
+			_documentFolder = documentFolder;
+		}
+
+		@GraphQLField
+		public DocumentPage getDocumentFolderDocumentsPage(
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") String filterString,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_documentResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				documentResource -> new DocumentPage(
+					documentResource.getDocumentFolderDocumentsPage(
+						_documentFolder.getId(), search,
+						_filterBiFunction.apply(documentResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(
+							documentResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(StructuredContent.class)
+	public class GetStructuredContentCommentsPageTypeExtension {
+
+		private StructuredContent _structuredContent;
+
+		public GetStructuredContentCommentsPageTypeExtension(
+			StructuredContent structuredContent) {
+
+			_structuredContent = structuredContent;
+		}
+
+		@GraphQLField
+		public CommentPage getStructuredContentCommentsPage(
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") String filterString,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_commentResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				commentResource -> new CommentPage(
+					commentResource.getStructuredContentCommentsPage(
+						_structuredContent.getId(), search,
+						_filterBiFunction.apply(commentResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(commentResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(WikiNode.class)
+	public class GetWikiNodeWikiPagesPageTypeExtension {
+
+		private WikiNode _wikiNode;
+
+		public GetWikiNodeWikiPagesPageTypeExtension(WikiNode wikiNode) {
+			_wikiNode = wikiNode;
+		}
+
+		@GraphQLField
+		public WikiPagePage getWikiNodeWikiPagesPage(
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") String filterString,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_wikiPageResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				wikiPageResource -> new WikiPagePage(
+					wikiPageResource.getWikiNodeWikiPagesPage(
+						_wikiNode.getId(), search,
+						_filterBiFunction.apply(wikiPageResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(
+							wikiPageResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(KnowledgeBaseArticle.class)
+	public class GetKnowledgeBaseArticleMyRatingTypeExtension {
+
+		private KnowledgeBaseArticle _knowledgeBaseArticle;
+
+		public GetKnowledgeBaseArticleMyRatingTypeExtension(
+			KnowledgeBaseArticle knowledgeBaseArticle) {
+
+			_knowledgeBaseArticle = knowledgeBaseArticle;
+		}
+
+		@GraphQLField
+		public Rating getKnowledgeBaseArticleMyRating() throws Exception {
+			return _applyComponentServiceObjects(
+				_knowledgeBaseArticleResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				knowledgeBaseArticleResource ->
+					knowledgeBaseArticleResource.
+						getKnowledgeBaseArticleMyRating(
+							_knowledgeBaseArticle.getId()));
+		}
+
+	}
+
+	@GraphQLTypeExtension(MessageBoardMessage.class)
+	public class GetMessageBoardThreadTypeExtension {
+
+		private MessageBoardMessage _messageBoardMessage;
+
+		public GetMessageBoardThreadTypeExtension(
+			MessageBoardMessage messageBoardMessage) {
+
+			_messageBoardMessage = messageBoardMessage;
+		}
+
+		@GraphQLField
+		public MessageBoardThread getMessageBoardThread() throws Exception {
+			return _applyComponentServiceObjects(
+				_messageBoardThreadResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				messageBoardThreadResource ->
+					messageBoardThreadResource.getMessageBoardThread(
+						_messageBoardMessage.getMessageBoardThreadId()));
+		}
+
+	}
+
+	@GraphQLTypeExtension(DocumentFolder.class)
+	public class GetDocumentFolderDocumentFoldersPageTypeExtension {
+
+		private DocumentFolder _documentFolder;
+
+		public GetDocumentFolderDocumentFoldersPageTypeExtension(
+			DocumentFolder documentFolder) {
+
+			_documentFolder = documentFolder;
+		}
+
+		@GraphQLField
+		public DocumentFolderPage getDocumentFolderDocumentFoldersPage(
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") String filterString,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_documentFolderResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				documentFolderResource -> new DocumentFolderPage(
+					documentFolderResource.getDocumentFolderDocumentFoldersPage(
+						_documentFolder.getId(), search,
+						_filterBiFunction.apply(
+							documentFolderResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(
+							documentFolderResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(KnowledgeBaseFolder.class)
+	public class GetKnowledgeBaseFolderKnowledgeBaseArticlesPageTypeExtension {
+
+		private KnowledgeBaseFolder _knowledgeBaseFolder;
+
+		public GetKnowledgeBaseFolderKnowledgeBaseArticlesPageTypeExtension(
+			KnowledgeBaseFolder knowledgeBaseFolder) {
+
+			_knowledgeBaseFolder = knowledgeBaseFolder;
+		}
+
+		@GraphQLField
+		public KnowledgeBaseArticlePage
+				getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
+					@GraphQLName("flatten") Boolean flatten,
+					@GraphQLName("search") String search,
+					@GraphQLName("filter") String filterString,
+					@GraphQLName("pageSize") int pageSize,
+					@GraphQLName("page") int page,
+					@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_knowledgeBaseArticleResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				knowledgeBaseArticleResource -> new KnowledgeBaseArticlePage(
+					knowledgeBaseArticleResource.
+						getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
+							_knowledgeBaseFolder.getId(), flatten, search,
+							_filterBiFunction.apply(
+								knowledgeBaseArticleResource, filterString),
+							Pagination.of(page, pageSize),
+							_sortsBiFunction.apply(
+								knowledgeBaseArticleResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(StructuredContent.class)
+	public class GetStructuredContentMyRatingTypeExtension {
+
+		private StructuredContent _structuredContent;
+
+		public GetStructuredContentMyRatingTypeExtension(
+			StructuredContent structuredContent) {
+
+			_structuredContent = structuredContent;
+		}
+
+		@GraphQLField
+		public Rating getStructuredContentMyRating() throws Exception {
+			return _applyComponentServiceObjects(
+				_structuredContentResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				structuredContentResource ->
+					structuredContentResource.getStructuredContentMyRating(
+						_structuredContent.getId()));
+		}
+
+	}
+
+	@GraphQLTypeExtension(BlogPosting.class)
+	public class GetBlogPostingMyRatingTypeExtension {
+
+		private BlogPosting _blogPosting;
+
+		public GetBlogPostingMyRatingTypeExtension(BlogPosting blogPosting) {
+			_blogPosting = blogPosting;
+		}
+
+		@GraphQLField
+		public Rating getBlogPostingMyRating() throws Exception {
+			return _applyComponentServiceObjects(
+				_blogPostingResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				blogPostingResource ->
+					blogPostingResource.getBlogPostingMyRating(
+						_blogPosting.getId()));
+		}
+
+	}
+
+	@GraphQLTypeExtension(Document.class)
+	public class GetDocumentCommentsPageTypeExtension {
+
+		private Document _document;
+
+		public GetDocumentCommentsPageTypeExtension(Document document) {
+			_document = document;
+		}
+
+		@GraphQLField
+		public CommentPage getDocumentCommentsPage(
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") String filterString,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_commentResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				commentResource -> new CommentPage(
+					commentResource.getDocumentCommentsPage(
+						_document.getId(), search,
+						_filterBiFunction.apply(commentResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(commentResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(KnowledgeBaseArticle.class)
+	public class
+		GetKnowledgeBaseArticleKnowledgeBaseAttachmentsPageTypeExtension {
+
+		private KnowledgeBaseArticle _knowledgeBaseArticle;
+
+		public GetKnowledgeBaseArticleKnowledgeBaseAttachmentsPageTypeExtension(
+			KnowledgeBaseArticle knowledgeBaseArticle) {
+
+			_knowledgeBaseArticle = knowledgeBaseArticle;
+		}
+
+		@GraphQLField
+		public KnowledgeBaseAttachmentPage
+				getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage()
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_knowledgeBaseAttachmentResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				knowledgeBaseAttachmentResource ->
+					new KnowledgeBaseAttachmentPage(
+						knowledgeBaseAttachmentResource.
+							getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
+								_knowledgeBaseArticle.getId())));
+		}
+
+	}
+
+	@GraphQLTypeExtension(StructuredContentFolder.class)
+	public class GetStructuredContentFolderStructuredContentsPageTypeExtension {
+
+		private StructuredContentFolder _structuredContentFolder;
+
+		public GetStructuredContentFolderStructuredContentsPageTypeExtension(
+			StructuredContentFolder structuredContentFolder) {
+
+			_structuredContentFolder = structuredContentFolder;
+		}
+
+		@GraphQLField
+		public StructuredContentPage
+				getStructuredContentFolderStructuredContentsPage(
+					@GraphQLName("search") String search,
+					@GraphQLName("filter") String filterString,
+					@GraphQLName("pageSize") int pageSize,
+					@GraphQLName("page") int page,
+					@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_structuredContentResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				structuredContentResource -> new StructuredContentPage(
+					structuredContentResource.
+						getStructuredContentFolderStructuredContentsPage(
+							_structuredContentFolder.getId(), search,
+							_filterBiFunction.apply(
+								structuredContentResource, filterString),
+							Pagination.of(page, pageSize),
+							_sortsBiFunction.apply(
+								structuredContentResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(StructuredContentFolder.class)
+	public class
+		GetStructuredContentFolderStructuredContentFoldersPageTypeExtension {
+
+		private StructuredContentFolder _structuredContentFolder;
+
+		public GetStructuredContentFolderStructuredContentFoldersPageTypeExtension(
+			StructuredContentFolder structuredContentFolder) {
+
+			_structuredContentFolder = structuredContentFolder;
+		}
+
+		@GraphQLField
+		public StructuredContentFolderPage
+				getStructuredContentFolderStructuredContentFoldersPage(
+					@GraphQLName("search") String search,
+					@GraphQLName("filter") String filterString,
+					@GraphQLName("pageSize") int pageSize,
+					@GraphQLName("page") int page,
+					@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_structuredContentFolderResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				structuredContentFolderResource ->
+					new StructuredContentFolderPage(
+						structuredContentFolderResource.
+							getStructuredContentFolderStructuredContentFoldersPage(
+								_structuredContentFolder.getId(), search,
+								_filterBiFunction.apply(
+									structuredContentFolderResource,
+									filterString),
+								Pagination.of(page, pageSize),
+								_sortsBiFunction.apply(
+									structuredContentFolderResource,
+									sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(MessageBoardMessage.class)
+	public class GetMessageBoardMessageMyRatingTypeExtension {
+
+		private MessageBoardMessage _messageBoardMessage;
+
+		public GetMessageBoardMessageMyRatingTypeExtension(
+			MessageBoardMessage messageBoardMessage) {
+
+			_messageBoardMessage = messageBoardMessage;
+		}
+
+		@GraphQLField
+		public Rating getMessageBoardMessageMyRating() throws Exception {
+			return _applyComponentServiceObjects(
+				_messageBoardMessageResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				messageBoardMessageResource ->
+					messageBoardMessageResource.getMessageBoardMessageMyRating(
+						_messageBoardMessage.getId()));
+		}
+
+	}
+
+	@GraphQLTypeExtension(MessageBoardMessage.class)
+	public class GetMessageBoardMessageMessageBoardMessagesPageTypeExtension {
+
+		private MessageBoardMessage _messageBoardMessage;
+
+		public GetMessageBoardMessageMessageBoardMessagesPageTypeExtension(
+			MessageBoardMessage messageBoardMessage) {
+
+			_messageBoardMessage = messageBoardMessage;
+		}
+
+		@GraphQLField
+		public MessageBoardMessagePage
+				getMessageBoardMessageMessageBoardMessagesPage(
+					@GraphQLName("search") String search,
+					@GraphQLName("filter") String filterString,
+					@GraphQLName("pageSize") int pageSize,
+					@GraphQLName("page") int page,
+					@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_messageBoardMessageResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				messageBoardMessageResource -> new MessageBoardMessagePage(
+					messageBoardMessageResource.
+						getMessageBoardMessageMessageBoardMessagesPage(
+							_messageBoardMessage.getId(), search,
+							_filterBiFunction.apply(
+								messageBoardMessageResource, filterString),
+							Pagination.of(page, pageSize),
+							_sortsBiFunction.apply(
+								messageBoardMessageResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(Comment.class)
+	public class GetCommentCommentsPageTypeExtension {
+
+		private Comment _comment;
+
+		public GetCommentCommentsPageTypeExtension(Comment comment) {
+			_comment = comment;
+		}
+
+		@GraphQLField
+		public CommentPage getCommentCommentsPage(
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") String filterString,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_commentResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				commentResource -> new CommentPage(
+					commentResource.getCommentCommentsPage(
+						_comment.getId(), search,
+						_filterBiFunction.apply(commentResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(commentResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(MessageBoardSection.class)
+	public class GetMessageBoardSectionMessageBoardSectionsPageTypeExtension {
+
+		private MessageBoardSection _messageBoardSection;
+
+		public GetMessageBoardSectionMessageBoardSectionsPageTypeExtension(
+			MessageBoardSection messageBoardSection) {
+
+			_messageBoardSection = messageBoardSection;
+		}
+
+		@GraphQLField
+		public MessageBoardSectionPage
+				getMessageBoardSectionMessageBoardSectionsPage(
+					@GraphQLName("search") String search,
+					@GraphQLName("filter") String filterString,
+					@GraphQLName("pageSize") int pageSize,
+					@GraphQLName("page") int page,
+					@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_messageBoardSectionResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				messageBoardSectionResource -> new MessageBoardSectionPage(
+					messageBoardSectionResource.
+						getMessageBoardSectionMessageBoardSectionsPage(
+							_messageBoardSection.getId(), search,
+							_filterBiFunction.apply(
+								messageBoardSectionResource, filterString),
+							Pagination.of(page, pageSize),
+							_sortsBiFunction.apply(
+								messageBoardSectionResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(StructuredContent.class)
+	public class GetContentStructureTypeExtension {
+
+		private StructuredContent _structuredContent;
+
+		public GetContentStructureTypeExtension(
+			StructuredContent structuredContent) {
+
+			_structuredContent = structuredContent;
+		}
+
+		@GraphQLField
+		public ContentStructure getContentStructure() throws Exception {
+			return _applyComponentServiceObjects(
+				_contentStructureResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				contentStructureResource ->
+					contentStructureResource.getContentStructure(
+						_structuredContent.getContentStructureId()));
+		}
+
+	}
+
+	@GraphQLTypeExtension(MessageBoardSection.class)
+	public class GetMessageBoardSectionMessageBoardThreadsPageTypeExtension {
+
+		private MessageBoardSection _messageBoardSection;
+
+		public GetMessageBoardSectionMessageBoardThreadsPageTypeExtension(
+			MessageBoardSection messageBoardSection) {
+
+			_messageBoardSection = messageBoardSection;
+		}
+
+		@GraphQLField
+		public MessageBoardThreadPage
+				getMessageBoardSectionMessageBoardThreadsPage(
+					@GraphQLName("search") String search,
+					@GraphQLName("filter") String filterString,
+					@GraphQLName("pageSize") int pageSize,
+					@GraphQLName("page") int page,
+					@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_messageBoardThreadResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				messageBoardThreadResource -> new MessageBoardThreadPage(
+					messageBoardThreadResource.
+						getMessageBoardSectionMessageBoardThreadsPage(
+							_messageBoardSection.getId(), search,
+							_filterBiFunction.apply(
+								messageBoardThreadResource, filterString),
+							Pagination.of(page, pageSize),
+							_sortsBiFunction.apply(
+								messageBoardThreadResource, sortsString))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(MessageBoardThread.class)
+	public class GetMessageBoardThreadMyRatingTypeExtension {
+
+		private MessageBoardThread _messageBoardThread;
+
+		public GetMessageBoardThreadMyRatingTypeExtension(
+			MessageBoardThread messageBoardThread) {
+
+			_messageBoardThread = messageBoardThread;
+		}
+
+		@GraphQLField
+		public Rating getMessageBoardThreadMyRating() throws Exception {
+			return _applyComponentServiceObjects(
+				_messageBoardThreadResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				messageBoardThreadResource ->
+					messageBoardThreadResource.getMessageBoardThreadMyRating(
+						_messageBoardThread.getId()));
+		}
+
+	}
+
+	@GraphQLTypeExtension(MessageBoardThread.class)
+	public class GetMessageBoardThreadMessageBoardMessagesPageTypeExtension {
+
+		private MessageBoardThread _messageBoardThread;
+
+		public GetMessageBoardThreadMessageBoardMessagesPageTypeExtension(
+			MessageBoardThread messageBoardThread) {
+
+			_messageBoardThread = messageBoardThread;
+		}
+
+		@GraphQLField
+		public MessageBoardMessagePage
+				getMessageBoardThreadMessageBoardMessagesPage(
+					@GraphQLName("search") String search,
+					@GraphQLName("filter") String filterString,
+					@GraphQLName("pageSize") int pageSize,
+					@GraphQLName("page") int page,
+					@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_messageBoardMessageResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				messageBoardMessageResource -> new MessageBoardMessagePage(
+					messageBoardMessageResource.
+						getMessageBoardThreadMessageBoardMessagesPage(
+							_messageBoardThread.getId(), search,
+							_filterBiFunction.apply(
+								messageBoardMessageResource, filterString),
+							Pagination.of(page, pageSize),
+							_sortsBiFunction.apply(
+								messageBoardMessageResource, sortsString))));
+		}
+
+	}
+
 	@GraphQLName("BlogPostingPage")
 	public class BlogPostingPage {
 
@@ -1770,6 +2684,8 @@ public class Query {
 
 		blogPostingResource.setContextAcceptLanguage(_acceptLanguage);
 		blogPostingResource.setContextCompany(_company);
+		blogPostingResource.setContextHttpServletRequest(_httpServletRequest);
+		blogPostingResource.setContextHttpServletResponse(_httpServletResponse);
 		blogPostingResource.setContextUser(_user);
 	}
 
@@ -1779,6 +2695,10 @@ public class Query {
 
 		blogPostingImageResource.setContextAcceptLanguage(_acceptLanguage);
 		blogPostingImageResource.setContextCompany(_company);
+		blogPostingImageResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		blogPostingImageResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		blogPostingImageResource.setContextUser(_user);
 	}
 
@@ -1787,6 +2707,8 @@ public class Query {
 
 		commentResource.setContextAcceptLanguage(_acceptLanguage);
 		commentResource.setContextCompany(_company);
+		commentResource.setContextHttpServletRequest(_httpServletRequest);
+		commentResource.setContextHttpServletResponse(_httpServletResponse);
 		commentResource.setContextUser(_user);
 	}
 
@@ -1796,6 +2718,10 @@ public class Query {
 
 		contentSetElementResource.setContextAcceptLanguage(_acceptLanguage);
 		contentSetElementResource.setContextCompany(_company);
+		contentSetElementResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		contentSetElementResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		contentSetElementResource.setContextUser(_user);
 	}
 
@@ -1805,6 +2731,10 @@ public class Query {
 
 		contentStructureResource.setContextAcceptLanguage(_acceptLanguage);
 		contentStructureResource.setContextCompany(_company);
+		contentStructureResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		contentStructureResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		contentStructureResource.setContextUser(_user);
 	}
 
@@ -1813,6 +2743,8 @@ public class Query {
 
 		documentResource.setContextAcceptLanguage(_acceptLanguage);
 		documentResource.setContextCompany(_company);
+		documentResource.setContextHttpServletRequest(_httpServletRequest);
+		documentResource.setContextHttpServletResponse(_httpServletResponse);
 		documentResource.setContextUser(_user);
 	}
 
@@ -1822,6 +2754,10 @@ public class Query {
 
 		documentFolderResource.setContextAcceptLanguage(_acceptLanguage);
 		documentFolderResource.setContextCompany(_company);
+		documentFolderResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		documentFolderResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		documentFolderResource.setContextUser(_user);
 	}
 
@@ -1831,6 +2767,10 @@ public class Query {
 
 		knowledgeBaseArticleResource.setContextAcceptLanguage(_acceptLanguage);
 		knowledgeBaseArticleResource.setContextCompany(_company);
+		knowledgeBaseArticleResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		knowledgeBaseArticleResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		knowledgeBaseArticleResource.setContextUser(_user);
 	}
 
@@ -1841,6 +2781,10 @@ public class Query {
 		knowledgeBaseAttachmentResource.setContextAcceptLanguage(
 			_acceptLanguage);
 		knowledgeBaseAttachmentResource.setContextCompany(_company);
+		knowledgeBaseAttachmentResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		knowledgeBaseAttachmentResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		knowledgeBaseAttachmentResource.setContextUser(_user);
 	}
 
@@ -1850,6 +2794,10 @@ public class Query {
 
 		knowledgeBaseFolderResource.setContextAcceptLanguage(_acceptLanguage);
 		knowledgeBaseFolderResource.setContextCompany(_company);
+		knowledgeBaseFolderResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		knowledgeBaseFolderResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		knowledgeBaseFolderResource.setContextUser(_user);
 	}
 
@@ -1860,6 +2808,10 @@ public class Query {
 		messageBoardAttachmentResource.setContextAcceptLanguage(
 			_acceptLanguage);
 		messageBoardAttachmentResource.setContextCompany(_company);
+		messageBoardAttachmentResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		messageBoardAttachmentResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		messageBoardAttachmentResource.setContextUser(_user);
 	}
 
@@ -1869,6 +2821,10 @@ public class Query {
 
 		messageBoardMessageResource.setContextAcceptLanguage(_acceptLanguage);
 		messageBoardMessageResource.setContextCompany(_company);
+		messageBoardMessageResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		messageBoardMessageResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		messageBoardMessageResource.setContextUser(_user);
 	}
 
@@ -1878,6 +2834,10 @@ public class Query {
 
 		messageBoardSectionResource.setContextAcceptLanguage(_acceptLanguage);
 		messageBoardSectionResource.setContextCompany(_company);
+		messageBoardSectionResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		messageBoardSectionResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		messageBoardSectionResource.setContextUser(_user);
 	}
 
@@ -1887,6 +2847,10 @@ public class Query {
 
 		messageBoardThreadResource.setContextAcceptLanguage(_acceptLanguage);
 		messageBoardThreadResource.setContextCompany(_company);
+		messageBoardThreadResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		messageBoardThreadResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		messageBoardThreadResource.setContextUser(_user);
 	}
 
@@ -1896,6 +2860,10 @@ public class Query {
 
 		structuredContentResource.setContextAcceptLanguage(_acceptLanguage);
 		structuredContentResource.setContextCompany(_company);
+		structuredContentResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		structuredContentResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		structuredContentResource.setContextUser(_user);
 	}
 
@@ -1906,6 +2874,10 @@ public class Query {
 		structuredContentFolderResource.setContextAcceptLanguage(
 			_acceptLanguage);
 		structuredContentFolderResource.setContextCompany(_company);
+		structuredContentFolderResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		structuredContentFolderResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		structuredContentFolderResource.setContextUser(_user);
 	}
 
@@ -1914,6 +2886,8 @@ public class Query {
 
 		wikiNodeResource.setContextAcceptLanguage(_acceptLanguage);
 		wikiNodeResource.setContextCompany(_company);
+		wikiNodeResource.setContextHttpServletRequest(_httpServletRequest);
+		wikiNodeResource.setContextHttpServletResponse(_httpServletResponse);
 		wikiNodeResource.setContextUser(_user);
 	}
 
@@ -1922,6 +2896,8 @@ public class Query {
 
 		wikiPageResource.setContextAcceptLanguage(_acceptLanguage);
 		wikiPageResource.setContextCompany(_company);
+		wikiPageResource.setContextHttpServletRequest(_httpServletRequest);
+		wikiPageResource.setContextHttpServletResponse(_httpServletResponse);
 		wikiPageResource.setContextUser(_user);
 	}
 
@@ -1966,6 +2942,8 @@ public class Query {
 	private BiFunction<Object, String, Filter> _filterBiFunction;
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private Company _company;
+	private HttpServletRequest _httpServletRequest;
+	private HttpServletResponse _httpServletResponse;
 	private User _user;
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -152,6 +152,22 @@ public abstract class BaseBlogPostingImageResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -338,6 +338,22 @@ public abstract class BaseBlogPostingResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -316,6 +316,22 @@ public abstract class BaseCommentResourceImpl implements CommentResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
@@ -142,6 +142,22 @@ public abstract class BaseContentSetElementResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -113,6 +113,22 @@ public abstract class BaseContentStructureResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -290,6 +290,22 @@ public abstract class BaseDocumentFolderResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -324,6 +324,22 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -485,6 +485,22 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
@@ -163,6 +163,22 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -301,6 +301,22 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -205,6 +205,22 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -162,6 +162,11 @@ public abstract class BaseMessageBoardMessageResourceImpl
 				messageBoardMessage.getKeywords());
 		}
 
+		if (messageBoardMessage.getMessageBoardThreadId() != null) {
+			existingMessageBoardMessage.setMessageBoardThreadId(
+				messageBoardMessage.getMessageBoardThreadId());
+		}
+
 		if (messageBoardMessage.getNumberOfMessageBoardAttachments() != null) {
 			existingMessageBoardMessage.setNumberOfMessageBoardAttachments(
 				messageBoardMessage.getNumberOfMessageBoardAttachments());
@@ -424,6 +429,22 @@ public abstract class BaseMessageBoardMessageResourceImpl
 
 	public void setContextCompany(Company contextCompany) {
 		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
 	}
 
 	public void setContextUser(User contextUser) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -312,6 +312,22 @@ public abstract class BaseMessageBoardSectionResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -409,6 +409,22 @@ public abstract class BaseMessageBoardThreadResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -327,6 +327,22 @@ public abstract class BaseStructuredContentFolderResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -522,6 +522,22 @@ public abstract class BaseStructuredContentResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -170,6 +170,22 @@ public abstract class BaseWikiNodeResourceImpl implements WikiNodeResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -174,6 +174,22 @@ public abstract class BaseWikiPageResourceImpl implements WikiPageResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/graphql/v1_0/test/BaseMessageBoardMessageGraphQLTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/graphql/v1_0/test/BaseMessageBoardMessageGraphQLTestCase.java
@@ -178,6 +178,17 @@ public abstract class BaseMessageBoardMessageGraphQLTestCase {
 				continue;
 			}
 
+			if (Objects.equals("messageBoardThreadId", fieldName)) {
+				if (!Objects.equals(
+						messageBoardMessage.getMessageBoardThreadId(),
+						(Long)jsonObject.getLong("messageBoardThreadId"))) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("showAsAnswer", fieldName)) {
 				if (!Objects.equals(
 						messageBoardMessage.getShowAsAnswer(),
@@ -221,6 +232,7 @@ public abstract class BaseMessageBoardMessageGraphQLTestCase {
 				encodingFormat = RandomTestUtil.randomString();
 				headline = RandomTestUtil.randomString();
 				id = RandomTestUtil.randomLong();
+				messageBoardThreadId = RandomTestUtil.randomLong();
 				showAsAnswer = RandomTestUtil.randomBoolean();
 				siteId = testGroup.getGroupId();
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -1229,6 +1229,16 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			}
 
 			if (Objects.equals(
+					"messageBoardThreadId", additionalAssertFieldName)) {
+
+				if (messageBoardMessage.getMessageBoardThreadId() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
 					"numberOfMessageBoardAttachments",
 					additionalAssertFieldName)) {
 
@@ -1444,6 +1454,19 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 				if (!Objects.deepEquals(
 						messageBoardMessage1.getKeywords(),
 						messageBoardMessage2.getKeywords())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"messageBoardThreadId", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						messageBoardMessage1.getMessageBoardThreadId(),
+						messageBoardMessage2.getMessageBoardThreadId())) {
 
 					return false;
 				}
@@ -1696,6 +1719,11 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("messageBoardThreadId")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("numberOfMessageBoardAttachments")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -1740,6 +1768,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 				encodingFormat = RandomTestUtil.randomString();
 				headline = RandomTestUtil.randomString();
 				id = RandomTestUtil.randomLong();
+				messageBoardThreadId = RandomTestUtil.randomLong();
 				showAsAnswer = RandomTestUtil.randomBoolean();
 				siteId = testGroup.getGroupId();
 			}

--- a/modules/apps/headless/headless-form/headless-form-api/build.gradle
+++ b/modules/apps/headless/headless-form/headless-form-api/build.gradle
@@ -2,6 +2,8 @@ dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.9"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormDocumentResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormDocumentResource.java
@@ -21,6 +21,11 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -44,6 +49,17 @@ public interface FormDocumentResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormRecordResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormRecordResource.java
@@ -23,6 +23,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -57,6 +62,17 @@ public interface FormRecordResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormResource.java
@@ -26,6 +26,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -58,6 +63,17 @@ public interface FormResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormStructureResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormStructureResource.java
@@ -23,6 +23,11 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -49,6 +54,17 @@ public interface FormStructureResource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/resources/com/liferay/headless/form/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/resources/com/liferay/headless/form/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/query/v1_0/Query.java
@@ -32,12 +32,16 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.function.BiFunction;
 
 import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.ComponentServiceObjects;
 
@@ -181,6 +185,71 @@ public class Query {
 					siteId, Pagination.of(page, pageSize))));
 	}
 
+	@GraphQLTypeExtension(FormRecord.class)
+	public class GetFormFormRecordsPageTypeExtension {
+
+		private FormRecord _formRecord;
+
+		public GetFormFormRecordsPageTypeExtension(FormRecord formRecord) {
+			_formRecord = formRecord;
+		}
+
+		@GraphQLField
+		public FormRecordPage getFormFormRecordsPage(
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_formRecordResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				formRecordResource -> new FormRecordPage(
+					formRecordResource.getFormFormRecordsPage(
+						_formRecord.getId(), Pagination.of(page, pageSize))));
+		}
+
+	}
+
+	@GraphQLTypeExtension(Form.class)
+	public class GetFormFormRecordByLatestDraftTypeExtension {
+
+		private Form _form;
+
+		public GetFormFormRecordByLatestDraftTypeExtension(Form form) {
+			_form = form;
+		}
+
+		@GraphQLField
+		public FormRecord getFormFormRecordByLatestDraft() throws Exception {
+			return _applyComponentServiceObjects(
+				_formRecordResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				formRecordResource ->
+					formRecordResource.getFormFormRecordByLatestDraft(
+						_form.getId()));
+		}
+
+	}
+
+	@GraphQLTypeExtension(FormRecord.class)
+	public class GetFormTypeExtension {
+
+		private FormRecord _formRecord;
+
+		public GetFormTypeExtension(FormRecord formRecord) {
+			_formRecord = formRecord;
+		}
+
+		@GraphQLField
+		public Form getForm() throws Exception {
+			return _applyComponentServiceObjects(
+				_formResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				formResource -> formResource.getForm(_formRecord.getFormId()));
+		}
+
+	}
+
 	@GraphQLName("FormPage")
 	public class FormPage {
 
@@ -301,6 +370,8 @@ public class Query {
 
 		formResource.setContextAcceptLanguage(_acceptLanguage);
 		formResource.setContextCompany(_company);
+		formResource.setContextHttpServletRequest(_httpServletRequest);
+		formResource.setContextHttpServletResponse(_httpServletResponse);
 		formResource.setContextUser(_user);
 	}
 
@@ -310,6 +381,9 @@ public class Query {
 
 		formDocumentResource.setContextAcceptLanguage(_acceptLanguage);
 		formDocumentResource.setContextCompany(_company);
+		formDocumentResource.setContextHttpServletRequest(_httpServletRequest);
+		formDocumentResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		formDocumentResource.setContextUser(_user);
 	}
 
@@ -318,6 +392,8 @@ public class Query {
 
 		formRecordResource.setContextAcceptLanguage(_acceptLanguage);
 		formRecordResource.setContextCompany(_company);
+		formRecordResource.setContextHttpServletRequest(_httpServletRequest);
+		formRecordResource.setContextHttpServletResponse(_httpServletResponse);
 		formRecordResource.setContextUser(_user);
 	}
 
@@ -327,6 +403,9 @@ public class Query {
 
 		formStructureResource.setContextAcceptLanguage(_acceptLanguage);
 		formStructureResource.setContextCompany(_company);
+		formStructureResource.setContextHttpServletRequest(_httpServletRequest);
+		formStructureResource.setContextHttpServletResponse(
+			_httpServletResponse);
 		formStructureResource.setContextUser(_user);
 	}
 
@@ -343,6 +422,8 @@ public class Query {
 	private BiFunction<Object, String, Filter> _filterBiFunction;
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private Company _company;
+	private HttpServletRequest _httpServletRequest;
+	private HttpServletResponse _httpServletResponse;
 	private User _user;
 
 }

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
@@ -91,6 +91,22 @@ public abstract class BaseFormDocumentResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
@@ -148,6 +148,22 @@ public abstract class BaseFormRecordResourceImpl implements FormRecordResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
@@ -131,6 +131,22 @@ public abstract class BaseFormResourceImpl implements FormResource {
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
@@ -100,6 +100,22 @@ public abstract class BaseFormStructureResourceImpl
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/annotation/GraphQLTypeExtension.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/annotation/GraphQLTypeExtension.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.graphql.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Javier Gamarra
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface GraphQLTypeExtension {
+
+	public Class<?> value();
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/annotation/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/annotation/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -136,6 +136,7 @@ import java.util.stream.Stream;
 import javax.servlet.Servlet;
 import javax.servlet.ServletConfig;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import javax.validation.ValidationException;
 import javax.validation.constraints.NotNull;
@@ -560,6 +561,19 @@ public class GraphQLServletExtender {
 					instance,
 					_companyLocalService.getCompany(
 						CompanyThreadLocal.getCompanyId()));
+			}
+			else if (fieldClass.isAssignableFrom(HttpServletRequest.class)) {
+				field.setAccessible(true);
+
+				field.set(instance, httpServletRequest);
+			}
+			else if (fieldClass.isAssignableFrom(HttpServletResponse.class)) {
+				field.setAccessible(true);
+
+				Optional<HttpServletResponse> httpServletResponseOptional =
+					graphQLContext.getHttpServletResponse();
+
+				field.set(instance, httpServletResponseOptional.orElse(null));
 			}
 			else if (fieldClass.isAssignableFrom(User.class)) {
 				field.setAccessible(true);

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -33,6 +33,8 @@ import com.liferay.portal.vulcan.yaml.openapi.Parameter;
 import com.liferay.portal.vulcan.yaml.openapi.RequestBody;
 import com.liferay.portal.vulcan.yaml.openapi.Schema;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -154,6 +156,74 @@ public class FreeMarkerTool {
 
 		return GraphQLOpenAPIParser.getParameters(
 			javaMethodParameters, operation, annotation);
+	}
+
+	public List<JavaMethodSignature> getGraphQLRelationJavaMethodSignatures(
+		ConfigYAML configYAML, final String graphQLType,
+		OpenAPIYAML openAPIYAML) {
+
+		List<JavaMethodSignature> javaMethodSignatures =
+			getGraphQLJavaMethodSignatures(
+				configYAML, graphQLType, openAPIYAML);
+
+		Map<String, JavaMethodSignature> javaMethodSignatureMap =
+			new HashMap<>();
+
+		for (JavaMethodSignature javaMethodSignature : javaMethodSignatures) {
+			List<JavaMethodParameter> javaMethodParameters =
+				javaMethodSignature.getJavaMethodParameters();
+
+			if (!javaMethodParameters.isEmpty()) {
+				JavaMethodParameter javaMethodParameter =
+					javaMethodParameters.get(0);
+
+				String parameterName = javaMethodParameter.getParameterName();
+
+				String methodName = javaMethodSignature.getMethodName();
+
+				for (JavaMethodSignature relationJavaMethodSignature :
+						javaMethodSignatures) {
+
+					if ((javaMethodSignature != relationJavaMethodSignature) &&
+						_isGraphQLPathRelation(
+							relationJavaMethodSignature, parameterName)) {
+
+						javaMethodSignatureMap.put(
+							methodName,
+							_getJavaMethodSignature(
+								javaMethodSignature,
+								relationJavaMethodSignature.getSchemaName()));
+					}
+				}
+
+				Components components = openAPIYAML.getComponents();
+
+				Map<String, Schema> schemas = components.getSchemas();
+
+				for (Map.Entry<String, Schema> entry : schemas.entrySet()) {
+					Schema schema = entry.getValue();
+
+					Map<String, Schema> propertySchemas =
+						schema.getPropertySchemas();
+
+					if (propertySchemas != null) {
+						for (String propertyName : propertySchemas.keySet()) {
+							if (_isGraphQLPropertyRelation(
+									javaMethodSignature, parameterName,
+									propertyName)) {
+
+								javaMethodSignatureMap.put(
+									methodName,
+									_getJavaMethodSignature(
+										javaMethodSignature, entry.getKey()));
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return new ArrayList<>(javaMethodSignatureMap.values());
 	}
 
 	public Set<String> getGraphQLSchemaNames(
@@ -402,6 +472,71 @@ public class FreeMarkerTool {
 	}
 
 	private FreeMarkerTool() {
+	}
+
+	private JavaMethodSignature _getJavaMethodSignature(
+		JavaMethodSignature javaMethodSignature, String parentSchemaName) {
+
+		List<JavaMethodParameter> javaMethodParameters =
+			javaMethodSignature.getJavaMethodParameters();
+
+		return new JavaMethodSignature(
+			javaMethodSignature.getPath(), javaMethodSignature.getPathItem(),
+			javaMethodSignature.getOperation(),
+			javaMethodSignature.getRequestBodyMediaTypes(),
+			javaMethodSignature.getSchemaName(),
+			javaMethodParameters.subList(1, javaMethodParameters.size()),
+			javaMethodSignature.getMethodName(),
+			javaMethodSignature.getReturnType(), parentSchemaName);
+	}
+
+	private boolean _isGraphQLPathRelation(
+		JavaMethodSignature javaMethodSignature, String parameterName) {
+
+		List<JavaMethodParameter> javaMethodParameters =
+			javaMethodSignature.getJavaMethodParameters();
+
+		if (javaMethodParameters.size() != 1) {
+			return false;
+		}
+
+		JavaMethodParameter javaMethodParameter = javaMethodParameters.get(0);
+
+		String returnType = javaMethodSignature.getReturnType();
+
+		String schemaName = javaMethodSignature.getSchemaName();
+
+		String relationParameterName = javaMethodParameter.getParameterName();
+
+		String property = StringUtil.upperCaseFirstLetter(
+			relationParameterName);
+
+		if ((returnType.endsWith(schemaName) &&
+			 parameterName.equals(relationParameterName)) ||
+			parameterName.equals("parent" + property)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isGraphQLPropertyRelation(
+		JavaMethodSignature javaMethodSignature, String parameterName,
+		String propertyName) {
+
+		String returnType = StringUtil.toLowerCase(
+			javaMethodSignature.getReturnType());
+
+		String schemaName = parameterName.replace("Id", "");
+
+		if (propertyName.equals(parameterName) &&
+			returnType.endsWith(StringUtil.toLowerCase(schemaName))) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static FreeMarkerTool _instance = new FreeMarkerTool();

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/JavaMethodSignature.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/JavaMethodSignature.java
@@ -33,6 +33,17 @@ public class JavaMethodSignature {
 		List<JavaMethodParameter> javaMethodParameters, String methodName,
 		String returnType) {
 
+		this(
+			path, pathItem, operation, requestBodyMediaTypes, schemaName,
+			javaMethodParameters, methodName, returnType, null);
+	}
+
+	public JavaMethodSignature(
+		String path, PathItem pathItem, Operation operation,
+		Set<String> requestBodyMediaTypes, String schemaName,
+		List<JavaMethodParameter> javaMethodParameters, String methodName,
+		String returnType, String parentSchemaName) {
+
 		_path = path;
 		_pathItem = pathItem;
 		_operation = operation;
@@ -51,6 +62,8 @@ public class JavaMethodSignature {
 				_pathJavaMethodParameters.add(javaMethodParameter);
 			}
 		}
+
+		_parentSchemaName = parentSchemaName;
 	}
 
 	public List<JavaMethodParameter> getJavaMethodParameters() {
@@ -63,6 +76,10 @@ public class JavaMethodSignature {
 
 	public Operation getOperation() {
 		return _operation;
+	}
+
+	public String getParentSchemaName() {
+		return _parentSchemaName;
 	}
 
 	public String getPath() {
@@ -92,6 +109,7 @@ public class JavaMethodSignature {
 	private final List<JavaMethodParameter> _javaMethodParameters;
 	private final String _methodName;
 	private final Operation _operation;
+	private final String _parentSchemaName;
 	private final String _path;
 	private final PathItem _pathItem;
 	private List<JavaMethodParameter> _pathJavaMethodParameters =

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -109,6 +109,20 @@ public abstract class Base${schemaName}ResourceImpl implements ${schemaName}Reso
 		this.contextCompany = contextCompany;
 	}
 
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
 	public void setContextUser(User contextUser) {
 		this.contextUser = contextUser;
 	}

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/resource.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/resource.ftl
@@ -21,7 +21,11 @@ import java.util.Date;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -45,6 +49,17 @@ public interface ${schemaName}Resource {
 	}
 
 	public void setContextCompany(Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
 
 	public void setContextUser(User contextUser);
 


### PR DESCRIPTION
This allows us to do 1 to n relations like (all the comments of a blog):
```
getBlogPosting(blogPostingId: 37206){
    getBlogPostingCommentsPage {
      items {
        text
      }
    }
  }
```

Also 1 to 1 relations based on a path (rating of a blog):
```
getBlogPosting(blogPostingId: 37206){
    getBlogPostingMyRating {
      bestRating
    }
  }
```

And we also check for columns named like an entity (like messageBoardThreadId or contentStructureId) and do n to 1 to relations based on a property (Structure of a StructuredContent):
```
query{
  getStructuredContent(structuredContentId: 37275){
    getContentStructure {
      name
    }
  }
}
```

Next PR will rename the relations and properties do a GraphQL convention (getContentStructure -> contentStructure or getBlogPosting -> blogPosting) for Query class (Mutations are Ok right now).