### PR TITLE
LPS-99129 Adds enableFontAwesome configuration setting to keep backwards compatibility in 7.2

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-admin/package.json
+++ b/modules/apps/frontend-theme/frontend-theme-admin/package.json
@@ -10,7 +10,6 @@
 	"liferayTheme": {
 		"baseTheme": "styled",
 		"distName": "admin-theme",
-		"fontAwesome": true,
 		"rubySass": false,
 		"version": "7.1"
 	},

--- a/modules/apps/frontend-theme/frontend-theme-admin/src/css/clay.scss
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/css/clay.scss
@@ -1,4 +1,1 @@
-@import 'liferay-font-awesome/scss/font-awesome';
-@import 'liferay-font-awesome/scss/glyphicons';
-
 @import 'clay/atlas';

--- a/modules/apps/frontend-theme/frontend-theme-classic/package.json
+++ b/modules/apps/frontend-theme/frontend-theme-classic/package.json
@@ -10,7 +10,6 @@
 	"liferayTheme": {
 		"baseTheme": "styled",
 		"distName": "classic-theme",
-		"fontAwesome": true,
 		"rubySass": false,
 		"version": "7.1"
 	},

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/clay.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/clay.scss
@@ -1,4 +1,1 @@
-@import 'liferay-font-awesome/scss/font-awesome';
-@import 'liferay-font-awesome/scss/glyphicons';
-
 @import 'clay/atlas';

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/bnd.bnd
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Frontend Theme Font Awesome Web
+Bundle-SymbolicName: com.liferay.frontend.theme.font.awesome.web
+Bundle-Version: 1.0.0
+Web-ContextPath: /frontend-theme-font-awesome-web

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/build.gradle
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/build.gradle
@@ -1,0 +1,39 @@
+import com.liferay.gradle.util.copy.StripPathSegmentsAction
+
+task buildFontAwesome(type: Copy)
+
+File fontAwesomeDestinationDir = new File("classes/META-INF/resources/font")
+
+buildCSS {
+	imports = [
+		new File(npmInstall.nodeModulesDir, "liferay-font-awesome")
+	]
+}
+
+buildFontAwesome {
+	eachFile new StripPathSegmentsAction(2)
+
+	from npmInstall.nodeModulesDir
+
+	include "liferay-font-awesome/font/*"
+
+	includeEmptyDirs = false
+	into fontAwesomeDestinationDir
+}
+
+classes {
+	dependsOn buildFontAwesome
+}
+
+dependencies {
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.1.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:portal-url-builder:portal-url-builder-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:petra:petra-string")
+}

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/package.json
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/package.json
@@ -1,0 +1,7 @@
+{
+	"dependencies": {
+		"liferay-font-awesome": "3.4.0"
+	},
+	"name": "frontend-theme-font-awesome-web",
+	"version": "1.0.0"
+}

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/java/com/liferay/frontend/theme/font/awesome/web/internal/configuration/CSSFontAwesomeConfiguration.java
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/java/com/liferay/frontend/theme/font/awesome/web/internal/configuration/CSSFontAwesomeConfiguration.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.theme.font.awesome.web.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author Chema Balsas
+ * @review
+ */
+@ExtendedObjectClassDefinition(category = "third-party")
+@Meta.OCD(
+	description = "frontend-theme-font-awesome-description",
+	id = "com.liferay.frontend.theme.font.awesome.web.internal.configuration.CSSFontAwesomeConfiguration",
+	localization = "content/Language",
+	name = "frontend-theme-font-awesome-configuration-name"
+)
+public interface CSSFontAwesomeConfiguration {
+
+	/**
+	 * Set this to <code>true</code> to enable Font Awesome usage.
+	 *
+	 * @return <code>true</code> if Liferay Font Awesome is enabled.
+	 * @review
+	 */
+	@Meta.AD(deflt = "true", name = "enable-font-awesome", required = false)
+	public boolean enableFontAwesome();
+
+}

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/java/com/liferay/frontend/theme/font/awesome/web/internal/servlet/taglib/FontAwesomeTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/java/com/liferay/frontend/theme/font/awesome/web/internal/servlet/taglib/FontAwesomeTopHeadDynamicInclude.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.theme.font.awesome.web.internal.servlet.taglib;
+
+import com.liferay.frontend.theme.font.awesome.web.internal.configuration.CSSFontAwesomeConfiguration;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.servlet.taglib.BaseDynamicInclude;
+import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Chema Balsas
+ */
+@Component(
+	configurationPid = "com.liferay.frontend.theme.font.awesome.web.internal.configuration.CSSFontAwesomeConfiguration",
+	immediate = true, service = DynamicInclude.class
+)
+public class FontAwesomeTopHeadDynamicInclude extends BaseDynamicInclude {
+
+	@Override
+	public void include(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String key)
+		throws IOException {
+
+		if (!_cssFontAwesomeConfiguration.enableFontAwesome()) {
+			return;
+		}
+
+		PrintWriter printWriter = httpServletResponse.getWriter();
+
+		StringBundler sb = new StringBundler(4);
+
+		AbsolutePortalURLBuilder absolutePortalURLBuilder =
+			_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+				httpServletRequest);
+
+		sb.append("<link charset=\"utf-8\" data-senna-track=\"permanent\" ");
+		sb.append("href=\"");
+		sb.append(
+			absolutePortalURLBuilder.forModule(
+				_bundleContext.getBundle(), "css/main.css"
+			).build());
+		sb.append("\" rel=\"stylesheet\"></script>");
+
+		printWriter.println(sb.toString());
+	}
+
+	@Override
+	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
+		dynamicIncludeRegistry.register("/html/common/themes/top_head.jsp#pre");
+	}
+
+	@Activate
+	@Modified
+	protected void activate(
+			BundleContext bundleContext, ComponentContext componentContext,
+			Map<String, Object> properties)
+		throws Exception {
+
+		_bundleContext = bundleContext;
+
+		_lastModified = System.currentTimeMillis();
+
+		_cssFontAwesomeConfiguration = ConfigurableUtil.createConfigurable(
+			CSSFontAwesomeConfiguration.class, properties);
+	}
+
+	@Reference
+	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
+
+	private BundleContext _bundleContext;
+	private volatile CSSFontAwesomeConfiguration _cssFontAwesomeConfiguration;
+	private long _lastModified;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,0 +1,2 @@
+@import 'scss/font-awesome';
+@import 'scss/glyphicons';

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome
+frontend-theme-font-awesome-configuration-name=Font Awesome
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_ar.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_bg.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_ca.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_cs.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_da.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_de.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_el.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_en.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome
+frontend-theme-font-awesome-configuration-name=Font Awesome
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_es.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_et.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_eu.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_fa.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_fi.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_fr.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_gl.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_hi_IN.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_hr.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_hu.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_in.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_it.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_iw.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_ja.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_kk.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_ko.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_lo.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_lt.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_nb.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_nl.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_nl_BE.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_pl.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_pt_BR.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_pt_PT.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_ro.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_ru.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_sk.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_sl.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_sr_RS.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_sv.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_ta_IN.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_th.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_tr.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_uk.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_vi.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_zh_CN.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/resources/content/Language_zh_TW.properties
@@ -1,0 +1,3 @@
+enable-font-awesome=Enable Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-configuration-name=Font Awesome (Automatic Copy)
+frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box (Automatic Copy)

--- a/modules/package.json
+++ b/modules/package.json
@@ -9,7 +9,6 @@
 		"jest-fetch-mock": "2.1.2",
 		"jsdoc": "3.6.3",
 		"karma": "4.0.0",
-		"liferay-font-awesome": "3.4.0",
 		"liferay-frontend-common-css": "1.0.4",
 		"liferay-jest-junit-reporter": "1.0.1",
 		"liferay-karma-alloy-config": "0.0.15",


### PR DESCRIPTION
Hey @brianchandotcom!

This PR does the following:
- Removes Font Awesome from the Classic Theme (it no longer includes it)
- Removes Font Awesome from the Admin Theme (it no longer includes it)
- Adds a module and configuration to add back Font Awesome by default to avoid breaking 7.2.x

**This is backportable, so please backport** :)

I'll send a non-backportable one after this changing the setting to false so we have master ready for our next release.

/cc @john-co, @mwilliams2014