### PR TITLE
LPS-107468 Use consistent, longer timeouts in Karma test runs

### DIFF
--- a/modules/apps/analytics/analytics-client-js/karma.conf.js
+++ b/modules/apps/analytics/analytics-client-js/karma.conf.js
@@ -16,9 +16,19 @@ const path = require('path');
 
 const webpack = require('./webpack.config.test');
 
+const TIMEOUT = 10000;
+
 module.exports = function(config) {
 	config.set({
+		browserDisconnectTimeout: TIMEOUT,
+
 		browsers: ['ChromeHeadless'],
+
+		client: {
+			mocha: {
+				timeout: TIMEOUT
+			}
+		},
 
 		coverageIstanbulReporter: {
 			dir: path.join(__dirname, 'test-coverage'),

--- a/modules/apps/analytics/analytics-client-js/package.json
+++ b/modules/apps/analytics/analytics-client-js/package.json
@@ -45,7 +45,7 @@
 		"build": "liferay-npm-scripts webpack",
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix",
-		"test": "karma start karma.conf.js"
+		"test": "karma start"
 	},
 	"version": "1.0.0"
 }

--- a/modules/apps/portal-search/portal-search-web/karma.conf.js
+++ b/modules/apps/portal-search/portal-search-web/karma.conf.js
@@ -15,6 +15,8 @@
 var liferayKarmaAlloyConfig = require('liferay-karma-alloy-config');
 var liferayKarmaConfig = require('liferay-karma-config');
 
+const TIMEOUT = 10000;
+
 module.exports = function(config) {
 	liferayKarmaConfig(config);
 
@@ -28,6 +30,12 @@ module.exports = function(config) {
 		format: '%b %T: %m',
 		level: 'log',
 		terminal: true
+	};
+
+	config.browserDisconnectTimeout = TIMEOUT;
+
+	config.client.mocha = {
+		timeout: TIMEOUT
 	};
 
 	config.singleRun = true;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/karma.conf.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/karma.conf.js
@@ -9,8 +9,10 @@
  * distribution rights of the Software.
  */
 
-var liferayKarmaAlloyConfig = require('liferay-karma-alloy-config');
-var liferayKarmaConfig = require('liferay-karma-config');
+const liferayKarmaAlloyConfig = require('liferay-karma-alloy-config');
+const liferayKarmaConfig = require('liferay-karma-config');
+
+const TIMEOUT = 10000;
 
 module.exports = function(config) {
 	liferayKarmaConfig(config);
@@ -25,14 +27,15 @@ module.exports = function(config) {
 		level: 'log',
 		terminal: false
 	};
+	config.browserDisconnectTimeout = TIMEOUT;
 	config.client.mocha = {
-		timeout: 10000
+		timeout: TIMEOUT
 	};
 	config.singleRun = true;
 
-	var resourcesPath = 'src/main/resources/META-INF/resources/';
-	var resourcesTestPath = 'src/test/resources/';
-	var testPath = 'src/test/testJS/';
+	const resourcesPath = 'src/main/resources/META-INF/resources/';
+	const resourcesTestPath = 'src/test/resources/';
+	const testPath = 'src/test/testJS/';
 
 	config.files.push(
 		{


### PR DESCRIPTION
As per this [comment](https://github.com/brianchandotcom/liferay-portal/pull/83566#issuecomment-576797790), this is another example of an unstable test, like the one we ameliorated in c652366bf373ed12f224eb50a5bcc7de6c1047a0. The related console output is:

> timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.

In this commit I am raising the timeouts across the board in the 3 places where we are currently using Karma. I'm not putting this config in [the "liferay-karma-config" package](https://www.npmjs.com/package/liferay-karma-config), because it is in a non-org repo, was last published 3 years ago, is only used in 2 of the 3 Karma usage sites, and we don't think we actually want to encourage further use of Karma precisely because of these kinds of stability issues.

Note that in addition to lifting the Mocha timeout, which is noted as [defaulting to 2000ms here](http://blog.jonathanargentiero.com/overriding-karma-mocha-default-timeout-2000ms/), I'm also lifting the `browserDisconnectTimeout`, because that's the other potential culprit here, as the only [other possible configuration value that defaults to 2000ms](http://karma-runner.github.io/4.0/config/configuration-file.html).

