### PR TITLE
LPS-105794 Include portletNamespace in the component

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/floating_toolbar/link/FloatingToolbarLinkPanel.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/floating_toolbar/link/FloatingToolbarLinkPanel.es.js
@@ -566,6 +566,7 @@ const ConnectedFloatingToolbarLinkPanel = getConnectedComponent(
 		'getAssetMappingFieldsURL',
 		'mappedInfoItems',
 		'mappingFieldsURL',
+		'portletNamespace',
 		'selectedMappingTypes',
 		'spritemap'
 	]


### PR DESCRIPTION
Hey @brianchandotcom
This should fix LocalFile.ContentPagesWithMapping#MapWebContentURLToLinkFragment test, the other one: LocalFile.ContentPages#AddContentPage is going to be fixed by @Tim-Cao

cc @ealonso