### PR TITLE
LRCI-638 Add jsf batch to upstream acceptance

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1189,6 +1189,7 @@
         #functional-upgrade-websphere90-mysql57-jdk8,\
         #functional-upgrade-weblogic122-mysql57-jdk8,\
         functional-upgrade-wildfly110-mariadb102-jdk8,\
+        jsf-jdk8,\
         jsp-runtime-compile-jdk8,\
         javadoc-jdk8,\
         js-unit-jdk8,\


### PR DESCRIPTION
Resend of https://github.com/brianchandotcom/liferay-portal/pull/78922

@brianchandotcom I think the failure in the original pull was related to a network download issue not a problem directly related to ci. I've retested this branch here: https://github.com/pyoo47/liferay-portal/pull/1120. The test seemed to run satisfactorily both when I ran ci:test and ci:test:jsf. The results of both tests were the same. There were three different tests that timed out for what looks like the same reason but I think you told me you were expecting the jsf tests to fail.