### PR TITLE
LPS-105653 Use BeforeClass annotation pattern to set up ElasticsearchFixture for ES7

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchSearchEngineTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchSearchEngineTest.java
@@ -41,9 +41,10 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.SnapshotClient;
 import org.elasticsearch.snapshots.SnapshotInfo;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -51,13 +52,21 @@ import org.junit.Test;
  */
 public class ElasticsearchSearchEngineTest {
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeClass
+	public static void setUpClass() throws Exception {
 		_elasticsearchFixture = new ElasticsearchFixture(
 			ElasticsearchSearchEngineTest.class.getSimpleName());
 
 		_elasticsearchFixture.setUp();
+	}
 
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_elasticsearchFixture.tearDown();
+	}
+
+	@Before
+	public void setUp() throws Exception {
 		_elasticsearchConnectionManager = createElasticsearchConnectionManager(
 			_elasticsearchFixture.getEmbeddedElasticsearchConnection());
 
@@ -74,11 +83,6 @@ public class ElasticsearchSearchEngineTest {
 
 		_searchEngineAdapter =
 			elasticsearchEngineAdapterFixture.getSearchEngineAdapter();
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		_elasticsearchFixture.tearDown();
 	}
 
 	@Test
@@ -259,8 +263,9 @@ public class ElasticsearchSearchEngineTest {
 		elasticsearchConnectionManager.connect();
 	}
 
+	private static ElasticsearchFixture _elasticsearchFixture;
+
 	private ElasticsearchConnectionManager _elasticsearchConnectionManager;
-	private ElasticsearchFixture _elasticsearchFixture;
 	private SearchEngineAdapter _searchEngineAdapter;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/EmbeddedElasticsearchConnectionHttpTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/EmbeddedElasticsearchConnectionHttpTest.java
@@ -38,9 +38,10 @@ import org.elasticsearch.client.RestHighLevelClient;
 
 import org.hamcrest.CoreMatchers;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.mockito.MockitoAnnotations;
@@ -50,11 +51,9 @@ import org.mockito.MockitoAnnotations;
  */
 public class EmbeddedElasticsearchConnectionHttpTest {
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeClass
+	public static void setUpClass() throws Exception {
 		setUpJSONFactoryUtil();
-
-		MockitoAnnotations.initMocks(this);
 
 		_clusterName = RandomTestUtil.randomString();
 
@@ -71,9 +70,14 @@ public class EmbeddedElasticsearchConnectionHttpTest {
 		_elasticsearchFixture.setUp();
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@AfterClass
+	public static void tearDownClass() throws Exception {
 		_elasticsearchFixture.tearDown();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
 	}
 
 	@Test
@@ -86,6 +90,12 @@ public class EmbeddedElasticsearchConnectionHttpTest {
 			status,
 			CoreMatchers.containsString(
 				"\"cluster_name\" : \"" + _clusterName));
+	}
+
+	protected static void setUpJSONFactoryUtil() {
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(_jsonFactory);
 	}
 
 	protected int getHttpPort() throws Exception {
@@ -124,20 +134,14 @@ public class EmbeddedElasticsearchConnectionHttpTest {
 		return 0;
 	}
 
-	protected void setUpJSONFactoryUtil() {
-		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
-
-		jsonFactoryUtil.setJSONFactory(_jsonFactory);
-	}
-
 	protected String toString(URL url) throws Exception {
 		try (InputStream inputStream = url.openStream()) {
 			return StringUtil.read(inputStream);
 		}
 	}
 
-	private String _clusterName;
-	private ElasticsearchFixture _elasticsearchFixture;
-	private final JSONFactory _jsonFactory = new JSONFactoryImpl();
+	private static String _clusterName;
+	private static ElasticsearchFixture _elasticsearchFixture;
+	private static final JSONFactory _jsonFactory = new JSONFactoryImpl();
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactoryTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactoryTest.java
@@ -38,9 +38,10 @@ import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -50,13 +51,21 @@ import org.junit.rules.TestName;
  */
 public class CompanyIndexFactoryTest {
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeClass
+	public static void setUpClass() throws Exception {
 		_elasticsearchFixture = new ElasticsearchFixture(
 			CompanyIndexFactoryTest.class.getSimpleName());
 
 		_elasticsearchFixture.setUp();
+	}
 
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_elasticsearchFixture.tearDown();
+	}
+
+	@Before
+	public void setUp() throws Exception {
 		_companyIndexFactoryFixture = new CompanyIndexFactoryFixture(
 			_elasticsearchFixture, testName.getMethodName());
 
@@ -67,11 +76,6 @@ public class CompanyIndexFactoryTest {
 			_elasticsearchFixture.getRestHighLevelClient(),
 			new IndexName(_companyIndexFactoryFixture.getIndexName()),
 			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		_elasticsearchFixture.tearDown();
 	}
 
 	@Test
@@ -426,9 +430,10 @@ public class CompanyIndexFactoryTest {
 			mappings, "kuromoji_liferay_custom", analyzer);
 	}
 
+	private static ElasticsearchFixture _elasticsearchFixture;
+
 	private CompanyIndexFactory _companyIndexFactory;
 	private CompanyIndexFactoryFixture _companyIndexFactoryFixture;
-	private ElasticsearchFixture _elasticsearchFixture;
 	private SingleFieldFixture _singleFieldFixture;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest.java
@@ -22,9 +22,10 @@ import com.liferay.portal.search.elasticsearch7.internal.connection.Elasticsearc
 import com.liferay.portal.search.elasticsearch7.internal.util.ResourceUtil;
 import com.liferay.portal.search.test.util.AssertUtils;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -34,23 +35,26 @@ import org.junit.rules.TestName;
  */
 public class ElasticsearchIndexInformationTest {
 
-	@Before
-	public void setUp() throws Exception {
-		ElasticsearchFixture elasticsearchFixture = new ElasticsearchFixture(
-			getClass());
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_elasticsearchFixture = new ElasticsearchFixture(
+			ElasticsearchIndexInformationTest.class.getSimpleName());
 
-		elasticsearchFixture.setUp();
-
-		_companyIndexFactoryFixture = createCompanyIndexFactoryFixture(
-			elasticsearchFixture);
-		_elasticsearchFixture = elasticsearchFixture;
-		_elasticsearchIndexInformation = createElasticsearchIndexInformation(
-			elasticsearchFixture);
+		_elasticsearchFixture.setUp();
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@AfterClass
+	public static void tearDownClass() throws Exception {
 		_elasticsearchFixture.tearDown();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_companyIndexFactoryFixture = createCompanyIndexFactoryFixture(
+			_elasticsearchFixture);
+
+		_elasticsearchIndexInformation = createElasticsearchIndexInformation(
+			_elasticsearchFixture);
 	}
 
 	@Test
@@ -125,8 +129,9 @@ public class ElasticsearchIndexInformationTest {
 		return _jsonFactory.createJSONObject(json);
 	}
 
+	private static ElasticsearchFixture _elasticsearchFixture;
+
 	private CompanyIndexFactoryFixture _companyIndexFactoryFixture;
-	private ElasticsearchFixture _elasticsearchFixture;
 	private ElasticsearchIndexInformation _elasticsearchIndexInformation;
 	private final JSONFactory _jsonFactory = new JSONFactoryImpl();
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/instant/InstantIndexesTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/instant/InstantIndexesTest.java
@@ -37,9 +37,10 @@ import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -47,16 +48,26 @@ import org.junit.Test;
  */
 public class InstantIndexesTest {
 
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_elasticsearchFixture = new ElasticsearchFixture(
+			InstantIndexesTest.class.getSimpleName());
+
+		_elasticsearchFixture.setUp();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_elasticsearchFixture.tearDown();
+	}
+
 	@Before
 	public void setUp() throws Exception {
-		ElasticsearchFixture elasticsearchFixture = new ElasticsearchFixture(
-			getClass());
-
 		IndexDefinitionsHolderImpl indexDefinitionsHolderImpl =
 			new IndexDefinitionsHolderImpl();
 
 		IndexSynchronizerImpl indexSynchronizerImpl = createIndexSynchronizer(
-			elasticsearchFixture, indexDefinitionsHolderImpl);
+			_elasticsearchFixture, indexDefinitionsHolderImpl);
 
 		IndexSynchronizationPortalInitializedListener
 			indexSynchronizationPortalInitializedListener =
@@ -74,7 +85,6 @@ public class InstantIndexesTest {
 			IndexRegistrar.class, indexSynchronizerImpl::addIndexRegistrar,
 			indexSynchronizationPortalInitializedListener::addIndexRegistrar);
 
-		_elasticsearchFixture = elasticsearchFixture;
 		_eventsIndexDefinition = new EventsIndexDefinition();
 		_indexSynchronizationPortalInitializedListener =
 			indexSynchronizationPortalInitializedListener;
@@ -82,13 +92,6 @@ public class InstantIndexesTest {
 			new InstancesAndProcessesIndexRegistrar();
 		_microcontainer = microcontainer;
 		_tasksIndexDefinition = new TasksIndexDefinition();
-
-		_elasticsearchFixture.setUp();
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		_elasticsearchFixture.tearDown();
 	}
 
 	@Test
@@ -225,7 +228,8 @@ public class InstantIndexesTest {
 		_microcontainer.start();
 	}
 
-	private ElasticsearchFixture _elasticsearchFixture;
+	private static ElasticsearchFixture _elasticsearchFixture;
+
 	private EventsIndexDefinition _eventsIndexDefinition;
 	private IndexSynchronizationPortalInitializedListener
 		_indexSynchronizationPortalInitializedListener;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/logging/ElasticsearchSearchEngineAdapterLoggingTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/logging/ElasticsearchSearchEngineAdapterLoggingTest.java
@@ -31,8 +31,9 @@ import java.util.logging.Level;
 
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -42,33 +43,34 @@ import org.junit.Test;
  */
 public class ElasticsearchSearchEngineAdapterLoggingTest {
 
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_elasticsearchFixture = new ElasticsearchFixture(
+			ElasticsearchSearchEngineAdapterLoggingTest.class.getSimpleName());
+
+		_elasticsearchFixture.setUp();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_elasticsearchFixture.tearDown();
+	}
+
 	@Before
 	public void setUp() throws Exception {
-		ElasticsearchFixture elasticsearchFixture = new ElasticsearchFixture(
-			getClass());
-
 		ElasticsearchEngineAdapterFixture elasticsearchEngineAdapterFixture =
 			new ElasticsearchEngineAdapterFixture() {
 				{
-					setElasticsearchClientResolver(elasticsearchFixture);
+					setElasticsearchClientResolver(_elasticsearchFixture);
 				}
 			};
 
 		elasticsearchEngineAdapterFixture.setUp();
 
-		elasticsearchFixture.setUp();
-
-		waitForElasticsearchToStart(elasticsearchFixture);
-
-		_elasticsearchFixture = elasticsearchFixture;
+		waitForElasticsearchToStart(_elasticsearchFixture);
 
 		_searchEngineAdapter =
 			elasticsearchEngineAdapterFixture.getSearchEngineAdapter();
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		_elasticsearchFixture.tearDown();
 	}
 
 	@Test
@@ -143,7 +145,8 @@ public class ElasticsearchSearchEngineAdapterLoggingTest {
 			});
 	}
 
-	private ElasticsearchFixture _elasticsearchFixture;
+	private static ElasticsearchFixture _elasticsearchFixture;
+
 	private SearchEngineAdapter _searchEngineAdapter;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterClusterRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterClusterRequestTest.java
@@ -41,8 +41,10 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -50,13 +52,23 @@ import org.junit.Test;
  */
 public class ElasticsearchSearchEngineAdapterClusterRequestTest {
 
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_elasticsearchFixture = new ElasticsearchFixture(
+			ElasticsearchSearchEngineAdapterClusterRequestTest.class.
+				getSimpleName());
+
+		_elasticsearchFixture.setUp();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_elasticsearchFixture.tearDown();
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		setUpJSONFactoryUtil();
-
-		_elasticsearchFixture = new ElasticsearchFixture(getClass());
-
-		_elasticsearchFixture.setUp();
 
 		_searchEngineAdapter = createSearchEngineAdapter(_elasticsearchFixture);
 
@@ -71,8 +83,6 @@ public class ElasticsearchSearchEngineAdapterClusterRequestTest {
 	@After
 	public void tearDown() throws Exception {
 		_deleteIndex();
-
-		_elasticsearchFixture.tearDown();
 	}
 
 	@Test
@@ -238,7 +248,8 @@ public class ElasticsearchSearchEngineAdapterClusterRequestTest {
 
 	private static final String _INDEX_NAME = "test_request_index";
 
-	private ElasticsearchFixture _elasticsearchFixture;
+	private static ElasticsearchFixture _elasticsearchFixture;
+
 	private IndicesClient _indicesClient;
 	private final JSONFactory _jsonFactory = new JSONFactoryImpl();
 	private SearchEngineAdapter _searchEngineAdapter;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
@@ -60,8 +60,10 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.RestStatus;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -69,12 +71,21 @@ import org.junit.Test;
  */
 public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 
-	@Before
-	public void setUp() throws Exception {
-		_elasticsearchFixture = new ElasticsearchFixture(getClass());
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_elasticsearchFixture = new ElasticsearchFixture(
+			ElasticsearchSearchEngineAdapterDocumentRequestTest.class);
 
 		_elasticsearchFixture.setUp();
+	}
 
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_elasticsearchFixture.tearDown();
+	}
+
+	@Before
+	public void setUp() throws Exception {
 		_searchEngineAdapter = createSearchEngineAdapter(_elasticsearchFixture);
 
 		_restHighLevelClient = _elasticsearchFixture.getRestHighLevelClient();
@@ -91,8 +102,6 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		_deleteIndex();
 
 		_documentFixture.tearDown();
-
-		_elasticsearchFixture.tearDown();
 	}
 
 	@Test
@@ -655,8 +664,9 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 	private static final String _MAPPING_SOURCE =
 		"{\"properties\":{\"matchDocument\":{\"type\":\"boolean\"}}}";
 
+	private static ElasticsearchFixture _elasticsearchFixture;
+
 	private final DocumentFixture _documentFixture = new DocumentFixture();
-	private ElasticsearchFixture _elasticsearchFixture;
 	private IndicesClient _indicesClient;
 	private RestHighLevelClient _restHighLevelClient;
 	private SearchEngineAdapter _searchEngineAdapter;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterSearchRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterSearchRequestTest.java
@@ -54,8 +54,10 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.xcontent.XContentType;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -63,13 +65,22 @@ import org.junit.Test;
  */
 public class ElasticsearchSearchEngineAdapterSearchRequestTest {
 
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_elasticsearchFixture = new ElasticsearchFixture(
+			ElasticsearchSearchEngineAdapterSearchRequestTest.class);
+
+		_elasticsearchFixture.setUp();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_elasticsearchFixture.tearDown();
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		_documentFixture.setUp();
-
-		_elasticsearchFixture = new ElasticsearchFixture(getClass());
-
-		_elasticsearchFixture.setUp();
 
 		_searchEngineAdapter = createSearchEngineAdapter(_elasticsearchFixture);
 
@@ -104,8 +115,6 @@ public class ElasticsearchSearchEngineAdapterSearchRequestTest {
 		_deleteIndex();
 
 		_documentFixture.tearDown();
-
-		_elasticsearchFixture.tearDown();
 	}
 
 	@Test
@@ -446,8 +455,9 @@ public class ElasticsearchSearchEngineAdapterSearchRequestTest {
 
 	private static final String _MAPPING_NAME = "test_mapping";
 
+	private static ElasticsearchFixture _elasticsearchFixture;
+
 	private final DocumentFixture _documentFixture = new DocumentFixture();
-	private ElasticsearchFixture _elasticsearchFixture;
 	private IndicesClient _indicesClient;
 	private RestHighLevelClient _restHighLevelClient;
 	private SearchEngineAdapter _searchEngineAdapter;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterSnapshotRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterSnapshotRequestTest.java
@@ -57,8 +57,10 @@ import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.snapshots.SnapshotInfo;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -66,12 +68,21 @@ import org.junit.Test;
  */
 public class ElasticsearchSearchEngineAdapterSnapshotRequestTest {
 
-	@Before
-	public void setUp() throws Exception {
-		_elasticsearchFixture = new ElasticsearchFixture(getClass());
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_elasticsearchFixture = new ElasticsearchFixture(
+			ElasticsearchSearchEngineAdapterSnapshotRequestTest.class);
 
 		_elasticsearchFixture.setUp();
+	}
 
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_elasticsearchFixture.tearDown();
+	}
+
+	@Before
+	public void setUp() throws Exception {
 		_searchEngineAdapter = createSearchEngineAdapter(_elasticsearchFixture);
 
 		RestHighLevelClient restHighLevelClient =
@@ -89,8 +100,6 @@ public class ElasticsearchSearchEngineAdapterSnapshotRequestTest {
 	public void tearDown() throws Exception {
 		_deleteIndex();
 		_deleteRepository(_TEST_REPOSITORY_NAME);
-
-		_elasticsearchFixture.tearDown();
 	}
 
 	@Test
@@ -450,7 +459,8 @@ public class ElasticsearchSearchEngineAdapterSnapshotRequestTest {
 	private static final String _TEST_REPOSITORY_NAME =
 		"testRepositoryOperations";
 
-	private ElasticsearchFixture _elasticsearchFixture;
+	private static ElasticsearchFixture _elasticsearchFixture;
+
 	private IndicesClient _indicesClient;
 	private SearchEngineAdapter _searchEngineAdapter;
 	private SnapshotClient _snapshotClient;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslatorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslatorTest.java
@@ -35,8 +35,10 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -44,11 +46,21 @@ import org.junit.Test;
  */
 public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_elasticsearchFixture = new ElasticsearchFixture(
+			ElasticsearchBulkableDocumentRequestTranslatorTest.class);
+
+		_elasticsearchFixture.setUp();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_elasticsearchFixture.tearDown();
+	}
+
 	@Before
 	public void setUp() throws Exception {
-		ElasticsearchFixture elasticsearchFixture = new ElasticsearchFixture(
-			getClass());
-
 		ElasticsearchDocumentFactory elasticsearchDocumentFactory =
 			createElasticsearchDocumentFactory();
 
@@ -62,17 +74,12 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 
 		_elasticsearchDocumentFactory = elasticsearchDocumentFactory;
 
-		_elasticsearchFixture = elasticsearchFixture;
-
 		_documentFixture.setUp();
-		_elasticsearchFixture.setUp();
 	}
 
 	@After
 	public void tearDown() throws Exception {
 		_documentFixture.tearDown();
-
-		_elasticsearchFixture.tearDown();
 	}
 
 	@Test
@@ -292,10 +299,11 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 
 	private static final String _MAPPING_NAME = "testMapping";
 
+	private static ElasticsearchFixture _elasticsearchFixture;
+
 	private final DocumentFixture _documentFixture = new DocumentFixture();
 	private ElasticsearchBulkableDocumentRequestTranslator
 		_elasticsearchBulkableDocumentRequestTranslator;
 	private ElasticsearchDocumentFactory _elasticsearchDocumentFactory;
-	private ElasticsearchFixture _elasticsearchFixture;
 
 }


### PR DESCRIPTION
**ci:test:search-es7 - 45 out of 49 jobs passed** https://github.com/BryanEngler/liferay-portal/pull/453#issuecomment-564778596
✅ The only failures unique to this pull are not caused by this pr, confirmed by @joshchong

Author(s): @BryanEngler

---
*[Task] Use BeforeClass annotation pattern to set up ElasticsearchFixture*
https://issues.liferay.com/browse/LPS-105653