### PR TITLE
LPS-99874 UpgradeSchema not present on Portal Upgrade Process Registry due to reverted change

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_3_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_3_x/PortalUpgradeProcessRegistryImpl.java
@@ -33,6 +33,8 @@ public class PortalUpgradeProcessRegistryImpl
 		upgradeProcesses.put(new Version(6, 0, 0), new UpgradeLayout());
 
 		upgradeProcesses.put(new Version(6, 0, 1), new UpgradeLayoutSet());
+
+		upgradeProcesses.put(new Version(6, 0, 2), new UpgradeSchema());
 	}
 
 }


### PR DESCRIPTION
On LPS-98197 we forget to de-revert this change.
No backport
Thanks!