### PR TITLE
LPS-105826 y property of clientRect is not supported in ie11, so use top when y is not defined

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/floating_toolbar/FloatingToolbar.es.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/floating_toolbar/FloatingToolbar.es.js
@@ -280,8 +280,9 @@ class FloatingToolbar extends Component {
 	_isAnchorElementVisible() {
 		if (this.anchorElement) {
 			const anchorElementRect = this.anchorElement.getBoundingClientRect();
+			const anchorElementY = anchorElementRect.y || anchorElementRect.top;
 			const anchorElementBottom =
-				anchorElementRect.y + anchorElementRect.height;
+				anchorElementY + anchorElementRect.height;
 
 			return (
 				anchorElementBottom >


### PR DESCRIPTION
@ealonso