### PR TITLE
LPS-99516 Update liferay-npm-scripts to v5.0.0

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/FragmentComment.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/comments/FragmentComment.es.js
@@ -183,7 +183,7 @@ const FragmentComment = props => {
 			)}
 
 			{!isReply && (
-				<React.Fragment>
+				<>
 					<footer className="fragments-editor__fragment-comment-replies">
 						{props.comment.children &&
 							props.comment.children.map(childComment => (
@@ -208,7 +208,7 @@ const FragmentComment = props => {
 						fragmentEntryLinkId={props.fragmentEntryLinkId}
 						parentCommentId={props.comment.commentId}
 					/>
-				</React.Fragment>
+				</>
 			)}
 
 			{showDeleteMask && (

--- a/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperiments.es.js
+++ b/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperiments.es.js
@@ -38,7 +38,7 @@ function SegmentsExperiments({
 	const [dropdown, setDropdown] = useState(false);
 
 	return (
-		<React.Fragment>
+		<>
 			{segmentsExperiences.length > 1 && (
 				<div className="form-group">
 					<label>{Liferay.Language.get('select-experience')}</label>
@@ -64,7 +64,7 @@ function SegmentsExperiments({
 			)}
 
 			{segmentsExperiment && (
-				<React.Fragment>
+				<>
 					<div className="d-flex justify-content-between align-items-center">
 						<h3 className="mb-0 text-dark">
 							{segmentsExperiment.name}
@@ -103,10 +103,10 @@ function SegmentsExperiments({
 					<ClayButton className="w-100 mt-2" disabled>
 						{Liferay.Language.get('review-and-run-test')}
 					</ClayButton>
-				</React.Fragment>
+				</>
 			)}
 			{!segmentsExperiment && (
-				<React.Fragment>
+				<>
 					<h4 className="text-dark">
 						{Liferay.Language.get(
 							'no-active-tests-were-found-for-the-selected-experience'
@@ -124,9 +124,9 @@ function SegmentsExperiments({
 					>
 						{Liferay.Language.get('create-test')}
 					</ClayButton>
-				</React.Fragment>
+				</>
 			)}
-		</React.Fragment>
+		</>
 	);
 
 	function _handleExperienceSelection(event) {

--- a/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsModal.es.js
+++ b/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsModal.es.js
@@ -38,7 +38,7 @@ function SegmentsExperimentsModal({
 		<ClayModal onClose={_handleModalClose} size="sm">
 			{onClose => {
 				return (
-					<React.Fragment>
+					<>
 						<ClayModal.Header>{title}</ClayModal.Header>
 						<ClayModal.Body>
 							<form onSubmit={_handleFormSubmit}>
@@ -97,7 +97,7 @@ function SegmentsExperimentsModal({
 								</ClayButton.Group>
 							}
 						/>
-					</React.Fragment>
+					</>
 				);
 			}}
 		</ClayModal>

--- a/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ValidatedInput/ValidatedInput.es.js
+++ b/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ValidatedInput/ValidatedInput.es.js
@@ -43,13 +43,13 @@ function ValidatedInput(props) {
 	return (
 		<label className={formGroupClasses}>
 			{label && (
-				<React.Fragment>
+				<>
 					{label}
 					<ClayIcon
 						className="reference-mark text-warning ml-1"
 						symbol="asterisk"
 					/>
-				</React.Fragment>
+				</>
 			)}
 
 			<input

--- a/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/variants/internal/VariantList.es.js
+++ b/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/variants/internal/VariantList.es.js
@@ -20,7 +20,7 @@ import {segmentsVariantType} from '../../../types.es';
 
 function VariantList({variants}) {
 	return (
-		<React.Fragment>
+		<>
 			<ClayTable bordered={false}>
 				<ClayTable.Body>
 					{variants.map((variant, i) => {
@@ -36,7 +36,7 @@ function VariantList({variants}) {
 				</ClayTable.Body>
 			</ClayTable>
 			{variants.length === 1 ? (
-				<React.Fragment>
+				<>
 					<h4>
 						{Liferay.Language.get(
 							'no-variants-have-been-created-for-this-test'
@@ -45,9 +45,9 @@ function VariantList({variants}) {
 					<p className="text-secondary small">
 						{Liferay.Language.get('variants-help')}
 					</p>
-				</React.Fragment>
+				</>
 			) : null}
-		</React.Fragment>
+		</>
 	);
 }
 

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
@@ -197,7 +197,7 @@ class ContributorBuilder extends React.Component {
 											return (
 												<React.Fragment key={i}>
 													{i !== 0 && (
-														<React.Fragment>
+														<>
 															<Conjunction
 																className="mb-4 ml-0 mt-4"
 																conjunctionName={
@@ -213,7 +213,7 @@ class ContributorBuilder extends React.Component {
 																	supportedConjunctions
 																}
 															/>
-														</React.Fragment>
+														</>
 													)}
 
 													<CriteriaBuilder

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/CriteriaGroup.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/CriteriaGroup.es.js
@@ -208,7 +208,7 @@ class CriteriaGroup extends Component {
 		} = this.props;
 
 		return (
-			<Fragment>
+			<>
 				<DropZone
 					dropIndex={index}
 					groupId={groupId}
@@ -232,7 +232,7 @@ class CriteriaGroup extends Component {
 					onMove={onMove}
 					propertyKey={propertyKey}
 				/>
-			</Fragment>
+			</>
 		);
 	};
 
@@ -341,7 +341,7 @@ class CriteriaGroup extends Component {
 						propertyKey={propertyKey}
 					/>
 				) : (
-					<Fragment>
+					<>
 						<DropZone
 							before
 							dropIndex={0}
@@ -374,7 +374,7 @@ class CriteriaGroup extends Component {
 									</Fragment>
 								);
 							})}
-					</Fragment>
+					</>
 				)}
 			</div>
 		);

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/CriteriaRow.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/CriteriaRow.es.js
@@ -413,7 +413,7 @@ class CriteriaRow extends Component {
 						{Liferay.Language.get('delete')}
 					</ClayButton>
 				) : (
-					<React.Fragment>
+					<>
 						<ClayButton
 							className="btn-outline-borderless"
 							displayType="secondary"
@@ -431,7 +431,7 @@ class CriteriaRow extends Component {
 						>
 							<ClayIcon symbol="times-circle" />
 						</ClayButton>
-					</React.Fragment>
+					</>
 				)}
 			</div>
 		);
@@ -473,7 +473,7 @@ class CriteriaRow extends Component {
 		});
 
 		return (
-			<React.Fragment>
+			<>
 				{connectDropTarget(
 					connectDragPreview(
 						<div className={classes}>
@@ -500,7 +500,7 @@ class CriteriaRow extends Component {
 					)
 				)}
 				{errorOnProperty && this._renderErrorMessage()}
-			</React.Fragment>
+			</>
 		);
 	}
 }

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/inputs/CollectionInput.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/inputs/CollectionInput.es.js
@@ -80,7 +80,7 @@ class CollectionInput extends React.Component {
 		const {key, value} = this._stringToKeyValueObject(this.props.value);
 
 		return (
-			<React.Fragment>
+			<>
 				<input
 					className="criterion-input form-control"
 					data-testid="collection-key-input"
@@ -102,7 +102,7 @@ class CollectionInput extends React.Component {
 					type="text"
 					value={value}
 				/>
-			</React.Fragment>
+			</>
 		);
 	}
 }

--- a/modules/package.json
+++ b/modules/package.json
@@ -17,7 +17,7 @@
 		"liferay-npm-bridge-generator": "2.11.0",
 		"liferay-npm-bundler": "2.11.0",
 		"liferay-npm-bundler-preset-standard": "2.11.0",
-		"liferay-npm-scripts": "4.18.0",
+		"liferay-npm-scripts": "5.0.0",
 		"liferay-theme-es2015-hook": "8.0.0-rc.2",
 		"metal-jest-serializer": "2.0.0"
 	},

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1413,13 +1413,12 @@
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
-"@jest/console@^24.3.0":
-  version "24.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.3.0.tgz#7bd920d250988ba0bf1352c4493a48e1cb97671e"
-  integrity sha512-NaCty/OOei6rSDcbPdMiCbYCI0KGFGPgGO6B09lwWt5QTxnkuhKYET9El5u5z1GAcSxkQmSMtM63e24YabCWqA==
+"@jest/console@^24.3.0", "@jest/console@^24.7.1":
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"
+  integrity sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==
   dependencies:
     "@jest/source-map" "^24.3.0"
-    "@types/node" "*"
     chalk "^2.0.1"
     slash "^2.0.0"
 
@@ -1467,15 +1466,14 @@
     "@types/node" "*"
     jest-mock "^24.5.0"
 
-"@jest/fake-timers@^24.5.0":
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-24.5.0.tgz#4a29678b91fd0876144a58f8d46e6c62de0266f0"
-  integrity sha512-i59KVt3QBz9d+4Qr4QxsKgsIg+NjfuCjSOWj3RQhjF5JNy+eVJDhANQ4WzulzNCHd72srMAykwtRn5NYDGVraw==
+"@jest/fake-timers@^24.5.0", "@jest/fake-timers@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-24.8.0.tgz#2e5b80a4f78f284bcb4bd5714b8e10dd36a8d3d1"
+  integrity sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==
   dependencies:
-    "@jest/types" "^24.5.0"
-    "@types/node" "*"
-    jest-message-util "^24.5.0"
-    jest-mock "^24.5.0"
+    "@jest/types" "^24.8.0"
+    jest-message-util "^24.8.0"
+    jest-mock "^24.8.0"
 
 "@jest/reporters@^24.5.0":
   version "24.5.0"
@@ -1512,30 +1510,30 @@
     graceful-fs "^4.1.15"
     source-map "^0.6.0"
 
-"@jest/test-result@^24.5.0":
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-24.5.0.tgz#ab66fb7741a04af3363443084e72ea84861a53f2"
-  integrity sha512-u66j2vBfa8Bli1+o3rCaVnVYa9O8CAFZeqiqLVhnarXtreSXG33YQ6vNYBogT7+nYiFNOohTU21BKiHlgmxD5A==
+"@jest/test-result@^24.5.0", "@jest/test-result@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-24.8.0.tgz#7675d0aaf9d2484caa65e048d9b467d160f8e9d3"
+  integrity sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==
   dependencies:
-    "@jest/console" "^24.3.0"
-    "@jest/types" "^24.5.0"
-    "@types/istanbul-lib-coverage" "^1.1.0"
+    "@jest/console" "^24.7.1"
+    "@jest/types" "^24.8.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
 
-"@jest/transform@^24.5.0":
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-24.5.0.tgz#6709fc26db918e6af63a985f2cc3c464b4cf99d9"
-  integrity sha512-XSsDz1gdR/QMmB8UCKlweAReQsZrD/DK7FuDlNo/pE8EcKMrfi2kqLRk8h8Gy/PDzgqJj64jNEzOce9pR8oj1w==
+"@jest/transform@^24.5.0", "@jest/transform@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-24.8.0.tgz#628fb99dce4f9d254c6fd9341e3eea262e06fef5"
+  integrity sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==
   dependencies:
     "@babel/core" "^7.1.0"
-    "@jest/types" "^24.5.0"
+    "@jest/types" "^24.8.0"
     babel-plugin-istanbul "^5.1.0"
     chalk "^2.0.1"
     convert-source-map "^1.4.0"
     fast-json-stable-stringify "^2.0.0"
     graceful-fs "^4.1.15"
-    jest-haste-map "^24.5.0"
+    jest-haste-map "^24.8.0"
     jest-regex-util "^24.3.0"
-    jest-util "^24.5.0"
+    jest-util "^24.8.0"
     micromatch "^3.1.10"
     realpath-native "^1.1.0"
     slash "^2.0.0"
@@ -3201,16 +3199,16 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.5.0.tgz#0ea042789810c2bec9065f7c8ab4dc18e1d28559"
-  integrity sha512-0fKCXyRwxFTJL0UXDJiT2xYxO9Lu2vBd9n+cC+eDjESzcVG3s2DRGAxbzJX21fceB1WYoBjAh8pQ83dKcl003g==
+babel-jest@^24.5.0, babel-jest@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.8.0.tgz#5c15ff2b28e20b0f45df43fe6b7f2aae93dba589"
+  integrity sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==
   dependencies:
-    "@jest/transform" "^24.5.0"
-    "@jest/types" "^24.5.0"
+    "@jest/transform" "^24.8.0"
+    "@jest/types" "^24.8.0"
     "@types/babel__core" "^7.1.0"
     babel-plugin-istanbul "^5.1.0"
-    babel-preset-jest "^24.3.0"
+    babel-preset-jest "^24.6.0"
     chalk "^2.4.2"
     slash "^2.0.0"
 
@@ -3316,10 +3314,10 @@ babel-plugin-istanbul@^5.1.0:
     istanbul-lib-instrument "^3.0.0"
     test-exclude "^5.0.0"
 
-babel-plugin-jest-hoist@^24.3.0:
-  version "24.3.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.3.0.tgz#f2e82952946f6e40bb0a75d266a3790d854c8b5b"
-  integrity sha512-nWh4N1mVH55Tzhx2isvUN5ebM5CDUvIpXPZYMRazQughie/EqGnbR+czzoQlhUmJG9pPJmYDRhvocotb2THl1w==
+babel-plugin-jest-hoist@^24.3.0, babel-plugin-jest-hoist@^24.6.0:
+  version "24.6.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz#f7f7f7ad150ee96d7a5e8e2c5da8319579e78019"
+  integrity sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
@@ -3858,13 +3856,13 @@ babel-preset-es2015@^6.0.0, babel-preset-es2015@^6.1.18:
     babel-plugin-transform-es2015-unicode-regex "^6.24.1"
     babel-plugin-transform-regenerator "^6.24.1"
 
-babel-preset-jest@^24.3.0:
-  version "24.3.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.3.0.tgz#db88497e18869f15b24d9c0e547d8e0ab950796d"
-  integrity sha512-VGTV2QYBa/Kn3WCOKdfS31j9qomaXSgJqi65B6o05/1GsJyj9LVhSljM9ro4S+IBGj/ENhNBuH9bpqzztKAQSw==
+babel-preset-jest@^24.3.0, babel-preset-jest@^24.6.0:
+  version "24.6.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz#66f06136eefce87797539c0d63f1769cc3915984"
+  integrity sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==
   dependencies:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
-    babel-plugin-jest-hoist "^24.3.0"
+    babel-plugin-jest-hoist "^24.6.0"
 
 babel-preset-liferay-standard@2.11.0:
   version "2.11.0"
@@ -7219,10 +7217,10 @@ escodegen@^1.6.1, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-4.6.0.tgz#9f240252f6240dc8cbf929b1cc4903153a0829e9"
-  integrity sha512-pcda6z896lZwc2e/AdEVyC1jQzwKGGWlVXz08uHKdWy4T54wuy2klPMxrBcncVVM/oMsGG4OfITs+az8k5ElCA==
+eslint-config-liferay@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-5.0.0.tgz#464305b05986da2f968940e809001cbf7e5494dc"
+  integrity sha512-V77yJ9eGLvR+7SnTuhqeNvnpjGleyCOzRx2f+XmxfPOd7oJtZoLL9cXbB/1v55oAXYg4DiKLe93k7a5twlA6CQ==
   dependencies:
     eslint-config-prettier "5.0.0"
     eslint-plugin-no-for-of-loops "^1.0.0"
@@ -10631,20 +10629,24 @@ jest-get-type@^24.3.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.3.0.tgz#582cfd1a4f91b5cdad1d43d2932f816d543c65da"
   integrity sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==
 
-jest-haste-map@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.5.0.tgz#3f17d0c548b99c0c96ed2893f9c0ccecb2eb9066"
-  integrity sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==
+jest-haste-map@^24.5.0, jest-haste-map@^24.8.0:
+  version "24.8.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.8.1.tgz#f39cc1d2b1d907e014165b4bd5a957afcb992982"
+  integrity sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==
   dependencies:
-    "@jest/types" "^24.5.0"
+    "@jest/types" "^24.8.0"
+    anymatch "^2.0.0"
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.15"
     invariant "^2.2.4"
     jest-serializer "^24.4.0"
-    jest-util "^24.5.0"
-    jest-worker "^24.4.0"
+    jest-util "^24.8.0"
+    jest-worker "^24.6.0"
     micromatch "^3.1.10"
     sane "^4.0.3"
+    walker "^1.0.7"
+  optionalDependencies:
+    fsevents "^1.2.7"
 
 jest-jasmine2@^24.5.0:
   version "24.5.0"
@@ -10685,26 +10687,26 @@ jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.5.0:
     jest-get-type "^24.3.0"
     pretty-format "^24.5.0"
 
-jest-message-util@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.5.0.tgz#181420a65a7ef2e8b5c2f8e14882c453c6d41d07"
-  integrity sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==
+jest-message-util@^24.5.0, jest-message-util@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.8.0.tgz#0d6891e72a4beacc0292b638685df42e28d6218b"
+  integrity sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@jest/test-result" "^24.5.0"
-    "@jest/types" "^24.5.0"
+    "@jest/test-result" "^24.8.0"
+    "@jest/types" "^24.8.0"
     "@types/stack-utils" "^1.0.1"
     chalk "^2.0.1"
     micromatch "^3.1.10"
     slash "^2.0.0"
     stack-utils "^1.0.1"
 
-jest-mock@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.5.0.tgz#976912c99a93f2a1c67497a9414aa4d9da4c7b76"
-  integrity sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==
+jest-mock@^24.5.0, jest-mock@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.8.0.tgz#2f9d14d37699e863f1febf4e4d5a33b7fdbbde56"
+  integrity sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==
   dependencies:
-    "@jest/types" "^24.5.0"
+    "@jest/types" "^24.8.0"
 
 jest-pnp-resolver@^1.2.1:
   version "1.2.1"
@@ -10813,17 +10815,16 @@ jest-snapshot@^24.5.0:
     pretty-format "^24.5.0"
     semver "^5.5.0"
 
-jest-util@^24.5.0:
-  version "24.5.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.5.0.tgz#9d9cb06d9dcccc8e7cc76df91b1635025d7baa84"
-  integrity sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==
+jest-util@^24.5.0, jest-util@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.8.0.tgz#41f0e945da11df44cc76d64ffb915d0716f46cd1"
+  integrity sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==
   dependencies:
-    "@jest/console" "^24.3.0"
-    "@jest/fake-timers" "^24.5.0"
+    "@jest/console" "^24.7.1"
+    "@jest/fake-timers" "^24.8.0"
     "@jest/source-map" "^24.3.0"
-    "@jest/test-result" "^24.5.0"
-    "@jest/types" "^24.5.0"
-    "@types/node" "*"
+    "@jest/test-result" "^24.8.0"
+    "@jest/types" "^24.8.0"
     callsites "^3.0.0"
     chalk "^2.0.1"
     graceful-fs "^4.1.15"
@@ -10858,12 +10859,11 @@ jest-watcher@^24.5.0:
     jest-util "^24.5.0"
     string-length "^2.0.0"
 
-jest-worker@^24.4.0:
-  version "24.4.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.4.0.tgz#fbc452b0120bb5c2a70cdc88fa132b48eeb11dd0"
-  integrity sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==
+jest-worker@^24.4.0, jest-worker@^24.6.0:
+  version "24.6.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.6.0.tgz#7f81ceae34b7cde0c9827a6980c35b7cdc0161b3"
+  integrity sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==
   dependencies:
-    "@types/node" "*"
     merge-stream "^1.0.1"
     supports-color "^6.1.0"
 
@@ -11635,10 +11635,10 @@ liferay-npm-bundler-plugin-resolve-linked-dependencies@2.11.0:
     read-json-sync "^2.0.0"
     semver "^5.5.0"
 
-liferay-npm-bundler-preset-liferay-dev@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-liferay-dev/-/liferay-npm-bundler-preset-liferay-dev-1.5.0.tgz#caa5bc3d6f71387a101aa6a580ebf5ad21d83f19"
-  integrity sha512-uqeIV8mDabkHJPLZovfO80QSBqVIAi1QW8A5g2xco2RqgcQSr7QzZEbyXaemzkdaagQtwSpX7glArWkVv8oHtA==
+liferay-npm-bundler-preset-liferay-dev@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-liferay-dev/-/liferay-npm-bundler-preset-liferay-dev-1.5.1.tgz#5b588a40f6934ce5c4e2aa5943e26918aee0108b"
+  integrity sha512-ZQ7lfGQ5S2Q1q601Z8WAvdIAo2IoD+NPl1dVmCr0OKpdYANQ276y4opJbZatRNYLUbLIxF8q8WPoSnUGG5+YAw==
   dependencies:
     babel-preset-liferay-standard "2.11.0"
     liferay-npm-bundler-plugin-exclude-imports "2.11.0"
@@ -11683,10 +11683,10 @@ liferay-npm-bundler@2.11.0:
     semver "^5.5.0"
     xml-js "^1.6.8"
 
-liferay-npm-scripts@4.18.0:
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-4.18.0.tgz#7304fde21c463df67969dc15903033d314f4702e"
-  integrity sha512-5nso8RG3KY6W6wIdMY8dQtA/a5wfZuUvqYafitn0sZAbILqq7F3RCdGMCwdkcaQNY9xIR1PEE1ldk0+BRY2mgw==
+liferay-npm-scripts@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-5.0.0.tgz#c9c438bd66c07c0b0dee298487df7d6084417ad4"
+  integrity sha512-4FeZTNceJNStPhCybF4nsvUBq6c8LYcGJbDvG527nJoZs0TKIk6bGHd1lw8jsqGRXI17OwHPh4ZZDVBos/m6Qw==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/plugin-proposal-class-properties" "7.4.4"
@@ -11702,6 +11702,7 @@ liferay-npm-scripts@4.18.0:
     "@testing-library/react" "8.0.7"
     "@testing-library/user-event" "4.2.4"
     babel-eslint "^10.0.2"
+    babel-jest "^24.8.0"
     babel-loader "8.0.6"
     cosmiconfig "^5.2.1"
     cross-env "^5.2.0"
@@ -11709,7 +11710,7 @@ liferay-npm-scripts@4.18.0:
     css-loader "^3.0.0"
     deepmerge "^4.0.0"
     eslint "6.1.0"
-    eslint-config-liferay "^4.6.0"
+    eslint-config-liferay "^5.0.0"
     glob "^7.1.3"
     http-proxy-middleware "^0.19.1"
     jest "^24.5.0"
@@ -11717,7 +11718,7 @@ liferay-npm-scripts@4.18.0:
     liferay-lang-key-dev-loader "^1.0.3"
     liferay-npm-bridge-generator "2.11.0"
     liferay-npm-bundler "2.11.0"
-    liferay-npm-bundler-preset-liferay-dev "1.5.0"
+    liferay-npm-bundler-preset-liferay-dev "1.5.1"
     liferay-theme-tasks "9.4.0"
     metal-tools-soy "4.3.2"
     minimist "^1.2.0"
@@ -18228,7 +18229,7 @@ walkdir@0.0.10:
   resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.0.10.tgz#36037cab663b5e1c0166007b5f7b918b3279a54f"
   integrity sha1-NgN8q2Y7XhwBZgB7X3uRizJ5pU8=
 
-walker@~1.0.5:
+walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=


### PR DESCRIPTION
- Fixes a regression introduced by LPS-97587 where frontend tests would not run due to a missing dependency.
- Enables new lint rule (eg. require use of React fragment shorthand; https://github.com/liferay/eslint-config-liferay/issues/57).
- Fixes build performance regression (https://github.com/liferay/liferay-npm-tools/pull/189).
- Fixed bug with soy dependencies that needs to be resolved in order to roll out Yarn/liferay-npm-scripts to the 7.0.x branch (https://github.com/liferay/liferay-npm-tools/pull/192).