### PR TITLE
LRCI-528 Switch from binaries cache 2017 to 2020 (master)

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -59,7 +59,7 @@
 ##
 
     build.binaries.cache.dir=../${build.binaries.cache.repository.name}
-    build.binaries.cache.repository.name=liferay-binaries-cache-2017
+    build.binaries.cache.repository.name=liferay-binaries-cache-2020
     build.binaries.cache.url=https://github.com/liferay/${build.binaries.cache.repository.name}.git
     build.binaries.gradle.file=gradle-4.10.2.LIFERAY-PATCHED-3-bin.zip
     build.binaries.gradle.url=https://github.com/liferay/${build.binaries.cache.repository.name}/raw/master/${build.binaries.gradle.file}


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-528

Related:
ee-6.1.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/26100
ee-6.1.30: https://github.com/brianchandotcom/liferay-portal-ee/pull/26101
ee-6.2.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/26102
ee-6.2.10: https://github.com/brianchandotcom/liferay-portal-ee/pull/26103
7.0.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/26104
7.1.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/26105
7.2.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/26106