### PR TITLE
LPS-101304 Remove overflow hidden from control-menu-icon to avoid display issues with menus and adding a class to hide overflow only on simulation icon

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -334,7 +334,6 @@ a.control-menu-icon,
 %control-menu-icon-monospaced {
 	height: 32px;
 	line-height: 32px;
-	overflow: hidden;
 	text-align: center;
 	width: 32px;
 }

--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,5 +1,5 @@
 <li class="control-menu-nav-item hidden-xs simulation-icon">
-	<a aria-label="${title}" class="control-menu-icon lfr-portal-tooltip product-menu-toggle sidenav-toggler" data-content="body" data-open-class="lfr-has-simulation-panel open-admin-panel" data-qa-id="simulation" data-target="#${portletNamespace}simulationPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" data-url="${simulationPanelURL}" href="javascript:;" id="${portletNamespace}simulationToggleId">
+	<a aria-label="${title}" class="control-menu-icon lfr-portal-tooltip overflow-hidden product-menu-toggle sidenav-toggler" data-content="body" data-open-class="lfr-has-simulation-panel open-admin-panel" data-qa-id="simulation" data-target="#${portletNamespace}simulationPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" data-url="${simulationPanelURL}" href="javascript:;" id="${portletNamespace}simulationToggleId">
 		${iconTag}
 	</a>
 </li>


### PR DESCRIPTION
/cc @pavel-savinov