### PR TITLE
LPS-98343 Support for ContentSets

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ContentSetElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ContentSetElementResourceImpl.java
@@ -24,7 +24,6 @@ import com.liferay.headless.delivery.dto.v1_0.converter.DefaultDTOConverterConte
 import com.liferay.headless.delivery.internal.dto.v1_0.converter.DTOConverterRegistry;
 import com.liferay.headless.delivery.resource.v1_0.ContentSetElementResource;
 import com.liferay.portal.kernel.util.CamelCaseUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.segments.provider.SegmentsEntryProviderRegistry;
@@ -32,12 +31,9 @@ import com.liferay.segments.provider.SegmentsEntryProviderRegistry;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 
-import java.util.List;
-import java.util.Map;
+import java.util.Enumeration;
 
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MultivaluedMap;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -90,17 +86,13 @@ public class ContentSetElementResourceImpl
 		com.liferay.segments.context.Context context =
 			new com.liferay.segments.context.Context();
 
-		MultivaluedMap<String, String> multivaluedMap =
-			_httpHeaders.getRequestHeaders();
+		Enumeration<String> headerNames =
+			contextHttpServletRequest.getHeaderNames();
 
-		for (Map.Entry<String, List<String>> entry :
-				multivaluedMap.entrySet()) {
+		while (headerNames.hasMoreElements()) {
+			String key = headerNames.nextElement();
 
-			String key = StringUtil.toLowerCase(entry.getKey());
-
-			List<String> values = entry.getValue();
-
-			String value = values.get(0);
+			String value = contextHttpServletRequest.getHeader(key);
 
 			if (key.equals("accept-language")) {
 				context.put(
@@ -192,9 +184,6 @@ public class ContentSetElementResourceImpl
 
 	@Reference
 	private AssetListEntryService _assetListEntryService;
-
-	@Context
-	private HttpHeaders _httpHeaders;
 
 	@Reference
 	private SegmentsEntryProviderRegistry _segmentsEntryProviderRegistry;


### PR DESCRIPTION
This PR fixes the ContentSet API without heavily modifying the existing REST code... right now the API returns _Object_ (but in reality it returns BlogPosting, StructuredContent but get converted by jackson into JSON/XML). 

To model that in GraphQL we need to use GraphQL interfaces and fragments. This PR adds a GraphQLNode interface (name can change, node is the common name but it's being used in workflow) to all the models that have a getId() method.

This allow to do queries with fragments, like this:

```
query {
  contentSetContentSetElements(contentSetId: 40194) {
    items {
      content {
        ... on BlogPosting {
          headline
          id
        }
        ... on StructuredContent {
          title
        }
      }
    }
    page
    pageSize
    totalCount
  }
}
```

Also add a an API to query an element by type and id, a common pattern in GraphQL:

```
query {
  graphQLNode(id: 38182, dataType: "BlogPosting") {
    id
    ... on BlogPosting {
      headline
      id
    }
  }
}
```