### PR TITLE
LPS-102599 Re-export namespace directly without intermediate step

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/actions/index.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/actions/index.js
@@ -25,7 +25,4 @@ export {default as unloadReducer} from './unloadReducer';
  * Action types.
  */
 
-// TODO: once LPS-103009 lands, change this to:
-// `export * as TYPES from './types';`
-import * as TYPES from './types';
-export {TYPES};
+export * as TYPES from './types';


### PR DESCRIPTION
Having updated our Babel transforms in the last update to liferay-npm-scripts, we can simplify the export here. Instead of importing the namespace only to export it, we can re-export the namespace directly.

Replaces: https://github.com/brianchandotcom/liferay-portal/pull/79747