### PR TITLE
Lps 106079

### DIFF
--- a/modules/util/source-formatter/documentation/api_expose_spi.markdown
+++ b/modules/util/source-formatter/documentation/api_expose_spi.markdown
@@ -1,0 +1,8 @@
+## API Expose SPI
+
+Exported types in API modules should not expose SPI types at signature level.
+Once a SPI type is exposed via an API type, it is practically promoted to become an API.
+
+You should consider:
+* Move the exposed SPI types to API modules to make them formal APIs
+* Make a cleaner separation to prevent SPI types from being exposed by APIs

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JavaModuleExposureCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JavaModuleExposureCheck.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.checks;
+
+import com.liferay.source.formatter.BNDSettings;
+import com.liferay.source.formatter.checks.util.BNDSourceUtil;
+import com.liferay.source.formatter.parser.JavaClass;
+import com.liferay.source.formatter.parser.JavaParameter;
+import com.liferay.source.formatter.parser.JavaSignature;
+import com.liferay.source.formatter.parser.JavaTerm;
+
+import java.io.IOException;
+
+import java.util.List;
+
+/**
+ * @author Hugo Huijser
+ */
+public class JavaModuleExposureCheck extends BaseJavaTermCheck {
+
+	@Override
+	public boolean isModuleSourceCheck() {
+		return true;
+	}
+
+	@Override
+	protected String doProcess(
+			String fileName, String absolutePath, JavaTerm javaTerm,
+			String fileContent)
+		throws IOException {
+
+		BNDSettings bndSettings = getBNDSettings(fileName);
+
+		if (bndSettings == null) {
+			return javaTerm.getContent();
+		}
+
+		String bundleSymbolicName = BNDSourceUtil.getDefinitionValue(
+			bndSettings.getContent(), "Bundle-SymbolicName");
+
+		if (!bundleSymbolicName.endsWith(".api")) {
+			return javaTerm.getContent();
+		}
+
+		JavaClass javaClass = javaTerm.getParentJavaClass();
+
+		while (true) {
+			if (javaClass.getParentJavaClass() == null) {
+				break;
+			}
+
+			javaClass = javaClass.getParentJavaClass();
+		}
+
+		if (!_hasExportPackage(javaClass.getPackageName(), bndSettings)) {
+			return javaTerm.getContent();
+		}
+
+		String exposedSPIType = _getExposedSPIType(
+			javaTerm, javaClass.getImports());
+
+		if (exposedSPIType != null) {
+			addMessage(
+				fileName,
+				"Do not expose '" + exposedSPIType + "' in 'api' module");
+		}
+
+		return javaTerm.getContent();
+	}
+
+	@Override
+	protected String[] getCheckableJavaTermNames() {
+		return new String[] {JAVA_CONSTRUCTOR, JAVA_METHOD};
+	}
+
+	private String _getExposedSPIType(
+		JavaTerm javaTerm, List<String> importNames) {
+
+		JavaSignature signature = javaTerm.getSignature();
+
+		if (signature == null) {
+			return null;
+		}
+
+		for (String importName : importNames) {
+			if (!importName.contains(".spi.")) {
+				continue;
+			}
+
+			if (importName.equals(signature.getReturnType()) ||
+				importName.endsWith("." + signature.getReturnType())) {
+
+				return signature.getReturnType();
+			}
+
+			for (JavaParameter javaParameter : signature.getParameters()) {
+				if (importName.equals(javaParameter.getParameterType()) ||
+					importName.endsWith(
+						"." + javaParameter.getParameterType())) {
+
+					return javaParameter.getParameterType();
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private boolean _hasExportPackage(
+		String packageName, BNDSettings bndSettings) {
+
+		List<String> exportPackages = BNDSourceUtil.getDefinitionValues(
+			bndSettings.getContent(), "Export-Package");
+
+		if (exportPackages.contains(packageName)) {
+			return true;
+		}
+
+		for (String exportPackage : exportPackages) {
+			if (exportPackage.endsWith(".*") &&
+				packageName.startsWith(
+					exportPackage.substring(0, exportPackage.length() - 2))) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JavaModuleExposureCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JavaModuleExposureCheck.java
@@ -74,7 +74,8 @@ public class JavaModuleExposureCheck extends BaseJavaTermCheck {
 		if (exposedSPIType != null) {
 			addMessage(
 				fileName,
-				"Do not expose '" + exposedSPIType + "' in 'api' module");
+				"Do not expose '" + exposedSPIType + "' in 'api' module",
+				"api_expose_spi.markdown");
 		}
 
 		return javaTerm.getContent();

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -264,6 +264,9 @@
 		<!-- Module Source Checks -->
 
 		<check name="JavaModuleComponentCheck" />
+		<check name="JavaModuleExposureCheck">
+			<property name="enabled" value="false" />
+		</check>
 		<check name="JavaModuleExtendedObjectClassDefinitionCheck" />
 		<check name="JavaModuleIllegalImportsCheck">
 			<property name="checkRegistryInTestClasses" value="false" />


### PR DESCRIPTION
See https://github.com/shuyangzhou/liferay-portal/pull/8638#issuecomment-567142055

@brianchandotcom can you have the data-engine and oauth2-provider owners fix the wrong SPI usages ?
```
Do not expose 'SPIDataDefinitionField' in 'api' module: C:/github/liferay-portal/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/field/type/FieldType.java (SourceCheck:JavaModuleExposureCheck)
Do not expose 'SPIDataDefinitionField' in 'api' module: C:/github/liferay-portal/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/rule/function/DataRuleFunction.java (SourceCheck:JavaModuleExposureCheck)
Do not expose 'SPIDataDefinitionField' in 'api' module: C:/github/liferay-portal/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/rule/function/DataRuleFunctionResult.java (SourceCheck:JavaModuleExposureCheck)
Do not expose 'SPIDataDefinitionField' in 'api' module: C:/github/liferay-portal/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/field/type/BaseFieldType.java (SourceCheck:JavaModuleExposureCheck)
Do not expose 'ApplicationDescriptor' in 'api' module: C:/github/liferay-portal/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/ApplicationDescriptorLocator.java (SourceCheck:JavaModuleExposureCheck)
Do not expose 'ScopeDescriptor' in 'api' module: C:/github/liferay-portal/modules/apps/oauth2-provider/oauth2-provider-scope-liferay-api/src/main/java/com/liferay/oauth2/provider/scope/liferay/ScopeDescriptorLocator.java (SourceCheck:JavaModuleExposureCheck)
```
We have 3 SPI interfaces that are exposed, SPIDataDefinitionField, ApplicationDescriptor, ScopeDescriptor. It is not easy for me to tell what's their intention. Once they are fixed, we can enable this SF rule.