### PR TITLE
LPS-100342 Build ServiceContext before ThemeDisplay otherwise the pre…

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1906,6 +1906,15 @@ public class ServicePreAction extends Action {
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
+		// Service context
+
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			httpServletRequest);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		// Theme display
+
 		ThemeDisplay themeDisplay = _initThemeDisplay(
 			httpServletRequest, httpServletResponse);
 
@@ -1914,13 +1923,6 @@ public class ServicePreAction extends Action {
 		}
 
 		httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
-
-		// Service context
-
-		ServiceContext serviceContext = ServiceContextFactory.getInstance(
-			httpServletRequest);
-
-		ServiceContextThreadLocal.pushServiceContext(serviceContext);
 
 		// Ajaxable render
 


### PR DESCRIPTION
…viously existing ServiceContext referres to a request originating before friendlyURL forwards providing the wrong parameter map among other things