### PR TITLE
LPS-102177 add exception mappers

### DIFF
--- a/modules/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/dto/v1_0/ExperimentVariant.java
+++ b/modules/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/dto/v1_0/ExperimentVariant.java
@@ -73,8 +73,8 @@ public class ExperimentVariant {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String id;
 
-	@DecimalMax("100")
-	@DecimalMin("0")
+	@DecimalMax("99")
+	@DecimalMin("1")
 	@Schema
 	public Double getTrafficSplit() {
 		return trafficSplit;

--- a/modules/apps/segments/segments-asah-rest-api/src/main/resources/com/liferay/segments/asah/rest/dto/v1_0/packageinfo
+++ b/modules/apps/segments/segments-asah-rest-api/src/main/resources/com/liferay/segments/asah/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.1
+version 1.0.2

--- a/modules/apps/segments/segments-asah-rest-impl/rest-openapi.yaml
+++ b/modules/apps/segments/segments-asah-rest-impl/rest-openapi.yaml
@@ -53,8 +53,8 @@ components:
                     type: string
                 trafficSplit:
                     format: double
-                    maximum: 100
-                    minimum: 0
+                    maximum: 99
+                    minimum: 1
                     type: number
             type: object
         Status:

--- a/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/jaxrs/exception/mapper/LockedExperimentExceptionMapper.java
+++ b/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/jaxrs/exception/mapper/LockedExperimentExceptionMapper.java
@@ -26,6 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * Converts any {@code LockedSegmentsExperimentException} to a {@code 400} error.
  *
  * @author Sarai Díaz
+ * @review
  */
 @Component(
 	property = {

--- a/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/jaxrs/exception/mapper/LockedExperimentExceptionMapper.java
+++ b/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/jaxrs/exception/mapper/LockedExperimentExceptionMapper.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.segments.asah.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.segments.exception.LockedSegmentsExperimentException;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Converts any {@code LockedSegmentsExperimentException} to a {@code 400} error.
+ *
+ * @author Sarai Díaz
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Segments.Asah.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Segments.Asah.REST.LockedExperimentExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class LockedExperimentExceptionMapper
+	implements ExceptionMapper<LockedSegmentsExperimentException> {
+
+	@Override
+	public Response toResponse(
+		LockedSegmentsExperimentException lockedSegmentsExperimentException) {
+
+		return Response.status(
+			400
+		).type(
+			MediaType.TEXT_PLAIN
+		).entity(
+			lockedSegmentsExperimentException.getMessage()
+		).build();
+	}
+
+}

--- a/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/jaxrs/exception/mapper/StatusExceptionMapper.java
+++ b/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/jaxrs/exception/mapper/StatusExceptionMapper.java
@@ -26,6 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * Converts any {@code SegmentsExperimentStatusException} to a {@code 400} error.
  *
  * @author Sarai Díaz
+ * @review
  */
 @Component(
 	property = {

--- a/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/jaxrs/exception/mapper/StatusExceptionMapper.java
+++ b/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/jaxrs/exception/mapper/StatusExceptionMapper.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.segments.asah.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.segments.exception.SegmentsExperimentStatusException;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Converts any {@code SegmentsExperimentStatusException} to a {@code 400} error.
+ *
+ * @author Sarai Díaz
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Segments.Asah.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Segments.Asah.REST.StatusExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class StatusExceptionMapper
+	implements ExceptionMapper<SegmentsExperimentStatusException> {
+
+	@Override
+	public Response toResponse(
+		SegmentsExperimentStatusException segmentsExperimentStatusException) {
+
+		return Response.status(
+			400
+		).type(
+			MediaType.TEXT_PLAIN
+		).entity(
+			segmentsExperimentStatusException.getMessage()
+		).build();
+	}
+
+}

--- a/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/jaxrs/exception/mapper/TrafficSplitExceptionMapper.java
+++ b/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/jaxrs/exception/mapper/TrafficSplitExceptionMapper.java
@@ -26,6 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * Converts any {@code SegmentsExperimentRelSplitException} to a {@code 400} error.
  *
  * @author Sarai Díaz
+ * @review
  */
 @Component(
 	property = {

--- a/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/jaxrs/exception/mapper/TrafficSplitExceptionMapper.java
+++ b/modules/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/jaxrs/exception/mapper/TrafficSplitExceptionMapper.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.segments.asah.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.segments.exception.SegmentsExperimentRelSplitException;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Converts any {@code SegmentsExperimentRelSplitException} to a {@code 400} error.
+ *
+ * @author Sarai Díaz
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Segments.Asah.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Segments.Asah.REST.TrafficSplitExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class TrafficSplitExceptionMapper
+	implements ExceptionMapper<SegmentsExperimentRelSplitException> {
+
+	@Override
+	public Response toResponse(
+		SegmentsExperimentRelSplitException
+			segmentsExperimentRelSplitException) {
+
+		return Response.status(
+			400
+		).type(
+			MediaType.TEXT_PLAIN
+		).entity(
+			segmentsExperimentRelSplitException.getMessage()
+		).build();
+	}
+
+}


### PR DESCRIPTION
Talked with @dgarciasarai, ExperimentStatus definitely is StatusExceptionMapper and RelSplit corresponds with TrafficSplit property in the API.