### PR TITLE
LPS-95853 RenderURL.setBeanParameter(PortletSerializable) sets an incorrect parameter name for CDI and Spring bean portlets

### DIFF
--- a/portal-impl/src/com/liferay/portlet/internal/PortletURLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletURLImpl.java
@@ -422,6 +422,27 @@ public class PortletURLImpl
 
 		if (Validator.isNull(paramName)) {
 			paramName = portletSerializableClass.getSimpleName();
+
+			if (paramName.endsWith("$$EnhancerBySpringCGLIB")) {
+
+				// If RenderURL.setBeanParameter(PortletSerializable) is called
+				// from within a bean portlet that uses Spring for IoC, and if
+				// Spring dynamically created the bean at runtime using CGLib,
+				// then the parameter name will have "$$EnhanderBySpringCGLib"
+				// as a suffix.
+
+				paramName = paramName.substring(
+					0, paramName.length() - "$$EnhancerBySpringCGLIB".length());
+			}
+			else if (paramName.endsWith("$Proxy$_$$_WeldClientProxy")) {
+
+				// Otherwise, if using CDI then the parameter name will have
+				// "$Proxy$_$$_WeldClientProxy" as a suffix.
+
+				paramName = paramName.substring(
+					0,
+					paramName.length() - "$Proxy$_$$_WeldClientProxy".length());
+			}
 		}
 
 		MutableRenderParameters mutableRenderParameters = getRenderParameters();


### PR DESCRIPTION
@brianchandotcom This falls in the "neutral" category according to what you wrote:

> Adding the addition $ in the PortletURLImpl is also neutral since it won't break stuff.