### PR TITLE
LPS-107726 Remove workaround for loader race

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/TreeviewCard.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/TreeviewCard.js
@@ -15,25 +15,11 @@
 import ClayCard from '@clayui/card';
 import ClayIcon from '@clayui/icon';
 import ClaySticker from '@clayui/sticker';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
 import TreeviewContext from './TreeviewContext';
-
-/**
- * Local version of `classnames()` required due to loader bug which prevents us
- * from importing the shared version.
- *
- * See: https://github.com/liferay/liferay-amd-loader/issues/225
- */
-function classNames(classes) {
-	return Object.entries(classes)
-		.map(([key, value]) => {
-			return value ? key : false;
-		})
-		.filter(Boolean)
-		.join(' ');
-}
 
 export default function TreeviewCard({node}) {
 	const {state} = useContext(TreeviewContext);


### PR DESCRIPTION
Back in November 2019 we were running into a race condition in the loader when trying to use a shared module as described [here](https://github.com/izaera/liferay-portal/pull/117). It was quite a surprising issue at the time, because we rely on shared modules extensively in this repo.

Back then, it reproduced reliably 100% of the time, but now it reproduces 0% of the time (tested with multiple developers on multiple machines at multiple branch points), so it should be safe to remove the local definition and rely on the shared module instead.