### PR TITLE
LPS-100001 portal-search-learning-to-rank: Bump master's version to allow backport to 7.2.x

### DIFF
--- a/modules/dxp/apps/portal-search-learning-to-rank/portal-search-learning-to-rank-api/bnd.bnd
+++ b/modules/dxp/apps/portal-search-learning-to-rank/portal-search-learning-to-rank-api/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-Name: Liferay Portal Search Learning To Rank API
 Bundle-SymbolicName: com.liferay.portal.search.learning.to.rank.api
-Bundle-Version: 1.0.0
+Bundle-Version: 2.0.0
 Export-Package: com.liferay.portal.search.learning.to.rank.configuration
 -fixupmessages: Classes found in the wrong directory: ...;is:=ignore

--- a/modules/dxp/apps/portal-search-learning-to-rank/portal-search-learning-to-rank-impl/bnd.bnd
+++ b/modules/dxp/apps/portal-search-learning-to-rank/portal-search-learning-to-rank-impl/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Portal Search Learning To Rank Implementation
 Bundle-SymbolicName: com.liferay.portal.search.learning.to.rank.impl
-Bundle-Version: 1.0.0
+Bundle-Version: 2.0.0
 -fixupmessages: Classes found in the wrong directory: ...;is:=ignore


### PR DESCRIPTION
Hey @brianchandotcom

We are backporting LTR to 7.2.x, so we need to increase master's version as described in
https://grow.liferay.com/share/Backporting+new+modules. This pull request does that.

Backport pull request: https://github.com/liferay/liferay-portal-ee/pull/16800
Original ticket https://issues.liferay.com/browse/LPS-100001
Backport ticket: https://issues.liferay.com/browse/BPR-36060