### PR TITLE
LPS-99723 Prepare for backport of ES7 module to 7.2.x

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-api/bnd.bnd
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search Elasticsearch 7 API
 Bundle-SymbolicName: com.liferay.portal.search.elasticsearch7.api
-Bundle-Version: 1.0.0
+Bundle-Version: 4.0.0
 Export-Package:\
 	com.liferay.portal.search.elasticsearch7.configuration,\
 	com.liferay.portal.search.elasticsearch7.constants,\

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/bnd.bnd
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search Elasticsearch 7 Implementation
 Bundle-SymbolicName: com.liferay.portal.search.elasticsearch7.impl
-Bundle-Version: 1.0.0
+Bundle-Version: 4.0.0
 Import-Package:\
 	!com.barchart.udt.*,\
 	\

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-spi/bnd.bnd
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-spi/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search Elasticsearch 7 SPI
 Bundle-SymbolicName: com.liferay.portal.search.elasticsearch7.spi
-Bundle-Version: 1.0.0
+Bundle-Version: 4.0.0
 Export-Package:\
 	com.liferay.portal.search.elasticsearch7.spi.index,\
 	com.liferay.portal.search.elasticsearch7.spi.index.helper


### PR DESCRIPTION
⚠️ **ci:test:search-es7 - 37 out of 45 jobs passed** https://github.com/BryanEngler/liferay-portal/pull/433#issuecomment-545663779
✅ The only failures unique to this pull are not caused by this pr, confirmed by @joshchong

⚠️ NOTE: The one thing I have a concern about is that running `gw baseline` from portal-search-elasticsearch7-api gives me an error. Updating the versions seems to be a pretty straight forward task, so I dont know if there is something wrong with baseline or my local environment or what. Let me know if you have any ideas.

Author(s): @BryanEngler

---
*[Task] Elasticsearch 7: Carbon Copy to Liferay 7.2.x*
https://issues.liferay.com/browse/LPS-99723