### PR TITLE
LPS-102115 - Disable toggle card in compatibility layer

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_vertical_card.jspf
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_vertical_card.jspf
@@ -16,7 +16,7 @@
 
 <liferay-frontend:vertical-card-sticker-bottom>
 	<liferay-document-library:mime-type-sticker
-		cssClass="sticker-bottom"
+		cssClass="sticker-bottom-left"
 		fileVersion="<%= latestFileVersion %>"
 	/>
 </liferay-frontend:vertical-card-sticker-bottom>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleEditor/RuleEditor.soy
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/RuleEditor/RuleEditor.soy
@@ -911,7 +911,7 @@
 		{/if}
 	{/let}
 
-	<div class="btn-group dropdown" style="block">
+	<div class="btn-group btn-group-item dropdown" style="block">
 		<button {$attributes}>
 			<span class="dropdown-toggle-selected-value">
 				{if $logicalOperator == 'and'}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/vertical_card_small_image/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/vertical_card_small_image/page.jsp
@@ -16,6 +16,6 @@
 
 <%@ include file="/card/vertical_card_small_image/init.jsp" %>
 
-<div class="sticker sticker-bottom <%= cssClass %>">
+<div class="sticker sticker-bottom-left <%= cssClass %>">
 	<img alt="thumbnail" class="img-responsive" src="<%= src %>" />
 </div>

--- a/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
@@ -9,6 +9,7 @@ $compat-alerts: false;
 $compat-breadcrumbs: false;
 $compat-button_groups: false;
 $compat-buttons: false;
+$compat-cards: false;
 $compat-dropdowns: false;
 $compat-responsive_utilities: false;
 $compat-stickers: false;

--- a/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
@@ -7,6 +7,7 @@ $small-font-size: 0.875rem;
 
 $compat-alerts: false;
 $compat-breadcrumbs: false;
+$compat-button_groups: false;
 $compat-buttons: false;
 $compat-dropdowns: false;
 $compat-responsive_utilities: false;

--- a/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
@@ -13,4 +13,5 @@ $compat-cards: false;
 $compat-dropdowns: false;
 $compat-responsive_utilities: false;
 $compat-stickers: false;
+$compat-toggle_card: false;
 $compat-utilities: false;

--- a/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
@@ -11,4 +11,5 @@ $compat-button_groups: false;
 $compat-buttons: false;
 $compat-dropdowns: false;
 $compat-responsive_utilities: false;
+$compat-stickers: false;
 $compat-utilities: false;

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
@@ -17,6 +17,7 @@ $compat-alerts: false;
 $compat-breadcrumbs: false;
 $compat-button_groups: false;
 $compat-buttons: false;
+$compat-cards: false;
 $compat-dropdowns: false;
 $compat-responsive_utilities: false;
 $compat-stickers: false;

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
@@ -19,4 +19,5 @@ $compat-button_groups: false;
 $compat-buttons: false;
 $compat-dropdowns: false;
 $compat-responsive_utilities: false;
+$compat-stickers: false;
 $compat-utilities: false;

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
@@ -15,6 +15,7 @@ $portlet-decorate-border: 1px solid $light-color;
 
 $compat-alerts: false;
 $compat-breadcrumbs: false;
+$compat-button_groups: false;
 $compat-buttons: false;
 $compat-dropdowns: false;
 $compat-responsive_utilities: false;

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
@@ -21,4 +21,5 @@ $compat-cards: false;
 $compat-dropdowns: false;
 $compat-responsive_utilities: false;
 $compat-stickers: false;
+$compat-toggle_card: false;
 $compat-utilities: false;

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_button_groups.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_button_groups.scss
@@ -1,21 +1,21 @@
+.button-holder {
+	display: flex;
+	margin: 20px 0;
+
+	.btn:not(:last-child) {
+		margin-right: 12px;
+	}
+
+	&.btn-group {
+		display: inline-flex;
+	}
+}
+
 @if $compat-button_groups {
 	.btn-group {
 		flex-flow: wrap;
 
 		&.dropdown {
-			display: inline-flex;
-		}
-	}
-
-	.button-holder {
-		display: flex;
-		margin: 20px 0;
-
-		.btn:not(:last-child) {
-			margin-right: 12px;
-		}
-
-		&.btn-group {
 			display: inline-flex;
 		}
 	}

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -361,7 +361,7 @@ ItemSelectorRepositoryEntryManagementToolbarDisplayContext itemSelectorRepositor
 												>
 													<liferay-frontend:vertical-card-sticker-bottom>
 														<liferay-document-library:mime-type-sticker
-															cssClass="sticker-bottom sticker-secondary"
+															cssClass="sticker-bottom-left sticker-secondary"
 															fileVersion="<%= latestFileVersion %>"
 														/>
 													</liferay-frontend:vertical-card-sticker-bottom>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/customization_settings.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/customization_settings.jsp
@@ -149,7 +149,7 @@ data.put("qa-id", "customizations");
 					</liferay-ui:icon-menu>
 				</li>
 				<li class="control-menu-nav-item d-block d-sm-none">
-					<div class="btn-group dropdown">
+					<div class="btn-group btn-group-item dropdown">
 						<aui:a cssClass="btn btn-primary" href="<%= toggleCustomizationViewURL %>" label="<%= toggleCustomizedViewMessage %>" />
 
 						<c:if test="<%= layoutTypePortlet.isCustomizedView() %>">

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/product_menu.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/product_menu.jsp
@@ -42,7 +42,7 @@
 								%>
 
 								<c:if test="<%= notificationsCount > 0 %>">
-									<span class="panel-notifications-count sticker sticker-right sticker-rounded sticker-sm sticker-warning"><%= notificationsCount %></span>
+									<span class="panel-notifications-count sticker sticker-rounded sticker-sm sticker-top-right sticker-warning"><%= notificationsCount %></span>
 								</c:if>
 
 								<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
@@ -103,7 +103,7 @@ PanelCategory panelCategory = siteAdministrationPanelCategoryDisplayContext.getP
 			</div>
 
 			<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.getNotificationsCount() > 0 %>">
-				<span class="panel-notifications-count sticker sticker-right sticker-rounded sticker-sm sticker-warning"><%= siteAdministrationPanelCategoryDisplayContext.getNotificationsCount() %></span>
+				<span class="panel-notifications-count sticker sticker-rounded sticker-sm sticker-top-right sticker-warning"><%= siteAdministrationPanelCategoryDisplayContext.getNotificationsCount() %></span>
 			</c:if>
 
 			<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
@@ -80,7 +80,7 @@ PanelCategory panelCategory = siteAdministrationPanelCategoryDisplayContext.getP
 							<div class="aspect-ratio-bg-cover sticker" style="background-image: url(<%= siteAdministrationPanelCategoryDisplayContext.getLogoURL() %>);"></div>
 						</c:when>
 						<c:otherwise>
-							<div class="sticker sticker-default">
+							<div class="sticker sticker-secondary">
 								<aui:icon image="<%= group.getIconCssClass() %>" markupView="lexicon" />
 							</div>
 						</c:otherwise>

--- a/modules/apps/product-navigation/product-navigation-user/src/main/resources/META-INF/resources/user_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-user/src/main/resources/META-INF/resources/user_header.jsp
@@ -49,7 +49,7 @@ ProductMenuDisplayContext productMenuDisplayContext = new ProductMenuDisplayCont
 	</span>
 
 	<c:if test="<%= notificationsCount > 0 %>">
-		<span class="badge badge-danger panel-notifications-count sticker-right">
+		<span class="badge badge-danger panel-notifications-count sticker-top-right">
 			<span class="badge-item badge-item-expand"><%= notificationsCount %></span>
 		</span>
 	</c:if>

--- a/portal-web/docroot/html/taglib/aui/button/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/button/end.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/html/taglib/aui/button/init.jsp" %>
 
 <c:if test="<%= dropdown %>">
-	<div class="btn-group dropdown" id="<%= id %>BtnGroup">
+	<div class="btn-group btn-group-item dropdown" id="<%= id %>BtnGroup">
 </c:if>
 
 <c:choose>


### PR DESCRIPTION
Hey @brianchandotcom, this includes **3 LPS**s as we continue updating legacy markup and disable unnecessary CSS.

For LPS-102089:
[ci:test:stable - 7 out of 9](https://github.com/jbalsas/liferay-portal/pull/2025#issuecomment-552472872)
[ci:test:relevant - 99 out of 112 jobs passed](https://github.com/jbalsas/liferay-portal/pull/2025#issuecomment-552472872)
[ci:test:default - 192 out of 224 jobs](https://github.com/jbalsas/liferay-portal/pull/2025#issuecomment-552482695)

From @john-co:
> Reviewed. Test failures are unrelated. ✔️
>
> The websphere smoke test failure seems to affect other pulls in it's test history.
>
> [See more...](https://github.com/jbalsas/liferay-portal/pull/2025#issuecomment-553005249)

For LPS-102113 and LPS-102115:
[ci:test:stable - 8 out of 9](https://github.com/jbalsas/liferay-portal/pull/2030#issuecomment-552989545)
[ci:test:relevant - 99 out of 114 jobs passed](https://github.com/jbalsas/liferay-portal/pull/2030#issuecomment-552989545)

From @john-co:
> Reviewed. Test failures are unrelated. ✔️
>
> the modules-unit test failure appears on upstream tests:
> https://test-1-11.liferay.com/job/test-portal-acceptance-upstream-batch(master)/46479/AXIS_VARIABLE=0,label_exp=!master/consoleFull