### PR TITLE
LPS-97886 OAuth2 "Bearer" is not recognized as a HTTP Authorization header scheme

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/auth/http/HttpAuthManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/http/HttpAuthManagerImpl.java
@@ -203,6 +203,12 @@ public class HttpAuthManagerImpl implements HttpAuthManager {
 			return parseDigest(
 				httpServletRequest, authorization, authorizationParts);
 		}
+		else if (StringUtil.equalsIgnoreCase(
+					scheme, HttpAuthorizationHeader.SCHEME_BEARER)) {
+
+			return new HttpAuthorizationHeader(
+				HttpAuthorizationHeader.SCHEME_BEARER);
+		}
 		else {
 			throw new UnsupportedOperationException("Scheme " + scheme);
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/http/HttpAuthorizationHeader.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/http/HttpAuthorizationHeader.java
@@ -41,6 +41,8 @@ public class HttpAuthorizationHeader {
 
 	public static final String SCHEME_BASIC = "Basic";
 
+	public static final String SCHEME_BEARER = "Bearer";
+
 	public static final String SCHEME_DIGEST = "Digest";
 
 	public HttpAuthorizationHeader(String scheme) {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/http/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/http/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
Hi Brian,

https://issues.liferay.com/browse/LPS-97886

Thank you.

/cc @holatuwol
/cc @wanderlast