### PR TITLE
LPS-104757 Unify spacer values like in separator and other components

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/spacer/index.json
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/spacer/index.json
@@ -11,15 +11,23 @@
 					"typeOptions": {
 						"validValues": [
 							{
-								"label": "small",
+								"label": "1",
+								"value": "py-1"
+							},
+							{
+								"label": "2",
+								"value": "py-2"
+							},
+							{
+								"label": "3",
 								"value": "py-3"
 							},
 							{
-								"label": "medium",
+								"label": "4",
 								"value": "py-4"
 							},
 							{
-								"label": "large",
+								"label": "5",
 								"value": "py-5"
 							}
 						]


### PR DESCRIPTION
Hey @brianchandotcom 

I think before we talked about different things, what I meant is that this change is backward compatible, if some user had this fragment added to the page it will work the same, as we are only adding values and changing labels, so no conflict will apper :)

Thanks