### PR TITLE
LPS-102048 FIX: Elasticsearch 7: IllegalArgumentException[Can only use phrase prefix queries on text fields - not on [properties] which is of type [keyword]]

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerLocalizedContentTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerLocalizedContentTest.java
@@ -94,11 +94,9 @@ public class DLFileEntryIndexerLocalizedContentTest {
 
 		String word1 = "新規";
 		String word2 = "作成";
-		String prefix1 = "新";
-		String prefix2 = "作";
 
 		Stream.of(
-			word1, word2, prefix1, prefix2
+			word1, word2
 		).forEach(
 			searchTerm -> {
 				Document document = _search(searchTerm, LocaleUtil.JAPAN);

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/mappings/LiferayFieldQueryFactoryTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/mappings/LiferayFieldQueryFactoryTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.mappings;
+
+import com.liferay.portal.search.elasticsearch6.internal.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.mappings.BaseLiferayFieldQueryFactoryTestCase;
+
+/**
+ * @author André de Oliveira
+ */
+public class LiferayFieldQueryFactoryTest
+	extends BaseLiferayFieldQueryFactoryTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() {
+		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/EmbeddedElasticsearchConnection.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/EmbeddedElasticsearchConnection.java
@@ -185,13 +185,6 @@ public class EmbeddedElasticsearchConnection
 
 	protected void configureHttp() {
 		settingsBuilder.put(
-			"http.enabled", elasticsearchConfiguration.httpEnabled());
-
-		if (!elasticsearchConfiguration.httpEnabled()) {
-			return;
-		}
-
-		settingsBuilder.put(
 			"http.cors.enabled", elasticsearchConfiguration.httpCORSEnabled());
 
 		if (!elasticsearchConfiguration.httpCORSEnabled()) {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/mappings/LiferayFieldQueryFactoryTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/mappings/LiferayFieldQueryFactoryTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.mappings;
+
+import com.liferay.portal.search.elasticsearch7.internal.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.mappings.BaseLiferayFieldQueryFactoryTestCase;
+
+/**
+ * @author André de Oliveira
+ */
+public class LiferayFieldQueryFactoryTest
+	extends BaseLiferayFieldQueryFactoryTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() {
+		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/index/AnalyzeIndexRequestExecutorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/index/AnalyzeIndexRequestExecutorTest.java
@@ -17,7 +17,7 @@ package com.liferay.portal.search.elasticsearch7.internal.search.engine.adapter.
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.engine.adapter.index.AnalyzeIndexRequest;
 
-import org.elasticsearch.action.admin.indices.analyze.AnalyzeRequest;
+import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction;
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeRequestBuilder;
 
 import org.junit.After;
@@ -60,7 +60,7 @@ public class AnalyzeIndexRequestExecutorTest {
 			analyzeIndexRequestExecutorImpl.createAnalyzeRequestBuilder(
 				analyzeIndexRequest);
 
-		AnalyzeRequest analyzeRequest = analyzeRequestBuilder.request();
+		AnalyzeAction.Request analyzeRequest = analyzeRequestBuilder.request();
 
 		Assert.assertEquals(_INDEX_NAME, analyzeRequest.index());
 	}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/expando/BaseExpandoTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/expando/BaseExpandoTestCase.java
@@ -29,9 +29,9 @@ import com.liferay.portal.kernel.search.query.FieldQueryFactory;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.search.analysis.FieldQueryBuilderFactory;
+import com.liferay.portal.search.internal.analysis.DescriptionFieldQueryBuilder;
 import com.liferay.portal.search.internal.analysis.SimpleKeywordTokenizer;
 import com.liferay.portal.search.internal.analysis.SubstringFieldQueryBuilder;
-import com.liferay.portal.search.internal.analysis.TitleFieldQueryBuilder;
 import com.liferay.portal.search.internal.expando.ExpandoFieldQueryBuilderFactory;
 import com.liferay.portal.search.internal.expando.ExpandoQueryContributorHelper;
 import com.liferay.portal.search.internal.query.FieldQueryFactoryImpl;
@@ -99,6 +99,16 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 		assertSearch("text", 1);
 	}
 
+	protected static DescriptionFieldQueryBuilder
+		createDescriptionFieldQueryBuilder() {
+
+		return new DescriptionFieldQueryBuilder() {
+			{
+				keywordTokenizer = new SimpleKeywordTokenizer();
+			}
+		};
+	}
+
 	protected static ExpandoFieldQueryBuilderFactory
 		createExpandoFieldQueryBuilderFactory() {
 
@@ -118,17 +128,10 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 
 		return new FieldQueryFactoryImpl() {
 			{
-				titleQueryBuilder = createTitleFieldQueryBuilder();
+				descriptionFieldQueryBuilder =
+					createDescriptionFieldQueryBuilder();
 
 				addFieldQueryBuilderFactory(fieldQueryBuilderFactory);
-			}
-		};
-	}
-
-	protected static TitleFieldQueryBuilder createTitleFieldQueryBuilder() {
-		return new TitleFieldQueryBuilder() {
-			{
-				keywordTokenizer = new SimpleKeywordTokenizer();
 			}
 		};
 	}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/BaseLiferayFieldQueryFactoryTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/BaseLiferayFieldQueryFactoryTestCase.java
@@ -1,0 +1,348 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.mappings;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.search.query.Query;
+import com.liferay.portal.search.query.field.FieldQueryFactory;
+import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
+
+import org.junit.Test;
+
+/**
+ * @author André de Oliveira
+ */
+public abstract class BaseLiferayFieldQueryFactoryTestCase
+	extends BaseIndexingTestCase {
+
+	@Test
+	public void testContentField() {
+		assertSearch(
+			"content", getEnglishBlueprint(),
+			getDescriptionStyleExpectations());
+	}
+
+	@Test
+	public void testContentFieldEnglish() {
+		assertSearch(
+			"content_en_US", getEnglishBlueprint(),
+			getDescriptionStyleExpectations());
+	}
+
+	@Test
+	public void testContentFieldJapanese() {
+		assertSearch(
+			"content_ja_JP", getJapaneseBlueprint(),
+			getDescriptionStyleExpectations());
+	}
+
+	@Test
+	public void testContentFieldPortuguese() {
+		assertSearch(
+			"content_pt_BR", getPortugueseBlueprint(),
+			new Expectations() {
+				{
+					word1 = true;
+					word2 = true;
+					wordPrefix1 = true;
+					wordPrefix2 = false;
+					phrasePrefix = true;
+				}
+			});
+	}
+
+	@Test
+	public void testDescriptionField() {
+		assertSearch(
+			"description", getEnglishBlueprint(),
+			getDescriptionStyleExpectations());
+	}
+
+	@Test
+	public void testDescriptionFieldEnglish() {
+		assertSearch(
+			"description_en_US", getEnglishBlueprint(),
+			getDescriptionStyleExpectations());
+	}
+
+	@Test
+	public void testDescriptionFieldJapanese() {
+		assertSearch(
+			"description_ja_JP", getJapaneseBlueprint(),
+			getDescriptionStyleExpectations());
+	}
+
+	@Test
+	public void testDescriptionFieldPortuguese() {
+		assertSearch(
+			"description_pt_BR", getPortugueseBlueprint(),
+			new Expectations() {
+				{
+					word1 = true;
+					word2 = true;
+					wordPrefix1 = true;
+					wordPrefix2 = false;
+					phrasePrefix = true;
+				}
+			});
+	}
+
+	@Test
+	public void testKeywordMappedField() {
+		assertSearch(
+			"properties", getEnglishBlueprint(),
+			new Expectations() {
+				{
+					word1 = false;
+					word2 = false;
+					wordPrefix1 = false;
+					wordPrefix2 = false;
+					phrasePrefix = false;
+				}
+			});
+	}
+
+	@Test
+	public void testKeywordMappedFieldEnglish() {
+		assertSearch(
+			"properties_en_US", getEnglishBlueprint(),
+			getDescriptionStyleExpectations());
+	}
+
+	@Test
+	public void testKeywordMappedFieldJapanese() {
+		assertSearch(
+			"properties_ja_JP", getJapaneseBlueprint(),
+			getDescriptionStyleExpectations());
+	}
+
+	@Test
+	public void testKeywordMappedFieldPortuguese() {
+		assertSearch(
+			"properties_pt_BR", getPortugueseBlueprint(),
+			new Expectations() {
+				{
+					word1 = true;
+					word2 = true;
+					wordPrefix1 = true;
+					wordPrefix2 = false;
+					phrasePrefix = true;
+				}
+			});
+	}
+
+	@Test
+	public void testNameField() {
+		assertSearch(
+			"name", getEnglishBlueprint(), getTitleStyleExpectations());
+	}
+
+	@Test
+	public void testNameFieldEnglish() {
+		assertSearch(
+			"name_en_US", getEnglishBlueprint(), getTitleStyleExpectations());
+	}
+
+	@Test
+	public void testNameFieldJapanese() {
+		assertSearch(
+			"name_ja_JP", getJapaneseBlueprint(), getTitleStyleExpectations());
+	}
+
+	@Test
+	public void testNameFieldPortuguese() {
+		assertSearch(
+			"name_pt_BR", getPortugueseBlueprint(),
+			getTitleStyleExpectations());
+	}
+
+	@Test
+	public void testTitleField() {
+		assertSearch(
+			"title", getEnglishBlueprint(), getTitleStyleExpectations());
+	}
+
+	@Test
+	public void testTitleFieldEnglish() {
+		assertSearch(
+			"title_en_US", getEnglishBlueprint(), getTitleStyleExpectations());
+	}
+
+	@Test
+	public void testTitleFieldJapanese() {
+		assertSearch(
+			"title_ja_JP", getJapaneseBlueprint(), getTitleStyleExpectations());
+	}
+
+	@Test
+	public void testTitleFieldPortuguese() {
+		assertSearch(
+			"title_pt_BR", getPortugueseBlueprint(),
+			getTitleStyleExpectations());
+	}
+
+	protected static Expectations getDescriptionStyleExpectations() {
+		return new Expectations() {
+			{
+				word1 = true;
+				word2 = true;
+				wordPrefix1 = false;
+				wordPrefix2 = false;
+				phrasePrefix = true;
+			}
+		};
+	}
+
+	protected static Blueprint getEnglishBlueprint() {
+		return new Blueprint() {
+			{
+				phrase = "alpha bravo";
+				phrasePrefix = "alpha brav";
+				word1 = "alpha";
+				word2 = "bravo";
+				wordPrefix1 = "alph";
+				wordPrefix2 = "brav";
+			}
+		};
+	}
+
+	protected static Blueprint getJapaneseBlueprint() {
+		return new Blueprint() {
+			{
+				phrase = "新規作成";
+				phrasePrefix = "新規作";
+				word1 = "新規";
+				word2 = "作成";
+				wordPrefix1 = "新";
+				wordPrefix2 = "作";
+			}
+		};
+	}
+
+	protected static Blueprint getPortugueseBlueprint() {
+		return new Blueprint() {
+			{
+				phrase = "João Ninguém";
+				phrasePrefix = "João Ningué";
+				word1 = "João";
+				word2 = "Ninguém";
+				wordPrefix1 = "Joã";
+				wordPrefix2 = "Ningué";
+			}
+		};
+	}
+
+	protected static Expectations getTitleStyleExpectations() {
+		return new Expectations() {
+			{
+				word1 = true;
+				word2 = true;
+				wordPrefix1 = true;
+				wordPrefix2 = true;
+				phrasePrefix = true;
+			}
+		};
+	}
+
+	protected void assertSearch(
+		String field, Blueprint blueprint, Expectations expectations) {
+
+		setFieldName(field);
+		setFieldValue(blueprint.phrase);
+
+		indexOneDocument();
+
+		assertSearch(blueprint.phrase, true);
+		assertSearch(blueprint.word1, expectations.word1);
+		assertSearch(blueprint.word2, expectations.word2);
+		assertSearch(blueprint.wordPrefix1, expectations.wordPrefix1);
+		assertSearch(blueprint.wordPrefix2, expectations.wordPrefix2);
+		assertSearch(blueprint.phrasePrefix, expectations.phrasePrefix);
+	}
+
+	protected void assertSearch(String value, boolean hit) {
+		FieldQueryFactory fieldQueryFactory =
+			_liferayFieldQueryFactoryFixture.getFieldQueryFactory();
+
+		Query query = fieldQueryFactory.createQuery(
+			_fieldName, value, false, false);
+
+		assertSearch(
+			indexingTestHelper -> {
+				indexingTestHelper.defineRequest(
+					searchRequestBuilder -> searchRequestBuilder.query(query));
+
+				indexingTestHelper.search();
+
+				indexingTestHelper.verifyResponse(
+					searchResponse -> DocumentsAssert.assertValues(
+						searchResponse.getRequestString(),
+						searchResponse.getDocumentsStream(), _fieldName,
+						StringPool.OPEN_BRACKET + getExpected(hit) +
+							StringPool.CLOSE_BRACKET));
+			});
+	}
+
+	protected String getExpected(boolean hit) {
+		if (hit) {
+			return _fieldValue;
+		}
+
+		return StringPool.BLANK;
+	}
+
+	protected void indexOneDocument() {
+		addDocument(
+			DocumentCreationHelpers.singleText(_fieldName, _fieldValue));
+	}
+
+	protected void setFieldName(String fieldName) {
+		_fieldName = fieldName;
+	}
+
+	protected void setFieldValue(String fieldValue) {
+		_fieldValue = fieldValue;
+	}
+
+	protected static class Blueprint {
+
+		protected String phrase;
+		protected String phrasePrefix;
+		protected String word1;
+		protected String word2;
+		protected String wordPrefix1;
+		protected String wordPrefix2;
+
+	}
+
+	protected static class Expectations {
+
+		protected boolean phrasePrefix;
+		protected boolean word1;
+		protected boolean word2;
+		protected boolean wordPrefix1;
+		protected boolean wordPrefix2;
+
+	}
+
+	private String _fieldName;
+	private String _fieldValue;
+	private final LiferayFieldQueryFactoryFixture
+		_liferayFieldQueryFactoryFixture =
+			new LiferayFieldQueryFactoryFixture();
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/LiferayFieldQueryFactoryFixture.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/LiferayFieldQueryFactoryFixture.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.mappings;
+
+import com.liferay.portal.search.internal.analysis.SimpleKeywordTokenizer;
+import com.liferay.portal.search.internal.query.QueriesImpl;
+import com.liferay.portal.search.internal.query.field.AssetTagNamesFieldQueryBuilderFactory;
+import com.liferay.portal.search.internal.query.field.DescriptionFieldQueryBuilder;
+import com.liferay.portal.search.internal.query.field.FieldQueryBuilderFactoryImpl;
+import com.liferay.portal.search.internal.query.field.FieldQueryFactoryImpl;
+import com.liferay.portal.search.internal.query.field.SubstringFieldQueryBuilder;
+import com.liferay.portal.search.internal.query.field.TitleFieldQueryBuilder;
+import com.liferay.portal.search.query.field.FieldQueryFactory;
+import com.liferay.portal.search.query.field.QueryPreProcessConfiguration;
+
+import org.mockito.Mockito;
+
+/**
+ * @author André de Oliveira
+ */
+public class LiferayFieldQueryFactoryFixture {
+
+	public LiferayFieldQueryFactoryFixture() {
+		QueriesImpl queriesImpl = new QueriesImpl();
+		SimpleKeywordTokenizer simpleKeywordTokenizer =
+			new SimpleKeywordTokenizer();
+
+		_descriptionFieldQueryBuilder = createDescriptionFieldQueryBuilder(
+			simpleKeywordTokenizer, queriesImpl);
+		_substringFieldQueryBuilder = createSubstringFieldQueryBuilder(
+			simpleKeywordTokenizer, queriesImpl);
+		_titleFieldQueryBuilder = createTitleFieldQueryBuilder(
+			simpleKeywordTokenizer, queriesImpl);
+
+		FieldQueryBuilderFactoryImpl fieldQueryBuilderFactoryImpl =
+			new FieldQueryBuilderFactoryImpl() {
+				{
+					descriptionFieldQueryBuilder =
+						_descriptionFieldQueryBuilder;
+					queryPreProcessConfiguration = Mockito.mock(
+						QueryPreProcessConfiguration.class);
+					substringFieldQueryBuilder = _substringFieldQueryBuilder;
+					titleFieldQueryBuilder = _titleFieldQueryBuilder;
+				}
+			};
+
+		AssetTagNamesFieldQueryBuilderFactory
+			assetTagNamesFieldQueryBuilderFactory =
+				new AssetTagNamesFieldQueryBuilderFactory() {
+					{
+						titleQueryBuilder = _titleFieldQueryBuilder;
+					}
+				};
+
+		_fieldQueryFactory = new FieldQueryFactoryImpl() {
+			{
+				descriptionFieldQueryBuilder = _descriptionFieldQueryBuilder;
+
+				addFieldQueryBuilderFactory(
+					assetTagNamesFieldQueryBuilderFactory);
+				addFieldQueryBuilderFactory(fieldQueryBuilderFactoryImpl);
+			}
+		};
+	}
+
+	public FieldQueryFactory getFieldQueryFactory() {
+		return _fieldQueryFactory;
+	}
+
+	protected static DescriptionFieldQueryBuilder
+		createDescriptionFieldQueryBuilder(
+			SimpleKeywordTokenizer simpleKeywordTokenizer,
+			QueriesImpl queriesImpl) {
+
+		return new DescriptionFieldQueryBuilder() {
+			{
+				keywordTokenizer = simpleKeywordTokenizer;
+				queries = queriesImpl;
+			}
+		};
+	}
+
+	protected static SubstringFieldQueryBuilder
+		createSubstringFieldQueryBuilder(
+			SimpleKeywordTokenizer simpleKeywordTokenizer,
+			QueriesImpl queriesImpl) {
+
+		return new SubstringFieldQueryBuilder() {
+			{
+				keywordTokenizer = simpleKeywordTokenizer;
+				queries = queriesImpl;
+			}
+		};
+	}
+
+	protected static TitleFieldQueryBuilder createTitleFieldQueryBuilder(
+		SimpleKeywordTokenizer simpleKeywordTokenizer,
+		QueriesImpl queriesImpl) {
+
+		return new TitleFieldQueryBuilder() {
+			{
+				keywordTokenizer = simpleKeywordTokenizer;
+				queries = queriesImpl;
+			}
+		};
+	}
+
+	private final DescriptionFieldQueryBuilder _descriptionFieldQueryBuilder;
+	private final FieldQueryFactory _fieldQueryFactory;
+	private final SubstringFieldQueryBuilder _substringFieldQueryBuilder;
+	private final TitleFieldQueryBuilder _titleFieldQueryBuilder;
+
+}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/FieldQueryBuilderFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/FieldQueryBuilderFactoryImpl.java
@@ -38,7 +38,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	immediate = true,
-	property = {"description.fields=description", "title.fields=title"},
+	property = {"description.fields=description", "title.fields=name|title"},
 	service = FieldQueryBuilderFactory.class
 )
 public class FieldQueryBuilderFactoryImpl implements FieldQueryBuilderFactory {
@@ -46,15 +46,19 @@ public class FieldQueryBuilderFactoryImpl implements FieldQueryBuilderFactory {
 	@Override
 	public FieldQueryBuilder getQueryBuilder(String field) {
 		if (queryPreProcessConfiguration.isSubstringSearchAlways(field)) {
-			return substringQueryBuilder;
+			return substringFieldQueryBuilder;
 		}
 
-		if (_descriptionFields.contains(field)) {
-			return descriptionQueryBuilder;
+		for (String descriptionField : _descriptionFields) {
+			if (field.startsWith(descriptionField)) {
+				return descriptionFieldQueryBuilder;
+			}
 		}
 
-		if (_titleFields.contains(field)) {
-			return titleQueryBuilder;
+		for (String titleField : _titleFields) {
+			if (field.startsWith(titleField)) {
+				return titleFieldQueryBuilder;
+			}
 		}
 
 		return null;
@@ -77,20 +81,20 @@ public class FieldQueryBuilderFactoryImpl implements FieldQueryBuilderFactory {
 	}
 
 	@Reference
-	protected DescriptionFieldQueryBuilder descriptionQueryBuilder;
+	protected DescriptionFieldQueryBuilder descriptionFieldQueryBuilder;
 
 	@Reference
 	protected QueryPreProcessConfiguration queryPreProcessConfiguration;
 
 	@Reference
-	protected SubstringFieldQueryBuilder substringQueryBuilder;
+	protected SubstringFieldQueryBuilder substringFieldQueryBuilder;
 
 	@Reference
-	protected TitleFieldQueryBuilder titleQueryBuilder;
+	protected TitleFieldQueryBuilder titleFieldQueryBuilder;
 
 	private volatile Collection<String> _descriptionFields =
 		Collections.singleton("description");
-	private volatile Collection<String> _titleFields = Collections.singleton(
-		"title");
+	private volatile Collection<String> _titleFields = new HashSet<>(
+		Arrays.asList("name", "title"));
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/FieldQueryFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/FieldQueryFactoryImpl.java
@@ -18,7 +18,7 @@ import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.query.FieldQueryFactory;
 import com.liferay.portal.search.analysis.FieldQueryBuilder;
 import com.liferay.portal.search.analysis.FieldQueryBuilderFactory;
-import com.liferay.portal.search.internal.analysis.TitleFieldQueryBuilder;
+import com.liferay.portal.search.internal.analysis.DescriptionFieldQueryBuilder;
 
 import java.util.HashSet;
 
@@ -54,7 +54,7 @@ public class FieldQueryFactoryImpl implements FieldQueryFactory {
 	}
 
 	protected FieldQueryBuilder getDefaultQueryBuilder() {
-		return titleQueryBuilder;
+		return descriptionFieldQueryBuilder;
 	}
 
 	protected FieldQueryBuilder getQueryBuilder(String fieldName) {
@@ -79,7 +79,7 @@ public class FieldQueryFactoryImpl implements FieldQueryFactory {
 	}
 
 	@Reference
-	protected TitleFieldQueryBuilder titleQueryBuilder;
+	protected DescriptionFieldQueryBuilder descriptionFieldQueryBuilder;
 
 	private final HashSet<FieldQueryBuilderFactory>
 		_fieldQueryBuilderFactories = new HashSet<>();

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/field/FieldQueryBuilderFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/field/FieldQueryBuilderFactoryImpl.java
@@ -23,7 +23,6 @@ import com.liferay.portal.search.query.field.QueryPreProcessConfiguration;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 
@@ -37,7 +36,9 @@ import org.osgi.service.component.annotations.Reference;
  * @author Rodrigo Paulino
  */
 @Component(
-	property = {"description.fields=description", "title.fields=title"},
+	property = {
+		"description.fields=content|description", "title.fields=name|title"
+	},
 	service = FieldQueryBuilderFactory.class
 )
 public class FieldQueryBuilderFactoryImpl implements FieldQueryBuilderFactory {
@@ -45,15 +46,19 @@ public class FieldQueryBuilderFactoryImpl implements FieldQueryBuilderFactory {
 	@Override
 	public FieldQueryBuilder getQueryBuilder(String field) {
 		if (queryPreProcessConfiguration.isSubstringSearchAlways(field)) {
-			return substringQueryBuilder;
+			return substringFieldQueryBuilder;
 		}
 
-		if (_descriptionFields.contains(field)) {
-			return descriptionQueryBuilder;
+		for (String descriptionField : _descriptionFields) {
+			if (field.startsWith(descriptionField)) {
+				return descriptionFieldQueryBuilder;
+			}
 		}
 
-		if (_titleFields.contains(field)) {
-			return titleQueryBuilder;
+		for (String titleField : _titleFields) {
+			if (field.startsWith(titleField)) {
+				return titleFieldQueryBuilder;
+			}
 		}
 
 		return null;
@@ -76,20 +81,20 @@ public class FieldQueryBuilderFactoryImpl implements FieldQueryBuilderFactory {
 	}
 
 	@Reference
-	protected DescriptionFieldQueryBuilder descriptionQueryBuilder;
+	protected DescriptionFieldQueryBuilder descriptionFieldQueryBuilder;
 
 	@Reference
 	protected QueryPreProcessConfiguration queryPreProcessConfiguration;
 
 	@Reference
-	protected SubstringFieldQueryBuilder substringQueryBuilder;
+	protected SubstringFieldQueryBuilder substringFieldQueryBuilder;
 
 	@Reference
-	protected TitleFieldQueryBuilder titleQueryBuilder;
+	protected TitleFieldQueryBuilder titleFieldQueryBuilder;
 
-	private volatile Collection<String> _descriptionFields =
-		Collections.singleton("description");
-	private volatile Collection<String> _titleFields = Collections.singleton(
-		"title");
+	private volatile Collection<String> _descriptionFields = Arrays.asList(
+		"content", "description");
+	private volatile Collection<String> _titleFields = new HashSet<>(
+		Arrays.asList("name", "title"));
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/field/FieldQueryFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/field/FieldQueryFactoryImpl.java
@@ -53,7 +53,7 @@ public class FieldQueryFactoryImpl implements FieldQueryFactory {
 	}
 
 	protected FieldQueryBuilder getDefaultQueryBuilder() {
-		return titleQueryBuilder;
+		return descriptionFieldQueryBuilder;
 	}
 
 	protected FieldQueryBuilder getQueryBuilder(String fieldName) {
@@ -78,7 +78,7 @@ public class FieldQueryFactoryImpl implements FieldQueryFactory {
 	}
 
 	@Reference
-	protected TitleFieldQueryBuilder titleQueryBuilder;
+	protected DescriptionFieldQueryBuilder descriptionFieldQueryBuilder;
 
 	private final HashSet<FieldQueryBuilderFactory>
 		_fieldQueryBuilderFactories = new HashSet<>();


### PR DESCRIPTION
Needed in DXP 7.2 SP1 for the upcoming Elasticsearch 7 Connector in Marketplace.

----

❌ **ci:test:search - 21 out of 24 jobs passed in 1 hour 11 minutes 8 seconds 566 ms**
https://github.com/arboliveira/liferay-portal/pull/770#issuecomment-533759913

Only 1 unique failure; CI infra hiccup with fix sent upstream already.
`LocalFile.Elasticsearch6#ElasticsearchRemoteClusterSmokeTest`
Fixed by: https://github.com/brianchandotcom/liferay-portal/pull/78689
Reference: https://issues.liferay.com/browse/LRQA-52265

----

Author: @BryanEngler 
Reviewer: @arboliveira

_[Bug] Elasticsearch 7: IllegalArgumentException[Can only use phrase prefix queries on text fields - not on [properties] which is of type [keyword]]_
https://issues.liferay.com/browse/LPS-102048
