### PR TITLE
LPS-100958

### DIFF
--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManager.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManager.java
@@ -238,22 +238,18 @@ public class DLOpenerGoogleDriveManager
 			String cmd, FileEntry fileEntry, long userId)
 		throws PortalException {
 
-		Map<String, Serializable> taskContextMap =
-			new HashMap<String, Serializable>() {
-				{
-					put(GoogleDriveBackgroundTaskConstants.CMD, cmd);
-					put(
-						GoogleDriveBackgroundTaskConstants.COMPANY_ID,
-						fileEntry.getCompanyId());
-					put(
-						BackgroundTaskContextMapConstants.DELETE_ON_SUCCESS,
-						true);
-					put(
-						GoogleDriveBackgroundTaskConstants.FILE_ENTRY_ID,
-						fileEntry.getFileEntryId());
-					put(GoogleDriveBackgroundTaskConstants.USER_ID, userId);
-				}
-			};
+		Map<String, Serializable> taskContextMap = new HashMap<>(5);
+
+		taskContextMap.put(GoogleDriveBackgroundTaskConstants.CMD, cmd);
+		taskContextMap.put(
+			GoogleDriveBackgroundTaskConstants.COMPANY_ID,
+			fileEntry.getCompanyId());
+		taskContextMap.put(
+			BackgroundTaskContextMapConstants.DELETE_ON_SUCCESS, true);
+		taskContextMap.put(
+			GoogleDriveBackgroundTaskConstants.FILE_ENTRY_ID,
+			fileEntry.getFileEntryId());
+		taskContextMap.put(GoogleDriveBackgroundTaskConstants.USER_ID, userId);
 
 		return _backgroundTaskManager.addBackgroundTask(
 			userId, CompanyConstants.SYSTEM,


### PR DESCRIPTION
Hey @brianchandotcom,

This is a resend of a commit you discarded yesterday.  Sorry, I added some comments to the commit but I didn't say anything in the PR description.

In this case, the use of the dynamic initialization pattern is causing some errors. The context map of background tasks is serialized/deserialized, and at some point the 
LiferayJSONDeserializationWhitelist class complains about the map class not being whitelisted.

It is not possible to whitelist an anonymous class, so the simplest way to get rid of the error is to use a regular instance of HashMap.

Thanks!