### PR TITLE
LPS-100182 Update to liferay-npm-scripts v8.0.0

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/edit_form_view.jsp
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/edit_form_view.jsp
@@ -36,10 +36,10 @@ String componentId = renderResponse.getNamespace() + "dataLayoutBuilder";
 	/>
 </aui:form>
 
-<aui:script require='<%= npmResolvedPackageName + "/js/pages/form-view/EditFormViewApp.es as App" %>'>
+<aui:script require='<%= npmResolvedPackageName + "/js/pages/form-view/EditFormViewApp.es as EditFormViewApp" %>'>
 	Liferay.componentReady('<%= componentId %>').then(
 		function(dataLayoutBuilder) {
-			App.default(
+			EditFormViewApp.default(
 				'<%= editFormViewRootElementId %>',
 				{
 					dataLayoutBuilder: dataLayoutBuilder

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/AppContext.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/AppContext.es.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import {ClayIconSpriteContext} from '@clayui/icon';
 import React, {createContext} from 'react';
 
 const AppContext = createContext();
@@ -21,13 +20,9 @@ const context = {
 	siteId: Liferay.ThemeDisplay.getCompanyGroupId()
 };
 
-const spritemap = `${Liferay.ThemeDisplay.getPathThemeImages()}/lexicon/icons.svg`;
-
 const AppContextProvider = ({basePortletURL, children}) => (
 	<AppContext.Provider value={{...context, basePortletURL}}>
-		<ClayIconSpriteContext.Provider value={spritemap}>
-			{children}
-		</ClayIconSpriteContext.Provider>
+		{children}
 	</AppContext.Provider>
 );
 

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormViewApp.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormViewApp.es.js
@@ -12,24 +12,16 @@
  * details.
  */
 
+import {render} from 'frontend-js-react-web';
 import React from 'react';
 import {AppContextProvider} from '../../AppContext.es';
 import EditFormView from './EditFormView.es';
-import ReactDOM from 'react-dom';
-
-const App = () => {
-	return (
-		<AppContextProvider>
-			<EditFormView />
-		</AppContextProvider>
-	);
-};
 
 export default id => {
-	const container = document.getElementById(id);
-	ReactDOM.render(<App />, container);
-
-	Liferay.once('destroyPortlet', () =>
-		ReactDOM.unmountComponentAtNode(container)
+	render(
+		<AppContextProvider>
+			<EditFormView />
+		</AppContextProvider>,
+		document.getElementById(id)
 	);
 };

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
@@ -23,13 +23,16 @@ import {ClayIconSpriteContext} from '@clayui/icon';
  * - Provides commonly-needed context (for example, the Clay spritemap).
  * - Unmounts when portlets are destroyed.
  *
+ * The React docs advise not to rely on the render return value, so we
+ * don't propagate it.
+ *
  * @see https://reactjs.org/docs/react-dom.html#render
  */
 export default function render(element, container, callback) {
 	const spritemap =
 		Liferay.ThemeDisplay.getPathThemeImages() + '/lexicon/icons.svg';
 
-	// React docs advise not to rely on return value, so we don't propagate it.
+	// eslint-disable-next-line liferay-portal/no-react-dom-render
 	ReactDOM.render(
 		<ClayIconSpriteContext.Provider value={spritemap}>
 			{element}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/store/ReactComponentAdapter.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/store/ReactComponentAdapter.es.js
@@ -37,6 +37,7 @@ function getConnectedReactComponentAdapter(ReactComponent, templates) {
 		_mountApp() {
 			ReactDOM.unmountComponentAtNode(this.refs.app);
 
+			// eslint-disable-next-line liferay-portal/no-react-dom-render
 			ReactDOM.render(
 				<ClayIconSpriteContext.Provider
 					value={this.store.getState().spritemap}

--- a/modules/package.json
+++ b/modules/package.json
@@ -16,7 +16,7 @@
 		"liferay-npm-bridge-generator": "2.12.0",
 		"liferay-npm-bundler": "2.12.0",
 		"liferay-npm-bundler-preset-standard": "2.12.0",
-		"liferay-npm-scripts": "7.2.0",
+		"liferay-npm-scripts": "8.0.0",
 		"liferay-theme-es2015-hook": "8.0.0-rc.2",
 		"metal-jest-serializer": "2.0.0"
 	},

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -7233,10 +7233,10 @@ escodegen@^1.6.1, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-7.0.0.tgz#f6efd7a6308f0b7bf6fa97339ee480a12f2d4235"
-  integrity sha512-pz0m1Ac8bSvYFIxOfoRS0wrawazLJYs8xxKUvSyCMG/z2mOPLc4fn8MC0lERrnSw1ycbZBZsXDFFXo+FYAolIg==
+eslint-config-liferay@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-8.0.0.tgz#2ee8154684da4548fe3f03d457d22615128640d8"
+  integrity sha512-aA91/hSGFMBvVmcrbjSrUuakhiO6Q/r9JCAKljrlgXdAMThSnNNlqTZ9DoFN6QYKRcbNKis7XTNYLAgg+bcqUg==
   dependencies:
     eslint-config-prettier "5.0.0"
     eslint-plugin-no-for-of-loops "^1.0.0"
@@ -11703,10 +11703,10 @@ liferay-npm-bundler@2.12.0:
     semver "^5.5.0"
     xml-js "^1.6.8"
 
-liferay-npm-scripts@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-7.2.0.tgz#2ed6e2857c1ad8565bd2b1daf1c757105c4d6dc8"
-  integrity sha512-lx/SIhMR65+pjcKpoThV6E1ZtA4lGTw6QP8OZUB4Y5XgyJp6K3+QLlt7coHBzcnJCIOjNqwO9Ecj3Co0RebHkQ==
+liferay-npm-scripts@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-8.0.0.tgz#05c7d0ab51e720c51300f5ca29fac1f990727bd1"
+  integrity sha512-L38c8oO8/YuEBrMD4f4yLhMmSQhLCRgn6/DyJz4ckARHgA0c71yvyhfCXD+VeIydTR6LaJn7ThgWLFXEkKJ2Gg==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/plugin-proposal-class-properties" "7.4.4"
@@ -11730,7 +11730,7 @@ liferay-npm-scripts@7.2.0:
     css-loader "^3.0.0"
     deepmerge "^4.0.0"
     eslint "6.1.0"
-    eslint-config-liferay "^7.0.0"
+    eslint-config-liferay "^8.0.0"
     glob "^7.1.3"
     http-proxy-middleware "^0.19.1"
     jest "^24.5.0"


### PR DESCRIPTION
This adds a new lint that enforces the pattern implemented in LPS-99399: specifically, we should use `render` from "frontend-js-react-web" and not use `ReactDOM.render` directly. It handles the "destroyPortlet" automatically, as well as providing the spritemap that Clay needs.

Rule details are [here](https://github.com/liferay/eslint-config-liferay/blob/master/plugins/eslint-plugin-liferay-portal/docs/rules/no-react-dom-render.md).

cc @brunobasto @brunofarache