### PR TITLE
LPS-102391 portal-search-test: Test.

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/ElasticsearchQueryTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/ElasticsearchQueryTranslator.java
@@ -50,6 +50,7 @@ import com.liferay.portal.search.query.TermQuery;
 import com.liferay.portal.search.query.TermsQuery;
 import com.liferay.portal.search.query.TermsSetQuery;
 import com.liferay.portal.search.query.WildcardQuery;
+import com.liferay.portal.search.query.WrapperQuery;
 
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -250,6 +251,11 @@ public class ElasticsearchQueryTranslator
 	@Override
 	public QueryBuilder visit(WildcardQuery wildcardQuery) {
 		return _wildcardQueryTranslator.translate(wildcardQuery);
+	}
+
+	@Override
+	public QueryBuilder visit(WrapperQuery wrapperQuery) {
+		return _wrapperQueryTranslator.translate(wrapperQuery);
 	}
 
 	@Reference(unbind = "-")
@@ -516,5 +522,6 @@ public class ElasticsearchQueryTranslator
 	private TermsQueryTranslator _termsQueryTranslator;
 	private TermsSetQueryTranslator _termsSetQueryTranslator;
 	private WildcardQueryTranslator _wildcardQueryTranslator;
+	private WrapperQueryTranslator _wrapperQueryTranslator;
 
 }

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/WrapperQueryTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/WrapperQueryTranslator.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.query;
+
+import com.liferay.portal.search.query.WrapperQuery;
+
+import org.elasticsearch.index.query.QueryBuilder;
+
+/**
+ * @author Adam Brandizzi
+ */
+public interface WrapperQueryTranslator {
+
+	public QueryBuilder translate(WrapperQuery wrapperQuery);
+
+}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/WrapperQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/WrapperQueryTranslatorImpl.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.query;
+
+import com.liferay.portal.search.query.WrapperQuery;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Adam Brandizzi
+ */
+@Component(service = WrapperQueryTranslator.class)
+public class WrapperQueryTranslatorImpl implements WrapperQueryTranslator {
+
+	@Override
+	public QueryBuilder translate(WrapperQuery wrapperQuery) {
+		return QueryBuilders.wrapperQuery(wrapperQuery.getSource());
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/Queries.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/Queries.java
@@ -138,4 +138,8 @@ public interface Queries {
 
 	public WildcardQuery wildcard(String field, String value);
 
+	public WrapperQuery wrapper(byte[] source);
+
+	public WrapperQuery wrapper(String source);
+
 }

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/QueryVisitor.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/QueryVisitor.java
@@ -89,4 +89,6 @@ public interface QueryVisitor<T> {
 
 	public T visit(WildcardQuery wildcardQuery);
 
+	public T visit(WrapperQuery wrapperQuery);
+
 }

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/WrapperQuery.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/WrapperQuery.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.query;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * @author Adam Brandizzi
+ */
+@ProviderType
+public interface WrapperQuery extends Query {
+
+	public byte[] getSource();
+
+}

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/query/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/query/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.1
+version 1.3.0

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/query/test/QueriesInstantiationTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/query/test/QueriesInstantiationTest.java
@@ -53,6 +53,7 @@ import com.liferay.portal.search.query.TermQuery;
 import com.liferay.portal.search.query.TermsQuery;
 import com.liferay.portal.search.query.TermsSetQuery;
 import com.liferay.portal.search.query.WildcardQuery;
+import com.liferay.portal.search.query.WrapperQuery;
 import com.liferay.portal.search.script.Script;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -424,6 +425,14 @@ public class QueriesInstantiationTest {
 		WildcardQuery wildcardQuery = _queries.wildcard("field", "value");
 
 		Assert.assertNotNull(wildcardQuery);
+	}
+
+	@Test
+	public void testWrapperQuery() {
+		WrapperQuery wrapperQuery = _queries.wrapper(
+			"{\"query\":\"match_all\":{}}");
+
+		Assert.assertNotNull(wrapperQuery);
 	}
 
 	@Inject

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/QueriesImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/QueriesImpl.java
@@ -52,6 +52,7 @@ import com.liferay.portal.search.query.TermQuery;
 import com.liferay.portal.search.query.TermsQuery;
 import com.liferay.portal.search.query.TermsSetQuery;
 import com.liferay.portal.search.query.WildcardQuery;
+import com.liferay.portal.search.query.WrapperQuery;
 import com.liferay.portal.search.script.Script;
 
 import java.util.Collections;
@@ -317,6 +318,16 @@ public class QueriesImpl implements Queries {
 	@Override
 	public WildcardQuery wildcard(String field, String value) {
 		return new WildcardQueryImpl(field, value);
+	}
+
+	@Override
+	public WrapperQuery wrapper(byte[] source) {
+		return new WrapperQueryImpl(source);
+	}
+
+	@Override
+	public WrapperQuery wrapper(String source) {
+		return new WrapperQueryImpl(source);
 	}
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/WrapperQueryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/WrapperQueryImpl.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.query;
+
+import com.liferay.portal.search.query.QueryVisitor;
+import com.liferay.portal.search.query.WrapperQuery;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author Michael C. Han
+ */
+public class WrapperQueryImpl extends BaseQueryImpl implements WrapperQuery {
+
+	public WrapperQueryImpl(byte[] source) {
+		_source = source;
+	}
+
+	public WrapperQueryImpl(String source) {
+		_source = source.getBytes(StandardCharsets.UTF_8);
+	}
+
+	@Override
+	public <T> T accept(QueryVisitor<T> queryVisitor) {
+		return queryVisitor.visit(this);
+	}
+
+	@Override
+	public byte[] getSource() {
+		return _source;
+	}
+
+	public void setSource(byte[] source) {
+		_source = source;
+	}
+
+	@Override
+	public String toString() {
+		return new String(_source);
+	}
+
+	private static final long serialVersionUID = 1L;
+
+	private byte[] _source;
+
+}


### PR DESCRIPTION
<h3>:x: ci:test:search - 27 out of 30 jobs passed in 1 hour 14 minutes 755 ms</h3>

Only unique failure on unrelated yarn failure on a private module

https://github.com/brandizzi/liferay-portal/pull/840#issuecomment-536117021

Author: @brandizzi

Create a WrapperQuery to send arbitrary JSON queries through the Elasticsearch Connector
https://issues.liferay.com/browse/LPS-102391