### PR TITLE
LPS-63259 Bump semver

### DIFF
--- a/modules/apps/flags/flags-test/bnd.bnd
+++ b/modules/apps/flags/flags-test/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Flags Test
 Bundle-SymbolicName: com.liferay.flags.test
-Bundle-Version: 1.0.0
+Bundle-Version: 4.0.0


### PR DESCRIPTION
Hi Brian,

We're bumping the bundle version for `flags-test` for semver compatibility because it's a new module, and we need to backport it all the way to 7.0.x. 

ref: https://github.com/liferay/liferay-portal-ee/pull/16892#issuecomment-549349063

/cc @drewbrokke @alee8888 @CsabaTurcsan