### PR TITLE
LPS-102782 Enable delete on App Builder's Custom Objects

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/custom-object/ListCustomObjects.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/custom-object/ListCustomObjects.es.js
@@ -155,7 +155,7 @@ export default ({history}) => {
 						name: 'divider'
 					},
 					{
-						callback: confirmDelete(
+						action: confirmDelete(
 							'/o/data-engine/v1.0/data-definitions/'
 						),
 						name: Liferay.Language.get('delete')


### PR DESCRIPTION
/cc @katienesterovich

Hello @brunofarache,

I looked through many of the App Builder LPS bug fixes and I see you made many of them. I am not sure if you are the correct person to send pull requests to for App Builder fixes, if not please let me know who I should send this to, thank you.

Notes from Katie:

> **Ticket**: https://issues.liferay.com/browse/LPS-102782
> 
> **Bug**: delete button does nothing.
> 
> **Reason**: no action provided for the button.
> 
> **Fix**: mimic `app` and `entry` deletion process - call on action instead of callback.
> 
> _Initial_
> ![image](https://user-images.githubusercontent.com/51712906/66327260-27db7680-e8f0-11e9-81f8-a49c037e846e.png)
> 
> _Alert_
> ![image](https://user-images.githubusercontent.com/51712906/66327274-2f028480-e8f0-11e9-98cc-be75a376fe33.png)
> 
> _Deleted_
> ![image](https://user-images.githubusercontent.com/51712906/66327296-37f35600-e8f0-11e9-8b8b-277a8e090c2b.png)