### PR TITLE
LPS-107135 Disable flakey JS tests in portal-workflow-kaleo-designer-web

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/package.json
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/package.json
@@ -4,7 +4,7 @@
 		"build": "liferay-npm-scripts build",
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix",
-		"test": "karma start"
+		"test_DISABLED": "karma start"
 	},
 	"version": "4.0.2"
 }


### PR DESCRIPTION
These tests pass fine when run locally:

https://gist.github.com/wincent/ca3c84a4b75ea07aad002d99f311fca8

but we've seen them blow up in multiple CI runs at this point (all due to timeouts); some examples:

- https://github.com/brianchandotcom/liferay-portal/pull/83324
- https://github.com/brianchandotcom/liferay-portal/pull/83270
- https://github.com/brianchandotcom/liferay-portal/pull/83312

Let's disable them to reduce noise and investigate separately.