### PR TITLE
LPS-98874 Checks for the field defensively. Rich Text fields are governed by different rules and not subject to be disabled, so there's no need for this generalization

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
@@ -430,25 +430,27 @@ AUI.add(
 					var fieldName = rule.fieldName;
 					var validatorName = rule.validatorName;
 
-					var field = this.formValidator
-						.getField(fieldName)
-						.getDOMNode();
+					var field = this.formValidator.getField(fieldName);
 
-					A.Do.after(
-						'_setFieldAttribute',
-						field,
-						'setAttribute',
-						instance,
-						fieldName
-					);
+					if (field) {
+						var fieldNode = field.getDOMNode();
 
-					A.Do.after(
-						'_removeFieldAttribute',
-						field,
-						'removeAttribute',
-						instance,
-						fieldName
-					);
+						A.Do.after(
+							'_setFieldAttribute',
+							fieldNode,
+							'setAttribute',
+							instance,
+							fieldName
+						);
+
+						A.Do.after(
+							'_removeFieldAttribute',
+							fieldNode,
+							'removeAttribute',
+							instance,
+							fieldName
+						);
+					}
 
 					if ((rule.body || rule.body === 0) && !rule.custom) {
 						value = rule.body;


### PR DESCRIPTION
/cc @antonio-ortega, @john-co