### PR TITLE
LPS-106396 AccountRoleLocalServiceTest is failing due to pagination not being supported in a searchAccountRole service call w PSQL,DB2,Hypersonic

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
@@ -189,7 +189,8 @@ public class AccountRoleLocalServiceImpl
 
 		return new BaseModelSearchResult<>(
 			accountRoles,
-			(int)roleLocalService.dynamicQueryCount(roleDynamicQuery));
+			(int)roleLocalService.dynamicQueryCount(
+				_getRoleDynamicQuery(accountEntryId, keywords, null)));
 	}
 
 	@Override


### PR DESCRIPTION
This is an update for [LPS-106396](https://issues.liferay.com/browse/LPS-106396).<br><br>/cc @pei-jung @alee8888 @ChrisKian @dejuknow @patriciajeanperez