### PR TITLE
LPS-104528 ModelListenerException failure in AccountRoleManagerTest

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
@@ -87,6 +87,9 @@ public class AccountRoleLocalServiceImpl
 
 		accountRole = super.deleteAccountRole(accountRole);
 
+		userGroupRoleLocalService.deleteUserGroupRolesByRoleId(
+			accountRole.getRoleId());
+
 		roleLocalService.deleteRole(accountRole.getRoleId());
 
 		return accountRole;
@@ -97,6 +100,9 @@ public class AccountRoleLocalServiceImpl
 		throws PortalException {
 
 		AccountRole accountRole = super.deleteAccountRole(accountRoleId);
+
+		userGroupRoleLocalService.deleteUserGroupRolesByRoleId(
+			accountRole.getRoleId());
 
 		roleLocalService.deleteRole(accountRole.getRoleId());
 
@@ -111,7 +117,14 @@ public class AccountRoleLocalServiceImpl
 					"deleting a company");
 		}
 
-		accountRolePersistence.removeByCompanyId(companyId);
+		for (AccountRole accountRole :
+				accountRolePersistence.findByCompanyId(companyId)) {
+
+			userGroupRoleLocalService.deleteUserGroupRolesByRoleId(
+				accountRole.getRoleId());
+
+			accountRolePersistence.remove(accountRole);
+		}
 	}
 
 	@Override

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
@@ -87,10 +87,10 @@ public class AccountRoleLocalServiceImpl
 
 		accountRole = super.deleteAccountRole(accountRole);
 
+		roleLocalService.deleteRole(accountRole.getRoleId());
+
 		userGroupRoleLocalService.deleteUserGroupRolesByRoleId(
 			accountRole.getRoleId());
-
-		roleLocalService.deleteRole(accountRole.getRoleId());
 
 		return accountRole;
 	}
@@ -101,10 +101,10 @@ public class AccountRoleLocalServiceImpl
 
 		AccountRole accountRole = super.deleteAccountRole(accountRoleId);
 
+		roleLocalService.deleteRole(accountRole.getRoleId());
+
 		userGroupRoleLocalService.deleteUserGroupRolesByRoleId(
 			accountRole.getRoleId());
-
-		roleLocalService.deleteRole(accountRole.getRoleId());
 
 		return accountRole;
 	}
@@ -120,10 +120,10 @@ public class AccountRoleLocalServiceImpl
 		for (AccountRole accountRole :
 				accountRolePersistence.findByCompanyId(companyId)) {
 
+			accountRolePersistence.remove(accountRole);
+
 			userGroupRoleLocalService.deleteUserGroupRolesByRoleId(
 				accountRole.getRoleId());
-
-			accountRolePersistence.remove(accountRole);
 		}
 	}
 

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
@@ -87,10 +87,10 @@ public class AccountRoleLocalServiceImpl
 
 		accountRole = super.deleteAccountRole(accountRole);
 
-		roleLocalService.deleteRole(accountRole.getRoleId());
-
 		userGroupRoleLocalService.deleteUserGroupRolesByRoleId(
 			accountRole.getRoleId());
+
+		roleLocalService.deleteRole(accountRole.getRoleId());
 
 		return accountRole;
 	}
@@ -101,10 +101,10 @@ public class AccountRoleLocalServiceImpl
 
 		AccountRole accountRole = super.deleteAccountRole(accountRoleId);
 
-		roleLocalService.deleteRole(accountRole.getRoleId());
-
 		userGroupRoleLocalService.deleteUserGroupRolesByRoleId(
 			accountRole.getRoleId());
+
+		roleLocalService.deleteRole(accountRole.getRoleId());
 
 		return accountRole;
 	}
@@ -120,10 +120,10 @@ public class AccountRoleLocalServiceImpl
 		for (AccountRole accountRole :
 				accountRolePersistence.findByCompanyId(companyId)) {
 
-			accountRolePersistence.remove(accountRole);
-
 			userGroupRoleLocalService.deleteUserGroupRolesByRoleId(
 				accountRole.getRoleId());
+
+			accountRolePersistence.remove(accountRole);
 		}
 	}
 

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountRoleLocalServiceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountRoleLocalServiceTest.java
@@ -199,7 +199,10 @@ public class AccountRoleLocalServiceTest {
 
 		_accountRoles.remove(accountRole);
 
-		_assertUserGroupRolesDeleted(accountRole);
+		Assert.assertFalse(
+			ArrayUtil.contains(
+				_getRoleIds(_users.get(0)), accountRole.getRoleId()));
+
 	}
 
 	@Test
@@ -211,7 +214,9 @@ public class AccountRoleLocalServiceTest {
 
 		_accountRoles.remove(accountRole);
 
-		_assertUserGroupRolesDeleted(accountRole);
+		Assert.assertFalse(
+			ArrayUtil.contains(
+				_getRoleIds(_users.get(0)), accountRole.getRoleId()));
 	}
 
 	@Test
@@ -303,15 +308,6 @@ public class AccountRoleLocalServiceTest {
 				_accountEntry1.getAccountEntryGroup(),
 				AccountEntry.class.getName(),
 				_accountEntry1.getAccountEntryId(), actionKey));
-	}
-
-	private void _assertUserGroupRolesDeleted(AccountRole accountRole)
-		throws Exception {
-
-		long[] roleIds = _getRoleIds(_users.get(0));
-
-		Assert.assertFalse(
-			ArrayUtil.contains(roleIds, accountRole.getRoleId()));
 	}
 
 	private long[] _getRoleIds(User user) throws Exception {

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountRoleLocalServiceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountRoleLocalServiceTest.java
@@ -22,6 +22,8 @@ import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.account.service.AccountRoleLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -192,31 +194,11 @@ public class AccountRoleLocalServiceTest {
 	}
 
 	@Test
-	public void testDeleteAccountRoleByObject() throws Exception {
-		AccountRole accountRole = _setUpDeleteAccountRoleTestCase();
-
-		_accountRoleLocalService.deleteAccountRole(accountRole);
-
-		_accountRoles.remove(accountRole);
-
-		Assert.assertFalse(
-			ArrayUtil.contains(
-				_getRoleIds(_users.get(0)), accountRole.getRoleId()));
-
-	}
-
-	@Test
-	public void testDeleteAccountRoleByPrimaryKey() throws Exception {
-		AccountRole accountRole = _setUpDeleteAccountRoleTestCase();
-
-		_accountRoleLocalService.deleteAccountRole(
-			accountRole.getAccountRoleId());
-
-		_accountRoles.remove(accountRole);
-
-		Assert.assertFalse(
-			ArrayUtil.contains(
-				_getRoleIds(_users.get(0)), accountRole.getRoleId()));
+	public void testDeleteAccountRole() throws Exception {
+		_testDeleteAccountRole(_accountRoleLocalService::deleteAccountRole);
+		_testDeleteAccountRole(
+			accountRole -> _accountRoleLocalService.deleteAccountRole(
+				accountRole.getAccountRoleId()));
 	}
 
 	@Test
@@ -330,7 +312,11 @@ public class AccountRoleLocalServiceTest {
 		return ArrayUtil.contains(accountRoleIds, roleId);
 	}
 
-	private AccountRole _setUpDeleteAccountRoleTestCase() throws Exception {
+	private void _testDeleteAccountRole(
+			UnsafeFunction<AccountRole, AccountRole, PortalException>
+				deleteAccountRoleFunction)
+		throws Exception {
+
 		AccountRole accountRole = _addAccountRole(
 			_accountEntry1.getAccountEntryId(), RandomTestUtil.randomString());
 
@@ -346,7 +332,13 @@ public class AccountRoleLocalServiceTest {
 
 		Assert.assertTrue(ArrayUtil.contains(roleIds, accountRole.getRoleId()));
 
-		return accountRole;
+		deleteAccountRoleFunction.apply(accountRole);
+
+		_accountRoles.remove(accountRole);
+
+		Assert.assertFalse(
+			ArrayUtil.contains(
+				_getRoleIds(_users.get(0)), accountRole.getRoleId()));
 	}
 
 	@DeleteAfterTestRun


### PR DESCRIPTION
This is an update for [LPS-104528](https://issues.liferay.com/browse/LPS-104528).<br><br>Hey Brian, I reverted the commit: 230a94aa51e7 that re-orders the operation. The main issue stems from the UserGroupRole not being deleted _before_ the role is removed from persistence. The failure we see in upstream occurs because of a UserGroupRoleModelListener that throws when it tries to fetch the corresponding role. For this reason, we need to remove the role after the UserGroupRole has been removed and all listeners are satisfied. I updated the test case to illustrate this: d20d0650c8ca.<br><br>/cc @pei-jung @alee8888 @ChrisKian @dejuknow