### PR TITLE
LPS-99399 Provide uniform way of instantiating React portlets

### DIFF
--- a/modules/apps/app-builder/app-builder-web/package.json
+++ b/modules/apps/app-builder/app-builder-web/package.json
@@ -13,11 +13,11 @@
 		"@clayui/pagination": "3.0.0-milestone.2",
 		"@clayui/table": "3.0.0-milestone.2",
 		"classnames": "^2.2.6",
+		"frontend-js-react-web": "^2.0.0",
 		"lodash.omit": "^4.5.0",
 		"moment": "^2.24.0",
 		"prop-types": "^15.7.2",
 		"react": "^16.8.6",
-		"react-dom": "^16.8.6",
 		"react-router-dom": "^5.0.1"
 	},
 	"description": "",

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/index.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/index.es.js
@@ -12,21 +12,15 @@
  * details.
  */
 
+import {render} from 'frontend-js-react-web';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import App from './App.es';
 
 export default (id, constants) => {
-	const container = document.getElementById(id);
-
-	ReactDOM.render(
+	render(
 		<div className="app-builder-root">
 			<App {...constants} />
 		</div>,
-		container
-	);
-
-	Liferay.once('destroyPortlet', () =>
-		ReactDOM.unmountComponentAtNode(container)
+		document.getElementById(id)
 	);
 };

--- a/modules/apps/flags/flags-taglib/package.json
+++ b/modules/apps/flags/flags-taglib/package.json
@@ -6,6 +6,7 @@
 		"@clayui/modal": "3.0.0-milestone.2",
 		"clay-button": "2.17.0",
 		"clay-icon": "2.17.0",
+		"frontend-js-react-web": "^2.0.0",
 		"frontend-js-web": "^4.0.0",
 		"metal-soy": "2.16.8",
 		"metal-state": "2.16.8",

--- a/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/react/js/ThemeContext.es.js
+++ b/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/react/js/ThemeContext.es.js
@@ -16,14 +16,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 const ThemeContext = React.createContext({
-	namespace: '',
-	spritemap: ''
+	namespace: ''
 });
 
 ThemeContext.Provider.propTypes = {
 	value: PropTypes.shape({
-		namespace: PropTypes.string,
-		spritemap: PropTypes.string
+		namespace: PropTypes.string
 	})
 };
 

--- a/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/react/js/components/Flags.es.js
+++ b/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/react/js/components/Flags.es.js
@@ -141,7 +141,6 @@ class Flags extends React.PureComponent {
 			signedIn
 		} = this.props;
 		const {isSending, reportDialogOpen, status} = this.state;
-		const {spritemap} = this.context;
 
 		return (
 			<>
@@ -163,7 +162,7 @@ class Flags extends React.PureComponent {
 								: undefined
 						}
 					>
-						<ClayIcon spritemap={spritemap} symbol="flag-empty" />
+						<ClayIcon symbol="flag-empty" />
 					</span>
 					<span className={onlyIcon ? 'sr-only' : undefined}>
 						{message}

--- a/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/react/js/components/FlagsModal.es.js
+++ b/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/react/js/components/FlagsModal.es.js
@@ -203,10 +203,8 @@ const FlagsModal = ({
 	signedIn,
 	status
 }) => {
-	const {spritemap} = useContext(ThemeContext);
-
 	return (
-		<ClayModal onClose={handleClose} size="md" spritemap={spritemap}>
+		<ClayModal onClose={handleClose} size="md">
 			{onClose => (
 				<>
 					<ClayModal.Header>

--- a/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/react/js/index.es.js
+++ b/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/react/js/index.es.js
@@ -12,14 +12,14 @@
  * details.
  */
 
+import {render} from 'frontend-js-react-web';
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 import Flags from './components/Flags.es';
 import ThemeContext from './ThemeContext.es';
 
 export default function reactDomRenderFlags(id, props, context) {
-	ReactDOM.render(
+	render(
 		<ThemeContext.Provider value={context}>
 			<Flags {...props} />
 		</ThemeContext.Provider>,

--- a/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/react/page.jsp
+++ b/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/react/page.jsp
@@ -78,8 +78,7 @@ if (Validator.isNull(message)) {
 			uri: '<%= uri %>'
 		},
 		{
-			namespace: '<%= PortalUtil.getPortletNamespace(PortletKeys.FLAGS) %>',
-			spritemap: Liferay.ThemeDisplay.getPathThemeImages() + '/lexicon/icons.svg'
+			namespace: '<%= PortalUtil.getPortletNamespace(PortletKeys.FLAGS) %>'
 		}
 	);
 </aui:script>

--- a/modules/apps/frontend-js/frontend-js-react-web/.babelrc
+++ b/modules/apps/frontend-js/frontend-js-react-web/.babelrc
@@ -1,0 +1,5 @@
+{
+	"presets": [
+		"@babel/preset-react"
+	]
+}

--- a/modules/apps/frontend-js/frontend-js-react-web/.eslintrc.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/.eslintrc.js
@@ -12,18 +12,6 @@
  * details.
  */
 
-import {render} from 'frontend-js-react-web';
-import React from 'react';
-import SegmentEdit from './components/segment_edit/SegmentEdit.es';
-import ThemeContext from './ThemeContext.es';
-
-export default function(id, props, context) {
-	render(
-		<ThemeContext.Provider value={context}>
-			<div className="segments-root">
-				<SegmentEdit {...props} />
-			</div>
-		</ThemeContext.Provider>,
-		document.getElementById(id)
-	);
-}
+module.exports = {
+	extends: ['liferay/react']
+};

--- a/modules/apps/frontend-js/frontend-js-react-web/.npmbundlerrc
+++ b/modules/apps/frontend-js/frontend-js-react-web/.npmbundlerrc
@@ -1,4 +1,11 @@
 {
+	"config": {
+		"imports": {
+			"frontend-taglib-clay": {
+				"@clayui/icon": ">=3.0.0-milestone.2"
+			}
+		}
+	},
 	"exclude": {
 		"babel-runtime": true,
 		"iconv-lite": true,

--- a/modules/apps/frontend-js/frontend-js-react-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-react-web/package.json
@@ -12,6 +12,7 @@
 		"react-dnd-test-backend": "7.7.0",
 		"react-dnd-test-utils": "7.7.0"
 	},
+	"main": "js/index.es.js",
 	"name": "frontend-js-react-web",
 	"scripts": {
 		"build": "liferay-npm-scripts build",

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.es.js
@@ -12,8 +12,4 @@
  * details.
  */
 
-module.exports = {
-	check: [],
-	fix: [],
-	preset: 'liferay-npm-scripts/src/presets/standard'
-};
+export {default as render} from './render.es';

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import {ClayIconSpriteContext} from '@clayui/icon';
+
+/**
+ * Wrapper for ReactDOM render that automatically:
+ *
+ * - Provides commonly-needed context (for example, the Clay spritemap).
+ * - Unmounts when portlets are destroyed.
+ *
+ * @see https://reactjs.org/docs/react-dom.html#render
+ */
+export default function render(element, container, callback) {
+	const spritemap =
+		Liferay.ThemeDisplay.getPathThemeImages() + '/lexicon/icons.svg';
+
+	// React docs advise not to rely on return value, so we don't propagate it.
+	ReactDOM.render(
+		<ClayIconSpriteContext.Provider value={spritemap}>
+			{element}
+		</ClayIconSpriteContext.Provider>,
+		container,
+		callback
+	);
+
+	Liferay.once('destroyPortlet', () =>
+		ReactDOM.unmountComponentAtNode(container)
+	);
+}

--- a/modules/apps/segments/segments-experiment-web/package.json
+++ b/modules/apps/segments/segments-experiment-web/package.json
@@ -6,9 +6,9 @@
 		"@clayui/icon": "3.0.0-milestone.2",
 		"@clayui/select": "3.0.0-milestone.2",
 		"classnames": "^2.2.6",
+		"frontend-js-react-web": "^2.0.0",
 		"prop-types": "15.7.2",
-		"react": "16.8.6",
-		"react-dom": "16.8.6"
+		"react": "16.8.6"
 	},
 	"jest": {
 		"setupFilesAfterEnv": [

--- a/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/index.es.js
+++ b/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/index.es.js
@@ -12,9 +12,8 @@
  * details.
  */
 
+import {render} from 'frontend-js-react-web';
 import React from 'react';
-import ReactDOM from 'react-dom';
-import {ClayIconSpriteContext} from '@clayui/icon';
 import SegmentsExperimentsUtil from './util/index.es';
 import SegmentsExperimentsSidebar from './components/SegmentsExperimentsSidebar.es';
 import SegmentsExperimentsContext from './context.es';
@@ -32,7 +31,7 @@ export default function segmentsExperimentsApp(id, props, context) {
 		editSegmentsVariantURL
 	} = endpoints;
 
-	ReactDOM.render(
+	render(
 		<SegmentsExperimentsContext.Provider
 			value={{
 				editVariantLayoutURL: editSegmentsVariantLayoutURL,
@@ -51,22 +50,16 @@ export default function segmentsExperimentsApp(id, props, context) {
 				})
 			}}
 		>
-			<ClayIconSpriteContext.Provider value={context.spritemap}>
-				<SegmentsExperimentsSidebar
-					initialGoals={props.segmentsExperimentGoals}
-					initialSegmentsExperiences={props.segmentsExperiences}
-					initialSegmentsExperiment={props.segmentsExperiment}
-					initialSegmentsVariants={props.initialSegmentsVariants}
-					initialSelectedSegmentsExperienceId={
-						props.selectedSegmentsExperienceId
-					}
-				/>
-			</ClayIconSpriteContext.Provider>
+			<SegmentsExperimentsSidebar
+				initialGoals={props.segmentsExperimentGoals}
+				initialSegmentsExperiences={props.segmentsExperiences}
+				initialSegmentsExperiment={props.segmentsExperiment}
+				initialSegmentsVariants={props.initialSegmentsVariants}
+				initialSelectedSegmentsExperienceId={
+					props.selectedSegmentsExperienceId
+				}
+			/>
 		</SegmentsExperimentsContext.Provider>,
 		rootElement
-	);
-
-	Liferay.once('destroyPortlet', () =>
-		ReactDOM.unmountComponentAtNode(rootElement)
 	);
 }

--- a/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/segments_experiment_panel.jsp
+++ b/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/segments_experiment_panel.jsp
@@ -49,8 +49,7 @@ String segmentsExperimentRootId = renderResponse.getNamespace() + "-segments-exp
 				classPK: '<%= themeDisplay.getPlid() %>',
 				classNameId: '<%= PortalUtil.getClassNameId(Layout.class.getName()) %>',
 				type: '<%= layout.getType() %>'
-			},
-			spritemap: '<%= themeDisplay.getPathThemeImages() + "/lexicon/icons.svg" %>'
+			}
 		}
 	);
 </aui:script>

--- a/modules/apps/segments/segments-web/package.json
+++ b/modules/apps/segments/segments-web/package.json
@@ -9,14 +9,14 @@
 		"classnames": "2.2.6",
 		"date-fns": "^1.30.1",
 		"formik": "1.4.3",
+		"frontend-js-react-web": "^2.0.0",
 		"frontend-js-web": "^4.0.0",
 		"metal": "2.16.8",
 		"odata-v4-parser": "^0.1.29",
 		"prop-types": "15.7.2",
 		"react": "16.8.6",
 		"react-dnd": "7.7.0",
-		"react-dnd-html5-backend": "7.7.0",
-		"react-dom": "16.8.6"
+		"react-dnd-html5-backend": "7.7.0"
 	},
 	"description": "",
 	"jest": {

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/edit_segments_entry.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/edit_segments_entry.jsp
@@ -117,8 +117,7 @@ renderResponse.setTitle(editSegmentsEntryDisplayContext.getTitle(locale));
 			{
 				assetsPath: '<%= PortalUtil.getPathContext(request) + "/assets" %>',
 				namespace: '<portlet:namespace />',
-				requestFieldValueNameURL: '<%= getSegmentsFieldValueNameURL %>',
-				spritemap: '<%= themeDisplay.getPathThemeImages() + "/lexicon/icons.svg" %>'
+				requestFieldValueNameURL: '<%= getSegmentsFieldValueNameURL %>'
 			}
 		);
 	</aui:script>

--- a/modules/package.json
+++ b/modules/package.json
@@ -17,7 +17,7 @@
 		"liferay-npm-bridge-generator": "2.12.0",
 		"liferay-npm-bundler": "2.12.0",
 		"liferay-npm-bundler-preset-standard": "2.12.0",
-		"liferay-npm-scripts": "7.1.0",
+		"liferay-npm-scripts": "7.2.0",
 		"liferay-theme-es2015-hook": "8.0.0-rc.2",
 		"metal-jest-serializer": "2.0.0"
 	},

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -11655,10 +11655,10 @@ liferay-npm-bundler-plugin-resolve-linked-dependencies@2.12.0:
     read-json-sync "^2.0.0"
     semver "^5.5.0"
 
-liferay-npm-bundler-preset-liferay-dev@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-liferay-dev/-/liferay-npm-bundler-preset-liferay-dev-1.6.0.tgz#1d80e2f6c5a8e7a2fbf9e282c605c19a00e58cfa"
-  integrity sha512-2Ezh53sdaULtLCvtfe/8Wht5rtGPTEc+PO1bjYSueUwtB1Cu4o2XCaCInFONQnUTcWpBcfqMLPGCuaVWZErWfg==
+liferay-npm-bundler-preset-liferay-dev@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-liferay-dev/-/liferay-npm-bundler-preset-liferay-dev-1.7.0.tgz#0c9f5038a2086ec5534e0bcffee9313769c783a5"
+  integrity sha512-UNnMurKUEI3Z5WZJjCxWhWyB2ic+E2zKWIOyXBLEN5BgYABefWgk7dlBEpOsLe986/l9nVppnd5s8JUGVt8k5A==
   dependencies:
     babel-preset-liferay-standard "2.12.0"
     liferay-npm-bundler-plugin-exclude-imports "2.12.0"
@@ -11703,10 +11703,10 @@ liferay-npm-bundler@2.12.0:
     semver "^5.5.0"
     xml-js "^1.6.8"
 
-liferay-npm-scripts@7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-7.1.0.tgz#d449bd093fa840d858e5a4067796f9ed00e15997"
-  integrity sha512-1HwD9zZ4Uf0qpeIy9Ew+F50z5RuLOVMTC4swC/yRKa8dOxlp7T0LHjKSjQjrtHeYiZ5ShYwWkw3q+eMl+AN7Iw==
+liferay-npm-scripts@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-7.2.0.tgz#2ed6e2857c1ad8565bd2b1daf1c757105c4d6dc8"
+  integrity sha512-lx/SIhMR65+pjcKpoThV6E1ZtA4lGTw6QP8OZUB4Y5XgyJp6K3+QLlt7coHBzcnJCIOjNqwO9Ecj3Co0RebHkQ==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/plugin-proposal-class-properties" "7.4.4"
@@ -11738,7 +11738,7 @@ liferay-npm-scripts@7.1.0:
     liferay-lang-key-dev-loader "^1.0.3"
     liferay-npm-bridge-generator "2.12.0"
     liferay-npm-bundler "2.12.0"
-    liferay-npm-bundler-preset-liferay-dev "1.6.0"
+    liferay-npm-bundler-preset-liferay-dev "1.7.0"
     liferay-theme-tasks "9.4.0"
     metal-tools-soy "4.3.2"
     minimist "^1.2.0"
@@ -15120,7 +15120,7 @@ react-docgen@^4.1.0:
     node-dir "^0.1.10"
     recast "^0.17.3"
 
-react-dom@16.8.6, react-dom@^16.8.3, react-dom@^16.8.6:
+react-dom@16.8.6, react-dom@^16.8.3:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
   integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==


### PR DESCRIPTION
This addresses:

- Memory leaks due to failure to unmount React components when portlets are destroyed.
- Boilerplate code needed by almost every React app that uses Clay (propagating the spritemap via context).

Note that this introduces a circular dependency because frontend-js-react-web now depends on frontend-taglib-clay (for the context), and frontend-taglib-clay obviously depends on React; fortunately, we recently added support for circular deps to the loader.

Next steps: I'll be adding a lint to ensure that people use the new API instead of using `ReactDOM.render`. Beyond that, we can explore providing a taglib to make instantiating React apps from JSP easier.

@brianchandotcom: I previously sent this as [#77216](https://github.com/brianchandotcom/liferay-portal/pull/77216), but it has a SF error that I don't understand:

```
fatal: Not a valid branch point: 'ad5ece730ba8b418252fc4b56d3f8031320d4ae3'.
```

That's the current HEAD of your fork's "master-private" branch. Note that I had to rebase off your fork's current "master" (instead of "liferay" "master") because otherwise it will have a conflict in one of the files this PR touches. "liferay" is currently 134 commits behind though, so if you'd prefer me to resend this tomorrow once the dust has settled, please let me know.