### PR TITLE
LPS-107459 FIX NullPointerException on JournalFolderTrashHandlerTest.testDeleteTrashVersions() due to null JournalFolderLocalService from registry when integration test starts before dependency injection finishes

### DIFF
--- a/modules/apps/journal/journal-test-util/bnd.bnd
+++ b/modules/apps/journal/journal-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal Test Utilities
 Bundle-SymbolicName: com.liferay.journal.test.util
-Bundle-Version: 7.0.2
+Bundle-Version: 7.1.0
 Export-Package:\
 	com.liferay.journal.test.util,\
 	com.liferay.journal.test.util.search

--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalFolderFixture.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalFolderFixture.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.test.util;
+
+import com.liferay.journal.model.JournalFolder;
+import com.liferay.journal.model.JournalFolderConstants;
+import com.liferay.journal.service.JournalFolderLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+
+import java.util.Objects;
+
+/**
+ * @author André de Oliveira
+ */
+public class JournalFolderFixture {
+
+	public JournalFolderFixture(
+		JournalFolderLocalService journalFolderLocalService) {
+
+		_journalFolderLocalService = Objects.requireNonNull(
+			journalFolderLocalService);
+	}
+
+	public JournalFolder addFolder(
+			long userId, long groupId, long parentFolderId, String name)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(groupId, userId);
+
+		return addFolder(parentFolderId, name, serviceContext);
+	}
+
+	public JournalFolder addFolder(
+			long groupId, long parentFolderId, String name)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				groupId, TestPropsValues.getUserId());
+
+		return addFolder(parentFolderId, name, serviceContext);
+	}
+
+	public JournalFolder addFolder(long groupId, String name) throws Exception {
+		return addFolder(
+			groupId, JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, name);
+	}
+
+	public JournalFolder addFolder(
+			long parentFolderId, String name, ServiceContext serviceContext)
+		throws Exception {
+
+		return addFolder(
+			parentFolderId, name, "This is a test folder.", serviceContext);
+	}
+
+	public JournalFolder addFolder(
+			long parentFolderId, String name, String description,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		JournalFolder folder = _journalFolderLocalService.fetchFolder(
+			serviceContext.getScopeGroupId(), parentFolderId, name);
+
+		if (folder != null) {
+			return folder;
+		}
+
+		return _journalFolderLocalService.addFolder(
+			serviceContext.getUserId(), serviceContext.getScopeGroupId(),
+			parentFolderId, name, description, serviceContext);
+	}
+
+	private final JournalFolderLocalService _journalFolderLocalService;
+
+}

--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
@@ -660,56 +660,81 @@ public class JournalTestUtil {
 			feedFormat, feedVersion, serviceContext);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             JournalFolderFixture#addFolder(long, long, long, String)}
+	 */
+	@Deprecated
 	public static JournalFolder addFolder(
 			long userId, long groupId, long parentFolderId, String name)
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(groupId, userId);
+		JournalFolderFixture journalFolderFixture = new JournalFolderFixture(
+			JournalFolderLocalServiceUtil.getService());
 
-		return addFolder(parentFolderId, name, serviceContext);
+		return journalFolderFixture.addFolder(
+			userId, groupId, parentFolderId, name);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             JournalFolderFixture#addFolder(long, long, String)}
+	 */
+	@Deprecated
 	public static JournalFolder addFolder(
 			long groupId, long parentFolderId, String name)
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				groupId, TestPropsValues.getUserId());
+		JournalFolderFixture journalFolderFixture = new JournalFolderFixture(
+			JournalFolderLocalServiceUtil.getService());
 
-		return addFolder(parentFolderId, name, serviceContext);
+		return journalFolderFixture.addFolder(groupId, parentFolderId, name);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             JournalFolderFixture#addFolder(long, String)}
+	 */
+	@Deprecated
 	public static JournalFolder addFolder(long groupId, String name)
 		throws Exception {
 
-		return addFolder(
-			groupId, JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, name);
+		JournalFolderFixture journalFolderFixture = new JournalFolderFixture(
+			JournalFolderLocalServiceUtil.getService());
+
+		return journalFolderFixture.addFolder(groupId, name);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             JournalFolderFixture#addFolder(long, String, ServiceContext)}
+	 */
+	@Deprecated
 	public static JournalFolder addFolder(
 			long parentFolderId, String name, ServiceContext serviceContext)
 		throws Exception {
 
-		return addFolder(
-			parentFolderId, name, "This is a test folder.", serviceContext);
+		JournalFolderFixture journalFolderFixture = new JournalFolderFixture(
+			JournalFolderLocalServiceUtil.getService());
+
+		return journalFolderFixture.addFolder(
+			parentFolderId, name, serviceContext);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             JournalFolderFixture#addFolder(long, String, String, ServiceContext)}
+	 */
+	@Deprecated
 	public static JournalFolder addFolder(
 			long parentFolderId, String name, String description,
 			ServiceContext serviceContext)
 		throws Exception {
 
-		JournalFolder folder = JournalFolderLocalServiceUtil.fetchFolder(
-			serviceContext.getScopeGroupId(), parentFolderId, name);
+		JournalFolderFixture journalFolderFixture = new JournalFolderFixture(
+			JournalFolderLocalServiceUtil.getService());
 
-		if (folder != null) {
-			return folder;
-		}
-
-		return JournalFolderLocalServiceUtil.addFolder(
-			serviceContext.getUserId(), serviceContext.getScopeGroupId(),
+		return journalFolderFixture.addFolder(
 			parentFolderId, name, description, serviceContext);
 	}
 

--- a/modules/apps/journal/journal-test-util/src/main/resources/com/liferay/journal/test/util/packageinfo
+++ b/modules/apps/journal/journal-test-util/src/main/resources/com/liferay/journal/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/portal-search/portal-search-web/build.gradle
+++ b/modules/apps/portal-search/portal-search-web/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 
 	testCompile group: "commons-configuration", name: "commons-configuration", version: "1.10"
 	testCompile group: "commons-httpclient", name: "commons-httpclient", version: "3.1"
+	testCompile group: "org.apache.httpcomponents", name: "httpclient", version: "4.5.1"
+	testCompile group: "org.apache.httpcomponents", name: "httpmime", version: "4.5.1"
 	testCompile group: "org.jabsorb", name: "jabsorb", version: "1.3.1"
 	testCompile group: "org.jodd", name: "jodd-bean", version: "3.6.4"
 	testCompile group: "org.jodd", name: "jodd-json", version: "3.6.4"


### PR DESCRIPTION
**❌ ci:test:search - 47 out of 50 jobs passed in 1 hour 30 minutes 5 seconds 353 ms**
https://github.com/arboliveira/liferay-portal/pull/798#issuecomment-577465189

----

Failures are unrelated, QA aware. Ran baseline post warning.

----

https://issues.liferay.com/browse/LPS-107459
