### PR TITLE
LPS-100272 portal-search-tuning-synonyms-web: Update synonym filter list after index creation.

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/build.gradle
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/build.gradle
@@ -82,6 +82,7 @@ dependencies {
 	compileOnly project(":apps:portal-search:portal-search-engine-adapter-api")
 	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-string")
 
 	elasticsearchPlugins ext: "zip", group: "com.liferay", name: "org.elasticsearch.plugin.analysis.icu", version: elasticsearchVersion

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
@@ -94,6 +94,7 @@ dependencies {
 	compileOnly project(":apps:portal-search:portal-search-engine-adapter-api")
 	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-string")
 
 	elasticsearchPlugins ext: "zip", group: "com.liferay", name: "org.elasticsearch.plugin.analysis.icu", version: elasticsearchVersion

--- a/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/index/contributor/IndexContributor.java
+++ b/modules/apps/portal-search/portal-search-spi/src/main/java/com/liferay/portal/search/spi/model/index/contributor/IndexContributor.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.spi.model.index.contributor;
+
+/**
+ * @author Adam Brandizzi
+ */
+public interface IndexContributor {
+
+	public void onAfterCreate(String indexName);
+
+}

--- a/modules/apps/portal-search/portal-search-spi/src/main/resources/com/liferay/portal/search/spi/model/index/contributor/packageinfo
+++ b/modules/apps/portal-search/portal-search-spi/src/main/resources/com/liferay/portal/search/spi/model/index/contributor/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.1
+version 1.1.0

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/contributor/SynonymSetIndexContributor.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/contributor/SynonymSetIndexContributor.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.portal.search.tuning.synonyms.web.internal.index.contributor;
+
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexResponse;
+import com.liferay.portal.search.spi.model.index.contributor.IndexContributor;
+import com.liferay.portal.search.tuning.synonyms.web.internal.index.SynonymSetFilterHelper;
+import com.liferay.portal.search.tuning.synonyms.web.internal.index.SynonymSetIndexDefinition;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adam Brandizzi
+ */
+@Component(immediate = true, service = IndexContributor.class)
+public class SynonymSetIndexContributor implements IndexContributor {
+
+	@Override
+	public void onAfterCreate(String indexName) {
+		if (isSynonymIndexAvailable()) {
+			_synonymSetFilterHelper.updateFilters(indexName);
+		}
+	}
+
+	protected boolean isSynonymIndexAvailable() {
+		IndicesExistsIndexRequest indicesExistsIndexRequest =
+			new IndicesExistsIndexRequest(SynonymSetIndexDefinition.INDEX_NAME);
+
+		IndicesExistsIndexResponse indicesExistsIndexResponse =
+			_searchEngineAdapter.execute(indicesExistsIndexRequest);
+
+		return indicesExistsIndexResponse.isExists();
+	}
+
+	@Reference
+	private SearchEngineAdapter _searchEngineAdapter;
+
+	@Reference
+	private SynonymSetFilterHelper _synonymSetFilterHelper;
+
+}


### PR DESCRIPTION
<h3><g-emoji class="g-emoji" alias="x" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/274c.png"><img class="emoji" alt="x" src="https://github.githubassets.com/images/icons/emoji/unicode/274c.png" width="20" height="20"></g-emoji> ci:test:search - 46 out of 51 jobs passed in 1 hour 16 minutes 57 seconds 931 ms</h3>

https://github.com/brandizzi/liferay-portal/pull/889#issuecomment-560582428

Unique failures are JavaScript tests in other bundles, seems unrelated.

Author: @brandizzi

[Bug] Reindexing erases synonyms
https://issues.liferay.com/browse/LPS-100272