### PR TITLE
LPS-99849 portal-search-tuning-rankings-web: Show asset type instead of class name

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/RankingMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/RankingMVCResourceCommand.java
@@ -83,7 +83,8 @@ public class RankingMVCResourceCommand implements MVCResourceCommand {
 	protected JSONObject getHiddenResults(ResourceRequest resourceRequest) {
 		RankingGetHiddenResultsBuilder rankingGetHiddenResultsBuilder =
 			new RankingGetHiddenResultsBuilder(
-				queries, rankingIndexReader, searchEngineAdapter);
+				queries, rankingIndexReader, resourceRequest,
+				searchEngineAdapter);
 
 		RankingMVCResourceRequest rankingMVCResourceRequest =
 			new RankingMVCResourceRequest(resourceRequest);
@@ -115,8 +116,8 @@ public class RankingMVCResourceCommand implements MVCResourceCommand {
 	protected JSONObject getSearchResults(ResourceRequest resourceRequest) {
 		RankingGetSearchResultsBuilder rankingGetSearchResultsBuilder =
 			new RankingGetSearchResultsBuilder(
-				complexQueryPartBuilderFactory, queries, searcher,
-				searchRequestBuilderFactory);
+				complexQueryPartBuilderFactory, queries, resourceRequest,
+				searcher, searchRequestBuilderFactory);
 
 		RankingMVCResourceRequest rankingMVCResourceRequest =
 			new RankingMVCResourceRequest(resourceRequest);
@@ -137,7 +138,7 @@ public class RankingMVCResourceCommand implements MVCResourceCommand {
 		RankingGetVisibleResultsBuilder rankingGetVisibleResultsBuilder =
 			new RankingGetVisibleResultsBuilder(
 				complexQueryPartBuilderFactory, rankingIndexReader,
-				rankingSearchRequestHelper, queries, searcher,
+				rankingSearchRequestHelper, resourceRequest, queries, searcher,
 				searchRequestBuilderFactory);
 
 		RankingMVCResourceRequest rankingMVCResourceRequest =

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetHiddenResultsBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetHiddenResultsBuilder.java
@@ -17,7 +17,9 @@ package com.liferay.portal.search.tuning.rankings.web.internal.results.builder;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.engine.adapter.document.GetDocumentRequest;
@@ -29,8 +31,11 @@ import com.liferay.portal.search.tuning.rankings.web.internal.index.Ranking;
 import com.liferay.portal.search.tuning.rankings.web.internal.index.RankingIndexReader;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Stream;
+
+import javax.portlet.ResourceRequest;
 
 /**
  * @author André de Oliveira
@@ -40,10 +45,12 @@ public class RankingGetHiddenResultsBuilder {
 
 	public RankingGetHiddenResultsBuilder(
 		Queries queries, RankingIndexReader rankingIndexReader,
+		ResourceRequest resourceRequest,
 		SearchEngineAdapter searchEngineAdapter) {
 
 		_queries = queries;
 		_rankingIndexReader = rankingIndexReader;
+		_resourceRequest = resourceRequest;
 		_searchEngineAdapter = searchEngineAdapter;
 	}
 
@@ -93,12 +100,15 @@ public class RankingGetHiddenResultsBuilder {
 
 		Stream<String> stream = ids.stream();
 
+		ThemeDisplay themeDisplay = (ThemeDisplay)_resourceRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
 		return stream.map(
 			id -> getDocument(ranking.getIndex(), id, LIFERAY_DOCUMENT_TYPE)
 		).filter(
 			document -> document != null
 		).map(
-			this::translate
+			document -> translate(document, themeDisplay.getLocale())
 		);
 	}
 
@@ -110,13 +120,15 @@ public class RankingGetHiddenResultsBuilder {
 		return idsQuery;
 	}
 
-	protected JSONObject translate(Document document) {
+	protected JSONObject translate(Document document, Locale locale) {
 		RankingJSONBuilder rankingJSONBuilder = new RankingJSONBuilder();
 
 		return rankingJSONBuilder.document(
 			document
 		).hidden(
 			true
+		).locale(
+			locale
 		).build();
 	}
 
@@ -125,6 +137,7 @@ public class RankingGetHiddenResultsBuilder {
 	private final Queries _queries;
 	private String _rankingId;
 	private final RankingIndexReader _rankingIndexReader;
+	private final ResourceRequest _resourceRequest;
 	private final SearchEngineAdapter _searchEngineAdapter;
 
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetSearchResultsBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetSearchResultsBuilder.java
@@ -17,6 +17,8 @@ package com.liferay.portal.search.tuning.rankings.web.internal.results.builder;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.filter.ComplexQueryPartBuilderFactory;
 import com.liferay.portal.search.query.Queries;
@@ -25,7 +27,10 @@ import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
 
+import java.util.Locale;
 import java.util.stream.Stream;
+
+import javax.portlet.ResourceRequest;
 
 /**
  * @author André de Oliveira
@@ -35,11 +40,12 @@ public class RankingGetSearchResultsBuilder {
 
 	public RankingGetSearchResultsBuilder(
 		ComplexQueryPartBuilderFactory complexQueryPartBuilderFactory,
-		Queries queries, Searcher searcher,
+		Queries queries, ResourceRequest resourceRequest, Searcher searcher,
 		SearchRequestBuilderFactory searchRequestBuilderFactory) {
 
 		_complexQueryPartBuilderFactory = complexQueryPartBuilderFactory;
 		_queries = queries;
+		_resourceRequest = resourceRequest;
 		_searcher = searcher;
 		_searchRequestBuilderFactory = searchRequestBuilderFactory;
 	}
@@ -103,14 +109,20 @@ public class RankingGetSearchResultsBuilder {
 
 		Stream<Document> stream = searchResponse.getDocumentsStream();
 
-		return stream.map(this::translate);
+		ThemeDisplay themeDisplay = (ThemeDisplay)_resourceRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		return stream.map(
+			document -> translate(document, themeDisplay.getLocale()));
 	}
 
-	protected JSONObject translate(Document document) {
+	protected JSONObject translate(Document document, Locale locale) {
 		RankingJSONBuilder rankingJSONBuilder = new RankingJSONBuilder();
 
 		return rankingJSONBuilder.document(
 			document
+		).locale(
+			locale
 		).build();
 	}
 
@@ -120,6 +132,7 @@ public class RankingGetSearchResultsBuilder {
 	private int _from;
 	private final Queries _queries;
 	private String _queryString;
+	private final ResourceRequest _resourceRequest;
 	private final Searcher _searcher;
 	private final SearchRequestBuilderFactory _searchRequestBuilderFactory;
 	private int _size;

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingJSONBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingJSONBuilder.java
@@ -17,8 +17,11 @@ package com.liferay.portal.search.tuning.rankings.web.internal.results.builder;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.document.Document;
+
+import java.util.Locale;
 
 /**
  * @author André de Oliveira
@@ -39,7 +42,7 @@ public class RankingJSONBuilder {
 			).put(
 				"title", getTitle()
 			).put(
-				"type", _document.getString(Field.ENTRY_CLASS_NAME)
+				"type", getType(_locale)
 			));
 	}
 
@@ -51,6 +54,12 @@ public class RankingJSONBuilder {
 
 	public RankingJSONBuilder hidden(boolean hidden) {
 		_hidden = hidden;
+
+		return this;
+	}
+
+	public RankingJSONBuilder locale(Locale locale) {
+		_locale = locale;
 
 		return this;
 	}
@@ -83,8 +92,17 @@ public class RankingJSONBuilder {
 		return _document.getString(Field.TITLE);
 	}
 
+	protected String getType(Locale locale) {
+		_locale = locale;
+
+		String entryClassName = _document.getString(Field.ENTRY_CLASS_NAME);
+
+		return ResourceActionsUtil.getModelResource(_locale, entryClassName);
+	}
+
 	private Document _document;
 	private boolean _hidden;
+	private Locale _locale;
 	private boolean _pinned;
 
 }


### PR DESCRIPTION
<h3>:x: ci:test:search - 44 out of 46 jobs passed in 1 hour 32 minutes 39 seconds 128 ms</h3>

Only unique failure is a semver problem on an unrelated module.

https://github.com/brandizzi/liferay-portal/pull/856#issuecomment-552710284

Author: @brandizzi

[Bug] Result Rankings: Search Result for asset types displays class names
https://issues.liferay.com/browse/LPS-99849