### PR TITLE
LPS-102883 Bump org.bouncycastle libs to 1.61

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/build.gradle
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/build.gradle
@@ -45,9 +45,9 @@ dependencies {
 	compileInclude group: "org.apache.lucene", name: "lucene-sandbox", version: luceneVersion
 	compileInclude group: "org.apache.lucene", name: "lucene-spatial", version: luceneVersion
 	compileInclude group: "org.apache.lucene", name: "lucene-suggest", version: luceneVersion
-	compileInclude group: "org.bouncycastle", name: "bcpg-jdk15on", version: "1.59"
-	compileInclude group: "org.bouncycastle", name: "bcpkix-jdk15on", version: "1.59"
-	compileInclude group: "org.bouncycastle", name: "bcprov-jdk15on", version: "1.59"
+	compileInclude group: "org.bouncycastle", name: "bcpg-jdk15on", version: "1.61"
+	compileInclude group: "org.bouncycastle", name: "bcpkix-jdk15on", version: "1.61"
+	compileInclude group: "org.bouncycastle", name: "bcprov-jdk15on", version: "1.61"
 	compileInclude group: "org.elasticsearch", name: "elasticsearch", version: elasticsearchVersion
 	compileInclude group: "org.elasticsearch", name: "elasticsearch-cli", version: elasticsearchVersion
 	compileInclude group: "org.elasticsearch", name: "elasticsearch-core", version: elasticsearchVersion

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
@@ -50,9 +50,9 @@ dependencies {
 	compileInclude group: "org.apache.lucene", name: "lucene-sandbox", version: luceneVersion
 	compileInclude group: "org.apache.lucene", name: "lucene-spatial", version: luceneVersion
 	compileInclude group: "org.apache.lucene", name: "lucene-suggest", version: luceneVersion
-	compileInclude group: "org.bouncycastle", name: "bcpg-jdk15on", version: "1.59"
-	compileInclude group: "org.bouncycastle", name: "bcpkix-jdk15on", version: "1.59"
-	compileInclude group: "org.bouncycastle", name: "bcprov-jdk15on", version: "1.59"
+	compileInclude group: "org.bouncycastle", name: "bcpg-jdk15on", version: "1.61"
+	compileInclude group: "org.bouncycastle", name: "bcpkix-jdk15on", version: "1.61"
+	compileInclude group: "org.bouncycastle", name: "bcprov-jdk15on", version: "1.61"
 	compileInclude group: "org.codelibs.elasticsearch.module", name: "analysis-common", version: elasticsearchVersion
 	compileInclude group: "org.elasticsearch", name: "elasticsearch", version: elasticsearchVersion
 	compileInclude group: "org.elasticsearch", name: "elasticsearch-cli", version: elasticsearchVersion


### PR DESCRIPTION
⚠️ **ci:test:search - 45 out of 48 jobs passed** https://github.com/BryanEngler/liferay-portal/pull/437#issuecomment-553437856
✅ The only failures unique to this pull are not caused by this pr, confirmed by @xbrianlee

Author(s): @lipusz
Reviewer(s): @BryanEngler
Cc: @arboliveira

---
*[Bug] Security vulnerability in Bouncy Castle Provider 1.45 (Elasticsearch connectors)*
https://issues.liferay.com/browse/LPS-102883