### PR TITLE
Lps 84108 1

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/init.jsp
@@ -224,14 +224,7 @@ if (calendarDisplayContext != null) {
 	defaultCalendar = calendarDisplayContext.getDefaultCalendar(groupCalendars, userCalendars);
 }
 
-TimeZone userTimeZone = null;
-
-if ((calendarBooking != null) && calendarBooking.isAllDay()) {
-	userTimeZone = TimeZone.getTimeZone(StringPool.UTC);
-}
-else {
-	userTimeZone = TimeZone.getTimeZone(timeZoneId);
-}
+TimeZone userTimeZone = TimeZone.getTimeZone(timeZoneId);
 
 TimeZone utcTimeZone = TimeZone.getTimeZone(StringPool.UTC);
 


### PR DESCRIPTION
/cc @knchau

Notes from Kim:
> https://issues.liferay.com/browse/LPS-84108
> 
> Update for https://github.com/brianchandotcom/liferay-portal/pull/81205
> 
> This commit is an addition needed to resolve the UI start time and end time display when clicking on the event's details. Instead of defaulting the timezone to UTC when an event is marked as All Day, use the user's set timezone.