### PR TITLE
LPS-90079 Update BREAKING_CHANGES document

### DIFF
--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -514,6 +514,51 @@ implementation for authentication.
 
 ---------------------------------------
 
+### AlloyEditor v2.0 updated to a major new version of React
+- **Date:** 2019-Feb-04
+- **JIRA Ticket:** [LPS-90079](https://issues.liferay.com/browse/LPS-90079)
+
+#### What changed?
+
+AlloyEditor was upgraded to version 2.0.0, which includes a major upgrade from
+React v15 to v16.
+
+`React.createClass` was
+[deprecated in React v15.5.0](https://reactjs.org/blog/2017/04/07/react-v15.5.0.html)
+(April 2017) and
+[removed in React v16.0.0](https://reactjs.org/blog/2017/09/26/react-v16.0.html)
+(September 2017). All the buttons bundled with AlloyEditor have been
+updated to use the ES6 class syntax instead of `React.createClass`.
+
+#### Who is affected?
+
+Developers who have built their own buttons using `React.createClass`
+will find that the `createClass` function is no longer available and
+attempts to access it at runtime will trigger an error.
+
+#### How should I update my code?
+
+1. Custom buttons can be ported from the `React.createClass` API to use
+the ES6 `class` API described in
+[the React documentation](https://reactjs.org/docs/react-component.html)
+(for example, see the changes made in moving to an
+[ES6 class-based button](https://github.com/liferay/alloy-editor/blob/b082c312179ae6626cb2ddcc04ad3ebc5b355e1b/src/components/buttons/button-ol.jsx),
+from
+[the previous `createClass`-based implementation](https://github.com/liferay/alloy-editor/blob/2826ab9ceabe17c6ba0d38985baf8a787c23db43/src/ui/react/src/components/buttons/button-ol.jsx));
+or:
+2. A compatibility adapter — the
+[create-react-class package](https://www.npmjs.com/package/create-react-class)
+which is described [here](https://reactjs.org/docs/react-without-es6.html) —
+can be injected into the page to restore the `createClass` API.
+
+#### Why was this change made?
+
+Moving to a newer major version of React brings performance and
+compatibility improvements, as well as reducing the bundle size due to
+the removal of deprecated APIs.
+
+---------------------------------------
+
 ### Deprecated dl.tabs.visible property
 - **Date:** 2019-Apr-10
 - **JIRA Ticket:** [LPS-93948](https://issues.liferay.com/browse/LPS-93948)


### PR DESCRIPTION
We neglected to document this v7.2 breaking change when we updated to AlloyEditor v2 in 1c75602deef. (Which additionally means that this PR should be backported to 7.2.x).

Related tickets:

- LPS-98752 Not possible to use custom AlloyEditor buttons created using `React.createClass`.
- v7.1.x PR avoiding the breaking change being backported to that branch: https://github.com/antonio-ortega/liferay-portal-ee/pull/64

Reviewed by @mwilliams2014 [here](https://github.com/wincent/liferay-portal/pull/50).

Looks like this when formatted:

![liferay-portal_BREAKING_CHANGES_markdown_at_f70174fb04efa6da9a3b27b5e5a8d7c24ae38b99_·_wincent_liferay-portal](https://user-images.githubusercontent.com/7074/62873643-162a8800-bd20-11e9-9941-9078307bd9a0.png)
