### PR TITLE
LRCI-914 Use full hostname in session cookie for tcserver based on tomcat ver 8.5+

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -7864,6 +7864,16 @@ javascript.fast.load=false</echo>
 
 module.framework.properties.blacklist.portal.profile.names=${blacklist.portal.profile.names}</echo>
 
+		<if>
+			<equals arg1="${app.server.type}" arg2="tcserver" />
+			<then>
+				<echo append="true" file="portal-impl/src/portal-ext.properties">
+
+session.cookie.use.full.hostname=true
+				</echo>
+			</then>
+		</if>
+
 		<get-testcase-property property.name="portal.version" />
 
 		<propertyregex


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-914

Related:
7.0.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/28513
7.1.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/28514
7.2.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/28515