### PR TITLE
LPS-102620 portal-search-elasticsearch7-impl: Create query translators and missing setter for wrapper query translator in Elasticsearch 7 query translator.

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/ElasticsearchQueryTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/ElasticsearchQueryTranslator.java
@@ -489,6 +489,13 @@ public class ElasticsearchQueryTranslator
 		_wildcardQueryTranslator = wildcardQueryTranslator;
 	}
 
+	@Reference(unbind = "-")
+	protected void setWrapperQueryTranslator(
+		WrapperQueryTranslator wrapperQueryTranslator) {
+
+		_wrapperQueryTranslator = wrapperQueryTranslator;
+	}
+
 	private BooleanQueryTranslator _booleanQueryTranslator;
 	private BoostingQueryTranslator _boostingQueryTranslator;
 	private CommonTermsQueryTranslator _commonTermsQueryTranslator;

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/query/ElasticsearchQueryTranslatorFixture.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/query/ElasticsearchQueryTranslatorFixture.java
@@ -68,6 +68,7 @@ public class ElasticsearchQueryTranslatorFixture {
 				setTermsQueryTranslator(new TermsQueryTranslatorImpl());
 				setTermsSetQueryTranslator(new TermsSetQueryTranslatorImpl());
 				setWildcardQueryTranslator(new WildcardQueryTranslatorImpl());
+				setWrapperQueryTranslator(new WrapperQueryTranslatorImpl());
 			}
 		};
 	}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/query/WrapperQueryTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/query/WrapperQueryTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.query;
+
+import com.liferay.portal.search.elasticsearch6.internal.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.query.BaseWrapperQueryTestCase;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class WrapperQueryTest extends BaseWrapperQueryTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslator.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslator.java
@@ -50,6 +50,7 @@ import com.liferay.portal.search.query.TermQuery;
 import com.liferay.portal.search.query.TermsQuery;
 import com.liferay.portal.search.query.TermsSetQuery;
 import com.liferay.portal.search.query.WildcardQuery;
+import com.liferay.portal.search.query.WrapperQuery;
 
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -250,6 +251,11 @@ public class ElasticsearchQueryTranslator
 	@Override
 	public QueryBuilder visit(WildcardQuery wildcardQuery) {
 		return _wildcardQueryTranslator.translate(wildcardQuery);
+	}
+
+	@Override
+	public QueryBuilder visit(WrapperQuery wrapperQuery) {
+		return _wrapperQueryTranslator.translate(wrapperQuery);
 	}
 
 	@Reference(unbind = "-")
@@ -483,6 +489,13 @@ public class ElasticsearchQueryTranslator
 		_wildcardQueryTranslator = wildcardQueryTranslator;
 	}
 
+	@Reference(unbind = "-")
+	protected void setWrapperQueryTranslator(
+		WrapperQueryTranslator wrapperQueryTranslator) {
+
+		_wrapperQueryTranslator = wrapperQueryTranslator;
+	}
+
 	private BooleanQueryTranslator _booleanQueryTranslator;
 	private BoostingQueryTranslator _boostingQueryTranslator;
 	private CommonTermsQueryTranslator _commonTermsQueryTranslator;
@@ -516,5 +529,6 @@ public class ElasticsearchQueryTranslator
 	private TermsQueryTranslator _termsQueryTranslator;
 	private TermsSetQueryTranslator _termsSetQueryTranslator;
 	private WildcardQueryTranslator _wildcardQueryTranslator;
+	private WrapperQueryTranslator _wrapperQueryTranslator;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/WrapperQueryTranslator.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/WrapperQueryTranslator.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.query;
+
+import com.liferay.portal.search.query.WrapperQuery;
+
+import org.elasticsearch.index.query.QueryBuilder;
+
+/**
+ * @author Adam Brandizzi
+ */
+public interface WrapperQueryTranslator {
+
+	public QueryBuilder translate(WrapperQuery wrapperQuery);
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/WrapperQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/query/WrapperQueryTranslatorImpl.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.query;
+
+import com.liferay.portal.search.query.WrapperQuery;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Adam Brandizzi
+ */
+@Component(service = WrapperQueryTranslator.class)
+public class WrapperQueryTranslatorImpl implements WrapperQueryTranslator {
+
+	@Override
+	public QueryBuilder translate(WrapperQuery wrapperQuery) {
+		return QueryBuilders.wrapperQuery(wrapperQuery.getSource());
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslatorFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/query/ElasticsearchQueryTranslatorFixture.java
@@ -68,6 +68,7 @@ public class ElasticsearchQueryTranslatorFixture {
 				setTermsQueryTranslator(new TermsQueryTranslatorImpl());
 				setTermsSetQueryTranslator(new TermsSetQueryTranslatorImpl());
 				setWildcardQueryTranslator(new WildcardQueryTranslatorImpl());
+				setWrapperQueryTranslator(new WrapperQueryTranslatorImpl());
 			}
 		};
 	}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/query/WrapperQueryTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/query/WrapperQueryTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.query;
+
+import com.liferay.portal.search.elasticsearch7.internal.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.query.BaseWrapperQueryTestCase;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class WrapperQueryTest extends BaseWrapperQueryTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseWrapperQueryTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseWrapperQueryTestCase.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.query;
+
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.engine.adapter.search.SearchSearchRequest;
+import com.liferay.portal.search.engine.adapter.search.SearchSearchResponse;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.query.WrapperQuery;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author Adam Brandizzi
+ */
+public abstract class BaseWrapperQueryTestCase extends BaseIndexingTestCase {
+
+	@BeforeClass
+	public static void setUpClassJSONUtil() {
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+	}
+
+	@Test
+	public void testWrapperQuery() {
+		addDocuments(
+			"java eclipse", "java liferay", "java liferay eclipse",
+			"C is the best language");
+
+		assertSearch(
+			"liferay uses java",
+			Arrays.asList(
+				"java liferay", "java liferay eclipse", "java eclipse"));
+	}
+
+	protected void addDocuments(String... values) {
+		addDocuments(
+			value -> DocumentCreationHelpers.singleText(_FIELD_NAME, value),
+			Arrays.asList(values));
+	}
+
+	protected void assertSearch(Object value, List<String> expectedValues) {
+		assertSearch(
+			indexingTestHelper -> {
+				String query = JSONUtil.put(
+					"match", JSONUtil.put(_FIELD_NAME, value)
+				).toString();
+
+				WrapperQuery wrapperQuery = queries.wrapper(query);
+
+				SearchSearchRequest searchSearchRequest =
+					new SearchSearchRequest();
+
+				searchSearchRequest.setIndexNames("_all");
+				searchSearchRequest.setQuery(wrapperQuery);
+				searchSearchRequest.setSize(30);
+
+				SearchEngineAdapter searchEngineAdapter =
+					getSearchEngineAdapter();
+
+				SearchSearchResponse searchSearchResponse =
+					searchEngineAdapter.execute(searchSearchRequest);
+
+				SearchHits searchHits = searchSearchResponse.getSearchHits();
+
+				Assert.assertEquals(
+					"Total hits", expectedValues.size(),
+					searchHits.getTotalHits());
+
+				List<SearchHit> searchHitsList = searchHits.getSearchHits();
+
+				Assert.assertEquals(
+					"Retrieved hits", expectedValues.size(),
+					searchHitsList.size());
+
+				List<String> actualValues = new ArrayList<>();
+
+				searchHitsList.forEach(
+					searchHit -> {
+						Document document = searchHit.getDocument();
+
+						actualValues.add(document.getString(_FIELD_NAME));
+					});
+
+				Assert.assertEquals(
+					"Retrieved hits ->" + actualValues,
+					expectedValues.toString(), actualValues.toString());
+			});
+	}
+
+	private static final String _FIELD_NAME = "content";
+
+}


### PR DESCRIPTION
<h3>:x: ci:test:search - 28 out of 32 jobs passed in 1 hour 4 minutes 55 seconds 385 ms</h3>

Only unique failure is a front-end validation error on Modified Facet. (Indeed I will try to reproduce it here as an unrelated bug.)

https://github.com/brandizzi/liferay-portal/pull/840#issuecomment-536117021

Author: @brandizzi

Write tests for WrapperQueries on Elasticsearch 6 and 7
https://issues.liferay.com/browse/LPS-102620