### PR TITLE
LPS-99426 Prevent internal-only comment from leaking into generated CSS

### DIFF
--- a/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/css/_click-goal.scss
+++ b/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/css/_click-goal.scss
@@ -3,12 +3,10 @@
 $target-overlay-background-color: rgba(128, 172, 255, 0.05);
 $target-overlay-border-color: rgba(128, 172, 255, 0.4);
 
-/**
- * You would think we could use Liferay.zIndex.OVERLAY (1000) here, but
- * we can't: see _variables.scss from layout-content-page-editor-web for
- * z-indices in the high 900s that apply to the top nav of the control
- * menu, and which we have to slide under while scrolling.
- */
+// You would think we could use Liferay.zIndex.OVERLAY (1000) here, but
+// we can't: see _variables.scss from layout-content-page-editor-web for
+// z-indices in the high 900s that apply to the top nav of the control
+// menu, and which we have to slide under while scrolling.
 $target-z-index: 900;
 
 .lfr-segments-experiment-click-goal-root {


### PR DESCRIPTION
Thanks to @marcoscv-work for the reminder [here](https://github.com/liferay/liferay-npm-tools/issues/232).

`/* ... */` comments get carried through into the compiled CSS files, so we should use `//` for internal only comments. As per the above issue, we'll add a lint to prevent this.

Verified by inspecting classes/META-INF/resources/css/.sass-cache/main.css before and after a build.