### PR TITLE
LPS-103539 Add build.gradle to portal-search-tuning

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/build.gradle
+++ b/modules/dxp/apps/portal-search-tuning/build.gradle
@@ -1,0 +1,1 @@
+apply plugin: "com.liferay.app.defaults.plugin"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-103539

Sending this because com.liferay.portal.modules.ModulesStructureTest.testScanBuildScripts is complaining that portal-search-tuning is missing build.gradle. Not too sure about this one though, let me know if this isn't correct.

7.2.x PR: https://github.com/brianchandotcom/liferay-portal-ee/pull/27204