### PR TITLE
[TS] LPS-102763 LDAP password gets overridden if the login fails for the first time

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.AuthException;
 import com.liferay.portal.kernel.security.auth.Authenticator;
+import com.liferay.portal.kernel.security.auth.PasswordModificationThreadLocal;
 import com.liferay.portal.kernel.security.ldap.LDAPSettings;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -382,6 +383,10 @@ public class LDAPAuth implements Authenticator {
 
 			User user = _ldapUserImporter.importUser(
 				ldapServerId, companyId, safeLdapContext, attributes, password);
+
+			if (!ldapAuthResult.isAuthenticated()) {
+				PasswordModificationThreadLocal.setPasswordModified(false);
+			}
 
 			// Process LDAP failure codes
 


### PR DESCRIPTION
Hi Brian,

https://issues.liferay.com/browse/LPS-102763

No relevant tests failures (https://github.com/topolik/liferay-portal/pull/821)

Thanks.

/cc @stian-sigvartsen