### PR TITLE
LPS-104941 - Fix result rankings test async timeout error in CI (Frontend Jest Test)

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/js/setup.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/js/setup.es.js
@@ -14,6 +14,13 @@ const LanguageUtil = require('../../src/main/resources/META-INF/resources/js/uti
 import {FETCH_HIDDEN_DOCUMENTS_URL, getMockResultsData} from './mocks/data.es';
 
 /**
+ * Extends the timeout session to prevent the following error: 'Timeout - Async
+ * callback was not invoked within the 5000ms timeout specified by
+ * jest.setTimeout.Error'
+ */
+jest.setTimeout(10000);
+
+/**
  * Mocks the `sub` function to be able to test the correct values are being
  * passed and displayed.
  */


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-104941

✔️ ci:test:sf - 1 out of 1 jobs passed in 2 minutes 33 seconds 893 ms https://github.com/thektan/liferay-portal/pull/105#issuecomment-564232875
❌ ci:test:search - 46 out of 51 jobs passed in 1 hour 57 minutes 10 seconds 362 ms https://github.com/thektan/liferay-portal/pull/105#issuecomment-564284054

1 unique failure, but shouldn't be related since it seems like an issue with the CI server. I contacted @joshchong to look further into it.

cc @oliv-yu