### PR TITLE
LPS-105452 Fix unwanted unmount/remount on dispatch

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Sidebar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Sidebar.js
@@ -200,7 +200,8 @@ export default function Sidebar() {
 						<ErrorBoundary handleError={() => setHasError(true)}>
 							<Suspense fallback={<ClayLoadingIndicator />}>
 								<SidebarPanel
-									plugin={getInstance(activePluginId)}
+									getInstance={getInstance}
+									pluginId={activePluginId}
 								/>
 							</Suspense>
 						</ErrorBoundary>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Toolbar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Toolbar.js
@@ -109,9 +109,8 @@ function ToolbarBody() {
 										}
 									>
 										<ToolbarSection
-											plugin={getInstance(
-												pluginEntryPoint
-											)}
+											getInstance={getInstance}
+											pluginId={pluginEntryPoint}
 										/>
 									</Suspense>
 								</ErrorBoundary>


### PR DESCRIPTION
Normally you would call `React.lazy` once at the top level of your module like this:

```javascript
const Something = React.lazy(() => import('./Something'));
```

That's not an option for us for a few reasons:

- We have to use `Liferay.Loader.require` under the covers instead of dynamic `import` calls.
- We don't know at build time what modules will be defined or necessary at runtime; we only find that out dynamically at runtime when the server tells us what plugins should be loaded (for now we're faking this but eventually plugins will be actually separate OSGi modules).
- `React.lazy` expects the module to export a component as its default but our plugins have one additionally layer of indirection -- a non-component plugin instance for managing the overall lifecycle -- and that requires us to construct a promise that returns a fake "module" with the expected shape.

So, because we are calling `React.lazy` in a way that is more dynamic than usual, we need to take special care to ensure that we only call it once for each module, otherwise React will unmount and remount our plugin components on every update.