### PR TITLE
SYNC-1807

### DIFF
--- a/modules/apps/sync/sync-service/bnd.bnd
+++ b/modules/apps/sync/sync-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Sync Service
 Bundle-SymbolicName: com.liferay.sync.service
 Bundle-Version: 4.0.0
-Liferay-Require-SchemaVersion: 1.0.4
+Liferay-Require-SchemaVersion: 1.0.5
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/upgrade/SyncServiceUpgrade.java
+++ b/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/upgrade/SyncServiceUpgrade.java
@@ -18,6 +18,7 @@ import com.liferay.document.library.sync.service.DLSyncEventLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.sync.internal.upgrade.v1_x_x.UpgradeSyncDLObject;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -37,7 +38,7 @@ public class SyncServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"1.0.1", "1.0.2",
 			new com.liferay.sync.internal.upgrade.v1_0_2.UpgradeSchema(),
-			new com.liferay.sync.internal.upgrade.v1_0_2.UpgradeSyncDLObject(
+			new UpgradeSyncDLObject(
 				_dlSyncEventLocalService, _groupLocalService));
 
 		registry.register(
@@ -47,6 +48,16 @@ public class SyncServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"1.0.3", "1.0.4",
 			new com.liferay.sync.internal.upgrade.v1_0_4.UpgradeSchema());
+
+		// SYNC-1807 The following upgrade steps populate the SyncDLObject table
+		// for first time installations but not for upgrades.
+
+		registry.register("1.0.4", "1.0.6", new DummyUpgradeStep());
+
+		registry.register(
+			"1.0.5", "1.0.6",
+			new UpgradeSyncDLObject(
+				_dlSyncEventLocalService, _groupLocalService));
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/upgrade/v1_x_x/UpgradeSyncDLObject.java
+++ b/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/upgrade/v1_x_x/UpgradeSyncDLObject.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.sync.internal.upgrade.v1_0_2;
+package com.liferay.sync.internal.upgrade.v1_x_x;
 
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.sync.service.DLSyncEventLocalService;


### PR DESCRIPTION
This PR may need some formatting changes. This is a workaround for LPS-101216. Hijacking the upgrade process for running logic on first time deployment. I don't think this pattern is used anywhere else yet. Created v1_x_x package because UpgradeSyncDLObject class will be compatible for all 1.x.x table schemas. lmk if you need to discuss.