### PR TITLE
LPS-101095 Create an API method to create and add a new account user

### DIFF
--- a/modules/apps/account/account-test/build.gradle
+++ b/modules/apps/account/account-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "org.hamcrest", name: "hamcrest-all", version: "1.3"
 	testIntegrationCompile project(":apps:account:account-api")
 	testIntegrationCompile project(":core:petra:petra-function")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")


### PR DESCRIPTION
This is an update for [LPS-101095](https://issues.liferay.com/browse/LPS-101095).

Hey Brian, the test cases below follow the `try/fail/catch` idiom outlined here: http://baddotrobot.com/blog/2012/03/27/expecting-exception-with-junit-rule/index.html.

The steps are:

1. `Assert.fail()` in the `try` block after the expression you want to throw.
2. Assert on the exception in the `catch` block
3. Additional (non-exception) assertions after the `catch` block.

/cc @pei-jung @alee8888 @ChrisKian @dejuknow