### PR TITLE
LRCI-498 Modify Sync-Dir to create symlinks instead of real copies

### DIFF
--- a/modules/sdk/ant-sync-dir/src/main/java/com/liferay/ant/sync/dir/SyncDirTask.java
+++ b/modules/sdk/ant-sync-dir/src/main/java/com/liferay/ant/sync/dir/SyncDirTask.java
@@ -14,10 +14,7 @@
 
 package com.liferay.ant.sync.dir;
 
-import java.io.Closeable;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 
 import java.nio.file.Files;
@@ -166,43 +163,15 @@ public class SyncDirTask extends Task {
 				return;
 			}
 
-			FileInputStream inputStream = null;
-			FileOutputStream outputStream = null;
-
 			try {
-				inputStream = new FileInputStream(_file);
-				outputStream = new FileOutputStream(_toFile);
-
-				byte[] buffer = new byte[8192];
-
-				int count;
-
-				while ((count = inputStream.read(buffer)) > 0) {
-					outputStream.write(buffer, 0, count);
-				}
+				Files.copy(
+					Paths.get(_file.toURI()), Paths.get(_toFile.toURI()));
 
 				_atomicInteger.incrementAndGet();
 			}
 			catch (IOException ioe) {
 				throw new RuntimeException(
 					"Unable to sync " + _file + " into " + _toFile, ioe);
-			}
-			finally {
-				_close(inputStream);
-				_close(outputStream);
-			}
-		}
-
-		private void _close(Closeable closeable) {
-			if (closeable == null) {
-				return;
-			}
-
-			try {
-				closeable.close();
-			}
-			catch (IOException ioe) {
-				ioe.printStackTrace();
 			}
 		}
 

--- a/modules/sdk/ant-sync-dir/src/main/java/com/liferay/ant/sync/dir/SyncDirTask.java
+++ b/modules/sdk/ant-sync-dir/src/main/java/com/liferay/ant/sync/dir/SyncDirTask.java
@@ -159,20 +159,19 @@ public class SyncDirTask extends Task {
 					throw new RuntimeException(
 						"Unable to sync " + _file + " into " + _toFile, ioe);
 				}
-
-				return;
+			}
+			else {
+				try {
+					Files.copy(
+						Paths.get(_file.toURI()), Paths.get(_toFile.toURI()));
+				}
+				catch (IOException ioe) {
+					throw new RuntimeException(
+						"Unable to sync " + _file + " into " + _toFile, ioe);
+				}
 			}
 
-			try {
-				Files.copy(
-					Paths.get(_file.toURI()), Paths.get(_toFile.toURI()));
-
-				_atomicInteger.incrementAndGet();
-			}
-			catch (IOException ioe) {
-				throw new RuntimeException(
-					"Unable to sync " + _file + " into " + _toFile, ioe);
-			}
+			_atomicInteger.incrementAndGet();
 		}
 
 		private final AtomicInteger _atomicInteger;

--- a/modules/sdk/ant-sync-dir/src/main/java/com/liferay/ant/sync/dir/SyncDirTask.java
+++ b/modules/sdk/ant-sync-dir/src/main/java/com/liferay/ant/sync/dir/SyncDirTask.java
@@ -156,25 +156,19 @@ public class SyncDirTask extends Task {
 		}
 
 		public void run() {
-			if (_symbolic) {
-				try {
+			try {
+				if (_symbolic) {
 					Files.createSymbolicLink(
 						Paths.get(_toFile.toURI()), Paths.get(_file.toURI()));
 				}
-				catch (IOException ioe) {
-					throw new RuntimeException(
-						"Unable to sync " + _file + " into " + _toFile, ioe);
-				}
-			}
-			else {
-				try {
+				else {
 					Files.copy(
 						Paths.get(_file.toURI()), Paths.get(_toFile.toURI()));
 				}
-				catch (IOException ioe) {
-					throw new RuntimeException(
-						"Unable to sync " + _file + " into " + _toFile, ioe);
-				}
+			}
+			catch (IOException ioe) {
+				throw new RuntimeException(
+					"Unable to sync " + _file + " into " + _toFile, ioe);
 			}
 
 			_atomicInteger.incrementAndGet();

--- a/modules/sdk/ant-sync-dir/src/main/java/com/liferay/ant/sync/dir/SyncDirTask.java
+++ b/modules/sdk/ant-sync-dir/src/main/java/com/liferay/ant/sync/dir/SyncDirTask.java
@@ -59,6 +59,10 @@ public class SyncDirTask extends Task {
 		_symbolic = symbolic;
 	}
 
+	public void setThreadCount(Integer threadCount) {
+		_threadCount = threadCount;
+	}
+
 	public void setToDir(File toDir) {
 		_toDir = toDir;
 	}
@@ -114,7 +118,8 @@ public class SyncDirTask extends Task {
 		List<SyncFileRunnable> syncFileRunnables = _buildSyncFileRunnables(
 			_dir, _toDir, new ArrayList<SyncFileRunnable>(), atomicInteger);
 
-		ExecutorService executorService = Executors.newFixedThreadPool(10);
+		ExecutorService executorService = Executors.newFixedThreadPool(
+			_threadCount);
 
 		for (SyncFileRunnable syncFileRunnable : syncFileRunnables) {
 			executorService.execute(syncFileRunnable);
@@ -135,6 +140,7 @@ public class SyncDirTask extends Task {
 
 	private File _dir;
 	private boolean _symbolic = true;
+	private int _threadCount = 10;
 	private File _toDir;
 
 	private static class SyncFileRunnable implements Runnable {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-498

@brianchandotcom I've removed references to the AtomicInteger object. It was just a somewhat clunky way of counting how many files were synchronized while maintaining thread safety.

### Original implementation:
```
 [sync-dir] Synchronizing /opt/dev/projects/github/liferay-binaries-cache-2017/.gradle/caches/modules-2/files-2.1 into /opt/dev/projects/github/liferay-portal/.gradle/caches/modules-2/files-2.1
 [sync-dir] 10179 files synchronized in 90166ms
```
### Using symlinks: 
```
 [sync-dir] Synchronizing /opt/dev/projects/github/liferay-binaries-cache-2017/.gradle/caches/modules-2/files-2.1 into /opt/dev/projects/github/liferay-portal/.gradle/caches/modules-2/files-2.1
 [sync-dir] 10179 files synchronized in 1621ms
```

This build used the symlink version of sync-dir and built the portal bundle successfully and is running downstream builds.
http://test-5-1/job/test-portal-acceptance-pullrequest(master)/2159/console 

*Please publish after merging*