### PR TITLE
LPS-103463 Sort classes in JSX className attributes

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/AdaptiveMediaOptionsHandler.es.js
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/AdaptiveMediaOptionsHandler.es.js
@@ -13,9 +13,9 @@
  */
 
 import {PortletBase} from 'frontend-js-web';
+import core from 'metal';
 import dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
-import core from 'metal';
 
 /**
  * Enables/disables the actions of the configuration entry's while

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/AdaptiveMediaProgress.es.js
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/AdaptiveMediaProgress.es.js
@@ -14,8 +14,8 @@
 
 import 'clay-progress-bar';
 import {PortletBase, fetch} from 'frontend-js-web';
-import Soy from 'metal-soy';
 import core from 'metal';
+import Soy from 'metal-soy';
 
 import templates from './AdaptiveMediaProgress.soy';
 

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/EditAdaptiveMediaConfig.es.js
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/EditAdaptiveMediaConfig.es.js
@@ -13,8 +13,8 @@
  */
 
 import {PortletBase} from 'frontend-js-web';
-import dom from 'metal-dom';
 import core from 'metal';
+import dom from 'metal-dom';
 
 /**
  * EditAdaptiveMediaConfig

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/App.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/App.es.js
@@ -12,10 +12,10 @@
  * details.
  */
 
-import HTML5Backend from 'react-dnd-html5-backend';
-import {DragDropContext as dragDropContext} from 'react-dnd';
-import {Route, HashRouter as Router, Switch} from 'react-router-dom';
 import React from 'react';
+import {DragDropContext as dragDropContext} from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
+import {Route, HashRouter as Router, Switch} from 'react-router-dom';
 
 import {AppContextProvider} from './AppContext.es';
 import {ToastContextProvider} from './components/toast/ToastContext.es';

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/button/Button.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/button/Button.es.js
@@ -14,8 +14,8 @@
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import classNames from 'classnames';
-import {Link} from 'react-router-dom';
 import React from 'react';
+import {Link} from 'react-router-dom';
 
 const Button = props => {
 	const {

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/control-menu/ControlMenu.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/control-menu/ControlMenu.es.js
@@ -13,9 +13,9 @@
  */
 
 import ClayIcon from '@clayui/icon';
+import React, {useEffect, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {Link, withRouter} from 'react-router-dom';
-import React, {useEffect, useState} from 'react';
 
 const CONTROL_MENU_CONTENT = '.control-menu-nav-item-content';
 
@@ -79,7 +79,7 @@ export default withRouter(({backURL, match: {url}, title, tooltip}) => {
 			{tooltip && (
 				<Portal containerSelector={CONTROL_MENU_CONTENT}>
 					<span
-						className="taglib-icon-help lfr-portal-tooltip"
+						className="lfr-portal-tooltip taglib-icon-help"
 						data-title={tooltip}
 					>
 						<ClayIcon symbol="question-circle-full" />

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/drag-and-drop/DragLayer.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/drag-and-drop/DragLayer.es.js
@@ -12,8 +12,8 @@
  * details.
  */
 
-import {useDragLayer} from 'react-dnd';
 import React from 'react';
+import {useDragLayer} from 'react-dnd';
 
 const layerStyles = {
 	cursor: 'grabbing',

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/field-types/FieldType.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/field-types/FieldType.es.js
@@ -15,9 +15,9 @@
 import ClayIcon from '@clayui/icon';
 import ClaySticker from '@clayui/sticker';
 import classnames from 'classnames';
-import {getEmptyImage} from 'react-dnd-html5-backend';
-import {useDrag} from 'react-dnd';
 import React, {useEffect} from 'react';
+import {useDrag} from 'react-dnd';
+import {getEmptyImage} from 'react-dnd-html5-backend';
 
 import {DRAG_FIELD_TYPE} from '../../utils/dragTypes.es';
 import FieldTypeDragPreview from './FieldTypeDragPreview.es';

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/hooks/useKeyDown.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/hooks/useKeyDown.es.js
@@ -23,8 +23,8 @@ export default (callback, targetKeyCode, element = window) => {
 
 	useEffect(() => {
 		const handler = () => {
-			if (event.keyCode === targetKeyCode) {
-				callbackRef.current(event);
+			if (window.event.keyCode === targetKeyCode) {
+				callbackRef.current(window.event);
 			}
 		};
 

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/DeployApp.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/DeployApp.es.js
@@ -20,7 +20,7 @@ import WidgetSettings from './WidgetSettings.es';
 
 const Divider = () => {
 	return (
-		<div className="autofit-row pl-2 pr-2 mb-4">
+		<div className="autofit-row mb-4 pl-2 pr-2">
 			<div className="col-md-12">
 				<h4 className="card-divider"></h4>
 			</div>
@@ -31,7 +31,7 @@ const Divider = () => {
 export default () => {
 	return (
 		<>
-			<div className="autofit-row pl-4 pr-4 mb-4">
+			<div className="autofit-row mb-4 pl-4 pr-4">
 				<div className="autofit-col-expand">
 					<h2>{`${Liferay.Language.get('deploy-as')}...`}</h2>
 				</div>

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/EditApp.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/EditApp.es.js
@@ -84,10 +84,10 @@ export default ({
 			<Loading isLoading={isLoading}>
 				<EditAppContext.Provider value={{dispatch, state}}>
 					<div className="container-fluid container-fluid-max-lg mt-4">
-						<div className="card card-root shadowless-card mb-0">
+						<div className="card card-root mb-0 shadowless-card">
 							<EditAppHeader />
 
-							<div className="card-body shadowless-card-body p-0">
+							<div className="card-body p-0 shadowless-card-body">
 								<div className="autofit-row">
 									<div className="col-md-12">
 										<MultiStepNav

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/EditAppBody.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/EditAppBody.es.js
@@ -37,13 +37,13 @@ export default ({endpoint, title, ...restProps}) => {
 
 	return (
 		<>
-			<div className="autofit-row pl-4 pr-4 mb-4">
+			<div className="autofit-row mb-4 pl-4 pr-4">
 				<div className="autofit-col-expand">
 					<h2>{title}</h2>
 				</div>
 			</div>
 
-			<div className="autofit-row pl-4 pr-4 mb-4">
+			<div className="autofit-row mb-4 pl-4 pr-4">
 				<div className="autofit-col-expand">
 					<div className="input-group">
 						<div className="input-group-item">

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/EditAppFooter.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/EditAppFooter.es.js
@@ -14,8 +14,8 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
-import {withRouter} from 'react-router-dom';
 import React, {useContext, useState} from 'react';
+import {withRouter} from 'react-router-dom';
 
 import {AppContext} from '../../AppContext.es';
 import Button from '../../components/button/Button.es';
@@ -106,7 +106,7 @@ export default withRouter(
 		};
 
 		return (
-			<div className="card-footer bg-transparent">
+			<div className="bg-transparent card-footer">
 				<div className="autofit-row">
 					<div className="col-md-4">
 						<Button displayType="secondary" onClick={onCancel}>

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/EditAppHeader.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/EditAppHeader.es.js
@@ -38,7 +38,7 @@ export default () => {
 
 	return (
 		<>
-			<div className="card-header align-items-center d-flex justify-content-between bg-transparent">
+			<div className="align-items-center bg-transparent card-header d-flex justify-content-between">
 				<UpperToolbarInput
 					onInput={onAppNameChange}
 					placeholder={Liferay.Language.get('untitled-app')}

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/ListApps.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/ListApps.es.js
@@ -14,8 +14,8 @@
 
 import ClayLabel from '@clayui/label';
 import moment from 'moment';
-import {Link} from 'react-router-dom';
 import React, {useContext} from 'react';
+import {Link} from 'react-router-dom';
 
 import {AppContext} from '../../AppContext.es';
 import Button from '../../components/button/Button.es';

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/ListItems.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/ListItems.es.js
@@ -50,7 +50,7 @@ const ListItems = ({itemType, items}) => {
 	};
 
 	return (
-		<table className="table table-responsive table-autofit table-hover table-heading-nowrap table-nowrap">
+		<table className="table table-autofit table-heading-nowrap table-hover table-nowrap table-responsive">
 			<Head>
 				<Row>
 					<Cell expanded={true} headingCell>

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/Settings.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/Settings.es.js
@@ -34,7 +34,7 @@ export default ({deploymentType, settings = () => <></>, subtitle, title}) => {
 
 	return (
 		<>
-			<div className="autofit-row pl-4 pr-4 mb-3">
+			<div className="autofit-row mb-3 pl-4 pr-4">
 				<div className="autofit-col-expand">
 					<section className="autofit-section">
 						<h3>{title}</h3>

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/custom-object/CustomObjectNavigationBar.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/custom-object/CustomObjectNavigationBar.es.js
@@ -13,8 +13,8 @@
  */
 
 import ClayNavigationBar from '@clayui/navigation-bar';
-import {NavLink, withRouter} from 'react-router-dom';
 import React from 'react';
+import {NavLink, withRouter} from 'react-router-dom';
 
 const {Item} = ClayNavigationBar;
 

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/custom-object/ListCustomObjects.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/custom-object/ListCustomObjects.es.js
@@ -13,8 +13,8 @@
  */
 
 import moment from 'moment';
-import {Link} from 'react-router-dom';
 import React, {useContext, useEffect, useRef, useState} from 'react';
+import {Link} from 'react-router-dom';
 
 import {AppContext} from '../../AppContext.es';
 import Button from '../../components/button/Button.es';

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/custom-object/ViewCustomObject.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/custom-object/ViewCustomObject.es.js
@@ -12,8 +12,8 @@
  * details.
  */
 
-import {Route, Switch} from 'react-router-dom';
 import React, {useEffect, useState} from 'react';
+import {Route, Switch} from 'react-router-dom';
 
 import ControlMenu from '../../components/control-menu/ControlMenu.es';
 import {getItem} from '../../utils/client.es';

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/entry/ListEntriesApp.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/entry/ListEntriesApp.es.js
@@ -12,8 +12,8 @@
  * details.
  */
 
-import {Route, HashRouter as Router, Switch} from 'react-router-dom';
 import React from 'react';
+import {Route, HashRouter as Router, Switch} from 'react-router-dom';
 
 import {AppContextProvider} from '../../AppContext.es';
 import ListEntries from './ListEntries.es';

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/DataLayoutBuilderColumn.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/DataLayoutBuilderColumn.es.js
@@ -14,8 +14,8 @@
 
 import {getIndexes} from 'dynamic-data-mapping-form-renderer/js/components/FormRenderer/FormSupport.es';
 import dom from 'metal-dom';
-import {useDrop} from 'react-dnd';
 import {useEffect, useCallback, useContext} from 'react';
+import {useDrop} from 'react-dnd';
 
 import {
 	DRAG_CUSTOM_OBJECT_FIELD,

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormView.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormView.es.js
@@ -12,8 +12,8 @@
  * details.
  */
 
-import {createPortal} from 'react-dom';
 import React, {useState} from 'react';
+import {createPortal} from 'react-dom';
 
 import CustomObjectSidebar from './CustomObjectSidebar.es';
 import DataLayoutBuilderDragAndDrop from './DataLayoutBuilderDragAndDrop.es';

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormViewApp.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormViewApp.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
-import HTML5Backend from 'react-dnd-html5-backend';
-import {DragDropContext as dragDropContext} from 'react-dnd';
 import React from 'react';
+import {DragDropContext as dragDropContext} from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
 
 import {AppContextProvider} from '../../AppContext.es';
 import EditFormView from './EditFormView.es';

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/DropZone.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/DropZone.es.js
@@ -13,8 +13,8 @@
  */
 
 import classNames from 'classnames';
-import {useDrop} from 'react-dnd';
 import React from 'react';
+import {useDrop} from 'react-dnd';
 
 import Button from '../../components/button/Button.es';
 import Table from '../../components/table/Table.es';
@@ -76,7 +76,7 @@ const DropZone = ({fields, onAddFieldName, onRemoveFieldName}) => {
 				key: label,
 				value: (
 					<div className="container p-0">
-						<div className="row align-items-center">
+						<div className="align-items-center row">
 							<div className="col">{label}</div>
 							<div className="col-md-auto">
 								<Button

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/ListTableViews.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/ListTableViews.es.js
@@ -13,8 +13,8 @@
  */
 
 import moment from 'moment';
-import {Link} from 'react-router-dom';
 import React from 'react';
+import {Link} from 'react-router-dom';
 
 import Button from '../../components/button/Button.es';
 import ListView from '../../components/list-view/ListView.es';

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/DataLayoutBuilder.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/DataLayoutBuilder.es.js
@@ -16,8 +16,8 @@ import FormBuilder from 'dynamic-data-mapping-form-builder/js/components/FormBui
 import LayoutProvider from 'dynamic-data-mapping-form-builder/js/components/LayoutProvider/LayoutProvider.es';
 import {pageStructure} from 'dynamic-data-mapping-form-builder/js/util/config.es';
 import {PagesVisitor} from 'dynamic-data-mapping-form-renderer/js/util/visitors.es';
-import Component, {Config} from 'metal-jsx';
 import core from 'metal';
+import Component, {Config} from 'metal-jsx';
 
 /**
  * Data Layout Builder.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
@@ -189,14 +189,14 @@ class DatePicker extends Component {
 
 			this.emit('fieldFocused', {
 				fieldInstance: this,
-				originalEvent: event
+				originalEvent: window.event
 			});
 		} else {
 			this._eventHandler.removeAllListeners();
 
 			this.emit('fieldBlurred', {
 				fieldInstance: this,
-				originalEvent: event
+				originalEvent: window.event
 			});
 		}
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Radio/Radio.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Radio/Radio.es.js
@@ -53,8 +53,8 @@ class Radio extends Component {
 	_handleFieldBlurred() {
 		this.emit('fieldBlurred', {
 			fieldInstance: this,
-			originalEvent: event,
-			value: event.target.value
+			originalEvent: window.event,
+			value: window.event.target.value
 		});
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.es.js
@@ -156,12 +156,12 @@ class Select extends Component {
 		if (newVal) {
 			this.emit('fieldFocused', {
 				fieldInstance: this,
-				originalEvent: event
+				originalEvent: window.event
 			});
 		} else {
 			this.emit('fieldBlurred', {
 				fieldInstance: this,
-				originalEvent: event
+				originalEvent: window.event
 			});
 		}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/PageRenderer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/PageRenderer.es.js
@@ -25,10 +25,10 @@ import 'clay-button';
 import 'clay-dropdown';
 
 import 'clay-modal';
+import core from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
 import {Config} from 'metal-state';
-import core from 'metal';
 
 import * as FormSupport from '../FormRenderer/FormSupport.es';
 import templates from './PageRenderer.soy.js';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
@@ -30,11 +30,11 @@ import {
 import {sub} from 'dynamic-data-mapping-form-builder/js/util/strings.es';
 import compose from 'dynamic-data-mapping-form-renderer/js/util/compose.es';
 import {PagesVisitor} from 'dynamic-data-mapping-form-renderer/js/util/visitors.es';
+import core from 'metal';
 import dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
 import Component from 'metal-jsx';
 import {Config} from 'metal-state';
-import core from 'metal';
 
 import PreviewButton from './components/PreviewButton/PreviewButton.es';
 import PublishButton from './components/PublishButton/PublishButton.es';

--- a/modules/apps/flags/flags-taglib/test/js/components/Flags.es.js
+++ b/modules/apps/flags/flags-taglib/test/js/components/Flags.es.js
@@ -19,8 +19,8 @@ import {
 	render,
 	waitForElement
 } from '@testing-library/react';
-import {act} from 'react-dom/test-utils';
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 
 import Flags from '../../../src/main/resources/META-INF/resources/flags/js/components/Flags.es';
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-brightness/src/main/resources/META-INF/resources/BrightnessComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-brightness/src/main/resources/META-INF/resources/BrightnessComponent.es.js
@@ -16,9 +16,9 @@ import {debounce} from 'frontend-js-web';
 
 import './BrightnessSlider.es';
 
+import {core} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
-import {core} from 'metal';
 
 import componentTemplates from './BrightnessComponent.soy';
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-brightness/src/main/resources/META-INF/resources/BrightnessSlider.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-brightness/src/main/resources/META-INF/resources/BrightnessSlider.es.js
@@ -12,12 +12,12 @@
  * details.
  */
 
+import core from 'metal';
 import Component from 'metal-component';
 import dom from 'metal-dom';
 import {Drag} from 'metal-drag-drop';
 import Position from 'metal-position';
 import Soy from 'metal-soy';
-import core from 'metal';
 
 import templates from './BrightnessSlider.soy';
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-contrast/src/main/resources/META-INF/resources/ContrastComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-contrast/src/main/resources/META-INF/resources/ContrastComponent.es.js
@@ -16,9 +16,9 @@ import {debounce} from 'frontend-js-web';
 
 import './ContrastSlider.es/';
 
+import {core} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
-import {core} from 'metal';
 
 import componentTemplates from './ContrastComponent.soy';
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-contrast/src/main/resources/META-INF/resources/ContrastSlider.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-contrast/src/main/resources/META-INF/resources/ContrastSlider.es.js
@@ -12,12 +12,12 @@
  * details.
  */
 
+import core from 'metal';
 import Component from 'metal-component';
 import dom from 'metal-dom';
 import {Drag} from 'metal-drag-drop';
 import Position from 'metal-position';
 import Soy from 'metal-soy';
-import core from 'metal';
 
 import templates from './ContrastSlider.soy';
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-crop/src/main/resources/META-INF/resources/CropComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-crop/src/main/resources/META-INF/resources/CropComponent.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {core} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
-import {core} from 'metal';
 
 import componentTemplates from './CropComponent.soy';
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-crop/src/main/resources/META-INF/resources/CropHandles.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-crop/src/main/resources/META-INF/resources/CropHandles.es.js
@@ -12,12 +12,12 @@
  * details.
  */
 
+import {async, core} from 'metal';
 import Component from 'metal-component';
 import dom from 'metal-dom';
 import {Drag} from 'metal-drag-drop';
 import Position from 'metal-position';
 import Soy from 'metal-soy';
-import {async, core} from 'metal';
 
 import handlesTemplates from './CropHandles.soy';
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {async, core} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
-import {async, core} from 'metal';
 
 import componentTemplates from './EffectsComponent.soy';
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-resize/src/main/resources/META-INF/resources/ResizeComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-resize/src/main/resources/META-INF/resources/ResizeComponent.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {core} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
-import {core} from 'metal';
 
 import componentTemplates from './ResizeComponent.soy';
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-rotate/src/main/resources/META-INF/resources/RotateComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-rotate/src/main/resources/META-INF/resources/RotateComponent.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import {core} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
-import {core} from 'metal';
 
 import componentTemplates from './RotateComponent.soy';
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-saturation/src/main/resources/META-INF/resources/SaturationComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-saturation/src/main/resources/META-INF/resources/SaturationComponent.es.js
@@ -16,9 +16,9 @@ import {debounce} from 'frontend-js-web';
 
 import './SaturationSlider.es';
 
+import {core} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
-import {core} from 'metal';
 
 import componentTemplates from './SaturationComponent.soy';
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-saturation/src/main/resources/META-INF/resources/SaturationSlider.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-saturation/src/main/resources/META-INF/resources/SaturationSlider.es.js
@@ -12,12 +12,12 @@
  * details.
  */
 
+import core from 'metal';
 import Component from 'metal-component';
 import dom from 'metal-dom';
 import {Drag} from 'metal-drag-drop';
 import Position from 'metal-position';
 import Soy from 'metal-soy';
-import core from 'metal';
 
 import templates from './SaturationSlider.soy';
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
@@ -16,9 +16,9 @@ import './ImageEditorLoading.es';
 
 import 'clay-dropdown';
 import {PortletBase} from 'frontend-js-web';
+import {async, core} from 'metal';
 import dom from 'metal-dom';
 import Soy from 'metal-soy';
-import {async, core} from 'metal';
 
 import templates from './ImageEditor.soy';
 import ImageEditorHistoryEntry from './ImageEditorHistoryEntry.es';

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
@@ -13,8 +13,8 @@
  */
 
 import {ClayIconSpriteContext} from '@clayui/icon';
-import ReactDOM from 'react-dom';
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 let counter = 0;
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
@@ -13,8 +13,8 @@
  */
 
 import {openToast} from 'frontend-js-web';
-import dom from 'metal-dom';
 import core from 'metal';
+import dom from 'metal-dom';
 import {App} from 'senna';
 
 import LiferaySurface from '../surface/Surface.es';

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
@@ -14,10 +14,10 @@
 
 'use strict';
 
-import {match} from 'metal-dom';
 import {async} from 'metal';
-import globals from 'senna/lib/globals/globals';
+import {match} from 'metal-dom';
 import {utils, version} from 'senna';
+import globals from 'senna/lib/globals/globals';
 
 import App from './app/App.es';
 import ActionURLScreen from './screen/ActionURLScreen.es';

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/screen/EventScreen.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/screen/EventScreen.es.js
@@ -12,8 +12,8 @@
  * details.
  */
 
-import globals from 'senna/lib/globals/globals';
 import {HtmlScreen} from 'senna';
+import globals from 'senna/lib/globals/globals';
 
 /**
  * EventScreen

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/surface/Surface.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/surface/Surface.es.js
@@ -12,8 +12,8 @@
  * details.
  */
 
-import dom from 'metal-dom';
 import core from 'metal';
+import dom from 'metal-dom';
 import Surface from 'senna/lib/surface/Surface';
 
 /**

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/CompatibilityEventProxy.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/CompatibilityEventProxy.es.js
@@ -12,8 +12,8 @@
  * details.
  */
 
-import State from 'metal-state';
 import {core} from 'metal';
+import State from 'metal-state';
 
 /**
  * Adds compatibility for YUI events, re-emitting events according to YUI naming

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import core from 'metal';
 import dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
-import core from 'metal';
 
 import PortletBase from './PortletBase.es';
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/PortletBase.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/PortletBase.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import core from 'metal';
 import Component from 'metal-component';
 import dom from 'metal-dom';
-import core from 'metal';
 
 import objectToFormData from './util/form/object_to_form_data.es';
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/compat/modal/Modal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/compat/modal/Modal.es.js
@@ -12,11 +12,11 @@
  * details.
  */
 
+import core from 'metal';
 import Component from 'metal-component';
 import dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
 import Soy from 'metal-soy';
-import core from 'metal';
 
 import templates from './Modal.soy';
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/compat/treeview/Treeview.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/compat/treeview/Treeview.es.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import core from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
-import core from 'metal';
 
 import KeyboardFocusManager from './../../keyboard-focus/KeyboardFocusManager.es';
 import templates from './Treeview.soy';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/keyboard-focus/KeyboardFocusManager.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/keyboard-focus/KeyboardFocusManager.es.js
@@ -14,8 +14,8 @@
 
 'use strict';
 
-import EventEmitter from 'metal-events';
 import core from 'metal';
+import EventEmitter from 'metal-events';
 
 /**
  * Listens to keyboard events and uses them to move focus between different

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
@@ -13,9 +13,9 @@
  */
 
 import 'clay-alert';
+import {isString} from 'metal';
 import Soy from 'metal-soy';
 import {Config} from 'metal-state';
-import {isString} from 'metal';
 
 import fetch from './../../util/fetch.es';
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -14,8 +14,8 @@
 
 import ClayAlert from '@clayui/alert';
 import {render} from 'frontend-js-react-web';
-import {unmountComponentAtNode} from 'react-dom';
 import React from 'react';
+import {unmountComponentAtNode} from 'react-dom';
 
 const DEFAULT_ALERT_CONTAINER_ID = 'alertContainer';
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/form/post_form.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/form/post_form.es.js
@@ -12,8 +12,8 @@
  * details.
  */
 
-import dom from 'metal-dom';
 import {isDef, isObject, isString} from 'metal';
+import dom from 'metal-dom';
 
 import setFormValues from './set_form_values.es';
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/contextual_sidebar/ContextualSidebar.es.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/contextual_sidebar/ContextualSidebar.es.js
@@ -12,10 +12,10 @@
  * details.
  */
 
+import {isFunction, isObject} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
 import {Config} from 'metal-state';
-import {isFunction, isObject} from 'metal';
 
 import templates from './ContextualSidebar.soy';
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff_version_comparator/DiffVersionComparator.es.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff_version_comparator/DiffVersionComparator.es.js
@@ -13,10 +13,10 @@
  */
 
 import {fetch} from 'frontend-js-web';
+import {isObject} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
 import {Config} from 'metal-state';
-import {isObject} from 'metal';
 
 import templates from './DiffVersionComparator.soy';
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/TranslationManager.es.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/TranslationManager.es.js
@@ -111,7 +111,7 @@ class TranslationManager extends Component {
 		const {availableLocales} = this;
 		const {localeId} = delegateTarget.dataset;
 
-		event.stopPropagation();
+		window.event.stopPropagation();
 
 		this.refs.deleteModal.events = {
 			clickButton: ({target}) => {

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/TranslationManager.es.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/TranslationManager.es.js
@@ -16,9 +16,9 @@ import 'clay-dropdown';
 
 import 'clay-modal';
 import {CompatibilityEventProxy} from 'frontend-js-web';
+import {core} from 'metal';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
-import {core} from 'metal';
 
 import templates from './TranslationManager.soy';
 

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -13,8 +13,8 @@
  */
 
 import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom';
 import React, {Component} from 'react';
+import ReactDOM from 'react-dom';
 
 import Carousel from './Carousel.es';
 import Footer from './Footer.es';

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -12,8 +12,8 @@
  * details.
  */
 
-import PortletBase from 'frontend-js-web/liferay/PortletBase.es';
 import {AOP} from 'frontend-js-web';
+import PortletBase from 'frontend-js-web/liferay/PortletBase.es';
 import {delegate, on} from 'metal-dom';
 import {EventHandler} from 'metal-events';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/floating_toolbar/fragment_configuration/field_types/ItemSelectorField.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/floating_toolbar/fragment_configuration/field_types/ItemSelectorField.es.js
@@ -88,7 +88,7 @@ class ItemSelectorField extends Component {
 	 * @review
 	 */
 	_handleSelectTemplateValueChanged() {
-		const targetElement = event.delegateTarget;
+		const targetElement = window.event.delegateTarget;
 
 		const selectedItem = this.configurationValues[this.field.name];
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/floating_toolbar/image_properties/FloatingToolbarImagePropertiesPanel.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/floating_toolbar/image_properties/FloatingToolbarImagePropertiesPanel.es.js
@@ -59,7 +59,7 @@ class FloatingToolbarImagePropertiesPanel extends Component {
 	 */
 	_handleAltTextInputChange() {
 		this._updateFragmentConfig({
-			[EDITABLE_FIELD_CONFIG_KEYS.alt]: event.delegateTarget.value
+			[EDITABLE_FIELD_CONFIG_KEYS.alt]: window.event.delegateTarget.value
 		});
 	}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/fragment_entry_link/FragmentEntryLinkContent.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/fragment_entry_link/FragmentEntryLinkContent.es.js
@@ -12,11 +12,11 @@
  * details.
  */
 
+import {isFunction, isObject} from 'metal';
 import Component from 'metal-component';
 import {closest, globalEval} from 'metal-dom';
 import Soy from 'metal-soy';
 import {Config} from 'metal-state';
-import {isFunction, isObject} from 'metal';
 
 import {getConnectedComponent} from '../../store/ConnectedComponent.es';
 import {shouldUpdateOnChangeProperties} from '../../utils/FragmentsEditorComponentUtils.es';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/fragment_processors/EditableRichTextFragmentProcessor.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/fragment_processors/EditableRichTextFragmentProcessor.es.js
@@ -12,8 +12,8 @@
  * details.
  */
 
-import {EventHandler} from 'metal-events';
 import {object} from 'metal';
+import {EventHandler} from 'metal-events';
 
 import {
 	FLOATING_TOOLBAR_BUTTONS,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/fragments/SidebarLayouts.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/fragments/SidebarLayouts.es.js
@@ -41,7 +41,7 @@ const layouts = [
 
 const SidebarLayoutCard = props => (
 	<div
-		className="card card-interactive card-interactive-secondary selector-button fragments-editor-sidebar-section__card fragments-editor__drag-source fragments-editor__drag-source--sidebar-layout"
+		className="card card-interactive card-interactive-secondary fragments-editor-sidebar-section__card fragments-editor__drag-source fragments-editor__drag-source--sidebar-layout selector-button"
 		data-drag-source-label={Liferay.Language.get('layout')}
 		data-layout-index={props.layoutIndex}
 		label={Liferay.Util.sub(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/page_content/PageContent.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/sidebar/page_content/PageContent.es.js
@@ -95,15 +95,15 @@ const PageContent = props => {
 				FRAGMENTS_EDITOR_ITEM_TYPES.mappedItem
 			}
 		>
-			<div className="d-flex py-3 pl-3 pr-2">
+			<div className="d-flex pl-3 pr-2 py-3">
 				<div className="autofit-col autofit-col-expand">
 					<strong className="list-group-title text-truncate">
 						{props.title}
 					</strong>
 
-					<span className="text-secondary small">{props.name}</span>
+					<span className="small text-secondary">{props.name}</span>
 
-					<span className="text-secondary small">
+					<span className="small text-secondary">
 						{props.usagesCount === 1
 							? Liferay.Language.get('used-in-1-page')
 							: Liferay.Util.sub(
@@ -130,7 +130,7 @@ const PageContent = props => {
 						onActiveChange={setActive}
 						trigger={
 							<ClayButton
-								className="text-secondary btn-monospaced btn-sm"
+								className="btn-monospaced btn-sm text-secondary"
 								displayType="unstyled"
 							>
 								<ClayIcon symbol="ellipsis-v" />

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/store/ReactComponentAdapter.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/store/ReactComponentAdapter.es.js
@@ -15,8 +15,8 @@
 import {ClayIconSpriteContext} from '@clayui/icon';
 import {Component} from 'metal-component';
 import Soy from 'metal-soy';
-import ReactDOM from 'react-dom';
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 import {getConnectedComponent} from './ConnectedComponent.es';
 import StateProvider from './StateProvider.es';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/actions/index.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/actions/index.js
@@ -25,7 +25,4 @@ export {default as unloadReducer} from './unloadReducer';
  * Action types.
  */
 
-// TODO: once LPS-103009 lands, change this to:
-// `export * as TYPES from './types';`
-import * as TYPES from './types';
-export {TYPES};
+export * as TYPES from './types';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/PageEditor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/PageEditor.js
@@ -37,7 +37,7 @@ export default function PageEditor() {
 	);
 }
 
-function Body({layoutData, fragmentEntryLinks}) {
+function Body({fragmentEntryLinks, layoutData}) {
 	return layoutData.structure.map((row, index) => {
 		return (
 			<Row

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Sidebar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Sidebar.js
@@ -19,9 +19,9 @@ import classNames from 'classnames';
 import {useIsMounted} from 'frontend-js-react-web';
 import React from 'react';
 
-import usePlugins from '../../core/hooks/usePlugins';
 import useLazy from '../../core/hooks/useLazy';
 import useLoad from '../../core/hooks/useLoad';
+import usePlugins from '../../core/hooks/usePlugins';
 import useStateSafe from '../../core/hooks/useStateSafe';
 import * as Actions from '../actions/index';
 import {ConfigContext} from '../config/index';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Toolbar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Toolbar.js
@@ -17,11 +17,11 @@ import {useIsMounted} from 'frontend-js-react-web';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import * as Actions from '../actions/index';
-import {ConfigContext} from '../config/index';
-import usePlugins from '../../core/hooks/usePlugins';
 import useLazy from '../../core/hooks/useLazy';
 import useLoad from '../../core/hooks/useLoad';
+import usePlugins from '../../core/hooks/usePlugins';
+import * as Actions from '../actions/index';
+import {ConfigContext} from '../config/index';
 import {DispatchContext} from '../reducers/index';
 import {StoreContext} from '../store/index';
 import UnsafeHTML from './UnsafeHTML';
@@ -105,7 +105,7 @@ function ToolbarBody() {
 	const {languageIcon} = availableLanguages[defaultLanguageId];
 
 	return (
-		<div className="page-editor-toolbar container-fluid container-fluid-max-xl">
+		<div className="container-fluid container-fluid-max-xl page-editor-toolbar">
 			<ul className="navbar-nav">
 				{toolbarPlugins.map(
 					({loadingPlaceholder, pluginEntryPoint}) => {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/index.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/index.js
@@ -14,11 +14,11 @@
 
 import React from 'react';
 
+import useThunk from '../core/hooks/useThunk';
 import App from './components/App';
 import {ConfigContext, getConfig} from './config/index';
-import useThunk from '../core/hooks/useThunk';
-import {StoreContext, getInitialState} from './store/index';
 import {DispatchContext, reducer} from './reducers/index';
+import {StoreContext, getInitialState} from './store/index';
 
 const {useReducer} = React;
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceToolbarSection.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceToolbarSection.js
@@ -18,7 +18,7 @@ import React from 'react';
 // TODO: show how to colocate CSS with plugins (may use loaders)
 export default function ExperienceToolbarSection({selectId}) {
 	return (
-		<div className="page-editor-toolbar-experience mr-2">
+		<div className="mr-2 page-editor-toolbar-experience">
 			<label className="mr-2" htmlFor={selectId}>
 				Experience
 			</label>

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/modal/openDisplayPageModal.es.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/modal/openDisplayPageModal.es.js
@@ -13,8 +13,8 @@
  */
 
 import {ClayIconSpriteContext} from '@clayui/icon';
-import ReactDOM from 'react-dom';
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 import DisplayPageModal from './DisplayPageModal.es';
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/js/MBPortlet.es.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/js/MBPortlet.es.js
@@ -13,8 +13,8 @@
  */
 
 import {PortletBase, fetch} from 'frontend-js-web';
-import {EventHandler} from 'metal-events';
 import core from 'metal';
+import {EventHandler} from 'metal-events';
 
 /**
  * MBPortlet handles the actions of replying or editing a

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/LayoutFinder.es.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/LayoutFinder.es.js
@@ -180,11 +180,11 @@ function LayoutFinder(props) {
 			)}
 
 			{loading && (
-				<ClayLoadingIndicator className="mt-3 mb-0" light small />
+				<ClayLoadingIndicator className="mb-0 mt-3" light small />
 			)}
 
 			{totalCount === 0 && !loading && keywords.length > 1 && (
-				<div className="text-center mt-3">
+				<div className="mt-3 text-center">
 					{Liferay.Language.get('page-not-found')}
 				</div>
 			)}

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
@@ -16,9 +16,9 @@ import ClayButton from '@clayui/button';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import getCN from 'classnames';
 import PropTypes from 'prop-types';
-import HTML5Backend from 'react-dnd-html5-backend';
-import {DragDropContext as dragDropContext} from 'react-dnd';
 import React from 'react';
+import {DragDropContext as dragDropContext} from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
 
 import {
 	conjunctionShape,
@@ -126,7 +126,7 @@ class ContributorBuilder extends React.Component {
 							<div className="content-wrapper">
 								<div className="sheet">
 									<div className="d-flex flex-wrap justify-content-between mb-4">
-										<h2 className="sheet-title mb-2">
+										<h2 className="mb-2 sheet-title">
 											{Liferay.Language.get('conditions')}
 										</h2>
 

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/CriteriaGroup.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/CriteriaGroup.es.js
@@ -15,8 +15,8 @@
 import ClayIcon from '@clayui/icon';
 import getCN from 'classnames';
 import {PropTypes} from 'prop-types';
-import {DragSource as dragSource} from 'react-dnd';
 import React, {Component, Fragment} from 'react';
+import {DragSource as dragSource} from 'react-dnd';
 
 import {CONJUNCTIONS} from '../../utils/constants.es';
 import {DragTypes} from '../../utils/drag-types.es';

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/CriteriaRow.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/CriteriaRow.es.js
@@ -19,8 +19,8 @@ import ClayIcon from '@clayui/icon';
 import getCN from 'classnames';
 import {fetch} from 'frontend-js-web';
 import {PropTypes} from 'prop-types';
-import {DragSource as dragSource, DropTarget as dropTarget} from 'react-dnd';
 import React, {Component} from 'react';
+import {DragSource as dragSource, DropTarget as dropTarget} from 'react-dnd';
 
 import ThemeContext from '../../ThemeContext.es';
 import {PROPERTY_TYPES} from '../../utils/constants.es';
@@ -234,7 +234,7 @@ class CriteriaRow extends Component {
 		return (
 			<span>
 				<b className="mr-1 text-dark">{propertyLabel}</b>
-				<span className="operator mr-1">{operatorLabel}</span>
+				<span className="mr-1 operator">{operatorLabel}</span>
 				<b>{parsedValue}</b>
 			</span>
 		);
@@ -348,7 +348,7 @@ class CriteriaRow extends Component {
 
 		return (
 			<ClayAlert
-				className="bg-transparent p-1 mt-1 border-0"
+				className="bg-transparent border-0 mt-1 p-1"
 				displayType="danger"
 				title={Liferay.Language.get('error')}
 			>
@@ -393,7 +393,7 @@ class CriteriaRow extends Component {
 				</span>
 
 				<ClaySelectWithOption
-					className="criterion-input operator-input form-control"
+					className="criterion-input form-control operator-input"
 					disabled={disabledInput}
 					onChange={this._handleInputChange('operatorName')}
 					options={filteredSupportedOperators.map(

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/DropZone.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/DropZone.es.js
@@ -14,8 +14,8 @@
 
 import getCN from 'classnames';
 import PropTypes from 'prop-types';
-import {DropTarget as dropTarget} from 'react-dnd';
 import React, {Component} from 'react';
+import {DropTarget as dropTarget} from 'react-dnd';
 
 import {DragTypes} from '../../utils/drag-types.es';
 

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/EmptyDropZone.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/EmptyDropZone.es.js
@@ -14,8 +14,8 @@
 
 import getCN from 'classnames';
 import PropTypes from 'prop-types';
-import {DropTarget as dropTarget} from 'react-dnd';
 import React, {Component} from 'react';
+import {DropTarget as dropTarget} from 'react-dnd';
 
 import ThemeContext from '../../ThemeContext.es';
 import {DragTypes} from '../../utils/drag-types.es';

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/EmptyPlaceholder.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/EmptyPlaceholder.es.js
@@ -18,7 +18,7 @@ import {sub} from '../../utils/utils.es';
 
 export default function EmptyPlaceholder() {
 	return (
-		<div className="taglib-empty-result-message mb-0 p-5 rounded empty-contributors">
+		<div className="empty-contributors mb-0 p-5 rounded taglib-empty-result-message">
 			<div className="taglib-empty-result-message-header" />
 			<div className="sheet-text text-center">
 				<h1 className="mb-3 mt-4">

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarCollapse.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarCollapse.es.js
@@ -97,7 +97,7 @@ class CriteriaSidebarCollapse extends Component {
 			: properties;
 
 		return (
-			<ul className="sidebar-collapse-groups list-unstyled">
+			<ul className="list-unstyled sidebar-collapse-groups">
 				{propertyGroups.map(propertyGroup => {
 					const active = propertyGroup.propertyKey === propertyKey;
 
@@ -121,7 +121,7 @@ class CriteriaSidebarCollapse extends Component {
 								className="sidebar-collapse-header-root"
 								onClick={this._handleClick(key, active)}
 							>
-								<a className="sidebar-collapse-header d-flex justify-content-between">
+								<a className="d-flex justify-content-between sidebar-collapse-header">
 									{propertyGroup.name}
 									<span className="collapse-icon">
 										<ClayIcon

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarItem.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarItem.es.js
@@ -15,8 +15,8 @@
 import ClayIcon from '@clayui/icon';
 import getCN from 'classnames';
 import PropTypes from 'prop-types';
-import {DragSource as dragSource} from 'react-dnd';
 import React, {Component} from 'react';
+import {DragSource as dragSource} from 'react-dnd';
 
 import {PROPERTY_TYPES} from '../../utils/constants.es';
 import {DragTypes} from '../../utils/drag-types.es';

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/title_editor/LocalizedDropdown.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/title_editor/LocalizedDropdown.es.js
@@ -109,7 +109,7 @@ class LocalizedDropdown extends React.Component {
 				</button>
 
 				{open && (
-					<ul className="dropdown-menu d-block" role="menu">
+					<ul className="d-block dropdown-menu" role="menu">
 						{availableLanguages.map(entry => {
 							const {hasValue, key} = entry;
 
@@ -125,7 +125,7 @@ class LocalizedDropdown extends React.Component {
 									role="presentation"
 								>
 									<span
-										className="dropdown-item palette-item lfr-icon-item taglib-icon"
+										className="dropdown-item lfr-icon-item palette-item taglib-icon"
 										role="menuitem"
 										tabIndex="0"
 										target="_self"
@@ -140,7 +140,7 @@ class LocalizedDropdown extends React.Component {
 										<span className="taglib-text-icon">
 											{keyLangToLanguageTag(key, false)}
 											{defaultLang === key && (
-												<span className="ml-1 label label-info">
+												<span className="label label-info ml-1">
 													{Liferay.Language.get(
 														'default-value'
 													)}
@@ -148,13 +148,13 @@ class LocalizedDropdown extends React.Component {
 											)}
 											{defaultLang !== key &&
 												(hasValue ? (
-													<span className="ml-1 label label-success">
+													<span className="label label-success ml-1">
 														{Liferay.Language.get(
 															'translated'
 														)}
 													</span>
 												) : (
-													<span className="ml-1 label label-warning">
+													<span className="label label-warning ml-1">
 														{Liferay.Language.get(
 															'untranslated'
 														)}

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/title_editor/LocalizedInput.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/title_editor/LocalizedInput.es.js
@@ -140,7 +140,7 @@ export default class LocalizedInput extends React.Component {
 				/>
 				<div className={inputGroupItemClasses}>
 					<input
-						className="rounded form-control language-value field form-control-inline form-control"
+						className="field form-control form-control-inline language-value rounded"
 						data-testid="localized-main-input"
 						onChange={this._handleInputChange}
 						placeholder={placeholder}

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaBuilder.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaBuilder.es.js
@@ -13,8 +13,8 @@
  */
 
 import {cleanup, render} from '@testing-library/react';
-import {wrapInTestContext} from 'react-dnd-test-utils';
 import React from 'react';
+import {wrapInTestContext} from 'react-dnd-test-utils';
 
 import {default as Component} from '../../../../src/main/resources/META-INF/resources/js/components/criteria_builder/CriteriaBuilder.es';
 

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaGroup.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/CriteriaGroup.es.js
@@ -13,8 +13,8 @@
  */
 
 import {cleanup, render} from '@testing-library/react';
-import {wrapInTestContext} from 'react-dnd-test-utils';
 import React from 'react';
+import {wrapInTestContext} from 'react-dnd-test-utils';
 
 import {default as Component} from '../../../../src/main/resources/META-INF/resources/js/components/criteria_builder/CriteriaGroup.es';
 

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/js/WikiPortlet.es.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/js/WikiPortlet.es.js
@@ -13,8 +13,8 @@
  */
 
 import {PortletBase, fetch} from 'frontend-js-web';
-import {EventHandler} from 'metal-events';
 import core from 'metal';
+import {EventHandler} from 'metal-events';
 
 /**
  * WikiPortlet

--- a/modules/package.json
+++ b/modules/package.json
@@ -8,7 +8,7 @@
 		"liferay-frontend-common-css": "1.0.4",
 		"liferay-karma-alloy-config": "0.0.15",
 		"liferay-karma-config": "0.0.3",
-		"liferay-npm-scripts": "12.0.0",
+		"liferay-npm-scripts": "13.0.0",
 		"metal-jest-serializer": "2.0.0"
 	},
 	"private": true,

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -7482,10 +7482,10 @@ escodegen@^1.6.1, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-11.1.1.tgz#2e13c773a4da68824d12fbfaa22d706fab787750"
-  integrity sha512-0RdnXrCxYEulT+hqs4NHlX3Ycg+3tR7OE27NKHvND1s4owJgL9FB+84FNNImPtSp56qURRsi7U+0mpD2fzTbmw==
+eslint-config-liferay@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-12.0.0.tgz#a78fb33981bb77d59ecbd7ca487cddfc2dec2f28"
+  integrity sha512-ovTjjC6ZZhi99jovM99epLYiIrZjSp1T44FeuHI6GXInVvAdGD71oupQ7EtOKRR5+pDwJCsaQugmav9PaTVoVA==
   dependencies:
     eslint-config-prettier "5.0.0"
     eslint-plugin-no-for-of-loops "^1.0.0"
@@ -11963,10 +11963,10 @@ liferay-npm-bundler@2.13.3:
     semver "^5.5.0"
     xml-js "^1.6.8"
 
-liferay-npm-scripts@12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-12.0.0.tgz#1c3297fe7eb2b6dd45e63334f11003420d1b9be6"
-  integrity sha512-dRW8+CrB5WU4bsRxJAyDBExliDt56KKv+lIPWvFngwk3LkAzaMpZFzxE3YAR1ICBqQTEFd2RzjOmmf58vq1+WQ==
+liferay-npm-scripts@13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-13.0.0.tgz#8bb0430d0261d69cd87f138825b8c788dcf4284e"
+  integrity sha512-TpY2GO2LYdv7SXjIQcAmpzOutJsruMJjZ28M8S1QJRgAzvG1RDFXV4kPsCH+kmPLqiLWbsVQr8P5Vvb6GCEAEg==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/plugin-proposal-class-properties" "7.4.4"
@@ -11991,7 +11991,7 @@ liferay-npm-scripts@12.0.0:
     css-loader "^3.0.0"
     deepmerge "^4.0.0"
     eslint "6.5.1"
-    eslint-config-liferay "11.1.1"
+    eslint-config-liferay "12.0.0"
     http-proxy-middleware "^0.19.1"
     jest "^24.5.0"
     jest-fetch-mock "^2.1.2"


### PR DESCRIPTION
As requested [here](https://github.com/brianchandotcom/liferay-portal/pull/79628#issuecomment-542975695).

This was [implemented in eslint-config-liferay v12.0.0](https://github.com/liferay/eslint-config-liferay/pull/114), and we bring that in by updating to [liferay-npm-scripts v13.0.0](https://github.com/liferay/liferay-npm-tools/pull/295), which means we get a couple of additional lint fixes as well:

- We fix an edge case that was causing imports like "metal-dom" to sort incorrectly before "metal".
- We enable the no-restricted-globals rule that will prevent sketchy implicit uses of esoteric globals such as `event`.