### PR TITLE
LRQA-50293 Do not include redundant test report from node_modules (master)

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6512,6 +6512,7 @@ go</echo>
 					erroronmissingdir="false"
 				>
 					<include name="**/TEST-*.xml" />
+					<exclude name="**/node_modules/**/TEST-*.xml" />
 				</fileset>
 				<fileset
 					dir="portal-impl/test-results"


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-50293

### Related
* 7.0.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/25487
* 7.1.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/25488
* 7.2.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/25489