### PR TITLE
LRCI-888 Use unar to decompress 7z bundle on mac os

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -190,11 +190,23 @@ module.framework.properties.osgi.console=11312</echo>
 			<if>
 				<matches pattern=".*\.7z$" string="${archive.basename}" />
 				<then>
-					<execute>
-						<![CDATA[
-							7z x @{src} -o@{dest} -aoa
-						]]>
-					</execute>
+					<if>
+						<os family="mac" />
+						<then>
+							<execute>
+								<![CDATA[
+									unar @{src} -o @{dest} -f
+								]]>
+							</execute>
+						</then>
+						<else>
+							<execute>
+								<![CDATA[
+									7z x @{src} -o @{dest} -aoa
+								]]>
+							</execute>
+						</else>
+					</if>
 				</then>
 				<elseif>
 					<matches pattern=".*\.tar\.gz$" string="${archive.basename}" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-888

Related:
7.0.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/28714
7.1.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/28715
7.2.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/28716

Tested here: https://test-2-1.liferay.com//userContent/jobs/test-portal-fixpack-environment%287.1.x-private%29/builds/102/jenkins-report.html

cc @pyoo47