### PR TITLE
LPS-103386 Unchecking "Structure Fields Indexable Enable" does not set the default value to no for a field in Structure

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -44,15 +44,17 @@ AUI.add(
 		var isValue = Lang.isValue;
 
 		var structureFieldIndexEnable = function() {
-			var indexTypeNode = A.one(
-				'#_' + Liferay.Portlet.list[0] + '_indexable'
-			);
+			for (var i = 0; i < Liferay.Portlet.list.length; i++) {
+				var indexTypeNode = A.one(
+					'#_' + Liferay.Portlet.list[i] + '_indexable'
+				);
 
-			if (indexTypeNode) {
-				var indexable = indexTypeNode.getAttribute('value');
+				if (indexTypeNode) {
+					var indexable = indexTypeNode.getAttribute('value');
 
-				if (indexable === 'false') {
-					return false;
+					if (indexable === 'false') {
+						return false;
+					}
 				}
 			}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -45,12 +45,12 @@ AUI.add(
 
 		var structureFieldIndexEnable = function() {
 			for (var i = 0; i < Liferay.Portlet.list.length; i++) {
-				var indexTypeNode = A.one(
+				var indexableNode = A.one(
 					'#_' + Liferay.Portlet.list[i] + '_indexable'
 				);
 
-				if (indexTypeNode) {
-					var indexable = indexTypeNode.getAttribute('value');
+				if (indexableNode) {
+					var indexable = indexableNode.getAttribute('value');
 
 					if (indexable === 'false') {
 						return false;


### PR DESCRIPTION
cc/ @leoadb

LPS: https://issues.liferay.com/browse/LPS-103386

This PR already went through engineer review: https://github.com/brianchandotcom/liferay-portal/pull/79646

These commits are needed for PR: [#79139](https://github.com/brianchandotcom/liferay-portal/pull/79139). PR https://github.com/brianchandotcom/liferay-portal/pull/79139 implemented `structureFieldIndexEnable()` but it did not consider the case that the attribute associated to the portlet may not be the first one in the portlet list.

QA testing failed [LPS-101515](https://issues.liferay.com/browse/LPS-101515) because the expected result didn't occur without clearing the cache.

This commit finds the attribute within the list and in result returns the true/false set in configuration without clearing the cache.

Thank you!