### PR TITLE
LPS-103292 Add "useTimeout" and "useInterval" hooks

### DIFF
--- a/modules/apps/frontend-js/frontend-js-react-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-react-web/package.json
@@ -18,7 +18,8 @@
 	"scripts": {
 		"build": "liferay-npm-scripts build",
 		"checkFormat": "liferay-npm-scripts check",
-		"format": "liferay-npm-scripts fix"
+		"format": "liferay-npm-scripts fix",
+		"test": "liferay-npm-scripts test"
 	},
 	"version": "2.0.0"
 }

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useInterval.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useInterval.es.js
@@ -12,9 +12,29 @@
  * details.
  */
 
-export {default as render} from './render.es';
-export {default as useEventListener} from './hooks/useEventListener.es';
-export {default as useInterval} from './hooks/useInterval.es';
-export {default as useIsMounted} from './hooks/useIsMounted.es';
-export {default as usePrevious} from './hooks/usePrevious.es';
-export {default as useTimeout} from './hooks/useTimeout.es';
+import {useCallback} from 'react';
+
+import useIsMounted from './useIsMounted.es';
+
+/**
+ * Hook for scheduling a repeating function call with the specified
+ * interval (in milliseconds).
+ */
+export default function useInterval() {
+	const isMounted = useIsMounted();
+
+	return useCallback(
+		function schedule(fn, ms) {
+			const handle = setInterval(() => {
+				if (isMounted()) {
+					fn();
+				} else {
+					clearInterval(handle);
+				}
+			}, ms);
+
+			return () => clearInterval(handle);
+		},
+		[isMounted]
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useTimeout.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useTimeout.es.js
@@ -12,9 +12,27 @@
  * details.
  */
 
-export {default as render} from './render.es';
-export {default as useEventListener} from './hooks/useEventListener.es';
-export {default as useInterval} from './hooks/useInterval.es';
-export {default as useIsMounted} from './hooks/useIsMounted.es';
-export {default as usePrevious} from './hooks/usePrevious.es';
-export {default as useTimeout} from './hooks/useTimeout.es';
+import {useCallback} from 'react';
+
+import useIsMounted from './useIsMounted.es';
+
+/**
+ * Hook for delaying a function call by the specified interval (in
+ * milliseconds).
+ */
+export default function useTimeout() {
+	const isMounted = useIsMounted();
+
+	return useCallback(
+		function delay(fn, ms) {
+			const handle = setTimeout(() => {
+				if (isMounted()) {
+					fn();
+				}
+			}, ms);
+
+			return () => clearTimeout(handle);
+		},
+		[isMounted]
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-react-web/test/js/hooks/useInterval.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/test/js/hooks/useInterval.es.js
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import React from 'react';
+
+import useInterval from '../../../src/main/resources/META-INF/resources/js/hooks/useInterval.es';
+
+const {useEffect, useState} = React;
+
+const INTERVAL = 100;
+
+const Component = ({callback, onRender, onSchedule}) => {
+	const schedule = useInterval();
+
+	useEffect(() => {
+		if (onRender) {
+			onRender(schedule);
+		}
+	});
+
+	const [, forceUpdate] = useState();
+
+	const invoke = () => {
+		const cancel = schedule(callback, INTERVAL);
+
+		if (onSchedule) {
+			onSchedule(cancel);
+		}
+	};
+
+	return (
+		<>
+			<button onClick={invoke}>Invoke</button>
+			<button onClick={forceUpdate}>Update</button>
+		</>
+	);
+};
+
+describe('useInterval()', () => {
+	beforeEach(jest.useFakeTimers);
+
+	afterEach(cleanup);
+
+	it('runs a function on a schedule', () => {
+		const fn = jest.fn();
+
+		const {getByText} = render(<Component callback={fn} />);
+
+		fireEvent.click(getByText('Invoke'));
+
+		expect(fn).not.toHaveBeenCalled();
+
+		jest.advanceTimersByTime(INTERVAL);
+
+		expect(fn).toHaveBeenCalledTimes(1);
+
+		jest.advanceTimersByTime(INTERVAL);
+
+		expect(fn).toHaveBeenCalledTimes(2);
+	});
+
+	it('returns a function that cancels the schedule', () => {
+		const fn = jest.fn();
+
+		let cancel;
+
+		const onSchedule = handle => {
+			cancel = handle;
+		};
+
+		const {getByText} = render(
+			<Component callback={fn} onSchedule={onSchedule} />
+		);
+
+		fireEvent.click(getByText('Invoke'));
+
+		expect(fn).not.toHaveBeenCalled();
+
+		jest.advanceTimersByTime(INTERVAL);
+
+		expect(fn).toHaveBeenCalledTimes(1);
+
+		cancel();
+
+		jest.advanceTimersByTime(INTERVAL);
+
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not run if unmounted', () => {
+		const fn = jest.fn();
+
+		const {getByText, unmount} = render(<Component callback={fn} />);
+
+		fireEvent.click(getByText('Invoke'));
+
+		unmount();
+
+		jest.advanceTimersByTime(INTERVAL);
+
+		expect(fn).not.toHaveBeenCalled();
+	});
+
+	it('does not run if unmounted and then remounted', () => {
+		const fn = jest.fn();
+
+		const {getByText, unmount} = render(<Component callback={fn} />);
+
+		fireEvent.click(getByText('Invoke'));
+
+		unmount();
+
+		render(<Component callback={fn} />);
+
+		jest.advanceTimersByTime(INTERVAL);
+
+		expect(fn).not.toHaveBeenCalled();
+	});
+
+	it('preserves the identity of the schedule function', () => {
+		const functions = [];
+
+		const {getByText} = render(
+			<Component onRender={schedule => functions.push(schedule)} />
+		);
+
+		expect(functions.length).toBe(1);
+
+		fireEvent.click(getByText('Update'));
+
+		expect(functions.length).toBe(2);
+
+		expect(functions[0]).toBe(functions[1]);
+	});
+});

--- a/modules/apps/frontend-js/frontend-js-react-web/test/js/hooks/useTimeout.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/test/js/hooks/useTimeout.es.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import React from 'react';
+
+import useTimeout from '../../../src/main/resources/META-INF/resources/js/hooks/useTimeout.es';
+
+const {useEffect, useState} = React;
+
+const INTERVAL = 100;
+
+const Component = ({callback, onDelay, onRender}) => {
+	const delay = useTimeout();
+
+	useEffect(() => {
+		if (onRender) {
+			onRender(delay);
+		}
+	});
+
+	const [, forceUpdate] = useState();
+
+	const invoke = () => {
+		const cancel = delay(callback, INTERVAL);
+
+		if (onDelay) {
+			onDelay(cancel);
+		}
+	};
+
+	return (
+		<>
+			<button onClick={invoke}>Invoke</button>
+			<button onClick={forceUpdate}>Update</button>
+		</>
+	);
+};
+
+describe('useTimeout()', () => {
+	beforeEach(jest.useFakeTimers);
+
+	afterEach(cleanup);
+
+	it('runs a function after a delay', () => {
+		const fn = jest.fn();
+
+		const {getByText} = render(<Component callback={fn} />);
+
+		fireEvent.click(getByText('Invoke'));
+
+		expect(fn).not.toHaveBeenCalled();
+
+		jest.runAllTimers();
+
+		expect(fn).toHaveBeenCalled();
+	});
+
+	it('returns a function that cancels the timeout', () => {
+		const fn = jest.fn();
+
+		let cancel;
+
+		const onDelay = handle => {
+			cancel = handle;
+		};
+
+		const {getByText} = render(
+			<Component callback={fn} onDelay={onDelay} />
+		);
+
+		fireEvent.click(getByText('Invoke'));
+
+		expect(fn).not.toHaveBeenCalled();
+
+		cancel();
+
+		jest.runAllTimers();
+
+		expect(fn).not.toHaveBeenCalled();
+	});
+
+	it('does not run if unmounted', () => {
+		const fn = jest.fn();
+
+		const {getByText, unmount} = render(<Component callback={fn} />);
+
+		fireEvent.click(getByText('Invoke'));
+
+		unmount();
+
+		jest.runAllTimers();
+
+		expect(fn).not.toHaveBeenCalled();
+	});
+
+	it('does not run if unmounted and then remounted', () => {
+		const fn = jest.fn();
+
+		const {getByText, unmount} = render(<Component callback={fn} />);
+
+		fireEvent.click(getByText('Invoke'));
+
+		unmount();
+
+		render(<Component callback={fn} />);
+
+		jest.runAllTimers();
+
+		expect(fn).not.toHaveBeenCalled();
+	});
+
+	it('preserves the identity of the delay function', () => {
+		const functions = [];
+
+		const {getByText} = render(
+			<Component onRender={delay => functions.push(delay)} />
+		);
+
+		expect(functions.length).toBe(1);
+
+		fireEvent.click(getByText('Update'));
+
+		expect(functions.length).toBe(2);
+
+		expect(functions[0]).toBe(functions[1]);
+	});
+});


### PR DESCRIPTION
We need to be careful about running side effects on unmounted components, so these hooks will help us to do the right thing. Basically, it will replace usages of `setTimeout` and `setInterval` with a hook that includes a baked-in `isMounted` check.

Subsequently, we will add a lint for `setTimeout` and `setInterval` in React components and suggest people use these hooks instead.

Originally reviewed [here](https://github.com/jbalsas/liferay-portal/pull/1990).