### PR TITLE
SYNC-1807 This is not needed because customers in 6.2 (first version to be able to upgrade to 7.2 directly) are already in the schema version 1.2

### DIFF
--- a/modules/apps/sync/sync-service/bnd.bnd
+++ b/modules/apps/sync/sync-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Sync Service
 Bundle-SymbolicName: com.liferay.sync.service
 Bundle-Version: 4.0.0
-Liferay-Require-SchemaVersion: 1.0.4
+Liferay-Require-SchemaVersion: 1.0.5
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/upgrade/SyncServiceUpgrade.java
+++ b/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/upgrade/SyncServiceUpgrade.java
@@ -18,6 +18,7 @@ import com.liferay.document.library.sync.service.DLSyncEventLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.sync.internal.upgrade.v1_x_x.UpgradeSyncDLObject;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -37,7 +38,7 @@ public class SyncServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"1.0.1", "1.0.2",
 			new com.liferay.sync.internal.upgrade.v1_0_2.UpgradeSchema(),
-			new com.liferay.sync.internal.upgrade.v1_0_2.UpgradeSyncDLObject(
+			new UpgradeSyncDLObject(
 				_dlSyncEventLocalService, _groupLocalService));
 
 		registry.register(
@@ -47,6 +48,16 @@ public class SyncServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"1.0.3", "1.0.4",
 			new com.liferay.sync.internal.upgrade.v1_0_4.UpgradeSchema());
+
+		// SYNC-1807 The following upgrade steps populate the SyncDLObject table
+		// for first time installations but not for upgrades.
+
+		registry.register("1.0.4", "1.0.6", new DummyUpgradeStep());
+
+		registry.register(
+			"1.0.5", "1.0.6",
+			new UpgradeSyncDLObject(
+				_dlSyncEventLocalService, _groupLocalService));
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/upgrade/SyncServiceUpgrade.java
+++ b/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/upgrade/SyncServiceUpgrade.java
@@ -18,7 +18,7 @@ import com.liferay.document.library.sync.service.DLSyncEventLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-import com.liferay.sync.internal.upgrade.v1_x_x.UpgradeSyncDLObject;
+import com.liferay.sync.internal.upgrade.v1_0_6.UpgradeSyncDLObject;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -37,9 +37,7 @@ public class SyncServiceUpgrade implements UpgradeStepRegistrator {
 
 		registry.register(
 			"1.0.1", "1.0.2",
-			new com.liferay.sync.internal.upgrade.v1_0_2.UpgradeSchema(),
-			new UpgradeSyncDLObject(
-				_dlSyncEventLocalService, _groupLocalService));
+			new com.liferay.sync.internal.upgrade.v1_0_2.UpgradeSchema());
 
 		registry.register(
 			"1.0.2", "1.0.3",

--- a/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/upgrade/v1_0_6/UpgradeSyncDLObject.java
+++ b/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/upgrade/v1_0_6/UpgradeSyncDLObject.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.sync.internal.upgrade.v1_x_x;
+package com.liferay.sync.internal.upgrade.v1_0_6;
 
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.sync.service.DLSyncEventLocalService;

--- a/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/upgrade/v1_x_x/UpgradeSyncDLObject.java
+++ b/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/upgrade/v1_x_x/UpgradeSyncDLObject.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.sync.internal.upgrade.v1_0_2;
+package com.liferay.sync.internal.upgrade.v1_x_x;
 
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.sync.service.DLSyncEventLocalService;


### PR DESCRIPTION
Hi @brianchandotcom, @dejuknow,

I have removed the other execution of UpgradeSyncDLObject because it was in the step 1.0.2 and all customers from 6.2 (lowest version to be able to upgrade directly to 7.2) had executed that step so it's not needed anymore.

The last two upgrades are a bit weird but until we implement [this](https://issues.liferay.com/browse/LPS-101216), we don't have a better option for this specific case.

I will be on PTO until October 7 so please @dejuknow take care of the pull in case any change is required.

Thanks.
Best regards.