### PR TITLE
LPS-100020 call ServicePreAction without initializing permission checker

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -61,7 +61,8 @@ import com.liferay.journal.util.JournalConverter;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.events.EventsProcessorUtil;
+import com.liferay.portal.events.ServicePreAction;
+import com.liferay.portal.events.ThemeServicePreAction;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Sort;
@@ -82,12 +83,10 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
@@ -298,19 +297,9 @@ public class StructuredContentResourceImpl
 		JournalArticle journalArticle = _journalArticleService.getLatestArticle(
 			structuredContentId);
 
-		EventsProcessorUtil.process(
-			PropsKeys.SERVLET_SERVICE_EVENTS_PRE,
-			PropsValues.SERVLET_SERVICE_EVENTS_PRE, contextHttpServletRequest,
-			new DummyHttpServletResponse());
-
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)contextHttpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		themeDisplay.setScopeGroupId(journalArticle.getGroupId());
-		themeDisplay.setSiteGroupId(journalArticle.getGroupId());
-
 		DDMTemplate ddmTemplate = _ddmTemplateService.getTemplate(templateId);
+
+		ThemeDisplay themeDisplay = _getThemeDisplay(journalArticle);
 
 		JournalArticleDisplay journalArticleDisplay =
 			_journalContent.getDisplay(
@@ -717,6 +706,33 @@ public class StructuredContentResourceImpl
 						com.liferay.portal.kernel.search.Field.ARTICLE_ID),
 					WorkflowConstants.STATUS_APPROVED)),
 			sorts);
+	}
+
+	private ThemeDisplay _getThemeDisplay(JournalArticle journalArticle)
+		throws Exception {
+
+		DummyHttpServletResponse dummyHttpServletResponse =
+			new DummyHttpServletResponse();
+
+		ServicePreAction servicePreAction = new ServicePreAction();
+
+		servicePreAction.servicePre(
+			false, contextHttpServletRequest, dummyHttpServletResponse);
+
+		ThemeServicePreAction themeServicePreAction =
+			new ThemeServicePreAction();
+
+		themeServicePreAction.run(
+			contextHttpServletRequest, dummyHttpServletResponse);
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)contextHttpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		themeDisplay.setScopeGroupId(journalArticle.getGroupId());
+		themeDisplay.setSiteGroupId(journalArticle.getGroupId());
+
+		return themeDisplay;
 	}
 
 	private Fields _toFields(

--- a/portal-impl/src/com/liferay/portal/events/packageinfo
+++ b/portal-impl/src/com/liferay/portal/events/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0


### PR DESCRIPTION
Extracting a Logic class without creating a breaking change is messier, because privateLARFile/publicLARFile are protected. Changing them to private breaks version and leaving them like protected means passing them through all the methods (it's used a lot in private methods).