### PR TITLE
LPS-100756 Updates react render pattern to use new renderFunction

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/index.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/index.es.js
@@ -16,11 +16,14 @@ import {render} from 'frontend-js-react-web';
 import React from 'react';
 import App from './App.es';
 
-export default (id, constants) => {
-	render(
+function renderComponent(constants) {
+	return (
 		<div className="app-builder-root">
 			<App {...constants} />
-		</div>,
-		document.getElementById(id)
+		</div>
 	);
-};
+}
+
+export default function(containerId, data) {
+	render(renderComponent, data, containerId);
+}

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormViewApp.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormViewApp.es.js
@@ -17,11 +17,14 @@ import React from 'react';
 import {AppContextProvider} from '../../AppContext.es';
 import EditFormView from './EditFormView.es';
 
-export default (id, {basePortletURL, ...props}) => {
-	render(
+function renderComponent({basePortletURL, ...props}) {
+	return (
 		<AppContextProvider basePortletURL={basePortletURL}>
 			<EditFormView {...props} />
-		</AppContextProvider>,
-		document.getElementById(id)
+		</AppContextProvider>
 	);
-};
+}
+
+export default function(containerId, data) {
+	render(renderComponent, data, containerId);
+}

--- a/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/react/js/index.es.js
+++ b/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/react/js/index.es.js
@@ -18,11 +18,14 @@ import React from 'react';
 import Flags from './components/Flags.es';
 import ThemeContext from './ThemeContext.es';
 
-export default function reactDomRenderFlags(id, props, context) {
-	render(
+function renderComponent({props, context}) {
+	return (
 		<ThemeContext.Provider value={context}>
 			<Flags {...props} />
-		</ThemeContext.Provider>,
-		document.getElementById(id)
+		</ThemeContext.Provider>
 	);
+}
+
+export default function(containerId, data) {
+	render(renderComponent, data, containerId);
 }

--- a/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/react/page.jsp
+++ b/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/react/page.jsp
@@ -64,21 +64,25 @@ if (Validator.isNull(message)) {
 	new FlagsComponent.default(
 		'<%= id %>',
 		{
-			baseData: <%= dataJSONObject %>,
-			companyName: '<%= companyName %>',
-			disabled: <%= !enabled %>,
-			forceLogin: <%= !flagsEnabled %>,
-			<c:if test="<%= Validator.isNotNull(message) %>">
-				message: '<%= message %>',
-			</c:if>
-			onlyIcon: <%= onlyIcon %>,
-			pathTermsOfUse: Liferay.ThemeDisplay.getPathMain() + '/portal/terms_of_use',
-			reasons: <%= JSONFactoryUtil.looseSerializeDeep(reasons) %>,
-			signedIn: <%= signedIn %>,
-			uri: '<%= uri %>'
-		},
-		{
-			namespace: '<%= PortalUtil.getPortletNamespace(PortletKeys.FLAGS) %>'
+			props: {
+				baseData: <%= dataJSONObject %>,
+				companyName: '<%= companyName %>',
+				disabled: <%= !enabled %>,
+				forceLogin: <%= !flagsEnabled %>,
+
+				<c:if test="<%= Validator.isNotNull(message) %>">
+					message: '<%= message %>',
+				</c:if>
+
+				onlyIcon: <%= onlyIcon %>,
+				pathTermsOfUse: Liferay.ThemeDisplay.getPathMain() + '/portal/terms_of_use',
+				reasons: <%= JSONFactoryUtil.looseSerializeDeep(reasons) %>,
+				signedIn: <%= signedIn %>,
+				uri: '<%= uri %>'
+			},
+			context: {
+				namespace: '<%= PortalUtil.getPortletNamespace(PortletKeys.FLAGS) %>'
+			}
 		}
 	);
 </aui:script>

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
@@ -24,8 +24,8 @@ let counter = 0;
  *
  * - Provides commonly-needed context (for example, the Clay spritemap).
  * - Unmounts when portlets are destroyed based on the received
- * `portletNamespace` value inside renderData. If none is passed, the component
- * will be automatically unmount before the next navigation
+ *   `portletId` value inside renderData. If none is passed, the
+ *   component will be automatically unmounted before the next navigation.
  *
  * The React docs advise not to rely on the render return value, so we
  * don't propagate it.

--- a/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/index.es.js
+++ b/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/index.es.js
@@ -18,9 +18,7 @@ import SegmentsExperimentsUtil from './util/index.es';
 import SegmentsExperimentsSidebar from './components/SegmentsExperimentsSidebar.es';
 import SegmentsExperimentsContext from './context.es';
 
-export default function segmentsExperimentsApp(id, props, context) {
-	const rootElement = document.getElementById(id);
-
+function renderComponent({props, context}) {
 	const {page, endpoints} = context;
 	const {
 		createSegmentsExperimentURL,
@@ -34,7 +32,7 @@ export default function segmentsExperimentsApp(id, props, context) {
 		runSegmentsExperimentURL
 	} = endpoints;
 
-	render(
+	return (
 		<SegmentsExperimentsContext.Provider
 			value={{
 				editVariantLayoutURL: editSegmentsVariantLayoutURL,
@@ -65,7 +63,10 @@ export default function segmentsExperimentsApp(id, props, context) {
 					props.selectedSegmentsExperienceId
 				}
 			/>
-		</SegmentsExperimentsContext.Provider>,
-		rootElement
+		</SegmentsExperimentsContext.Provider>
 	);
+}
+
+export default function(containerId, data) {
+	render(renderComponent, data, containerId);
 }

--- a/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/segments_experiment_panel.jsp
+++ b/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/segments_experiment_panel.jsp
@@ -31,30 +31,32 @@
 			segmentsExperimentsApp.default(
 				'<%= segmentsExperimentRootId %>',
 				{
-					initialSegmentsVariants: <%= segmentsExperimentDisplayContext.getSegmentsExperimentRelsJSONArray(locale) %>,
-					segmentsExperiences: <%= segmentsExperimentDisplayContext.getSegmentsExperiencesJSONArray(locale) %>,
-					segmentsExperiment: <%= segmentsExperimentDisplayContext.getSegmentsExperimentJSONObject(locale) %>,
-					segmentsExperimentGoals: <%= segmentsExperimentDisplayContext.getSegmentsExperimentGoalsJSONArray(locale) %>,
-					selectedSegmentsExperienceId: '<%= segmentsExperimentDisplayContext.getSelectedSegmentsExperienceId() %>'
-				},
-				{
-					contentPageEditorNamespace: '<%= segmentsExperimentDisplayContext.getContentPageEditorPortletNamespace() %>',
-					endpoints: {
-						createSegmentsExperimentURL: '<%= segmentsExperimentDisplayContext.getCreateSegmentsExperimentURL() %>',
-						createSegmentsVariantURL: '<%= segmentsExperimentDisplayContext.getCreateSegmentsVariantURL() %>',
-						deleteSegmentsExperimentURL: '<%= segmentsExperimentDisplayContext.getDeleteSegmentsExperimentURL() %>',
-						deleteSegmentsVariantURL: '<%= segmentsExperimentDisplayContext.getDeleteSegmentsVariantURL() %>',
-						editSegmentsExperimentStatusURL: '<%= segmentsExperimentDisplayContext.getEditSegmentsExperimentStatusURL() %>',
-						editSegmentsExperimentURL: '<%= segmentsExperimentDisplayContext.getEditSegmentsExperimentURL() %>',
-						editSegmentsVariantLayoutURL: '<%= segmentsExperimentDisplayContext.getEditSegmentsVariantLayoutURL() %>',
-						editSegmentsVariantURL: '<%= segmentsExperimentDisplayContext.getEditSegmentsVariantURL() %>',
-						runSegmentsExperimentURL: '<%= segmentsExperimentDisplayContext.getRunSegmentsExperimenttURL() %>'
-			},
-					namespace: '<portlet:namespace />',
-					page: {
-						classPK: '<%= themeDisplay.getPlid() %>',
-						classNameId: '<%= PortalUtil.getClassNameId(Layout.class.getName()) %>',
-						type: '<%= layout.getType() %>'
+					props: {
+						initialSegmentsVariants: <%= segmentsExperimentDisplayContext.getSegmentsExperimentRelsJSONArray(locale) %>,
+						segmentsExperiences: <%= segmentsExperimentDisplayContext.getSegmentsExperiencesJSONArray(locale) %>,
+						segmentsExperiment: <%= segmentsExperimentDisplayContext.getSegmentsExperimentJSONObject(locale) %>,
+						segmentsExperimentGoals: <%= segmentsExperimentDisplayContext.getSegmentsExperimentGoalsJSONArray(locale) %>,
+						selectedSegmentsExperienceId: '<%= segmentsExperimentDisplayContext.getSelectedSegmentsExperienceId() %>'
+					},
+					context: {
+						contentPageEditorNamespace: '<%= segmentsExperimentDisplayContext.getContentPageEditorPortletNamespace() %>',
+						endpoints: {
+							createSegmentsExperimentURL: '<%= segmentsExperimentDisplayContext.getCreateSegmentsExperimentURL() %>',
+							createSegmentsVariantURL: '<%= segmentsExperimentDisplayContext.getCreateSegmentsVariantURL() %>',
+							deleteSegmentsExperimentURL: '<%= segmentsExperimentDisplayContext.getDeleteSegmentsExperimentURL() %>',
+							deleteSegmentsVariantURL: '<%= segmentsExperimentDisplayContext.getDeleteSegmentsVariantURL() %>',
+							editSegmentsExperimentStatusURL: '<%= segmentsExperimentDisplayContext.getEditSegmentsExperimentStatusURL() %>',
+							editSegmentsExperimentURL: '<%= segmentsExperimentDisplayContext.getEditSegmentsExperimentURL() %>',
+							editSegmentsVariantLayoutURL: '<%= segmentsExperimentDisplayContext.getEditSegmentsVariantLayoutURL() %>',
+							editSegmentsVariantURL: '<%= segmentsExperimentDisplayContext.getEditSegmentsVariantURL() %>',
+							runSegmentsExperimentURL: '<%= segmentsExperimentDisplayContext.getRunSegmentsExperimenttURL() %>'
+						},
+						namespace: '<portlet:namespace />',
+						page: {
+							classPK: '<%= themeDisplay.getPlid() %>',
+							classNameId: '<%= PortalUtil.getClassNameId(Layout.class.getName()) %>',
+							type: '<%= layout.getType() %>'
+						}
 					}
 				}
 			);

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/edit_segments_entry.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/edit_segments_entry.jsp
@@ -83,41 +83,43 @@ renderResponse.setTitle(editSegmentsEntryDisplayContext.getTitle(locale));
 		SegmentEdit.default(
 			'<%= segmentEditRootElementId %>',
 			{
-				availableLocales: availableLocales,
-				contributors: <%= editSegmentsEntryDisplayContext.getContributorsJSONArray() %>,
-				defaultLanguageId: '<%= editSegmentsEntryDisplayContext.getDefaultLanguageId() %>',
-				formId: '<portlet:namespace />editSegmentFm',
-				hasUpdatePermission: <%= editSegmentsEntryDisplayContext.hasUpdatePermission() %>,
-				initialMembersCount: <%= editSegmentsEntryDisplayContext.getSegmentsEntryClassPKsCount() %>,
-				initialSegmentActive: <%= (segmentsEntry == null) ? false : segmentsEntry.isActive() %>,
+				context: {
+					assetsPath: '<%= PortalUtil.getPathContext(request) + "/assets" %>',
+					namespace: '<portlet:namespace />',
+					requestFieldValueNameURL: '<%= getSegmentsFieldValueNameURL %>'
+				},
+				props: {
+					availableLocales: availableLocales,
+					contributors: <%= editSegmentsEntryDisplayContext.getContributorsJSONArray() %>,
+					defaultLanguageId: '<%= editSegmentsEntryDisplayContext.getDefaultLanguageId() %>',
+					formId: '<portlet:namespace />editSegmentFm',
+					hasUpdatePermission: <%= editSegmentsEntryDisplayContext.hasUpdatePermission() %>,
+					initialMembersCount: <%= editSegmentsEntryDisplayContext.getSegmentsEntryClassPKsCount() %>,
+					initialSegmentActive: <%= (segmentsEntry == null) ? false : segmentsEntry.isActive() %>,
 
-				<c:choose>
-					<c:when test="<%= segmentsEntry != null %>">
+					<c:choose>
+						<c:when test="<%= segmentsEntry != null %>">
 
-						<%
-						JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
-						%>
+							<%
+							JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
+							%>
 
-						initialSegmentName: <%= JSONFactoryUtil.createJSONObject(jsonSerializer.serializeDeep(segmentsEntry.getNameMap())) %>,
-					</c:when>
-					<c:otherwise>
-						initialSegmentName: null,
-					</c:otherwise>
-				</c:choose>
+							initialSegmentName: <%= JSONFactoryUtil.createJSONObject(jsonSerializer.serializeDeep(segmentsEntry.getNameMap())) %>,
+						</c:when>
+						<c:otherwise>
+							initialSegmentName: null,
+						</c:otherwise>
+					</c:choose>
 
-				locale: '<%= locale %>',
-				portletNamespace: '<portlet:namespace />',
-				previewMembersURL: '<%= previewMembersURL %>',
-				propertyGroups: <%= editSegmentsEntryDisplayContext.getPropertyGroupsJSONArray(locale) %>,
-				redirect: '<%= HtmlUtil.escape(redirect) %>',
-				requestMembersCountURL: '<%= getSegmentsEntryClassPKsCountURL %>',
-				showInEditMode: <%= editSegmentsEntryDisplayContext.isShowInEditMode() %>,
-				source: '<%= editSegmentsEntryDisplayContext.getSource() %>'
-			},
-			{
-				assetsPath: '<%= PortalUtil.getPathContext(request) + "/assets" %>',
-				namespace: '<portlet:namespace />',
-				requestFieldValueNameURL: '<%= getSegmentsFieldValueNameURL %>'
+					locale: '<%= locale %>',
+					portletNamespace: '<portlet:namespace />',
+					previewMembersURL: '<%= previewMembersURL %>',
+					propertyGroups: <%= editSegmentsEntryDisplayContext.getPropertyGroupsJSONArray(locale) %>,
+					redirect: '<%= HtmlUtil.escape(redirect) %>',
+					requestMembersCountURL: '<%= getSegmentsEntryClassPKsCountURL %>',
+					showInEditMode: <%= editSegmentsEntryDisplayContext.isShowInEditMode() %>,
+					source: '<%= editSegmentsEntryDisplayContext.getSource() %>',
+				}
 			}
 		);
 	</aui:script>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/edit_segments_entry.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/edit_segments_entry.jsp
@@ -118,7 +118,7 @@ renderResponse.setTitle(editSegmentsEntryDisplayContext.getTitle(locale));
 					redirect: '<%= HtmlUtil.escape(redirect) %>',
 					requestMembersCountURL: '<%= getSegmentsEntryClassPKsCountURL %>',
 					showInEditMode: <%= editSegmentsEntryDisplayContext.isShowInEditMode() %>,
-					source: '<%= editSegmentsEntryDisplayContext.getSource() %>',
+					source: '<%= editSegmentsEntryDisplayContext.getSource() %>'
 				}
 			}
 		);

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/index.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/index.es.js
@@ -17,13 +17,16 @@ import React from 'react';
 import SegmentEdit from './components/segment_edit/SegmentEdit.es';
 import ThemeContext from './ThemeContext.es';
 
-export default function(id, props, context) {
-	render(
+function renderComponent({props, context}) {
+	return (
 		<ThemeContext.Provider value={context}>
 			<div className="segments-root">
 				<SegmentEdit {...props} />
 			</div>
-		</ThemeContext.Provider>,
-		document.getElementById(id)
+		</ThemeContext.Provider>
 	);
+}
+
+export default function(containerId, data) {
+	render(renderComponent, data, containerId);
 }


### PR DESCRIPTION
Replacement for: #77735

This is an intermediate step towards wrapping up existing React set-up in JSP files inside a `<react:component />` tag. This is why you see changes like the following in this PR:

Before:

```javascript
export default function(id, props) {
  render(
    <Component {...props} />,
    document.getElementById(id)
  );
}
```

Intermediate (this PR):

```javascript
function renderComponent(props) {
  return <Component {...props} />;
}

export default function(id, data) {
  render(renderComponent, data, id);
}
```

Which looks like an unnecessary layer of indirection, but the eventual end state will be that people use `<react:component />` in their JSP, and these JS files will simplify as follows:

```javascript
export default function(props) {
  return <Component {...props} />;
}
```

ie. `renderComponent` will become the new default export, and the old default export will be deleted.

cc: @epgarcia, @andresfulla, @adolfopa, @boton, @brunofarache, @brunobasto

Also, @arboliveira, @thektan, note that this change will break portal-search-tuning-rankings-web until the corresponding master-private PR goes in: thektan/liferay-portal-ee#34

Reviewed here: wincent#59

/cc @wincent, rebased from https://github.com/brianchandotcom/liferay-portal/pull/77741