### PR TITLE
LPS-99774 Update liferay-npm-scripts to v7.1.0

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -17,7 +17,7 @@
 		"liferay-npm-bridge-generator": "2.12.0",
 		"liferay-npm-bundler": "2.12.0",
 		"liferay-npm-bundler-preset-standard": "2.12.0",
-		"liferay-npm-scripts": "7.0.0",
+		"liferay-npm-scripts": "7.1.0",
 		"liferay-theme-es2015-hook": "8.0.0-rc.2",
 		"metal-jest-serializer": "2.0.0"
 	},

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -11683,10 +11683,10 @@ liferay-npm-bundler@2.12.0:
     semver "^5.5.0"
     xml-js "^1.6.8"
 
-liferay-npm-scripts@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-7.0.0.tgz#8ecc81e45a6130b87050a2bae9705b583194f540"
-  integrity sha512-zosQ6xtQ8LswNpS8XmFJf22KMIvGs654MecJwDvQoSSYGR6H37qBD8AQtVMm+tozUf63VbVP3lajsLCVc+zuDg==
+liferay-npm-scripts@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-7.1.0.tgz#d449bd093fa840d858e5a4067796f9ed00e15997"
+  integrity sha512-1HwD9zZ4Uf0qpeIy9Ew+F50z5RuLOVMTC4swC/yRKa8dOxlp7T0LHjKSjQjrtHeYiZ5ShYwWkw3q+eMl+AN7Iw==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/plugin-proposal-class-properties" "7.4.4"


### PR DESCRIPTION
This is "defense in depth", [making sure](https://github.com/liferay/liferay-npm-tools/pull/198) that liferay-npm-scripts always uses the "test" environment when running Jest, even if passed an incorrect NODE_ENV.