### PR TITLE
LPS-100102 Update frontend-js-react-web to react and react-dom v16.9.0

### DIFF
--- a/modules/apps/app-builder/app-builder-web/package.json
+++ b/modules/apps/app-builder/app-builder-web/package.json
@@ -17,7 +17,7 @@
 		"lodash.omit": "^4.5.0",
 		"moment": "^2.24.0",
 		"prop-types": "^15.7.2",
-		"react": "^16.8.6",
+		"react": "16.9.0",
 		"react-router-dom": "^5.0.1"
 	},
 	"description": "",

--- a/modules/apps/flags/flags-taglib/package.json
+++ b/modules/apps/flags/flags-taglib/package.json
@@ -11,8 +11,8 @@
 		"metal-soy": "2.16.8",
 		"metal-state": "2.16.8",
 		"prop-types": "15.7.2",
-		"react": "16.8.6",
-		"react-dom": "16.8.6"
+		"react": "16.9.0",
+		"react-dom": "16.9.0"
 	},
 	"jest": {
 		"setupFilesAfterEnv": [

--- a/modules/apps/frontend-js/frontend-js-react-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-react-web/package.json
@@ -3,10 +3,10 @@
 		"classnames": "2.2.6",
 		"formik": "1.4.3",
 		"prop-types": "15.7.2",
-		"react": "16.8.6",
+		"react": "16.9.0",
 		"react-dnd": "7.7.0",
 		"react-dnd-html5-backend": "7.7.0",
-		"react-dom": "16.8.6"
+		"react-dom": "16.9.0"
 	},
 	"devDependencies": {
 		"react-dnd-test-backend": "7.7.0",

--- a/modules/apps/layout/layout-content-page-editor-web/package.json
+++ b/modules/apps/layout/layout-content-page-editor-web/package.json
@@ -21,8 +21,8 @@
 		"metal-state": "2.16.8",
 		"metal-throttle": "3.0.1",
 		"prop-types": "15.7.2",
-		"react": "16.8.6",
-		"react-dom": "16.8.6"
+		"react": "16.9.0",
+		"react-dom": "16.9.0"
 	},
 	"jest": {
 		"setupFiles": [

--- a/modules/apps/segments/segments-experiment-web/package.json
+++ b/modules/apps/segments/segments-experiment-web/package.json
@@ -8,7 +8,7 @@
 		"classnames": "^2.2.6",
 		"frontend-js-react-web": "^2.0.0",
 		"prop-types": "15.7.2",
-		"react": "16.8.6"
+		"react": "16.9.0"
 	},
 	"jest": {
 		"setupFilesAfterEnv": [

--- a/modules/apps/segments/segments-web/package.json
+++ b/modules/apps/segments/segments-web/package.json
@@ -14,7 +14,7 @@
 		"metal": "2.16.8",
 		"odata-v4-parser": "^0.1.29",
 		"prop-types": "15.7.2",
-		"react": "16.8.6",
+		"react": "16.9.0",
 		"react-dnd": "7.7.0",
 		"react-dnd-html5-backend": "7.7.0"
 	},

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -15120,15 +15120,15 @@ react-docgen@^4.1.0:
     node-dir "^0.1.10"
     recast "^0.17.3"
 
-react-dom@16.8.6, react-dom@^16.8.3:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
-  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
+react-dom@16.9.0, react-dom@^16.8.3:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
+  integrity sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.6"
+    scheduler "^0.15.0"
 
 react-draggable@^3.1.1:
   version "3.3.0"
@@ -15326,15 +15326,14 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react@16.8.6, react@^16.8.3, react@^16.8.6:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
-  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
+react@16.9.0, react@^16.8.3:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
+  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.6"
 
 reactcss@^1.2.0:
   version "1.2.3"
@@ -16128,10 +16127,10 @@ sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.13.6:
-  version "0.13.6"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
-  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+scheduler@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
+  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Full changelog:

https://github.com/facebook/react/releases/tag/v16.9.0

Main motivation here is that:

- Clay [wants to use it](https://github.com/liferay/clay/issues/2255).
- And we need the new version in order to silence console spew during the segments-experiments-web test runs.