### PR TITLE
LPS-104726 portal-search-similar-results-web: Avoid null value errors in ftl

### DIFF
--- a/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/java/com/liferay/portal/search/similar/results/web/internal/builder/DestinationBuilderImpl.java
+++ b/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/java/com/liferay/portal/search/similar/results/web/internal/builder/DestinationBuilderImpl.java
@@ -18,6 +18,7 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.similar.results.web.spi.contributor.helper.DestinationBuilder;
 
 /**
@@ -37,7 +38,9 @@ public class DestinationBuilderImpl implements DestinationBuilder {
 
 	@Override
 	public DestinationBuilder replace(String oldSub, String newSub) {
-		_urlString = StringUtil.replaceFirst(_urlString, oldSub, newSub);
+		if (Validator.isNotNull(oldSub) && Validator.isNotNull(newSub)) {
+			_urlString = StringUtil.replaceFirst(_urlString, oldSub, newSub);
+		}
 
 		return this;
 	}

--- a/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/java/com/liferay/portal/search/similar/results/web/internal/builder/SimilarResultsDocumentDisplayContextBuilder.java
+++ b/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/java/com/liferay/portal/search/similar/results/web/internal/builder/SimilarResultsDocumentDisplayContextBuilder.java
@@ -612,17 +612,17 @@ public class SimilarResultsDocumentDisplayContextBuilder {
 		AssetEntry assetEntry, AssetRenderer<?> assetRenderer, String className,
 		long classPK) {
 
-		String urlString = _portal.getCurrentURL(_renderRequest);
+		String currentURL = _portal.getCurrentURL(_renderRequest);
 
 		if (_similarResultsRoute == null) {
-			return urlString;
+			return currentURL;
 		}
 
 		SimilarResultsContributor similarResultsContributor =
 			_similarResultsRoute.getContributor();
 
 		DestinationBuilderImpl destinationBuilderImpl =
-			new DestinationBuilderImpl(urlString, _http);
+			new DestinationBuilderImpl(currentURL, _http);
 
 		DestinationHelper destinationHelper = new DestinationHelper() {
 

--- a/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/java/com/liferay/portal/search/similar/results/web/internal/display/context/SimilarResultsDocumentDisplayContext.java
+++ b/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/java/com/liferay/portal/search/similar/results/web/internal/display/context/SimilarResultsDocumentDisplayContext.java
@@ -14,49 +14,52 @@
 
 package com.liferay.portal.search.similar.results.web.internal.display.context;
 
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.Validator;
+
 /**
  * @author Kevin Tan
  */
 public class SimilarResultsDocumentDisplayContext {
 
 	public String getCategoriesString() {
-		return _categoriesString;
+		return _getNonnullValue(_categoriesString);
 	}
 
 	public String getContent() {
-		return _content;
+		return _getNonnullValue(_content);
 	}
 
 	public String getCreationDateString() {
-		return _creationDateString;
+		return _getNonnullValue(_creationDateString);
 	}
 
 	public String getCreatorUserName() {
-		return _creatorUserName;
+		return _getNonnullValue(_creatorUserName);
 	}
 
 	public String getIconId() {
-		if (_iconId == null) {
-			_iconId = "web-content";
+		if (Validator.isNull(_iconId)) {
+			return "web-content";
 		}
 
 		return _iconId;
 	}
 
 	public String getModelResource() {
-		return _modelResource;
+		return _getNonnullValue(_modelResource);
 	}
 
 	public String getThumbnailURLString() {
-		return _thumbnailURLString;
+		return _getNonnullValue(_thumbnailURLString);
 	}
 
 	public String getTitle() {
-		return _title;
+		return _getNonnullValue(_title);
 	}
 
 	public String getViewURL() {
-		return _viewURL;
+		return _getNonnullValue(_viewURL);
 	}
 
 	public boolean isTemporarilyUnavailable() {
@@ -101,6 +104,14 @@ public class SimilarResultsDocumentDisplayContext {
 
 	public void setViewURL(String viewURL) {
 		_viewURL = viewURL;
+	}
+
+	private String _getNonnullValue(String value) {
+		if (Validator.isNull(value)) {
+			return StringPool.BLANK;
+		}
+
+		return value;
 	}
 
 	private String _categoriesString;

--- a/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/java/com/liferay/portal/search/similar/results/web/internal/portlet/SimilarResultsPortlet.java
+++ b/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/java/com/liferay/portal/search/similar/results/web/internal/portlet/SimilarResultsPortlet.java
@@ -161,10 +161,17 @@ public class SimilarResultsPortlet extends MVCPortlet {
 			similarResultsDocumentDisplayContexts = new ArrayList<>();
 
 		for (Document document : documents) {
-			similarResultsDocumentDisplayContexts.add(
-				doBuildSummary(
+			SimilarResultsDocumentDisplayContext
+				similarResultsDocumentDisplayContext = doBuildSummary(
 					document, similarResultsRoute, renderRequest,
-					renderResponse, themeDisplay));
+					renderResponse, themeDisplay);
+
+			if (!similarResultsDocumentDisplayContext.
+					isTemporarilyUnavailable()) {
+
+				similarResultsDocumentDisplayContexts.add(
+					similarResultsDocumentDisplayContext);
+			}
 		}
 
 		return similarResultsDocumentDisplayContexts;

--- a/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/resources/META-INF/resources/css/_display_list.scss
+++ b/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/resources/META-INF/resources/css/_display_list.scss
@@ -13,8 +13,16 @@
 			line-height: 18px;
 		}
 
-		.related-results-metadata + .related-results-description {
+		.similar-results-metadata + .similar-results-description {
 			margin-top: 8px;
+		}
+
+		.similar-results-metadata {
+			.subtext-item + .subtext-item {
+				&:before {
+					content: ' - ';
+				}
+			}
 		}
 	}
 }

--- a/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/resources/com/liferay/search/similar/results/web/portlet/template/dependencies/portlet_display_template_card.ftl
+++ b/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/resources/com/liferay/search/similar/results/web/portlet/template/dependencies/portlet_display_template_card.ftl
@@ -18,7 +18,7 @@
 							<div class="card-row">
 								<div class="autofit-col autofit-col-expand">
 									<section class="autofit-section">
-										<#if validator.isNotNull(entry.getCategoriesString())>
+										<#if (entry.getCategoriesString()??) && validator.isNotNull(entry.getCategoriesString())>
 											<span class="card-category text-truncate-inline">
 												${entry.getCategoriesString()}
 											</span>
@@ -30,21 +30,25 @@
 											</a>
 										</h3>
 
-										<p class="card-subtitle">
-											<span class="text-truncate-inline">
-												<span class="text-truncate">
-													${htmlUtil.escape(entry.getCreatorUserName())}
+										<#if (entry.getCreatorUserName()??) && validator.isNotNull(entry.getCreatorUserName())>
+											<p class="card-subtitle">
+												<span class="text-truncate-inline">
+													<span class="text-truncate">
+														${htmlUtil.escape(entry.getCreatorUserName())}
+													</span>
 												</span>
-											</span>
-										</p>
+											</p>
+										</#if>
 
-										<p class="card-subtitle">
-											<span class="text-truncate-inline">
-												<span class="text-truncate">
-													${entry.getCreationDateString()}
+										<#if (entry.getCreationDateString()??) && validator.isNotNull(entry.getCreationDateString())>
+											<p class="card-subtitle">
+												<span class="text-truncate-inline">
+													<span class="text-truncate">
+														${entry.getCreationDateString()}
+													</span>
 												</span>
-											</span>
-										</p>
+											</p>
+										</#if>
 
 										<p class="card-subtitle">
 											<span class="text-truncate-inline">

--- a/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/resources/com/liferay/search/similar/results/web/portlet/template/dependencies/portlet_display_template_list.ftl
+++ b/modules/dxp/apps/portal-search-similar-results/portal-search-similar-results-web/src/main/resources/com/liferay/search/similar/results/web/portlet/template/dependencies/portlet_display_template_list.ftl
@@ -19,7 +19,17 @@
 
 							<div class="similar-results-metadata">
 								<p class="list-group-subtext">
-									${htmlUtil.escape(entry.getCreatorUserName())} - ${entry.getCreationDateString()}
+									<#if (entry.getCreatorUserName()??) && validator.isNotNull(entry.getCreatorUserName())>
+										<span class="subtext-item">
+											${htmlUtil.escape(entry.getCreatorUserName())}
+										</span>
+									</#if>
+
+									<#if (entry.getCreationDateString()??) && validator.isNotNull(entry.getCreationDateString())>
+										<span class="subtext-item">
+											${entry.getCreationDateString()}
+										</span>
+									</#if>
 								</p>
 
 								<p class="list-group-subtext">


### PR DESCRIPTION
<h3><g-emoji class="g-emoji" alias="x" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/274c.png"><img class="emoji" alt="x" src="https://github.githubassets.com/images/icons/emoji/unicode/274c.png" width="20" height="20"></g-emoji> ci:test:search - 47 out of 50 jobs passed in 1 hour 14 minutes 40 seconds 467 ms</h3>

Only unique failure has happened in unrelated pull requests, is in a totally different portlet and is often flaky so I am confident it is not related to the current pull request.

https://github.com/brandizzi/liferay-portal/pull/877#issuecomment-557328385

Author: @thektan
Reviewer: @brandizzi

[Bug] Similar results displays template error when selecting a blog on a content page
https://issues.liferay.com/browse/LPS-104726