### PR TITLE
LPS-98124 Fix NPE

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
@@ -637,8 +637,8 @@ public class DataDefinitionResourceImpl
 
 	private SPIDataLayoutResource _getSPIDataLayoutResource() {
 		return new SPIDataLayoutResource<>(
-			_ddmFormLayoutSerializer, _ddmStructureLayoutLocalService,
-			_ddmStructureLocalService, _ddmStructureVersionLocalService,
+			_ddmStructureLayoutLocalService, _ddmStructureLocalService,
+			_ddmStructureVersionLocalService,
 			_deDataDefinitionFieldLinkLocalService,
 			DataLayoutUtil::toDataLayout);
 	}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataLayoutResourceImpl.java
@@ -178,8 +178,8 @@ public class DataLayoutResourceImpl
 
 	private SPIDataLayoutResource _getSPIDataLayoutResource() {
 		return new SPIDataLayoutResource<>(
-			_ddmFormLayoutSerializer, _ddmStructureLayoutLocalService,
-			_ddmStructureLocalService, _ddmStructureVersionLocalService,
+			_ddmStructureLayoutLocalService, _ddmStructureLocalService,
+			_ddmStructureVersionLocalService,
 			_deDataDefinitionFieldLinkLocalService,
 			DataLayoutUtil::toDataLayout);
 	}

--- a/modules/apps/data-engine/data-engine-spi/src/main/java/com/liferay/data/engine/spi/resource/SPIDataLayoutResource.java
+++ b/modules/apps/data-engine/data-engine-spi/src/main/java/com/liferay/data/engine/spi/resource/SPIDataLayoutResource.java
@@ -19,7 +19,6 @@ import com.jayway.jsonpath.JsonPath;
 
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.service.DEDataDefinitionFieldLinkLocalService;
-import com.liferay.dynamic.data.mapping.io.DDMFormLayoutSerializer;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMStructureLayout;
 import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
@@ -60,7 +59,6 @@ import javax.validation.ValidationException;
 public class SPIDataLayoutResource<T> {
 
 	public SPIDataLayoutResource(
-		DDMFormLayoutSerializer ddmFormLayoutSerializer,
 		DDMStructureLayoutLocalService ddmStructureLayoutLocalService,
 		DDMStructureLocalService ddmStructureLocalService,
 		DDMStructureVersionLocalService ddmStructureVersionLocalService,
@@ -68,7 +66,6 @@ public class SPIDataLayoutResource<T> {
 			deDataDefinitionFieldLinkLocalService,
 		UnsafeFunction<DDMStructureLayout, T, Exception> toDataLayoutFunction) {
 
-		_ddmFormLayoutSerializer = ddmFormLayoutSerializer;
 		_ddmStructureLayoutLocalService = ddmStructureLayoutLocalService;
 		_ddmStructureLocalService = ddmStructureLocalService;
 		_ddmStructureVersionLocalService = ddmStructureVersionLocalService;
@@ -311,7 +308,6 @@ public class SPIDataLayoutResource<T> {
 		}
 	}
 
-	private final DDMFormLayoutSerializer _ddmFormLayoutSerializer;
 	private final DDMStructureLayoutLocalService
 		_ddmStructureLayoutLocalService;
 	private final DDMStructureLocalService _ddmStructureLocalService;

--- a/modules/apps/data-engine/data-engine-spi/src/main/java/com/liferay/data/engine/spi/resource/SPIDataLayoutResource.java
+++ b/modules/apps/data-engine/data-engine-spi/src/main/java/com/liferay/data/engine/spi/resource/SPIDataLayoutResource.java
@@ -298,8 +298,8 @@ public class SPIDataLayoutResource<T> {
 		}
 
 		name.forEach(
-			(locale, localeName) -> {
-				if (Validator.isNull((String)localeName)) {
+			(locale, localizedName) -> {
+				if (Validator.isNull(localizedName)) {
 					throw new ValidationException("Name is required");
 				}
 			});

--- a/modules/apps/data-engine/data-engine-spi/src/main/java/com/liferay/data/engine/spi/resource/SPIDataLayoutResource.java
+++ b/modules/apps/data-engine/data-engine-spi/src/main/java/com/liferay/data/engine/spi/resource/SPIDataLayoutResource.java
@@ -297,6 +297,13 @@ public class SPIDataLayoutResource<T> {
 			throw new ValidationException("Name is required");
 		}
 
+		name.forEach(
+			(locale, localeName) -> {
+				if (Validator.isNull((String)localeName)) {
+					throw new ValidationException("Name is required");
+				}
+			});
+
 		List<String> fieldNames = _getFieldNames(content);
 
 		if (ListUtil.isEmpty(fieldNames)) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/ValidatorIsNullCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/ValidatorIsNullCheck.java
@@ -74,8 +74,9 @@ public class ValidatorIsNullCheck extends BaseCheck {
 
 			childDetailAST = typeDetailAST.getFirstChild();
 
-			if ((childDetailAST.getType() == TokenTypes.LITERAL_INT) ||
-				(childDetailAST.getType() == TokenTypes.LITERAL_LONG)) {
+			if ((childDetailAST != null) &&
+				((childDetailAST.getType() == TokenTypes.LITERAL_INT) ||
+				 (childDetailAST.getType() == TokenTypes.LITERAL_LONG))) {
 
 				log(
 					methodCallDetailAST, _MSG_INVALID_METHOD_NAME,


### PR DESCRIPTION
Hello @petershin and @hhuijser. 

Please take a look at https://github.com/brianchandotcom/liferay-portal/pull/83979/commits/9560c8c4beaf97931d5576740d20182c6bf74579

I had to do a null check before validating the childDetail. 
This https://github.com/brianchandotcom/liferay-portal/pull/83979/commits/73c5ec8a425b370af9aafdb37559145e27cafd34 was generating the NPE in SF if there was no cast in the parameter for `Validator.isNull`. I removed the cast( it's unnecessary ) and made the fix directly to SF.