### PR TITLE
LPS-102773 Capture tag exception

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/jaxrs/exception/mapper/DuplicateKeywordExceptionMapper.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/jaxrs/exception/mapper/DuplicateKeywordExceptionMapper.java
@@ -43,11 +43,11 @@ public class DuplicateKeywordExceptionMapper
 	public Response toResponse(DuplicateTagException duplicateTagException) {
 		return Response.status(
 			409
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				duplicateTagException.getMessage(), "tag", "keyword")
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/jaxrs/exception/mapper/DuplicateTaxonomyCategoryExceptionMapper.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/jaxrs/exception/mapper/DuplicateTaxonomyCategoryExceptionMapper.java
@@ -45,12 +45,12 @@ public class DuplicateTaxonomyCategoryExceptionMapper
 
 		return Response.status(
 			409
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				duplicateCategoryException.getMessage(), "category",
 				"taxonomy category")
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/jaxrs/exception/mapper/DuplicateTaxonomyVocabularyExceptionMapper.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/jaxrs/exception/mapper/DuplicateTaxonomyVocabularyExceptionMapper.java
@@ -45,12 +45,12 @@ public class DuplicateTaxonomyVocabularyExceptionMapper
 
 		return Response.status(
 			409
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				duplicateVocabularyException.getMessage(),
 				"category vocabulary", "taxonomy vocabulary")
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/jaxrs/exception/mapper/EmptyKeywordExceptionMapper.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/jaxrs/exception/mapper/EmptyKeywordExceptionMapper.java
@@ -14,7 +14,8 @@
 
 package com.liferay.headless.admin.taxonomy.internal.jaxrs.exception.mapper;
 
-import com.liferay.asset.kernel.exception.AssetTagException;
+import com.liferay.asset.kernel.exception.AssetTagNameException;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -23,7 +24,7 @@ import javax.ws.rs.ext.ExceptionMapper;
 import org.osgi.service.component.annotations.Component;
 
 /**
- * Converts any {@code AssetTagException} to a {@code 400} error.
+ * Converts any {@code AssetTagNameException} to a {@code 400} error.
  *
  * @author Víctor Galán
  */
@@ -31,20 +32,20 @@ import org.osgi.service.component.annotations.Component;
 	property = {
 		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Taxonomy)",
 		"osgi.jaxrs.extension=true",
-		"osgi.jaxrs.name=Liferay.Headless.Admin.Taxonomy.KeywordNameExceptionMapper"
+		"osgi.jaxrs.name=Liferay.Headless.Admin.Taxonomy.EmptyKeywordExceptionMapper"
 	},
 	service = ExceptionMapper.class
 )
-public class KeywordNameExceptionMapper
-	implements ExceptionMapper<AssetTagException> {
+public class EmptyKeywordExceptionMapper
+	implements ExceptionMapper<AssetTagNameException> {
 
 	@Override
-	public Response toResponse(AssetTagException assetTagException) {
+	public Response toResponse(AssetTagNameException assetTagNameException) {
 		return Response.status(
 			400
 		).entity(
-			"Keyword name is too long or contains invalid characters: " +
-				assetTagException.getMessage()
+			StringUtil.replace(
+				assetTagNameException.getMessage(), "Tag", "Keyword")
 		).type(
 			MediaType.TEXT_PLAIN
 		).build();

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/jaxrs/exception/mapper/TaxonomyCategoryNameExceptionMapper.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/jaxrs/exception/mapper/TaxonomyCategoryNameExceptionMapper.java
@@ -45,12 +45,12 @@ public class TaxonomyCategoryNameExceptionMapper
 
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				assetCategoryNameException.getMessage(), "category",
 				"taxonomy category")
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/jaxrs/exception/mapper/TaxonomyVocabularyNameExceptionMapper.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/jaxrs/exception/mapper/TaxonomyVocabularyNameExceptionMapper.java
@@ -45,12 +45,12 @@ public class TaxonomyVocabularyNameExceptionMapper
 
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				vocabularyNameException.getMessage(), "Category vocabulary",
 				"Taxonomy vocabulary")
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/BlogPostingArticleBodyExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/BlogPostingArticleBodyExceptionMapper.java
@@ -43,11 +43,11 @@ public class BlogPostingArticleBodyExceptionMapper
 	public Response toResponse(EntryContentException entryContentException) {
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				entryContentException.getMessage(), "Content", "Article body")
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/BlogPostingFriendlyURLExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/BlogPostingFriendlyURLExceptionMapper.java
@@ -43,12 +43,12 @@ public class BlogPostingFriendlyURLExceptionMapper
 	public Response toResponse(EntryUrlTitleException entryUrlTitleException) {
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				entryUrlTitleException.getMessage(), "URL title",
 				"Friendly URL")
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/BlogPostingHeadlineExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/BlogPostingHeadlineExceptionMapper.java
@@ -43,11 +43,11 @@ public class BlogPostingHeadlineExceptionMapper
 	public Response toResponse(EntryTitleException entryTitleException) {
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				entryTitleException.getMessage(), "Title", "Headline")
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DocumentFileExtensionExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DocumentFileExtensionExceptionMapper.java
@@ -42,10 +42,10 @@ public class DocumentFileExtensionExceptionMapper
 	public Response toResponse(FileExtensionException fileExtensionException) {
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			fileExtensionException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DocumentFileNameExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DocumentFileNameExceptionMapper.java
@@ -42,10 +42,10 @@ public class DocumentFileNameExceptionMapper
 	public Response toResponse(FileNameException fileNameException) {
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			fileNameException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DocumentFileSizeExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DocumentFileSizeExceptionMapper.java
@@ -42,10 +42,10 @@ public class DocumentFileSizeExceptionMapper
 	public Response toResponse(FileSizeException fileSizeException) {
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			fileSizeException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DocumentFolderNameExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DocumentFolderNameExceptionMapper.java
@@ -43,11 +43,11 @@ public class DocumentFolderNameExceptionMapper
 	public Response toResponse(FolderNameException folderNameException) {
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				folderNameException.getMessage(), "Folder", "Document folder")
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DocumentSourceFileNameExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DocumentSourceFileNameExceptionMapper.java
@@ -44,10 +44,10 @@ public class DocumentSourceFileNameExceptionMapper
 
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			sourceFileNameException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DuplicateDocumentExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DuplicateDocumentExceptionMapper.java
@@ -45,12 +45,12 @@ public class DuplicateDocumentExceptionMapper
 
 		return Response.status(
 			409
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				duplicateFileEntryException.getMessage(), "file entry",
 				"document")
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DuplicateDocumentFolderNameExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DuplicateDocumentFolderNameExceptionMapper.java
@@ -45,12 +45,12 @@ public class DuplicateDocumentFolderNameExceptionMapper
 
 		return Response.status(
 			409
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				duplicateFolderNameException.getMessage(), "folder",
 				"document folder")
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DuplicateFriendlyURLEntryExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DuplicateFriendlyURLEntryExceptionMapper.java
@@ -45,10 +45,10 @@ public class DuplicateFriendlyURLEntryExceptionMapper
 
 		return Response.status(
 			409
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			"Duplicate friendly URL"
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DuplicateKnowledgeBaseFolderNameExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DuplicateKnowledgeBaseFolderNameExceptionMapper.java
@@ -44,10 +44,10 @@ public class DuplicateKnowledgeBaseFolderNameExceptionMapper
 
 		return Response.status(
 			409
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			duplicateKBFolderNameException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DuplicateStructuredContentFolderNameExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DuplicateStructuredContentFolderNameExceptionMapper.java
@@ -44,11 +44,11 @@ public class DuplicateStructuredContentFolderNameExceptionMapper
 
 		return Response.status(
 			409
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			"A structured content folder already exists with the name " +
 				duplicateFolderNameException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DuplicateWikiNodeNameExceptionExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/DuplicateWikiNodeNameExceptionExceptionMapper.java
@@ -44,11 +44,11 @@ public class DuplicateWikiNodeNameExceptionExceptionMapper
 
 		return Response.status(
 			409
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			"A wiki node already exists with the name " +
 				duplicateNodeNameException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/InvalidKnowledgeBaseFolderNameExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/InvalidKnowledgeBaseFolderNameExceptionMapper.java
@@ -44,10 +44,10 @@ public class InvalidKnowledgeBaseFolderNameExceptionMapper
 
 		return Response.status(
 			409
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			invalidKBFolderNameException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/KnowledgeBaseArticleArticleBodyExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/KnowledgeBaseArticleArticleBodyExceptionMapper.java
@@ -45,12 +45,12 @@ public class KnowledgeBaseArticleArticleBodyExceptionMapper
 
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				kbArticleContentException.getMessage(), "Content",
 				"Article body")
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/KnowledgeBaseArticleFriendlyURLExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/KnowledgeBaseArticleFriendlyURLExceptionMapper.java
@@ -53,12 +53,12 @@ public class KnowledgeBaseArticleFriendlyURLExceptionMapper
 
 		return Response.status(
 			statusCode
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				kbArticleUrlTitleException.getMessage(), "URL title",
 				"Friendly URL")
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/KnowledgeBaseArticleTitleExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/KnowledgeBaseArticleTitleExceptionMapper.java
@@ -44,10 +44,10 @@ public class KnowledgeBaseArticleTitleExceptionMapper
 
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			kbArticleTitleException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/LockedMessageBoardThreadExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/LockedMessageBoardThreadExceptionMapper.java
@@ -42,10 +42,10 @@ public class LockedMessageBoardThreadExceptionMapper
 	public Response toResponse(LockedThreadException lockedThreadException) {
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			lockedThreadException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/MessageBoardMessageSubjectExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/MessageBoardMessageSubjectExceptionMapper.java
@@ -45,13 +45,13 @@ public class MessageBoardMessageSubjectExceptionMapper
 
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				messageSubjectException.getMessage(),
 				new String[] {"Subject", "body"},
 				new String[] {"Headline", "article body"})
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/MessageBoardSectionNameExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/MessageBoardSectionNameExceptionMapper.java
@@ -43,11 +43,11 @@ public class MessageBoardSectionNameExceptionMapper
 	public Response toResponse(CategoryNameException categoryNameException) {
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			StringUtil.replace(
 				categoryNameException.getMessage(), "Name", "Title")
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/StructuredContentFolderNameExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/StructuredContentFolderNameExceptionMapper.java
@@ -42,11 +42,11 @@ public class StructuredContentFolderNameExceptionMapper
 	public Response toResponse(FolderNameException folderNameException) {
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			"Invalid structured content folder name " +
 				folderNameException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/StructuredContentTitleExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/StructuredContentTitleExceptionMapper.java
@@ -42,10 +42,10 @@ public class StructuredContentTitleExceptionMapper
 	public Response toResponse(ArticleTitleException articleTitleException) {
 		return Response.status(
 			400
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			articleTitleException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/ExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/ExceptionMapper.java
@@ -32,10 +32,10 @@ public class ExceptionMapper
 
 		return Response.status(
 			500
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			exception.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/NoSuchModelExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/NoSuchModelExceptionMapper.java
@@ -48,10 +48,10 @@ public class NoSuchModelExceptionMapper
 
 		return Response.status(
 			Response.Status.NOT_FOUND
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			noSuchModelException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/PortalExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/PortalExceptionMapper.java
@@ -32,10 +32,10 @@ public class PortalExceptionMapper implements ExceptionMapper<PortalException> {
 	public Response toResponse(PortalException portalException) {
 		return Response.status(
 			Response.Status.INTERNAL_SERVER_ERROR
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			portalException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/ValidationExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/ValidationExceptionMapper.java
@@ -33,10 +33,10 @@ public class ValidationExceptionMapper
 	public Response toResponse(ValidationException validationException) {
 		return Response.status(
 			Response.Status.BAD_REQUEST
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			validationException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/WebApplicationExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/WebApplicationExceptionMapper.java
@@ -41,10 +41,10 @@ public class WebApplicationExceptionMapper
 
 		return Response.status(
 			response.getStatus()
-		).type(
-			MediaType.TEXT_PLAIN
 		).entity(
 			webApplicationException.getMessage()
+		).type(
+			MediaType.TEXT_PLAIN
 		).build();
 	}
 


### PR DESCRIPTION
KeywordNameExceptionMapper gets renamed to EmptyNameExceptionMapper because it's only thrown (AssetTagNameException) when name is empty. I create KeywordNameExceptionMapper to catch all other name invalid cases (AssetTagException)