### PR TITLE
LPS-105255 Fix errors detected by turning on ESLint for JS inside JSP files

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/add_domains.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/add_domains.jsp
@@ -52,12 +52,14 @@ String eventName = ParamUtil.getString(request, "eventName", liferayPortletRespo
 
 		// Email domain regex from aui-form-validator.js
 
-		const pattern = new RegExp(
+		var pattern = new RegExp(
 			'^((([a-z]|\\d|[\\u00A0-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFEF])|(([a-z]|\\d|[\\u00A0-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFEF])([a-z]|\\d|-|\\.|_|~|[\\u00A0-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFEF])*([a-z]|\\d|[\\u00A0-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFEF])))\\.)+(([a-z]|[\\u00A0-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFEF])|(([a-z]|[\\u00A0-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFEF])([a-z]|\\d|-|\\.|_|~|[\\u00A0-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFEF])*([a-z]|[\\u00A0-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFEF])))\\.?$',
 			'i'
 		);
 
-		for (const domain of domains) {
+		for (var i = 0; i < domains.length; i++) {
+			var domain = domains[i];
+
 			if (!pattern.test(domain.trim())) {
 				var domainAlert = document.getElementById(
 					'<portlet:namespace />domainAlert'

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
@@ -264,7 +264,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 </liferay-frontend:edit-form>
 
 <aui:script require="metal-dom/src/dom">
-	let dom = metalDomSrcDom.default;
+	var dom = metalDomSrcDom.default;
 
 	var form = document.getElementById('<portlet:namespace />fm');
 

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/entry_select_scope.jspf
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/entry_select_scope.jspf
@@ -119,7 +119,7 @@ boolean hasDistributionScope = false;
 
 <c:if test="<%= !hasDistributionScope %>">
 	<aui:script require="metal-dom/src/dom">
-		let dom = metalDomSrcDom.default;
+		var dom = metalDomSrcDom.default;
 
 		dom.addClasses('#<portlet:namespace />fieldSet', 'hide');
 	</aui:script>

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category_action.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category_action.jsp
@@ -100,7 +100,7 @@ AssetCategory category = (AssetCategory)row.getObject();
 
 		if (moveCategoryIcon) {
 			moveCategoryIcon.addEventListener('click', function(event) {
-				const itemSelectorDialog = new ItemSelectorDialog.default({
+				var itemSelectorDialog = new ItemSelectorDialog.default({
 					eventName: '<portlet:namespace />selectCategory',
 					singleSelect: true,
 					title:
@@ -111,7 +111,7 @@ AssetCategory category = (AssetCategory)row.getObject();
 				itemSelectorDialog.open();
 
 				itemSelectorDialog.on('selectedItemChange', function(event) {
-					const selectedItem = event.selectedItem;
+					var selectedItem = event.selectedItem;
 
 					if (selectedItem) {
 						var parentCategoryId = 0;

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
@@ -158,9 +158,9 @@
 		function(event) {
 			event.preventDefault();
 
-			const delegateTarget = event.delegateTarget;
+			var delegateTarget = event.delegateTarget;
 
-			const itemSelectorDialog = new ItemSelectorDialog.default({
+			var itemSelectorDialog = new ItemSelectorDialog.default({
 				eventName: '<portlet:namespace />selectAsset',
 				title: encodeURI(delegateTarget.dataset.title),
 				url: delegateTarget.dataset.href
@@ -169,10 +169,10 @@
 			itemSelectorDialog.open();
 
 			itemSelectorDialog.on('selectedItemChange', function(event) {
-				const selectedItems = event.selectedItem;
+				var selectedItems = event.selectedItem;
 
 				if (selectedItems) {
-					const assetEntryIds = [];
+					var assetEntryIds = [];
 
 					Array.prototype.forEach.call(selectedItems, function(
 						assetEntry

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/add_asset_selector.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/add_asset_selector.jsp
@@ -109,13 +109,13 @@ String redirect = PortalUtil.getLayoutFullURL(layout, themeDisplay);
 
 <aui:script>
 	function <portlet:namespace />addAssetEntry() {
-		const visibleItem = document.querySelector('.asset-entry-type:not(.hide)');
+		var visibleItem = document.querySelector('.asset-entry-type:not(.hide)');
 
-		const assetEntryTypeSelector = visibleItem.querySelector(
+		var assetEntryTypeSelector = visibleItem.querySelector(
 			'.asset-entry-type-select'
 		);
 
-		const selectedOption =
+		var selectedOption =
 			assetEntryTypeSelector.options[assetEntryTypeSelector.selectedIndex];
 
 		Liferay.Util.navigate(selectedOption.dataset.url);

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
@@ -255,9 +255,9 @@ for (long groupId : groupIds) {
 		function(event) {
 			event.preventDefault();
 
-			const delegateTarget = event.delegateTarget;
+			var delegateTarget = event.delegateTarget;
 
-			const itemSelectorDialog = new ItemSelectorDialog.default({
+			var itemSelectorDialog = new ItemSelectorDialog.default({
 				eventName: '<%= eventName %>',
 				title: delegateTarget.dataset.title,
 				url: delegateTarget.dataset.href
@@ -266,7 +266,7 @@ for (long groupId : groupIds) {
 			itemSelectorDialog.open();
 
 			itemSelectorDialog.on('selectedItemChange', function(event) {
-				const selectedItems = event.selectedItem;
+				var selectedItems = event.selectedItem;
 
 				if (selectedItems) {
 					selectAssets(selectedItems);

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
@@ -142,7 +142,7 @@ SearchContainer searchContainer = assetPublisherDisplayContext.getSearchContaine
 </c:if>
 
 <aui:script sandbox="<%= true %>">
-	const assetEntryId = '<%= assetPublisherDisplayContext.getAssetEntryId() %>';
+	var assetEntryId = '<%= assetPublisherDisplayContext.getAssetEntryId() %>';
 
 	if (assetEntryId) {
 		window.location.hash = assetEntryId;

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
@@ -94,7 +94,7 @@
 	);
 
 	chooseSpecificDisplayPage.addEventListener('click', function(event) {
-		const itemSelectorDialog = new ItemSelectorDialog.default({
+		var itemSelectorDialog = new ItemSelectorDialog.default({
 			eventName: '<%= selectAssetDisplayPageDisplayContext.getEventName() %>',
 			singleSelect: true,
 			title: '<liferay-ui:message key="select-page" />',
@@ -105,7 +105,7 @@
 		itemSelectorDialog.open();
 
 		itemSelectorDialog.on('selectedItemChange', function(event) {
-			const selectedItem = event.selectedItem;
+			var selectedItem = event.selectedItem;
 
 			assetDisplayPageIdInput.value = '';
 

--- a/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/select_single.jsp
+++ b/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/select_single.jsp
@@ -62,7 +62,7 @@ assetTagsSelectorDisplayContext = new AssetTagsSelectorDisplayContext(renderRequ
 </aui:form>
 
 <aui:script>
-	const Util = Liferay.Util;
+	var Util = Liferay.Util;
 
 	Util.selectEntityHandler(
 		'#<portlet:namespace />selectAssetTagFm',

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/configuration.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/configuration.jsp
@@ -137,7 +137,7 @@ if (organizationId > 0) {
 				</aui:script>
 
 				<aui:script require="metal-dom/src/dom">
-					let dom = metalDomSrcDom.default;
+					var dom = metalDomSrcDom.default;
 
 					var <portlet:namespace />selectionMethod = document.getElementById(
 						'<portlet:namespace />selectionMethod'

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/global_settings.jspf
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/global_settings.jspf
@@ -38,10 +38,9 @@
 	function <portlet:namespace />doSubmitRedirectToOverview() {
 		event.preventDefault();
 
-		const form = document.<portlet:namespace />fm;
+		var form = document.<portlet:namespace />fm;
 
-		const redirectToOverviewInput =
-			form.<portlet:namespace />redirectToOverview;
+		var redirectToOverviewInput = form.<portlet:namespace />redirectToOverview;
 
 		redirectToOverviewInput.value = true;
 
@@ -49,9 +48,9 @@
 	}
 
 	function <portlet:namespace />updateSubmitRedirectToOverview() {
-		const form = document.<portlet:namespace />fm;
+		var form = document.<portlet:namespace />fm;
 
-		const enableChangeListsInput = form.<portlet:namespace />enableChangeLists;
+		var enableChangeListsInput = form.<portlet:namespace />enableChangeLists;
 
 		Liferay.Util.toggleDisabled(
 			'#<portlet:namespace />submitRedirectToOverview',

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -705,7 +705,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 					}
 				);
 
-				if (!!response.commentId) {
+				if (response.commentId) {
 					var messageTextNode = document.querySelector(
 						'input[name^="<%= namespace %>body"]'
 					);

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/languages.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/languages.jsp
@@ -194,27 +194,27 @@ boolean inheritLocales = GetterUtil.getBoolean(typeSettingsProperties.getPropert
 </script>
 
 <aui:script use="aui-alert,aui-base">
-	const languageSelectInput = A.one('#<portlet:namespace />languageId');
+	var languageSelectInput = A.one('#<portlet:namespace />languageId');
 
 	if (languageSelectInput) {
-		const nameMapString = '<%= nameMap %>';
+		var nameMapString = '<%= nameMap %>';
 
 		languageSelectInput.on('change', function(event) {
-			const select = event.currentTarget.getDOMNode();
+			var select = event.currentTarget.getDOMNode();
 
-			const selectedOption = select.options[select.selectedIndex];
+			var selectedOption = select.options[select.selectedIndex];
 
 			Liferay.fire('inputLocalized:defaultLocaleChanged', {
 				item: selectedOption
 			});
 
-			const defaultLanguage = languageSelectInput.val();
+			var defaultLanguage = languageSelectInput.val();
 
 			var defaultLanguageName = null;
 
 			if (nameMapString) {
 				try {
-					let nameMap = JSON.parse(nameMapString);
+					var nameMap = JSON.parse(nameMapString);
 					if (nameMap) {
 						defaultLanguageName = nameMap[defaultLanguage];
 					}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance.jsp
@@ -106,7 +106,8 @@ FormInstancePermissionCheckerHelper formInstancePermissionCheckerHelper = ddmFor
 <aui:script require='<%= mainRequire + "/admin/js/components/ShareFormPopover/ShareFormPopover.es as ShareFormPopover" %>'>
 	var spritemap = themeDisplay.getPathThemeImages() + '/lexicon/icons.svg';
 
-	Liferay.after('<portlet:namespace />copyFormURL', function({url}) {
+	Liferay.after('<portlet:namespace />copyFormURL', function(data) {
+		var url = data.url;
 		var trigger = Liferay.Menu._INSTANCE._activeTrigger;
 
 		var popover = new ShareFormPopover.default({
@@ -116,8 +117,8 @@ FormInstancePermissionCheckerHelper formInstancePermissionCheckerHelper = ddmFor
 					popover.dispose();
 				}
 			},
-			spritemap,
-			url,
+			spritemap: spritemap,
+			url: url,
 			visible: true
 		});
 	});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
@@ -212,7 +212,7 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 							</liferay-portlet:resourceURL>
 
 							function <portlet:namespace />autoSave() {
-								const data = new URLSearchParams({
+								var data = new URLSearchParams({
 									<portlet:namespace />formInstanceId: <%= formInstanceId %>,
 									<portlet:namespace />serializedDDMFormValues: JSON.stringify(
 										<portlet:namespace />form.toJSON()
@@ -259,7 +259,7 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 					</c:choose>
 
 					function <portlet:namespace />enableForm() {
-						const container = document.querySelector(
+						var container = document.querySelector(
 							'#<%= ddmFormDisplayContext.getContainerId() %>container'
 						);
 

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/advanced_properties.jspf
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/advanced_properties.jspf
@@ -142,9 +142,9 @@
 	function populatePrecisionType(precisionTypeElement, numberSize) {
 		var numberSizeOptions = '';
 
-		for (var bit of numberSize) {
+		numberSize.forEach(function(bit) {
 			numberSizeOptions += '<option value="' + bit + '">' + bit + '</option>';
-		}
+		});
 
 		precisionTypeElement.innerHTML = numberSizeOptions;
 	}

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/default_value_input.jspf
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/default_value_input.jspf
@@ -320,7 +320,7 @@
 	}
 
 	function updateElement(formElementIds, action) {
-		for (var formElementId of formElementIds) {
+		formElementIds.forEach(function(formElementId) {
 			var formElement = document.getElementById(
 				'<portlet:namespace />' + formElementId
 			);
@@ -338,6 +338,6 @@
 					formElement.classList.remove('hide');
 				}
 			}
-		}
+		});
 	}
 </script>

--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
@@ -191,7 +191,7 @@
 
 <c:if test='<%= iFramePortletInstanceConfiguration.auth() && StringUtil.equals(iFramePortletInstanceConfiguration.authType(), "basic") %>'>
 	<aui:script>
-		const headers = new Headers();
+		var headers = new Headers();
 
 		headers.append(
 			'Authorization',

--- a/modules/apps/invitation/invitation-invite-members-web/src/main/resources/META-INF/resources/invite_members/view.jsp
+++ b/modules/apps/invitation/invitation-invite-members-web/src/main/resources/META-INF/resources/invite_members/view.jsp
@@ -56,7 +56,7 @@ Group group = GroupLocalServiceUtil.getGroup(scopeGroupId);
 	</c:when>
 	<c:otherwise>
 		<aui:script require="metal-dom/src/dom">
-			let dom = metalDomSrcDom.default;
+			var dom = metalDomSrcDom.default;
 
 			var portlet = document.getElementById('p_p_id<portlet:namespace />');
 

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -55,10 +55,10 @@ String redirect = ParamUtil.getString(request, "redirect");
 </liferay-frontend:edit-form>
 
 <aui:script require="metal-dom/src/all/dom as dom, frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
-	const articlePreview = document.getElementById(
+	var articlePreview = document.getElementById(
 		'<portlet:namespace />articlePreview'
 	);
-	const assetEntryIdInput = document.getElementById(
+	var assetEntryIdInput = document.getElementById(
 		'<portlet:namespace />assetEntryId'
 	);
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -158,7 +158,7 @@ renderResponse.setTitle(title);
 								selectFolderButton.addEventListener('click', function(event) {
 									event.preventDefault();
 
-									const itemSelectorDialog = new ItemSelectorDialog.default({
+									var itemSelectorDialog = new ItemSelectorDialog.default({
 										eventName: '<portlet:namespace />selectFolder',
 										singleSelect: true,
 										title: '<liferay-ui:message arguments="folder" key="select-x" />',
@@ -175,7 +175,7 @@ renderResponse.setTitle(title);
 									itemSelectorDialog.open();
 
 									itemSelectorDialog.on('selectedItemChange', function(event) {
-										const selectedItem = event.selectedItem;
+										var selectedItem = event.selectedItem;
 
 										if (selectedItem) {
 											var folderData = {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
@@ -98,7 +98,7 @@ JournalViewMoreMenuItemsDisplayContext journalViewMoreMenuItemsDisplayContext = 
 <aui:script require="metal-dom/src/all/dom as dom">
 	var Util = Liferay.Util;
 
-	const addMenuItemFm = document.getElementById(
+	var addMenuItemFm = document.getElementById(
 		'<portlet:namespace />addMenuItemFm'
 	);
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
@@ -165,16 +165,16 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 </div>
 
 <aui:script require="metal-dom/src/all/dom as dom">
-	const layoutPageTemplateEntries = document.getElementById(
+	var layoutPageTemplateEntries = document.getElementById(
 		'<portlet:namespace />layoutPageTemplateEntries'
 	);
 
-	const addLayoutActionOptionQueryClickHandler = dom.delegate(
+	var addLayoutActionOptionQueryClickHandler = dom.delegate(
 		layoutPageTemplateEntries,
 		'click',
 		'.add-layout-action-option',
 		function(event) {
-			const actionElement = event.delegateTarget;
+			var actionElement = event.delegateTarget;
 
 			Liferay.Util.openWindow({
 				dialog: {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
@@ -156,7 +156,7 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 			document.<portlet:namespace />layoutPageTemplateCollectionsFm;
 
 		if (layoutPageTemplateCollectionsFm) {
-			const itemSelectorDialog = new ItemSelectorDialog.default({
+			var itemSelectorDialog = new ItemSelectorDialog.default({
 				buttonAddLabel: '<liferay-ui:message key="delete" />',
 				eventName: '<portlet:namespace />selectCollections',
 				title: '<liferay-ui:message key="delete-collection" />',
@@ -165,7 +165,7 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 			});
 
 			itemSelectorDialog.on('selectedItemChange', function(event) {
-				const selectedItems = event.selectedItem;
+				var selectedItems = event.selectedItem;
 
 				if (selectedItems) {
 					if (

--- a/modules/apps/nested-portlets/nested-portlets-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/main/resources/META-INF/resources/view.jsp
@@ -22,7 +22,7 @@
 	</div>
 
 	<aui:script require="metal-dom/src/dom">
-		let dom = metalDomSrcDom.default;
+		var dom = metalDomSrcDom.default;
 
 		var portletWrapper = document.getElementById(
 			'p_p_id_<%= portletDisplay.getId() %>_'

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
@@ -50,13 +50,13 @@
 				'change',
 				'input[type=checkbox]',
 				function(event) {
-					const toggle = event.delegateTarget;
+					var toggle = event.delegateTarget;
 
-					const disableOnChecked = toggle.dataset.disableonchecked;
-					const inputs = document.querySelectorAll(toggle.dataset.inputselector);
+					var disableOnChecked = toggle.dataset.disableonchecked;
+					var inputs = document.querySelectorAll(toggle.dataset.inputselector);
 
-					for (let i = 0; i < inputs.length; i++) {
-						const input = inputs[i];
+					for (var i = 0; i < inputs.length; i++) {
+						var input = inputs[i];
 
 						input.disabled = disableOnChecked
 							? !toggle.checked

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
@@ -82,7 +82,7 @@ pageTypeSelectorData.put("namespace", PortalUtil.getPortletNamespace(ProductNavi
 
 <aui:script>
 	function destroyTreeComponent() {
-		Liferay.destroyComponent(`${props.namespace}pagesTree`);
+		Liferay.destroyComponent(props.namespace + 'pagesTree');
 		Liferay.detach('destroyPortlet', destroyTreeComponent);
 	}
 

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
@@ -62,15 +62,15 @@ portletURL.setWindowState(LiferayWindowState.EXCLUSIVE);
 					return response.text();
 				})
 				.then(function(response) {
-					const sidebar = document.querySelector('.sidebar-body');
+					var sidebar = document.querySelector('.sidebar-body');
 					sidebar.innerHTML = '';
 
-					const range = document.createRange();
+					var range = document.createRange();
 					range.selectNode(sidebar);
 
-					const fragment = range.createContextualFragment(response);
+					var fragment = range.createContextualFragment(response);
 
-					const pagesTree = document.createElement('div');
+					var pagesTree = document.createElement('div');
 					pagesTree.setAttribute('class', 'pages-tree');
 					pagesTree.appendChild(fragment);
 

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role.jsp
@@ -194,17 +194,17 @@ renderResponse.setTitle((role == null) ? LanguageUtil.get(request, "new-role") :
 
 <c:if test="<%= role == null %>">
 	<aui:script require="frontend-js-web/liferay/debounce/debounce.es as debounceModule">
-		const form = document.getElementById('<portlet:namespace />fm');
+		var form = document.getElementById('<portlet:namespace />fm');
 
 		if (form) {
-			const nameInput = form.querySelector('#<portlet:namespace />name');
-			const titleInput = form.querySelector('#<portlet:namespace />title');
+			var nameInput = form.querySelector('#<portlet:namespace />name');
+			var titleInput = form.querySelector('#<portlet:namespace />title');
 
 			if (nameInput && titleInput) {
-				const debounce = debounceModule.default;
+				var debounce = debounceModule.default;
 
-				const handleOnTitleInput = function(event) {
-					let value = event.target.value;
+				var handleOnTitleInput = function(event) {
+					var value = event.target.value;
 
 					if (nameInput.hasAttribute('maxLength')) {
 						value = value.substring(0, nameInput.getAttribute('maxLength'));

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/edit_site_navigation_menu.jsp
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/edit_site_navigation_menu.jsp
@@ -157,16 +157,15 @@ sb.append("/js/SiteNavigationMenuItemDOMHandler.es as siteNavigationMenuItemDOMH
 	var showSiteNavigationMenuSettingsButtonClickHandler = null;
 	var sidebar = null;
 	var sidebarBodyChangeHandler = null;
+	var sidebarHeaderButtonClickEventListener = null;
 	var siteNavigationMenuEditor = null;
 	var siteNavigationMenuItemRemoveButtonClickHandler = null;
 	var siteNavigationMenuItemRemoveButtonKeyupHandler = null;
 
-	let sidebarHeaderButtonClickEventListener = null;
-
 	var closeSidebar = function() {
-		let form = document.querySelector('#<portlet:namespace />fm');
+		var form = document.querySelector('#<portlet:namespace />fm');
 
-		let error = form ? form.querySelector('[role="alert"]') : null;
+		var error = form ? form.querySelector('[role="alert"]') : null;
 
 		var saveChanges = false;
 
@@ -179,7 +178,7 @@ sb.append("/js/SiteNavigationMenuItemDOMHandler.es as siteNavigationMenuItemDOMH
 		}
 
 		if (saveChanges) {
-			const sidebarForm = document.querySelector(
+			var sidebarForm = document.querySelector(
 				'#<portlet:namespace />sidebarBody form'
 			);
 
@@ -210,7 +209,7 @@ sb.append("/js/SiteNavigationMenuItemDOMHandler.es as siteNavigationMenuItemDOMH
 	};
 
 	var handleSelectedMenuItemChanged = function(event) {
-		const siteNavigationMenuItem = event.newVal;
+		var siteNavigationMenuItem = event.newVal;
 
 		if (!closeSidebar() || !siteNavigationMenuItem) {
 			return;
@@ -307,11 +306,11 @@ sb.append("/js/SiteNavigationMenuItemDOMHandler.es as siteNavigationMenuItemDOMH
 				return response.text();
 			})
 			.then(function(responseContent) {
-				const sidebarBody = document.getElementById(
+				var sidebarBody = document.getElementById(
 					'<portlet:namespace />sidebarBody'
 				);
 
-				const sidebarHeaderButton = document.getElementById(
+				var sidebarHeaderButton = document.getElementById(
 					'<portlet:namespace />sidebarHeaderButton'
 				);
 

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
@@ -92,7 +92,7 @@ if (selLayout != null) {
 		Liferay.Loader.require(
 			'frontend-js-web/liferay/ItemSelectorDialog.es',
 			function(ItemSelectorDialog) {
-				const itemSelectorDialog = new ItemSelectorDialog.default({
+				var itemSelectorDialog = new ItemSelectorDialog.default({
 					eventName: '<%= eventName %>',
 					singleSelect: true,
 					title: '<liferay-ui:message key="select-layout" />',

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -331,7 +331,7 @@ else {
 				uri
 			);
 
-			const itemSelectorDialog = new ItemSelectorDialog.default({
+			var itemSelectorDialog = new ItemSelectorDialog.default({
 				eventName:
 					'<%= siteNavigationMenuDisplayContext.getRootMenuItemEventName() %>',
 				singleSelect: true,
@@ -341,7 +341,7 @@ else {
 			});
 
 			itemSelectorDialog.on('selectedItemChange', function(event) {
-				const selectedItem = event.selectedItem;
+				var selectedItem = event.selectedItem;
 
 				if (selectedItem) {
 					rootMenuItemIdInput.value =

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/display_settings.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/display_settings.jsp
@@ -208,21 +208,21 @@ if ((publicLayoutSet.isLayoutSetPrototypeLinkEnabled() || privateLayoutSet.isLay
 </script>
 
 <aui:script use="aui-alert,aui-base">
-	const languageSelectInput = A.one('#<portlet:namespace />languageId');
+	var languageSelectInput = A.one('#<portlet:namespace />languageId');
 
 	if (languageSelectInput) {
-		const nameInput = Liferay.component('<portlet:namespace />name');
+		var nameInput = Liferay.component('<portlet:namespace />name');
 
 		languageSelectInput.on('change', function(event) {
-			const select = event.currentTarget.getDOMNode();
+			var select = event.currentTarget.getDOMNode();
 
-			const selectedOption = select.options[select.selectedIndex];
+			var selectedOption = select.options[select.selectedIndex];
 
 			Liferay.fire('inputLocalized:defaultLocaleChanged', {
 				item: selectedOption
 			});
 
-			const defaultLanguage = languageSelectInput.val();
+			var defaultLanguage = languageSelectInput.val();
 
 			var defaultLanguageSiteName = null;
 

--- a/modules/apps/site/site-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -119,9 +119,9 @@
 </aui:form>
 
 <aui:script>
-	const Util = Liferay.Util;
+	var Util = Liferay.Util;
 
-	const openingLiferay = Util.getOpener().Liferay;
+	var openingLiferay = Util.getOpener().Liferay;
 
 	openingLiferay.fire('<portlet:namespace />enableRemovedSites', {
 		selectors: document.querySelectorAll('.selector-button:disabled')

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
@@ -219,11 +219,11 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 </portlet:renderURL>
 
 <aui:script require="metal-dom/src/dom as dom">
-	const baseURL = '<%= reviewUADDataURL %>';
+	var baseURL = '<%= reviewUADDataURL %>';
 
-	const clickListeners = [];
+	var clickListeners = [];
 
-	const registerClickHandler = function(element, clickHandlerFn) {
+	var registerClickHandler = function(element, clickHandlerFn) {
 		clickListeners.push(
 			dom.delegate(element, 'click', 'input', clickHandlerFn)
 		);
@@ -232,7 +232,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 	registerClickHandler(<portlet:namespace />applicationPanelBody, function(
 		event
 	) {
-		const url = new URL(baseURL, window.location.origin);
+		var url = new URL(baseURL, window.location.origin);
 
 		url.searchParams.set(
 			'<portlet:namespace />applicationKey',
@@ -246,7 +246,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 		registerClickHandler(<portlet:namespace />entitiesTypePanelBody, function(
 			event
 		) {
-			const url = new URL(baseURL, window.location.origin);
+			var url = new URL(baseURL, window.location.origin);
 
 			url.searchParams.set(
 				'<portlet:namespace />uadRegistryKey',
@@ -258,7 +258,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 	</c:if>
 
 	registerClickHandler(<portlet:namespace />scopePanelBody, function(event) {
-		const url = new URL(baseURL, window.location.origin);
+		var url = new URL(baseURL, window.location.origin);
 
 		url.searchParams.set('<portlet:namespace />applicationKey', '');
 		url.searchParams.set('<portlet:namespace />scope', event.target.value);
@@ -267,7 +267,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 	});
 
 	function handleDestroyPortlet() {
-		for (let i = 0; i < clickListeners.length; i++) {
+		for (var i = 0; i < clickListeners.length; i++) {
 			clickListeners[i].removeListener();
 		}
 

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -178,7 +178,7 @@ PortletURL portletURL = viewUserGroupsManagementToolbarDisplayContext.getPortlet
 	<liferay-portlet:resourceURL id="/users_admin/get_users_count" portletName="<%= UsersAdminPortletKeys.USERS_ADMIN %>" var="getUsersCountResourceURL" />
 
 	function <portlet:namespace />getUsersCount(className, ids, status, callback) {
-		const url = new URL(
+		var url = new URL(
 			'<%= getUsersCountResourceURL %>',
 			window.location.origin
 		);

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_address.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_address.jsp
@@ -142,7 +142,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 </aui:form>
 
 <aui:script use="liferay-form">
-	const addressCountry = document.getElementById(
+	var addressCountry = document.getElementById(
 		'<portlet:namespace />addressCountryId'
 	);
 
@@ -163,7 +163,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 	}
 
 	function handleSelectChange(event) {
-		const value = Number(event.currentTarget.value);
+		var value = Number(event.currentTarget.value);
 
 		if (value > 0) {
 			checkCountry(value);
@@ -173,13 +173,13 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 	}
 
 	function updateAddressZipRequired(required) {
-		const addressZipRequiredWrapper = document.getElementById(
+		var addressZipRequiredWrapper = document.getElementById(
 			'<portlet:namespace />addressZipRequiredWrapper'
 		);
-		const formValidator = Liferay.Form.get('<portlet:namespace />fm')
+		var formValidator = Liferay.Form.get('<portlet:namespace />fm')
 			.formValidator;
 
-		const rules = formValidator._getAttr('rules');
+		var rules = formValidator._getAttr('rules');
 
 		if (required) {
 			addressZipRequiredWrapper.removeAttribute('hidden');


### PR DESCRIPTION
Three major categories of problems fixed here:

-   Stuff which isn't well supported by IE: eg. `let` and `const`:

    https://caniuse.com/#search=const
    https://caniuse.com/#search=let

-   Stuff which will make IE blow up: template literals, `for`/`of` syntax, object property shorthand, destructuring etc.

    https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of

-   Unnecessary boolean coercion.

All of these problems were found by passing JS in JSP through ESLint, which I will automate with a separate update to liferay-npm-scripts (see LPS-10254).