### PR TITLE
LPS-100269 portal-search: FIX: java.lang.NoClassDefFoundError: com/liferay/petra/function/UnsafeFunction

### DIFF
--- a/modules/apps/portal-search/portal-search/build.gradle
+++ b/modules/apps/portal-search/portal-search/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-string")
 
 	testCompile group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
+	testCompile project(":core:petra:petra-function")
 	testCompile project(":core:petra:petra-memory")
 	testCompile project(":core:petra:petra-reflect")
 	testCompile project(":core:registry-api")


### PR DESCRIPTION
**❌ ci:test:search - 44 out of 49 jobs passed in 1 hour 29 minutes 43 seconds 290 ms**
https://github.com/arboliveira/liferay-portal/pull/795#issuecomment-569816924

Failures unrelated, likely infrastructure hiccups.

`java.lang.NullPointerException: no workspace from node hudson.slaves.DumbSlave[cloud-10-0-11-17] which is computer hudson.slaves.SlaveComputer@30783eaf and has channel null`

`java.lang.RuntimeException: Unable to create local branch master-private at 795780cfb463ce0f37817086ef3edcb02790c91c`

`Could not GET 'http://repository-cdn.liferay.com/nexus/service/local/repo_groups/private/content/com/liferay/com.liferay.document.library.repository.external.api/4.0.0-SNAPSHOT/maven-metadata.xml'. Received status code 503 from server: Service Unavailable`

----

`ResourcePermissionLocalService` now imports `UnsafeFunction`. (https://github.com/liferay/liferay-portal/commit/689e05430bc71a928244ae7274ae7a0c7bf9f508#diff-3ebe1a1e87873b409cd7dc277200f991R17)

Hence, `build.gradle` needs `petra-function` for ultra-fast clone-and-test `gradlew test`, as performed by Search CI Server. (no `ant all` at all.)

https://issues.liferay.com/browse/LPS-100269
