### PR TITLE
LPS-98651 Ensure that the userId is valid

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -117,7 +117,8 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 			getGroupId(), JournalConstants.SERVICE_NAME, serviceContext);
 
 		Folder folder = PortletFileRepositoryUtil.addPortletFolder(
-			getUserId(), repository.getRepositoryId(),
+			PortalUtil.getValidUserId(getCompanyId(), getUserId()),
+			repository.getRepositoryId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			String.valueOf(getResourcePrimKey()), serviceContext);
 


### PR DESCRIPTION
Basically the same logic as in [KBArticleImpl.getAttachmentsFolderId()](https://github.com/liferay/liferay-portal/blob/4072a7e5766d6a5258832d16da9a8811c8f50edd/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBArticleImpl.java#L84) 