### PR TITLE
LPS-100272

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/filter/SynonymSetFilterReaderImpl.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/filter/SynonymSetFilterReaderImpl.java
@@ -49,8 +49,8 @@ public class SynonymSetFilterReaderImpl implements SynonymSetFilterReader {
 			jsonObject = jsonFactory.createJSONObject(
 				settings.get(companyIndexName));
 		}
-		catch (JSONException jsonException) {
-			throw new RuntimeException(jsonException);
+		catch (JSONException jsone) {
+			throw new RuntimeException(jsone);
 		}
 
 		return JSONUtil.toStringArray(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/creation/contributor/SynonymSetIndexCreationIndexContributor.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/creation/contributor/SynonymSetIndexCreationIndexContributor.java
@@ -15,10 +15,9 @@
 package com.liferay.portal.search.tuning.synonyms.web.internal.index.creation.contributor;
 
 import com.liferay.portal.search.spi.model.index.contributor.IndexContributor;
-import com.liferay.portal.search.tuning.synonyms.web.internal.index.SynonymSetIndexCreator;
 import com.liferay.portal.search.tuning.synonyms.web.internal.index.SynonymSetIndexReader;
-import com.liferay.portal.search.tuning.synonyms.web.internal.index.name.SynonymSetIndexName;
 import com.liferay.portal.search.tuning.synonyms.web.internal.index.name.SynonymSetIndexNameBuilder;
+import com.liferay.portal.search.tuning.synonyms.web.internal.synchronizer.IndexToFilterSynchronizer;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -32,32 +31,18 @@ public class SynonymSetIndexCreationIndexContributor
 
 	@Override
 	public void onAfterCreate(String companyIndexName) {
-		SynonymSetIndexName synonymSetIndexName =
-			_synonymSetIndexNameBuilder.getSynonymSetIndexName(
-				companyIndexName);
+		if (!_synonymSetIndexReader.isExists(
+				_synonymSetIndexNameBuilder.getSynonymSetIndexName(
+					companyIndexName))) {
 
-		if (_synonymSetIndexReader.isExists(synonymSetIndexName)) {
 			return;
 		}
 
-		_synonymSetIndexCreator.create(synonymSetIndexName);
-	}
-
-	@Override
-	public void onBeforeRemove(String companyIndexName) {
-		SynonymSetIndexName synonymSetIndexName =
-			_synonymSetIndexNameBuilder.getSynonymSetIndexName(
-				companyIndexName);
-
-		if (!_synonymSetIndexReader.isExists(synonymSetIndexName)) {
-			return;
-		}
-
-		_synonymSetIndexCreator.delete(synonymSetIndexName);
+		_indexToFilterSynchronizer.copyToFilter(companyIndexName);
 	}
 
 	@Reference
-	private SynonymSetIndexCreator _synonymSetIndexCreator;
+	private IndexToFilterSynchronizer _indexToFilterSynchronizer;
 
 	@Reference
 	private SynonymSetIndexNameBuilder _synonymSetIndexNameBuilder;

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/creation/model/listener/SynonymSetIndexCreationCompanyModelListener.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/index/creation/model/listener/SynonymSetIndexCreationCompanyModelListener.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.portal.search.tuning.synonyms.web.internal.index.creation.model.listener;
+
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.search.index.IndexNameBuilder;
+import com.liferay.portal.search.tuning.synonyms.web.internal.index.SynonymSetIndexCreator;
+import com.liferay.portal.search.tuning.synonyms.web.internal.index.SynonymSetIndexReader;
+import com.liferay.portal.search.tuning.synonyms.web.internal.index.name.SynonymSetIndexName;
+import com.liferay.portal.search.tuning.synonyms.web.internal.index.name.SynonymSetIndexNameBuilder;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adam Brandizzi
+ */
+@Component(immediate = true, service = ModelListener.class)
+public class SynonymSetIndexCreationCompanyModelListener
+	extends BaseModelListener<Company> {
+
+	@Override
+	public void onAfterCreate(Company company) {
+		SynonymSetIndexName synonymSetIndexName =
+			_synonymSetIndexNameBuilder.getSynonymSetIndexName(
+				getCompanyIndexName(company));
+
+		if (_synonymSetIndexReader.isExists(synonymSetIndexName)) {
+			return;
+		}
+
+		_synonymSetIndexCreator.create(synonymSetIndexName);
+	}
+
+	@Override
+	public void onBeforeRemove(Company company) {
+		SynonymSetIndexName synonymSetIndexName =
+			_synonymSetIndexNameBuilder.getSynonymSetIndexName(
+				getCompanyIndexName(company));
+
+		if (!_synonymSetIndexReader.isExists(synonymSetIndexName)) {
+			return;
+		}
+
+		_synonymSetIndexCreator.delete(synonymSetIndexName);
+	}
+
+	protected String getCompanyIndexName(Company company) {
+		return _indexNameBuilder.getIndexName(company.getCompanyId());
+	}
+
+	@Reference
+	private IndexNameBuilder _indexNameBuilder;
+
+	@Reference
+	private SynonymSetIndexCreator _synonymSetIndexCreator;
+
+	@Reference
+	private SynonymSetIndexNameBuilder _synonymSetIndexNameBuilder;
+
+	@Reference
+	private SynonymSetIndexReader _synonymSetIndexReader;
+
+}


### PR DESCRIPTION
<h3><g-emoji class="g-emoji" alias="x" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/274c.png"><img class="emoji" alt="x" src="https://github.githubassets.com/images/icons/emoji/unicode/274c.png" width="20" height="20"></g-emoji> ci:test:search - 46 out of 50 jobs passed in 1 hour 42 minutes 56 seconds 291 ms</h3>

I checked on testray and three of the unique failures are failing for some time now. The other one was failing on unrelated pull requests for a short time, when it was not finding a checkbox because there was a dialog over it.

https://github.com/brandizzi/liferay-portal/pull/964#issuecomment-575866428

Author: @brandizzi

https://issues.liferay.com/browse/LPS-100272