### PR TITLE
LPS-105111 Use function declarations instead of arrow functions

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/js/main.js
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/js/main.js
@@ -12,7 +12,8 @@
  * details.
  */
 
-AUI().ready('liferay-sign-in-modal', A => {
+/* eslint-disable prefer-arrow-callback */
+AUI().ready('liferay-sign-in-modal', function(A) {
 	var signIn = A.one('.sign-in > a');
 
 	if (signIn && signIn.getData('redirect') !== 'true') {

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/js/main.js
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/js/main.js
@@ -12,13 +12,14 @@
  * details.
  */
 
+/* eslint-disable prefer-arrow-callback */
 AUI().ready(
 	/*
 	This function gets loaded when all the HTML, not including the portlets, is
 	loaded.
 	*/
 
-	() => {}
+	function() {}
 );
 
 Liferay.Portlet.ready(
@@ -29,7 +30,7 @@ Liferay.Portlet.ready(
 	node: the Alloy Node object of the current portlet
 	*/
 
-	(_portletId, _node) => {}
+	function(_portletId, _node) {}
 );
 
 Liferay.on(
@@ -40,5 +41,5 @@ Liferay.on(
 	the page.
 	*/
 
-	() => {}
+	function() {}
 );


### PR DESCRIPTION
Themes aren't transpiled, and therefore the use of arrow functions
in older browsers like IE11 causes syntax errors. 
For the moment we're disabling an eslint rule that forces to use arrow functions for callbacks.