### PR TITLE
Lps 100865

### DIFF
--- a/modules/apps/app-builder/app-builder-rest-impl/src/main/java/com/liferay/app/builder/rest/internal/odata/entity/v1_0/AppBuilderAppEntityModel.java
+++ b/modules/apps/app-builder/app-builder-rest-impl/src/main/java/com/liferay/app/builder/rest/internal/odata/entity/v1_0/AppBuilderAppEntityModel.java
@@ -22,9 +22,6 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Gabriel Albuquerque
@@ -32,7 +29,7 @@ import java.util.stream.Stream;
 public class AppBuilderAppEntityModel implements EntityModel {
 
 	public AppBuilderAppEntityModel() {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new DateTimeEntityField(
 				"dateCreated",
 				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
@@ -44,10 +41,8 @@ public class AppBuilderAppEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(LocaleUtil.toLanguageId(locale))))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+					"localized_name_".concat(
+						LocaleUtil.toLanguageId(locale)))));
 	}
 
 	@Override

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/odata/entity/v1_0/CollectionEntityModel.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/odata/entity/v1_0/CollectionEntityModel.java
@@ -21,9 +21,6 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Javier Gamarra
@@ -31,7 +28,7 @@ import java.util.stream.Stream;
 public class CollectionEntityModel implements EntityModel {
 
 	public CollectionEntityModel() {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new DateTimeEntityField(
 				"dateCreated", locale -> Field.CREATE_DATE,
 				locale -> Field.CREATE_DATE),
@@ -40,10 +37,7 @@ public class CollectionEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new DateTimeEntityField(
 				"dateStatus", locale -> "statusDate", locale -> "statusDate"),
-			new StringEntityField("name", locale -> Field.NAME)
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+			new StringEntityField("name", locale -> Field.NAME));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v1_0/DataDefinitionEntityModel.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v1_0/DataDefinitionEntityModel.java
@@ -22,9 +22,6 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Gabriel Albuquerque
@@ -32,7 +29,7 @@ import java.util.stream.Stream;
 public class DataDefinitionEntityModel implements EntityModel {
 
 	public DataDefinitionEntityModel() {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new DateTimeEntityField(
 				"dateCreated",
 				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
@@ -44,10 +41,8 @@ public class DataDefinitionEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(LocaleUtil.toLanguageId(locale))))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+					"localized_name_".concat(
+						LocaleUtil.toLanguageId(locale)))));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v1_0/DataLayoutEntityModel.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v1_0/DataLayoutEntityModel.java
@@ -22,9 +22,6 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Gabriel Albuquerque
@@ -32,7 +29,7 @@ import java.util.stream.Stream;
 public class DataLayoutEntityModel implements EntityModel {
 
 	public DataLayoutEntityModel() {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new DateTimeEntityField(
 				"dateCreated",
 				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
@@ -44,10 +41,8 @@ public class DataLayoutEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(LocaleUtil.toLanguageId(locale))))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+					"localized_name_".concat(
+						LocaleUtil.toLanguageId(locale)))));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v1_0/DataListViewEntityModel.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v1_0/DataListViewEntityModel.java
@@ -22,9 +22,6 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Jeyvison Nascimento
@@ -32,7 +29,7 @@ import java.util.stream.Stream;
 public class DataListViewEntityModel implements EntityModel {
 
 	public DataListViewEntityModel() {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new DateTimeEntityField(
 				"dateCreated",
 				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
@@ -44,10 +41,8 @@ public class DataListViewEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(LocaleUtil.toLanguageId(locale))))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+					"localized_name_".concat(
+						LocaleUtil.toLanguageId(locale)))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/CategoryEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/CategoryEntityModel.java
@@ -22,9 +22,6 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Sarai Díaz
@@ -32,7 +29,7 @@ import java.util.stream.Stream;
 public class CategoryEntityModel implements EntityModel {
 
 	public CategoryEntityModel() {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new DateTimeEntityField(
 				"dateCreated",
 				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
@@ -44,10 +41,7 @@ public class CategoryEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_title_" + LocaleUtil.toLanguageId(locale)))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+					"localized_title_" + LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/KeywordEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/KeywordEntityModel.java
@@ -23,9 +23,6 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Cristina González
@@ -33,7 +30,7 @@ import java.util.stream.Stream;
 public class KeywordEntityModel implements EntityModel {
 
 	public KeywordEntityModel() {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new DateTimeEntityField(
 				"dateCreated",
 				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
@@ -46,10 +43,7 @@ public class KeywordEntityModel implements EntityModel {
 				Field.NAME,
 				locale -> Field.getSortableFieldName(
 					StringBundler.concat(
-						Field.NAME, StringPool.UNDERLINE, "String")))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+						Field.NAME, StringPool.UNDERLINE, "String"))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/VocabularyEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/VocabularyEntityModel.java
@@ -22,9 +22,6 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Víctor Galán
@@ -32,7 +29,7 @@ import java.util.stream.Stream;
 public class VocabularyEntityModel implements EntityModel {
 
 	public VocabularyEntityModel() {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new DateTimeEntityField(
 				"dateCreated",
 				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
@@ -44,10 +41,7 @@ public class VocabularyEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_title_" + LocaleUtil.toLanguageId(locale)))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+					"localized_title_" + LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/OrganizationEntityModel.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/OrganizationEntityModel.java
@@ -23,9 +23,6 @@ import com.liferay.portal.odata.entity.IdEntityField;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Javier Gamarra
@@ -33,7 +30,7 @@ import java.util.stream.Stream;
 public class OrganizationEntityModel implements EntityModel {
 
 	public OrganizationEntityModel() {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new CollectionEntityField(
 				new StringEntityField(
 					"keywords", locale -> "assetTagNames.raw")),
@@ -45,10 +42,7 @@ public class OrganizationEntityModel implements EntityModel {
 				"parentOrganizationId", locale -> "parentOrganizationId",
 				String::valueOf),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.NAME))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+				"name", locale -> Field.getSortableFieldName(Field.NAME)));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/UserAccountEntityModel.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/UserAccountEntityModel.java
@@ -23,9 +23,6 @@ import com.liferay.portal.odata.entity.IdEntityField;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Javier Gamarra
@@ -33,7 +30,7 @@ import java.util.stream.Stream;
 public class UserAccountEntityModel implements EntityModel {
 
 	public UserAccountEntityModel() {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new CollectionEntityField(
 				new StringEntityField(
 					"keywords", locale -> "assetTagNames.raw")),
@@ -57,10 +54,7 @@ public class UserAccountEntityModel implements EntityModel {
 			new StringEntityField(
 				"givenName", locale -> Field.getSortableFieldName("firstName")),
 			new StringEntityField(
-				"jobTitle", locale -> Field.getSortableFieldName("jobTitle"))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+				"jobTitle", locale -> Field.getSortableFieldName("jobTitle")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-common-spi/src/main/java/com/liferay/headless/common/spi/odata/entity/CommentEntityModel.java
+++ b/modules/apps/headless/headless-common-spi/src/main/java/com/liferay/headless/common/spi/odata/entity/CommentEntityModel.java
@@ -21,9 +21,6 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.IntegerEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Víctor Galán
@@ -31,7 +28,7 @@ import java.util.stream.Stream;
 public class CommentEntityModel implements EntityModel {
 
 	public CommentEntityModel() {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new DateTimeEntityField(
 				"dateCreated",
 				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
@@ -40,10 +37,7 @@ public class CommentEntityModel implements EntityModel {
 				"dateModified",
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE),
-			new IntegerEntityField("creatorId", locale -> Field.USER_ID)
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+			new IntegerEntityField("creatorId", locale -> Field.USER_ID));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingEntityModel.java
@@ -25,9 +25,6 @@ import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Cristina González
@@ -35,7 +32,7 @@ import java.util.stream.Stream;
 public class BlogPostingEntityModel implements EntityModel {
 
 	public BlogPostingEntityModel(List<EntityField> entityFields) {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new CollectionEntityField(
 				new IntegerEntityField(
 					"taxonomyCategoryIds", locale -> "assetCategoryIds")),
@@ -53,10 +50,7 @@ public class BlogPostingEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("creatorId", locale -> Field.USER_ID),
 			new StringEntityField(
-				"headline", locale -> Field.getSortableFieldName(Field.TITLE))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+				"headline", locale -> Field.getSortableFieldName(Field.TITLE)));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingImageEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingImageEntityModel.java
@@ -25,9 +25,6 @@ import com.liferay.portal.odata.entity.IntegerEntityField;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Sarai Díaz
@@ -35,7 +32,7 @@ import java.util.stream.Stream;
 public class BlogPostingImageEntityModel implements EntityModel {
 
 	public BlogPostingImageEntityModel() {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new IdEntityField(
 				"encodingFormat",
 				locale -> Field.getSortableFieldName(
@@ -57,10 +54,8 @@ public class BlogPostingImageEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+					"localized_title_".concat(
+						LocaleUtil.toLanguageId(locale)))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentStructureEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentStructureEntityModel.java
@@ -22,9 +22,6 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Víctor Galán
@@ -32,7 +29,7 @@ import java.util.stream.Stream;
 public class ContentStructureEntityModel implements EntityModel {
 
 	public ContentStructureEntityModel() {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new DateTimeEntityField(
 				"dateCreated",
 				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
@@ -44,10 +41,8 @@ public class ContentStructureEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(LocaleUtil.toLanguageId(locale))))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+					"localized_name_".concat(
+						LocaleUtil.toLanguageId(locale)))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/DocumentEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/DocumentEntityModel.java
@@ -29,9 +29,6 @@ import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Sarai Díaz
@@ -39,7 +36,7 @@ import java.util.stream.Stream;
 public class DocumentEntityModel implements EntityModel {
 
 	public DocumentEntityModel(List<EntityField> entityFields) {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new CollectionEntityField(
 				new IntegerEntityField(
 					"taxonomyCategoryIds", locale -> "assetCategoryIds")),
@@ -77,10 +74,8 @@ public class DocumentEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+					"localized_title_".concat(
+						LocaleUtil.toLanguageId(locale)))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/DocumentFolderEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/DocumentFolderEntityModel.java
@@ -24,9 +24,6 @@ import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Sarai Díaz
@@ -34,7 +31,7 @@ import java.util.stream.Stream;
 public class DocumentFolderEntityModel implements EntityModel {
 
 	public DocumentFolderEntityModel(List<EntityField> entityFields) {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new ComplexEntityField("customFields", entityFields),
 			new DateTimeEntityField(
 				"dateCreated",
@@ -46,10 +43,7 @@ public class DocumentFolderEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("creatorId", locale -> Field.USER_ID),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.TITLE))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+				"name", locale -> Field.getSortableFieldName(Field.TITLE)));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/KnowledgeBaseArticleEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/KnowledgeBaseArticleEntityModel.java
@@ -26,9 +26,6 @@ import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Javier Gamarra
@@ -36,7 +33,7 @@ import java.util.stream.Stream;
 public class KnowledgeBaseArticleEntityModel implements EntityModel {
 
 	public KnowledgeBaseArticleEntityModel(List<EntityField> entityFields) {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new CollectionEntityField(
 				new IntegerEntityField(
 					"taxonomyCategoryIds", locale -> "assetCategoryIds")),
@@ -55,10 +52,8 @@ public class KnowledgeBaseArticleEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+					"localized_title_".concat(
+						LocaleUtil.toLanguageId(locale)))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/MessageBoardMessageEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/MessageBoardMessageEntityModel.java
@@ -25,9 +25,6 @@ import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Javier Gamarra
@@ -35,7 +32,7 @@ import java.util.stream.Stream;
 public class MessageBoardMessageEntityModel implements EntityModel {
 
 	public MessageBoardMessageEntityModel(List<EntityField> entityFields) {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new ComplexEntityField("customFields", entityFields),
 			new DateTimeEntityField(
 				"dateCreated",
@@ -51,10 +48,8 @@ public class MessageBoardMessageEntityModel implements EntityModel {
 			new StringEntityField(
 				"headline",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+					"localized_title_".concat(
+						LocaleUtil.toLanguageId(locale)))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/MessageBoardSectionEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/MessageBoardSectionEntityModel.java
@@ -24,9 +24,6 @@ import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Javier Gamarra
@@ -34,7 +31,7 @@ import java.util.stream.Stream;
 public class MessageBoardSectionEntityModel implements EntityModel {
 
 	public MessageBoardSectionEntityModel(List<EntityField> entityFields) {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new ComplexEntityField("customFields", entityFields),
 			new DateTimeEntityField(
 				"dateCreated",
@@ -46,10 +43,7 @@ public class MessageBoardSectionEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("creatorId", locale -> Field.USER_ID),
 			new StringEntityField(
-				"title", locale -> Field.getSortableFieldName(Field.NAME))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+				"title", locale -> Field.getSortableFieldName(Field.NAME)));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentEntityModel.java
@@ -26,9 +26,6 @@ import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Julio Camarero
@@ -40,7 +37,7 @@ public class StructuredContentEntityModel implements EntityModel {
 	public StructuredContentEntityModel(
 		List<EntityField> entityFields, List<EntityField> customEntityFields) {
 
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new CollectionEntityField(
 				new IntegerEntityField(
 					"taxonomyCategoryIds", locale -> "assetCategoryIds")),
@@ -67,10 +64,8 @@ public class StructuredContentEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+					"localized_title_".concat(
+						LocaleUtil.toLanguageId(locale)))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentFolderEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentFolderEntityModel.java
@@ -25,9 +25,6 @@ import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Víctor Galán
@@ -35,7 +32,7 @@ import java.util.stream.Stream;
 public class StructuredContentFolderEntityModel implements EntityModel {
 
 	public StructuredContentFolderEntityModel(List<EntityField> entityFields) {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new ComplexEntityField("customFields", entityFields),
 			new DateTimeEntityField(
 				"dateCreated",
@@ -49,10 +46,8 @@ public class StructuredContentFolderEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+					"localized_title_".concat(
+						LocaleUtil.toLanguageId(locale)))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/WikiNodeEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/WikiNodeEntityModel.java
@@ -22,9 +22,6 @@ import com.liferay.portal.odata.entity.IntegerEntityField;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Javier Gamarra
@@ -32,7 +29,7 @@ import java.util.stream.Stream;
 public class WikiNodeEntityModel implements EntityModel {
 
 	public WikiNodeEntityModel() {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new DateTimeEntityField(
 				"dateCreated",
 				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
@@ -43,10 +40,7 @@ public class WikiNodeEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("creatorId", locale -> Field.USER_ID),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.TITLE))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+				"name", locale -> Field.getSortableFieldName(Field.TITLE)));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/WikiPageEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/WikiPageEntityModel.java
@@ -24,9 +24,6 @@ import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Cristina González
@@ -34,7 +31,7 @@ import java.util.stream.Stream;
 public class WikiPageEntityModel implements EntityModel {
 
 	public WikiPageEntityModel(List<EntityField> entityFields) {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new ComplexEntityField("customFields", entityFields),
 			new DateTimeEntityField(
 				"dateCreated",
@@ -47,10 +44,8 @@ public class WikiPageEntityModel implements EntityModel {
 			new StringEntityField(
 				"headline",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))))
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+					"localized_title_".concat(
+						LocaleUtil.toLanguageId(locale)))));
 	}
 
 	@Override

--- a/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/scope/SAPEntryScopeDescriptorFinderRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/service/access/policy/scope/SAPEntryScopeDescriptorFinderRegistrator.java
@@ -35,8 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -183,18 +181,19 @@ public class SAPEntryScopeDescriptorFinderRegistrator {
 	}
 
 	protected List<SAPEntryScope> loadSAPEntryScopes(long companyId) {
-		List<SAPEntry> sapEntries = _sapEntryLocalService.getCompanySAPEntries(
-			companyId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+		List<SAPEntryScope> sapEntryScopes = new ArrayList<>();
 
-		Stream<SAPEntry> stream = sapEntries.stream();
+		for (SAPEntry sapEntry :
+				_sapEntryLocalService.getCompanySAPEntries(
+					companyId, QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
 
-		return stream.filter(
-			this::isOAuth2ExportedSAPEntry
-		).map(
-			sapEntry -> new SAPEntryScope(sapEntry, _parseScope(sapEntry))
-		).collect(
-			Collectors.toList()
-		);
+			if (isOAuth2ExportedSAPEntry(sapEntry)) {
+				sapEntryScopes.add(
+					new SAPEntryScope(sapEntry, _parseScope(sapEntry)));
+			}
+		}
+
+		return sapEntryScopes;
 	}
 
 	protected void removeJaxRsApplicationName(

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/spi/prefix/handler/PrefixHandlerFactoryImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/spi/prefix/handler/PrefixHandlerFactoryImpl.java
@@ -30,15 +30,12 @@ import java.io.IOException;
 import java.io.StringReader;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -116,14 +113,17 @@ public class PrefixHandlerFactoryImpl implements PrefixHandlerFactory {
 
 		_delimiter = bundlePrefixHandlerFactoryConfiguration.delimiter();
 
-		Stream<String> stream = Arrays.stream(
-			bundlePrefixHandlerFactoryConfiguration.excludedScopes());
+		List<String> excludedInputs = new ArrayList<>();
 
-		_excludedInputs = stream.filter(
-			e -> !Validator.isBlank(e)
-		).collect(
-			Collectors.toList()
-		);
+		for (String excludedScope :
+				bundlePrefixHandlerFactoryConfiguration.excludedScopes()) {
+
+			if (!Validator.isBlank(excludedScope)) {
+				excludedInputs.add(excludedScope);
+			}
+		}
+
+		_excludedInputs = excludedInputs;
 
 		_includeBundleSymbolicName =
 			bundlePrefixHandlerFactoryConfiguration.includeBundleSymbolicName();

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudPortalInstanceLifecycleListener.java
@@ -67,14 +67,11 @@ import com.liferay.portal.security.service.access.policy.service.SAPEntryLocalSe
 import java.io.InputStream;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -106,14 +103,13 @@ public class AnalyticsCloudPortalInstanceLifecycleListener
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		Stream<String[]> stream = Arrays.stream(_SAP_ENTRY_OBJECT_ARRAYS);
+		_scopeAliasesList = new ArrayList<>(_SAP_ENTRY_OBJECT_ARRAYS.length);
 
-		_scopeAliasesList = stream.map(
-			sapEntryObjectArray -> StringUtil.replaceFirst(
-				sapEntryObjectArray[0], "OAUTH2_", StringPool.BLANK)
-		).collect(
-			Collectors.toList()
-		);
+		for (String[] sapEntryObjectArray : _SAP_ENTRY_OBJECT_ARRAYS) {
+			_scopeAliasesList.add(
+				StringUtil.replaceFirst(
+					sapEntryObjectArray[0], "OAUTH2_", StringPool.BLANK));
+		}
 
 		Dictionary<String, Object> properties = new HashMapDictionary<>();
 

--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/ComplexEntityField.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/ComplexEntityField.java
@@ -16,12 +16,10 @@ package com.liferay.portal.odata.entity;
 
 import com.liferay.petra.string.StringBundler;
 
-import java.util.AbstractMap;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Models an complex entity field. A Entity field with a {@code
@@ -49,15 +47,11 @@ public class ComplexEntityField extends EntityField {
 			_entityFieldsMap = Collections.emptyMap();
 		}
 		else {
-			Stream<EntityField> stream = entityFields.stream();
+			_entityFieldsMap = new HashMap<>();
 
-			_entityFieldsMap = stream.map(
-				entityField -> new AbstractMap.SimpleEntry<>(
-					entityField.getName(), entityField)
-			).collect(
-				Collectors.toMap(
-					entry -> entry.getKey(), entry -> entry.getValue())
-			);
+			for (EntityField entityField : entityFields) {
+				_entityFieldsMap.put(entityField.getName(), entityField);
+			}
 		}
 	}
 

--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/EntityModel.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/EntityModel.java
@@ -16,6 +16,7 @@ package com.liferay.portal.odata.entity;
 
 import com.liferay.petra.string.CharPool;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -25,6 +26,18 @@ import java.util.Map;
  * @review
  */
 public interface EntityModel {
+
+	public static Map<String, EntityField> toEntityFieldsMap(
+		EntityField... entityFields) {
+
+		Map<String, EntityField> entityFieldsMap = new HashMap<>();
+
+		for (EntityField entityField : entityFields) {
+			entityFieldsMap.put(entityField.getName(), entityField);
+		}
+
+		return entityFieldsMap;
+	}
 
 	/**
 	 * Returns a Map with all the entity fields used to create the EDM.

--- a/modules/apps/portal-odata/portal-odata-api/src/main/resources/com/liferay/portal/odata/entity/packageinfo
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/resources/com/liferay/portal/odata/entity/packageinfo
@@ -1,1 +1,1 @@
-version 1.8.0
+version 1.9.0

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/EmbeddedElasticsearchPluginManager.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/EmbeddedElasticsearchPluginManager.java
@@ -25,8 +25,6 @@ import java.nio.file.Path;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Stream;
 
 import org.elasticsearch.Version;
 
@@ -66,13 +64,13 @@ public class EmbeddedElasticsearchPluginManager {
 		PluginManager pluginManager =
 			_pluginManagerFactory.createPluginManager();
 
-		Optional<Path> pathOptional = getInstalledPluginPath(pluginManager);
+		Path path = getInstalledPluginPath(pluginManager);
 
-		if (!pathOptional.isPresent()) {
+		if (path == null) {
 			return;
 		}
 
-		if (pluginManager.isCurrentVersion(pathOptional.get())) {
+		if (pluginManager.isCurrentVersion(path)) {
 			return;
 		}
 
@@ -104,14 +102,16 @@ public class EmbeddedElasticsearchPluginManager {
 		}
 	}
 
-	protected Optional<Path> getInstalledPluginPath(PluginManager pluginManager)
+	protected Path getInstalledPluginPath(PluginManager pluginManager)
 		throws IOException {
 
-		return Stream.of(
-			pluginManager.getInstalledPluginsPaths()
-		).filter(
-			path -> path.endsWith(_pluginName)
-		).findAny();
+		for (Path path : pluginManager.getInstalledPluginsPaths()) {
+			if (path.endsWith(_pluginName)) {
+				return path;
+			}
+		}
+
+		return null;
 	}
 
 	protected String getPluginZipFileName(String pluginName) {
@@ -145,13 +145,13 @@ public class EmbeddedElasticsearchPluginManager {
 		PluginManager pluginManager =
 			_pluginManagerFactory.createPluginManager();
 
-		Optional<Path> pathOptional = getInstalledPluginPath(pluginManager);
+		Path path = getInstalledPluginPath(pluginManager);
 
-		if (pathOptional.isPresent()) {
-			return true;
+		if (path == null) {
+			return false;
 		}
 
-		return false;
+		return true;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/search/SearchSearchRequestAssemblerImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/search/SearchSearchRequestAssemblerImpl.java
@@ -38,7 +38,6 @@ import com.liferay.portal.search.stats.StatsRequestBuilder;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
@@ -214,15 +213,9 @@ public class SearchSearchRequestAssemblerImpl
 		SearchRequestBuilder searchRequestBuilder,
 		SearchSearchRequest searchSearchRequest) {
 
-		List<Sort> sorts = searchSearchRequest.getSorts();
-
-		Stream<Sort> stream = sorts.stream();
-
-		stream.map(
-			_sortFieldTranslator::translate
-		).forEach(
-			searchRequestBuilder::addSort
-		);
+		for (Sort sort : searchSearchRequest.getSorts()) {
+			searchRequestBuilder.addSort(_sortFieldTranslator.translate(sort));
+		}
 
 		_sortTranslator.translate(
 			searchRequestBuilder, searchSearchRequest.getSorts71());

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/hits/SearchHitBuilder.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/hits/SearchHitBuilder.java
@@ -17,6 +17,7 @@ package com.liferay.portal.search.hits;
 import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.highlight.HighlightField;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -30,6 +31,14 @@ public interface SearchHitBuilder {
 
 	public SearchHitBuilder addHighlightField(HighlightField highlightField);
 
+	public SearchHitBuilder addHighlightFields(
+		Collection<HighlightField> highlightFields);
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #addHighlightFields(Collection))}
+	 */
+	@Deprecated
 	public SearchHitBuilder addHighlightFields(
 		Stream<HighlightField> highlightFieldStream);
 

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/hits/SearchHitsBuilder.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/hits/SearchHitsBuilder.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.hits;
 
+import java.util.Collection;
 import java.util.stream.Stream;
 
 import org.osgi.annotation.versioning.ProviderType;
@@ -26,6 +27,13 @@ public interface SearchHitsBuilder {
 
 	public SearchHitsBuilder addSearchHit(SearchHit searchHit);
 
+	public SearchHitsBuilder addSearchHits(Collection<SearchHit> searchHits);
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #addSearchHits(Collection))}
+	 */
+	@Deprecated
 	public SearchHitsBuilder addSearchHits(Stream<SearchHit> searchHitStream);
 
 	public SearchHits build();

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/hits/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/hits/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.1
+version 1.1.0

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/hits/SearchHitImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/hits/SearchHitImpl.java
@@ -22,8 +22,10 @@ import com.liferay.portal.search.hits.SearchHitBuilder;
 
 import java.io.Serializable;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -32,10 +34,8 @@ import java.util.stream.Stream;
  */
 public class SearchHitImpl implements SearchHit, Serializable {
 
-	public void addHighlightFields(
-		Stream<HighlightField> highlightFieldStream) {
-
-		highlightFieldStream.forEach(this::addHighlightField);
+	public void addHighlightFields(Collection<HighlightField> highlightFields) {
+		highlightFields.forEach(this::addHighlightField);
 	}
 
 	public void addSources(Map<String, Object> sourcesMap) {
@@ -146,9 +146,24 @@ public class SearchHitImpl implements SearchHit, Serializable {
 
 		@Override
 		public SearchHitBuilder addHighlightFields(
+			Collection<HighlightField> highlightFields) {
+
+			_searchHitImpl.addHighlightFields(highlightFields);
+
+			return this;
+		}
+
+		/**
+		 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+		 *             #addHighlightFields(Collection))}
+		 */
+		@Deprecated
+		@Override
+		public SearchHitBuilder addHighlightFields(
 			Stream<HighlightField> highlightFieldStream) {
 
-			_searchHitImpl.addHighlightFields(highlightFieldStream);
+			_searchHitImpl.addHighlightFields(
+				highlightFieldStream.collect(Collectors.toList()));
 
 			return this;
 		}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/hits/SearchHitsImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/hits/SearchHitsImpl.java
@@ -21,7 +21,9 @@ import com.liferay.portal.search.hits.SearchHitsBuilder;
 import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -29,8 +31,8 @@ import java.util.stream.Stream;
  */
 public class SearchHitsImpl implements SearchHits, Serializable {
 
-	public void addSearchHits(Stream<SearchHit> searchHitStream) {
-		searchHitStream.forEach(_searchHits::add);
+	public void addSearchHits(Collection<SearchHit> searchHits) {
+		searchHits.forEach(_searchHits::add);
 	}
 
 	@Override
@@ -91,9 +93,24 @@ public class SearchHitsImpl implements SearchHits, Serializable {
 
 		@Override
 		public SearchHitsBuilder addSearchHits(
+			Collection<SearchHit> searchHits) {
+
+			_searchHitsImpl.addSearchHits(searchHits);
+
+			return this;
+		}
+
+		/**
+		 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+		 *             #addSearchHits(Collection))}
+		 */
+		@Deprecated
+		@Override
+		public SearchHitsBuilder addSearchHits(
 			Stream<SearchHit> searchHitStream) {
 
-			_searchHitsImpl.addSearchHits(searchHitStream);
+			_searchHitsImpl.addSearchHits(
+				searchHitStream.collect(Collectors.toList()));
 
 			return this;
 		}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/DefaultIndexer.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/DefaultIndexer.java
@@ -41,7 +41,6 @@ import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
@@ -122,10 +121,7 @@ public class DefaultIndexer<T extends BaseModel<?>> implements Indexer<T> {
 
 	@Override
 	public IndexerPostProcessor[] getIndexerPostProcessors() {
-		Stream<IndexerPostProcessor> stream =
-			_indexerPostProcessorsHolder.stream();
-
-		return stream.toArray(IndexerPostProcessor[]::new);
+		return _indexerPostProcessorsHolder.toArray();
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerDocumentBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerDocumentBuilderImpl.java
@@ -20,12 +20,9 @@ import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentContributor;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.search.IndexerPostProcessor;
 import com.liferay.portal.search.indexer.BaseModelDocumentFactory;
 import com.liferay.portal.search.indexer.IndexerDocumentBuilder;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
-
-import java.util.stream.Stream;
 
 /**
  * @author Michael C. Han
@@ -71,10 +68,7 @@ public class IndexerDocumentBuilderImpl implements IndexerDocumentBuilder {
 	protected <T extends BaseModel<?>> void postProcessDocument(
 		Document document, T baseModel) {
 
-		Stream<IndexerPostProcessor> stream =
-			_indexerPostProcessorsHolder.stream();
-
-		stream.forEach(
+		_indexerPostProcessorsHolder.forEach(
 			indexerPostProcessor -> {
 				try {
 					indexerPostProcessor.postProcessDocument(

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerPostProcessorsHolder.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerPostProcessorsHolder.java
@@ -18,7 +18,7 @@ import com.liferay.portal.kernel.search.IndexerPostProcessor;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
+import java.util.function.Consumer;
 
 /**
  * @author André de Oliveira
@@ -31,14 +31,18 @@ public class IndexerPostProcessorsHolder {
 		_indexerPostProcessors.add(indexerPostProcessor);
 	}
 
+	public void forEach(Consumer<IndexerPostProcessor> consumer) {
+		_indexerPostProcessors.forEach(consumer);
+	}
+
 	public void removeIndexerPostProcessor(
 		IndexerPostProcessor indexerPostProcessor) {
 
 		_indexerPostProcessors.remove(indexerPostProcessor);
 	}
 
-	public Stream<IndexerPostProcessor> stream() {
-		return _indexerPostProcessors.stream();
+	public IndexerPostProcessor[] toArray() {
+		return _indexerPostProcessors.toArray(new IndexerPostProcessor[0]);
 	}
 
 	private final List<IndexerPostProcessor> _indexerPostProcessors =

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerQueryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerQueryBuilderImpl.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Indexer;
-import com.liferay.portal.kernel.search.IndexerPostProcessor;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.ParseException;
 import com.liferay.portal.kernel.search.Query;
@@ -224,10 +223,7 @@ public class IndexerQueryBuilderImpl<T extends BaseModel<?>>
 	protected void postProcessFullQuery(
 		BooleanQuery booleanQuery, SearchContext searchContext) {
 
-		Stream<IndexerPostProcessor> stream =
-			_indexerPostProcessorsHolder.stream();
-
-		stream.forEach(
+		_indexerPostProcessorsHolder.forEach(
 			indexerPostProcessor -> {
 				try {
 					indexerPostProcessor.postProcessFullQuery(
@@ -275,10 +271,7 @@ public class IndexerQueryBuilderImpl<T extends BaseModel<?>>
 		BooleanQuery booleanQuery, BooleanFilter booleanFilter,
 		SearchContext searchContext) {
 
-		Stream<IndexerPostProcessor> stream =
-			_indexerPostProcessorsHolder.stream();
-
-		stream.forEach(
+		_indexerPostProcessorsHolder.forEach(
 			indexerPostProcessor -> {
 				try {
 					indexerPostProcessor.postProcessSearchQuery(

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerSummaryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerSummaryBuilderImpl.java
@@ -15,13 +15,11 @@
 package com.liferay.portal.search.internal.indexer;
 
 import com.liferay.portal.kernel.search.Document;
-import com.liferay.portal.kernel.search.IndexerPostProcessor;
 import com.liferay.portal.kernel.search.Summary;
 import com.liferay.portal.search.indexer.IndexerSummaryBuilder;
 import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
 
 import java.util.Locale;
-import java.util.stream.Stream;
 
 /**
  * @author Michael C. Han
@@ -47,10 +45,7 @@ public class IndexerSummaryBuilderImpl implements IndexerSummaryBuilder {
 		Summary summary = _modelSummaryContributor.getSummary(
 			document, locale, snippet);
 
-		Stream<IndexerPostProcessor> stream =
-			_indexerPostProcessorsHolder.stream();
-
-		stream.forEach(
+		_indexerPostProcessorsHolder.forEach(
 			indexerPostProcessor -> indexerPostProcessor.postProcessSummary(
 				summary, document, locale, snippet));
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelPreFilterContributorsHolder.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelPreFilterContributorsHolder.java
@@ -16,13 +16,14 @@ package com.liferay.portal.search.internal.indexer;
 
 import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
 
-import java.util.stream.Stream;
+import java.util.function.Consumer;
 
 /**
  * @author André de Oliveira
  */
 public interface ModelPreFilterContributorsHolder {
 
-	public Stream<ModelPreFilterContributor> getByModel(String entryClassName);
+	public void forEach(
+		String entryClassName, Consumer<ModelPreFilterContributor> consumer);
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelPreFilterContributorsHolderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelPreFilterContributorsHolderImpl.java
@@ -18,9 +18,8 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
+import java.util.function.Consumer;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -35,13 +34,21 @@ public class ModelPreFilterContributorsHolderImpl
 	implements ModelPreFilterContributorsHolder {
 
 	@Override
-	public Stream<ModelPreFilterContributor> getByModel(String entryClassName) {
-		List<ModelPreFilterContributor> list = new ArrayList<>();
+	public void forEach(
+		String entryClassName, Consumer<ModelPreFilterContributor> consumer) {
 
-		_addAll(list, _serviceTrackerMap.getService("ALL"));
-		_addAll(list, _serviceTrackerMap.getService(entryClassName));
+		List<ModelPreFilterContributor> list = _serviceTrackerMap.getService(
+			"ALL");
 
-		return list.stream();
+		if (list != null) {
+			list.forEach(consumer);
+		}
+
+		list = _serviceTrackerMap.getService(entryClassName);
+
+		if (list != null) {
+			list.forEach(consumer);
+		}
 	}
 
 	@Activate
@@ -54,12 +61,6 @@ public class ModelPreFilterContributorsHolderImpl
 	@Deactivate
 	protected void deactivate() {
 		_serviceTrackerMap.close();
-	}
-
-	private static <T> void _addAll(List<T> list1, List<T> list2) {
-		if (list2 != null) {
-			list1.addAll(list2);
-		}
 	}
 
 	private ServiceTrackerMap<String, List<ModelPreFilterContributor>>

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/PreFilterContributorHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/PreFilterContributorHelperImpl.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.search.SearchPermissionChecker;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.search.permission.SearchPermissionFilterContributor;
-import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
 import com.liferay.portal.search.spi.model.query.contributor.QueryPreFilterContributor;
 import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
 
@@ -76,11 +75,8 @@ public class PreFilterContributorHelperImpl
 		BooleanFilter booleanFilter, ModelSearchSettings modelSearchSettings,
 		SearchContext searchContext) {
 
-		Stream<ModelPreFilterContributor> stream =
-			modelPreFilterContributorsHolder.getByModel(
-				modelSearchSettings.getClassName());
-
-		stream.forEach(
+		modelPreFilterContributorsHolder.forEach(
+			modelSearchSettings.getClassName(),
 			modelPreFilterContributor -> modelPreFilterContributor.contribute(
 				booleanFilter, modelSearchSettings, searchContext));
 	}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/PreFilterContributorHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/PreFilterContributorHelperImpl.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.search.SearchPermissionChecker;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.search.permission.SearchPermissionFilterContributor;
-import com.liferay.portal.search.spi.model.query.contributor.QueryPreFilterContributor;
 import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
 
 import java.util.List;
@@ -139,10 +138,7 @@ public class PreFilterContributorHelperImpl
 	private void _addPreFilters(
 		BooleanFilter booleanFilter, SearchContext searchContext) {
 
-		Stream<QueryPreFilterContributor> stream =
-			queryPreFilterContributorsHolder.getAll();
-
-		stream.forEach(
+		queryPreFilterContributorsHolder.forEach(
 			queryPreFilterContributor -> queryPreFilterContributor.contribute(
 				booleanFilter, searchContext));
 	}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/QueryPreFilterContributorsHolder.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/QueryPreFilterContributorsHolder.java
@@ -16,13 +16,13 @@ package com.liferay.portal.search.internal.indexer;
 
 import com.liferay.portal.search.spi.model.query.contributor.QueryPreFilterContributor;
 
-import java.util.stream.Stream;
+import java.util.function.Consumer;
 
 /**
  * @author André de Oliveira
  */
 public interface QueryPreFilterContributorsHolder {
 
-	public Stream<QueryPreFilterContributor> getAll();
+	public void forEach(Consumer<QueryPreFilterContributor> consumer);
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/QueryPreFilterContributorsHolderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/QueryPreFilterContributorsHolderImpl.java
@@ -18,8 +18,7 @@ import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.portal.search.spi.model.query.contributor.QueryPreFilterContributor;
 
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
+import java.util.function.Consumer;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -34,8 +33,8 @@ public class QueryPreFilterContributorsHolderImpl
 	implements QueryPreFilterContributorsHolder {
 
 	@Override
-	public Stream<QueryPreFilterContributor> getAll() {
-		return StreamSupport.stream(_serviceTrackerList.spliterator(), false);
+	public void forEach(Consumer<QueryPreFilterContributor> consumer) {
+		_serviceTrackerList.forEach(consumer);
 	}
 
 	@Activate

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/legacy/searcher/SearchRequestBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/legacy/searcher/SearchRequestBuilderImpl.java
@@ -31,13 +31,15 @@ import com.liferay.portal.search.stats.StatsRequest;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 /**
  * @author André de Oliveira
@@ -95,7 +97,7 @@ public class SearchRequestBuilderImpl implements SearchRequestBuilder {
 	public SearchRequestBuilder addFederatedSearchRequest(
 		SearchRequest searchRequest) {
 
-		addFederatedSearchRequests(Stream.of(searchRequest));
+		addFederatedSearchRequests(Arrays.asList(searchRequest));
 
 		return this;
 	}
@@ -408,20 +410,28 @@ public class SearchRequestBuilderImpl implements SearchRequestBuilder {
 		return value;
 	}
 
-	protected void addFederatedSearchRequests(Stream<SearchRequest> stream) {
+	protected void addFederatedSearchRequests(
+		List<SearchRequest> searchRequests) {
+
 		withSearchRequestImpl(
-			searchRequestImpl -> stream.forEach(
+			searchRequestImpl -> searchRequests.forEach(
 				searchRequestImpl::addFederatedSearchRequest));
 	}
 
-	protected Stream<SearchRequest> buildFederatedSearchRequests() {
+	protected List<SearchRequest> buildFederatedSearchRequests() {
 		Collection<SearchRequestBuilder> searchRequestBuilders =
 			_federatedSearchRequestBuildersMap.values();
 
-		return searchRequestBuilders.stream(
-		).map(
-			SearchRequestBuilder::build
-		);
+		List<SearchRequest> searchRequests = new ArrayList<>(
+			searchRequestBuilders.size());
+
+		for (SearchRequestBuilder searchRequestBuilder :
+				searchRequestBuilders) {
+
+			searchRequests.add(searchRequestBuilder.build());
+		}
+
+		return searchRequests;
 	}
 
 	protected SearchRequestBuilder newFederatedSearchRequestBuilder(

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/localization/SearchLocalizationHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/localization/SearchLocalizationHelperImpl.java
@@ -21,12 +21,10 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.search.localization.SearchLocalizationHelper;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.LongStream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -65,15 +63,19 @@ public class SearchLocalizationHelperImpl implements SearchLocalizationHelper {
 			return locales.toArray(new Locale[0]);
 		}
 
-		LongStream stream = Arrays.stream(groupIds);
+		if (groupIds.length == 1) {
+			Set<Locale> locales = _language.getAvailableLocales(groupIds[0]);
 
-		return stream.mapToObj(
-			_language::getAvailableLocales
-		).flatMap(
-			locales -> locales.stream()
-		).toArray(
-			size -> new Locale[size]
-		);
+			return locales.toArray(new Locale[0]);
+		}
+
+		Set<Locale> locales = new HashSet<>();
+
+		for (long groupId : groupIds) {
+			locales.addAll(_language.getAvailableLocales(groupId));
+		}
+
+		return locales.toArray(new Locale[0]);
 	}
 
 	@Override

--- a/modules/apps/segments/segments-criteria-extension-sample/src/main/java/com/liferay/segments/criteria/extension/sample/internal/odata/entity/KBArticleEntityModel.java
+++ b/modules/apps/segments/segments-criteria-extension-sample/src/main/java/com/liferay/segments/criteria/extension/sample/internal/odata/entity/KBArticleEntityModel.java
@@ -19,9 +19,6 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Provides the entity data model from the KB Article.
@@ -33,11 +30,8 @@ public class KBArticleEntityModel implements EntityModel {
 	public static final String NAME = "KBArticle";
 
 	public KBArticleEntityModel() {
-		_entityFieldsMap = Stream.of(
-			new StringEntityField("title", locale -> "titleKeyword")
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
+			new StringEntityField("title", locale -> "titleKeyword"));
 	}
 
 	@Override

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/ContextEntityModel.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/ContextEntityModel.java
@@ -27,9 +27,6 @@ import com.liferay.segments.context.Context;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Provides the entity data model for the context that segments users.
@@ -41,7 +38,7 @@ public class ContextEntityModel implements EntityModel {
 	public static final String NAME = "Context";
 
 	public ContextEntityModel(List<EntityField> customEntityFields) {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new BooleanEntityField(
 				Context.SIGNED_IN, locale -> Context.SIGNED_IN),
 			new CollectionEntityField(
@@ -77,10 +74,7 @@ public class ContextEntityModel implements EntityModel {
 				Context.REFERRER_URL, locale -> Context.REFERRER_URL),
 			new StringEntityField(Context.URL, locale -> Context.URL),
 			new StringEntityField(
-				Context.USER_AGENT, locale -> Context.USER_AGENT)
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+				Context.USER_AGENT, locale -> Context.USER_AGENT));
 	}
 
 	@Override

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/OrganizationEntityModel.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/OrganizationEntityModel.java
@@ -24,9 +24,6 @@ import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Provides the entity data model from the Organization.
@@ -38,7 +35,7 @@ public class OrganizationEntityModel implements EntityModel {
 	public static final String NAME = "Organization";
 
 	public OrganizationEntityModel(List<EntityField> customEntityFields) {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new ComplexEntityField("customField", customEntityFields),
 			new DateTimeEntityField(
 				"dateModified",
@@ -59,10 +56,7 @@ public class OrganizationEntityModel implements EntityModel {
 			new StringEntityField(
 				"nameTreePath",
 				locale -> Field.getSortableFieldName("nameTreePath_String")),
-			new StringEntityField("type", locale -> Field.TYPE)
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+			new StringEntityField("type", locale -> Field.TYPE));
 	}
 
 	@Override

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/UserEntityModel.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/UserEntityModel.java
@@ -24,9 +24,6 @@ import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Provides the entity data model from the User.
@@ -38,7 +35,7 @@ public class UserEntityModel implements EntityModel {
 	public static final String NAME = "User";
 
 	public UserEntityModel(List<EntityField> customEntityFields) {
-		_entityFieldsMap = Stream.of(
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new ComplexEntityField("customField", customEntityFields),
 			new DateTimeEntityField(
 				"dateModified",
@@ -76,10 +73,7 @@ public class UserEntityModel implements EntityModel {
 			new StringEntityField(
 				"screenName",
 				locale -> Field.getSortableFieldName("screenName")),
-			new StringEntityField("userName", locale -> Field.USER_NAME)
-		).collect(
-			Collectors.toMap(EntityField::getName, Function.identity())
-		);
+			new StringEntityField("userName", locale -> Field.USER_NAME));
 	}
 
 	@Override

--- a/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/permission/SharingEntrySearchPermissionDocumentContributor.java
+++ b/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/permission/SharingEntrySearchPermissionDocumentContributor.java
@@ -15,14 +15,12 @@
 package com.liferay.sharing.search.internal.permission;
 
 import com.liferay.portal.kernel.search.Document;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.search.spi.model.permission.SearchPermissionFieldContributor;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -51,17 +49,19 @@ public class SharingEntrySearchPermissionDocumentContributor
 			_sharingEntryLocalService.getSharingEntries(
 				_portal.getClassNameId(className), classPK);
 
-		Stream<SharingEntry> stream = sharingEntries.stream();
-
-		Long[] userIds = stream.map(
-			SharingEntry::getToUserId
-		).toArray(
-			Long[]::new
-		);
-
-		if (ArrayUtil.isNotEmpty(userIds)) {
-			document.addKeyword("sharedToUserId", userIds);
+		if (sharingEntries.isEmpty()) {
+			return;
 		}
+
+		long[] userIds = new long[sharingEntries.size()];
+
+		for (int i = 0; i < userIds.length; i++) {
+			SharingEntry sharingEntry = sharingEntries.get(i);
+
+			userIds[i] = sharingEntry.getToUserId();
+		}
+
+		document.addKeyword("sharedToUserId", userIds);
 	}
 
 	@Reference

--- a/modules/core/registry-api/src/main/java/com/liferay/registry/ServiceRankingUtil.java
+++ b/modules/core/registry-api/src/main/java/com/liferay/registry/ServiceRankingUtil.java
@@ -14,11 +14,9 @@
 
 package com.liferay.registry;
 
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * @author Shuyang Zhou
@@ -47,11 +45,22 @@ public class ServiceRankingUtil {
 
 		Set<Map.Entry<ServiceReference<S>, T>> entrySet = services.entrySet();
 
-		Stream<Map.Entry<ServiceReference<S>, T>> stream = entrySet.stream();
+		if (entrySet.isEmpty()) {
+			return Optional.empty();
+		}
 
-		return stream.max(
-			Comparator.comparing(
-				Map.Entry::getKey, ServiceRankingUtil::compare));
+		Map.Entry<ServiceReference<S>, T> maxEntry = null;
+
+		for (Map.Entry<ServiceReference<S>, T> entry : entrySet) {
+			if (maxEntry == null) {
+				maxEntry = entry;
+			}
+			else if (compare(entry.getKey(), maxEntry.getKey()) > 0) {
+				maxEntry = entry;
+			}
+		}
+
+		return Optional.of(maxEntry);
 	}
 
 	private static int _getServiceRanking(


### PR DESCRIPTION
@brianchandotcom in general we can only get real benefit from using Stream in some really rare cases, for example using true parallel stream for performance (but even in this case, a handcoded threadpool usage will still perform better, the stream may only give you more compact code.). In normal cases, Stream code is both slow and clumsy, you can see after the change, most touched files are having fewer total lines.

I am not suggesting banding stream usage in general, since most developers prefers to use it for some non-performance related reasons (however I do doubt most of them are necessary or even correct).

But we should at least remove all usages of it from startup and runtime performance critical paths. But unfortunately there is no automatically way to scan them(unless we band them all unconditionally), this will need to be manually rescanned every once a while.

And this is only for our code, necessary lib clean up will come later.

@arboliveira I did not touch ES7, only ES6, since I am doing this based on the profile results. You should have them synced, and in case ES7 has more stream usages during startup time, clean them up too. By the time you pull the switch, I can rescan it again.