### PR TITLE
LPS-98520 No need to order. Reasons: 1) We are saving the result into…

### DIFF
--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
@@ -332,8 +332,7 @@ public class ConfigurationPersistenceManager
 		try (Connection connection = _dataSource.getConnection();
 			PreparedStatement preparedStatement = connection.prepareStatement(
 				_db.buildSQL(
-					"select configurationId, dictionary from Configuration_ " +
-						"ORDER BY configurationId ASC"),
+					"select configurationId, dictionary from Configuration_"),
 				ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 


### PR DESCRIPTION
… a map which does not care about the order 2) the _verifyDictionary() won't be affected by order cause pid as the primary key of the table will be unique.