### PR TITLE
LPS-103511 Fix plural/singular concordance in comment

### DIFF
--- a/modules/.prettierignore
+++ b/modules/.prettierignore
@@ -18,9 +18,9 @@
 ##
 
 	#
-	# These files defines the copyright headers the linter should add
+	# These files define the copyright headers the linter should add
 	# to any file that does not have them. In order to produce the
-	# desired result when prepended, it must have a trailing blank
+	# desired result when prepended, each must have a trailing blank
 	# line. Prettier would remove the blank line if we did not ignore it
 	# here.
 	#


### PR DESCRIPTION
Commit bcfe5bae23f5c changed to plural "files" but I overlooked a couple of other necessary adjustments.