### PR TITLE
LPS-99917 Liferay-Require-SchemaVersion can only be used together wit…

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/bnd.bnd
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/bnd.bnd
@@ -1,5 +1,4 @@
 Bundle-Name: Liferay Adaptive Media Document Library Thumbnails
 Bundle-SymbolicName: com.liferay.adaptive.media.document.library.thumbnails
 Bundle-Version: 4.0.0
-Liferay-Require-SchemaVersion: 1.0.0
 -dsannotations-options: inherit

--- a/modules/apps/asset/asset-entry-query-processor-custom-user-attributes/bnd.bnd
+++ b/modules/apps/asset/asset-entry-query-processor-custom-user-attributes/bnd.bnd
@@ -1,5 +1,4 @@
 Bundle-Name: Liferay Asset Entry Query Processor Custom User Attributes
 Bundle-SymbolicName: com.liferay.asset.entry.query.processor.custom.user.attributes
 Bundle-Version: 5.0.0
-Liferay-Require-SchemaVersion: 1.0.0
 Web-ContextPath: /asset-entry-query-processor-custom-user-attributes

--- a/modules/apps/export-import/export-import-changeset-service/bnd.bnd
+++ b/modules/apps/export-import/export-import-changeset-service/bnd.bnd
@@ -2,4 +2,3 @@ Bundle-Activator: com.liferay.exportimport.changeset.internal.activator.Changese
 Bundle-Name: Liferay Export Import Changeset Service
 Bundle-SymbolicName: com.liferay.exportimport.changeset.service
 Bundle-Version: 3.0.0
-Liferay-Require-SchemaVersion: 1.0.0

--- a/modules/apps/export-import/export-import-service/bnd.bnd
+++ b/modules/apps/export-import/export-import-service/bnd.bnd
@@ -1,5 +1,4 @@
 Bundle-Name: Liferay Export Import Service
 Bundle-SymbolicName: com.liferay.exportimport.service
 Bundle-Version: 7.0.0
-Liferay-Require-SchemaVersion: 1.0.0
 -includeresource: content=../../staging/staging-lang/src/main/resources/content

--- a/modules/apps/layout/layout-impl/bnd.bnd
+++ b/modules/apps/layout/layout-impl/bnd.bnd
@@ -1,4 +1,3 @@
 Bundle-Name: Liferay Layout Implementation
 Bundle-SymbolicName: com.liferay.layout.impl
 Bundle-Version: 5.0.0
-Liferay-Require-SchemaVersion: 1.0.0

--- a/modules/apps/license-manager/license-manager-web/bnd.bnd
+++ b/modules/apps/license-manager/license-manager-web/bnd.bnd
@@ -1,4 +1,3 @@
 Bundle-Name: Liferay License Manager Web
 Bundle-SymbolicName: com.liferay.license.manager.web
 Bundle-Version: 5.0.0
-Liferay-Require-SchemaVersion: 1.0.1

--- a/modules/apps/portal-remote/portal-remote-soap-extender-impl/bnd.bnd
+++ b/modules/apps/portal-remote/portal-remote-soap-extender-impl/bnd.bnd
@@ -31,4 +31,3 @@ Import-Package:\
 	!org.springframework.*,\
 	\
 	*
-Liferay-Require-SchemaVersion: 1.0.0

--- a/modules/apps/portal-search/portal-search-web/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-web/bnd.bnd
@@ -6,5 +6,4 @@ Import-Package:\
 	\
 	*
 Liferay-JS-Config: /META-INF/resources/js/config.js
-Liferay-Require-SchemaVersion: 2.0.0
 Web-ContextPath: /portal-search-web

--- a/modules/apps/portal-security-sso/portal-security-sso-token-impl/bnd.bnd
+++ b/modules/apps/portal-security-sso/portal-security-sso-token-impl/bnd.bnd
@@ -1,4 +1,3 @@
 Bundle-Name: Liferay Portal Security SSO Token Implementation
 Bundle-SymbolicName: com.liferay.portal.security.sso.token.impl
 Bundle-Version: 4.0.0
-Liferay-Require-SchemaVersion: 1.0.0

--- a/modules/apps/portal-security/portal-security-auth-verifier/bnd.bnd
+++ b/modules/apps/portal-security/portal-security-auth-verifier/bnd.bnd
@@ -1,5 +1,4 @@
 Bundle-Name: Liferay Portal Security Auth Verifier
 Bundle-SymbolicName: com.liferay.portal.security.auth.verifier
 Bundle-Version: 5.0.0
-Liferay-Require-SchemaVersion: 1.0.0
 -metatype-inherit: True

--- a/modules/apps/portal-template/portal-template-soy-impl/bnd.bnd
+++ b/modules/apps/portal-template/portal-template-soy-impl/bnd.bnd
@@ -26,4 +26,3 @@ Import-Package:\
 	!org.objectweb.asm.util,\
 	\
 	*
-Liferay-Require-SchemaVersion: 1.0.0

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/bnd.bnd
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/bnd.bnd
@@ -1,5 +1,4 @@
 Bundle-Name: Liferay Portal Workflow Kaleo Runtime Implementation
 Bundle-SymbolicName: com.liferay.portal.workflow.kaleo.runtime.impl
 Bundle-Version: 5.0.0
-Liferay-Require-SchemaVersion: 2.0.3
 -dsannotations-options: inherit

--- a/modules/apps/portal/portal-messaging/bnd.bnd
+++ b/modules/apps/portal/portal-messaging/bnd.bnd
@@ -1,4 +1,3 @@
 Bundle-Name: Liferay Portal Messaging
 Bundle-SymbolicName: com.liferay.portal.messaging
 Bundle-Version: 7.0.0
-Liferay-Require-SchemaVersion: 1.0.0

--- a/modules/apps/portal/portal-monitoring/bnd.bnd
+++ b/modules/apps/portal/portal-monitoring/bnd.bnd
@@ -5,4 +5,3 @@ Import-Package:\
 	com.liferay.portal.kernel.portlet;version="[9.0.0,9.1)",\
 	\
 	*
-Liferay-Require-SchemaVersion: 1.0.0


### PR DESCRIPTION
…h "Liferay-Service: true"
@hhuijser can you SF this?
Basically "Liferay-Require-SchemaVersion" can only be used when there is "Liferay-Service: true".
