### PR TITLE
LPS-101098 Create an API method to search for users assigned to an account

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/retriever/AccountUserRetrieverImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/retriever/AccountUserRetrieverImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Validator;
@@ -124,7 +125,8 @@ public class AccountUserRetrieverImpl implements AccountUserRetriever {
 				sortOrder = SortOrder.DESC;
 			}
 
-			FieldSort sort = _sorts.field(sortField, sortOrder);
+			FieldSort sort = _sorts.field(
+				Field.getSortableFieldName(sortField), sortOrder);
 
 			searchRequestBuilder.sorts(sort);
 		}


### PR DESCRIPTION
This is an update for [LPS-101098](https://issues.liferay.com/browse/LPS-101098).<br><br>Hey Brian, this fixes an issue with using sort field names that are not marked as keywords in liferay-type-mappings.json.<br><br>/cc @pei-jung @alee8888 @ChrisKian @dejuknow