### PR TITLE
LPS-83567 Trace logging

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/search/SearchSearchRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/search/SearchSearchRequestExecutorImpl.java
@@ -50,11 +50,11 @@ public class SearchSearchRequestExecutorImpl
 		_searchSearchRequestAssembler.assemble(
 			searchRequestBuilder, searchSearchRequest);
 
-		if (_log.isDebugEnabled()) {
-			String debugRequestString = _getDebugRequestString(
+		if (_log.isTraceEnabled()) {
+			String prettyPrintedRequestString = _getPrettyPrintedRequestString(
 				searchRequestBuilder);
 
-			_log.debug("Search query: " + debugRequestString);
+			_log.trace("Search query: " + prettyPrintedRequestString);
 		}
 
 		SearchResponse searchResponse = searchRequestBuilder.get();
@@ -97,7 +97,7 @@ public class SearchSearchRequestExecutorImpl
 		_searchSearchResponseAssembler = searchSearchResponseAssembler;
 	}
 
-	private String _getDebugRequestString(
+	private String _getPrettyPrintedRequestString(
 		SearchRequestBuilder searchRequestBuilder) {
 
 		GsonBuilder gsonBuilder = new GsonBuilder();

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/logging/ElasticsearchIndexSearcherLoggingTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/logging/ElasticsearchIndexSearcherLoggingTest.java
@@ -66,9 +66,9 @@ public class ElasticsearchIndexSearcherLoggingTest
 	}
 
 	@Test
-	public void testSearchSearchRequestExecutorLogsDebugString() {
+	public void testSearchSearchRequestExecutorLogsPrettyPrintedString() {
 		expectedLogTestRule.configure(
-			SearchSearchRequestExecutorImpl.class, Level.FINE);
+			SearchSearchRequestExecutorImpl.class, Level.FINEST);
 
 		expectedLogTestRule.expectMessage("Search query:");
 


### PR DESCRIPTION
this is a follow up in regards to the changes you made here https://github.com/brianchandotcom/liferay-portal/pull/77027#issuecomment-521834037

just to give you more context, the DEBUG logging is technically already covered by this https://github.com/brianchandotcom/liferay-portal/commit/d3d839e828f4393f85c6ea2ebd2b771004d8fa30#diff-9cb782dce776da418872e383019240ffR72 

however, searchSearchResponse.getSearchRequestString() is not really in a human readable format, so it is helpful to have the pretty printed version available as well, mainly for inspection/copying/pasting while debugging, but also to give an idea as to what the search query contains before sending it to the search engine, in case an exception occurs at the search engine. but the pretty printed format would be 1) redundant to log under DEBUG, and 2) not the ideal format for logs, so i think it would be more suitable under TRACE. i also changed the variable name to better reflect what it is, in case the "debug" wording caused confusion. let me know if this breaks any coding conventions in regards to TRACE, since i know we dont use it very often

https://issues.liferay.com/browse/LPS-83567