### PR TITLE
LPS-96723 Remove pointless comma operator

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/debounce/debounce.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/debounce/debounce.es.js
@@ -23,7 +23,7 @@ function debounce(fn, delay) {
 		const args = arguments;
 		cancelDebounce(debounced);
 		debounced.id = setTimeout(() => {
-			fn(...(null, args));
+			fn(...args);
 		}, delay);
 	};
 }


### PR DESCRIPTION
This pattern:

    fn(...(null, args));

looks like a mistranslation of:

    fn.apply(null, args);

ie. call function `fn` with its context (`this`) set to `null`, and passing it `args`.

However, [the comma operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_Operator) has no effect. It evaluates the first operand (`null`), discards it, then evaluates the second one (`args`) and uses that as the result of the expression:

In other words, it can be rewritten as just:

    fn(...args);