### PR TITLE
LPS-96766 Remove unnecessary spread

### DIFF
--- a/modules/.eslintrc.js
+++ b/modules/.eslintrc.js
@@ -28,10 +28,8 @@ try {
 
 config = {
 	...config,
-	...{
-		rules: {
-			'liferay-portal/no-global-fetch': 'off'
-		}
+	rules: {
+		'liferay-portal/no-global-fetch': 'off'
 	}
 };
 


### PR DESCRIPTION
Rather than spreading in an object, we can just add the "rules" property; the effect is exactly the same.