### PR TITLE
LPS-101932 Allow importing org.slf4j classes as they are needed

### DIFF
--- a/modules/apps/frontend-css/frontend-css-rtl-servlet/bnd.bnd
+++ b/modules/apps/frontend-css/frontend-css-rtl-servlet/bnd.bnd
@@ -7,7 +7,4 @@ Import-Package:\
 	\
 	!org.omg.CORBA_2_3.*,\
 	\
-	!org.slf4j,\
-	!org.slf4j.*,\
-	\
 	*


### PR DESCRIPTION
Hey @brianchandotcom , the headers I'm removing in this PR were added in this other PR -> https://github.com/brianchandotcom/liferay-portal-ee/pull/19044 by @shuyangzhou.

Letting those packages be imported again makes the RTL servlet work, but it is very strange that those headers have been around so much time without making anything fail so I suspect that the LPS can be caused by some other change in a different place. However, I don't have information to propose another candidate as the cause.

Maybe any of you (@brianchandotcom , @shuyangzhou) can think of some other reason. If not, I would say just use my PR as it fixes the LPS and doesn't seem to break anything else.

Cheers.
