### PR TITLE
[TECHNICAL SUPPORT] LPS-99386 disable Senna for this form, whose response may redirect to an external domain

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
@@ -86,7 +86,7 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 				%>
 
 				<div class="portlet-forms">
-					<aui:form action="<%= addFormInstanceRecordActionURL %>" data-DDMFormInstanceId="<%= formInstanceId %>" method="post" name="fm">
+					<aui:form action="<%= addFormInstanceRecordActionURL %>" data-DDMFormInstanceId="<%= formInstanceId %>" data-senna-off="true" method="post" name="fm">
 
 						<%
 						String redirectURL = ddmFormDisplayContext.getRedirectURL();


### PR DESCRIPTION
For context, see https://github.com/natocesarrego/liferay-portal/pull/159 and https://issues.liferay.com/browse/PTR-1155.

I talked to Matusalém and due to limitations of how `XMLHttpRequest` works, it's not possible to Senna get the redirect information needed. So we won't be able to redirect properly if we use Senna as it currently is. Matu told me that the Senna team is progressively migrating to `fetch` and abandoning `XMLHttpRequest`, but it's not totally merged and functional yet.

/cc @natocesarrego