### PR TITLE
LPS-102982 ant-compress.jar was moved from portal to development folder, so it is necessary to updated versions-ext.xml file

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -4477,6 +4477,18 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>lib/development/ant-compress.jar</file-name>
+				<version>1.5</version>
+				<project-name>Apache Compress Antlib</project-name>
+				<project-url>https://ant.apache.org/antlibs/compress/</project-url>
+				<licenses>
+					<license>
+						<license-name>Apache License 2.0</license-name>
+						<license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>lib/development/ant-contrib.jar</file-name>
 				<version>1.0 B3</version>
 				<project-name>Ant-Contrib Tasks</project-name>
@@ -5387,18 +5399,6 @@
 				<version>1.1.3</version>
 				<project-name>Abdera</project-name>
 				<project-url>http://abdera.apache.org</project-url>
-				<licenses>
-					<license>
-						<license-name>Apache License 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
-					</license>
-				</licenses>
-			</library>
-			<library>
-				<file-name>lib/portal/ant-compress.jar</file-name>
-				<version>1.5</version>
-				<project-name>Apache Compress Antlib</project-name>
-				<project-url>https://ant.apache.org/antlibs/compress/</project-url>
 				<licenses>
 					<license>
 						<license-name>Apache License 2.0</license-name>

--- a/lib/versions-ext.xml
+++ b/lib/versions-ext.xml
@@ -53,6 +53,18 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>lib/development/ant-compress.jar</file-name>
+				<version>1.5</version>
+				<project-name>Apache Compress Antlib</project-name>
+				<project-url>https://ant.apache.org/antlibs/compress/</project-url>
+				<licenses>
+					<license>
+						<license-name>Apache License 2.0</license-name>
+						<license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>lib/development/appium.jar</file-name>
 				<version>1.6.2</version>
 				<project-name>Appium</project-name>
@@ -927,18 +939,6 @@
 				<version>1.1.3</version>
 				<project-name>Abdera</project-name>
 				<project-url>http://abdera.apache.org</project-url>
-				<licenses>
-					<license>
-						<license-name>Apache License 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
-					</license>
-				</licenses>
-			</library>
-			<library>
-				<file-name>lib/portal/ant-compress.jar</file-name>
-				<version>1.5</version>
-				<project-name>Apache Compress Antlib</project-name>
-				<project-url>https://ant.apache.org/antlibs/compress/</project-url>
 				<licenses>
 					<license>
 						<license-name>Apache License 2.0</license-name>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -1952,6 +1952,11 @@
 </td><td></td>
 </tr>
 <tr>
+<td nowrap>lib/development/ant-compress.jar</td><td nowrap>1.5</td><td nowrap><a href="https://ant.apache.org/antlibs/compress/">Apache Compress Antlib</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<br>
+</td><td></td>
+</tr>
+<tr>
 <td nowrap>lib/development/ant-contrib.jar</td><td nowrap>1.0 B3</td><td nowrap><a href="http://ant-contrib.sourceforge.net">Ant-Contrib Tasks</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-1.1">Apache License 1.1</a>
 <br>
 <copyright-notice>Copyright (c) 2001-2003 Ant-Contrib project. All rights reserved.</copyright-notice>
@@ -2353,11 +2358,6 @@
 </tr>
 <tr>
 <td nowrap>lib/portal/abdera.jar</td><td nowrap>1.1.3</td><td nowrap><a href="http://abdera.apache.org">Abdera</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
-<br>
-</td><td></td>
-</tr>
-<tr>
-<td nowrap>lib/portal/ant-compress.jar</td><td nowrap>1.5</td><td nowrap><a href="https://ant.apache.org/antlibs/compress/">Apache Compress Antlib</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
 <br>
 </td><td></td>
 </tr>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-102982

I have detected by chance that ant-compress.jar was moved from portal to development folder in 870da74761a443bd9782b9a183701dbaaa01e4f2 commit, so it is necessary to also update **versions-ext.xml** file

Our current **"ant build-lib-versions"** script only regenerates `versions.html` and `versions-complete.xml`.
Perhaps it could be extended in order to also regenerate `versions-ext.xml` from `dependencies.properties` file changes