### PR TITLE
LPS-97585 Use raw keyword multi-field for aggregations on expando fields

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -51,6 +51,11 @@
 				"template_expando_keyword": {
 					"mapping": {
 						"analyzer" : "keyword_lowercase",
+						"fields": {
+							"raw" : {
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"type": "text"
 					},

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/resources/com/liferay/portal/search/elasticsearch6/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/resources/com/liferay/portal/search/elasticsearch6/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
@@ -53,6 +53,11 @@
 						"template_expando_keyword" : {
 							"mapping" : {
 								"analyzer" : "keyword_lowercase",
+								"fields" : {
+									"raw" : {
+										"type" : "keyword"
+									}
+								},
 								"store" : true,
 								"type" : "text"
 							},

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -51,6 +51,11 @@
 				"template_expando_keyword": {
 					"mapping": {
 						"analyzer" : "keyword_lowercase",
+						"fields": {
+							"raw" : {
+								"type": "keyword"
+							}
+						},
 						"store": true,
 						"type": "text"
 					},

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
@@ -52,6 +52,11 @@
 					"template_expando_keyword" : {
 						"mapping" : {
 							"analyzer" : "keyword_lowercase",
+							"fields" : {
+								"raw" : {
+									"type" : "keyword"
+								}
+							},
 							"store" : true,
 							"type" : "text"
 						},


### PR DESCRIPTION
⚠️ **ci:test:search - 47 out of 50 jobs passed** https://github.com/BryanEngler/liferay-portal/pull/442#issuecomment-556426494
✅ The only failures unique to this pull are also failing on the upstream canary https://github.com/xbrianlee/liferay-portal/pull/369#issuecomment-556030601

⚠️ **ci:test:search-es7 - 44 out of 47 jobs passed** https://github.com/BryanEngler/liferay-portal/pull/442#issuecomment-556416510
✅ The only failures unique to this pull are also failing on the upstream canary https://github.com/xbrianlee/liferay-portal/pull/369#issuecomment-555779319

Author(s): @BryanEngler @brianikim @katienesterovich @JavierMoral
Reviewer(s): @BryanEngler
Cc: @arboliveira @lipusz

---
*[Bug] Fields that match "expando__keyword__*" are not indexed as keyword*
https://issues.liferay.com/browse/LPS-97585