### PR TITLE
LPS-101098 Create an API method to search for users assigned to an account

### DIFF
--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/retriever/AccountUserRetriever.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/retriever/AccountUserRetriever.java
@@ -14,6 +14,7 @@
 
 package com.liferay.account.retriever;
 
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 
 import java.util.List;
@@ -24,5 +25,14 @@ import java.util.List;
 public interface AccountUserRetriever {
 
 	public List<User> getAccountUsers(long accountEntryId);
+
+	public List<User> searchAccountUsers(
+			long accountEntryId, String keywords, int status, int cur,
+			int delta, String sortField, boolean reverse)
+		throws PortalException;
+
+	public long searchCountAccountUsers(
+			long accountEntryId, String keywords, int status)
+		throws PortalException;
 
 }

--- a/modules/apps/account/account-service/build.gradle
+++ b/modules/apps/account/account-service/build.gradle
@@ -9,6 +9,8 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:account:account-api")
+	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/retriever/AccountUserRetrieverImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/retriever/AccountUserRetrieverImpl.java
@@ -14,13 +14,34 @@
 
 package com.liferay.account.internal.retriever;
 
+import com.liferay.account.model.AccountEntry;
 import com.liferay.account.retriever.AccountUserRetriever;
+import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryUserRelLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.searcher.SearchRequest;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.sort.FieldSort;
+import com.liferay.portal.search.sort.SortOrder;
+import com.liferay.portal.search.sort.Sorts;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
+import java.io.Serializable;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -40,8 +61,140 @@ public class AccountUserRetrieverImpl implements AccountUserRetriever {
 				accountEntryUserRel.getAccountUserId()));
 	}
 
+	@Override
+	public List<User> searchAccountUsers(
+			long accountEntryId, String keywords, int status, int cur,
+			int delta, String sortField, boolean reverse)
+		throws PortalException {
+
+		SearchResponse searchResponse = _getSearchResponse(
+			accountEntryId, keywords, status, cur, delta, sortField, reverse);
+
+		SearchHits searchHits = searchResponse.getSearchHits();
+
+		return TransformUtil.transform(
+			searchHits.getSearchHits(),
+			searchHit -> {
+				Document document = searchHit.getDocument();
+
+				long userId = document.getLong("userId");
+
+				return _userLocalService.getUser(userId);
+			});
+	}
+
+	@Override
+	public long searchCountAccountUsers(
+			long accountEntryId, String keywords, int status)
+		throws PortalException {
+
+		SearchResponse searchResponse = _getSearchResponse(
+			accountEntryId, keywords, status, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null, false);
+
+		return searchResponse.getTotalHits();
+	}
+
+	private SearchResponse _getSearchResponse(
+			long accountEntryId, String keywords, int status, int cur,
+			int delta, String sortField, boolean reverse)
+		throws PortalException {
+
+		AccountEntry accountEntry = _accountEntryLocalService.getAccountEntry(
+			accountEntryId);
+
+		SearchRequestBuilder searchRequestBuilder =
+			_searchRequestBuilderFactory.builder();
+
+		searchRequestBuilder.entryClassNames(
+			User.class.getName()
+		).withSearchContext(
+			searchContext -> _populateSearchContext(
+				searchContext, accountEntry, keywords, status)
+		).emptySearchEnabled(
+			true
+		).highlightEnabled(
+			false
+		);
+
+		if (Validator.isNotNull(sortField)) {
+			SortOrder sortOrder = SortOrder.ASC;
+
+			if (reverse) {
+				sortOrder = SortOrder.DESC;
+			}
+
+			FieldSort sort = _sorts.field(sortField, sortOrder);
+
+			searchRequestBuilder.sorts(sort);
+		}
+
+		if (cur != QueryUtil.ALL_POS) {
+			searchRequestBuilder.from(
+				cur
+			).size(
+				delta
+			);
+		}
+
+		SearchRequest searchRequest = searchRequestBuilder.build();
+
+		return _searcher.search(searchRequest);
+	}
+
+	private void _populateSearchContext(
+		SearchContext searchContext, AccountEntry accountEntry, String keywords,
+		int status) {
+
+		boolean andSearch = false;
+
+		if (Validator.isNull(keywords)) {
+			andSearch = true;
+		}
+		else {
+			searchContext.setKeywords(keywords);
+		}
+
+		searchContext.setAndSearch(andSearch);
+
+		Map<String, Serializable> attributes = new HashMap<>();
+
+		attributes.put("city", keywords);
+		attributes.put("country", keywords);
+		attributes.put("emailAddress", keywords);
+		attributes.put("firstName", keywords);
+		attributes.put("fullName", keywords);
+		attributes.put("lastName", keywords);
+		attributes.put("middleName", keywords);
+		attributes.put("region", keywords);
+		attributes.put("screenName", keywords);
+		attributes.put("street", keywords);
+		attributes.put("zip", keywords);
+
+		attributes.put(
+			"accountEntryIds", new long[] {accountEntry.getAccountEntryId()});
+		attributes.put("params", new LinkedHashMap<>());
+		attributes.put("status", status);
+
+		searchContext.setAttributes(attributes);
+
+		searchContext.setCompanyId(accountEntry.getCompanyId());
+	}
+
+	@Reference
+	private AccountEntryLocalService _accountEntryLocalService;
+
 	@Reference
 	private AccountEntryUserRelLocalService _accountEntryUserRelLocalService;
+
+	@Reference
+	private Searcher _searcher;
+
+	@Reference
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+	@Reference
+	private Sorts _sorts;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/search/spi/model/query/contributor/UserModelPreFilterContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/search/spi/model/query/contributor/UserModelPreFilterContributor.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.account.internal.search.search.spi.model.query.contributor;
+
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.portal.kernel.model.User",
+	service = ModelPreFilterContributor.class
+)
+public class UserModelPreFilterContributor
+	implements ModelPreFilterContributor {
+
+	@Override
+	public void contribute(
+		BooleanFilter booleanFilter, ModelSearchSettings modelSearchSettings,
+		SearchContext searchContext) {
+
+		long[] accountEntryIds = (long[])searchContext.getAttribute(
+			"accountEntryIds");
+
+		if (ArrayUtil.isNotEmpty(accountEntryIds)) {
+			TermsFilter accountEntryTermsFilter = new TermsFilter(
+				"accountEntryIds");
+
+			accountEntryTermsFilter.addValues(
+				ArrayUtil.toStringArray(accountEntryIds));
+
+			booleanFilter.add(accountEntryTermsFilter, BooleanClauseOccur.MUST);
+		}
+	}
+
+}

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/index/contributor/UserModelDocumentContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/index/contributor/UserModelDocumentContributor.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.account.internal.search.spi.model.index.contributor;
+
+import com.liferay.account.model.AccountEntryUserRel;
+import com.liferay.account.service.AccountEntryUserRelLocalService;
+import com.liferay.portal.kernel.dao.orm.DynamicQuery;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Drew Brokke
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.portal.kernel.model.User",
+	service = ModelDocumentContributor.class
+)
+public class UserModelDocumentContributor
+	implements ModelDocumentContributor<User> {
+
+	@Override
+	public void contribute(Document document, User user) {
+		try {
+			document.addKeyword("accountEntryIds", getAccountEntryIds(user));
+		}
+		catch (Exception e) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to index user " + user.getUserId(), e);
+			}
+		}
+	}
+
+	protected long[] getAccountEntryIds(User user) throws Exception {
+		Set<Long> accountEntryIds = new HashSet<>();
+
+		DynamicQuery dynamicQuery =
+			accountEntryUserRelLocalService.dynamicQuery();
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.eq("accountUserId", user.getUserId()));
+
+		List<AccountEntryUserRel> accountEntryUserRels =
+			accountEntryUserRelLocalService.dynamicQuery(dynamicQuery);
+
+		for (AccountEntryUserRel accountEntryUserRel : accountEntryUserRels) {
+			accountEntryIds.add(accountEntryUserRel.getAccountEntryId());
+		}
+
+		return ArrayUtil.toLongArray(accountEntryIds);
+	}
+
+	@Reference
+	protected AccountEntryUserRelLocalService accountEntryUserRelLocalService;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UserModelDocumentContributor.class);
+
+}

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/retriever/test/AccountUserRetrieverTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/retriever/test/AccountUserRetrieverTest.java
@@ -131,10 +131,39 @@ public class AccountUserRetrieverTest {
 		_assertSearch(searchTerm, 1);
 	}
 
+	@Test
+	public void testSearchAccountUsersPaginated() throws Exception {
+		String searchTerm = RandomTestUtil.randomString();
+
+		_users.add(UserTestUtil.addUser(searchTerm + 1, null));
+		_users.add(UserTestUtil.addUser(searchTerm + 2, null));
+		_users.add(UserTestUtil.addUser(searchTerm + 3, null));
+		_users.add(UserTestUtil.addUser(searchTerm + 4, null));
+
+		for (User user : _users) {
+			_accountEntryUserRels.add(
+				_accountEntryUserRelLocalService.addAccountEntryUserRel(
+					_accountEntry.getAccountEntryId(), user.getUserId()));
+		}
+
+		Assert.assertEquals(4, _searchCount(searchTerm));
+
+		List<User> actualUsers = _search(searchTerm, 1, 2, false);
+
+		Assert.assertEquals(actualUsers.toString(), 2, actualUsers.size());
+		Assert.assertEquals(_users.get(1), actualUsers.get(0));
+
+		actualUsers = _search(searchTerm, 0, 4, true);
+
+		Assert.assertEquals(actualUsers.toString(), 4, actualUsers.size());
+		Assert.assertEquals(_users.get(3), actualUsers.get(0));
+	}
+
 	private void _assertSearch(String keywords, int expectedSize)
 		throws Exception {
 
-		List<User> actualUsers = _search(keywords);
+		List<User> actualUsers = _search(
+			keywords, QueryUtil.ALL_POS, QueryUtil.ALL_POS, false);
 
 		Assert.assertEquals(
 			actualUsers.toString(), expectedSize, actualUsers.size());
@@ -142,11 +171,14 @@ public class AccountUserRetrieverTest {
 		Assert.assertEquals(expectedSize, _searchCount(keywords));
 	}
 
-	private List<User> _search(String keywords) throws Exception {
+	private List<User> _search(
+			String keywords, int cur, int delta, boolean reverse)
+		throws Exception {
+
 		return _accountUserRetriever.searchAccountUsers(
 			_accountEntry.getAccountEntryId(), keywords,
-			WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS, "screenName", false);
+			WorkflowConstants.STATUS_APPROVED, cur, delta, "screenName",
+			reverse);
 	}
 
 	private long _searchCount(String keywords) throws Exception {

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/retriever/test/AccountUserRetrieverTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/retriever/test/AccountUserRetrieverTest.java
@@ -93,21 +93,17 @@ public class AccountUserRetrieverTest {
 		// Add a user that is part of the account but will not hit a keyword
 		// search
 
-		List<User> accountUsers = new ArrayList<>();
-
-		accountUsers.add(UserTestUtil.addUser());
+		_users.add(UserTestUtil.addUser());
 
 		// Add a user that is part of the account and will hit a keyword search
 
 		String searchTerm = RandomTestUtil.randomString();
 
-		accountUsers.add(
+		_users.add(
 			UserTestUtil.addUser(
 				searchTerm + RandomTestUtil.randomString(), null));
 
-		_users.addAll(accountUsers);
-
-		for (User user : accountUsers) {
+		for (User user : _users) {
 			_accountEntryUserRels.add(
 				_accountEntryUserRelLocalService.addAccountEntryUserRel(
 					_accountEntry.getAccountEntryId(), user.getUserId()));

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/retriever/test/AccountUserRetrieverTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/retriever/test/AccountUserRetrieverTest.java
@@ -90,14 +90,6 @@ public class AccountUserRetrieverTest {
 	@Test
 	public void testSearchAccountUsers() throws Exception {
 
-		// Add a user that is not part of the account
-
-		_users.add(UserTestUtil.addUser());
-
-		// Assert that null keyword search does not hit non-account users
-
-		_assertSearch(null, 0);
-
 		// Add a user that is part of the account but will not hit a keyword
 		// search
 
@@ -132,7 +124,19 @@ public class AccountUserRetrieverTest {
 	}
 
 	@Test
-	public void testSearchAccountUsersPaginated() throws Exception {
+	public void testSearchAccountUsersWithNoAccountUsers() throws Exception {
+
+		// Add a user that is not part of the account
+
+		_users.add(UserTestUtil.addUser());
+
+		// Assert that null keyword search does not hit non-account users
+
+		_assertSearch(null, 0);
+	}
+
+	@Test
+	public void testSearchAccountUsersWithPagination() throws Exception {
 		String searchTerm = RandomTestUtil.randomString();
 
 		_users.add(UserTestUtil.addUser(searchTerm + 1, null));

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/retriever/test/AccountUserRetrieverTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/retriever/test/AccountUserRetrieverTest.java
@@ -21,10 +21,13 @@ import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.account.service.test.AccountEntryTestUtil;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -33,6 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,11 +53,14 @@ public class AccountUserRetrieverTest {
 	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Test
-	public void testGetAccountUsers() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		_accountEntry = AccountEntryTestUtil.addAccountEntry(
 			_accountEntryLocalService);
+	}
 
+	@Test
+	public void testGetAccountUsers() throws Exception {
 		_users.add(UserTestUtil.addUser());
 		_users.add(UserTestUtil.addUser());
 		_users.add(UserTestUtil.addUser());
@@ -78,6 +85,74 @@ public class AccountUserRetrieverTest {
 		Arrays.sort(actualUserIds);
 
 		Assert.assertArrayEquals(expectedUserIds, actualUserIds);
+	}
+
+	@Test
+	public void testSearchAccountUsers() throws Exception {
+
+		// Add a user that is not part of the account
+
+		_users.add(UserTestUtil.addUser());
+
+		// Assert that null keyword search does not hit non-account users
+
+		_assertSearch(null, 0);
+
+		// Add a user that is part of the account but will not hit a keyword
+		// search
+
+		List<User> accountUsers = new ArrayList<>();
+
+		accountUsers.add(UserTestUtil.addUser());
+
+		// Add a user that is part of the account and will hit a keyword search
+
+		String searchTerm = RandomTestUtil.randomString();
+
+		accountUsers.add(
+			UserTestUtil.addUser(
+				searchTerm + RandomTestUtil.randomString(), null));
+
+		_users.addAll(accountUsers);
+
+		for (User user : accountUsers) {
+			_accountEntryUserRels.add(
+				_accountEntryUserRelLocalService.addAccountEntryUserRel(
+					_accountEntry.getAccountEntryId(), user.getUserId()));
+		}
+
+		// Assert that null keyword search hits only account users
+
+		_assertSearch(null, 2);
+
+		// Assert that non-null keyword search hits only account users that
+		// match
+
+		_assertSearch(searchTerm, 1);
+	}
+
+	private void _assertSearch(String keywords, int expectedSize)
+		throws Exception {
+
+		List<User> actualUsers = _search(keywords);
+
+		Assert.assertEquals(
+			actualUsers.toString(), expectedSize, actualUsers.size());
+
+		Assert.assertEquals(expectedSize, _searchCount(keywords));
+	}
+
+	private List<User> _search(String keywords) throws Exception {
+		return _accountUserRetriever.searchAccountUsers(
+			_accountEntry.getAccountEntryId(), keywords,
+			WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, "screenName", false);
+	}
+
+	private long _searchCount(String keywords) throws Exception {
+		return _accountUserRetriever.searchCountAccountUsers(
+			_accountEntry.getAccountEntryId(), keywords,
+			WorkflowConstants.STATUS_APPROVED);
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryUserRelLocalServiceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryUserRelLocalServiceTest.java
@@ -19,9 +19,11 @@ import com.liferay.account.exception.NoSuchEntryException;
 import com.liferay.account.model.AccountEntry;
 import com.liferay.account.model.AccountEntryUserRel;
 import com.liferay.account.model.AccountEntryUserRelModel;
+import com.liferay.account.retriever.AccountUserRetriever;
 import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.UserEmailAddressException;
 import com.liferay.portal.kernel.model.User;
@@ -33,6 +35,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -123,6 +126,14 @@ public class AccountEntryUserRelLocalServiceTest {
 		Assert.assertEquals(_userInfo.screenName, user.getScreenName());
 		Assert.assertEquals(
 			accountEntryUserRel.getAccountUserId(), user.getUserId());
+
+		List<User> actualUsers = _accountUserRetriever.searchAccountUsers(
+			_accountEntry.getAccountEntryId(), user.getScreenName(),
+			WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, "screenName", false);
+
+		Assert.assertEquals(actualUsers.toString(), 1, actualUsers.size());
+		Assert.assertEquals(actualUsers.get(0), user);
 	}
 
 	@Test
@@ -235,6 +246,9 @@ public class AccountEntryUserRelLocalServiceTest {
 	@DeleteAfterTestRun
 	private final List<AccountEntryUserRel> _accountEntryUserRels =
 		new ArrayList<>();
+
+	@Inject
+	private AccountUserRetriever _accountUserRetriever;
 
 	@DeleteAfterTestRun
 	private User _user;


### PR DESCRIPTION
This is an update for [LPS-101098](https://issues.liferay.com/browse/LPS-101098).

Hey Brian, this pull just uses the separate `search` and `searchCount` methods for now. I talked with Jorge, and we're going to try to add `Page` to `info-api`. Once that goes in, I'll update this API to take advantage of that.

/cc @pei-jung @alee8888 @ChrisKian @dejuknow