### PR TITLE
LPS-102392 Move username and password out of source code. This is not…

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/HypersonicLoader.java
+++ b/portal-impl/src/com/liferay/portal/tools/HypersonicLoader.java
@@ -71,17 +71,32 @@ public class HypersonicLoader {
 		String databaseName = arguments.get("db.database.name");
 		String sqlDir = arguments.get("db.sql.dir");
 		String fileNames = arguments.get("db.file.names");
+		String username = arguments.get("db.database.username");
+		String password = arguments.get("db.database.password");
 
 		try {
-			new HypersonicLoader(databaseName, sqlDir, fileNames);
+			new HypersonicLoader(
+				databaseName, sqlDir, fileNames, username, password);
 		}
 		catch (Exception e) {
 			ArgumentsUtil.processMainException(arguments, e);
 		}
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link
+	 *             #HypersonicLoader(String, String, String, String, String)}
+	 */
+	@Deprecated
 	public HypersonicLoader(
-			String databaseName, String sqlDir, String fileNames)
+		String databaseName, String sqlDir, String fileNames) {
+
+		throw new UnsupportedOperationException();
+	}
+
+	public HypersonicLoader(
+			String databaseName, String sqlDir, String fileNames,
+			String username, String password)
 		throws Exception {
 
 		ToolDependencies.wireBasic();
@@ -95,7 +110,7 @@ public class HypersonicLoader {
 				StringBundler.concat(
 					"jdbc:hsqldb:", sqlDir, "/", databaseName,
 					";hsqldb.write_delay=false;shutdown=true"),
-				"sa", "")) {
+				username, password)) {
 
 			if (Validator.isNull(fileNames)) {
 				loadHypersonic(con, sqlDir + "/portal/portal-hypersonic.sql");

--- a/portal-impl/src/com/liferay/portal/tools/packageinfo
+++ b/portal-impl/src/com/liferay/portal/tools/packageinfo
@@ -1,1 +1,1 @@
-version 2.4.0
+version 2.5.0

--- a/sql/build-parent.xml
+++ b/sql/build-parent.xml
@@ -108,6 +108,8 @@
 			<arg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
 			<arg value="-Dfile.encoding=UTF-8" />
 			<arg value="db.database.name=${database.name}" />
+			<arg value="db.database.password=" />
+			<arg value="db.database.username=sa" />
 			<arg value="db.sql.dir=${basedir}" />
 			<arg value="db.file.name=portal${database.create.suffix}/portal${database.create.suffix}-hypersonic.sql,indexes.sql" />
 		</java>


### PR DESCRIPTION
… a real problem, since HypersonicLoader is just a tool used during ant all, not by production runtime. Doing this just to keep the security scanner quiet.