### PR TITLE
LPS-104801 | Correct inconsistency displaying the template language extension

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditDDMTemplateDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditDDMTemplateDisplayContext.java
@@ -309,7 +309,7 @@ public class JournalEditDDMTemplateDisplayContext {
 		sb.append(StringPool.SPACE);
 		sb.append(StringPool.OPEN_PARENTHESIS);
 		sb.append(StringPool.PERIOD);
-		sb.append(getLanguage());
+		sb.append(templateLanguageType);
 		sb.append(StringPool.CLOSE_PARENTHESIS);
 
 		return sb.toString();


### PR DESCRIPTION
Hi @brianchandotcom, 

This is a small correction to LPS-104801 to show the correct extension  of each template language, instead of the same one for all available languages (that of the display context). 

Please let me know if you have any questions. 
Thanks!