### PR TITLE
LPS-99455 Unable to assign user group to a user when setting users.search.with.index=false & user.groups.search.with.index=false

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
@@ -1182,6 +1182,10 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 	}
 
 	protected boolean isUseCustomSQL(LinkedHashMap<String, Object> params) {
+		if (MapUtil.isEmpty(params)) {
+			return false;
+		}
+
 		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
 			UserGroup.class);
 


### PR DESCRIPTION
This is an update for [LPS-99455](https://issues.liferay.com/browse/LPS-99455).<br><br>/cc @pei-jung @alee8888 @ChrisKian @dejuknow