### PR TITLE
LPS-99725 - when registering a background task executor, we should be…

### DIFF
--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskExecutorRegistryImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskExecutorRegistryImpl.java
@@ -53,7 +53,8 @@ public class BackgroundTaskExecutorRegistryImpl
 		Dictionary<String, Object> properties = new HashMapDictionary<>();
 
 		properties.put(
-			"background.task.executor.class.name", backgroundTaskExecutor);
+			"background.task.executor.class.name",
+			backgroundTaskExecutorClassName);
 
 		ServiceRegistration<BackgroundTaskExecutor> serviceRegistration =
 			_bundleContext.registerService(


### PR DESCRIPTION
… adding the class name to the properties map, not the executor itself