### PR TITLE
LPS-99625 Change operation to change the experiment status to POST and use a JSON body

### DIFF
--- a/modules/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/dto/v1_0/ExperimentStatus.java
+++ b/modules/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/dto/v1_0/ExperimentStatus.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.segments.asah.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@GraphQLName("ExperimentStatus")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "ExperimentStatus")
+public class ExperimentStatus {
+
+	@Schema
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	@JsonIgnore
+	public void setStatus(
+		UnsafeSupplier<String, Exception> statusUnsafeSupplier) {
+
+		try {
+			status = statusUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String status;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof ExperimentStatus)) {
+			return false;
+		}
+
+		ExperimentStatus experimentStatus = (ExperimentStatus)object;
+
+		return Objects.equals(toString(), experimentStatus.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		if (status != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"status\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(status));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		return string.replaceAll("\"", "\\\\\"");
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\":");
+			sb.append("\"");
+			sb.append(entry.getValue());
+			sb.append("\"");
+
+			if (iterator.hasNext()) {
+				sb.append(",");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/resource/v1_0/ExperimentResource.java
+++ b/modules/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/resource/v1_0/ExperimentResource.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.segments.asah.rest.dto.v1_0.Experiment;
+import com.liferay.segments.asah.rest.dto.v1_0.ExperimentStatus;
 
 import javax.annotation.Generated;
 
@@ -40,7 +41,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface ExperimentResource {
 
-	public Experiment patchExperiment(Long experimentId, String string)
+	public Experiment postExperimentStatu(
+			Long experimentId, ExperimentStatus experimentStatus)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/dto/v1_0/ExperimentStatus.java
+++ b/modules/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/dto/v1_0/ExperimentStatus.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.segments.asah.rest.client.dto.v1_0;
+
+import com.liferay.segments.asah.rest.client.function.UnsafeSupplier;
+import com.liferay.segments.asah.rest.client.serdes.v1_0.ExperimentStatusSerDes;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class ExperimentStatus {
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public void setStatus(
+		UnsafeSupplier<String, Exception> statusUnsafeSupplier) {
+
+		try {
+			status = statusUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String status;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof ExperimentStatus)) {
+			return false;
+		}
+
+		ExperimentStatus experimentStatus = (ExperimentStatus)object;
+
+		return Objects.equals(toString(), experimentStatus.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return ExperimentStatusSerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/json/BaseJSONParser.java
@@ -163,7 +163,7 @@ public abstract class BaseJSONParser<T> {
 
 			_readWhileLastCharIsWhiteSpace();
 
-			map.put(key, _readValue());
+			map.put(key, _readValue(true));
 
 			_readWhileLastCharIsWhiteSpace();
 		}
@@ -353,6 +353,10 @@ public abstract class BaseJSONParser<T> {
 	}
 
 	private Object _readValue() {
+		return _readValue(false);
+	}
+
+	private Object _readValue(boolean parseMaps) {
 		if (_lastChar == '[') {
 			return _readValueAsArray();
 		}
@@ -367,6 +371,9 @@ public abstract class BaseJSONParser<T> {
 		}
 		else if (_lastChar == '"') {
 			return _readValueAsString();
+		}
+		else if (parseMaps && _lastChar == '{') {
+			return parseToMap(_readValueAsStringJSON());
 		}
 		else if (_lastChar == '{') {
 			return _readValueAsStringJSON();

--- a/modules/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/resource/v1_0/ExperimentResource.java
+++ b/modules/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/resource/v1_0/ExperimentResource.java
@@ -36,11 +36,16 @@ public interface ExperimentResource {
 		return new Builder();
 	}
 
-	public Experiment patchExperiment(Long experimentId, String string)
+	public Experiment postExperimentStatu(
+			Long experimentId,
+			com.liferay.segments.asah.rest.client.dto.v1_0.ExperimentStatus
+				experimentStatus)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse patchExperimentHttpResponse(
-			Long experimentId, String string)
+	public HttpInvoker.HttpResponse postExperimentStatuHttpResponse(
+			Long experimentId,
+			com.liferay.segments.asah.rest.client.dto.v1_0.ExperimentStatus
+				experimentStatus)
 		throws Exception;
 
 	public static class Builder {
@@ -98,11 +103,14 @@ public interface ExperimentResource {
 
 	public static class ExperimentResourceImpl implements ExperimentResource {
 
-		public Experiment patchExperiment(Long experimentId, String string)
+		public Experiment postExperimentStatu(
+				Long experimentId,
+				com.liferay.segments.asah.rest.client.dto.v1_0.ExperimentStatus
+					experimentStatus)
 			throws Exception {
 
-			HttpInvoker.HttpResponse httpResponse = patchExperimentHttpResponse(
-				experimentId, string);
+			HttpInvoker.HttpResponse httpResponse =
+				postExperimentStatuHttpResponse(experimentId, experimentStatus);
 
 			String content = httpResponse.getContent();
 
@@ -125,13 +133,15 @@ public interface ExperimentResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse patchExperimentHttpResponse(
-				Long experimentId, String string)
+		public HttpInvoker.HttpResponse postExperimentStatuHttpResponse(
+				Long experimentId,
+				com.liferay.segments.asah.rest.client.dto.v1_0.ExperimentStatus
+					experimentStatus)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
 
-			httpInvoker.body(string.toString(), "application/json");
+			httpInvoker.body(experimentStatus.toString(), "application/json");
 
 			if (_builder._locale != null) {
 				httpInvoker.header(
@@ -150,12 +160,12 @@ public interface ExperimentResource {
 				httpInvoker.parameter(entry.getKey(), entry.getValue());
 			}
 
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PATCH);
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/segments-asah/v1.0/experiments/{experimentId}",
+						"/o/segments-asah/v1.0/experiments/{experimentId}/status",
 				experimentId);
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/serdes/v1_0/ExperimentSerDes.java
+++ b/modules/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/serdes/v1_0/ExperimentSerDes.java
@@ -245,16 +245,41 @@ public class ExperimentSerDes {
 			sb.append("\"");
 			sb.append(entry.getKey());
 			sb.append("\":");
-			sb.append("\"");
 
-			if (entry.getValue() instanceof String) {
+			Object value = entry.getValue();
+
+			Class valueClass = value.getClass();
+
+			if (value instanceof Map) {
+				sb.append(_toJSON((Map)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
 				sb.append(_escape(entry.getValue()));
+				sb.append("\"");
+			}
+			else if (valueClass.isArray()) {
+				Object[] values = (Object[])value;
+
+				sb.append("[");
+
+				for (int i = 0; i < values.length; i++) {
+					sb.append("\"");
+					sb.append(_escape(values[i]));
+					sb.append("\"");
+
+					if ((i + 1) < values.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
 			}
 			else {
+				sb.append("\"");
 				sb.append(entry.getValue());
+				sb.append("\"");
 			}
-
-			sb.append("\"");
 
 			if (iterator.hasNext()) {
 				sb.append(",");

--- a/modules/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/serdes/v1_0/ExperimentStatusSerDes.java
+++ b/modules/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/serdes/v1_0/ExperimentStatusSerDes.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.segments.asah.rest.client.serdes.v1_0;
+
+import com.liferay.segments.asah.rest.client.dto.v1_0.ExperimentStatus;
+import com.liferay.segments.asah.rest.client.json.BaseJSONParser;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class ExperimentStatusSerDes {
+
+	public static ExperimentStatus toDTO(String json) {
+		ExperimentStatusJSONParser experimentStatusJSONParser =
+			new ExperimentStatusJSONParser();
+
+		return experimentStatusJSONParser.parseToDTO(json);
+	}
+
+	public static ExperimentStatus[] toDTOs(String json) {
+		ExperimentStatusJSONParser experimentStatusJSONParser =
+			new ExperimentStatusJSONParser();
+
+		return experimentStatusJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(ExperimentStatus experimentStatus) {
+		if (experimentStatus == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (experimentStatus.getStatus() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"status\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(experimentStatus.getStatus()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		ExperimentStatusJSONParser experimentStatusJSONParser =
+			new ExperimentStatusJSONParser();
+
+		return experimentStatusJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(ExperimentStatus experimentStatus) {
+		if (experimentStatus == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		if (experimentStatus.getStatus() == null) {
+			map.put("status", null);
+		}
+		else {
+			map.put("status", String.valueOf(experimentStatus.getStatus()));
+		}
+
+		return map;
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		string = string.replace("\\", "\\\\");
+
+		return string.replace("\"", "\\\"");
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\":");
+
+			Object value = entry.getValue();
+
+			Class valueClass = value.getClass();
+
+			if (value instanceof Map) {
+				sb.append(_toJSON((Map)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(entry.getValue()));
+				sb.append("\"");
+			}
+			else if (valueClass.isArray()) {
+				Object[] values = (Object[])value;
+
+				sb.append("[");
+
+				for (int i = 0; i < values.length; i++) {
+					sb.append("\"");
+					sb.append(_escape(values[i]));
+					sb.append("\"");
+
+					if ((i + 1) < values.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else {
+				sb.append("\"");
+				sb.append(entry.getValue());
+				sb.append("\"");
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(",");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static class ExperimentStatusJSONParser
+		extends BaseJSONParser<ExperimentStatus> {
+
+		@Override
+		protected ExperimentStatus createDTO() {
+			return new ExperimentStatus();
+		}
+
+		@Override
+		protected ExperimentStatus[] createDTOArray(int size) {
+			return new ExperimentStatus[size];
+		}
+
+		@Override
+		protected void setField(
+			ExperimentStatus experimentStatus, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "status")) {
+				if (jsonParserFieldValue != null) {
+					experimentStatus.setStatus((String)jsonParserFieldValue);
+				}
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+	}
+
+}

--- a/modules/apps/segments/segments-asah-rest-impl/rest-openapi.yaml
+++ b/modules/apps/segments/segments-asah-rest-impl/rest-openapi.yaml
@@ -1,6 +1,7 @@
 components:
     schemas:
         Experiment:
+            description: ""
             properties:
                 dateCreated:
                     format: date-time
@@ -20,16 +21,22 @@ components:
                     type: integer
                 status:
                     type: string
+        ExperimentStatus:
+            description: ""
+            properties:
+                status:
+                    type: string
+            type: object
 info:
     description: ""
     title: "Segments Asah"
     version: v1.0
 openapi: 3.0.1
 paths:
-    "/experiments/{experimentId}":
-        patch:
+    "/experiments/{experimentId}/status":
+        post:
             description: ""
-            operationId: patchExperiment
+            operationId: postExperimentStatu
             parameters:
                 - in: path
                   name: experimentId
@@ -39,9 +46,12 @@ paths:
                       type: integer
             requestBody:
                 content:
-                    text/plain:
+                    application/json:
                         schema:
-                            type: string
+                            $ref: "#/components/schemas/ExperimentStatus"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/ExperimentStatus"
             responses:
                 200:
                     content:

--- a/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -21,6 +21,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.segments.asah.rest.dto.v1_0.Experiment;
+import com.liferay.segments.asah.rest.dto.v1_0.ExperimentStatus;
 import com.liferay.segments.asah.rest.resource.v1_0.ExperimentResource;
 
 import javax.annotation.Generated;
@@ -43,17 +44,16 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	@GraphQLName("patchExperimentExperimentIdString")
-	public Experiment patchExperiment(
+	public Experiment createExperimentStatu(
 			@GraphQLName("experimentId") Long experimentId,
-			@GraphQLName("string") String string)
+			@GraphQLName("experimentStatus") ExperimentStatus experimentStatus)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
 			_experimentResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			experimentResource -> experimentResource.patchExperiment(
-				experimentId, string));
+			experimentResource -> experimentResource.postExperimentStatu(
+				experimentId, experimentStatus));
 	}
 
 	private <T, R, E1 extends Throwable, E2 extends Throwable> R

--- a/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/graphql/query/v1_0/Query.java
@@ -29,6 +29,8 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.core.UriInfo;
+
 import org.osgi.service.component.ComponentServiceObjects;
 
 /**
@@ -63,6 +65,7 @@ public class Query {
 	private Company _company;
 	private HttpServletRequest _httpServletRequest;
 	private HttpServletResponse _httpServletResponse;
+	private UriInfo _uriInfo;
 	private User _user;
 
 }

--- a/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentResourceImpl.java
+++ b/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.segments.asah.rest.dto.v1_0.Experiment;
+import com.liferay.segments.asah.rest.dto.v1_0.ExperimentStatus;
 import com.liferay.segments.asah.rest.resource.v1_0.ExperimentResource;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,7 +40,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.NotNull;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.PATCH;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -53,20 +54,25 @@ import javax.ws.rs.core.UriInfo;
 @Path("/v1.0")
 public abstract class BaseExperimentResourceImpl implements ExperimentResource {
 
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/segments-asah/v1.0/experiments/{experimentId}/status' -d $'{"status": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
 	@Override
-	@Consumes("text/plain")
+	@Consumes({"application/json", "application/xml"})
 	@Operation(description = "")
-	@PATCH
+	@POST
 	@Parameters(
 		value = {@Parameter(in = ParameterIn.PATH, name = "experimentId")}
 	)
-	@Path("/experiments/{experimentId}")
+	@Path("/experiments/{experimentId}/status")
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "Experiment")})
-	public Experiment patchExperiment(
+	public Experiment postExperimentStatu(
 			@NotNull @Parameter(hidden = true) @PathParam("experimentId") Long
 				experimentId,
-			String string)
+			ExperimentStatus experimentStatus)
 		throws Exception {
 
 		return new Experiment();

--- a/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/ExperimentResourceImpl.java
+++ b/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/ExperimentResourceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.segments.asah.rest.dto.v1_0.Experiment;
+import com.liferay.segments.asah.rest.dto.v1_0.ExperimentStatus;
 import com.liferay.segments.asah.rest.resource.v1_0.ExperimentResource;
 import com.liferay.segments.constants.SegmentsExperimentConstants;
 import com.liferay.segments.model.SegmentsExperiment;
@@ -39,7 +40,8 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class ExperimentResourceImpl extends BaseExperimentResourceImpl {
 
 	@Override
-	public Experiment patchExperiment(Long segmentsExperimentKey, String status)
+	public Experiment postExperimentStatu(
+			Long segmentsExperimentKey, ExperimentStatus experimentStatus)
 		throws Exception {
 
 		ServiceContext serviceContext =
@@ -55,7 +57,8 @@ public class ExperimentResourceImpl extends BaseExperimentResourceImpl {
 
 		return _toExperiment(
 			_segmentsExperimentService.updateSegmentsExperiment(
-				String.valueOf(segmentsExperimentKey), _parseStatus(status)));
+				String.valueOf(segmentsExperimentKey),
+				_parseStatus(experimentStatus.getStatus())));
 	}
 
 	private int _parseStatus(String status) {

--- a/modules/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/graphql/v1_0/test/BaseExperimentGraphQLTestCase.java
+++ b/modules/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/graphql/v1_0/test/BaseExperimentGraphQLTestCase.java
@@ -14,6 +14,7 @@
 
 package com.liferay.segments.asah.rest.graphql.v1_0.test;
 
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -26,7 +27,6 @@ import com.liferay.segments.asah.rest.client.dto.v1_0.Experiment;
 import com.liferay.segments.asah.rest.client.http.HttpInvoker;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +35,7 @@ import java.util.Objects;
 import javax.annotation.Generated;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -64,13 +65,27 @@ public abstract class BaseExperimentGraphQLTestCase {
 		GroupTestUtil.deleteGroup(testGroup);
 	}
 
+	protected void assertEqualsIgnoringOrder(
+		List<Experiment> experiments, JSONArray jsonArray) {
+
+		for (Experiment experiment : experiments) {
+			boolean contains = false;
+
+			for (Object object : jsonArray) {
+				if (equals(experiment, (JSONObject)object)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				jsonArray + " does not contain " + experiment, contains);
+		}
+	}
+
 	protected boolean equals(Experiment experiment, JSONObject jsonObject) {
-		List<String> fieldNames = new ArrayList(
-			Arrays.asList(getAdditionalAssertFieldNames()));
-
-		fieldNames.add("id");
-
-		for (String fieldName : fieldNames) {
+		for (String fieldName : getAdditionalAssertFieldNames()) {
 			if (Objects.equals("description", fieldName)) {
 				if (!Objects.equals(
 						experiment.getDescription(),
@@ -137,6 +152,37 @@ public abstract class BaseExperimentGraphQLTestCase {
 		return new String[0];
 	}
 
+	protected List<GraphQLField> getGraphQLFields() {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		graphQLFields.add(new GraphQLField("id"));
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			graphQLFields.add(new GraphQLField(additionalAssertFieldName));
+		}
+
+		return graphQLFields;
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path("http://localhost:8080/o/graphql");
+		httpInvoker.userNameAndPassword("test@liferay.com:test");
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
 	protected Experiment randomExperiment() throws Exception {
 		return new Experiment() {
 			{
@@ -151,26 +197,15 @@ public abstract class BaseExperimentGraphQLTestCase {
 		};
 	}
 
+	protected Experiment testExperiment_addExperiment() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
 	protected Company testCompany;
 	protected Group testGroup;
 
-	private String _invoke(String query) throws Exception {
-		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-		JSONObject jsonObject = JSONUtil.put("query", query);
-
-		httpInvoker.body(jsonObject.toString(), "application/json");
-
-		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-		httpInvoker.path("http://localhost:8080/o/graphql");
-		httpInvoker.userNameAndPassword("test@liferay.com:test");
-
-		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
-
-		return httpResponse.getContent();
-	}
-
-	private class GraphQLField {
+	protected class GraphQLField {
 
 		public GraphQLField(String key, GraphQLField... graphQLFields) {
 			this(key, new HashMap<>(), graphQLFields);

--- a/modules/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentResourceTestCase.java
+++ b/modules/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentResourceTestCase.java
@@ -187,8 +187,22 @@ public abstract class BaseExperimentResourceTestCase {
 	}
 
 	@Test
-	public void testPatchExperiment() throws Exception {
-		Assert.assertTrue(false);
+	public void testPostExperimentStatu() throws Exception {
+		Experiment randomExperiment = randomExperiment();
+
+		Experiment postExperiment = testPostExperimentStatu_addExperiment(
+			randomExperiment);
+
+		assertEquals(randomExperiment, postExperiment);
+		assertValid(postExperiment);
+	}
+
+	protected Experiment testPostExperimentStatu_addExperiment(
+			Experiment experiment)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected void assertHttpResponseStatusCode(


### PR DESCRIPTION
Hey @brianchandotcom,
Please see: 
* https://github.com/dgarciasarai/liferay-portal/blob/79e6c15c4cee06c1ff31db9d201c2707eeff4aee/modules/apps/segments/segments-asah-rest-impl/rest-openapi.yaml#L39
* https://github.com/dgarciasarai/liferay-portal/blob/79e6c15c4cee06c1ff31db9d201c2707eeff4aee/modules/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/resource/v1_0/ExperimentResource.java#L44

We created a private endpoint to change the status of the experiment (A/B Testing) from Analytics Cloud:
* `/experiment/{experimentId}/status` 

But the generator doesn't like that word and creates the method `postExperimentStatu`, without `s`. I think it's for the plural, right? How can we manage that? Internally, it's a little bit weird.

\cc @nhpatt

Thanks :)