### PR TITLE
LRCI-745

### DIFF
--- a/portal-web/test.properties
+++ b/portal-web/test.properties
@@ -14,4 +14,4 @@
     #
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
-        (portal.acceptance == true)
+        (portal.acceptance == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mysql)


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-745

@brianwulbern, when we switched to use the build dxp profile in CI, this meant that the test.run.environment versions were set to 'EE'. So the PQL that I changed was grabbing things it wasn't before. This change makes it more consistent with what's in the PQL's in test.properties. Let me know if you have any questions