### PR TITLE
Lps 101009

### DIFF
--- a/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
@@ -48,6 +48,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.DirectTag;
 import com.liferay.taglib.servlet.PipingServletResponse;
 import com.liferay.taglib.util.PortalIncludeUtil;
+import com.liferay.taglib.util.ThreadLocalUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -478,7 +479,9 @@ public class RuntimeTag extends TagSupport implements DirectTag {
 	private static final Log _log = LogFactoryUtil.getLog(RuntimeTag.class);
 
 	private static final ThreadLocal<Stack<String>> _embeddedPortletIds =
-		new CentralizedThreadLocal<>(RuntimeTag.class + "._embeddedPortletIds");
+		ThreadLocalUtil.create(
+			RuntimeTag.class, "_embeddedPortletIds",
+			name -> new CentralizedThreadLocal<>(name));
 
 	private String _defaultPreferences;
 	private String _instanceId;

--- a/util-taglib/src/com/liferay/taglib/util/ThreadLocalUtil.java
+++ b/util-taglib/src/com/liferay/taglib/util/ThreadLocalUtil.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.taglib.util;
+
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
+
+import java.lang.reflect.Field;
+
+import java.util.function.Function;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class ThreadLocalUtil {
+
+	public static <T> ThreadLocal<T> create(
+		Class<?> declaringClass, String fieldName,
+		Function<String, ThreadLocal<T>> function) {
+
+		ClassLoader portalClassLoader = PortalClassLoaderUtil.getClassLoader();
+
+		if (declaringClass.getClassLoader() == portalClassLoader) {
+			return function.apply(declaringClass.getName() + "." + fieldName);
+		}
+
+		try {
+			Class<?> portalDeclaringClass = portalClassLoader.loadClass(
+				declaringClass.getName());
+
+			Field field = portalDeclaringClass.getDeclaredField(fieldName);
+
+			field.setAccessible(true);
+
+			return (ThreadLocal<T>)field.get(null);
+		}
+		catch (ReflectiveOperationException roe) {
+			return ReflectionUtil.throwException(roe);
+		}
+	}
+
+}

--- a/util-taglib/src/com/liferay/taglib/util/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/util/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.1
+version 8.1.0


### PR DESCRIPTION
@hhuijser we need a protection SF scan for this.

Basically, all threadlocal usage within util-taglib must be using the ThreadLocalUtil to be initialized.
This is only for util-taglib, no others need it. And so far we only have this RuntimeTag usage which is already fixed here. We just to be make sure the future usages will be following the rule. Thanks!