### PR TITLE
LPS-102214 Match signature method for segments experiments creation with the one in SegmentsExperimentServiceImpl

### DIFF
--- a/modules/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/Experiment.java
+++ b/modules/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/Experiment.java
@@ -127,6 +127,10 @@ public final class Experiment {
 		return _pageURL;
 	}
 
+	public String getPublishedDXPVariantId() {
+		return _publishedDXPVariantId;
+	}
+
 	@JsonFormat(
 		pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
 		shape = JsonFormat.Shape.STRING, timezone = "UTC"
@@ -219,6 +223,10 @@ public final class Experiment {
 		_pageURL = pageURL;
 	}
 
+	public void setPublishedDXPVariantId(String publishedDXPVariantId) {
+		_publishedDXPVariantId = publishedDXPVariantId;
+	}
+
 	public void setStartedDate(Date startedDate) {
 		if (startedDate != null) {
 			_startedDate = new Date(startedDate.getTime());
@@ -244,6 +252,7 @@ public final class Experiment {
 	private String _pageRelativePath;
 	private String _pageTitle;
 	private String _pageURL;
+	private String _publishedDXPVariantId;
 	private Date _startedDate;
 
 }

--- a/modules/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/util/ExperimentUtil.java
+++ b/modules/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/util/ExperimentUtil.java
@@ -125,6 +125,13 @@ public class ExperimentUtil {
 		experiment.setPageTitle(layout.getTitle(locale));
 		experiment.setPageURL(pageURL);
 
+		if (segmentsExperiment.getStatus() ==
+				SegmentsExperimentConstants.STATUS_COMPLETED) {
+
+			experiment.setPublishedDXPVariantId(
+				segmentsExperiment.getWinnerSegmentsExperienceKey());
+		}
+
 		if (segmentsExperiment.getSegmentsExperienceId() ==
 				SegmentsExperienceConstants.ID_DEFAULT) {
 

--- a/modules/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/client/model/util/ExperimentUtilTest.java
+++ b/modules/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/client/model/util/ExperimentUtilTest.java
@@ -74,10 +74,10 @@ public class ExperimentUtilTest {
 			layoutFriendlyURL, locale, layoutTitle, layoutUuid);
 
 		SegmentsExperiment segmentsExperiment = _createSegmentsExperiment(
-			classPK, createDate, modifiedDate, name, description,
-			SegmentsExperienceConstants.ID_DEFAULT, segmentsExperimentKey,
+			SegmentsExperienceConstants.ID_DEFAULT, classPK, name, description,
 			SegmentsExperimentConstants.Goal.BOUNCE_RATE.getLabel(),
-			StringPool.BLANK, SegmentsExperimentConstants.STATUS_DRAFT,
+			StringPool.BLANK, createDate, modifiedDate, segmentsExperimentKey,
+			SegmentsExperimentConstants.STATUS_DRAFT,
 			SegmentsExperienceConstants.KEY_DEFAULT);
 
 		Experiment experiment = ExperimentUtil.toExperiment(
@@ -169,11 +169,10 @@ public class ExperimentUtilTest {
 		);
 
 		SegmentsExperiment segmentsExperiment = _createSegmentsExperiment(
-			classPK, createDate, modifiedDate, name, description,
-			segmentsExperienceId, segmentsExperimentKey,
+			segmentsExperienceId, classPK, name, description,
 			SegmentsExperimentConstants.Goal.BOUNCE_RATE.getLabel(),
-			StringPool.BLANK, SegmentsExperimentConstants.STATUS_DRAFT,
-			segmentsExperienceKey);
+			StringPool.BLANK, createDate, modifiedDate, segmentsExperimentKey,
+			SegmentsExperimentConstants.STATUS_DRAFT, segmentsExperienceKey);
 
 		Experiment experiment = ExperimentUtil.toExperiment(
 			dataSourceId, RandomTestUtil.randomString(),
@@ -249,12 +248,12 @@ public class ExperimentUtilTest {
 		);
 
 		SegmentsExperiment segmentsExperiment = _createSegmentsExperiment(
-			RandomTestUtil.randomLong(), RandomTestUtil.nextDate(),
-			RandomTestUtil.nextDate(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), segmentsExperienceId,
-			RandomTestUtil.randomString(),
+			segmentsExperienceId, RandomTestUtil.randomLong(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			SegmentsExperimentConstants.Goal.BOUNCE_RATE.getLabel(),
-			StringPool.BLANK, SegmentsExperimentConstants.STATUS_COMPLETED,
+			StringPool.BLANK, RandomTestUtil.nextDate(),
+			RandomTestUtil.nextDate(), RandomTestUtil.randomString(),
+			SegmentsExperimentConstants.STATUS_COMPLETED,
 			segmentsExperience.getSegmentsExperienceKey());
 
 		String dataSourceId = RandomTestUtil.randomString();
@@ -389,10 +388,10 @@ public class ExperimentUtilTest {
 	}
 
 	private SegmentsExperiment _createSegmentsExperiment(
-		long classPK, Date createDate, Date modifiedDate, String name,
-		String description, long segmentsExperienceId,
-		String segmentsExperimentKey, String goal, String goalTarget,
-		int status, String winnerSegmentsExperienceKey) {
+		long segmentsExperienceId, long classPK, String name,
+		String description, String goal, String goalTarget, Date createDate,
+		Date modifiedDate, String segmentsExperimentKey, int status,
+		String winnerSegmentsExperienceKey) {
 
 		SegmentsExperiment segmentsExperiment = Mockito.mock(
 			SegmentsExperiment.class);


### PR DESCRIPTION
From https://github.com/brianchandotcom/liferay-portal/pull/78852#issuecomment-535121318

Hi @brianchandotcom, I've tried to match as much as possible the signature of method `com.liferay.segments.asah.connector.internal.client.model.util.ExperimentUtilTest#_createSegmentsExperiment `with `com.liferay.segments.service.impl.SegmentsExperimentServiceImpl#addSegmentsExperiment`. Did I get it correctly? 
As you can see, one method requires more parameters than other, which is ok for me (they're doing different things) . Let me know if it requires more changes. Thanks!

@epgarcia