### PR TITLE
LPS-98556 Not needed

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSubscription.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSubscription.java
@@ -79,9 +79,6 @@ public class UpgradeSubscription extends UpgradeProcess {
 
 		updateSubscriptionClassNames(
 			Folder.class.getName(), DLFolder.class.getName());
-		updateSubscriptionClassNames(
-			"com.liferay.portlet.journal.model.JournalArticle",
-			"com.liferay.portlet.journal.model.JournalFolder");
 
 		updateSubscriptionGroupIds();
 	}


### PR DESCRIPTION
We can remove this logic because:
- In 6.1.x JournalArticleFolder didn't exist.
- In 6.2 they were created but users can't subscribe to Journal Folders.

The previous code was added by https://issues.liferay.com/browse/LPS-51280 incorrectly (that's my guess).

Thanks @NorbertKocsis!

cc/ @ealonso @4lejandrito @robertodiaz