### PR TITLE
LPS-102608 Remove unused reference to RescoreBuilderFactory

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexSearcher.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexSearcher.java
@@ -48,7 +48,6 @@ import com.liferay.portal.search.engine.adapter.search.SearchSearchResponse;
 import com.liferay.portal.search.index.IndexNameBuilder;
 import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.legacy.searcher.SearchResponseBuilderFactory;
-import com.liferay.portal.search.rescore.RescoreBuilderFactory;
 import com.liferay.portal.search.searcher.SearchRequest;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.searcher.SearchResponseBuilder;
@@ -504,9 +503,6 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 
 		_searchResponseBuilderFactory = searchResponseBuilderFactory;
 	}
-
-	@Reference
-	protected RescoreBuilderFactory rescoreBuilderFactory;
 
 	private SearchRequestBuilder _getSearchRequestBuilder(
 		SearchContext searchContext) {


### PR DESCRIPTION
✅ **ci:test:search - This pull contains no unique failures.** Tested as part of https://github.com/BryanEngler/liferay-portal/pull/405#issuecomment-536908479

Author(s): @BryanEngler

---
*[Task] Remove unused reference to RescoreBuilderFactory in ElasticsearchIndexSearcher*
https://issues.liferay.com/browse/LPS-102608