### PR TITLE
LPS-100565 The cache usage change from LPS-100352 is making this poss…

### DIFF
--- a/modules/apps/portal-lock/portal-lock-service/src/main/java/com/liferay/portal/lock/service/impl/LockLocalServiceImpl.java
+++ b/modules/apps/portal-lock/portal-lock-service/src/main/java/com/liferay/portal/lock/service/impl/LockLocalServiceImpl.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 
+import org.hibernate.ObjectNotFoundException;
 import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.exception.LockAcquisitionException;
 
@@ -319,7 +320,8 @@ public class LockLocalServiceImpl extends LockLocalServiceBaseImpl {
 				}
 
 				if (cause instanceof ConstraintViolationException ||
-					cause instanceof LockAcquisitionException) {
+					cause instanceof LockAcquisitionException ||
+					cause instanceof ObjectNotFoundException) {
 
 					continue;
 				}
@@ -434,7 +436,8 @@ public class LockLocalServiceImpl extends LockLocalServiceBaseImpl {
 				}
 
 				if (cause instanceof ConstraintViolationException ||
-					cause instanceof LockAcquisitionException) {
+					cause instanceof LockAcquisitionException ||
+					cause instanceof ObjectNotFoundException) {
 
 					continue;
 				}


### PR DESCRIPTION
…ible. When a lock removal and lock creation is overlapped, due to the transactional cache commiting is not atomic, the creator may see the removed lock from FinderCache, but EntityCache won't be able to load it due it was already removed from DB. The solution is simply going on with another retry which will most likely see fully updated caches.