### PR TITLE
LPS-103658 Delete instance cause portal broken when site team assigned to site

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.exception.GroupInheritContentException;
 import com.liferay.portal.kernel.exception.GroupKeyException;
 import com.liferay.portal.kernel.exception.GroupParentException;
 import com.liferay.portal.kernel.exception.LocaleException;
+import com.liferay.portal.kernel.exception.NoSuchCompanyException;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.NoSuchLayoutSetException;
 import com.liferay.portal.kernel.exception.PendingBackgroundTaskException;
@@ -4923,10 +4924,17 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		}
 
 		if (site) {
-			Company company = companyLocalService.getCompany(companyId);
+			try {
+				Company company = companyLocalService.getCompany(companyId);
 
-			if (groupKey.equals(company.getName())) {
-				throw new DuplicateGroupException();
+				if (groupKey.equals(company.getName())) {
+					throw new DuplicateGroupException();
+				}
+			}
+			catch (NoSuchCompanyException nsce) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(nsce, nsce);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hey @brianchandotcom, had to catch the exception here, because: company is removed, then the teams are removed, which triggers an update in the group, and then the company is checked for groupKey (and fails). This should be safe, since we are only checking for the group key at that moment. Still, let me know if it would be better to find another solution.

Thanks 