### PR TITLE
[TS] LPS-92932 Indirect permission checks in *LocalServiceImpl classes

### DIFF
--- a/modules/apps/directory/directory-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/directory/directory-web/src/main/resources/META-INF/resources/init.jsp
@@ -59,6 +59,7 @@ page import="com.liferay.portal.kernel.service.OrganizationServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.PhoneServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.RegionServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.UserGroupLocalServiceUtil" %><%@
+page import="com.liferay.portal.kernel.service.UserGroupServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.WebsiteServiceUtil" %><%@
 page import="com.liferay.portal.kernel.util.CalendarFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.CalendarUtil" %><%@

--- a/modules/apps/directory/directory-web/src/main/resources/META-INF/resources/view_user_groups.jsp
+++ b/modules/apps/directory/directory-web/src/main/resources/META-INF/resources/view_user_groups.jsp
@@ -46,11 +46,11 @@ if (Validator.isNotNull(keywords)) {
 	userGroupParams.put("expandoAttributes", keywords);
 }
 
-int userGroupsCount = UserGroupLocalServiceUtil.searchCount(company.getCompanyId(), keywords, userGroupParams);
+int userGroupsCount = UserGroupServiceUtil.searchCount(company.getCompanyId(), keywords, userGroupParams);
 
 userGroupSearch.setTotal(userGroupsCount);
 
-List<UserGroup> userGroups = UserGroupLocalServiceUtil.search(company.getCompanyId(), keywords, userGroupParams, userGroupSearch.getStart(), userGroupSearch.getEnd(), userGroupSearch.getOrderByComparator());
+List<UserGroup> userGroups = UserGroupServiceUtil.search(company.getCompanyId(), keywords, userGroupParams, userGroupSearch.getStart(), userGroupSearch.getEnd(), userGroupSearch.getOrderByComparator());
 
 userGroupSearch.setResults(userGroups);
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordSetLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordSetLocalServiceImpl.java
@@ -402,7 +402,7 @@ public class DDLRecordSetLocalServiceImpl
 	}
 
 	public List<DDLRecordSet> getRecordSets(long groupId, int start, int end) {
-		return ddlRecordSetPersistence.filterFindByGroupId(groupId, start, end);
+		return ddlRecordSetPersistence.findByGroupId(groupId, start, end);
 	}
 
 	/**

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
@@ -988,7 +988,7 @@ public class DDMStructureLocalServiceImpl
 		long companyId, long[] groupIds, long classNameId, int start, int end,
 		OrderByComparator<DDMStructure> orderByComparator) {
 
-		return ddmStructureFinder.filterFindByC_G_C_S(
+		return ddmStructureFinder.findByC_G_C_S(
 			companyId, groupIds, classNameId, WorkflowConstants.STATUS_ANY,
 			start, end, orderByComparator);
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureServiceImpl.java
@@ -357,8 +357,9 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 		long companyId, long[] groupIds, long classNameId, int start, int end,
 		OrderByComparator<DDMStructure> orderByComparator) {
 
-		return ddmStructureLocalService.getStructures(
-			companyId, groupIds, classNameId, start, end, orderByComparator);
+		return ddmStructureFinder.filterFindByC_G_C_S(
+			companyId, groupIds, classNameId, WorkflowConstants.STATUS_ANY,
+			start, end, orderByComparator);
 	}
 
 	@Override
@@ -376,7 +377,7 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 	public int getStructuresCount(
 		long companyId, long[] groupIds, long classNameId) {
 
-		return _ddmStructureFinder.countByC_G_C_S(
+		return _ddmStructureFinder.filterCountByC_G_C_S(
 			companyId, groupIds, classNameId, WorkflowConstants.STATUS_ANY);
 	}
 

--- a/modules/apps/user-groups-admin/user-groups-admin-test/src/testIntegration/java/com/liferay/user/groups/admin/service/test/UserGroupLocalServiceTest.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-test/src/testIntegration/java/com/liferay/user/groups/admin/service/test/UserGroupLocalServiceTest.java
@@ -17,15 +17,12 @@ package com.liferay.user.groups.admin.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.ResourceAction;
-import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SortFactoryUtil;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
@@ -37,7 +34,6 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.ResourcePermissionTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -90,51 +86,28 @@ public class UserGroupLocalServiceTest {
 
 	@Test
 	public void testDatabaseSearchNoPermissionCheck() throws Exception {
-		User groupUser = UserTestUtil.addUser();
-		User publicAdminUser = UserTestUtil.addUser();
-
-		Role publicAdminRole = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+		User user = UserTestUtil.addUser();
 
 		try {
 			_userGroupLocalService.addUserUserGroup(
-				groupUser.getUserId(), _userGroup1);
-
-			_userGroupLocalService.addUserUserGroup(
-				groupUser.getUserId(), _userGroup2);
-
-			_roleLocalService.addUserRole(
-				publicAdminUser.getUserId(), publicAdminRole);
-
-			ResourceAction viewAction =
-				_resourceActionLocalService.fetchResourceAction(
-					UserGroup.class.getName(), ActionKeys.VIEW);
-
-			ResourcePermissionTestUtil.addResourcePermission(
-				viewAction.getBitwiseValue(), UserGroup.class.getName(),
-				String.valueOf(_userGroup1.getUserGroupId()),
-				publicAdminRole.getRoleId(),
-				ResourceConstants.SCOPE_INDIVIDUAL);
+				user.getUserId(), _userGroup1);
 
 			PermissionThreadLocal.setPermissionChecker(
-				_permissionCheckerFactory.create(publicAdminUser));
-
-			String keywords = null;
+				_permissionCheckerFactory.create(user));
 
 			LinkedHashMap<String, Object> userGroupParams =
 				new LinkedHashMap<>();
 
 			userGroupParams.put(
 				UserGroupFinderConstants.PARAM_KEY_USER_GROUPS_USERS,
-				Long.valueOf(groupUser.getUserId()));
+				user.getUserId());
 
-			List<UserGroup> userGroups = _search(keywords, userGroupParams);
+			List<UserGroup> userGroups = _search(null, userGroupParams);
 
-			Assert.assertEquals(userGroups.toString(), 2, userGroups.size());
+			Assert.assertEquals(userGroups.toString(), 1, userGroups.size());
 		}
 		finally {
-			_userLocalService.deleteUser(groupUser);
-			_userLocalService.deleteUser(publicAdminUser);
-			_roleLocalService.deleteRole(publicAdminRole);
+			_userLocalService.deleteUser(user);
 		}
 	}
 

--- a/modules/apps/user-groups-admin/user-groups-admin-test/src/testIntegration/java/com/liferay/user/groups/admin/service/test/UserGroupLocalServiceTest.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-test/src/testIntegration/java/com/liferay/user/groups/admin/service/test/UserGroupLocalServiceTest.java
@@ -96,11 +96,9 @@ public class UserGroupLocalServiceTest {
 				_permissionCheckerFactory.create(user));
 
 			LinkedHashMap<String, Object> userGroupParams =
-				new LinkedHashMap<>();
-
-			userGroupParams.put(
-				UserGroupFinderConstants.PARAM_KEY_USER_GROUPS_USERS,
-				user.getUserId());
+				LinkedHashMapBuilder.<String, Object>put(
+					UserGroupFinderConstants.PARAM_KEY_USER_GROUPS_USERS,
+					Long.valueOf(user.getUserId()));
 
 			List<UserGroup> userGroups = _search(null, userGroupParams);
 

--- a/modules/apps/user-groups-admin/user-groups-admin-test/src/testIntegration/java/com/liferay/user/groups/admin/service/test/UserGroupLocalServiceTest.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-test/src/testIntegration/java/com/liferay/user/groups/admin/service/test/UserGroupLocalServiceTest.java
@@ -91,48 +91,51 @@ public class UserGroupLocalServiceTest {
 	@Test
 	public void testDatabaseSearchNoPermissionCheck() throws Exception {
 		User groupUser = UserTestUtil.addUser();
-
-		_userGroupLocalService.addUserUserGroup(
-			groupUser.getUserId(), _userGroup1);
-
-		_userGroupLocalService.addUserUserGroup(
-			groupUser.getUserId(), _userGroup2);
-
 		User publicAdminUser = UserTestUtil.addUser();
 
 		Role publicAdminRole = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
-		_roleLocalService.addUserRole(
-			publicAdminUser.getUserId(), publicAdminRole);
+		try {
+			_userGroupLocalService.addUserUserGroup(
+				groupUser.getUserId(), _userGroup1);
 
-		ResourceAction viewAction =
-			_resourceActionLocalService.fetchResourceAction(
-				UserGroup.class.getName(), ActionKeys.VIEW);
+			_userGroupLocalService.addUserUserGroup(
+				groupUser.getUserId(), _userGroup2);
 
-		ResourcePermissionTestUtil.addResourcePermission(
-			viewAction.getBitwiseValue(), UserGroup.class.getName(),
-			String.valueOf(_userGroup1.getUserGroupId()),
-			publicAdminRole.getRoleId(), ResourceConstants.SCOPE_INDIVIDUAL);
+			_roleLocalService.addUserRole(
+				publicAdminUser.getUserId(), publicAdminRole);
 
-		PermissionThreadLocal.setPermissionChecker(
-			_permissionCheckerFactory.create(publicAdminUser));
+			ResourceAction viewAction =
+				_resourceActionLocalService.fetchResourceAction(
+					UserGroup.class.getName(), ActionKeys.VIEW);
 
-		String keywords = null;
+			ResourcePermissionTestUtil.addResourcePermission(
+				viewAction.getBitwiseValue(), UserGroup.class.getName(),
+				String.valueOf(_userGroup1.getUserGroupId()),
+				publicAdminRole.getRoleId(),
+				ResourceConstants.SCOPE_INDIVIDUAL);
 
-		LinkedHashMap<String, Object> userGroupParams = new LinkedHashMap<>();
+			PermissionThreadLocal.setPermissionChecker(
+				_permissionCheckerFactory.create(publicAdminUser));
 
-		userGroupParams.put(
-			UserGroupFinderConstants.PARAM_KEY_USER_GROUPS_USERS,
-			Long.valueOf(groupUser.getUserId()));
+			String keywords = null;
 
-		List<UserGroup> userGroups = _search(keywords, userGroupParams);
+			LinkedHashMap<String, Object> userGroupParams =
+				new LinkedHashMap<>();
 
-		Assert.assertEquals(userGroups.toString(), 2, userGroups.size());
+			userGroupParams.put(
+				UserGroupFinderConstants.PARAM_KEY_USER_GROUPS_USERS,
+				Long.valueOf(groupUser.getUserId()));
 
-		_userLocalService.deleteUser(groupUser);
-		_userLocalService.deleteUser(publicAdminUser);
+			List<UserGroup> userGroups = _search(keywords, userGroupParams);
 
-		_roleLocalService.deleteRole(publicAdminRole);
+			Assert.assertEquals(userGroups.toString(), 2, userGroups.size());
+		}
+		finally {
+			_userLocalService.deleteUser(groupUser);
+			_userLocalService.deleteUser(publicAdminUser);
+			_roleLocalService.deleteRole(publicAdminRole);
+		}
 	}
 
 	@Test

--- a/modules/apps/user-groups-admin/user-groups-admin-test/src/testIntegration/java/com/liferay/user/groups/admin/service/test/UserGroupServiceTest.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-test/src/testIntegration/java/com/liferay/user/groups/admin/service/test/UserGroupServiceTest.java
@@ -191,11 +191,10 @@ public class UserGroupServiceTest {
 	}
 
 	private void _assertSearch(User user, int expected) throws Exception {
-		LinkedHashMap<String, Object> userGroupParams = new LinkedHashMap<>();
-
-		userGroupParams.put(
-			UserGroupFinderConstants.PARAM_KEY_USER_GROUPS_USERS,
-			user.getUserId());
+		LinkedHashMap<String, Object> userGroupParams =
+			LinkedHashMapBuilder.<String, Object>put(
+				UserGroupFinderConstants.PARAM_KEY_USER_GROUPS_USERS,
+				Long.valueOf(user.getUserId()));
 
 		List<UserGroup> userGroups = _userGroupService.search(
 			user.getCompanyId(), null, userGroupParams, QueryUtil.ALL_POS,

--- a/modules/apps/user-groups-admin/user-groups-admin-test/src/testIntegration/java/com/liferay/user/groups/admin/service/test/UserGroupServiceTest.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-test/src/testIntegration/java/com/liferay/user/groups/admin/service/test/UserGroupServiceTest.java
@@ -71,55 +71,59 @@ public class UserGroupServiceTest {
 
 	@Test
 	public void testDatabaseSearchPermissionCheck() throws Exception {
-		UserGroup publicUserGroup = _addUserGroup();
-		UserGroup privateUserGroup = _addUserGroup();
-
 		User groupUser = UserTestUtil.addUser();
-
-		_userGroupLocalService.addUserUserGroup(
-			groupUser.getUserId(), publicUserGroup);
-
-		_userGroupLocalService.addUserUserGroup(
-			groupUser.getUserId(), privateUserGroup);
-
 		User publicAdminUser = UserTestUtil.addUser();
 
 		Role publicAdminRole = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
-		RoleLocalServiceUtil.addUserRole(
-			publicAdminUser.getUserId(), publicAdminRole);
+		try {
+			UserGroup publicUserGroup = _addUserGroup();
+			UserGroup privateUserGroup = _addUserGroup();
 
-		ResourceAction viewAction =
-			_resourceActionLocalService.fetchResourceAction(
-				UserGroup.class.getName(), ActionKeys.VIEW);
+			_userGroupLocalService.addUserUserGroup(
+				groupUser.getUserId(), publicUserGroup);
 
-		ResourcePermissionTestUtil.addResourcePermission(
-			viewAction.getBitwiseValue(), UserGroup.class.getName(),
-			String.valueOf(publicUserGroup.getUserGroupId()),
-			publicAdminRole.getRoleId(), ResourceConstants.SCOPE_INDIVIDUAL);
+			_userGroupLocalService.addUserUserGroup(
+				groupUser.getUserId(), privateUserGroup);
 
-		PermissionThreadLocal.setPermissionChecker(
-			_permissionCheckerFactory.create(publicAdminUser));
+			RoleLocalServiceUtil.addUserRole(
+				publicAdminUser.getUserId(), publicAdminRole);
 
-		String keywords = null;
+			ResourceAction viewAction =
+				_resourceActionLocalService.fetchResourceAction(
+					UserGroup.class.getName(), ActionKeys.VIEW);
 
-		LinkedHashMap<String, Object> userGroupParams = new LinkedHashMap<>();
+			ResourcePermissionTestUtil.addResourcePermission(
+				viewAction.getBitwiseValue(), UserGroup.class.getName(),
+				String.valueOf(publicUserGroup.getUserGroupId()),
+				publicAdminRole.getRoleId(),
+				ResourceConstants.SCOPE_INDIVIDUAL);
 
-		userGroupParams.put(
-			UserGroupFinderConstants.PARAM_KEY_USER_GROUPS_USERS,
-			Long.valueOf(groupUser.getUserId()));
+			PermissionThreadLocal.setPermissionChecker(
+				_permissionCheckerFactory.create(publicAdminUser));
 
-		List<UserGroup> userGroups = _userGroupService.search(
-			publicAdminRole.getCompanyId(), keywords, userGroupParams,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-			UsersAdminUtil.getUserGroupOrderByComparator("name", "asc"));
+			String keywords = null;
 
-		Assert.assertEquals(userGroups.toString(), 1, userGroups.size());
+			LinkedHashMap<String, Object> userGroupParams =
+				new LinkedHashMap<>();
 
-		_userLocalService.deleteUser(groupUser);
-		_userLocalService.deleteUser(publicAdminUser);
+			userGroupParams.put(
+				UserGroupFinderConstants.PARAM_KEY_USER_GROUPS_USERS,
+				Long.valueOf(groupUser.getUserId()));
 
-		_roleLocalService.deleteRole(publicAdminRole);
+			List<UserGroup> userGroups = _userGroupService.search(
+				publicAdminRole.getCompanyId(), keywords, userGroupParams,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				UsersAdminUtil.getUserGroupOrderByComparator("name", "asc"));
+
+			Assert.assertEquals(userGroups.toString(), 1, userGroups.size());
+		}
+		finally {
+			_userLocalService.deleteUser(groupUser);
+			_userLocalService.deleteUser(publicAdminUser);
+
+			_roleLocalService.deleteRole(publicAdminRole);
+		}
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/service/http/UserGroupServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/UserGroupServiceHttp.java
@@ -478,6 +478,139 @@ public class UserGroupServiceHttp {
 		}
 	}
 
+	public static java.util.List<com.liferay.portal.kernel.model.UserGroup>
+		search(
+			HttpPrincipal httpPrincipal, long companyId, String keywords,
+			java.util.LinkedHashMap<String, Object> params, int start, int end,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.portal.kernel.model.UserGroup> obc) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				UserGroupServiceUtil.class, "search", _searchParameterTypes12);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, keywords, params, start, end, obc);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					e);
+			}
+
+			return (java.util.List<com.liferay.portal.kernel.model.UserGroup>)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static java.util.List<com.liferay.portal.kernel.model.UserGroup>
+		search(
+			HttpPrincipal httpPrincipal, long companyId, String name,
+			String description, java.util.LinkedHashMap<String, Object> params,
+			boolean andOperator, int start, int end,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.portal.kernel.model.UserGroup> obc) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				UserGroupServiceUtil.class, "search", _searchParameterTypes13);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, name, description, params, andOperator,
+				start, end, obc);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					e);
+			}
+
+			return (java.util.List<com.liferay.portal.kernel.model.UserGroup>)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static int searchCount(
+		HttpPrincipal httpPrincipal, long companyId, String keywords,
+		java.util.LinkedHashMap<String, Object> params) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				UserGroupServiceUtil.class, "searchCount",
+				_searchCountParameterTypes14);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, keywords, params);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					e);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static int searchCount(
+		HttpPrincipal httpPrincipal, long companyId, String name,
+		String description, java.util.LinkedHashMap<String, Object> params,
+		boolean andOperator) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				UserGroupServiceUtil.class, "searchCount",
+				_searchCountParameterTypes15);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, name, description, params, andOperator);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					e);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static void unsetGroupUserGroups(
 			HttpPrincipal httpPrincipal, long groupId, long[] userGroupIds)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -485,7 +618,7 @@ public class UserGroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				UserGroupServiceUtil.class, "unsetGroupUserGroups",
-				_unsetGroupUserGroupsParameterTypes12);
+				_unsetGroupUserGroupsParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userGroupIds);
@@ -519,7 +652,7 @@ public class UserGroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				UserGroupServiceUtil.class, "unsetTeamUserGroups",
-				_unsetTeamUserGroupsParameterTypes13);
+				_unsetTeamUserGroupsParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, teamId, userGroupIds);
@@ -555,7 +688,7 @@ public class UserGroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				UserGroupServiceUtil.class, "updateUserGroup",
-				_updateUserGroupParameterTypes14);
+				_updateUserGroupParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, userGroupId, name, description, serviceContext);
@@ -616,11 +749,27 @@ public class UserGroupServiceHttp {
 		new Class[] {long.class, String.class};
 	private static final Class<?>[] _getUserUserGroupsParameterTypes11 =
 		new Class[] {long.class};
-	private static final Class<?>[] _unsetGroupUserGroupsParameterTypes12 =
+	private static final Class<?>[] _searchParameterTypes12 = new Class[] {
+		long.class, String.class, java.util.LinkedHashMap.class, int.class,
+		int.class, com.liferay.portal.kernel.util.OrderByComparator.class
+	};
+	private static final Class<?>[] _searchParameterTypes13 = new Class[] {
+		long.class, String.class, String.class, java.util.LinkedHashMap.class,
+		boolean.class, int.class, int.class,
+		com.liferay.portal.kernel.util.OrderByComparator.class
+	};
+	private static final Class<?>[] _searchCountParameterTypes14 = new Class[] {
+		long.class, String.class, java.util.LinkedHashMap.class
+	};
+	private static final Class<?>[] _searchCountParameterTypes15 = new Class[] {
+		long.class, String.class, String.class, java.util.LinkedHashMap.class,
+		boolean.class
+	};
+	private static final Class<?>[] _unsetGroupUserGroupsParameterTypes16 =
 		new Class[] {long.class, long[].class};
-	private static final Class<?>[] _unsetTeamUserGroupsParameterTypes13 =
+	private static final Class<?>[] _unsetTeamUserGroupsParameterTypes17 =
 		new Class[] {long.class, long[].class};
-	private static final Class<?>[] _updateUserGroupParameterTypes14 =
+	private static final Class<?>[] _updateUserGroupParameterTypes18 =
 		new Class[] {
 			long.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
@@ -1190,10 +1190,13 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
 			UserGroup.class);
 
-		if (indexer.isIndexerEnabled() &&
-			PropsValues.USER_GROUPS_SEARCH_WITH_INDEX &&
-			MapUtil.isEmpty(params)) {
+		if (!indexer.isIndexerEnabled() ||
+			!PropsValues.USER_GROUPS_SEARCH_WITH_INDEX) {
 
+			return true;
+		}
+
+		if (MapUtil.isEmpty(params)) {
 			return false;
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
@@ -535,7 +535,7 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 		int start, int end, OrderByComparator<UserGroup> obc) {
 
 		if (isUseCustomSQL(params)) {
-			return userGroupFinder.filterFindByKeywords(
+			return userGroupFinder.findByKeywords(
 				companyId, keywords, params, start, end, obc);
 		}
 
@@ -650,7 +650,7 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 		int end, OrderByComparator<UserGroup> obc) {
 
 		if (isUseCustomSQL(params)) {
-			return userGroupFinder.filterFindByC_N_D(
+			return userGroupFinder.findByC_N_D(
 				companyId, name, description, params, andOperator, start, end,
 				obc);
 		}
@@ -746,8 +746,7 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 		long companyId, String keywords, LinkedHashMap<String, Object> params) {
 
 		if (isUseCustomSQL(params)) {
-			return userGroupFinder.filterCountByKeywords(
-				companyId, keywords, params);
+			return userGroupFinder.countByKeywords(companyId, keywords, params);
 		}
 
 		String name = null;
@@ -802,7 +801,7 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 		LinkedHashMap<String, Object> params, boolean andOperator) {
 
 		if (isUseCustomSQL(params)) {
-			return userGroupFinder.filterCountByC_N_D(
+			return userGroupFinder.countByC_N_D(
 				companyId, name, description, params, andOperator);
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
@@ -1179,6 +1179,9 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 		}
 	}
 
+	/**
+	 * @see UserGroupServiceImpl#isUseCustomSQL
+	 */
 	protected boolean isUseCustomSQL(LinkedHashMap<String, Object> params) {
 		if (MapUtil.isEmpty(params)) {
 			return false;

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupServiceImpl.java
@@ -30,10 +30,14 @@ import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 import com.liferay.portal.kernel.service.permission.TeamPermissionUtil;
 import com.liferay.portal.kernel.service.permission.UserGroupPermissionUtil;
 import com.liferay.portal.kernel.service.permission.UserPermissionUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.comparator.UserGroupIdComparator;
 import com.liferay.portal.service.base.UserGroupServiceBaseImpl;
+import com.liferay.portal.service.persistence.constants.UserGroupFinderConstants;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.users.admin.kernel.util.UsersAdminUtil;
 
 import java.util.ArrayList;
@@ -484,6 +488,33 @@ public class UserGroupServiceImpl extends UserGroupServiceBaseImpl {
 		}
 
 		return filteredGroups;
+	}
+
+	/**
+	 * @see UserGroupLocalServiceImpl#isUseCustomSQL
+	 */
+	protected boolean isUseCustomSQL(LinkedHashMap<String, Object> params) {
+		if (MapUtil.isEmpty(params)) {
+			return false;
+		}
+
+		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
+			UserGroup.class);
+
+		if (indexer.isIndexerEnabled() &&
+			PropsValues.USER_GROUPS_SEARCH_WITH_INDEX &&
+			MapUtil.isEmpty(params)) {
+
+			return false;
+		}
+
+		for (String key : params.keySet()) {
+			if (ArrayUtil.contains(UserGroupFinderConstants.PARAM_KEYS, key)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupServiceImpl.java
@@ -501,10 +501,13 @@ public class UserGroupServiceImpl extends UserGroupServiceBaseImpl {
 		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
 			UserGroup.class);
 
-		if (indexer.isIndexerEnabled() &&
-			PropsValues.USER_GROUPS_SEARCH_WITH_INDEX &&
-			MapUtil.isEmpty(params)) {
+		if (!indexer.isIndexerEnabled() ||
+			!PropsValues.USER_GROUPS_SEARCH_WITH_INDEX) {
 
+			return true;
+		}
+
+		if (MapUtil.isEmpty(params)) {
 			return false;
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupServiceImpl.java
@@ -15,8 +15,13 @@
 package com.liferay.portal.service.impl;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.security.membershippolicy.UserGroupMembershipPolicyUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -25,11 +30,14 @@ import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 import com.liferay.portal.kernel.service.permission.TeamPermissionUtil;
 import com.liferay.portal.kernel.service.permission.UserGroupPermissionUtil;
 import com.liferay.portal.kernel.service.permission.UserPermissionUtil;
+import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.comparator.UserGroupIdComparator;
 import com.liferay.portal.service.base.UserGroupServiceBaseImpl;
+import com.liferay.users.admin.kernel.util.UsersAdminUtil;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 /**
@@ -226,6 +234,180 @@ public class UserGroupServiceImpl extends UserGroupServiceBaseImpl {
 			userId);
 
 		return filterUserGroups(userGroups);
+	}
+
+	/**
+	 * Returns an ordered range of all the user groups that match the keywords.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  companyId the primary key of the user group's company
+	 * @param  keywords the keywords (space separated), which may occur in the
+	 *         user group's name or description (optionally <code>null</code>)
+	 * @param  params the finder params (optionally <code>null</code>). For more
+	 *         information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @param  start the lower bound of the range of user groups to return
+	 * @param  end the upper bound of the range of user groups to return (not
+	 *         inclusive)
+	 * @param  obc the comparator to order the user groups (optionally
+	 *         <code>null</code>)
+	 * @return the matching user groups ordered by comparator <code>obc</code>
+	 * @see    com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	@Override
+	public List<UserGroup> search(
+		long companyId, String keywords, LinkedHashMap<String, Object> params,
+		int start, int end, OrderByComparator<UserGroup> obc) {
+
+		if (isUseCustomSQL(params)) {
+			return userGroupFinder.filterFindByKeywords(
+				companyId, keywords, params, start, end, obc);
+		}
+
+		String orderByCol = obc.getOrderByFields()[0];
+
+		String orderByType = "asc";
+
+		if (!obc.isAscending()) {
+			orderByType = "desc";
+		}
+
+		Sort sort = SortFactoryUtil.getSort(
+			UserGroup.class, orderByCol, orderByType);
+
+		try {
+			return UsersAdminUtil.getUserGroups(
+				userGroupLocalService.search(
+					companyId, keywords, params, start, end, sort));
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+	}
+
+	/**
+	 * Returns an ordered range of all the user groups that match the name and
+	 * description.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param  companyId the primary key of the user group's company
+	 * @param  name the user group's name (optionally <code>null</code>)
+	 * @param  description the user group's description (optionally
+	 *         <code>null</code>)
+	 * @param  params the finder params (optionally <code>null</code>). For more
+	 *         information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @param  andOperator whether every field must match its keywords or just
+	 *         one field
+	 * @param  start the lower bound of the range of user groups to return
+	 * @param  end the upper bound of the range of user groups to return (not
+	 *         inclusive)
+	 * @param  obc the comparator to order the user groups (optionally
+	 *         <code>null</code>)
+	 * @return the matching user groups ordered by comparator <code>obc</code>
+	 * @see    com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	@Override
+	public List<UserGroup> search(
+		long companyId, String name, String description,
+		LinkedHashMap<String, Object> params, boolean andOperator, int start,
+		int end, OrderByComparator<UserGroup> obc) {
+
+		if (isUseCustomSQL(params)) {
+			return userGroupFinder.filterFindByC_N_D(
+				companyId, name, description, params, andOperator, start, end,
+				obc);
+		}
+
+		String orderByCol = obc.getOrderByFields()[0];
+
+		String orderByType = "asc";
+
+		if (!obc.isAscending()) {
+			orderByType = "desc";
+		}
+
+		Sort sort = SortFactoryUtil.getSort(
+			UserGroup.class, orderByCol, orderByType);
+
+		try {
+			return UsersAdminUtil.getUserGroups(
+				userGroupLocalService.search(
+					companyId, name, description, params, andOperator, start,
+					end, sort));
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+	}
+
+	/**
+	 * Returns the number of user groups that match the keywords
+	 *
+	 * @param  companyId the primary key of the user group's company
+	 * @param  keywords the keywords (space separated), which may occur in the
+	 *         user group's name or description (optionally <code>null</code>)
+	 * @param  params the finder params (optionally <code>null</code>). For more
+	 *         information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @return the number of matching user groups
+	 * @see    com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	@Override
+	public int searchCount(
+		long companyId, String keywords, LinkedHashMap<String, Object> params) {
+
+		if (isUseCustomSQL(params)) {
+			return userGroupFinder.filterCountByKeywords(
+				companyId, keywords, params);
+		}
+
+		return userGroupLocalService.searchCount(companyId, keywords, params);
+	}
+
+	/**
+	 * Returns the number of user groups that match the name and description.
+	 *
+	 * @param  companyId the primary key of the user group's company
+	 * @param  name the user group's name (optionally <code>null</code>)
+	 * @param  description the user group's description (optionally
+	 *         <code>null</code>)
+	 * @param  params the finder params (optionally <code>null</code>). For more
+	 *         information see {@link
+	 *         com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @param  andOperator whether every field must match its keywords or just
+	 *         one field
+	 * @return the number of matching user groups
+	 * @see    com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	@Override
+	public int searchCount(
+		long companyId, String name, String description,
+		LinkedHashMap<String, Object> params, boolean andOperator) {
+
+		if (isUseCustomSQL(params)) {
+			return userGroupFinder.filterCountByC_N_D(
+				companyId, name, description, params, andOperator);
+		}
+
+		return userGroupLocalService.searchCount(
+			companyId, name, description, params, andOperator);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserGroupService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserGroupService.java
@@ -22,7 +22,9 @@ import com.liferay.portal.kernel.security.access.control.AccessControlled;
 import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.util.OrderByComparator;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import org.osgi.annotation.versioning.ProviderType;
@@ -152,6 +154,109 @@ public interface UserGroupService extends BaseService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<UserGroup> getUserUserGroups(long userId)
 		throws PortalException;
+
+	/**
+	 * Returns an ordered range of all the user groups that match the keywords.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user group's company
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user group's name or description (optionally <code>null</code>)
+	 * @param params the finder params (optionally <code>null</code>). For more
+	 information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @param start the lower bound of the range of user groups to return
+	 * @param end the upper bound of the range of user groups to return (not
+	 inclusive)
+	 * @param obc the comparator to order the user groups (optionally
+	 <code>null</code>)
+	 * @return the matching user groups ordered by comparator <code>obc</code>
+	 * @see com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<UserGroup> search(
+		long companyId, String keywords, LinkedHashMap<String, Object> params,
+		int start, int end, OrderByComparator<UserGroup> obc);
+
+	/**
+	 * Returns an ordered range of all the user groups that match the name and
+	 * description.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user group's company
+	 * @param name the user group's name (optionally <code>null</code>)
+	 * @param description the user group's description (optionally
+	 <code>null</code>)
+	 * @param params the finder params (optionally <code>null</code>). For more
+	 information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @param andOperator whether every field must match its keywords or just
+	 one field
+	 * @param start the lower bound of the range of user groups to return
+	 * @param end the upper bound of the range of user groups to return (not
+	 inclusive)
+	 * @param obc the comparator to order the user groups (optionally
+	 <code>null</code>)
+	 * @return the matching user groups ordered by comparator <code>obc</code>
+	 * @see com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<UserGroup> search(
+		long companyId, String name, String description,
+		LinkedHashMap<String, Object> params, boolean andOperator, int start,
+		int end, OrderByComparator<UserGroup> obc);
+
+	/**
+	 * Returns the number of user groups that match the keywords
+	 *
+	 * @param companyId the primary key of the user group's company
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user group's name or description (optionally <code>null</code>)
+	 * @param params the finder params (optionally <code>null</code>). For more
+	 information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @return the number of matching user groups
+	 * @see com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCount(
+		long companyId, String keywords, LinkedHashMap<String, Object> params);
+
+	/**
+	 * Returns the number of user groups that match the name and description.
+	 *
+	 * @param companyId the primary key of the user group's company
+	 * @param name the user group's name (optionally <code>null</code>)
+	 * @param description the user group's description (optionally
+	 <code>null</code>)
+	 * @param params the finder params (optionally <code>null</code>). For more
+	 information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @param andOperator whether every field must match its keywords or just
+	 one field
+	 * @return the number of matching user groups
+	 * @see com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCount(
+		long companyId, String name, String description,
+		LinkedHashMap<String, Object> params, boolean andOperator);
 
 	/**
 	 * Removes the user groups from the group.

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserGroupServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserGroupServiceUtil.java
@@ -181,6 +181,127 @@ public class UserGroupServiceUtil {
 	}
 
 	/**
+	 * Returns an ordered range of all the user groups that match the keywords.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user group's company
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user group's name or description (optionally <code>null</code>)
+	 * @param params the finder params (optionally <code>null</code>). For more
+	 information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @param start the lower bound of the range of user groups to return
+	 * @param end the upper bound of the range of user groups to return (not
+	 inclusive)
+	 * @param obc the comparator to order the user groups (optionally
+	 <code>null</code>)
+	 * @return the matching user groups ordered by comparator <code>obc</code>
+	 * @see com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	public static java.util.List<com.liferay.portal.kernel.model.UserGroup>
+		search(
+			long companyId, String keywords,
+			java.util.LinkedHashMap<String, Object> params, int start, int end,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.portal.kernel.model.UserGroup> obc) {
+
+		return getService().search(
+			companyId, keywords, params, start, end, obc);
+	}
+
+	/**
+	 * Returns an ordered range of all the user groups that match the name and
+	 * description.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user group's company
+	 * @param name the user group's name (optionally <code>null</code>)
+	 * @param description the user group's description (optionally
+	 <code>null</code>)
+	 * @param params the finder params (optionally <code>null</code>). For more
+	 information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @param andOperator whether every field must match its keywords or just
+	 one field
+	 * @param start the lower bound of the range of user groups to return
+	 * @param end the upper bound of the range of user groups to return (not
+	 inclusive)
+	 * @param obc the comparator to order the user groups (optionally
+	 <code>null</code>)
+	 * @return the matching user groups ordered by comparator <code>obc</code>
+	 * @see com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	public static java.util.List<com.liferay.portal.kernel.model.UserGroup>
+		search(
+			long companyId, String name, String description,
+			java.util.LinkedHashMap<String, Object> params, boolean andOperator,
+			int start, int end,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.portal.kernel.model.UserGroup> obc) {
+
+		return getService().search(
+			companyId, name, description, params, andOperator, start, end, obc);
+	}
+
+	/**
+	 * Returns the number of user groups that match the keywords
+	 *
+	 * @param companyId the primary key of the user group's company
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user group's name or description (optionally <code>null</code>)
+	 * @param params the finder params (optionally <code>null</code>). For more
+	 information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @return the number of matching user groups
+	 * @see com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	public static int searchCount(
+		long companyId, String keywords,
+		java.util.LinkedHashMap<String, Object> params) {
+
+		return getService().searchCount(companyId, keywords, params);
+	}
+
+	/**
+	 * Returns the number of user groups that match the name and description.
+	 *
+	 * @param companyId the primary key of the user group's company
+	 * @param name the user group's name (optionally <code>null</code>)
+	 * @param description the user group's description (optionally
+	 <code>null</code>)
+	 * @param params the finder params (optionally <code>null</code>). For more
+	 information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @param andOperator whether every field must match its keywords or just
+	 one field
+	 * @return the number of matching user groups
+	 * @see com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	public static int searchCount(
+		long companyId, String name, String description,
+		java.util.LinkedHashMap<String, Object> params, boolean andOperator) {
+
+		return getService().searchCount(
+			companyId, name, description, params, andOperator);
+	}
+
+	/**
 	 * Removes the user groups from the group.
 	 *
 	 * @param groupId the primary key of the group

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserGroupServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserGroupServiceWrapper.java
@@ -189,6 +189,129 @@ public class UserGroupServiceWrapper
 	}
 
 	/**
+	 * Returns an ordered range of all the user groups that match the keywords.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user group's company
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user group's name or description (optionally <code>null</code>)
+	 * @param params the finder params (optionally <code>null</code>). For more
+	 information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @param start the lower bound of the range of user groups to return
+	 * @param end the upper bound of the range of user groups to return (not
+	 inclusive)
+	 * @param obc the comparator to order the user groups (optionally
+	 <code>null</code>)
+	 * @return the matching user groups ordered by comparator <code>obc</code>
+	 * @see com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	@Override
+	public java.util.List<com.liferay.portal.kernel.model.UserGroup> search(
+		long companyId, String keywords,
+		java.util.LinkedHashMap<String, Object> params, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<com.liferay.portal.kernel.model.UserGroup> obc) {
+
+		return _userGroupService.search(
+			companyId, keywords, params, start, end, obc);
+	}
+
+	/**
+	 * Returns an ordered range of all the user groups that match the name and
+	 * description.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end -
+	 * start</code> instances. <code>start</code> and <code>end</code> are not
+	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
+	 * refers to the first result in the set. Setting both <code>start</code>
+	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * result set.
+	 * </p>
+	 *
+	 * @param companyId the primary key of the user group's company
+	 * @param name the user group's name (optionally <code>null</code>)
+	 * @param description the user group's description (optionally
+	 <code>null</code>)
+	 * @param params the finder params (optionally <code>null</code>). For more
+	 information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @param andOperator whether every field must match its keywords or just
+	 one field
+	 * @param start the lower bound of the range of user groups to return
+	 * @param end the upper bound of the range of user groups to return (not
+	 inclusive)
+	 * @param obc the comparator to order the user groups (optionally
+	 <code>null</code>)
+	 * @return the matching user groups ordered by comparator <code>obc</code>
+	 * @see com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	@Override
+	public java.util.List<com.liferay.portal.kernel.model.UserGroup> search(
+		long companyId, String name, String description,
+		java.util.LinkedHashMap<String, Object> params, boolean andOperator,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<com.liferay.portal.kernel.model.UserGroup> obc) {
+
+		return _userGroupService.search(
+			companyId, name, description, params, andOperator, start, end, obc);
+	}
+
+	/**
+	 * Returns the number of user groups that match the keywords
+	 *
+	 * @param companyId the primary key of the user group's company
+	 * @param keywords the keywords (space separated), which may occur in the
+	 user group's name or description (optionally <code>null</code>)
+	 * @param params the finder params (optionally <code>null</code>). For more
+	 information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @return the number of matching user groups
+	 * @see com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	@Override
+	public int searchCount(
+		long companyId, String keywords,
+		java.util.LinkedHashMap<String, Object> params) {
+
+		return _userGroupService.searchCount(companyId, keywords, params);
+	}
+
+	/**
+	 * Returns the number of user groups that match the name and description.
+	 *
+	 * @param companyId the primary key of the user group's company
+	 * @param name the user group's name (optionally <code>null</code>)
+	 * @param description the user group's description (optionally
+	 <code>null</code>)
+	 * @param params the finder params (optionally <code>null</code>). For more
+	 information see {@link
+	 com.liferay.portal.kernel.service.persistence.UserGroupFinder}
+	 * @param andOperator whether every field must match its keywords or just
+	 one field
+	 * @return the number of matching user groups
+	 * @see com.liferay.portal.kernel.service.persistence.UserGroupFinder
+	 */
+	@Override
+	public int searchCount(
+		long companyId, String name, String description,
+		java.util.LinkedHashMap<String, Object> params, boolean andOperator) {
+
+		return _userGroupService.searchCount(
+			companyId, name, description, params, andOperator);
+	}
+
+	/**
 	 * Removes the user groups from the group.
 	 *
 	 * @param groupId the primary key of the group

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserGroupServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserGroupServiceWrapper.java
@@ -216,8 +216,9 @@ public class UserGroupServiceWrapper
 	 */
 	@Override
 	public java.util.List<com.liferay.portal.kernel.model.UserGroup> search(
-		long companyId, String keywords,
-		java.util.LinkedHashMap<String, Object> params, int start, int end,
+		long companyId, java.lang.String keywords,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator
 			<com.liferay.portal.kernel.model.UserGroup> obc) {
 
@@ -257,9 +258,9 @@ public class UserGroupServiceWrapper
 	 */
 	@Override
 	public java.util.List<com.liferay.portal.kernel.model.UserGroup> search(
-		long companyId, String name, String description,
-		java.util.LinkedHashMap<String, Object> params, boolean andOperator,
-		int start, int end,
+		long companyId, java.lang.String name, java.lang.String description,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator
 			<com.liferay.portal.kernel.model.UserGroup> obc) {
 
@@ -281,8 +282,8 @@ public class UserGroupServiceWrapper
 	 */
 	@Override
 	public int searchCount(
-		long companyId, String keywords,
-		java.util.LinkedHashMap<String, Object> params) {
+		long companyId, java.lang.String keywords,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params) {
 
 		return _userGroupService.searchCount(companyId, keywords, params);
 	}
@@ -304,8 +305,9 @@ public class UserGroupServiceWrapper
 	 */
 	@Override
 	public int searchCount(
-		long companyId, String name, String description,
-		java.util.LinkedHashMap<String, Object> params, boolean andOperator) {
+		long companyId, java.lang.String name, java.lang.String description,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator) {
 
 		return _userGroupService.searchCount(
 			companyId, name, description, params, andOperator);

--- a/portal-web/docroot/html/taglib/ui/user_group_search_container_results/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/user_group_search_container_results/page.jsp
@@ -35,11 +35,11 @@ SearchContainer userGroupSearchContainer = (SearchContainer)request.getAttribute
 			userGroupParams.put("expandoAttributes", keywords);
 		}
 
-		total = UserGroupLocalServiceUtil.searchCount(company.getCompanyId(), keywords, userGroupParams);
+		total = UserGroupServiceUtil.searchCount(company.getCompanyId(), keywords, userGroupParams);
 
 		searchContainer.setTotal(total);
 
-		results = UserGroupLocalServiceUtil.search(company.getCompanyId(), keywords, userGroupParams, searchContainer.getStart(), searchContainer.getEnd(), searchContainer.getOrderByComparator());
+		results = UserGroupServiceUtil.search(company.getCompanyId(), keywords, userGroupParams, searchContainer.getStart(), searchContainer.getEnd(), searchContainer.getOrderByComparator());
 
 		searchContainer.setResults(results);
 		%>


### PR DESCRIPTION
[LPS-92932](https://issues.liferay.com/browse/LPS-92932)

Hi Brian,

This is the continuation of https://github.com/brianchandotcom/liferay-portal/pull/80527 .

> UserGroupLocalServiceImpl#isUseCustomSQL and UserGroupServiceImpl#isUseCustomSQL are different. Is that intentional? Please make them the same and resend with an @see on each method to see the other (or move it to a common util).

You are right, they were different. Made them identical and added @see to both. I added this changes to commit "LPS-92932 Missing helper method in remote service" where they belong.

Thank you,
Istvan