### PR TITLE
LPS-103684 Create an API to assign users to account roles

### DIFF
--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/role/test/AccountRoleManagerTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/role/test/AccountRoleManagerTest.java
@@ -23,8 +23,10 @@ import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.account.service.test.AccountEntryTestUtil;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -167,6 +169,29 @@ public class AccountRoleManagerTest {
 		Assert.assertTrue(ArrayUtil.contains(roleIds, accountRole.getRoleId()));
 		Assert.assertTrue(
 			ArrayUtil.contains(roleIds, defaultAccountRole.getRoleId()));
+
+		_assertHasPermission(user, ActionKeys.DELETE, false);
+		_assertHasPermission(user, ActionKeys.MANAGE_USERS, false);
+		_assertHasPermission(user, ActionKeys.UPDATE, false);
+
+		_resourcePermissionLocalService.addResourcePermission(
+			TestPropsValues.getCompanyId(), AccountEntry.class.getName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()),
+			accountRole.getRoleId(), ActionKeys.DELETE);
+		_resourcePermissionLocalService.addResourcePermission(
+			TestPropsValues.getCompanyId(), AccountEntry.class.getName(),
+			ResourceConstants.SCOPE_GROUP,
+			String.valueOf(_accountEntry1.getAccountEntryGroupId()),
+			accountRole.getRoleId(), ActionKeys.MANAGE_USERS);
+		_resourcePermissionLocalService.addResourcePermission(
+			TestPropsValues.getCompanyId(), AccountEntry.class.getName(),
+			ResourceConstants.SCOPE_GROUP_TEMPLATE, "0",
+			defaultAccountRole.getRoleId(), ActionKeys.UPDATE);
+
+		_assertHasPermission(user, ActionKeys.DELETE, true);
+		_assertHasPermission(user, ActionKeys.MANAGE_USERS, true);
+		_assertHasPermission(user, ActionKeys.UPDATE, true);
 	}
 
 	@Test
@@ -245,6 +270,20 @@ public class AccountRoleManagerTest {
 		_names.add(accountRole.getName());
 
 		return accountRole;
+	}
+
+	private void _assertHasPermission(
+		User user, String actionKey, boolean hasPermission) {
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(user);
+
+		Assert.assertEquals(
+			hasPermission,
+			permissionChecker.hasPermission(
+				_accountEntry1.getAccountEntryGroup(),
+				AccountEntry.class.getName(),
+				_accountEntry1.getAccountEntryId(), actionKey));
 	}
 
 	private long[] _getRoleIds(User user) throws Exception {


### PR DESCRIPTION
This is an update for [LPS-103684](https://issues.liferay.com/browse/LPS-103684).<br><br>Hey Brian, this adds one more test case for account roles that asserts on actual permission checks.<br><br>/cc @pei-jung @alee8888 @ChrisKian @dejuknow