### PR TITLE
LPS-99924 portal-search-tuning-rankings-web: Stop showing blank titles

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingJSONBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingJSONBuilder.java
@@ -29,7 +29,7 @@ public class RankingJSONBuilder {
 	public JSONObject build() {
 		return build(
 			JSONUtil.put(
-				"author", _document.getString(Field.USER_NAME)
+				"author", getAuthor()
 			).put(
 				"clicks", _document.getString("clicks")
 			).put(
@@ -73,6 +73,16 @@ public class RankingJSONBuilder {
 		return jsonObject;
 	}
 
+	protected String getAuthor() {
+		String entryClassName = _document.getString(Field.ENTRY_CLASS_NAME);
+
+		if (entryClassName.equals("com.liferay.portal.kernel.model.User")) {
+			return _document.getString("screenName");
+		}
+
+		return _document.getString(Field.USER_NAME);
+	}
+
 	protected String getTitle() {
 		String title = _document.getString(Field.TITLE + "_en_US");
 
@@ -80,7 +90,19 @@ public class RankingJSONBuilder {
 			return title;
 		}
 
-		return _document.getString(Field.TITLE);
+		title = _document.getString(Field.TITLE);
+
+		if (!Validator.isBlank(title)) {
+			return title;
+		}
+
+		String entryClassName = _document.getString(Field.ENTRY_CLASS_NAME);
+
+		if (entryClassName.equals("com.liferay.portal.kernel.model.User")) {
+			return _document.getString("fullName");
+		}
+
+		return _document.getString("name");
 	}
 
 	private Document _document;


### PR DESCRIPTION
<h3>:x: ci:test:search - 43 out of 46 jobs passed in 2 hours 15 minutes 9 seconds 278 ms</h3>

Only unique failure is a semver problem on an unrelated module.
https://github.com/brandizzi/liferay-portal/pull/857#issuecomment-552724114

Author: @brandizzi

[Bug] Result Rankings: Search Result for users have blank titles
https://issues.liferay.com/browse/LPS-99924