### PR TITLE
LPS-102665 Silence warnings about "PropTypes" assignment

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/widgets/Collapse.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/widgets/Collapse.es.js
@@ -45,7 +45,7 @@ const Collapse = props => {
 	);
 };
 
-Collapse.PropTypes = {
+Collapse.propTypes = {
 	children: PropTypes.node.isRequired,
 	open: PropTypes.bool
 };

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/widgets/Widget.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/widgets/Widget.es.js
@@ -42,7 +42,7 @@ const Widget = props => {
 	);
 };
 
-Widget.PropTypes = {
+Widget.propTypes = {
 	widget: PropTypes.shape({
 		instanceable: PropTypes.bool.isRequired,
 		title: PropTypes.string.isRequired,


### PR DESCRIPTION
Silences warnings:

    Warning: Component Widget declared `PropTypes` instead of
    `propTypes`. Did you misspell the property assignment?