### PR TITLE
LPS-105824 Remove unwanted ignore field in .babelrc

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/.babelrc
+++ b/modules/apps/item-selector/item-selector-taglib/.babelrc
@@ -1,8 +1,4 @@
 {
-    "ignore": [
-    	"**/image_selector.js",
-        "**/config.js"
-    ],
     "presets": [
 		"@babel/preset-react"
 	]


### PR DESCRIPTION
This was preventing files to be transpiled by babel, which would then cause syntax errors in IE11.