### PR TITLE
LPS-102524 Ignore relevance when results have undetermined order

### DIFF
--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/BaseSubstringFieldQueryBuilderTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/BaseSubstringFieldQueryBuilderTestCase.java
@@ -160,7 +160,7 @@ public abstract class BaseSubstringFieldQueryBuilderTestCase
 		addDocument("Ultimate Nullifier");
 		addDocument("llun");
 
-		assertSearch(
+		assertSearchIgnoreRelevance(
 			"null",
 			Arrays.asList(
 				"null", "anulled", "the word null is in this sentence",
@@ -294,6 +294,11 @@ public abstract class BaseSubstringFieldQueryBuilderTestCase
 		addDocument("Who? When? Where?");
 		addDocument("Who. When. Where.");
 
+		assertSearch("AAA+???-CCC?DDD]", Arrays.asList("aaa+bbb-ccc{ddd]"));
+		assertSearch("AAA+*{DDD*", Arrays.asList("aaa+bbb-ccc{ddd]"));
+		assertSearch("AA?+BB?-CC?{DD?]", Arrays.asList("aaa+bbb-ccc{ddd]"));
+		assertSearch("AA*+BB*-CC*{DD*]", Arrays.asList("aaa+bbb-ccc{ddd]"));
+
 		assertSearchIgnoreRelevance(
 			"M*A*S*H", Arrays.asList("m*a*s*h", "m... a... s... h"));
 		assertSearchIgnoreRelevance(
@@ -307,31 +312,26 @@ public abstract class BaseSubstringFieldQueryBuilderTestCase
 				"m*a*s*h", "m... a... s... h", "aaa+bbb-ccc{ddd]",
 				"aaa bbb ccc ddd", "who? when? where?", "who. when. where."));
 
-		assertSearch("AAA+???-CCC?DDD]", Arrays.asList("aaa+bbb-ccc{ddd]"));
-		assertSearch("AAA+*{DDD*", Arrays.asList("aaa+bbb-ccc{ddd]"));
-		assertSearch("AA?+BB?-CC?{DD?]", Arrays.asList("aaa+bbb-ccc{ddd]"));
-		assertSearch("AA*+BB*-CC*{DD*]", Arrays.asList("aaa+bbb-ccc{ddd]"));
-
-		assertSearch(
+		assertSearchIgnoreRelevance(
 			"When?", Arrays.asList("who? when? where?", "who. when. where."));
-		assertSearch(
+		assertSearchIgnoreRelevance(
 			"Who? When?",
 			Arrays.asList("who? when? where?", "who. when. where."));
-		assertSearch(
+		assertSearchIgnoreRelevance(
 			"Who? *en? Where?",
 			Arrays.asList("who? when? where?", "who. when. where."));
-		assertSearch(
+		assertSearchIgnoreRelevance(
 			"Who? * Where?",
 			Arrays.asList(
 				"who? when? where?", "who. when. where.", "aaa+bbb-ccc{ddd]",
 				"aaa bbb ccc ddd", "m*a*s*h", "m... a... s... h"));
-		assertSearch(
+		assertSearchIgnoreRelevance(
 			"Who?   When?   Where?",
 			Arrays.asList("who? when? where?", "who. when. where."));
-		assertSearch(
+		assertSearchIgnoreRelevance(
 			"Wh?? W?en? Wher??",
 			Arrays.asList("who? when? where?", "who. when. where."));
-		assertSearch(
+		assertSearchIgnoreRelevance(
 			"Wh* W*en* Wher*",
 			Arrays.asList("who? when? where?", "who. when. where."));
 	}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/BaseTitleFieldQueryBuilderTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/BaseTitleFieldQueryBuilderTestCase.java
@@ -305,11 +305,6 @@ public abstract class BaseTitleFieldQueryBuilderTestCase
 		addDocument("Who? When? Where?");
 		addDocument("Who. When. Where.");
 
-		assertSearch(
-			"AAA+???-CCC?DDD]",
-			Arrays.asList("AAA+BBB-CCC{DDD]", "AAA BBB CCC DDD"));
-		assertSearch(
-			"AAA+*{DDD*", Arrays.asList("AAA+BBB-CCC{DDD]", "AAA BBB CCC DDD"));
 		assertSearch("AA?+BB?-CC?{DD?]", Arrays.asList());
 		assertSearch("AA*+BB*-CC*{DD*]", Arrays.asList());
 
@@ -318,22 +313,29 @@ public abstract class BaseTitleFieldQueryBuilderTestCase
 		assertSearch(
 			"M* A* *S *H", Arrays.asList("M*A*S*H", "M... A... S... H"));
 
-		assertSearch(
-			"When?", Arrays.asList("Who? When? Where?", "Who. When. Where."));
-		assertSearch(
-			"Who? When?",
-			Arrays.asList("Who? When? Where?", "Who. When. Where."));
-		assertSearch(
-			"Who? *en? Where?",
-			Arrays.asList("Who? When? Where?", "Who. When. Where."));
-		assertSearch(
-			"Who? * Where?",
-			Arrays.asList("Who? When? Where?", "Who. When. Where."));
-		assertSearch(
-			"Who?   When?   Where?",
-			Arrays.asList("Who? When? Where?", "Who. When. Where."));
 		assertSearch("Wh?? W?en? Wher??", Arrays.asList());
 		assertSearch("Wh* W*en* Wher*", Arrays.asList());
+
+		assertSearchIgnoreRelevance(
+			"AAA+???-CCC?DDD]",
+			Arrays.asList("AAA+BBB-CCC{DDD]", "AAA BBB CCC DDD"));
+		assertSearchIgnoreRelevance(
+			"AAA+*{DDD*", Arrays.asList("AAA+BBB-CCC{DDD]", "AAA BBB CCC DDD"));
+
+		assertSearchIgnoreRelevance(
+			"When?", Arrays.asList("Who? When? Where?", "Who. When. Where."));
+		assertSearchIgnoreRelevance(
+			"Who? When?",
+			Arrays.asList("Who? When? Where?", "Who. When. Where."));
+		assertSearchIgnoreRelevance(
+			"Who? *en? Where?",
+			Arrays.asList("Who? When? Where?", "Who. When. Where."));
+		assertSearchIgnoreRelevance(
+			"Who? * Where?",
+			Arrays.asList("Who? When? Where?", "Who. When. Where."));
+		assertSearchIgnoreRelevance(
+			"Who?   When?   Where?",
+			Arrays.asList("Who? When? Where?", "Who. When. Where."));
 	}
 
 	@Test

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseStringQueryTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseStringQueryTestCase.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.search.test.util.query;
 
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.engine.adapter.search.SearchSearchRequest;
@@ -24,10 +25,10 @@ import com.liferay.portal.search.hits.SearchHits;
 import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.StringQuery;
 import com.liferay.portal.search.query.TermQuery;
+import com.liferay.portal.search.test.util.DocumentsAssert;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -242,18 +243,11 @@ public abstract class BaseStringQueryTestCase extends BaseIndexingTestCase {
 
 				List<SearchHit> searchHitsList = searchHits.getSearchHits();
 
-				List<String> actualValues = new ArrayList<>();
+				Hits hits = searchSearchResponse.getHits();
 
-				searchHitsList.forEach(
-					searchHit -> {
-						Document document = searchHit.getDocument();
-
-						actualValues.add(document.getString(_FIELD_NAME));
-					});
-
-				Assert.assertEquals(
-					"Retrieved hits ->" + actualValues,
-					expectedValues.toString(), actualValues.toString());
+				DocumentsAssert.assertValuesIgnoreRelevance(
+					"Retrieved hits ->", hits.getDocs(), _FIELD_NAME,
+					expectedValues);
 
 				Assert.assertEquals(
 					"Retrieved hits", expectedValues.size(),


### PR DESCRIPTION
✅ **ci:test:search - This pull contains no unique failures.** https://github.com/BryanEngler/liferay-portal/pull/406#issuecomment-537109222

✅ **ci:test:search-es7 - This pull contains no unique failures.** https://github.com/BryanEngler/liferay-portal/pull/406#issuecomment-537109481

⚠️ **ci:test:search-solr - 20 out of 23 jobs passed** https://github.com/BryanEngler/liferay-portal/pull/406#issuecomment-537135728
✅ The only failures unique to this pull are also failing on the upstream canary https://github.com/xbrianlee/liferay-portal/pull/240#issuecomment-537041528

Author(s): @BryanEngler
Cc: @arboliveira

---
*[Technical Task] Elasticsearch 7: Ignore relevance in tests where results dont have score*
https://issues.liferay.com/browse/LPS-102524