### PR TITLE
LPS-102168 Use querySelector instead of getElementById since the experiment goal target element is stored as a query selector

### DIFF
--- a/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
+++ b/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
@@ -22,7 +22,7 @@ SegmentsExperiment segmentsExperiment = (SegmentsExperiment)request.getAttribute
 
 <aui:script sandbox="<%= true %>">
 	<c:if test='<%= (segmentsExperiment != null) && Objects.equals(segmentsExperiment.getGoal(), "click") && Validator.isNotNull(segmentsExperiment.getGoalTarget()) %>'>
-		var element = document.getElementById('<%= segmentsExperiment.getGoalTarget() %>');
+		var element = document.querySelector('<%= segmentsExperiment.getGoalTarget() %>');
 
 		if (element) {
 			element.addEventListener(


### PR DESCRIPTION
@marcellustavares @andreldm 
@andresfulla @manoelcyreno