### PR TITLE
LPS-99713 Functional tests: Synonyms entry under new Search Tuning category in Control Panel

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/Elasticsearch6EE.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/Elasticsearch6EE.testcase
@@ -30,9 +30,9 @@ definition {
 
 	test AssertSynonymBulkActions {
 		ProductMenu.gotoPortlet(
-			category = "Configuration",
+			category = "Search Tuning",
 			panel = "Control Panel",
-			portlet = "Search Tuning");
+			portlet = "Synonyms");
 
 		AssertElementNotPresent(locator1 = "Pagination#PAGINATION_BAR");
 
@@ -202,9 +202,9 @@ definition {
 		}
 
 		ProductMenu.gotoPortlet(
-			category = "Configuration",
+			category = "Search Tuning",
 			panel = "Control Panel",
-			portlet = "Search Tuning");
+			portlet = "Synonyms");
 
 		SearchAdministration.addSynonymSet(synonyms = "banana,red apple,blue.berry!,&quot;xigua&quot;,fruit,sweet");
 
@@ -229,9 +229,9 @@ definition {
 		}
 
 		ProductMenu.gotoPortlet(
-			category = "Configuration",
+			category = "Search Tuning",
 			panel = "Control Panel",
-			portlet = "Search Tuning");
+			portlet = "Synonyms");
 
 		SearchAdministration.editSynonymSet(
 			addSynonyms = "pear",
@@ -271,9 +271,9 @@ definition {
 			searchTerm = "red apple");
 
 		ProductMenu.gotoPortlet(
-			category = "Configuration",
+			category = "Search Tuning",
 			panel = "Control Panel",
-			portlet = "Search Tuning");
+			portlet = "Synonyms");
 
 		SearchAdministration.addSynonymSet(synonyms = "red apple,citrus-orange");
 
@@ -296,9 +296,9 @@ definition {
 			searchTerm = "citrus-orange");
 
 		ProductMenu.gotoPortlet(
-			category = "Configuration",
+			category = "Search Tuning",
 			panel = "Control Panel",
-			portlet = "Search Tuning");
+			portlet = "Synonyms");
 
 		SearchAdministration.deleteSynonymSet(synonymSet = "red apple, blue.berry!, &quot;xigua&quot;, fruit, sweet, pear");
 


### PR DESCRIPTION
Resend of https://github.com/brianchandotcom/liferay-portal/pull/77183, matching the resend of  https://github.com/brianchandotcom/liferay-portal-ee/pull/26054, made to address concerns from https://github.com/brianchandotcom/liferay-portal/pull/77183#issuecomment-522831233.

----

**❌ ci:test:search - 21 out of 25 jobs passed in 1 hour 31 minutes 17 seconds 109 ms**
https://github.com/arboliveira/liferay-portal-ee/pull/79#issuecomment-522797401

**This pull contains no unique failures.**

----

This `master` changeset requires the corresponding `master-private` changeset to pass tests.

https://github.com/brianchandotcom/liferay-portal-ee/pull/26076

----

_[Task] Synonyms entry under new Search Tuning category in Control Panel_
https://issues.liferay.com/browse/LPS-99713