### PR TITLE
LPS-99867 portal-search-tuning-rankings-web: Show correct icons.

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/build.gradle
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:application-list:application-list-api")
+	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
@@ -17,6 +18,7 @@ dependencies {
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-search:portal-search-engine-adapter-api")
 	compileOnly project(":apps:portal-search:portal-search-spi")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/RankingMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/action/RankingMVCResourceCommand.java
@@ -14,11 +14,13 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.portlet.action;
 
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
@@ -83,8 +85,8 @@ public class RankingMVCResourceCommand implements MVCResourceCommand {
 	protected JSONObject getHiddenResults(ResourceRequest resourceRequest) {
 		RankingGetHiddenResultsBuilder rankingGetHiddenResultsBuilder =
 			new RankingGetHiddenResultsBuilder(
-				queries, rankingIndexReader, resourceRequest,
-				searchEngineAdapter);
+				dlAppLocalService, queries, rankingIndexReader, resourceActions,
+				resourceRequest, searchEngineAdapter);
 
 		RankingMVCResourceRequest rankingMVCResourceRequest =
 			new RankingMVCResourceRequest(resourceRequest);
@@ -116,8 +118,9 @@ public class RankingMVCResourceCommand implements MVCResourceCommand {
 	protected JSONObject getSearchResults(ResourceRequest resourceRequest) {
 		RankingGetSearchResultsBuilder rankingGetSearchResultsBuilder =
 			new RankingGetSearchResultsBuilder(
-				complexQueryPartBuilderFactory, queries, resourceRequest,
-				searcher, searchRequestBuilderFactory);
+				complexQueryPartBuilderFactory, dlAppLocalService, queries,
+				resourceActions, resourceRequest, searcher,
+				searchRequestBuilderFactory);
 
 		RankingMVCResourceRequest rankingMVCResourceRequest =
 			new RankingMVCResourceRequest(resourceRequest);
@@ -137,8 +140,9 @@ public class RankingMVCResourceCommand implements MVCResourceCommand {
 	protected JSONObject getVisibleResults(ResourceRequest resourceRequest) {
 		RankingGetVisibleResultsBuilder rankingGetVisibleResultsBuilder =
 			new RankingGetVisibleResultsBuilder(
-				complexQueryPartBuilderFactory, rankingIndexReader,
-				rankingSearchRequestHelper, resourceRequest, queries, searcher,
+				complexQueryPartBuilderFactory, dlAppLocalService,
+				rankingIndexReader, rankingSearchRequestHelper, resourceActions,
+				resourceRequest, queries, searcher,
 				searchRequestBuilderFactory);
 
 		RankingMVCResourceRequest rankingMVCResourceRequest =
@@ -179,6 +183,9 @@ public class RankingMVCResourceCommand implements MVCResourceCommand {
 	protected ComplexQueryPartBuilderFactory complexQueryPartBuilderFactory;
 
 	@Reference
+	protected DLAppLocalService dlAppLocalService;
+
+	@Reference
 	protected Queries queries;
 
 	@Reference
@@ -186,6 +193,9 @@ public class RankingMVCResourceCommand implements MVCResourceCommand {
 
 	@Reference
 	protected RankingSearchRequestHelper rankingSearchRequestHelper;
+
+	@Reference
+	protected ResourceActions resourceActions;
 
 	@Reference
 	protected SearchEngineAdapter searchEngineAdapter;

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetHiddenResultsBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetHiddenResultsBuilder.java
@@ -14,9 +14,11 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.results.builder;
 
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -44,12 +46,15 @@ import javax.portlet.ResourceRequest;
 public class RankingGetHiddenResultsBuilder {
 
 	public RankingGetHiddenResultsBuilder(
-		Queries queries, RankingIndexReader rankingIndexReader,
+		DLAppLocalService dlAppLocalService, Queries queries,
+		RankingIndexReader rankingIndexReader, ResourceActions resourceActions,
 		ResourceRequest resourceRequest,
 		SearchEngineAdapter searchEngineAdapter) {
 
+		_dlAppLocalService = dlAppLocalService;
 		_queries = queries;
 		_rankingIndexReader = rankingIndexReader;
+		_resourceActions = resourceActions;
 		_resourceRequest = resourceRequest;
 		_searchEngineAdapter = searchEngineAdapter;
 	}
@@ -121,7 +126,8 @@ public class RankingGetHiddenResultsBuilder {
 	}
 
 	protected JSONObject translate(Document document, Locale locale) {
-		RankingJSONBuilder rankingJSONBuilder = new RankingJSONBuilder();
+		RankingJSONBuilder rankingJSONBuilder = new RankingJSONBuilder(
+			_dlAppLocalService, _resourceActions);
 
 		return rankingJSONBuilder.document(
 			document
@@ -134,9 +140,11 @@ public class RankingGetHiddenResultsBuilder {
 
 	protected static final String LIFERAY_DOCUMENT_TYPE = "LiferayDocumentType";
 
+	private final DLAppLocalService _dlAppLocalService;
 	private final Queries _queries;
 	private String _rankingId;
 	private final RankingIndexReader _rankingIndexReader;
+	private final ResourceActions _resourceActions;
 	private final ResourceRequest _resourceRequest;
 	private final SearchEngineAdapter _searchEngineAdapter;
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetSearchResultsBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetSearchResultsBuilder.java
@@ -14,9 +14,11 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.results.builder;
 
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.document.Document;
@@ -40,11 +42,15 @@ public class RankingGetSearchResultsBuilder {
 
 	public RankingGetSearchResultsBuilder(
 		ComplexQueryPartBuilderFactory complexQueryPartBuilderFactory,
-		Queries queries, ResourceRequest resourceRequest, Searcher searcher,
+		DLAppLocalService dlAppLocalService, Queries queries,
+		ResourceActions resourceActions, ResourceRequest resourceRequest,
+		Searcher searcher,
 		SearchRequestBuilderFactory searchRequestBuilderFactory) {
 
 		_complexQueryPartBuilderFactory = complexQueryPartBuilderFactory;
+		_dlAppLocalService = dlAppLocalService;
 		_queries = queries;
+		_resourceActions = resourceActions;
 		_resourceRequest = resourceRequest;
 		_searcher = searcher;
 		_searchRequestBuilderFactory = searchRequestBuilderFactory;
@@ -117,7 +123,8 @@ public class RankingGetSearchResultsBuilder {
 	}
 
 	protected JSONObject translate(Document document, Locale locale) {
-		RankingJSONBuilder rankingJSONBuilder = new RankingJSONBuilder();
+		RankingJSONBuilder rankingJSONBuilder = new RankingJSONBuilder(
+			_dlAppLocalService, _resourceActions);
 
 		return rankingJSONBuilder.document(
 			document
@@ -129,9 +136,11 @@ public class RankingGetSearchResultsBuilder {
 	private long _companyId;
 	private final ComplexQueryPartBuilderFactory
 		_complexQueryPartBuilderFactory;
+	private final DLAppLocalService _dlAppLocalService;
 	private int _from;
 	private final Queries _queries;
 	private String _queryString;
+	private final ResourceActions _resourceActions;
 	private final ResourceRequest _resourceRequest;
 	private final Searcher _searcher;
 	private final SearchRequestBuilderFactory _searchRequestBuilderFactory;

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetVisibleResultsBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetVisibleResultsBuilder.java
@@ -14,10 +14,12 @@
 
 package com.liferay.portal.search.tuning.rankings.web.internal.results.builder;
 
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -47,14 +49,18 @@ public class RankingGetVisibleResultsBuilder {
 
 	public RankingGetVisibleResultsBuilder(
 		ComplexQueryPartBuilderFactory complexQueryPartBuilderFactory,
+		DLAppLocalService dlAppLocalService,
 		RankingIndexReader rankingIndexReader,
 		RankingSearchRequestHelper rankingSearchRequestHelper,
-		ResourceRequest resourceRequest, Queries queries, Searcher searcher,
+		ResourceActions resourceActions, ResourceRequest resourceRequest,
+		Queries queries, Searcher searcher,
 		SearchRequestBuilderFactory searchRequestBuilderFactory) {
 
 		_complexQueryPartBuilderFactory = complexQueryPartBuilderFactory;
+		_dlAppLocalService = dlAppLocalService;
 		_rankingIndexReader = rankingIndexReader;
 		_rankingSearchRequestHelper = rankingSearchRequestHelper;
+		_resourceActions = resourceActions;
 		_resourceRequest = resourceRequest;
 		_queries = queries;
 		_searcher = searcher;
@@ -155,7 +161,8 @@ public class RankingGetVisibleResultsBuilder {
 	protected JSONObject translate(
 		Document document, Ranking ranking, Locale locale) {
 
-		RankingJSONBuilder rankingJSONBuilder = new RankingJSONBuilder();
+		RankingJSONBuilder rankingJSONBuilder = new RankingJSONBuilder(
+			_dlAppLocalService, _resourceActions);
 
 		return rankingJSONBuilder.document(
 			document
@@ -169,12 +176,14 @@ public class RankingGetVisibleResultsBuilder {
 	private long _companyId;
 	private final ComplexQueryPartBuilderFactory
 		_complexQueryPartBuilderFactory;
+	private final DLAppLocalService _dlAppLocalService;
 	private int _from;
 	private final Queries _queries;
 	private String _queryString;
 	private String _rankingId;
 	private final RankingIndexReader _rankingIndexReader;
 	private final RankingSearchRequestHelper _rankingSearchRequestHelper;
+	private final ResourceActions _resourceActions;
 	private final ResourceRequest _resourceRequest;
 	private final Searcher _searcher;
 	private final SearchRequestBuilderFactory _searchRequestBuilderFactory;

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/Item.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/Item.es.js
@@ -25,6 +25,8 @@ import {sub} from '../../utils/language.es';
 import {isNil} from '../../utils/util.es';
 import ItemDropdown from './ItemDropdown.es';
 
+const DEFAULT_ICON = 'web-content';
+
 const HOVER_TYPES = {
 	BOTTOM: 'bottom',
 	TOP: 'top'
@@ -226,6 +228,7 @@ class Item extends PureComponent {
 		extension: PropTypes.string,
 		focus: PropTypes.bool,
 		hidden: PropTypes.bool,
+		icon: PropTypes.string,
 		id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 		index: PropTypes.number,
 		initialPinned: PropTypes.number,
@@ -391,6 +394,7 @@ class Item extends PureComponent {
 			extension,
 			focus,
 			hidden,
+			icon,
 			id,
 			onClickHide,
 			onClickPin,
@@ -476,7 +480,7 @@ class Item extends PureComponent {
 						{extension ? (
 							extension.toUpperCase()
 						) : (
-							<ClayIcon symbol="web-content" />
+							<ClayIcon symbol={icon ? icon : DEFAULT_ICON} />
 						)}
 					</span>
 				</div>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/List.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/List.es.js
@@ -192,6 +192,7 @@ class List extends PureComponent {
 				extension={item.extension}
 				focus={index === focusIndex}
 				hidden={item.hidden}
+				icon={item.icon}
 				id={item.id}
 				index={index}
 				key={item.id}


### PR DESCRIPTION
<h3>:heavy_check_mark: ci:test:search - 48 out of 48 jobs passed in 2 hours 20 minutes 42 seconds 208 ms</h3>

That is new :)

https://github.com/brandizzi/liferay-portal/pull/859#issuecomment-553620884

Author: oliv-yu
Reviewer: @thektan @brandizzi

[Bug] Result Rankings: Each search result shows a blank thumbnail icon
https://issues.liferay.com/browse/LPS-99867