### PR TITLE
LPS-98866 Do no print traces for upgrades twice

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/ChangeTrackingServiceUpgrade.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/upgrade/ChangeTrackingServiceUpgrade.java
@@ -14,7 +14,6 @@
 
 package com.liferay.change.tracking.internal.upgrade;
 
-import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -27,8 +26,6 @@ public class ChangeTrackingServiceUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
-
 		registry.register(
 			"1.0.0", "1.0.1",
 			new com.liferay.change.tracking.internal.upgrade.v1_0_1.

--- a/modules/apps/portal/portal-output-stream-container-api/src/main/java/com/liferay/portal/output/stream/container/OutputStreamContainerFactory.java
+++ b/modules/apps/portal/portal-output-stream-container-api/src/main/java/com/liferay/portal/output/stream/container/OutputStreamContainerFactory.java
@@ -21,4 +21,8 @@ public interface OutputStreamContainerFactory {
 
 	public OutputStreamContainer create(String hint);
 
+	public default String getFactoryName() {
+		return null;
+	}
+
 }

--- a/modules/apps/portal/portal-output-stream-container-api/src/main/java/com/liferay/portal/output/stream/container/OutputStreamContainerFactoryTracker.java
+++ b/modules/apps/portal/portal-output-stream-container-api/src/main/java/com/liferay/portal/output/stream/container/OutputStreamContainerFactoryTracker.java
@@ -23,6 +23,12 @@ import java.util.Set;
  */
 public interface OutputStreamContainerFactoryTracker {
 
+	public default OutputStreamContainerFactory
+		getDummyOutputStreamContainerFactory() {
+
+		throw new UnsupportedOperationException();
+	}
+
 	public OutputStreamContainerFactory getOutputStreamContainerFactory();
 
 	public OutputStreamContainerFactory getOutputStreamContainerFactory(

--- a/modules/apps/portal/portal-output-stream-container-api/src/main/resources/com/liferay/portal/output/stream/container/packageinfo
+++ b/modules/apps/portal/portal-output-stream-container-api/src/main/resources/com/liferay/portal/output/stream/container/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/portal/portal-output-stream-container/build.gradle
+++ b/modules/apps/portal/portal-output-stream-container/build.gradle
@@ -6,4 +6,5 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:portal:portal-output-stream-container-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
+	compileOnly project(":core:petra:petra-io")
 }

--- a/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/ConsoleOutputStreamContainerFactory.java
+++ b/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/ConsoleOutputStreamContainerFactory.java
@@ -49,4 +49,11 @@ public class ConsoleOutputStreamContainerFactory
 		};
 	}
 
+	@Override
+	public String getFactoryName() {
+		return _FACTORY_NAME;
+	}
+
+	private static final String _FACTORY_NAME = "console";
+
 }

--- a/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/ConsoleOutputStreamContainerFactory.java
+++ b/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/ConsoleOutputStreamContainerFactory.java
@@ -26,11 +26,17 @@ import org.osgi.service.component.annotations.Component;
  * @author Carlos Sierra Andrés
  */
 @Component(
-	immediate = true, property = "service.ranking:Integer=100",
+	immediate = true,
+	property = {
+		"name=" + ConsoleOutputStreamContainerFactory.FACTORY_NAME,
+		"service.ranking:Integer=100"
+	},
 	service = OutputStreamContainerFactory.class
 )
 public class ConsoleOutputStreamContainerFactory
 	implements OutputStreamContainerFactory {
+
+	public static final String FACTORY_NAME = "console";
 
 	@Override
 	public OutputStreamContainer create(String hint) {
@@ -51,9 +57,7 @@ public class ConsoleOutputStreamContainerFactory
 
 	@Override
 	public String getFactoryName() {
-		return _FACTORY_NAME;
+		return FACTORY_NAME;
 	}
-
-	private static final String _FACTORY_NAME = "console";
 
 }

--- a/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/DummyOutputStreamContainerFactory.java
+++ b/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/DummyOutputStreamContainerFactory.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.output.stream.container.internal;
+
+import com.liferay.petra.io.DummyOutputStream;
+import com.liferay.portal.output.stream.container.OutputStreamContainer;
+import com.liferay.portal.output.stream.container.OutputStreamContainerFactory;
+
+import java.io.OutputStream;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Mariano Álvaro Sáiz
+ */
+@Component(
+	immediate = true, property = {"name=dummy", "service.ranking:Integer=-100"},
+	service = OutputStreamContainerFactory.class
+)
+public class DummyOutputStreamContainerFactory
+	implements OutputStreamContainerFactory {
+
+	@Override
+	public OutputStreamContainer create(String hint) {
+		return new OutputStreamContainer() {
+
+			@Override
+			public String getDescription() {
+				return "Dummy";
+			}
+
+			@Override
+			public OutputStream getOutputStream() {
+				return _DUMMY_OUTPUT_STREAM;
+			}
+
+		};
+	}
+
+	private static final DummyOutputStream _DUMMY_OUTPUT_STREAM =
+		new DummyOutputStream();
+
+}

--- a/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/DummyOutputStreamContainerFactory.java
+++ b/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/DummyOutputStreamContainerFactory.java
@@ -26,11 +26,17 @@ import org.osgi.service.component.annotations.Component;
  * @author Mariano Álvaro Sáiz
  */
 @Component(
-	immediate = true, property = {"name=dummy", "service.ranking:Integer=-100"},
+	immediate = true,
+	property = {
+		"name=" + DummyOutputStreamContainerFactory.FACTORY_NAME,
+		"service.ranking:Integer=-100"
+	},
 	service = OutputStreamContainerFactory.class
 )
 public class DummyOutputStreamContainerFactory
 	implements OutputStreamContainerFactory {
+
+	public static final String FACTORY_NAME = "dummy";
 
 	@Override
 	public OutputStreamContainer create(String hint) {
@@ -47,6 +53,11 @@ public class DummyOutputStreamContainerFactory
 			}
 
 		};
+	}
+
+	@Override
+	public String getFactoryName() {
+		return FACTORY_NAME;
 	}
 
 	private static final DummyOutputStream _DUMMY_OUTPUT_STREAM =

--- a/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/OutputStreamContainerFactoryTrackerImpl.java
+++ b/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/OutputStreamContainerFactoryTrackerImpl.java
@@ -55,6 +55,10 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 public class OutputStreamContainerFactoryTrackerImpl
 	implements OutputStreamContainerFactoryTracker {
 
+	public OutputStreamContainerFactory getDummyOutputStreamContainerFactory() {
+		return _dummyOutputStreamContainerFactory;
+	}
+
 	@Override
 	public OutputStreamContainerFactory getOutputStreamContainerFactory() {
 		OutputStreamContainerFactory outputStreamContainerFactory =
@@ -197,6 +201,9 @@ public class OutputStreamContainerFactoryTrackerImpl
 	private final OutputStreamContainerFactory
 		_consoleOutputStreamContainerFactory =
 			new ConsoleOutputStreamContainerFactory();
+	private final OutputStreamContainerFactory
+		_dummyOutputStreamContainerFactory =
+			new DummyOutputStreamContainerFactory();
 	private ServiceTrackerMap<String, OutputStreamContainerFactory>
 		_outputStreamContainerFactories;
 

--- a/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/TempFileOutputStreamContainerFactory.java
+++ b/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/TempFileOutputStreamContainerFactory.java
@@ -32,11 +32,14 @@ import org.osgi.service.component.annotations.Component;
  * @author Carlos Sierra Andrés
  */
 @Component(
-	immediate = true, property = "name=temp_file",
+	immediate = true,
+	property = "name=" + TempFileOutputStreamContainerFactory.FACTORY_NAME,
 	service = OutputStreamContainerFactory.class
 )
 public class TempFileOutputStreamContainerFactory
 	implements OutputStreamContainerFactory {
+
+	public static final String FACTORY_NAME = "temp_file";
 
 	@Override
 	public OutputStreamContainer create(String hint) {
@@ -73,6 +76,11 @@ public class TempFileOutputStreamContainerFactory
 		catch (IOException ioe) {
 			throw new RuntimeException(ioe);
 		}
+	}
+
+	@Override
+	public String getFactoryName() {
+		return FACTORY_NAME;
 	}
 
 }

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/SwappedLogExecutor.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/SwappedLogExecutor.java
@@ -31,9 +31,30 @@ import org.osgi.service.component.annotations.Reference;
 public class SwappedLogExecutor {
 
 	public void execute(String bundleSymbolicName, Runnable runnable) {
-		OutputStreamContainerFactory outputStreamContainerFactory =
+		_execute(
+			bundleSymbolicName, runnable,
 			_outputStreamContainerFactoryTracker.
-				getOutputStreamContainerFactory();
+				getOutputStreamContainerFactory());
+	}
+
+	public void execute(
+		String bundleSymbolicName, Runnable runnable,
+		String outputStreamContainerFactoryName) {
+
+		_execute(
+			bundleSymbolicName, runnable,
+			_outputStreamContainerFactoryTracker.
+				getOutputStreamContainerFactory(
+					outputStreamContainerFactoryName));
+	}
+
+	public OutputStream getOutputStream() {
+		return _outputStreamThreadLocal.get();
+	}
+
+	private void _execute(
+		String bundleSymbolicName, Runnable runnable,
+		OutputStreamContainerFactory outputStreamContainerFactory) {
 
 		OutputStreamContainer outputStreamContainer =
 			outputStreamContainerFactory.create(
@@ -53,10 +74,6 @@ public class SwappedLogExecutor {
 		finally {
 			_outputStreamThreadLocal.remove();
 		}
-	}
-
-	public OutputStream getOutputStream() {
-		return _outputStreamThreadLocal.get();
 	}
 
 	@Reference

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/SwappedLogExecutor.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/SwappedLogExecutor.java
@@ -21,6 +21,8 @@ import com.liferay.portal.output.stream.container.OutputStreamContainerFactoryTr
 import java.io.IOException;
 import java.io.OutputStream;
 
+import java.util.Set;
+
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -58,6 +60,11 @@ public class SwappedLogExecutor {
 
 	public OutputStream getOutputStream() {
 		return _outputStreamThreadLocal.get();
+	}
+
+	public Set<String> getOutputStreamContainerFactoryNames() {
+		return _outputStreamContainerFactoryTracker.
+			getOutputStreamContainerFactoryNames();
 	}
 
 	private void _execute(

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/SwappedLogExecutor.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/SwappedLogExecutor.java
@@ -48,6 +48,14 @@ public class SwappedLogExecutor {
 					outputStreamContainerFactoryName));
 	}
 
+	public String getDummyOutputStreamContainerFactoryName() {
+		OutputStreamContainerFactory dummyOutputStreamContainerFactory =
+			_outputStreamContainerFactoryTracker.
+				getDummyOutputStreamContainerFactory();
+
+		return dummyOutputStreamContainerFactory.getFactoryName();
+	}
+
 	public OutputStream getOutputStream() {
 		return _outputStreamThreadLocal.get();
 	}

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
@@ -35,7 +35,6 @@ import com.liferay.portal.upgrade.internal.release.ReleasePublisher;
 import java.io.OutputStream;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.osgi.framework.Bundle;
@@ -53,42 +52,12 @@ public class UpgradeExecutor {
 	public void execute(
 		String bundleSymbolicName, List<UpgradeInfo> upgradeInfos) {
 
-		_execute(bundleSymbolicName, upgradeInfos, Optional.empty());
+		execute(bundleSymbolicName, upgradeInfos, null);
 	}
 
 	public void execute(
 		String bundleSymbolicName, List<UpgradeInfo> upgradeInfos,
 		String outputStreamContainerFactoryName) {
-
-		_execute(
-			bundleSymbolicName, upgradeInfos,
-			Optional.of(outputStreamContainerFactoryName));
-	}
-
-	public void executeUpgradeInfos(
-		String bundleSymbolicName, List<UpgradeInfo> upgradeInfos) {
-
-		_executeUpgradeInfos(
-			bundleSymbolicName, upgradeInfos, Optional.empty());
-	}
-
-	public void executeUpgradeInfos(
-		String bundleSymbolicName, List<UpgradeInfo> upgradeInfos,
-		String outputStreamContainerFactoryName) {
-
-		_executeUpgradeInfos(
-			bundleSymbolicName, upgradeInfos,
-			Optional.of(outputStreamContainerFactoryName));
-	}
-
-	@Activate
-	protected void activate(BundleContext bundleContext) {
-		_bundleContext = bundleContext;
-	}
-
-	private void _execute(
-		String bundleSymbolicName, List<UpgradeInfo> upgradeInfos,
-		Optional<String> outputStreamContainerFactoryName) {
 
 		ReleaseGraphManager releaseGraphManager = new ReleaseGraphManager(
 			upgradeInfos);
@@ -119,19 +88,25 @@ public class UpgradeExecutor {
 			return;
 		}
 
-		if (outputStreamContainerFactoryName.isPresent()) {
+		if (Validator.isNotNull(outputStreamContainerFactoryName)) {
 			executeUpgradeInfos(
 				bundleSymbolicName, upgradeInfosList.get(0),
-				outputStreamContainerFactoryName.get());
+				outputStreamContainerFactoryName);
 		}
 		else {
 			executeUpgradeInfos(bundleSymbolicName, upgradeInfosList.get(0));
 		}
 	}
 
-	private void _executeUpgradeInfos(
+	public void executeUpgradeInfos(
+		String bundleSymbolicName, List<UpgradeInfo> upgradeInfos) {
+
+		executeUpgradeInfos(bundleSymbolicName, upgradeInfos, null);
+	}
+
+	public void executeUpgradeInfos(
 		String bundleSymbolicName, List<UpgradeInfo> upgradeInfos,
-		Optional<String> outputStreamContainerFactoryName) {
+		String outputStreamContainerFactoryName) {
 
 		Release release = _releaseLocalService.fetchRelease(bundleSymbolicName);
 
@@ -143,10 +118,10 @@ public class UpgradeExecutor {
 			bundleSymbolicName, upgradeInfos,
 			() -> _swappedLogExecutor.getOutputStream());
 
-		if (outputStreamContainerFactoryName.isPresent()) {
+		if (Validator.isNotNull(outputStreamContainerFactoryName)) {
 			_swappedLogExecutor.execute(
 				bundleSymbolicName, upgradeInfosRunnable,
-				outputStreamContainerFactoryName.get());
+				outputStreamContainerFactoryName);
 		}
 		else {
 			_swappedLogExecutor.execute(
@@ -158,6 +133,11 @@ public class UpgradeExecutor {
 		if (release != null) {
 			_releasePublisher.publish(release);
 		}
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistratorTracker.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistratorTracker.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.upgrade.internal.configuration.ReleaseManagerConfiguration;
 import com.liferay.portal.upgrade.internal.executor.SwappedLogExecutor;
 import com.liferay.portal.upgrade.internal.executor.UpgradeExecutor;
-import com.liferay.portal.upgrade.internal.release.osgi.commands.ReleaseManagerOSGiCommands;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import java.util.ArrayList;
@@ -84,13 +83,15 @@ public class UpgradeStepRegistratorTracker {
 
 	private BundleContext _bundleContext;
 	private ReleaseManagerConfiguration _releaseManagerConfiguration;
-
-	@Reference
-	private ReleaseManagerOSGiCommands _releaseManagerOSGiCommands;
-
 	private ServiceTracker
 		<UpgradeStepRegistrator, Collection<ServiceRegistration<UpgradeStep>>>
 			_serviceTracker;
+
+	@Reference
+	private SwappedLogExecutor _swappedLogExecutor;
+
+	@Reference
+	private UpgradeExecutor _upgradeExecutor;
 
 	private class UpgradeStepRegistratorServiceTrackerCustomizer
 		implements ServiceTrackerCustomizer
@@ -214,12 +215,6 @@ public class UpgradeStepRegistratorTracker {
 
 		private final Log _log = LogFactoryUtil.getLog(
 			UpgradeStepRegistratorTracker.class);
-
-		@Reference
-		private SwappedLogExecutor _swappedLogExecutor;
-
-		@Reference
-		private UpgradeExecutor _upgradeExecutor;
 
 	}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistratorTracker.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/registry/UpgradeStepRegistratorTracker.java
@@ -171,7 +171,7 @@ public class UpgradeStepRegistratorTracker {
 			}
 
 			if (_releaseManagerConfiguration.autoUpgrade()) {
-				_releaseManagerOSGiCommands.execute(bundleSymbolicName);
+				_releaseManagerOSGiCommands.executeTo(bundleSymbolicName, null);
 			}
 
 			return serviceRegistrations;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/osgi/commands/ReleaseManagerOSGiCommands.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/osgi/commands/ReleaseManagerOSGiCommands.java
@@ -328,7 +328,10 @@ public class ReleaseManagerOSGiCommands {
 					List<UpgradeInfo> upgradeSteps =
 						_serviceTrackerMap.getService(bundleSymbolicName);
 
-					_upgradeExecutor.execute(bundleSymbolicName, upgradeSteps);
+					_upgradeExecutor.execute(
+						bundleSymbolicName, upgradeSteps,
+						_swappedLogExecutor.
+							getDummyOutputStreamContainerFactoryName());
 				}
 
 				bundleSymbolicNames = _serviceTrackerMap.keySet();

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/osgi/commands/ReleaseManagerOSGiCommands.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/osgi/commands/ReleaseManagerOSGiCommands.java
@@ -68,7 +68,8 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 	property = {
 		"osgi.command.function=check", "osgi.command.function=execute",
 		"osgi.command.function=executeAll", "osgi.command.function=executeTo",
-		"osgi.command.function=list", "osgi.command.scope=upgrade"
+		"osgi.command.function=list", "osgi.command.function=showReports",
+		"osgi.command.scope=upgrade"
 	},
 	service = ReleaseManagerOSGiCommands.class
 )
@@ -273,6 +274,18 @@ public class ReleaseManagerOSGiCommands {
 		sb.setIndex(sb.index() - 1);
 
 		return sb.toString();
+	}
+
+	@Descriptor("Show all available outputs")
+	public void showReports() {
+		Set<String> outputStreamContainerFactoryNames =
+			_swappedLogExecutor.getOutputStreamContainerFactoryNames();
+
+		for (String outputStreamContainerFactoryName :
+				outputStreamContainerFactoryNames) {
+
+			System.out.println(outputStreamContainerFactoryName);
+		}
 	}
 
 	@Activate

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/osgi/commands/ReleaseManagerOSGiCommands.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/osgi/commands/ReleaseManagerOSGiCommands.java
@@ -67,8 +67,7 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 	configurationPolicy = ConfigurationPolicy.OPTIONAL, immediate = true,
 	property = {
 		"osgi.command.function=check", "osgi.command.function=execute",
-		"osgi.command.function=executeAll", "osgi.command.function=executeTo",
-		"osgi.command.function=list", "osgi.command.function=showReports",
+		"osgi.command.function=executeAll", "osgi.command.function=list",
 		"osgi.command.scope=upgrade"
 	},
 	service = ReleaseManagerOSGiCommands.class
@@ -202,40 +201,6 @@ public class ReleaseManagerOSGiCommands {
 		return sb.toString();
 	}
 
-	@Descriptor("Execute upgrade for a specific module with a specific output")
-	public String executeTo(
-		String bundleSymbolicName, String outputStreamContainerFactoryName) {
-
-		if (_serviceTrackerMap.getService(bundleSymbolicName) == null) {
-			return "No upgrade processes registered for " + bundleSymbolicName;
-		}
-
-		try {
-			List<UpgradeInfo> upgradeInfos = _serviceTrackerMap.getService(
-				bundleSymbolicName);
-
-			if (outputStreamContainerFactoryName == null) {
-				outputStreamContainerFactoryName =
-					_swappedLogExecutor.
-						getDummyOutputStreamContainerFactoryName();
-			}
-
-			_upgradeExecutor.execute(
-				bundleSymbolicName, upgradeInfos,
-				outputStreamContainerFactoryName);
-		}
-		catch (Throwable t) {
-			_swappedLogExecutor.execute(
-				bundleSymbolicName,
-				() -> _log.error(
-					"Failed upgrade process for module ".concat(
-						bundleSymbolicName),
-					t));
-		}
-
-		return null;
-	}
-
 	@Descriptor("List registered upgrade processes for all modules")
 	public String list() {
 		Set<String> keySet = _serviceTrackerMap.keySet();
@@ -274,18 +239,6 @@ public class ReleaseManagerOSGiCommands {
 		sb.setIndex(sb.index() - 1);
 
 		return sb.toString();
-	}
-
-	@Descriptor("Show all available outputs")
-	public void showReports() {
-		Set<String> outputStreamContainerFactoryNames =
-			_swappedLogExecutor.getOutputStreamContainerFactoryNames();
-
-		for (String outputStreamContainerFactoryName :
-				outputStreamContainerFactoryNames) {
-
-			System.out.println(outputStreamContainerFactoryName);
-		}
 	}
 
 	@Activate

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -474,7 +474,13 @@ public class VerifyProcessTrackerOSGiCommands {
 			String key, VerifyProcess serviceVerifyProcess,
 			List<VerifyProcess> contentVerifyProcesses) {
 
-			_execute(verifyProcessTrackerMap, key, null, false);
+			OutputStreamContainerFactory dummyOutputStreamContainerFactory =
+				outputStreamContainerFactoryTracker.
+					getDummyOutputStreamContainerFactory();
+
+			_execute(
+				verifyProcessTrackerMap, key,
+				dummyOutputStreamContainerFactory.getFactoryName(), false);
 		}
 
 		@Override


### PR DESCRIPTION
Hi @marianoalvarosaiz,

Thanks for the implementation of this because it's really complex. It was trying to understand the logic regarding the appender a few days ago and it was really hard. With your changes and the useful comments for every commit it has been much easier.

I have kept the pull as it was except three things:
- I have removed the new commands for the ReleaseManager. At least right now we don't want users to be able to select the ouput. Upgrades are already quite complext now and it's better to simplify API. We have it for verifiers and in four years I haven't heard someone using it.
- I prefer to call the upgradeExecutor [here](https://github.com/brianchandotcom/liferay-portal/pull/78649/commits/9df8f8786cd1f826d49ff792ad9ad86bcbe7feb9#diff-6fb597ad8065ce8ab63bb5eb49acd6eaR179) because we already have the upgradeInfos and it's better to keep the ReleaseManager commands only for manual executions from Gogo Console.
- I have tried to simplify [this API](https://github.com/brianchandotcom/liferay-portal/pull/78649/commits/c58f688edbbb863c535e20c1e7fb00f6f25245e9) because the UpgradeExecutor is enough complex now :-(

Please, let me know if you consider any of my assumptions wrong.

I have tested the pull in different ways and it seems to work, but, can you keep an eye for any regression and issue that can arise? I will be on vacation for two weeks and I won't be able to check it. If @brianchandotcom ask for any change, please, send directly to him.

Thanks again!

cc/ @Preston-Crary

