### PR TITLE
LRQA-53768 | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -7357,7 +7357,11 @@ portal.security.manager.strategy=liferay</echo>
 		</if>
 
 		<if>
-			<equals arg1="${javascript.fast.load}" arg2="false" />
+			<or>
+				<equals arg1="${app.server.type}" arg2="weblogic" />
+				<equals arg1="${app.server.type}" arg2="websphere" />
+				<equals arg1="${javascript.fast.load}" arg2="false" />
+			</or>
 			<then>
 				<echo append="true" file="portal-impl/src/portal-ext.properties">
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-53768

@jbalsas @john-co @manoelcyreno This is a temporarily to solution to continued instability of Weblogic and Websphere in our Poshi automation. Currently we have low visibilty on these app servers because most Poshi tests fail when run on CI. This is even causing the base PortalSmoke testcase to routinely fail on PRs. The issues are not reproducible locally so it is difficult to debug. It is specific to the CI environment. During 7.2 release testing we just used another machine to run Poshi on these App Servers. See https://issues.liferay.com/browse/LRQA-47912 and linked issues for additional context.

Backported to 7.2.x and 7.1.x
https://github.com/brianchandotcom/liferay-portal-ee/pull/27772
https://github.com/brianchandotcom/liferay-portal-ee/pull/27773

CC @brianwulbern