### PR TITLE
LPS-107224 Pagination must support infinity

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/pagination/Pagination.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/pagination/Pagination.java
@@ -25,6 +25,10 @@ public class Pagination {
 	}
 
 	public int getEndPosition() {
+		if ((_page < 0) || (_pageSize < 0)) {
+			return -1;
+		}
+
 		return _page * _pageSize;
 	}
 
@@ -37,6 +41,10 @@ public class Pagination {
 	}
 
 	public int getStartPosition() {
+		if ((_page < 0) || (_pageSize < 0)) {
+			return -1;
+		}
+
 		return (_page - 1) * _pageSize;
 	}
 


### PR DESCRIPTION
We agreed on the convention before the previous PR: passing -1 => return all results (as the services are already using), passing nothing means return the defaults (pageSize 20), passing 0 means a explicit 0 (null value, the developer should decide what to do).

This PR shouldn't break any use of other values (passing nothing or 0)