### PR TITLE
LPS-103124 Fix error when redeploying Elastic 7

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/EmbeddedElasticsearchConnection.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/EmbeddedElasticsearchConnection.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration;
 import com.liferay.portal.search.elasticsearch7.internal.cluster.ClusterSettingsContext;
 import com.liferay.portal.search.elasticsearch7.internal.settings.SettingsBuilder;
+import com.liferay.portal.search.elasticsearch7.internal.util.ClassLoaderUtil;
 import com.liferay.portal.search.elasticsearch7.internal.util.ResourceUtil;
 import com.liferay.portal.search.elasticsearch7.settings.ClientSettingsHelper;
 import com.liferay.portal.search.elasticsearch7.settings.SettingsContributor;
@@ -307,11 +308,16 @@ public class EmbeddedElasticsearchConnection
 	protected RestHighLevelClient createRestHighLevelClient() {
 		startNode();
 
-		return new RestHighLevelClient(
-			RestClient.builder(
-				new HttpHost(
-					"localhost", elasticsearchConfiguration.embeddedHttpPort(),
-					"http")));
+		Class<? extends EmbeddedElasticsearchConnection> clazz = getClass();
+
+		return ClassLoaderUtil.getWithContextClassLoader(
+			() -> new RestHighLevelClient(
+				RestClient.builder(
+					new HttpHost(
+						"localhost",
+						elasticsearchConfiguration.embeddedHttpPort(),
+						"http"))),
+			clazz);
 	}
 
 	@Deactivate

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/RemoteElasticsearchConnection.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/RemoteElasticsearchConnection.java
@@ -17,6 +17,7 @@ package com.liferay.portal.search.elasticsearch7.internal.connection;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration;
+import com.liferay.portal.search.elasticsearch7.internal.util.ClassLoaderUtil;
 
 import java.io.InputStream;
 
@@ -113,7 +114,10 @@ public class RemoteElasticsearchConnection extends BaseElasticsearchConnection {
 			configureSecurity(restClientBuilder);
 		}
 
-		return new RestHighLevelClient(restClientBuilder);
+		Class<? extends RemoteElasticsearchConnection> clazz = getClass();
+
+		return ClassLoaderUtil.getWithContextClassLoader(
+			() -> new RestHighLevelClient(restClientBuilder), clazz);
 	}
 
 	protected SSLContext createSSLContext() {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/RemoteElasticsearchConnection.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/RemoteElasticsearchConnection.java
@@ -35,7 +35,6 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
 
@@ -72,22 +71,15 @@ public class RemoteElasticsearchConnection extends BaseElasticsearchConnection {
 
 	protected void configureSecurity(RestClientBuilder restClientBuilder) {
 		restClientBuilder.setHttpClientConfigCallback(
-			new RestClientBuilder.HttpClientConfigCallback() {
+			httpClientBuilder -> {
+				httpClientBuilder.setDefaultCredentialsProvider(
+					createCredentialsProvider());
 
-				@Override
-				public HttpAsyncClientBuilder customizeHttpClient(
-					HttpAsyncClientBuilder httpClientBuilder) {
-
-					httpClientBuilder.setDefaultCredentialsProvider(
-						createCredentialsProvider());
-
-					if (elasticsearchConfiguration.httpSSLEnabled()) {
-						httpClientBuilder.setSSLContext(createSSLContext());
-					}
-
-					return httpClientBuilder;
+				if (elasticsearchConfiguration.httpSSLEnabled()) {
+					httpClientBuilder.setSSLContext(createSSLContext());
 				}
 
+				return httpClientBuilder;
 			});
 	}
 
@@ -104,6 +96,7 @@ public class RemoteElasticsearchConnection extends BaseElasticsearchConnection {
 		return credentialsProvider;
 	}
 
+	@Override
 	protected RestHighLevelClient createRestHighLevelClient() {
 		String[] networkHostAddresses =
 			elasticsearchConfiguration.networkHostAddresses();

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/index/CreateIndexRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/index/CreateIndexRequestExecutorImpl.java
@@ -17,6 +17,7 @@ package com.liferay.portal.search.elasticsearch7.internal.search.engine.adapter.
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchClientResolver;
+import com.liferay.portal.search.elasticsearch7.internal.util.ClassLoaderUtil;
 import com.liferay.portal.search.elasticsearch7.internal.util.LogUtil;
 import com.liferay.portal.search.engine.adapter.index.CreateIndexRequest;
 import com.liferay.portal.search.engine.adapter.index.CreateIndexResponse;
@@ -63,9 +64,13 @@ public class CreateIndexRequestExecutorImpl
 				new org.elasticsearch.action.admin.indices.create.
 					CreateIndexRequest(createIndexRequest.getIndexName());
 
+		Class<? extends CreateIndexRequestExecutorImpl> clazz = getClass();
+
 		if (createIndexRequest.getSource() != null) {
-			elasticsearchCreateIndexRequest.source(
-				createIndexRequest.getSource(), XContentType.JSON);
+			ClassLoaderUtil.getWithContextClassLoader(
+				() -> elasticsearchCreateIndexRequest.source(
+					createIndexRequest.getSource(), XContentType.JSON),
+				clazz);
 		}
 
 		return elasticsearchCreateIndexRequest;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/util/ClassLoaderUtil.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/util/ClassLoaderUtil.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.util;
+
+import java.util.function.Supplier;
+
+/**
+ * @author André de Oliveira
+ */
+public class ClassLoaderUtil {
+
+	public static <T> T getWithContextClassLoader(
+		Supplier<T> supplier, Class<?> clazz) {
+
+		Thread thread = Thread.currentThread();
+
+		ClassLoader contextClassLoader = thread.getContextClassLoader();
+
+		thread.setContextClassLoader(clazz.getClassLoader());
+
+		try {
+			return supplier.get();
+		}
+		finally {
+			thread.setContextClassLoader(contextClassLoader);
+		}
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/RemoteElasticsearchConnectionTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/RemoteElasticsearchConnectionTest.java
@@ -90,8 +90,7 @@ public class RemoteElasticsearchConnectionTest {
 
 	protected void assertNetworkHostAddress(String hostString, int port) {
 		RestHighLevelClient restHighLevelClient =
-			(RestHighLevelClient)
-				_remoteElasticsearchConnection.getRestHighLevelClient();
+			_remoteElasticsearchConnection.getRestHighLevelClient();
 
 		RestClient restClient = restHighLevelClient.getLowLevelClient();
 


### PR DESCRIPTION
**ci:test:search - 43 out of 47 jobs passed** https://github.com/BryanEngler/liferay-portal/pull/444#issuecomment-556520627
✅ The only failures unique to this pull are also failing on the upstream canary https://github.com/xbrianlee/liferay-portal/pull/369#issuecomment-556600691

Author(s): @arboliveira
Reviewer(s): @BryanEngler

---
*[Bug] Redeploying Elasticsearch 7 Connector with REST client: "java.util.ServiceConfigurationError: org.elasticsearch.plugins.spi.NamedXContentProvider: Provider org.elasticsearch.client.dataframe.DataFrameNamedXContentProvider not a subtype"*
https://issues.liferay.com/browse/LPS-103124