### PR TITLE
LPS-104208 Update AbsolutePortalURLBuilder to match the result of ServicePreAction preparing ThemeDisplay

### DIFF
--- a/modules/apps/frontend-js/frontend-js-jquery-web/src/main/java/com/liferay/frontend/js/jquery/web/internal/servlet/taglib/JQueryTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-jquery-web/src/main/java/com/liferay/frontend/js/jquery/web/internal/servlet/taglib/JQueryTopHeadDynamicInclude.java
@@ -72,6 +72,8 @@ public class JQueryTopHeadDynamicInclude extends BaseDynamicInclude {
 				WebKeys.THEME_DISPLAY);
 
 		if (themeDisplay.isThemeJsFastLoad()) {
+			absolutePortalURLBuilder.ignoreCDNHost();
+
 			sb.append("<script data-senna-track=\"permanent\" src=\"");
 			sb.append(
 				_portal.getStaticResourceURL(

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/resolution/BrowserModulesResolver.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/resolution/BrowserModulesResolver.java
@@ -270,6 +270,8 @@ public class BrowserModulesResolver {
 			_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
 				httpServletRequest);
 
+		absolutePortalURLBuilder.ignoreCDNHost();
+
 		browserModulesResolution.putPath(
 			moduleName,
 			absolutePortalURLBuilder.forResource(

--- a/modules/apps/frontend-js/frontend-js-top-head-extender/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-top-head-extender/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"

--- a/modules/apps/frontend-js/frontend-js-top-head-extender/src/main/java/com/liferay/frontend/js/top/head/extender/internal/servlet/taglib/TopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-top-head-extender/src/main/java/com/liferay/frontend/js/top/head/extender/internal/servlet/taglib/TopHeadDynamicInclude.java
@@ -194,8 +194,13 @@ public class TopHeadDynamicInclude implements DynamicInclude {
 					topHeadResourcesServiceReference);
 
 				try {
-					String servletContextPath =
-						topHeadResources.getServletContextPath();
+					String portalPathContext = _portal.getPathContext();
+
+					String servletPathContext = _portal.getPathContext(
+						topHeadResources.getServletContextPath());
+
+					String servletContextPath = servletPathContext.substring(
+						portalPathContext.length());
 
 					for (String jsResourcePath :
 							topHeadResources.getJsResourcePaths()) {
@@ -237,8 +242,16 @@ public class TopHeadDynamicInclude implements DynamicInclude {
 			jsLastModified = _portalWebResources.getLastModified();
 		}
 
-		String comboURL = _portal.getStaticResourceURL(
+		String comboPath = _portal.getStaticResourceURL(
 			httpServletRequest, "/combo", "minifierType=js", jsLastModified);
+
+		AbsolutePortalURLBuilder absolutePortalURLBuilder =
+			_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+				httpServletRequest);
+
+		String comboURL = absolutePortalURLBuilder.forResource(
+			comboPath
+		).build();
 
 		for (String url : urls) {
 			if ((sb.length() + url.length() + 1) >= 2000) {
@@ -248,14 +261,7 @@ public class TopHeadDynamicInclude implements DynamicInclude {
 			}
 
 			if (sb.length() == 0) {
-				AbsolutePortalURLBuilder absolutePortalURLBuilder =
-					_absolutePortalURLBuilderFactory.
-						getAbsolutePortalURLBuilder(httpServletRequest);
-
-				sb.append(
-					absolutePortalURLBuilder.forResource(
-						comboURL
-					).build());
+				sb.append(comboURL);
 			}
 
 			sb.append(StringPool.AMPERSAND);

--- a/modules/apps/portal-url-builder/portal-url-builder-impl/src/main/java/com/liferay/portal/url/builder/internal/AbsolutePortalURLBuilderImpl.java
+++ b/modules/apps/portal-url-builder/portal-url-builder-impl/src/main/java/com/liferay/portal/url/builder/internal/AbsolutePortalURLBuilderImpl.java
@@ -222,14 +222,15 @@ public class AbsolutePortalURLBuilderImpl implements AbsolutePortalURLBuilder {
 		boolean ignoreCDNHost, boolean ignorePathProxy, String pathPrefix,
 		String relativeURL) {
 
-		StringBundler sb = new StringBundler(5);
+		StringBundler sb = new StringBundler(6);
 
 		String cdnHost = _getCDNHost(_httpServletRequest);
 
 		if (!ignoreCDNHost && !Validator.isBlank(cdnHost)) {
 			sb.append(cdnHost);
 		}
-		else if (!ignorePathProxy) {
+
+		if (!ignorePathProxy) {
 			sb.append(_getPathProxy());
 		}
 

--- a/modules/apps/portal-url-builder/portal-url-builder-impl/src/test/java/com/liferay/portal/url/builder/internal/ResourceAbsolutePortalURLBuilderTest.java
+++ b/modules/apps/portal-url-builder/portal-url-builder-impl/src/test/java/com/liferay/portal/url/builder/internal/ResourceAbsolutePortalURLBuilderTest.java
@@ -42,8 +42,9 @@ public class ResourceAbsolutePortalURLBuilderTest
 		return Arrays.asList(
 			new Object[][] {
 				{0, false, false, false}, {1, false, false, true},
-				{2, true, false, false}, {3, true, true, false},
-				{4, false, true, false}
+				{2, false, true, false}, {3, false, true, true},
+				{4, true, false, false}, {5, true, false, true},
+				{6, true, true, false}, {7, true, true, true}
 			});
 	}
 
@@ -106,24 +107,31 @@ public class ResourceAbsolutePortalURLBuilderTest
 
 	private static final String[] _RESULTS = {
 		"/path/to/resource", "http://cdn-host/path/to/resource",
-		"/context/path/to/resource", "/proxy/context/path/to/resource",
-		"/proxy/path/to/resource"
+		"/proxy/path/to/resource", "http://cdn-host/proxy/path/to/resource",
+		"/context/path/to/resource", "http://cdn-host/context/path/to/resource",
+		"/proxy/context/path/to/resource",
+		"http://cdn-host/proxy/context/path/to/resource"
 	};
 
 	private static final String[] _RESULTS_IGNORE_CDN = {
-		"/path/to/resource", "/path/to/resource", "/context/path/to/resource",
-		"/proxy/context/path/to/resource", "/proxy/path/to/resource"
+		"/path/to/resource", "/path/to/resource", "/proxy/path/to/resource",
+		"/proxy/path/to/resource", "/context/path/to/resource",
+		"/context/path/to/resource", "/proxy/context/path/to/resource",
+		"/proxy/context/path/to/resource"
 	};
 
 	private static final String[] _RESULTS_IGNORE_CDN_AND_PROXY = {
-		"/path/to/resource", "/path/to/resource", "/context/path/to/resource",
-		"/context/path/to/resource", "/path/to/resource"
+		"/path/to/resource", "/path/to/resource", "/path/to/resource",
+		"/path/to/resource", "/context/path/to/resource",
+		"/context/path/to/resource", "/context/path/to/resource",
+		"/context/path/to/resource"
 	};
 
 	private static final String[] _RESULTS_IGNORE_PROXY = {
 		"/path/to/resource", "http://cdn-host/path/to/resource",
-		"/context/path/to/resource", "/context/path/to/resource",
-		"/path/to/resource"
+		"/path/to/resource", "http://cdn-host/path/to/resource",
+		"/context/path/to/resource", "http://cdn-host/context/path/to/resource",
+		"/context/path/to/resource", "http://cdn-host/context/path/to/resource"
 	};
 
 	private AbsolutePortalURLBuilder _absolutePortalURLBuilder;

--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -141,16 +141,16 @@ public class ComboServlet extends HttpServlet {
 
 			ServletContext servletContext = getServletContext();
 
-			String contextPath = servletContext.getContextPath();
-
-			if (name.startsWith(contextPath)) {
-				name = name.replaceFirst(contextPath, StringPool.BLANK);
-			}
-
 			String pathProxy = PortalUtil.getPathProxy();
 
 			if (name.startsWith(pathProxy)) {
 				name = name.replaceFirst(pathProxy, StringPool.BLANK);
+			}
+
+			String contextPath = servletContext.getContextPath();
+
+			if (name.startsWith(contextPath)) {
+				name = name.replaceFirst(contextPath, StringPool.BLANK);
 			}
 
 			modulePathsSet.add(name);


### PR DESCRIPTION
/CC @holatuwol

@holatuwol I've removed one of your commits (the one extracting the `AbsolutePortalURLBuilder`) because `AbsolutePortalURLBuilder` objects cannot be reused as they are stateful.

/CC @jbalsas