### PR TITLE
LPS-106304

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/index/contributor/IndexContributorReceiver.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/index/contributor/IndexContributorReceiver.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.index.contributor;
+
+import com.liferay.portal.search.spi.model.index.contributor.IndexContributor;
+
+/**
+ * @author Adam Brandizzi
+ */
+public interface IndexContributorReceiver {
+
+	public void addIndexContributor(IndexContributor indexContributor);
+
+	public void removeIndexContributor(IndexContributor indexContributor);
+
+}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/index/contributor/IndexContributorsHolder.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/index/contributor/IndexContributorsHolder.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.index.contributor;
+
+import com.liferay.portal.search.spi.model.index.contributor.IndexContributor;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+/**
+ * @author Adam Brandizzi
+ */
+@Component(immediate = true, service = IndexContributorsHolder.class)
+public class IndexContributorsHolder {
+
+	@Reference(
+		cardinality = ReferenceCardinality.MULTIPLE,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
+	protected void addIndexContributor(IndexContributor indexContributor) {
+		for (IndexContributorReceiver indexContributorReceiver :
+				_indexContributorReceivers) {
+
+			indexContributorReceiver.addIndexContributor(indexContributor);
+		}
+	}
+
+	@Reference(
+		cardinality = ReferenceCardinality.MULTIPLE,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
+	protected void addIndexContributorReceiver(
+		IndexContributorReceiver indexContributorReceiver) {
+
+		_indexContributorReceivers.add(indexContributorReceiver);
+
+		for (IndexContributor indexContributor : _indexContributors) {
+			indexContributorReceiver.addIndexContributor(indexContributor);
+		}
+	}
+
+	protected void removeIndexContributor(IndexContributor indexContributor) {
+		_indexContributors.remove(indexContributor);
+
+		for (IndexContributorReceiver indexContributorReceiver :
+				_indexContributorReceivers) {
+
+			indexContributorReceiver.removeIndexContributor(indexContributor);
+		}
+	}
+
+	protected void removeIndexContributorReceiver(
+		IndexContributorReceiver indexContributorReceiver) {
+
+		_indexContributorReceivers.remove(indexContributorReceiver);
+	}
+
+	private final List<IndexContributorReceiver> _indexContributorReceivers =
+		new CopyOnWriteArrayList<>();
+	private final List<IndexContributor> _indexContributors =
+		new CopyOnWriteArrayList<>();
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactory.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactory.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration;
+import com.liferay.portal.search.elasticsearch7.internal.index.contributor.IndexContributorReceiver;
 import com.liferay.portal.search.elasticsearch7.internal.settings.SettingsBuilder;
 import com.liferay.portal.search.elasticsearch7.internal.util.LogUtil;
 import com.liferay.portal.search.elasticsearch7.internal.util.ResourceUtil;
@@ -60,9 +61,15 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
  */
 @Component(
 	configurationPid = "com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration",
-	immediate = true, service = IndexFactory.class
+	immediate = true,
+	service = {IndexContributorReceiver.class, IndexFactory.class}
 )
-public class CompanyIndexFactory implements IndexFactory {
+public class CompanyIndexFactory
+	implements IndexContributorReceiver, IndexFactory {
+
+	public void addIndexContributor(IndexContributor indexContributor) {
+		_indexContributors.add(indexContributor);
+	}
 
 	@Override
 	public void createIndices(IndicesClient indicesClient, long companyId) {
@@ -99,6 +106,10 @@ public class CompanyIndexFactory implements IndexFactory {
 		}
 	}
 
+	public void removeIndexContributor(IndexContributor indexContributor) {
+		_indexContributors.remove(indexContributor);
+	}
+
 	@Activate
 	@Modified
 	protected void activate(Map<String, Object> properties) {
@@ -116,15 +127,6 @@ public class CompanyIndexFactory implements IndexFactory {
 			elasticsearchConfiguration.indexNumberOfShards());
 		setOverrideTypeMappings(
 			elasticsearchConfiguration.overrideTypeMappings());
-	}
-
-	@Reference(
-		cardinality = ReferenceCardinality.MULTIPLE,
-		policy = ReferencePolicy.DYNAMIC,
-		policyOption = ReferencePolicyOption.GREEDY
-	)
-	protected void addIndexContributor(IndexContributor indexContributor) {
-		_indexContributors.add(indexContributor);
 	}
 
 	@Reference(
@@ -309,10 +311,6 @@ public class CompanyIndexFactory implements IndexFactory {
 			indexSettingsContributor.contribute(
 				indexName, liferayDocumentTypeFactory);
 		}
-	}
-
-	protected void removeIndexContributor(IndexContributor indexContributor) {
-		_indexContributors.remove(indexContributor);
 	}
 
 	protected void removeIndexSettingsContributor(

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/contributor/IndexContributorReceiver.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/contributor/IndexContributorReceiver.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.index.contributor;
+
+import com.liferay.portal.search.spi.model.index.contributor.IndexContributor;
+
+/**
+ * @author Adam Brandizzi
+ */
+public interface IndexContributorReceiver {
+
+	public void addIndexContributor(IndexContributor indexContributor);
+
+	public void removeIndexContributor(IndexContributor indexContributor);
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/contributor/IndexContributorsHolder.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/contributor/IndexContributorsHolder.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.index.contributor;
+
+import com.liferay.portal.search.spi.model.index.contributor.IndexContributor;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+/**
+ * @author Adam Brandizzi
+ */
+@Component(immediate = true, service = IndexContributorsHolder.class)
+public class IndexContributorsHolder {
+
+	@Reference(
+		cardinality = ReferenceCardinality.MULTIPLE,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
+	protected void addIndexContributor(IndexContributor indexContributor) {
+		for (IndexContributorReceiver indexContributorReceiver :
+				_indexContributorReceivers) {
+
+			indexContributorReceiver.addIndexContributor(indexContributor);
+		}
+	}
+
+	@Reference(
+		cardinality = ReferenceCardinality.MULTIPLE,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
+	protected void addIndexContributorReceiver(
+		IndexContributorReceiver indexContributorReceiver) {
+
+		_indexContributorReceivers.add(indexContributorReceiver);
+
+		for (IndexContributor indexContributor : _indexContributors) {
+			indexContributorReceiver.addIndexContributor(indexContributor);
+		}
+	}
+
+	protected void removeIndexContributor(IndexContributor indexContributor) {
+		_indexContributors.remove(indexContributor);
+
+		for (IndexContributorReceiver indexContributorReceiver :
+				_indexContributorReceivers) {
+
+			indexContributorReceiver.removeIndexContributor(indexContributor);
+		}
+	}
+
+	protected void removeIndexContributorReceiver(
+		IndexContributorReceiver indexContributorReceiver) {
+
+		_indexContributorReceivers.remove(indexContributorReceiver);
+	}
+
+	private final List<IndexContributorReceiver> _indexContributorReceivers =
+		new CopyOnWriteArrayList<>();
+	private final List<IndexContributor> _indexContributors =
+		new CopyOnWriteArrayList<>();
+
+}


### PR DESCRIPTION
<h3><g-emoji class="g-emoji" alias="x" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/274c.png"><img class="emoji" alt="x" src="https://github.githubassets.com/images/icons/emoji/unicode/274c.png" width="20" height="20"></g-emoji> ci:test:search - 47 out of 49 jobs passed in 1 hour 33 minutes 51 seconds 119 ms</h3>

Only unique failure caused by failure to download artifacts from LAX CDN. The affected test is in an unrelated component so I guess it is of no concern.

https://github.com/brandizzi/liferay-portal/pull/938#issuecomment-569123144

Author: @brandizzi

[Bug] Soft circular dependency between Search Engine Adapter and Index Contributors
https://issues.liferay.com/browse/LPS-106304