### PR TITLE
LPS-105225 add full URL

### DIFF
--- a/modules/apps/headless/headless-discovery/src/main/java/com/liferay/headless/discovery/internal/jaxrs/application/HeadlessDiscoveryApplication.java
+++ b/modules/apps/headless/headless-discovery/src/main/java/com/liferay/headless/discovery/internal/jaxrs/application/HeadlessDiscoveryApplication.java
@@ -128,9 +128,10 @@ public class HeadlessDiscoveryApplication extends Application {
 				for (ResourceMethodInfoDTO resourceMethodInfoDTO :
 						resourceDTO.resourceMethods) {
 
-					String path =
-						serverURL + applicationDTO.base +
-							resourceMethodInfoDTO.path;
+					resourceMethodInfoDTO.path =
+						applicationDTO.base + resourceMethodInfoDTO.path;
+
+					String path = serverURL + resourceMethodInfoDTO.path;
 
 					List<ResourceMethodInfoDTO> resourceMethodInfoDTOS =
 						resourcesMap.get(path);


### PR DESCRIPTION
This
`resourceMethodInfoDTO.path = applicationDTO.base + resourceMethodInfoDTO.path;`

is not an issue because I'm iterating through _resourceMethodInfoDTO_

`for (ResourceMethodInfoDTO resourceMethodInfoDTO : resourceDTO.resourceMethods) {`

So a different DTO object is used every time, I don't reuse the same instance in each loop cycle.