### PR TITLE
LPS-104435 Enforce the version for com.liferay.portal dependencies

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1943,8 +1943,6 @@ rerun your task.
 					<propertyref name="sdk.dir" />
 					<propertyref name="timeout.app.server.wait" />
 					<propertyref name="upgrade.table.dir" />
-					<propertyref prefix="compat.com.liferay.portal." />
-					<propertyref prefix="compat.com.liferay.util." />
 					<propertyref prefix="gradle.publish." />
 					<propertyref prefix="gradle.releng.pom." />
 					<propertyref prefix="ivy.pom." />

--- a/build-common.xml
+++ b/build-common.xml
@@ -1943,8 +1943,8 @@ rerun your task.
 					<propertyref name="sdk.dir" />
 					<propertyref name="timeout.app.server.wait" />
 					<propertyref name="upgrade.table.dir" />
-					<propertyref prefix="build.compat.version.com.liferay.portal." />
-					<propertyref prefix="build.compat.version.com.liferay.util." />
+					<propertyref prefix="compat.com.liferay.portal." />
+					<propertyref prefix="compat.com.liferay.util." />
 					<propertyref prefix="gradle.publish." />
 					<propertyref prefix="gradle.releng.pom." />
 					<propertyref prefix="ivy.pom." />

--- a/build.properties
+++ b/build.properties
@@ -68,7 +68,7 @@
     #
     # Set the default version for "com.liferay.portal" dependencies at compile
     # time so the artifact can be deployed on previously released bundles.
-    # Leave the property empty to compile against the source.
+    # Leave the property empty to compile against the source code.
     #
     build.compat.version.com.liferay.portal.impl=
     build.compat.version.com.liferay.portal.kernel=

--- a/build.properties
+++ b/build.properties
@@ -66,17 +66,6 @@
     build.bnd.print.enabled=false
 
     #
-    # Set the default version for "com.liferay.portal" dependencies at compile
-    # time so the artifact can be deployed on previously released bundles.
-    # Leave the property empty to compile against the source code.
-    #
-    build.compat.version.com.liferay.portal.impl=
-    build.compat.version.com.liferay.portal.kernel=
-    build.compat.version.com.liferay.util.bridges=
-    build.compat.version.com.liferay.util.java=
-    build.compat.version.com.liferay.util.taglib=
-
-    #
     # Set the module directories to exclude when running "ant all".
     #
     build.exclude.dirs=
@@ -270,6 +259,17 @@
 
     ant.build.javac.source=1.8
     ant.build.javac.target=1.8
+
+    #
+    # Set the default version for "com.liferay.portal" dependencies at compile
+    # time so the artifact can be deployed on previously released bundles.
+    # Leave the property empty to compile against the source code.
+    #
+    build.compat.version.com.liferay.portal.impl=
+    build.compat.version.com.liferay.portal.kernel=
+    build.compat.version.com.liferay.util.bridges=
+    build.compat.version.com.liferay.util.java=
+    build.compat.version.com.liferay.util.taglib=
 
     #javac.compiler=com.google.errorprone.ErrorProneAntCompilerAdapter
     javac.compiler=modern

--- a/build.properties
+++ b/build.properties
@@ -265,11 +265,11 @@
     # time so the artifact can be deployed on previously released bundles.
     # Leave the property empty to compile against the source code.
     #
-    build.compat.version.com.liferay.portal.impl=
-    build.compat.version.com.liferay.portal.kernel=
-    build.compat.version.com.liferay.util.bridges=
-    build.compat.version.com.liferay.util.java=
-    build.compat.version.com.liferay.util.taglib=
+    compat.com.liferay.portal.impl.version=
+    compat.com.liferay.portal.kernel.version=
+    compat.com.liferay.util.bridges.version=
+    compat.com.liferay.util.java.version=
+    compat.com.liferay.util.taglib.version=
 
     #javac.compiler=com.google.errorprone.ErrorProneAntCompilerAdapter
     javac.compiler=modern

--- a/build.properties
+++ b/build.properties
@@ -260,17 +260,6 @@
     ant.build.javac.source=1.8
     ant.build.javac.target=1.8
 
-    #
-    # Set the default version for "com.liferay.portal" dependencies at compile
-    # time so the artifact can be deployed on previously released bundles.
-    # Leave the property empty to compile against the source code.
-    #
-    compat.com.liferay.portal.impl.version=
-    compat.com.liferay.portal.kernel.version=
-    compat.com.liferay.util.bridges.version=
-    compat.com.liferay.util.java.version=
-    compat.com.liferay.util.taglib.version=
-
     #javac.compiler=com.google.errorprone.ErrorProneAntCompilerAdapter
     javac.compiler=modern
 

--- a/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/LiferayOSGiDefaultsPlugin.java
+++ b/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/LiferayOSGiDefaultsPlugin.java
@@ -457,7 +457,7 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 
 		_configureBasePlugin(project, portalRootDir);
 		_configureBundleDefaultInstructions(project, portalRootDir, publishing);
-		_configureConfigurations(project, liferayExtension);
+		_configureConfigurations(project, liferayExtension, publishing);
 		_configureDependencyChecker(project);
 		_configureDeployDir(
 			project, liferayExtension, deployToAppServerLibs, deployToTools);
@@ -2390,7 +2390,8 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 	}
 
 	private void _configureConfigurations(
-		Project project, LiferayExtension liferayExtension) {
+		Project project, LiferayExtension liferayExtension,
+		boolean publishing) {
 
 		_configureConfigurationDefault(project);
 		_configureConfigurationJspC(project, liferayExtension);
@@ -2410,10 +2411,12 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 				project, JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME,
 				false);
 
-			_configureDependenciesGroupPortal(
-				project, JavaPlugin.COMPILE_CONFIGURATION_NAME);
-			_configureDependenciesGroupPortal(
-				project, JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
+			if (publishing) {
+				_configureDependenciesGroupPortal(
+					project, JavaPlugin.COMPILE_CONFIGURATION_NAME);
+				_configureDependenciesGroupPortal(
+					project, JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
+			}
 		}
 
 		_configureDependenciesTransitive(
@@ -2531,10 +2534,10 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 
 					String name = externalModuleDependency.getName();
 
-					String compatVersion = GradleUtil.getProperty(
-						project, "compat." + name + ".version", (String)null);
+					String newVersion = GradleUtil.getProperty(
+						project, name + ".version", (String)null);
 
-					if (Validator.isNull(compatVersion)) {
+					if (Validator.isNull(newVersion)) {
 						return;
 					}
 
@@ -2554,7 +2557,15 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 					sb.append(':');
 					sb.append(name);
 					sb.append(':');
-					sb.append(compatVersion);
+
+					int x = newVersion.lastIndexOf("-SNAPSHOT");
+
+					if (x != -1) {
+						sb.append("(," + newVersion.substring(0, x) + ")");
+					}
+					else {
+						sb.append("(," + newVersion + ")");
+					}
 
 					String newNotation = sb.toString();
 

--- a/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/LiferayOSGiDefaultsPlugin.java
+++ b/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/LiferayOSGiDefaultsPlugin.java
@@ -2532,7 +2532,7 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 					String name = externalModuleDependency.getName();
 
 					String compatVersion = GradleUtil.getProperty(
-						project, "build.compat.version." + name, (String)null);
+						project, "compat." + name + ".version", (String)null);
 
 					if (Validator.isNull(compatVersion)) {
 						return;

--- a/modules/source-formatter.properties
+++ b/modules/source-formatter.properties
@@ -5,6 +5,10 @@
 ## for available properties.
 ##
 
+    #source.check.gradle.dependency.artifacts.check.enforceGroupPortalVersionArtifacts=\
+    #    com.liferay.portal.impl:5.0.0,\
+    #    com.liferay.portal.kernel:5.0.0
+
     source.check.gradle.dependency.artifacts.check.enforceVersionArtifacts=\
         biz.aQute.bnd:biz.aQute.bnd.annotation:4.2.0,\
         com.fasterxml.jackson.core:jackson-annotations:2.9.10,\

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/GradleDependencyArtifactsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/GradleDependencyArtifactsCheck.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -47,8 +46,7 @@ public class GradleDependencyArtifactsCheck extends BaseFileCheck {
 		List<String> enforceVersionArtifacts = getAttributeValues(
 			_ENFORCE_VERSION_ARTIFACTS_KEY, absolutePath);
 
-		content = _enforceDependencyVersions(
-			absolutePath, content, enforceVersionArtifacts);
+		content = _enforceDependencyVersions(content, enforceVersionArtifacts);
 
 		Matcher matcher = _artifactPattern.matcher(content);
 
@@ -74,21 +72,11 @@ public class GradleDependencyArtifactsCheck extends BaseFileCheck {
 	}
 
 	private String _enforceDependencyVersions(
-		String absolutePath, String content,
-		List<String> enforceVersionArtifacts) {
-
-		boolean testModule = _isTestModule(absolutePath);
-		boolean testUtilModule = _isTestUtilModule(absolutePath);
+		String content, List<String> enforceVersionArtifacts) {
 
 		for (String artifact : enforceVersionArtifacts) {
 			String[] artifactParts = StringUtil.split(
 				artifact, StringPool.COLON);
-
-			if ((testModule || testUtilModule) &&
-				Objects.equals(artifactParts[0], "com.liferay.portal")) {
-
-				continue;
-			}
 
 			Pattern pattern = Pattern.compile(
 				StringBundler.concat(
@@ -205,14 +193,6 @@ public class GradleDependencyArtifactsCheck extends BaseFileCheck {
 		else if (!version.equals("default") &&
 				 !_isMasterOnlyFile(absolutePath)) {
 
-			for (String enforceVersionArtifact : enforceVersionArtifacts) {
-				if (enforceVersionArtifact.startsWith(
-						"com.liferay.portal:" + name + ":")) {
-
-					return content;
-				}
-			}
-
 			return StringUtil.replaceFirst(content, version, "default", pos);
 		}
 
@@ -283,20 +263,6 @@ public class GradleDependencyArtifactsCheck extends BaseFileCheck {
 				return true;
 			}
 		}
-	}
-
-	private boolean _isTestModule(String absolutePath) {
-		int x = absolutePath.lastIndexOf(StringPool.SLASH);
-
-		int y = absolutePath.lastIndexOf(StringPool.SLASH, x - 1);
-
-		String moduleName = absolutePath.substring(y + 1, x);
-
-		if (!moduleName.endsWith("-test")) {
-			return false;
-		}
-
-		return true;
 	}
 
 	private boolean _isTestUtilModule(String absolutePath) {


### PR DESCRIPTION
Hi Brian, manually or automatically trying to reduce the bnd calculated package version floor isn't safe.  It's ok to raise the ceiling, but not lower the floor.  Its safer to pin the `com.liferay.portal` with the version in the oldest `GA` bundle that needs to be supported.

After the `7.3` branch is created, the lines below will need to be added and then an `ant format-source-all`:

```
source.check.gradle.dependency.artifacts.check.enforceGroupPortalVersionArtifacts=\
    com.liferay.portal.impl:5.0.0,\
    com.liferay.portal.kernel:5.0.0
```
