### PR TITLE
LPS-107477 jsonWebServiceClassName can contain "$" chars

### DIFF
--- a/portal-web/docroot/html/portal/api/jsonws/actions.jsp
+++ b/portal-web/docroot/html/portal/api/jsonws/actions.jsp
@@ -90,7 +90,7 @@ Set<String> contextNames = JSONWebServiceActionsManagerUtil.getContextNames();
 		<liferay-ui:panel
 			collapsible="<%= true %>"
 			extended="<%= true %>"
-			id='<%= "apiService" + jsonWebServiceClassName + "Panel" %>'
+			id='<%= "apiService" + HtmlUtil.getAUICompatibleId(jsonWebServiceClassName) + "Panel" %>'
 			persistState="<%= true %>"
 			title="<%= panelTitle %>"
 		>


### PR DESCRIPTION
[LPS-107477](https://issues.liferay.com/browse/LPS-107477)

p.s. QA will be adding functional test(s) for to catch JS errors on /api/jsonws in future.

/cc @csierra @topolik