### PR TITLE
LPS-100949 Upgrade cas-client-core to latest 3.x version

### DIFF
--- a/modules/apps/portal-security-sso/portal-security-sso-cas-impl/build.gradle
+++ b/modules/apps/portal-security-sso/portal-security-sso-cas-impl/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
-	compileInclude group: "org.jasig.cas.client", name: "cas-client-core", version: "3.1.12"
-	compileInclude group: "org.opensaml", name: "opensaml", version: "1.1"
+	compileInclude group: "org.bouncycastle", name: "bcpkix-jdk15on", version: "1.61"
+	compileInclude group: "org.bouncycastle", name: "bcprov-jdk15on", version: "1.61"
+	compileInclude group: "org.jasig.cas.client", name: "cas-client-core", version: "3.6.1"
 
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"


### PR DESCRIPTION
[LPS-100949](https://issues.liferay.com/browse/LPS-100949)

The latest 3.x version was chosen because the major version represents the CAS protocol version. CAS SSO support is already deprecated and v3.3.x is the final release we support.

Agreed with @topolik .

/cc @csierra @brianikim