### PR TITLE
LPS-98468 Baseline

### DIFF
--- a/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/field/type/BaseFieldType.java
+++ b/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/field/type/BaseFieldType.java
@@ -22,8 +22,8 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageConstants;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -158,6 +158,7 @@ public abstract class BaseFieldType implements FieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
@@ -182,6 +183,11 @@ public abstract class BaseFieldType implements FieldType {
 			"localizable", spiDataDefinitionField.getLocalizable()
 		).put(
 			"name", name
+		).put(
+			"nestedFields",
+			_toJSONArray(
+				fieldTypeTracker,
+				spiDataDefinitionField.getNestedSPIDataDefinitionFields())
 		).put(
 			"repeatable", spiDataDefinitionField.getRepeatable()
 		).put(
@@ -223,6 +229,32 @@ public abstract class BaseFieldType implements FieldType {
 
 		spiDataDefinitionField.setNestedSPIDataDefinitionFields(
 			spiDataDefinitionFields.toArray(new SPIDataDefinitionField[0]));
+	}
+
+	private JSONArray _toJSONArray(
+			FieldTypeTracker fieldTypeTracker,
+			SPIDataDefinitionField[] spiDataDefinitionFields)
+		throws Exception {
+
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+		if (ArrayUtil.isEmpty(spiDataDefinitionFields)) {
+			return jsonArray;
+		}
+
+		for (SPIDataDefinitionField spiDataDefinitionField :
+				spiDataDefinitionFields) {
+
+			FieldType fieldType = fieldTypeTracker.getFieldType(
+				spiDataDefinitionField.getFieldType());
+
+			JSONObject jsonObject = fieldType.toJSONObject(
+				fieldTypeTracker, spiDataDefinitionField);
+
+			jsonArray.put(jsonObject);
+		}
+
+		return jsonArray;
 	}
 
 }

--- a/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/field/type/BaseFieldType.java
+++ b/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/field/type/BaseFieldType.java
@@ -16,16 +16,21 @@ package com.liferay.data.engine.field.type;
 
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.spi.dto.SPIDataDefinitionField;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageConstants;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -38,7 +43,8 @@ import javax.servlet.http.HttpServletResponse;
 public abstract class BaseFieldType implements FieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		if (!jsonObject.has("name")) {
@@ -71,6 +77,16 @@ public abstract class BaseFieldType implements FieldType {
 		spiDataDefinitionField.setLocalizable(
 			jsonObject.getBoolean("localizable", false));
 		spiDataDefinitionField.setName(jsonObject.getString("name"));
+
+		if (jsonObject.has("nestedFields")) {
+			_deserializeNestedFields(
+				fieldTypeTracker,
+				(JSONArray)GetterUtil.getObject(
+					jsonObject.getJSONArray("nestedFields"),
+					JSONFactoryUtil.createJSONArray()),
+				spiDataDefinitionField);
+		}
+
 		spiDataDefinitionField.setRepeatable(
 			jsonObject.getBoolean("repeatable", false));
 		spiDataDefinitionField.setTip(
@@ -184,5 +200,29 @@ public abstract class BaseFieldType implements FieldType {
 		Map<String, Object> context, HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse,
 		SPIDataDefinitionField spiDataDefinitionField);
+
+	private void _deserializeNestedFields(
+			FieldTypeTracker fieldTypeTracker, JSONArray jsonArray,
+			SPIDataDefinitionField spiDataDefinitionField)
+		throws Exception {
+
+		List<SPIDataDefinitionField> spiDataDefinitionFields =
+			new ArrayList<>();
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+			if (jsonObject.has("type")) {
+				FieldType fieldType = fieldTypeTracker.getFieldType(
+					jsonObject.getString("type"));
+
+				spiDataDefinitionFields.add(
+					fieldType.deserialize(fieldTypeTracker, jsonObject));
+			}
+		}
+
+		spiDataDefinitionField.setNestedSPIDataDefinitionFields(
+			spiDataDefinitionFields.toArray(new SPIDataDefinitionField[0]));
+	}
 
 }

--- a/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/field/type/BaseFieldType.java
+++ b/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/field/type/BaseFieldType.java
@@ -104,6 +104,9 @@ public abstract class BaseFieldType implements FieldType {
 		context.put("localizable", spiDataDefinitionField.getLocalizable());
 		context.put("name", spiDataDefinitionField.getName());
 		context.put(
+			"nestedFields",
+			spiDataDefinitionField.getNestedSPIDataDefinitionFields());
+		context.put(
 			"readOnly",
 			MapUtil.getBoolean(
 				spiDataDefinitionField.getCustomProperties(), "readOnly",

--- a/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/field/type/FieldType.java
+++ b/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/field/type/FieldType.java
@@ -39,6 +39,7 @@ public interface FieldType {
 		SPIDataDefinitionField spiDataDefinitionField);
 
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception;
 

--- a/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/field/type/FieldType.java
+++ b/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/field/type/FieldType.java
@@ -27,7 +27,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 public interface FieldType {
 
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception;
 
 	public String getName();

--- a/modules/apps/data-engine/data-engine-api/src/main/resources/com/liferay/data/engine/field/type/packageinfo
+++ b/modules/apps/data-engine/data-engine-api/src/main/resources/com/liferay/data/engine/field/type/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/dto/v1_0/DataDefinitionField.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/dto/v1_0/DataDefinitionField.java
@@ -267,6 +267,38 @@ public class DataDefinitionField {
 	protected String name;
 
 	@Schema
+	public DataDefinitionField[] getNestedDataDefinitionFields() {
+		return nestedDataDefinitionFields;
+	}
+
+	public void setNestedDataDefinitionFields(
+		DataDefinitionField[] nestedDataDefinitionFields) {
+
+		this.nestedDataDefinitionFields = nestedDataDefinitionFields;
+	}
+
+	@JsonIgnore
+	public void setNestedDataDefinitionFields(
+		UnsafeSupplier<DataDefinitionField[], Exception>
+			nestedDataDefinitionFieldsUnsafeSupplier) {
+
+		try {
+			nestedDataDefinitionFields =
+				nestedDataDefinitionFieldsUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected DataDefinitionField[] nestedDataDefinitionFields;
+
+	@Schema
 	public Boolean getRepeatable() {
 		return repeatable;
 	}
@@ -435,6 +467,26 @@ public class DataDefinitionField {
 			sb.append(_escape(name));
 
 			sb.append("\"");
+		}
+
+		if (nestedDataDefinitionFields != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"nestedDataDefinitionFields\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < nestedDataDefinitionFields.length; i++) {
+				sb.append(String.valueOf(nestedDataDefinitionFields[i]));
+
+				if ((i + 1) < nestedDataDefinitionFields.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		if (repeatable != null) {

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/dto/v1_0/DataDefinitionField.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/dto/v1_0/DataDefinitionField.java
@@ -195,6 +195,31 @@ public class DataDefinitionField {
 
 	protected String name;
 
+	public DataDefinitionField[] getNestedDataDefinitionFields() {
+		return nestedDataDefinitionFields;
+	}
+
+	public void setNestedDataDefinitionFields(
+		DataDefinitionField[] nestedDataDefinitionFields) {
+
+		this.nestedDataDefinitionFields = nestedDataDefinitionFields;
+	}
+
+	public void setNestedDataDefinitionFields(
+		UnsafeSupplier<DataDefinitionField[], Exception>
+			nestedDataDefinitionFieldsUnsafeSupplier) {
+
+		try {
+			nestedDataDefinitionFields =
+				nestedDataDefinitionFieldsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected DataDefinitionField[] nestedDataDefinitionFields;
+
 	public Boolean getRepeatable() {
 		return repeatable;
 	}

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/serdes/v1_0/DataDefinitionFieldSerDes.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/serdes/v1_0/DataDefinitionFieldSerDes.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.annotation.Generated;
 
@@ -143,6 +144,34 @@ public class DataDefinitionFieldSerDes {
 			sb.append("\"");
 		}
 
+		if (dataDefinitionField.getNestedDataDefinitionFields() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"nestedDataDefinitionFields\": ");
+
+			sb.append("[");
+
+			for (int i = 0;
+				 i < dataDefinitionField.getNestedDataDefinitionFields().length;
+				 i++) {
+
+				sb.append(
+					String.valueOf(
+						dataDefinitionField.getNestedDataDefinitionFields()
+							[i]));
+
+				if ((i + 1) < dataDefinitionField.
+						getNestedDataDefinitionFields().length) {
+
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (dataDefinitionField.getRepeatable() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -248,6 +277,16 @@ public class DataDefinitionFieldSerDes {
 		}
 		else {
 			map.put("name", String.valueOf(dataDefinitionField.getName()));
+		}
+
+		if (dataDefinitionField.getNestedDataDefinitionFields() == null) {
+			map.put("nestedDataDefinitionFields", null);
+		}
+		else {
+			map.put(
+				"nestedDataDefinitionFields",
+				String.valueOf(
+					dataDefinitionField.getNestedDataDefinitionFields()));
 		}
 
 		if (dataDefinitionField.getRepeatable() == null) {
@@ -404,6 +443,21 @@ public class DataDefinitionFieldSerDes {
 			else if (Objects.equals(jsonParserFieldName, "name")) {
 				if (jsonParserFieldValue != null) {
 					dataDefinitionField.setName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "nestedDataDefinitionFields")) {
+
+				if (jsonParserFieldValue != null) {
+					dataDefinitionField.setNestedDataDefinitionFields(
+						Stream.of(
+							toStrings((Object[])jsonParserFieldValue)
+						).map(
+							object -> DataDefinitionFieldSerDes.toDTO(
+								(String)object)
+						).toArray(
+							size -> new DataDefinitionField[size]
+						));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "repeatable")) {

--- a/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
+++ b/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
@@ -64,6 +64,11 @@ components:
                     type: boolean
                 name:
                     type: string
+                nestedDataDefinitionFields:
+                    items:
+                        $ref: '#/components/schemas/DataDefinitionField'
+                    type:
+                        array
                 repeatable:
                     type: boolean
                 tip:

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/dto/v1_0/util/DataDefinitionFieldUtil.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/dto/v1_0/util/DataDefinitionFieldUtil.java
@@ -18,6 +18,9 @@ import com.liferay.data.engine.rest.dto.v1_0.DataDefinitionField;
 import com.liferay.data.engine.spi.dto.SPIDataDefinitionField;
 import com.liferay.portal.kernel.util.GetterUtil;
 
+import java.util.Arrays;
+import java.util.stream.Stream;
+
 /**
  * @author Leonardo Barros
  */
@@ -42,11 +45,32 @@ public class DataDefinitionFieldUtil {
 		spiDataDefinitionField.setLocalizable(
 			GetterUtil.getBoolean(dataDefinitionField.getLocalizable()));
 		spiDataDefinitionField.setName(dataDefinitionField.getName());
+		spiDataDefinitionField.setNestedSPIDataDefinitionFields(
+			_toSPIDataDefinitionFields(
+				dataDefinitionField.getNestedDataDefinitionFields()));
 		spiDataDefinitionField.setRepeatable(
 			GetterUtil.getBoolean(dataDefinitionField.getRepeatable()));
 		spiDataDefinitionField.setTip(dataDefinitionField.getTip());
 
 		return spiDataDefinitionField;
+	}
+
+
+	private static SPIDataDefinitionField[] _toSPIDataDefinitionFields(
+		DataDefinitionField[] dataDefinitionFields) {
+
+		if (ArrayUtil.isNotEmpty(dataDefinitionFields)) {
+			Stream<DataDefinitionField> stream = Arrays.stream(
+				dataDefinitionFields);
+
+			return stream.map(
+				DataDefinitionFieldUtil::toSPIDataDefinitionField
+			).toArray(
+				SPIDataDefinitionField[]::new
+			);
+		}
+
+		return new SPIDataDefinitionField[0];
 	}
 
 }

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/dto/v1_0/util/DataDefinitionFieldUtil.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/dto/v1_0/util/DataDefinitionFieldUtil.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.dto.v1_0.util;
 
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinitionField;
 import com.liferay.data.engine.spi.dto.SPIDataDefinitionField;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.Arrays;
@@ -25,6 +26,32 @@ import java.util.stream.Stream;
  * @author Leonardo Barros
  */
 public class DataDefinitionFieldUtil {
+
+	public static DataDefinitionField toDataDefinitionField(
+		SPIDataDefinitionField spiDataDefinitionField) {
+
+		DataDefinitionField dataDefinitionField = new DataDefinitionField();
+
+		dataDefinitionField.setCustomProperties(
+			spiDataDefinitionField.getCustomProperties());
+		dataDefinitionField.setDefaultValue(
+			spiDataDefinitionField.getDefaultValue());
+		dataDefinitionField.setFieldType(spiDataDefinitionField.getFieldType());
+		dataDefinitionField.setId(spiDataDefinitionField.getId());
+		dataDefinitionField.setIndexable(spiDataDefinitionField.getIndexable());
+		dataDefinitionField.setLabel(spiDataDefinitionField.getLabel());
+		dataDefinitionField.setLocalizable(
+			spiDataDefinitionField.getLocalizable());
+		dataDefinitionField.setName(spiDataDefinitionField.getName());
+		dataDefinitionField.setNestedDataDefinitionFields(
+			_toDataDefinitionFields(
+				spiDataDefinitionField.getNestedSPIDataDefinitionFields()));
+		dataDefinitionField.setRepeatable(
+			spiDataDefinitionField.getRepeatable());
+		dataDefinitionField.setTip(spiDataDefinitionField.getTip());
+
+		return dataDefinitionField;
+	}
 
 	public static SPIDataDefinitionField toSPIDataDefinitionField(
 		DataDefinitionField dataDefinitionField) {
@@ -55,6 +82,22 @@ public class DataDefinitionFieldUtil {
 		return spiDataDefinitionField;
 	}
 
+	private static DataDefinitionField[] _toDataDefinitionFields(
+		SPIDataDefinitionField[] spiDataDefinitionFields) {
+
+		if (ArrayUtil.isNotEmpty(spiDataDefinitionFields)) {
+			Stream<SPIDataDefinitionField> stream = Arrays.stream(
+				spiDataDefinitionFields);
+
+			return stream.map(
+				DataDefinitionFieldUtil::toDataDefinitionField
+			).toArray(
+				DataDefinitionField[]::new
+			);
+		}
+
+		return new DataDefinitionField[0];
+	}
 
 	private static SPIDataDefinitionField[] _toSPIDataDefinitionFields(
 		DataDefinitionField[] dataDefinitionFields) {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/dto/v1_0/util/DataDefinitionUtil.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/dto/v1_0/util/DataDefinitionUtil.java
@@ -30,7 +30,8 @@ import com.liferay.portal.kernel.json.JSONUtil;
  */
 public class DataDefinitionUtil {
 
-	public static DataDefinition toDataDefinition(DDMStructure ddmStructure)
+	public static DataDefinition toDataDefinition(
+			DDMStructure ddmStructure, FieldTypeTracker fieldTypeTracker)
 		throws Exception {
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
@@ -40,7 +41,8 @@ public class DataDefinitionUtil {
 			{
 				dataDefinitionFields = JSONUtil.toArray(
 					jsonObject.getJSONArray("fields"),
-					fieldJSONObject -> _toDataDefinitionField(fieldJSONObject),
+					fieldJSONObject -> _toDataDefinitionField(
+						fieldTypeTracker, fieldJSONObject),
 					DataDefinitionField.class);
 				dataDefinitionKey = ddmStructure.getStructureKey();
 				dataDefinitionRules = JSONUtil.toArray(
@@ -80,49 +82,18 @@ public class DataDefinitionUtil {
 	}
 
 	private static DataDefinitionField _toDataDefinitionField(
-			JSONObject jsonObject)
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
-		return new DataDefinitionField() {
-			{
-				if (jsonObject.has("predefinedValue")) {
-					defaultValue = LocalizedValueUtil.toLocalizedValues(
-						jsonObject.getJSONObject("predefinedValue"));
-				}
+		if (jsonObject.has("type")) {
+			FieldType fieldType = fieldTypeTracker.getFieldType(
+				jsonObject.getString("type"));
 
-				if (!jsonObject.has("type")) {
-					throw new Exception("Type is required");
-				}
+			return DataDefinitionFieldUtil.toDataDefinitionField(
+				fieldType.deserialize(fieldTypeTracker, jsonObject));
+		}
 
-				fieldType = jsonObject.getString("type");
-
-				indexable = jsonObject.getBoolean("indexable", true);
-
-				if (!jsonObject.has("label")) {
-					throw new Exception("Label is required");
-				}
-
-				label = LocalizedValueUtil.toLocalizedValues(
-					jsonObject.getJSONObject("label"));
-
-				localizable = jsonObject.getBoolean("localizable", false);
-
-				if (!jsonObject.has("name")) {
-					throw new Exception("Name is required");
-				}
-
-				name = jsonObject.getString("name");
-
-				repeatable = jsonObject.getBoolean("repeatable", false);
-
-				if (!jsonObject.has("tip")) {
-					throw new Exception("Tip is required");
-				}
-
-				tip = LocalizedValueUtil.toLocalizedValues(
-					jsonObject.getJSONObject("tip"));
-			}
-		};
+		return new DataDefinitionField();
 	}
 
 	private static DataDefinitionRule _toDataDefinitionRule(

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/dto/v1_0/util/DataDefinitionUtil.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/dto/v1_0/util/DataDefinitionUtil.java
@@ -14,6 +14,8 @@
 
 package com.liferay.data.engine.rest.internal.dto.v1_0.util;
 
+import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinition;
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinitionField;
@@ -22,7 +24,6 @@ import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.util.Validator;
 
 /**
  * @author Jeyvison Nascimento
@@ -60,14 +61,16 @@ public class DataDefinitionUtil {
 		};
 	}
 
-	public static String toJSON(DataDefinition dataDefinition)
+	public static String toJSON(
+			DataDefinition dataDefinition, FieldTypeTracker fieldTypeTracker)
 		throws Exception {
 
 		return JSONUtil.put(
 			"fields",
 			JSONUtil.toJSONArray(
 				dataDefinition.getDataDefinitionFields(),
-				dataDefinitionField -> _toJSONObject(dataDefinitionField))
+				dataDefinitionField -> _toJSONObject(
+					dataDefinitionField, fieldTypeTracker))
 		).put(
 			"rules",
 			JSONUtil.toJSONArray(
@@ -140,39 +143,17 @@ public class DataDefinitionUtil {
 	}
 
 	private static JSONObject _toJSONObject(
-			DataDefinitionField dataDefinitionField)
+			DataDefinitionField dataDefinitionField,
+			FieldTypeTracker fieldTypeTracker)
 		throws Exception {
 
-		String name = dataDefinitionField.getName();
+		FieldType fieldType = fieldTypeTracker.getFieldType(
+			dataDefinitionField.getFieldType());
 
-		if (Validator.isNull(name)) {
-			throw new Exception("Name is required");
-		}
-
-		String type = dataDefinitionField.getFieldType();
-
-		if ((type == null) || type.isEmpty()) {
-			throw new Exception("Type is required");
-		}
-
-		return JSONUtil.put(
-			"defaultValue", dataDefinitionField.getDefaultValue()
-		).put(
-			"indexable", dataDefinitionField.getIndexable()
-		).put(
-			"label",
-			LocalizedValueUtil.toJSONObject(dataDefinitionField.getLabel())
-		).put(
-			"localizable", dataDefinitionField.getLocalizable()
-		).put(
-			"name", name
-		).put(
-			"repeatable", dataDefinitionField.getRepeatable()
-		).put(
-			"tip", LocalizedValueUtil.toJSONObject(dataDefinitionField.getTip())
-		).put(
-			"type", type
-		);
+		return fieldType.toJSONObject(
+			fieldTypeTracker,
+			DataDefinitionFieldUtil.toSPIDataDefinitionField(
+				dataDefinitionField));
 	}
 
 	private static JSONObject _toJSONObject(

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/CheckboxFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/CheckboxFieldType.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.CustomPropertiesUtil;
 import com.liferay.data.engine.spi.dto.SPIDataDefinitionField;
@@ -50,11 +51,12 @@ import org.osgi.service.component.annotations.Component;
 public class CheckboxFieldType extends BaseFieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
-			jsonObject);
+			fieldTypeTracker, jsonObject);
 
 		Map<String, Object> customProperties =
 			spiDataDefinitionField.getCustomProperties();
@@ -76,10 +78,12 @@ public class CheckboxFieldType extends BaseFieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
-		JSONObject jsonObject = super.toJSONObject(spiDataDefinitionField);
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
 
 		return jsonObject.put(
 			"predefinedValue",

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/CheckboxMultipleFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/CheckboxMultipleFieldType.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.CustomPropertiesUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.DataFieldOptionUtil;
@@ -50,11 +51,12 @@ import org.osgi.service.component.annotations.Component;
 public class CheckboxMultipleFieldType extends BaseFieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
-			jsonObject);
+			fieldTypeTracker, jsonObject);
 
 		Map<String, Object> customProperties =
 			spiDataDefinitionField.getCustomProperties();
@@ -81,10 +83,12 @@ public class CheckboxMultipleFieldType extends BaseFieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
-		JSONObject jsonObject = super.toJSONObject(spiDataDefinitionField);
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
 
 		return jsonObject.put(
 			"inline",

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/DateFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/DateFieldType.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.CustomPropertiesUtil;
 import com.liferay.data.engine.spi.dto.SPIDataDefinitionField;
@@ -49,11 +50,12 @@ import org.osgi.service.component.annotations.Component;
 public class DateFieldType extends BaseFieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
-			jsonObject);
+			fieldTypeTracker, jsonObject);
 
 		spiDataDefinitionField.setDefaultValue(
 			LocalizedValueUtil.toLocalizedValues(
@@ -69,10 +71,12 @@ public class DateFieldType extends BaseFieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
-		JSONObject jsonObject = super.toJSONObject(spiDataDefinitionField);
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
 
 		return jsonObject.put(
 			"predefinedValue",

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/DocumentLibraryFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/DocumentLibraryFieldType.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.CustomPropertiesUtil;
 import com.liferay.data.engine.spi.dto.SPIDataDefinitionField;
 import com.liferay.document.library.kernel.service.DLAppService;
@@ -70,11 +71,12 @@ import org.osgi.service.component.annotations.Reference;
 public class DocumentLibraryFieldType extends BaseFieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
-			jsonObject);
+			fieldTypeTracker, jsonObject);
 
 		Map<String, Object> customProperties =
 			spiDataDefinitionField.getCustomProperties();
@@ -99,10 +101,12 @@ public class DocumentLibraryFieldType extends BaseFieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
-		JSONObject jsonObject = super.toJSONObject(spiDataDefinitionField);
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
 
 		return jsonObject.put(
 			"groupId",

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/EditorFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/EditorFieldType.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.CustomPropertiesUtil;
 import com.liferay.data.engine.spi.dto.SPIDataDefinitionField;
@@ -45,11 +46,12 @@ import org.osgi.service.component.annotations.Component;
 public class EditorFieldType extends BaseFieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
-			jsonObject);
+			fieldTypeTracker, jsonObject);
 
 		Map<String, Object> customProperties =
 			spiDataDefinitionField.getCustomProperties();
@@ -69,10 +71,12 @@ public class EditorFieldType extends BaseFieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
-		JSONObject jsonObject = super.toJSONObject(spiDataDefinitionField);
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
 
 		return jsonObject.put(
 			"placeholder",

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/FieldSetFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/FieldSetFieldType.java
@@ -16,10 +16,11 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.CustomPropertiesUtil;
 import com.liferay.data.engine.spi.dto.SPIDataDefinitionField;
+import com.liferay.portal.kernel.json.JSONObject;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -43,8 +44,41 @@ import org.osgi.service.component.annotations.Component;
 public class FieldSetFieldType extends BaseFieldType {
 
 	@Override
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
+		throws Exception {
+
+		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
+			fieldTypeTracker, jsonObject);
+
+		Map<String, Object> customProperties =
+			spiDataDefinitionField.getCustomProperties();
+
+		customProperties.put(
+			"orientation", jsonObject.getString("orientation", "horizontal"));
+
+		return spiDataDefinitionField;
+	}
+
+	@Override
 	public String getName() {
 		return "fieldset";
+	}
+
+	@Override
+	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
+			SPIDataDefinitionField spiDataDefinitionField)
+		throws Exception {
+
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
+
+		return jsonObject.put(
+			"orientation",
+			CustomPropertiesUtil.getString(
+				spiDataDefinitionField.getCustomProperties(), "orientation",
+				"horizontal"));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/FieldSetFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/FieldSetFieldType.java
@@ -87,18 +87,17 @@ public class FieldSetFieldType extends BaseFieldType {
 		HttpServletResponse httpServletResponse,
 		SPIDataDefinitionField spiDataDefinitionField) {
 
-		List<Object> nestedFieldContexts = CustomPropertiesUtil.getValue(
-			spiDataDefinitionField.getCustomProperties(), "nestedFields");
+		SPIDataDefinitionField[] nestedSPIDataDefinitionFields =
+			spiDataDefinitionField.getNestedSPIDataDefinitionFields();
 
-		if (nestedFieldContexts != null) {
+		if (nestedSPIDataDefinitionFields != null) {
 			context.put(
 				"columnSize",
 				_getColumnSize(
-					nestedFieldContexts.size(),
+					nestedSPIDataDefinitionFields.length,
 					CustomPropertiesUtil.getString(
 						spiDataDefinitionField.getCustomProperties(),
 						"orientation", "horizontal")));
-			context.put("nestedFields", nestedFieldContexts);
 		}
 
 		if (context.containsKey("label")) {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/GridFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/GridFieldType.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.CustomPropertiesUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.DataFieldOptionUtil;
 import com.liferay.data.engine.spi.dto.SPIDataDefinitionField;
@@ -49,11 +50,12 @@ import org.osgi.service.component.annotations.Component;
 public class GridFieldType extends BaseFieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
-			jsonObject);
+			fieldTypeTracker, jsonObject);
 
 		Map<String, Object> customProperties =
 			spiDataDefinitionField.getCustomProperties();
@@ -77,10 +79,12 @@ public class GridFieldType extends BaseFieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
-		JSONObject jsonObject = super.toJSONObject(spiDataDefinitionField);
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
 
 		return jsonObject.put(
 			"columns",

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/KeyValueFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/KeyValueFieldType.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.CustomPropertiesUtil;
 import com.liferay.data.engine.spi.dto.SPIDataDefinitionField;
@@ -46,11 +47,12 @@ import org.osgi.service.component.annotations.Component;
 public class KeyValueFieldType extends BaseFieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
-			jsonObject);
+			fieldTypeTracker, jsonObject);
 
 		Map<String, Object> customProperties =
 			spiDataDefinitionField.getCustomProperties();
@@ -75,10 +77,12 @@ public class KeyValueFieldType extends BaseFieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
-		JSONObject jsonObject = super.toJSONObject(spiDataDefinitionField);
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
 
 		return jsonObject.put(
 			"autoFocus",

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/NumericFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/NumericFieldType.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.CustomPropertiesUtil;
 import com.liferay.data.engine.spi.dto.SPIDataDefinitionField;
@@ -57,11 +58,12 @@ import org.osgi.service.component.annotations.Component;
 public class NumericFieldType extends BaseFieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
-			jsonObject);
+			fieldTypeTracker, jsonObject);
 
 		Map<String, Object> customProperties =
 			spiDataDefinitionField.getCustomProperties();
@@ -90,10 +92,12 @@ public class NumericFieldType extends BaseFieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
-		JSONObject jsonObject = super.toJSONObject(spiDataDefinitionField);
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
 
 		jsonObject.put(
 			"dataType",

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/OptionsFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/OptionsFieldType.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.DataFieldOptionUtil;
 import com.liferay.data.engine.spi.dto.SPIDataDefinitionField;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -43,11 +44,12 @@ import org.osgi.service.component.annotations.Component;
 public class OptionsFieldType extends BaseFieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
-			jsonObject);
+			fieldTypeTracker, jsonObject);
 
 		Map<String, Object> customProperties =
 			spiDataDefinitionField.getCustomProperties();
@@ -66,10 +68,12 @@ public class OptionsFieldType extends BaseFieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
-		JSONObject jsonObject = super.toJSONObject(spiDataDefinitionField);
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
 
 		return jsonObject.put(
 			"allowEmptyOptions",

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/ParagraphFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/ParagraphFieldType.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.CustomPropertiesUtil;
 import com.liferay.data.engine.spi.dto.SPIDataDefinitionField;
@@ -48,11 +49,12 @@ import org.osgi.service.component.annotations.Component;
 public class ParagraphFieldType extends BaseFieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
-			jsonObject);
+			fieldTypeTracker, jsonObject);
 
 		Map<String, Object> customProperties =
 			spiDataDefinitionField.getCustomProperties();
@@ -72,10 +74,12 @@ public class ParagraphFieldType extends BaseFieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
-		JSONObject jsonObject = super.toJSONObject(spiDataDefinitionField);
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
 
 		return jsonObject.put(
 			"text",

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/PasswordFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/PasswordFieldType.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.CustomPropertiesUtil;
 import com.liferay.data.engine.spi.dto.SPIDataDefinitionField;
@@ -46,11 +47,12 @@ import org.osgi.service.component.annotations.Component;
 public class PasswordFieldType extends BaseFieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
-			jsonObject);
+			fieldTypeTracker, jsonObject);
 
 		Map<String, Object> customProperties =
 			spiDataDefinitionField.getCustomProperties();
@@ -74,10 +76,12 @@ public class PasswordFieldType extends BaseFieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
-		JSONObject jsonObject = super.toJSONObject(spiDataDefinitionField);
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
 
 		return jsonObject.put(
 			"placeholder",

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/RadioFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/RadioFieldType.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.CustomPropertiesUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.DataFieldOptionUtil;
@@ -54,11 +55,12 @@ import org.osgi.service.component.annotations.Component;
 public class RadioFieldType extends BaseFieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
-			jsonObject);
+			fieldTypeTracker, jsonObject);
 
 		Map<String, Object> customProperties =
 			spiDataDefinitionField.getCustomProperties();
@@ -83,10 +85,12 @@ public class RadioFieldType extends BaseFieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
-		JSONObject jsonObject = super.toJSONObject(spiDataDefinitionField);
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
 
 		return jsonObject.put(
 			"inline",

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/SelectFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/SelectFieldType.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.CustomPropertiesUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.DataFieldOptionUtil;
@@ -51,11 +52,12 @@ import org.osgi.service.component.annotations.Component;
 public class SelectFieldType extends BaseFieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
-			jsonObject);
+			fieldTypeTracker, jsonObject);
 
 		Map<String, Object> customProperties =
 			spiDataDefinitionField.getCustomProperties();
@@ -82,10 +84,12 @@ public class SelectFieldType extends BaseFieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
-		JSONObject jsonObject = super.toJSONObject(spiDataDefinitionField);
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
 
 		return jsonObject.put(
 			"dataSourceType",

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/TextFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/TextFieldType.java
@@ -16,6 +16,7 @@ package com.liferay.data.engine.rest.internal.field.type.v1_0;
 
 import com.liferay.data.engine.field.type.BaseFieldType;
 import com.liferay.data.engine.field.type.FieldType;
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.CustomPropertiesUtil;
 import com.liferay.data.engine.rest.internal.field.type.v1_0.util.DataFieldOptionUtil;
@@ -49,11 +50,12 @@ import org.osgi.service.component.annotations.Component;
 public class TextFieldType extends BaseFieldType {
 
 	@Override
-	public SPIDataDefinitionField deserialize(JSONObject jsonObject)
+	public SPIDataDefinitionField deserialize(
+			FieldTypeTracker fieldTypeTracker, JSONObject jsonObject)
 		throws Exception {
 
 		SPIDataDefinitionField spiDataDefinitionField = super.deserialize(
-			jsonObject);
+			fieldTypeTracker, jsonObject);
 
 		Map<String, Object> customProperties =
 			spiDataDefinitionField.getCustomProperties();
@@ -90,10 +92,12 @@ public class TextFieldType extends BaseFieldType {
 
 	@Override
 	public JSONObject toJSONObject(
+			FieldTypeTracker fieldTypeTracker,
 			SPIDataDefinitionField spiDataDefinitionField)
 		throws Exception {
 
-		JSONObject jsonObject = super.toJSONObject(spiDataDefinitionField);
+		JSONObject jsonObject = super.toJSONObject(
+			fieldTypeTracker, spiDataDefinitionField);
 
 		return jsonObject.put(
 			"autocompleteEnabled",

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/renderer/v1_0/DataLayoutRendererImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/renderer/v1_0/DataLayoutRendererImpl.java
@@ -84,7 +84,7 @@ public class DataLayoutRendererImpl implements DataLayoutRenderer {
 
 		return _render(
 			DataDefinitionUtil.toDataDefinition(
-				ddmStructureVersion.getStructure()),
+				ddmStructureVersion.getStructure(), _fieldTypeTracker),
 			DataLayoutUtil.toDataLayout(ddmStructureLayout.getDefinition()),
 			dataLayoutRendererContext);
 	}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/DataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/DataDefinitionResourceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.data.engine.rest.internal.resource.v1_0;
 
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinition;
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinitionPermission;
@@ -106,7 +107,8 @@ public class DataDefinitionResourceImpl
 			ActionKeys.VIEW);
 
 		return DataDefinitionUtil.toDataDefinition(
-			_ddmStructureLocalService.getStructure(dataDefinitionId));
+			_ddmStructureLocalService.getStructure(dataDefinitionId),
+			_fieldTypeTracker);
 	}
 
 	@Override
@@ -123,7 +125,8 @@ public class DataDefinitionResourceImpl
 
 		return DataDefinitionUtil.toDataDefinition(
 			_ddmStructureLocalService.getStructure(
-				siteId, _getClassNameId(), dataDefinitionKey));
+				siteId, _getClassNameId(), dataDefinitionKey),
+			_fieldTypeTracker);
 	}
 
 	@Override
@@ -163,7 +166,8 @@ public class DataDefinitionResourceImpl
 			},
 			document -> DataDefinitionUtil.toDataDefinition(
 				_ddmStructureLocalService.getStructure(
-					GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)))),
+					GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK))),
+				_fieldTypeTracker),
 			sorts);
 	}
 
@@ -222,8 +226,9 @@ public class DataDefinitionResourceImpl
 				LocalizedValueUtil.toLocaleStringMap(dataDefinition.getName()),
 				LocalizedValueUtil.toLocaleStringMap(
 					dataDefinition.getDescription()),
-				DataDefinitionUtil.toJSON(dataDefinition),
-				dataDefinition.getStorageType(), serviceContext));
+				DataDefinitionUtil.toJSON(dataDefinition, _fieldTypeTracker),
+				dataDefinition.getStorageType(), serviceContext),
+			_fieldTypeTracker);
 
 		_resourceLocalService.addModelResources(
 			contextCompany.getCompanyId(), siteId,
@@ -299,8 +304,9 @@ public class DataDefinitionResourceImpl
 				LocalizedValueUtil.toLocaleStringMap(dataDefinition.getName()),
 				LocalizedValueUtil.toLocaleStringMap(
 					dataDefinition.getDescription()),
-				DataDefinitionUtil.toJSON(dataDefinition),
-				new ServiceContext()));
+				DataDefinitionUtil.toJSON(dataDefinition, _fieldTypeTracker),
+				new ServiceContext()),
+			_fieldTypeTracker);
 	}
 
 	@Reference(
@@ -335,6 +341,9 @@ public class DataDefinitionResourceImpl
 
 	@Reference
 	private DDMStructureVersionLocalService _ddmStructureVersionLocalService;
+
+	@Reference
+	private FieldTypeTracker _fieldTypeTracker;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/DataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v1_0/DataRecordResourceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.data.engine.rest.internal.resource.v1_0;
 
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinition;
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinitionField;
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinitionRule;
@@ -132,7 +133,7 @@ public class DataRecordResourceImpl extends BaseDataRecordResourceImpl {
 			dataRecordCollectionId, DataActionKeys.EXPORT_DATA_RECORDS);
 
 		DataRecordExporter dataRecordExporter = new DataRecordExporter(
-			_ddlRecordSetLocalService);
+			_ddlRecordSetLocalService, _fieldTypeTracker);
 
 		return dataRecordExporter.export(
 			transform(
@@ -195,7 +196,9 @@ public class DataRecordResourceImpl extends BaseDataRecordResourceImpl {
 		DDMStructure ddmStructure = ddlRecordSet.getDDMStructure();
 
 		_validate(
-			DataDefinitionUtil.toDataDefinition(ddmStructure), dataRecord);
+			DataDefinitionUtil.toDataDefinition(
+				ddmStructure, _fieldTypeTracker),
+			dataRecord);
 
 		DataStorage dataStorage = _getDataStorage(
 			ddmStructure.getStorageType());
@@ -229,7 +232,9 @@ public class DataRecordResourceImpl extends BaseDataRecordResourceImpl {
 		DDMStructure ddmStructure = ddlRecordSet.getDDMStructure();
 
 		_validate(
-			DataDefinitionUtil.toDataDefinition(ddmStructure), dataRecord);
+			DataDefinitionUtil.toDataDefinition(
+				ddmStructure, _fieldTypeTracker),
+			dataRecord);
 
 		DataStorage dataStorage = _getDataStorage(
 			ddmStructure.getStorageType());
@@ -426,6 +431,9 @@ public class DataRecordResourceImpl extends BaseDataRecordResourceImpl {
 
 	@Reference
 	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Reference
+	private FieldTypeTracker _fieldTypeTracker;
 
 	private ModelResourcePermission<InternalDataRecordCollection>
 		_modelResourcePermission;

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/storage/DataRecordExporter.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/storage/DataRecordExporter.java
@@ -14,6 +14,7 @@
 
 package com.liferay.data.engine.rest.internal.storage;
 
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.rest.dto.v1_0.DataDefinition;
 import com.liferay.data.engine.rest.dto.v1_0.DataRecord;
 import com.liferay.data.engine.rest.internal.dto.v1_0.util.DataDefinitionUtil;
@@ -34,9 +35,11 @@ import java.util.stream.Stream;
 public class DataRecordExporter {
 
 	public DataRecordExporter(
-		DDLRecordSetLocalService ddlRecordSetLocalService) {
+		DDLRecordSetLocalService ddlRecordSetLocalService,
+		FieldTypeTracker fieldTypeTracker) {
 
 		_ddlRecordSetLocalService = ddlRecordSetLocalService;
+		_fieldTypeTracker = fieldTypeTracker;
 	}
 
 	public String export(List<DataRecord> dataRecords) throws Exception {
@@ -50,7 +53,7 @@ public class DataRecordExporter {
 			dataRecord.getDataRecordCollectionId());
 
 		DataDefinition dataDefinition = DataDefinitionUtil.toDataDefinition(
-			ddlRecordSet.getDDMStructure());
+			ddlRecordSet.getDDMStructure(), _fieldTypeTracker);
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
@@ -78,5 +81,6 @@ public class DataRecordExporter {
 	}
 
 	private final DDLRecordSetLocalService _ddlRecordSetLocalService;
+	private final FieldTypeTracker _fieldTypeTracker;
 
 }

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/storage/JSONDataStorage.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/storage/JSONDataStorage.java
@@ -14,6 +14,7 @@
 
 package com.liferay.data.engine.rest.internal.storage;
 
+import com.liferay.data.engine.field.type.FieldTypeTracker;
 import com.liferay.data.engine.rest.dto.v1_0.DataRecord;
 import com.liferay.data.engine.rest.dto.v1_0.DataRecordCollection;
 import com.liferay.data.engine.rest.internal.dto.v1_0.util.DataDefinitionUtil;
@@ -62,7 +63,8 @@ public class JSONDataStorage implements DataStorage {
 
 		return DataRecordValuesUtil.toDataRecordValues(
 			DataDefinitionUtil.toDataDefinition(
-				_ddmStructureLocalService.getStructure(dataDefinitionId)),
+				_ddmStructureLocalService.getStructure(dataDefinitionId),
+				_fieldTypeTracker),
 			ddmContent.getData());
 	}
 
@@ -82,7 +84,8 @@ public class JSONDataStorage implements DataStorage {
 			DataRecordValuesUtil.toJSON(
 				DataDefinitionUtil.toDataDefinition(
 					_ddmStructureLocalService.getStructure(
-						dataRecordCollection.getDataDefinitionId())),
+						dataRecordCollection.getDataDefinitionId()),
+					_fieldTypeTracker),
 				dataRecordValues),
 			new ServiceContext() {
 				{
@@ -102,5 +105,8 @@ public class JSONDataStorage implements DataStorage {
 
 	@Reference
 	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Reference
+	private FieldTypeTracker _fieldTypeTracker;
 
 }

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/DataDefinitionResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/DataDefinitionResourceTest.java
@@ -161,7 +161,7 @@ public class DataDefinitionResourceTest
 									put("en_US", RandomTestUtil.randomString());
 								}
 							};
-							fieldType = "fieldType";
+							fieldType = "text";
 							label = new HashMap<String, Object>() {
 								{
 									put("label", RandomTestUtil.randomString());

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/resources/com/liferay/data/engine/rest/resource/v1_0/test/util/dependencies/test-structured-content-structure.json
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/resources/com/liferay/data/engine/rest/resource/v1_0/test/util/dependencies/test-structured-content-structure.json
@@ -12,6 +12,21 @@
 			},
 			"localizable": true,
 			"name": "MyText",
+			"options": {
+				"en_US": [
+					{
+						"label": "option1",
+						"value": "option1"
+					},
+					{
+						"label": "option2",
+						"value": "option2"
+					}
+				]
+			},
+			"placeholder": {
+				"en_US": ""
+			},
 			"predefinedValue": {
 				"en_US": ""
 			},
@@ -20,6 +35,9 @@
 			"required": false,
 			"showLabel": true,
 			"tip": {
+				"en_US": ""
+			},
+			"tooltip": {
 				"en_US": ""
 			},
 			"type": "text"

--- a/modules/apps/data-engine/data-engine-spi/src/main/java/com/liferay/data/engine/spi/dto/SPIDataDefinitionField.java
+++ b/modules/apps/data-engine/data-engine-spi/src/main/java/com/liferay/data/engine/spi/dto/SPIDataDefinitionField.java
@@ -48,6 +48,9 @@ public class SPIDataDefinitionField {
 			Objects.equals(_label, spiDataDefinitionField._label) &&
 			Objects.equals(_localizable, spiDataDefinitionField._localizable) &&
 			Objects.equals(_name, spiDataDefinitionField._name) &&
+			Objects.equals(
+				_nestedSPIDataDefinitionFields,
+				spiDataDefinitionField._nestedSPIDataDefinitionFields) &&
 			Objects.equals(_repeatable, spiDataDefinitionField._repeatable) &&
 			Objects.equals(_tip, spiDataDefinitionField._tip)) {
 
@@ -89,6 +92,10 @@ public class SPIDataDefinitionField {
 		return _name;
 	}
 
+	public SPIDataDefinitionField[] getNestedSPIDataDefinitionFields() {
+		return _nestedSPIDataDefinitionFields;
+	}
+
 	public boolean getRepeatable() {
 		return _repeatable;
 	}
@@ -108,6 +115,7 @@ public class SPIDataDefinitionField {
 		hash = HashUtil.hash(hash, _label);
 		hash = HashUtil.hash(hash, _localizable);
 		hash = HashUtil.hash(hash, _name);
+		hash = HashUtil.hash(hash, _nestedSPIDataDefinitionFields);
 		hash = HashUtil.hash(hash, _repeatable);
 
 		return HashUtil.hash(hash, _tip);
@@ -151,6 +159,12 @@ public class SPIDataDefinitionField {
 		_name = name;
 	}
 
+	public void setNestedSPIDataDefinitionFields(
+		SPIDataDefinitionField[] nestedSPIDataDefinitionFields) {
+
+		_nestedSPIDataDefinitionFields = nestedSPIDataDefinitionFields;
+	}
+
 	public void setRepeatable(boolean repeatable) {
 		_repeatable = repeatable;
 	}
@@ -169,6 +183,7 @@ public class SPIDataDefinitionField {
 	private final Map<String, Object> _label = new HashMap<>();
 	private boolean _localizable;
 	private String _name;
+	private SPIDataDefinitionField[] _nestedSPIDataDefinitionFields;
 	private boolean _repeatable;
 	private final Map<String, Object> _tip = new HashMap<>();
 

--- a/modules/apps/data-engine/data-engine-spi/src/main/resources/com/liferay/data/engine/spi/dto/packageinfo
+++ b/modules/apps/data-engine/data-engine-spi/src/main/resources/com/liferay/data/engine/spi/dto/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
We kept **nestedFields** in https://github.com/brianchandotcom/liferay-portal/pull/76686/commits/687817c2e480cfc224ae920b1658f68bfa7bc6b7#diff-efca5889797da7b077c6f9f1933fe65bR107 because it shouldn't matter for the frontend (that will consume the context) if it comes from SPIDatadefinitionFields or DataDefinitionsFields.  