### PR TITLE
LPS-102391 portal-search-elasticsearch6-impl: Implement the WrapperQuery visitor.

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/ElasticsearchQueryTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/ElasticsearchQueryTranslator.java
@@ -50,6 +50,7 @@ import com.liferay.portal.search.query.TermQuery;
 import com.liferay.portal.search.query.TermsQuery;
 import com.liferay.portal.search.query.TermsSetQuery;
 import com.liferay.portal.search.query.WildcardQuery;
+import com.liferay.portal.search.query.WrapperQuery;
 
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -250,6 +251,11 @@ public class ElasticsearchQueryTranslator
 	@Override
 	public QueryBuilder visit(WildcardQuery wildcardQuery) {
 		return _wildcardQueryTranslator.translate(wildcardQuery);
+	}
+
+	@Override
+	public QueryBuilder visit(WrapperQuery wrapperQuery) {
+		return _wrapperQueryTranslator.translate(wrapperQuery);
 	}
 
 	@Reference(unbind = "-")
@@ -516,5 +522,6 @@ public class ElasticsearchQueryTranslator
 	private TermsQueryTranslator _termsQueryTranslator;
 	private TermsSetQueryTranslator _termsSetQueryTranslator;
 	private WildcardQueryTranslator _wildcardQueryTranslator;
+	private WrapperQueryTranslator _wrapperQueryTranslator;
 
 }

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/WrapperQueryTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/WrapperQueryTranslator.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.query;
+
+import com.liferay.portal.search.query.WrapperQuery;
+
+import org.elasticsearch.index.query.QueryBuilder;
+
+/**
+ * @author Adam Brandizzi
+ */
+public interface WrapperQueryTranslator {
+
+	public QueryBuilder translate(WrapperQuery wrapperQuery);
+
+}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/WrapperQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/WrapperQueryTranslatorImpl.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.query;
+
+import com.liferay.portal.search.query.WrapperQuery;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Adam Brandizzi
+ */
+@Component(service = WrapperQueryTranslator.class)
+public class WrapperQueryTranslatorImpl implements WrapperQueryTranslator {
+
+	@Override
+	public QueryBuilder translate(WrapperQuery wrapperQuery) {
+		return QueryBuilders.wrapperQuery(wrapperQuery.getSource());
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/QueryVisitor.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/QueryVisitor.java
@@ -89,4 +89,6 @@ public interface QueryVisitor<T> {
 
 	public T visit(WildcardQuery wildcardQuery);
 
+	public T visit(WrapperQuery wrapperQuery);
+
 }

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/WrapperQuery.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/WrapperQuery.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.query;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * @author Adam Brandizzi
+ */
+@ProviderType
+public interface WrapperQuery extends Query {
+
+	public byte[] getSource();
+
+}


### PR DESCRIPTION
<h3>:x: ci:test:search - 27 out of 30 jobs passed in 1 hour 23 minutes 28 seconds 241 ms</h3>

Only unique failure on unrelated alloymvc module

https://github.com/brandizzi/liferay-portal/pull/838#issuecomment-535770670

Author: @brandizzi

Create a WrapperQuery to send arbitrary JSON queries through the Elasticsearch Connector
https://issues.liferay.com/browse/LPS-102391