### PR TITLE
LPS-105984 Fix broken Treeview tests

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/TreeviewLabel.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/TreeviewLabel.js
@@ -12,13 +12,9 @@
  * details.
  */
 
-import React, {useContext} from 'react';
-
-import TreeviewContext from './TreeviewContext';
+import React from 'react';
 
 export default function TreeviewLabel({node}) {
-	const {dispatch} = useContext(TreeviewContext);
-
 	const inputId = `${node.id}-treeview-label-input`;
 
 	return (
@@ -27,9 +23,9 @@ export default function TreeviewLabel({node}) {
 				checked={node.selected}
 				className="sr-only"
 				id={inputId}
-				onChange={() =>
-					dispatch({nodeId: node.id, type: 'TOGGLE_SELECT'})
-				}
+				onChange={() => {
+					// Let NodeListItem handle checked state.
+				}}
 				type="checkbox"
 			/>
 
@@ -38,6 +34,7 @@ export default function TreeviewLabel({node}) {
 					node.selected ? 'font-weight-bold' : 'font-weight-normal'
 				}
 				htmlFor={inputId}
+				onClick={event => event.preventDefault()}
 			>
 				{node.name}
 			</label>

--- a/modules/apps/frontend-js/frontend-js-components-web/test/treeview/Treeview.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/treeview/Treeview.js
@@ -13,12 +13,11 @@
  */
 
 import {cleanup, fireEvent, render} from '@testing-library/react';
-import React, {useContext} from 'react';
+import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
 
 import Treeview from '../../src/main/resources/META-INF/resources/treeview/Treeview';
-import TreeviewContext from '../../src/main/resources/META-INF/resources/treeview/TreeviewContext';
 
 const nodes = [
 	{
@@ -199,19 +198,11 @@ describe('Treeview', () => {
 			<Treeview
 				initialSelectedNodeIds={[]}
 				NodeComponent={({node}) => {
-					const {dispatch} = useContext(TreeviewContext);
-
 					return (
 						<button
 							data-icon={node.icon}
 							data-selected={node.selected}
 							data-size={node.size}
-							onClick={() =>
-								dispatch({
-									nodeId: node.id,
-									type: 'TOGGLE_SELECT'
-								})
-							}
 							type="button"
 						>
 							Super {node.name}


### PR DESCRIPTION
These tests were broken as a result of the refactor in LPS-102563, which hoisted the management of actions out of the "leaf" components like `TreeviewLabel` up into the abstract `NodeListItem` higher up in the tree.

As such, it became redundant to dispatch an action from the `TreeviewLabel`, so we turn the `onChange()` handler into a no-op so that the ancestor can control the checked state (the only reason we don't remove it outright is because otherwise React will warn about the input being effectively read-only).

For the same reason, we suppress the `onClick` on the `label` because we want only the ancestor to be responsible for state changes.

Risk is very low here because `TreeviewLabel` isn't even being used in liferay-portal yet.