### PR TITLE
LPS-105364 Improve accessibility of Treeview component

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/NodeList.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/NodeList.js
@@ -25,6 +25,7 @@ export default function NodeList({
 	nodes,
 	onBlur,
 	onFocus,
+	role = 'group',
 	tabIndex = -1
 }) {
 	const {dispatch} = useContext(TreeviewContext);
@@ -58,6 +59,7 @@ export default function NodeList({
 			}}
 			onKeyDown={handleKeyDown}
 			ref={focusable}
+			role={role}
 			tabIndex={tabIndex}
 		>
 			{nodes.map(node => (

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/TreeviewCard.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/TreeviewCard.js
@@ -48,7 +48,7 @@ export default function TreeviewCard({node}) {
 		) : null;
 
 	return (
-		<div className="p-2">
+		<div className="p-2" role="treeitem">
 			<ClayCard
 				className={classNames({
 					disabled: node.disabled,
@@ -59,7 +59,6 @@ export default function TreeviewCard({node}) {
 				onClick={() => {
 					dispatch({nodeId: node.id, type: 'TOGGLE_SELECT'});
 				}}
-				role="treeitem"
 				selectable={true}
 			>
 				<ClayCard.Body>


### PR DESCRIPTION
We're not correctly setting the role attributes as specified here:

https://www.w3.org/WAI/GL/wiki/Using_ARIA_trees

We had `role="treeview"` at the top, but we weren't propagating that to the DOM, and we were missing `role="group"` on nodes with children. We had `role="treeitem"` on the `TreeviewCard` component, but that wasn't working either because `ClayCard` was overwriting it with `role="button"`.