### PR TITLE
LPS-101095 Create an API method to create and add a new account user

### DIFF
--- a/modules/apps/account/account-test/build.gradle
+++ b/modules/apps/account/account-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "org.hamcrest", name: "hamcrest-all", version: "1.3"
 	testIntegrationCompile project(":apps:account:account-api")
 	testIntegrationCompile project(":core:petra:petra-function")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryUserRelLocalServiceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryUserRelLocalServiceTest.java
@@ -23,17 +23,25 @@ import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
+import com.liferay.portal.kernel.exception.UserEmailAddressException;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
+
+import org.hamcrest.CoreMatchers;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -107,6 +115,74 @@ public class AccountEntryUserRelLocalServiceTest {
 
 	@Test
 	public void testAddAccountEntryUserRel2() throws Exception {
+		AccountEntry accountEntry = AccountEntryTestUtil.addAccountEntry(
+			_accountEntryLocalService);
+		UserInfo userInfo = new UserInfo();
+
+		AccountEntryUserRel accountEntryUserRel = _addAccountEntryUserRel(
+			accountEntry.getAccountEntryId(), userInfo);
+
+		User user = _userLocalService.fetchUser(
+			accountEntryUserRel.getAccountUserId());
+
+		Assert.assertNotNull(user);
+		Assert.assertEquals(
+			accountEntryUserRel.getAccountUserId(), user.getUserId());
+		Assert.assertEquals(userInfo.screenName, user.getScreenName());
+	}
+
+	@Test
+	public void testAddAccountEntryUserRel2UserNotCreatedWithInvalidAccountEntryId()
+		throws Exception {
+
+		long invalidAccountEntryId = RandomTestUtil.nextLong();
+		UserInfo userInfo = new UserInfo();
+
+		try {
+			_addAccountEntryUserRel(invalidAccountEntryId, userInfo);
+
+			Assert.fail();
+		}
+		catch (NoSuchEntryException nsee) {
+			Assert.assertThat(
+				nsee.getMessage(),
+				CoreMatchers.containsString(
+					"No AccountEntry exists with the primary key " +
+						invalidAccountEntryId));
+		}
+
+		Assert.assertNull(
+			_userLocalService.fetchUserByScreenName(
+				TestPropsValues.getCompanyId(), userInfo.screenName));
+	}
+
+	@Test
+	public void testAddAccountEntryUserRel2UserNotCreatedWithInvalidUserInfo()
+		throws Exception {
+
+		UserInfo userInfo = new UserInfo();
+
+		String invalidEmailAddress = "liferay";
+
+		userInfo.emailAddress = invalidEmailAddress;
+
+		try {
+			_addAccountEntryUserRel(
+				_accountEntry.getAccountEntryId(), userInfo);
+
+			Assert.fail();
+		}
+		catch (UserEmailAddressException.MustValidate ueaemv) {
+			Assert.assertThat(
+				ueaemv.getMessage(),
+				CoreMatchers.containsString(
+					"Email name address " + invalidEmailAddress +
+						" must validate with"));
+		}
+
+		Assert.assertNull(
+			_userLocalService.fetchUserByScreenName(
+				TestPropsValues.getCompanyId(), userInfo.screenName));
 	}
 
 	@Test
@@ -139,6 +215,23 @@ public class AccountEntryUserRelLocalServiceTest {
 		Assert.assertArrayEquals(expectedUserIds, actualUserIds);
 	}
 
+	private AccountEntryUserRel _addAccountEntryUserRel(
+			long accountId, UserInfo userInfo)
+		throws Exception {
+
+		AccountEntryUserRel accountEntryUserRel =
+			_accountEntryUserRelLocalService.addAccountEntryUserRel(
+				accountId, TestPropsValues.getUserId(), userInfo.screenName,
+				userInfo.emailAddress, userInfo.locale, userInfo.firstName,
+				userInfo.middleName, userInfo.lastName, userInfo.prefixId,
+				userInfo.suffixId);
+
+		_users.add(
+			_userLocalService.getUser(accountEntryUserRel.getAccountUserId()));
+
+		return accountEntryUserRel;
+	}
+
 	@DeleteAfterTestRun
 	private AccountEntry _accountEntry;
 
@@ -155,7 +248,25 @@ public class AccountEntryUserRelLocalServiceTest {
 	@DeleteAfterTestRun
 	private User _user;
 
+	@Inject
+	private UserLocalService _userLocalService;
+
 	@DeleteAfterTestRun
 	private final List<User> _users = new ArrayList<>();
+
+	private static class UserInfo {
+
+		public String emailAddress =
+			RandomTestUtil.randomString() + "@liferay.com";
+		public String firstName = RandomTestUtil.randomString();
+		public String lastName = RandomTestUtil.randomString();
+		public Locale locale = LocaleThreadLocal.getDefaultLocale();
+		public String middleName = RandomTestUtil.randomString();
+		public long prefixId = RandomTestUtil.randomLong();
+		public String screenName = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+		public long suffixId = RandomTestUtil.randomLong();
+
+	}
 
 }


### PR DESCRIPTION
This is an update for [LPS-101095](https://issues.liferay.com/browse/LPS-101095).

Hey Brian, the test cases below follow the `try/fail/catch` idiom outlined here: http://baddotrobot.com/blog/2012/03/27/expecting-exception-with-junit-rule/index.html.

The steps are:

1. `Assert.fail()` in the `try` block after the expression you want to throw.
2. Assert on the exception in the `catch` block
3. Additional (non-exception) assertions after the `catch` block.

/cc @pei-jung @alee8888 @ChrisKian @dejuknow