### PR TITLE
[TS] LPS-102827 portal-search-web: Search results portlet does not have translated the X "results for" Y text

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp
@@ -69,7 +69,7 @@ com.liferay.portal.kernel.dao.search.SearchContainer<com.liferay.portal.kernel.s
 </style>
 
 <p class="search-total-label text-default">
-	<%= searchContainer1.getTotal() %> results for <strong><%= HtmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) %></strong>
+    <liferay-ui:message key="x-results-for-x" arguments='<%= new String[]{String.valueOf(searchContainer1.getTotal()),"<strong>"+ HtmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"}%>'/>
 </p>
 
 <liferay-ui:search-container

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp
@@ -69,7 +69,7 @@ com.liferay.portal.kernel.dao.search.SearchContainer<com.liferay.portal.kernel.s
 </style>
 
 <p class="search-total-label text-default">
-    <liferay-ui:message key="x-results-for-x" arguments='<%= new String[]{String.valueOf(searchContainer1.getTotal()),"<strong>"+ HtmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"}%>'/>
+	<liferay-ui:message arguments='<%= new String[] {String.valueOf(searchContainer1.getTotal()), "<strong>" + HtmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>"} %>' key="x-results-for-x" />
 </p>
 
 <liferay-ui:search-container


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-102827

✔️ ci:test:sf - 1 out of 1 jobs passed in 2 minutes 29 seconds 929 ms https://github.com/thektan/liferay-portal/pull/70#issuecomment-540849143
❌ ci:test:search - 29 out of 33 jobs passed in 1 hour 24 minutes 17 seconds 985 ms https://github.com/thektan/liferay-portal/pull/70#issuecomment-540863753

Failures look unrelated since this is only a change to a `search-web` jsp and the failure is in blogs admin.

cc: @rodrigomier 