### PR TITLE
LPS-103714 Prune unnecessary lines from eslintignore

### DIFF
--- a/modules/.eslintignore
+++ b/modules/.eslintignore
@@ -6,28 +6,8 @@
 	# Ignore apps that are no longer under active development.
 	#
 	apps/archived
-	apps/chat
 	apps/google-maps
-	apps/mail-reader
 	apps/microblogs
-
-##
-## Configuration Files
-##
-
-	#
-	# Unignore configuration files because they should be treated as "modern"
-	# despite not having an ".es.js" extension.
-	#
-	!.eslintrc.js
-	!npmscripts.config.js
-
-	#
-	# Unlike the other configuration files (which can appear inside project
-	# subdirectories), there should only ever be one global Prettier configuration
-	# file at the top-level, so we do not use a recursive ("**/*") glob here.
-	#
-	!.prettierrc.js
 
 ##
 ## Generated Files


### PR DESCRIPTION
- We no longer need "apps/chat" and "apps/mail-read" (they have been moved into "apps/archived").
- And we no longer need the negation for the configuration files (as of acd128235c413836fd66, we lint basically ".js" files instead of just the ".es.js" ones).