### PR TITLE
LPS-96819 Poshi Script syntax fix

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Notifications.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Notifications.macro
@@ -121,7 +121,7 @@ definition {
 
 			AssertTextEquals.assertPartialText(
 				locator1 = "Notifications#NOTIFICATIONS_TITLE",
-				value1 = '''in the "Content Page Name" page.''');
+				value1 = "in the &quot;Content Page Name&quot; page.");
 		}
 
 		else {


### PR DESCRIPTION
@austinchiang, there's some stuff that is getting through Poshi Script validation, but the syntax there won't work. I'm fixing the Poshi validation with the next poshi runner release, so this would start failing at that time. Since this is a function, the locator1 and value1 parameters behave differently than other vars. The ''' notation can only be used for vars. Might be able to change this in the future, to make it more consistent though. Let me know if you have any questions