### PR TITLE
LPS-105721 Make `useIsMounted` work in child component edge case

### DIFF
--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useIsMounted.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useIsMounted.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {useCallback, useEffect, useRef} from 'react';
+import {useCallback, useLayoutEffect, useRef} from 'react';
 
 /**
  * Hook for determining whether a component is still mounted.
@@ -36,7 +36,7 @@ export default function useIsMounted() {
 	const mountedRef = useRef(false);
 	const isMounted = useCallback(() => mountedRef.current, []);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		mountedRef.current = true;
 
 		return () => {

--- a/modules/apps/frontend-js/frontend-js-react-web/test/js/hooks/useIsMounted.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/test/js/hooks/useIsMounted.es.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+import useIsMounted from '../../../src/main/resources/META-INF/resources/js/hooks/useIsMounted.es';
+
+const {useEffect} = React;
+
+describe('useIsMounted()', () => {
+	afterEach(cleanup);
+
+	/*
+	 * Regression test for LPS-105721.
+	 */
+	it("can be used in a child component's useEffect callback", () => {
+		let mounted = false;
+
+		const Parent = ({children}) => {
+			const isMounted = useIsMounted();
+
+			const child = React.Children.only(children);
+
+			return React.cloneElement(child, {isMounted});
+		};
+
+		const Child = ({isMounted}) => {
+			useEffect(() => {
+				mounted = isMounted();
+			}, [isMounted]);
+
+			return <></>;
+		};
+
+		render(
+			<Parent>
+				<Child />
+			</Parent>
+		);
+
+		expect(mounted).toBe(true);
+	});
+});


### PR DESCRIPTION
**tl;dr:** this fixes an obscure edge case that we ran into in the React content page editor.

For anybody curious about React inner workings, full description follows:

---

This commit makes the `useIsMounted` hook work from inside child components' on-mount `useEffect` callbacks. It's very edge-casey, but is something we just saw in the React content page editor when we tried to move from `useState` for managing the currently active sidebar panel, to using our reducer-based store.

Our top-level `useReducer` hook uses `useIsMounted` internally (via `useThunk`) to prevent us from ever accidentally dispatching actions when we have unmounted, but we found an edge case in the sidebar where actions were not getting propagated during mount. The sequence basically looks like this:

1. Top-level app component renders (sets up reducer).
2. Grand-child component (`<Sidebar />`) does initial render.
3. Grand-child does a `useEffect` to run a side effect (loading the first panel into view; note that because this app is dynamic we don't actually know what the first panel will be until we run).

That last step worked fine when we using `useState` to set the active panel ID, but stopped working when we switched to `dispatch`. The reason is that the `dispatch` method comes from the top-level, and it is wrapped in a call to `useThunk` which internally uses `useIsMounted`. `useIsMounted` uses `useEffect` to toggle its internal "is-mounted" book-keeping from `false` to `true` once it has mounted.

Thus, when the grand-child invokes `dispatch` from inside `useEffect`, it is relying on the value returned by `isMounted()` as determined by the top-level component. But child component `useEffect` callbacks run before their parents', so `isMounted()` actually ends up returning `false`. In general, in React, "being mounted" means "component and all of its descendants are mounted", so children get notified first.

The fix is to make `useIsMounted` update its book-keeping a little earlier, before the child component `useEffect` runs. We do this by switching to `useLayoutEffect`. This is the execution order:

1. Child `useLayoutEffect` runs.
2. Parent `useLayoutEffect` runs.
3. Child `useEffect` runs.
4. Parent `useEffect` runs.

In other words, `useIsMounted` is now more robust for the common use cases (which all use `useEffect`). The rarer use cases (using `useLayoutEffect`) are still subject to this quirk of children running their callbacks before their parents. Most of the time we use `useIsMounted` locally and there is no reason to worry about any of this, but in a pattern that is probably going to become common in the future — using `useReducer` in conjunction with `useThunk` — the change in this commit makes us more robust.