### PR TITLE
LPS-98032 Restructure JSP to avoid special cases

### DIFF
--- a/modules/.prettierignore
+++ b/modules/.prettierignore
@@ -40,17 +40,6 @@
 	/apps/fragment/fragment-test/src/testIntegration/resources/com/liferay/fragment/dependencies/**/*.js
 
 ##
-## Special cases
-##
-
-	#
-	# Specify JSP files with tags inside their script blocks that, when
-	# removed, produce and invalid JS syntax tree.
-	#
-	apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/end.jsp
-	apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/edit_content_redirect.jsp
-
-##
 ## Third-Party
 ##
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/end.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/end.jsp
@@ -35,51 +35,48 @@ String fullName = namespace + HtmlUtil.escapeJS(name);
 %>
 
 <aui:script use="liferay-form">
-	Liferay.Form.register(
-		{
-			id: '<%= fullName %>'
+	var config = {
+		id: '<%= fullName %>',
+		validateOnBlur: <%= validateOnBlur %>
+	};
 
-			<c:if test="<%= validatorTagsMap != null %>">
-				, fieldRules: [
+	<c:if test="<%= validatorTagsMap != null %>">
+		config.fieldRules = [];
 
-					<%
-					int i = 0;
+		<%
+		int i = 0;
 
-					for (Map.Entry<String, List<ValidatorTag>> entry : validatorTagsMap.entrySet()) {
-						String fieldName = entry.getKey();
-						List<ValidatorTag> validatorTags = entry.getValue();
+		for (Map.Entry<String, List<ValidatorTag>> entry : validatorTagsMap.entrySet()) {
+			String fieldName = entry.getKey();
+			List<ValidatorTag> validatorTags = entry.getValue();
 
-						for (ValidatorTag validatorTag : validatorTags) {
-					%>
+			for (ValidatorTag validatorTag : validatorTags) {
+		%>
 
-							<%= (i != 0) ? StringPool.COMMA : StringPool.BLANK %>
+				config.fieldRules.push({
+					body: <%= validatorTag.getBody() %>,
+					custom: <%= validatorTag.isCustom() %>,
+					errorMessage:
+						'<%= UnicodeLanguageUtil.get(resourceBundle, validatorTag.getErrorMessage()) %>',
+					fieldName: '<%= namespace + HtmlUtil.escapeJS(fieldName) %>',
+					validatorName: '<%= validatorTag.getName() %>'
+				});
 
-							{
-								body: <%= validatorTag.getBody() %>,
-								custom: <%= validatorTag.isCustom() %>,
-								errorMessage: '<%= UnicodeLanguageUtil.get(resourceBundle, validatorTag.getErrorMessage()) %>',
-								fieldName: '<%= namespace + HtmlUtil.escapeJS(fieldName) %>',
-								validatorName: '<%= validatorTag.getName() %>'
-							}
-
-					<%
-							i++;
-						}
-					}
-					%>
-
-				]
-			</c:if>
-
-			<c:if test="<%= Validator.isNotNull(onSubmit) %>">
-				, onSubmit: function(event) {
-					<%= onSubmit %>
-				}
-			</c:if>
-
-			, validateOnBlur: <%= validateOnBlur %>
+		<%
+				i++;
+			}
 		}
-	);
+		%>
+
+	</c:if>
+
+	<c:if test="<%= Validator.isNotNull(onSubmit) %>">
+		config.onSubmit = function(event) {
+			<%= onSubmit %>;
+		};
+	</c:if>
+
+	Liferay.Form.register(config);
 
 	var onDestroyPortlet = function(event) {
 		if (event.portletId === '<%= portletDisplay.getId() %>') {
@@ -93,10 +90,7 @@ String fullName = namespace + HtmlUtil.escapeJS(name);
 		A.all('#<%= fullName %> .input-container').removeAttribute('disabled');
 	</c:if>
 
-	Liferay.fire(
-		'<portlet:namespace />formReady',
-		{
-			formName: '<%= fullName %>'
-		}
-	);
+	Liferay.fire('<portlet:namespace />formReady', {
+		formName: '<%= fullName %>'
+	});
 </aui:script>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/edit_content_redirect.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/edit_content_redirect.jsp
@@ -33,20 +33,19 @@ redirect = PortalUtil.escapeRedirect(redirect);
 %>
 
 <aui:script>
-	Liferay.fire(
-		'closeWindow',
-		{
-			id: '<portlet:namespace />editAsset',
-			portletAjaxable: true,
+	var data = {
+		id: '<portlet:namespace />editAsset',
+		portletAjaxable: true
+	};
 
-			<c:choose>
-				<c:when test="<%= redirect != null %>">
-					redirect: '<%= HtmlUtil.escapeJS(redirect) %>'
-				</c:when>
-				<c:otherwise>
-					refresh: '<%= portletDisplay.getId() %>'
-				</c:otherwise>
-			</c:choose>
-		}
-	);
+	<c:choose>
+		<c:when test="<%= redirect != null %>">
+			data.redirect = '<%= HtmlUtil.escapeJS(redirect) %>';
+		</c:when>
+		<c:otherwise>
+			data.refresh = '<%= portletDisplay.getId() %>';
+		</c:otherwise>
+	</c:choose>
+
+	Liferay.fire('closeWindow', data);
 </aui:script>


### PR DESCRIPTION
As requested [here](https://github.com/brianchandotcom/liferay-portal/pull/79731#issuecomment-543483079), we remove the special cases by restructuring the JSP.

There were two files that we were excluding. I'll explain the simplest one as an example:

```jsp
{
	id: '<portlet:namespace />editAsset',
	portletAjaxable: true,

	<c:choose>
		<c:when test="<%= redirect != null %>">
			redirect: '<%= HtmlUtil.escapeJS(redirect) %>'
		</c:when>
		<c:otherwise>
			refresh: '<%= portletDisplay.getId() %>'
		</c:otherwise>
	</c:choose>
}
```

The problem there is that when the tags are temporarily removed to turn it into JS for formatting, you're left with an invalid object (note the lack of trailing commas):

```jsp
{
	id: '<portlet:namespace />editAsset',
	portletAjaxable: true,
	redirect: '<%= HtmlUtil.escapeJS(redirect) %>'
	refresh: '<%= portletDisplay.getId() %>'
}
```

We can't just put a trailing comma after both properties because IE 11 will crash if the last key-value pair has a comma.

They can be rewritten — with a temporary variable — like this:

```jsp
var data = {
	id: '<portlet:namespace />editAsset',
	portletAjaxable: true
};

<c:choose>
	<c:when test="<%= redirect != null %>">
		data.redirect = '<%= HtmlUtil.escapeJS(redirect) %>';
	</c:when>
	<c:otherwise>
		data.refresh = '<%= portletDisplay.getId() %>';
	</c:otherwise>
</c:choose>
```

which has the same behavior at runtime, but without the ~downside~ upside of being ~invalid~ valid (😂) JS once the tags are stripped. The other example is much more complex, so I'll let the diff speak for itself: it is basically doing the same thing though (creating a config object and mutating it rather than trying to do it all inline).