### PR TITLE
LPS-105900 Make new ci-only module for checking bundle blacklist mana…

### DIFF
--- a/modules/apps/portal-osgi-debug/portal-osgi-debug-missing-component/bnd.bnd
+++ b/modules/apps/portal-osgi-debug/portal-osgi-debug-missing-component/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Portal OSGi Debug Missing Component
+Bundle-SymbolicName: com.liferay.portal.osgi.debug.missing.component
+Bundle-Version: 1.0.0

--- a/modules/apps/portal-osgi-debug/portal-osgi-debug-missing-component/build.gradle
+++ b/modules/apps/portal-osgi-debug/portal-osgi-debug-missing-component/build.gradle
@@ -1,0 +1,10 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:portal-osgi-debug:portal-osgi-debug-api")
+	compileOnly project(":apps:static:osgi:osgi-util")
+	compileOnly project(":apps:static:portal-bundle-blacklist:portal-bundle-blacklist-api")
+	compileOnly project(":core:petra:petra-string")
+}

--- a/modules/apps/portal-osgi-debug/portal-osgi-debug-missing-component/src/main/java/com/liferay/portal/osgi/debug/missing/component/internal/MissingComponentSystemChecker.java
+++ b/modules/apps/portal-osgi-debug/portal-osgi-debug-missing-component/src/main/java/com/liferay/portal/osgi/debug/missing/component/internal/MissingComponentSystemChecker.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.osgi.debug.missing.component.internal;
+
+import com.liferay.portal.osgi.debug.SystemChecker;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+
+/**
+ * @author Matthew Tambara
+ */
+@Component(immediate = true, service = SystemChecker.class)
+public class MissingComponentSystemChecker implements SystemChecker {
+
+	@Override
+	public String check() {
+		return MissingComponentUtil.scan(
+			_bundleContext, _serviceComponentRuntime);
+	}
+
+	@Override
+	public String getName() {
+		return "Missing Component Scanner";
+	}
+
+	@Override
+	public String getOSGiCommand() {
+		return "ds:missing";
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+	}
+
+	private BundleContext _bundleContext;
+
+	@Reference
+	private ServiceComponentRuntime _serviceComponentRuntime;
+
+}

--- a/modules/apps/portal-osgi-debug/portal-osgi-debug-missing-component/src/main/java/com/liferay/portal/osgi/debug/missing/component/internal/MissingComponentUtil.java
+++ b/modules/apps/portal-osgi-debug/portal-osgi-debug-missing-component/src/main/java/com/liferay/portal/osgi/debug/missing/component/internal/MissingComponentUtil.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.osgi.debug.missing.component.internal;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.bundle.blacklist.BundleBlacklistManager;
+
+import java.util.Objects;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+import org.osgi.service.component.runtime.dto.ComponentConfigurationDTO;
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
+import org.osgi.service.component.runtime.dto.SatisfiedReferenceDTO;
+import org.osgi.service.component.runtime.dto.UnsatisfiedReferenceDTO;
+
+/**
+ * @author Matthew Tambara
+ */
+public class MissingComponentUtil {
+
+	public static String scan(
+		BundleContext bundleContext,
+		ServiceComponentRuntime serviceComponentRuntime) {
+
+		Bundle blacklistBundle = null;
+
+		for (Bundle bundle : bundleContext.getBundles()) {
+			if (Objects.equals(
+					bundle.getSymbolicName(),
+					"com.liferay.portal.bundle.blacklist.impl")) {
+
+				blacklistBundle = bundle;
+
+				break;
+			}
+		}
+
+		ServiceReference<BundleBlacklistManager> serviceReference =
+			bundleContext.getServiceReference(BundleBlacklistManager.class);
+
+		if (serviceReference != null) {
+			return null;
+		}
+
+		ComponentDescriptionDTO componentDescriptionDTO =
+			serviceComponentRuntime.getComponentDescriptionDTO(
+				blacklistBundle,
+				"com.liferay.portal.bundle.blacklist.internal." +
+					"BundleBlacklistManagerImpl");
+
+		StringBundler sb = new StringBundler();
+
+		sb.append("@@@@Name: ");
+		sb.append(componentDescriptionDTO.name);
+		sb.append("\n@@Instances:");
+
+		for (ComponentConfigurationDTO componentConfigurationDTO :
+				serviceComponentRuntime.getComponentConfigurationDTOs(
+					componentDescriptionDTO)) {
+
+			sb.append("\nid: ");
+			sb.append(componentConfigurationDTO.id);
+			sb.append("\nState: ");
+			sb.append(componentConfigurationDTO.state);
+			sb.append("\n Satisfied references: ");
+
+			for (SatisfiedReferenceDTO satisfiedReference :
+					componentConfigurationDTO.satisfiedReferences) {
+
+				sb.append("\n\tName: ");
+				sb.append(satisfiedReference.name);
+			}
+
+			sb.append("\nUnsatisfied References: ");
+
+			for (UnsatisfiedReferenceDTO unsatisfiedReference :
+					componentConfigurationDTO.unsatisfiedReferences) {
+
+				sb.append("\n\tName: ");
+				sb.append(unsatisfiedReference.name);
+			}
+		}
+
+		return sb.toString();
+	}
+
+}


### PR DESCRIPTION
…ger status when service is unavailable

@brianchandotcom this is a ci only debug module to help us find out what happens when bundle blacklist manager is missing during startup. Once the issue is solved, this module will be removed, so it only temporary and ci only, don't need to worry about the output format.