### PR TITLE
LPS-100243 Maybe it it better if we use the API name?.

### DIFF
--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManagerImpl.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManagerImpl.java
@@ -253,7 +253,7 @@ public class DLOpenerGoogleDriveManagerImpl
 		return _backgroundTaskManager.addBackgroundTask(
 			userId, CompanyConstants.SYSTEM,
 			StringBundler.concat(
-				DLOpenerGoogleDriveManagerImpl.class.getName(),
+				DLOpenerGoogleDriveManagerImpl.class.getSimpleName(),
 				StringPool.POUND, fileEntry.getFileEntryId()),
 			UploadGoogleDriveDocumentBackgroundTaskExecutor.class.getName(),
 			taskContextMap, new ServiceContext());

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManagerImpl.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManagerImpl.java
@@ -253,7 +253,7 @@ public class DLOpenerGoogleDriveManagerImpl
 		return _backgroundTaskManager.addBackgroundTask(
 			userId, CompanyConstants.SYSTEM,
 			StringBundler.concat(
-				DLOpenerGoogleDriveManagerImpl.class.getSimpleName(),
+				DLOpenerGoogleDriveManager.class.getSimpleName(),
 				StringPool.POUND, fileEntry.getFileEntryId()),
 			UploadGoogleDriveDocumentBackgroundTaskExecutor.class.getName(),
 			taskContextMap, new ServiceContext());


### PR DESCRIPTION
Hey @brianchandotcom!

About DLOpenerGoogleDriveManagerImpl vs. DLOpenerOneDriveManager.java. we are not sure why there is an API, but the DLOpenerOneDriveManager is only used in the WEB module, so we think it was used outside this module in the beginning and it is maintained as a separate API for keeping backward compatibility.

Thanks! 