### PR TITLE
LPS-102619 portal-search-elasticsearch6-impl: Finish implementing Rescoring in Elasticsearch 6

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssemblerImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssemblerImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.search.filter.ComplexQueryBuilderFactory;
 import com.liferay.portal.search.filter.ComplexQueryPart;
 import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.Query;
+import com.liferay.portal.search.rescore.Rescore;
 import com.liferay.portal.search.stats.StatsRequest;
 
 import java.util.ArrayList;
@@ -350,15 +351,41 @@ public class CommonSearchRequestBuilderAssemblerImpl
 		SearchRequestBuilder searchRequestBuilder,
 		BaseSearchRequest baseSearchRequest) {
 
-		Query query = baseSearchRequest.getRescoreQuery();
+		setRescorers(searchRequestBuilder, baseSearchRequest.getRescores());
+
+		setRescorerQuery(
+			searchRequestBuilder, baseSearchRequest.getRescoreQuery());
+	}
+
+	protected void setRescorerQuery(
+		SearchRequestBuilder searchRequestBuilder, Query query) {
 
 		if (query == null) {
 			return;
 		}
 
-		searchRequestBuilder.setRescorer(
+		searchRequestBuilder.addRescorer(
 			new QueryRescorerBuilder(
 				_queryToQueryBuilderTranslator.translate(query)));
+	}
+
+	protected void setRescorers(
+		SearchRequestBuilder searchRequestBuilder, List<Rescore> rescores) {
+
+		if (rescores == null) {
+			return;
+		}
+
+		for (Rescore rescore : rescores) {
+			QueryRescorerBuilder queryRescorerBuilder =
+				new QueryRescorerBuilder(
+					_queryToQueryBuilderTranslator.translate(
+						rescore.getQuery()));
+
+			queryRescorerBuilder.windowSize(rescore.getWindowSize());
+
+			searchRequestBuilder.addRescorer(queryRescorerBuilder);
+		}
 	}
 
 	protected void setStatsRequests(

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/rescore/RescorerTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/rescore/RescorerTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.rescore;
+
+import com.liferay.portal.search.elasticsearch6.internal.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.rescore.BaseRescoreTestCase;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class RescorerTest extends BaseRescoreTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssemblerImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssemblerImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.search.filter.ComplexQueryBuilderFactory;
 import com.liferay.portal.search.filter.ComplexQueryPart;
 import com.liferay.portal.search.query.BooleanQuery;
 import com.liferay.portal.search.query.Query;
+import com.liferay.portal.search.rescore.Rescore;
 import com.liferay.portal.search.stats.StatsRequest;
 
 import java.util.ArrayList;
@@ -350,15 +351,41 @@ public class CommonSearchRequestBuilderAssemblerImpl
 		SearchRequestBuilder searchRequestBuilder,
 		BaseSearchRequest baseSearchRequest) {
 
-		Query query = baseSearchRequest.getRescoreQuery();
+		setRescorers(searchRequestBuilder, baseSearchRequest.getRescores());
+
+		setRescorerQuery(
+			searchRequestBuilder, baseSearchRequest.getRescoreQuery());
+	}
+
+	protected void setRescorerQuery(
+		SearchRequestBuilder searchRequestBuilder, Query query) {
 
 		if (query == null) {
 			return;
 		}
 
-		searchRequestBuilder.setRescorer(
+		searchRequestBuilder.addRescorer(
 			new QueryRescorerBuilder(
 				_queryToQueryBuilderTranslator.translate(query)));
+	}
+
+	protected void setRescorers(
+		SearchRequestBuilder searchRequestBuilder, List<Rescore> rescores) {
+
+		if (rescores == null) {
+			return;
+		}
+
+		for (Rescore rescore : rescores) {
+			QueryRescorerBuilder queryRescorerBuilder =
+				new QueryRescorerBuilder(
+					_queryToQueryBuilderTranslator.translate(
+						rescore.getQuery()));
+
+			queryRescorerBuilder.windowSize(rescore.getWindowSize());
+
+			searchRequestBuilder.addRescorer(queryRescorerBuilder);
+		}
 	}
 
 	protected void setStatsRequests(

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/rescore/RescorerTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/rescore/RescorerTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.rescore;
+
+import com.liferay.portal.search.elasticsearch7.internal.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.rescore.BaseRescoreTestCase;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class RescorerTest extends BaseRescoreTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java
@@ -47,9 +47,11 @@ import com.liferay.portal.search.internal.highlight.HighlightsImpl;
 import com.liferay.portal.search.internal.legacy.searcher.SearchRequestBuilderImpl;
 import com.liferay.portal.search.internal.legacy.searcher.SearchResponseBuilderImpl;
 import com.liferay.portal.search.internal.query.QueriesImpl;
+import com.liferay.portal.search.internal.rescore.RescoreBuilderFactoryImpl;
 import com.liferay.portal.search.internal.script.ScriptsImpl;
 import com.liferay.portal.search.internal.sort.SortsImpl;
 import com.liferay.portal.search.query.Queries;
+import com.liferay.portal.search.rescore.RescoreBuilderFactory;
 import com.liferay.portal.search.script.Scripts;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.searcher.SearchResponse;
@@ -293,6 +295,8 @@ public abstract class BaseIndexingTestCase {
 	protected final GeoBuilders geoBuilders = new GeoBuildersImpl();
 	protected final Highlights highlights = new HighlightsImpl();
 	protected final Queries queries = new QueriesImpl();
+	protected final RescoreBuilderFactory rescoreBuilderFactory =
+		new RescoreBuilderFactoryImpl();
 	protected final Scripts scripts = new ScriptsImpl();
 	protected final Sorts sorts = new SortsImpl();
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/rescore/BaseRescoreTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/rescore/BaseRescoreTestCase.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.rescore;
+
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.document.Field;
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.engine.adapter.search.SearchSearchRequest;
+import com.liferay.portal.search.engine.adapter.search.SearchSearchResponse;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.query.Query;
+import com.liferay.portal.search.rescore.Rescore;
+import com.liferay.portal.search.rescore.RescoreBuilder;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Adam Brandizzi
+ */
+public abstract class BaseRescoreTestCase extends BaseIndexingTestCase {
+
+	@Test
+	public void testRescore() {
+		addDocuments(
+			value -> DocumentCreationHelpers.singleText(_TITLE, value),
+			Arrays.asList("alpha zeta", "alpha alpha", "alpha beta beta"));
+
+		Query query = queries.string(_TITLE.concat(":alpha"));
+
+		assertSearch(
+			_TITLE, query, (List<Rescore>)null,
+			Arrays.asList("alpha alpha", "alpha zeta", "alpha beta beta"));
+
+		assertSearch(
+			_TITLE, query, Arrays.asList(buildRescore(_TITLE, "beta")),
+			Arrays.asList("alpha beta beta", "alpha alpha", "alpha zeta"));
+	}
+
+	@Test
+	public void testRescoreQuery() {
+		addDocuments(
+			value -> DocumentCreationHelpers.singleText(_TITLE, value),
+			Arrays.asList(
+				"alpha alpha", "alpha gamma gamma", "alpha beta beta"));
+
+		Query query = queries.string(_TITLE.concat(":alpha"));
+
+		assertSearch(
+			_TITLE, query, (Query)null,
+			Arrays.asList(
+				"alpha alpha", "alpha gamma gamma", "alpha beta beta"));
+
+		Query rescoreQuery = queries.match(_TITLE, "beta");
+
+		assertSearch(
+			_TITLE, query, rescoreQuery,
+			Arrays.asList(
+				"alpha beta beta", "alpha alpha", "alpha gamma gamma"));
+	}
+
+	@Test
+	public void testRescores() {
+		addDocuments(
+			value -> DocumentCreationHelpers.singleText(_TITLE, value),
+			Arrays.asList(
+				"alpha alpha", "alpha gamma gamma", "alpha beta beta beta"));
+
+		Query query = queries.string(_TITLE.concat(":alpha"));
+
+		assertSearch(
+			_TITLE, query, (List<Rescore>)null,
+			Arrays.asList(
+				"alpha alpha", "alpha gamma gamma", "alpha beta beta beta"));
+
+		assertSearch(
+			_TITLE, query,
+			Arrays.asList(
+				buildRescore(_TITLE, "beta"), buildRescore(_TITLE, "gamma")),
+			Arrays.asList(
+				"alpha beta beta beta", "alpha gamma gamma", "alpha alpha"));
+	}
+
+	protected void assertSearch(
+		String fieldName, Query query, List<Rescore> rescores,
+		List<String> expectedValues) {
+
+		assertSearch(
+			indexingTestHelper -> {
+				SearchSearchRequest searchSearchRequest =
+					getSearchSearchRequest(query);
+
+				searchSearchRequest.setRescores(rescores);
+
+				List<String> actualValues = getFieldValues(
+					searchSearchRequest, fieldName);
+
+				Assert.assertEquals(
+					expectedValues.toString(), actualValues.toString());
+			});
+	}
+
+	protected void assertSearch(
+		String fieldName, Query query, Query rescoreQuery,
+		List<String> expectedValues) {
+
+		assertSearch(
+			indexingTestHelper -> {
+				SearchSearchRequest searchSearchRequest =
+					getSearchSearchRequest(query);
+
+				searchSearchRequest.setRescoreQuery(rescoreQuery);
+
+				List<String> actualValues = getFieldValues(
+					searchSearchRequest, fieldName);
+
+				Assert.assertEquals(
+					expectedValues.toString(), actualValues.toString());
+			});
+	}
+
+	protected Rescore buildRescore(String fieldName, String value) {
+		RescoreBuilder rescoreBuilder =
+			rescoreBuilderFactory.getRescoreBuilder();
+
+		Query rescoreQuery = queries.match(fieldName, value);
+
+		return rescoreBuilder.query(
+			rescoreQuery
+		).windowSize(
+			100
+		).build();
+	}
+
+	protected String getFieldValue(String fieldName, SearchHit searchHit) {
+		Document document = searchHit.getDocument();
+
+		Map<String, Field> fields = document.getFields();
+
+		Field field = fields.get(fieldName);
+
+		return (String)field.getValue();
+	}
+
+	protected List<String> getFieldValues(
+		SearchSearchRequest searchSearchRequest, String fieldName) {
+
+		SearchEngineAdapter searchEngineAdapter = getSearchEngineAdapter();
+
+		SearchSearchResponse searchSearchResponse = searchEngineAdapter.execute(
+			searchSearchRequest);
+
+		SearchHits searchHits = searchSearchResponse.getSearchHits();
+
+		List<SearchHit> searchHitsList = searchHits.getSearchHits();
+
+		Stream<SearchHit> stream = searchHitsList.stream();
+
+		return stream.map(
+			searchHit -> getFieldValue(fieldName, searchHit)
+		).collect(
+			Collectors.toList()
+		);
+	}
+
+	protected SearchSearchRequest getSearchSearchRequest(Query query) {
+		SearchSearchRequest searchSearchRequest = new SearchSearchRequest();
+
+		searchSearchRequest.setIndexNames("_all");
+		searchSearchRequest.setQuery(query);
+		searchSearchRequest.setSize(30);
+
+		return searchSearchRequest;
+	}
+
+	private static final String _TITLE = "title";
+
+}


### PR DESCRIPTION
<h3>:x: ci:test:search - 30 out of 32 jobs passed in 1 hour 19 minutes 41 seconds 859 ms</h3>

Only unique failures are semver issues in unrelated modules.

https://github.com/brandizzi/liferay-portal/pull/844#issuecomment-538550037

Author: @brandizzi

Enable new rescorer API on Elasticsearch 7
https://issues.liferay.com/browse/LPS-102619