### PR TITLE
LPS-104291 Search for *.jspf files as well so that the in the case of…

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JSPServletFactoryImpl.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JSPServletFactoryImpl.java
@@ -94,7 +94,7 @@ public class JSPServletFactoryImpl implements JSPServletFactory {
 			}
 
 			Enumeration<URL> enumeration = bundle.findEntries(
-				_DIR_NAME_RESOURCES, "*.jsp", true);
+				_DIR_NAME_RESOURCES, "*.jsp*", true);
 
 			if (enumeration == null) {
 				return null;


### PR DESCRIPTION
… a fragment module only contain JSPFs they are still compiled and override the existing files as expected