### PR TITLE
LPS-102881 Update to alloyeditor v2.11.0

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"alloyeditor": "2.10.0"
+		"alloyeditor": "2.11.0"
 	},
 	"name": "frontend-editor-alloyeditor-web",
 	"scripts": {

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -2683,16 +2683,15 @@ alloy-ui@^3.1.0-deprecated.1, alloy-ui@^3.1.0-deprecated.40:
   resolved "https://registry.yarnpkg.com/alloy-ui/-/alloy-ui-3.1.0.tgz#95842e4c793abbfe84aa8abfc5a637cd36dda823"
   integrity sha1-lYQuTHk6u/6Eqoq/xaY3zTbdqCM=
 
-alloyeditor@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/alloyeditor/-/alloyeditor-2.10.0.tgz#043210124d44c08b1887eb8015059859c95c4eff"
-  integrity sha512-B62q5BMB861i2rJx4gTbn46FuMv32UidK+PLFLvVGF8wjmXWtLLKf+ILTXpY0ZEbghXHbijGt5rZCRmyVHW3qg==
+alloyeditor@2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/alloyeditor/-/alloyeditor-2.11.0.tgz#9e88d07a3934033f3599da69f88a55fd7f1f73e7"
+  integrity sha512-bVhyQs+Vg0NUQelFDb+UyDnmxxc+eAjU3INkgsvVejJ7H8BQmaK9o+TkR1lNEHmOoOIVRScQdI+IgtIhV7vYVA==
   dependencies:
     clay-css "^2.11.1"
     prop-types "^15.6.2"
     react "^16.8.3"
     react-dom "^16.8.3"
-    val-loader "1.1.1"
 
 amdefine@>=0.0.4:
   version "1.0.1"
@@ -16109,14 +16108,6 @@ schema-utils@^0.3.0:
   dependencies:
     ajv "^5.0.0"
 
-schema-utils@^0.4.5:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
-  integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
-  dependencies:
-    ajv "^6.1.0"
-    ajv-keywords "^3.1.0"
-
 schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
@@ -17997,14 +17988,6 @@ v8flags@^2.0.2:
   integrity sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=
   dependencies:
     user-home "^1.1.1"
-
-val-loader@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/val-loader/-/val-loader-1.1.1.tgz#32ba8ed5c3607504134977251db2966499e15ef7"
-  integrity sha512-JLqLXJWCVLXTxbUeHhLpWkgl3+X3U8Bl0vY7rTFZgFSbLJaEtAxuD2ixy/cM8w/gzC7sS3NE5IDSzClDt332sw==
-  dependencies:
-    loader-utils "^1.0.0"
-    schema-utils "^0.4.5"
 
 vali-date@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The new version exports helpers to facilitate the creation of custom buttons. This should make creating custom buttons in v2.x as straightforward as it used to be in v1.x.

Full release notes:

https://github.com/liferay/alloy-editor/releases/tag/v2.11.0

- feat: make it possible to build custom buttons that use "mixins"
- refactor: prepare to export "mixins"
- fix: move val-loader out of dependencies into devDependencies
- chore: update linting and formatting