### PR TITLE
LPS-78524 Make Properties tabs in Server Admin consistent with Lexicon design

### DIFF
--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/constants/ServerAdminNavigationEntryConstants.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/constants/ServerAdminNavigationEntryConstants.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.server.admin.web.internal.constants;
+
+/**
+ * @author Albert Lee
+ */
+public class ServerAdminNavigationEntryConstants {
+
+	public static final String CATEGORY_KEY_PORTAL_PROPERTIES =
+		"portal-properties";
+
+	public static final String CATEGORY_KEY_SYSTEM_PROPERTIES =
+		"system-properties";
+
+	public static final String ENTRY_KEY_PORTAL_PROPERTIES =
+		"portal-properties";
+
+	public static final String ENTRY_KEY_SYSTEM_PROPERTIES =
+		"system-properties";
+
+	public static final String SCREEN_NAVIGATION_KEY_PROPERTIES =
+		"properties.form";
+
+}

--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/frontend/taglib/servlet/taglib/ServerPortalPropertiesScreenNavigationEntry.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/frontend/taglib/servlet/taglib/ServerPortalPropertiesScreenNavigationEntry.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.server.admin.web.internal.frontend.taglib.servlet.taglib;
+
+import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationCategory;
+import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationEntry;
+import com.liferay.frontend.taglib.servlet.taglib.util.JSPRenderer;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.server.admin.web.internal.constants.ServerAdminNavigationEntryConstants;
+
+import java.io.IOException;
+
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Albert Lee
+ */
+@Component(
+	property = {
+		"screen.navigation.category.order:Integer=20",
+		"screen.navigation.entry.order:Integer=10"
+	},
+	service = {ScreenNavigationCategory.class, ScreenNavigationEntry.class}
+)
+public class ServerPortalPropertiesScreenNavigationEntry
+	implements ScreenNavigationCategory, ScreenNavigationEntry {
+
+	public String getCategoryKey() {
+		return ServerAdminNavigationEntryConstants.
+			CATEGORY_KEY_PORTAL_PROPERTIES;
+	}
+
+	public String getEntryKey() {
+		return ServerAdminNavigationEntryConstants.ENTRY_KEY_PORTAL_PROPERTIES;
+	}
+
+	public String getLabel(Locale locale) {
+		return LanguageUtil.get(locale, "portal-properties");
+	}
+
+	public String getScreenNavigationKey() {
+		return ServerAdminNavigationEntryConstants.
+			SCREEN_NAVIGATION_KEY_PROPERTIES;
+	}
+
+	public void render(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException {
+
+		_jspRenderer.renderJSP(
+			httpServletRequest, httpServletResponse, "/portal_properties.jsp");
+	}
+
+	@Reference
+	private JSPRenderer _jspRenderer;
+
+}

--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/frontend/taglib/servlet/taglib/ServerSystemPropertiesScreenNavigationEntry.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/frontend/taglib/servlet/taglib/ServerSystemPropertiesScreenNavigationEntry.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.server.admin.web.internal.frontend.taglib.servlet.taglib;
+
+import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationCategory;
+import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationEntry;
+import com.liferay.frontend.taglib.servlet.taglib.util.JSPRenderer;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.server.admin.web.internal.constants.ServerAdminNavigationEntryConstants;
+
+import java.io.IOException;
+
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Albert Lee
+ */
+@Component(
+	property = {
+		"screen.navigation.category.order:Integer=10",
+		"screen.navigation.entry.order:Integer=10"
+	},
+	service = {ScreenNavigationCategory.class, ScreenNavigationEntry.class}
+)
+public class ServerSystemPropertiesScreenNavigationEntry
+	implements ScreenNavigationCategory, ScreenNavigationEntry {
+
+	public String getCategoryKey() {
+		return ServerAdminNavigationEntryConstants.
+			CATEGORY_KEY_SYSTEM_PROPERTIES;
+	}
+
+	public String getEntryKey() {
+		return ServerAdminNavigationEntryConstants.ENTRY_KEY_SYSTEM_PROPERTIES;
+	}
+
+	public String getLabel(Locale locale) {
+		return LanguageUtil.get(locale, "system-properties");
+	}
+
+	public String getScreenNavigationKey() {
+		return ServerAdminNavigationEntryConstants.
+			SCREEN_NAVIGATION_KEY_PROPERTIES;
+	}
+
+	public void render(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException {
+
+		_jspRenderer.renderJSP(
+			httpServletRequest, httpServletResponse, "/system_properties.jsp");
+	}
+
+	@Reference
+	private JSPRenderer _jspRenderer;
+
+}

--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/ViewPortalPropertiesMVCRenderCommand.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/ViewPortalPropertiesMVCRenderCommand.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.server.admin.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.util.PortletKeys;
+
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Albert Lee
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + PortletKeys.SERVER_ADMIN,
+		"mvc.command.name=/server_admin/view_portal_properties"
+	},
+	service = MVCRenderCommand.class
+)
+public class ViewPortalPropertiesMVCRenderCommand implements MVCRenderCommand {
+
+	@Override
+	public String render(
+		RenderRequest renderRequest, RenderResponse renderResponse) {
+
+		return "/portal_properties.jsp";
+	}
+
+}

--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/ViewSystemPropertiesMVCRenderCommand.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/ViewSystemPropertiesMVCRenderCommand.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.server.admin.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.util.PortletKeys;
+
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Albert Lee
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + PortletKeys.SERVER_ADMIN,
+		"mvc.command.name=/server_admin/view_system_properties"
+	},
+	service = MVCRenderCommand.class
+)
+public class ViewSystemPropertiesMVCRenderCommand implements MVCRenderCommand {
+
+	@Override
+	public String render(
+		RenderRequest renderRequest, RenderResponse renderResponse) {
+
+		return "/system_properties.jsp";
+	}
+
+}

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -71,6 +71,7 @@ page import="com.liferay.portal.util.PrefsPropsUtil" %><%@
 page import="com.liferay.portal.util.PropsUtil" %><%@
 page import="com.liferay.portal.util.PropsValues" %><%@
 page import="com.liferay.portal.util.ShutdownUtil" %><%@
+page import="com.liferay.server.admin.web.internal.constants.ServerAdminNavigationEntryConstants" %><%@
 page import="com.liferay.server.admin.web.internal.display.context.ServerDisplayContext" %><%@
 page import="com.liferay.taglib.servlet.PipingServletResponse" %>
 

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/portal_properties.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/portal_properties.jsp
@@ -1,0 +1,155 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+int delta = ParamUtil.getInteger(request, SearchContainer.DEFAULT_DELTA_PARAM, SearchContainer.DEFAULT_DELTA);
+String keywords = ParamUtil.getString(request, "keywords");
+String screenNavigationCategoryKey = ParamUtil.getString(request, "screenNavigationCategoryKey", ServerAdminNavigationEntryConstants.CATEGORY_KEY_PORTAL_PROPERTIES);
+String screenNavigationEntryKey = ParamUtil.getString(request, "screenNavigationEntryKey", ServerAdminNavigationEntryConstants.ENTRY_KEY_PORTAL_PROPERTIES);
+
+PortletURL serverURL = renderResponse.createRenderURL();
+
+serverURL.setParameter("mvcRenderCommandName", "/server_admin/view");
+serverURL.setParameter("tabs1", tabs1);
+serverURL.setParameter("delta", String.valueOf(delta));
+serverURL.setParameter("screenNavigationCategoryKey", screenNavigationCategoryKey);
+serverURL.setParameter("screenNavigationEntryKey", screenNavigationEntryKey);
+
+PortletURL clearResultsURL = PortletURLUtil.clone(serverURL, liferayPortletResponse);
+
+clearResultsURL.setParameter("navigation", (String)null);
+clearResultsURL.setParameter("keywords", StringPool.BLANK);
+
+Map<String, String> filteredProperties = new TreeMap<String, String>();
+
+List<String> overriddenProperties = new ArrayList<>();
+
+PortletPreferences serverPortletPreferences = PrefsPropsUtil.getPreferences();
+
+Map<String, String[]> serverPortletPreferencesMap = serverPortletPreferences.getMap();
+
+PortletPreferences companyPortletPreferences = PrefsPropsUtil.getPreferences(company.getCompanyId());
+
+Map<String, String[]> companyPortletPreferencesMap = companyPortletPreferences.getMap();
+
+Properties properties = PropsUtil.getProperties(true);
+
+for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+	String property = (String)entry.getKey();
+	String value = StringPool.BLANK;
+
+	boolean overriddenPropertyValue = serverPortletPreferencesMap.containsKey(property) || companyPortletPreferencesMap.containsKey(property);
+
+	if (ArrayUtil.contains(PropsValues.ADMIN_OBFUSCATED_PROPERTIES, property)) {
+		value = StringPool.EIGHT_STARS;
+	}
+	else if (serverPortletPreferencesMap.containsKey(property)) {
+		value = serverPortletPreferences.getValue(property, StringPool.BLANK);
+	}
+	else if (companyPortletPreferencesMap.containsKey(property)) {
+		value = companyPortletPreferences.getValue(property, StringPool.BLANK);
+	}
+	else {
+		value = (String)entry.getValue();
+	}
+
+	if (Validator.isNull(keywords) || property.contains(keywords) || value.contains(keywords)) {
+		filteredProperties.put(property, value);
+
+		if (overriddenPropertyValue) {
+			overriddenProperties.add(property);
+		}
+	}
+}
+
+List filteredPropertiesList = ListUtil.fromCollection(filteredProperties.entrySet());
+
+SearchContainer propertiesSearchContainer = new SearchContainer(liferayPortletRequest, serverURL, null, null);
+
+propertiesSearchContainer.setResults(ListUtil.subList(filteredPropertiesList, propertiesSearchContainer.getStart(), propertiesSearchContainer.getEnd()));
+propertiesSearchContainer.setTotal(filteredPropertiesList.size());
+%>
+
+<clay:management-toolbar
+	clearResultsURL="<%= String.valueOf(clearResultsURL) %>"
+	itemsTotal="<%= propertiesSearchContainer.getTotal() %>"
+	searchActionURL="<%= String.valueOf(serverURL) %>"
+	searchFormName="searchFm"
+	selectable="<%= false %>"
+	showSearch="<%= true %>"
+/>
+
+<div class="container-fluid-1280">
+	<liferay-ui:search-container
+		emptyResultsMessage='<%= tabs2.equals("portal-properties") ? "no-portal-properties-were-found-that-matched-the-keywords" : "no-system-properties-were-found-that-matched-the-keywords" %>'
+		iteratorURL="<%= serverURL %>"
+		total="<%= filteredPropertiesList.size() %>"
+	>
+		<liferay-ui:search-container-results
+			results="<%= ListUtil.subList(filteredPropertiesList, searchContainer.getStart(), searchContainer.getEnd()) %>"
+		/>
+
+		<liferay-ui:search-container-row
+			className="java.util.Map.Entry"
+			modelVar="entry"
+		>
+
+			<%
+			String property = (String)entry.getKey();
+			String value = (String)entry.getValue();
+
+			boolean overriddenPropertyValue = overriddenProperties.contains(property);
+			%>
+
+			<liferay-ui:search-container-column-text
+				name="property"
+				value="<%= HtmlUtil.escape(StringUtil.shorten(property, 80)) %>"
+			/>
+
+			<liferay-ui:search-container-column-text
+				name="value"
+			>
+				<c:if test="<%= Validator.isNotNull(value) %>">
+					<c:choose>
+						<c:when test="<%= value.length() > 80 %>">
+							<span onmouseover="Liferay.Portal.ToolTip.show(this, '<%= HtmlUtil.escapeJS(value) %>');">
+								<%= HtmlUtil.escape(StringUtil.shorten(value, 80)) %>
+							</span>
+						</c:when>
+						<c:otherwise>
+							<%= HtmlUtil.escape(value) %>
+						</c:otherwise>
+					</c:choose>
+				</c:if>
+			</liferay-ui:search-container-column-text>
+
+			<liferay-ui:search-container-column-text
+				name="source"
+			>
+				<liferay-ui:icon
+					iconCssClass='<%= overriddenPropertyValue ? "icon-hdd" : "icon-file-alt" %>'
+					message='<%= LanguageUtil.get(request, overriddenPropertyValue ? "the-value-of-this-property-was-overridden-using-the-control-panel-and-is-stored-in-the-database" : "the-value-of-this-property-is-read-from-a-portal.properties-file-or-one-of-its-extension-files") %>'
+				/>
+			</liferay-ui:search-container-column-text>
+		</liferay-ui:search-container-row>
+
+		<liferay-ui:search-iterator
+			markupView="lexicon"
+		/>
+	</liferay-ui:search-container>
+</div>

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
@@ -85,6 +85,9 @@ for (Map.Entry<Object, Object> entry : properties.entrySet()) {
 List filteredPropertiesList = ListUtil.fromCollection(filteredProperties.entrySet());
 
 SearchContainer propertiesSearchContainer = new SearchContainer(liferayPortletRequest, serverURL, null, null);
+
+propertiesSearchContainer.setResults(ListUtil.subList(filteredPropertiesList, propertiesSearchContainer.getStart(), propertiesSearchContainer.getEnd()));
+propertiesSearchContainer.setTotal(filteredPropertiesList.size());
 %>
 
 <div class="server-admin-tabs">
@@ -107,6 +110,7 @@ SearchContainer propertiesSearchContainer = new SearchContainer(liferayPortletRe
 		</aui:nav>
 
 		<clay:management-toolbar
+			itemsTotal="<%= propertiesSearchContainer.getTotal() %>"
 			searchActionURL="<%= String.valueOf(serverURL) %>"
 			searchFormName="searchFm"
 			selectable="<%= false %>"

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
@@ -51,13 +51,12 @@ serverURL.setParameter("tabs2", tabs2);
 
 		</aui:nav>
 
-		<aui:nav-bar-search>
-			<liferay-ui:input-search
-				autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) %>"
-				markupView="lexicon"
-				placeholder='<%= LanguageUtil.get(request, "keywords") %>'
-			/>
-		</aui:nav-bar-search>
+		<clay:management-toolbar
+			searchActionURL="<%= String.valueOf(serverURL) %>"
+			searchFormName="searchFm"
+			selectable="<%= false %>"
+			showSearch="<%= true %>"
+		/>
 	</aui:nav-bar>
 
 	<%

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
@@ -23,6 +23,7 @@ if (!ArrayUtil.contains(tabs2Names, tabs2)) {
 	tabs2 = tabs2Names[0];
 }
 
+int delta = ParamUtil.getInteger(request, SearchContainer.DEFAULT_DELTA_PARAM, SearchContainer.DEFAULT_DELTA);
 String keywords = ParamUtil.getString(request, "keywords");
 
 PortletURL serverURL = renderResponse.createRenderURL();
@@ -30,6 +31,7 @@ PortletURL serverURL = renderResponse.createRenderURL();
 serverURL.setParameter("mvcRenderCommandName", "/server_admin/view");
 serverURL.setParameter("tabs1", tabs1);
 serverURL.setParameter("tabs2", tabs2);
+serverURL.setParameter("delta", String.valueOf(delta));
 
 PortletURL clearResultsURL = PortletURLUtil.clone(serverURL, liferayPortletResponse);
 

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
@@ -31,6 +31,11 @@ serverURL.setParameter("mvcRenderCommandName", "/server_admin/view");
 serverURL.setParameter("tabs1", tabs1);
 serverURL.setParameter("tabs2", tabs2);
 
+PortletURL clearResultsURL = PortletURLUtil.clone(serverURL, liferayPortletResponse);
+
+clearResultsURL.setParameter("navigation", (String)null);
+clearResultsURL.setParameter("keywords", StringPool.BLANK);
+
 Map<String, String> filteredProperties = new TreeMap<String, String>();
 
 List<String> overriddenProperties = new ArrayList<>();
@@ -110,6 +115,7 @@ propertiesSearchContainer.setTotal(filteredPropertiesList.size());
 		</aui:nav>
 
 		<clay:management-toolbar
+			clearResultsURL="<%= String.valueOf(clearResultsURL) %>"
 			itemsTotal="<%= propertiesSearchContainer.getTotal() %>"
 			searchActionURL="<%= String.valueOf(serverURL) %>"
 			searchFormName="searchFm"

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
@@ -17,172 +17,19 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String[] tabs2Names = {"system-properties", "portal-properties"};
-
-if (!ArrayUtil.contains(tabs2Names, tabs2)) {
-	tabs2 = tabs2Names[0];
-}
-
 int delta = ParamUtil.getInteger(request, SearchContainer.DEFAULT_DELTA_PARAM, SearchContainer.DEFAULT_DELTA);
-String keywords = ParamUtil.getString(request, "keywords");
 
 PortletURL serverURL = renderResponse.createRenderURL();
 
 serverURL.setParameter("mvcRenderCommandName", "/server_admin/view");
 serverURL.setParameter("tabs1", tabs1);
-serverURL.setParameter("tabs2", tabs2);
 serverURL.setParameter("delta", String.valueOf(delta));
-
-PortletURL clearResultsURL = PortletURLUtil.clone(serverURL, liferayPortletResponse);
-
-clearResultsURL.setParameter("navigation", (String)null);
-clearResultsURL.setParameter("keywords", StringPool.BLANK);
-
-Map<String, String> filteredProperties = new TreeMap<String, String>();
-
-List<String> overriddenProperties = new ArrayList<>();
-
-PortletPreferences serverPortletPreferences = PrefsPropsUtil.getPreferences();
-
-Map<String, String[]> serverPortletPreferencesMap = serverPortletPreferences.getMap();
-
-PortletPreferences companyPortletPreferences = PrefsPropsUtil.getPreferences(company.getCompanyId());
-
-Map<String, String[]> companyPortletPreferencesMap = companyPortletPreferences.getMap();
-
-Properties properties = null;
-
-boolean portalPropertiesTab = tabs2.equals("portal-properties");
-
-if (portalPropertiesTab) {
-	properties = PropsUtil.getProperties(true);
-}
-else {
-	properties = System.getProperties();
-}
-
-for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-	String property = String.valueOf(entry.getKey());
-	String value = StringPool.BLANK;
-
-	boolean overriddenPropertyValue = portalPropertiesTab && (serverPortletPreferencesMap.containsKey(property) || companyPortletPreferencesMap.containsKey(property));
-
-	if (ArrayUtil.contains(PropsValues.ADMIN_OBFUSCATED_PROPERTIES, property)) {
-		value = StringPool.EIGHT_STARS;
-	}
-	else if (portalPropertiesTab && serverPortletPreferencesMap.containsKey(property)) {
-		value = serverPortletPreferences.getValue(property, StringPool.BLANK);
-	}
-	else if (portalPropertiesTab && companyPortletPreferencesMap.containsKey(property)) {
-		value = companyPortletPreferences.getValue(property, StringPool.BLANK);
-	}
-	else {
-		value = String.valueOf(entry.getValue());
-	}
-
-	if (Validator.isNull(keywords) || property.contains(keywords) || value.contains(keywords)) {
-		filteredProperties.put(property, value);
-
-		if (overriddenPropertyValue) {
-			overriddenProperties.add(property);
-		}
-	}
-}
-
-List filteredPropertiesList = ListUtil.fromCollection(filteredProperties.entrySet());
-
-SearchContainer propertiesSearchContainer = new SearchContainer(liferayPortletRequest, serverURL, null, null);
-
-propertiesSearchContainer.setResults(ListUtil.subList(filteredPropertiesList, propertiesSearchContainer.getStart(), propertiesSearchContainer.getEnd()));
-propertiesSearchContainer.setTotal(filteredPropertiesList.size());
 %>
 
-<div class="server-admin-tabs">
-	<aui:nav-bar cssClass="collapse-basic-search" markupView="lexicon">
-		<aui:nav cssClass="navbar-nav">
-
-			<%
-			for (String tabs2Name : tabs2Names) {
-				serverURL.setParameter("tabs2", tabs2Name);
-			%>
-
-				<aui:nav-item href="<%= serverURL.toString() %>" label="<%= tabs2Name %>" selected="<%= tabs2.equals(tabs2Name) %>" />
-
-			<%
-			}
-
-			serverURL.setParameter("tabs2", tabs2);
-			%>
-
-		</aui:nav>
-
-		<clay:management-toolbar
-			clearResultsURL="<%= String.valueOf(clearResultsURL) %>"
-			itemsTotal="<%= propertiesSearchContainer.getTotal() %>"
-			searchActionURL="<%= String.valueOf(serverURL) %>"
-			searchFormName="searchFm"
-			selectable="<%= false %>"
-			showSearch="<%= true %>"
-		/>
-	</aui:nav-bar>
-
-	<liferay-ui:search-container
-		emptyResultsMessage='<%= tabs2.equals("portal-properties") ? "no-portal-properties-were-found-that-matched-the-keywords" : "no-system-properties-were-found-that-matched-the-keywords" %>'
-		iteratorURL="<%= serverURL %>"
-		total="<%= filteredPropertiesList.size() %>"
-	>
-		<liferay-ui:search-container-results
-			results="<%= ListUtil.subList(filteredPropertiesList, searchContainer.getStart(), searchContainer.getEnd()) %>"
-		/>
-
-		<liferay-ui:search-container-row
-			className="java.util.Map.Entry"
-			modelVar="entry"
-		>
-
-			<%
-			String property = String.valueOf(entry.getKey());
-			String value = String.valueOf(entry.getValue());
-
-			boolean overriddenPropertyValue = portalPropertiesTab && overriddenProperties.contains(property);
-			%>
-
-			<liferay-ui:search-container-column-text
-				name="property"
-				value="<%= HtmlUtil.escape(StringUtil.shorten(property, 80)) %>"
-			/>
-
-			<liferay-ui:search-container-column-text
-				name="value"
-			>
-				<c:if test="<%= Validator.isNotNull(value) %>">
-					<c:choose>
-						<c:when test="<%= value.length() > 80 %>">
-							<span onmouseover="Liferay.Portal.ToolTip.show(this, '<%= HtmlUtil.escapeJS(value) %>');">
-								<%= HtmlUtil.escape(StringUtil.shorten(value, 80)) %>
-							</span>
-						</c:when>
-						<c:otherwise>
-							<%= HtmlUtil.escape(value) %>
-						</c:otherwise>
-					</c:choose>
-				</c:if>
-			</liferay-ui:search-container-column-text>
-
-			<c:if test='<%= tabs2.equals("portal-properties") %>'>
-				<liferay-ui:search-container-column-text
-					name="source"
-				>
-					<liferay-ui:icon
-						iconCssClass='<%= overriddenPropertyValue ? "icon-hdd" : "icon-file-alt" %>'
-						message='<%= LanguageUtil.get(request, overriddenPropertyValue ? "the-value-of-this-property-was-overridden-using-the-control-panel-and-is-stored-in-the-database" : "the-value-of-this-property-is-read-from-a-portal.properties-file-or-one-of-its-extension-files") %>'
-					/>
-				</liferay-ui:search-container-column-text>
-			</c:if>
-		</liferay-ui:search-container-row>
-
-		<liferay-ui:search-iterator
-			markupView="lexicon"
-		/>
-	</liferay-ui:search-container>
-</div>
+<liferay-frontend:screen-navigation
+	containerWrapperCssClass=""
+	headerContainerCssClass=""
+	inverted="<%= false %>"
+	key="<%= ServerAdminNavigationEntryConstants.SCREEN_NAVIGATION_KEY_PROPERTIES %>"
+	portletURL="<%= serverURL %>"
+/>

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/server.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/server.jsp
@@ -31,7 +31,7 @@
 			navigationItems="<%= serverDisplayContext.getServerNavigationItems() %>"
 		/>
 
-		<div class="<%= tabs1.equals("log-levels") ? StringPool.BLANK : "container-fluid-1280" %>">
+		<div class="<%= (tabs1.equals("log-levels") || tabs1.equals("properties")) ? StringPool.BLANK : "container-fluid-1280" %>">
 			<c:choose>
 				<c:when test='<%= tabs1.equals("log-levels") %>'>
 					<liferay-util:include page="/log_levels.jsp" servletContext="<%= application %>" />

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/system_properties.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/system_properties.jsp
@@ -1,0 +1,124 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+int delta = ParamUtil.getInteger(request, SearchContainer.DEFAULT_DELTA_PARAM, SearchContainer.DEFAULT_DELTA);
+String keywords = ParamUtil.getString(request, "keywords");
+String screenNavigationCategoryKey = ParamUtil.getString(request, "screenNavigationCategoryKey", ServerAdminNavigationEntryConstants.CATEGORY_KEY_SYSTEM_PROPERTIES);
+String screenNavigationEntryKey = ParamUtil.getString(request, "screenNavigationEntryKey", ServerAdminNavigationEntryConstants.ENTRY_KEY_SYSTEM_PROPERTIES);
+
+PortletURL serverURL = renderResponse.createRenderURL();
+
+serverURL.setParameter("mvcRenderCommandName", "/server_admin/view");
+serverURL.setParameter("tabs1", tabs1);
+serverURL.setParameter("delta", String.valueOf(delta));
+serverURL.setParameter("screenNavigationCategoryKey", screenNavigationCategoryKey);
+serverURL.setParameter("screenNavigationEntryKey", screenNavigationEntryKey);
+
+PortletURL clearResultsURL = PortletURLUtil.clone(serverURL, liferayPortletResponse);
+
+clearResultsURL.setParameter("navigation", StringPool.NULL);
+clearResultsURL.setParameter("keywords", StringPool.BLANK);
+
+Map<String, String> filteredProperties = new TreeMap<String, String>();
+
+Properties properties = System.getProperties();
+
+for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+	String property = String.valueOf(entry.getKey());
+	String value = StringPool.BLANK;
+
+	if (ArrayUtil.contains(PropsValues.ADMIN_OBFUSCATED_PROPERTIES, property)) {
+		value = StringPool.EIGHT_STARS;
+	}
+	else {
+		value = String.valueOf(entry.getValue());
+	}
+
+	if (Validator.isNull(keywords) || property.contains(keywords) || value.contains(keywords)) {
+		filteredProperties.put(property, value);
+	}
+}
+
+List filteredPropertiesList = ListUtil.fromCollection(filteredProperties.entrySet());
+
+SearchContainer propertiesSearchContainer = new SearchContainer(liferayPortletRequest, serverURL, null, null);
+
+propertiesSearchContainer.setResults(ListUtil.subList(filteredPropertiesList, propertiesSearchContainer.getStart(), propertiesSearchContainer.getEnd()));
+propertiesSearchContainer.setTotal(filteredPropertiesList.size());
+%>
+
+<clay:management-toolbar
+	clearResultsURL="<%= String.valueOf(clearResultsURL) %>"
+	itemsTotal="<%= propertiesSearchContainer.getTotal() %>"
+	searchActionURL="<%= String.valueOf(serverURL) %>"
+	searchFormName="searchFm"
+	selectable="<%= false %>"
+	showSearch="<%= true %>"
+/>
+
+<div class="container-fluid-1280">
+	<liferay-ui:search-container
+		emptyResultsMessage='<%= tabs2.equals("portal-properties") ? "no-portal-properties-were-found-that-matched-the-keywords" : "no-system-properties-were-found-that-matched-the-keywords" %>'
+		iteratorURL="<%= serverURL %>"
+		total="<%= filteredPropertiesList.size() %>"
+	>
+		<liferay-ui:search-container-results
+			results="<%= ListUtil.subList(filteredPropertiesList, searchContainer.getStart(), searchContainer.getEnd()) %>"
+		/>
+
+		<liferay-ui:search-container-row
+			className="java.util.Map.Entry"
+			modelVar="entry"
+		>
+
+			<%
+			String property = String.valueOf(entry.getKey());
+			String value = String.valueOf(entry.getValue());
+			%>
+
+			<liferay-ui:search-container-column-text
+				cssClass="table-cell-expand"
+				name="property"
+				value="<%= HtmlUtil.escape(StringUtil.shorten(property, 80)) %>"
+			/>
+
+			<liferay-ui:search-container-column-text
+				cssClass="table-cell-expand"
+				name="value"
+			>
+				<c:if test="<%= Validator.isNotNull(value) %>">
+					<c:choose>
+						<c:when test="<%= value.length() > 80 %>">
+							<span onmouseover="Liferay.Portal.ToolTip.show(this, '<%= HtmlUtil.escapeJS(value) %>');">
+								<%= HtmlUtil.escape(StringUtil.shorten(value, 80)) %>
+							</span>
+						</c:when>
+						<c:otherwise>
+							<%= HtmlUtil.escape(value) %>
+						</c:otherwise>
+					</c:choose>
+				</c:if>
+			</liferay-ui:search-container-column-text>
+		</liferay-ui:search-container-row>
+
+		<liferay-ui:search-iterator
+			markupView="lexicon"
+		/>
+	</liferay-ui:search-container>
+</div>


### PR DESCRIPTION
This is something Albert Lee prepared a while back which came on to my radar because we're sweeping through looking to remove legacy code in the repo (this PR moves from  `aui:nav-bar` to `clay:management-toolbar`).

Originally reviewed here: https://github.com/pei-jung/liferay-portal/pull/478

I ran the tests on it and did some manual QA in my fork here: https://github.com/wincent/liferay-portal/pull/109