### PR TITLE
LPS-103653 Only removing include for now, through cleanup will come l…

### DIFF
--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -11,7 +11,6 @@ Include-Resource:\
 	classes,\
 	@../tmp/lib-pre/com.liferay.portal.kernel.concurrent.compat.jar,\
 	@../tmp/lib-pre/com.liferay.portal.kernel.io.compat.jar,\
-	@../tmp/lib-pre/com.liferay.portal.kernel.memory.compat.jar,\
 	@../tmp/lib-pre/com.liferay.portal.kernel.nio.compat.jar,\
 	@../tmp/lib-pre/com.liferay.portal.kernel.util.compat.jar
 -include ../common.bnd


### PR DESCRIPTION
…ater.

@dantewang please work on the portal-kernel-memory-compat removal first, it is causing a weird semantic versioning problem, most likely due to some publish from older branch. Since we want to remove it anyway, let's do this first to fix the problem.
I am only removing the include here, please remove the model and all related bnd.bnd includes, and do a through test, this could only affect tools.
Please move this ticket to be a proper subtask under your current work plan for compat removal.