### PR TITLE
LPS-106785 Show scripting error to the user.

### DIFF
--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -45,6 +45,7 @@ page import="com.liferay.portal.kernel.model.*" %><%@
 page import="com.liferay.portal.kernel.model.impl.*" %><%@
 page import="com.liferay.portal.kernel.patcher.PatcherUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletURLUtil" %><%@
+page import="com.liferay.portal.kernel.scripting.ScriptingException" %><%@
 page import="com.liferay.portal.kernel.scripting.ScriptingUtil" %><%@
 page import="com.liferay.portal.kernel.service.*" %><%@
 page import="com.liferay.portal.kernel.servlet.SessionMessages" %><%@

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/script.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/script.jsp
@@ -32,6 +32,15 @@ if (SessionMessages.contains(renderRequest, "script")) {
 String scriptOutput = (String)SessionMessages.get(renderRequest, "scriptOutput");
 %>
 
+<liferay-ui:error exception="<%= ScriptingException.class %>">
+
+	<%
+	ScriptingException se = (ScriptingException)errorException;
+	%>
+
+	<pre><%= se.getMessage() %></pre>
+</liferay-ui:error>
+
 <aui:fieldset-group markupView="lexicon">
 	<aui:fieldset>
 		<aui:select name="language">


### PR DESCRIPTION
@jhinkey rather than limiting the script size, this is properly showing the error from backend, so the user can see what went wrong. Let me know if this is still not enough for the end users.