### PR TITLE
LRCI-648 Rename suite to test just Oracle 19 environments

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -17,6 +17,7 @@ ci.test.available.suites=\
     documents,\
     dummy,\
     environments,\
+    environments-oracle19,\
     gauntlet,\
     gradle-plugins,\
     jdk11,\
@@ -28,7 +29,6 @@ ci.test.available.suites=\
     oauth2,\
     onedrive,\
     onlineediting,\
-    oracle19,\
     poshi,\
     poshi-gauntlet,\
     project-templates,\

--- a/test.properties
+++ b/test.properties
@@ -1843,6 +1843,18 @@
     test.batch.run.property.query[functional-smoke-*][environments]=environment.acceptance == true
 
     #
+    # Environment Oracle 19.3
+    #
+
+    test.batch.dist.app.servers[environments-oracle19]=tomcat
+
+    test.batch.names[environments-oracle19]=\
+        functional-smoke-tomcat90-oracle193-jdk8,\
+        functional-tomcat90-oracle193-jdk8,\
+        functional-upgrade-tomcat90-oracle193-jdk8,\
+        modules-integration-oracle193-jdk8
+
+    #
     # Gauntlet
     #
 
@@ -2068,18 +2080,6 @@
             (testray.component.names ~ "Online Editing") OR \
             (testray.main.component.name ~ "Online Editing")\
         )
-
-    #
-    # Oracle 19
-    #
-
-    test.batch.dist.app.servers[oracle19]=tomcat
-
-    test.batch.names[oracle19]=\
-        functional-smoke-tomcat90-oracle193-jdk8,\
-        functional-tomcat90-oracle193-jdk8,\
-        functional-upgrade-tomcat90-oracle193-jdk8,\
-        modules-integration-oracle193-jdk8
 
     #
     # Poshi


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-648

@brianchandotcom - I renamed it, because there's another suite that has a similar function but it is used for all the environments.  Sorry about that..