### PR TITLE
LPS-107841 AccountEntryOrganizationRel is not deleted when the corresponding AccountEntry is deleted

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/AccountEntryModelListener.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/AccountEntryModelListener.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.account.internal.model.listener;
+
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.model.AccountEntryOrganizationRel;
+import com.liferay.account.model.AccountEntryUserRel;
+import com.liferay.account.model.AccountRole;
+import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
+import com.liferay.account.service.AccountEntryUserRelLocalService;
+import com.liferay.account.service.AccountRoleLocalService;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@Component(immediate = true, service = ModelListener.class)
+public class AccountEntryModelListener extends BaseModelListener<AccountEntry> {
+
+	@Override
+	public void onAfterRemove(AccountEntry accountEntry)
+		throws ModelListenerException {
+
+		// Account Organizations
+
+		List<AccountEntryOrganizationRel> accountEntryOrganizationRels =
+			_accountEntryOrganizationRelLocalService.
+				getAccountEntryOrganizationRels(
+					accountEntry.getAccountEntryId());
+
+		for (AccountEntryOrganizationRel accountEntryOrganizationRel :
+				accountEntryOrganizationRels) {
+
+			_accountEntryOrganizationRelLocalService.
+				deleteAccountEntryOrganizationRel(accountEntryOrganizationRel);
+		}
+
+		// Account Roles
+
+		List<AccountRole> accountRoles =
+			_accountRoleLocalService.getAccountRolesByAccountEntryIds(
+				new long[] {accountEntry.getAccountEntryId()});
+
+		try {
+			for (AccountRole accountRole : accountRoles) {
+				_accountRoleLocalService.deleteAccountRole(accountRole);
+			}
+		}
+		catch (Exception exception) {
+			throw new ModelListenerException(exception);
+		}
+
+		// Account Users
+
+		List<AccountEntryUserRel> accountEntryUserRels =
+			_accountEntryUserRelLocalService.
+				getAccountEntryUserRelsByAccountEntryId(
+					accountEntry.getAccountEntryId());
+
+		for (AccountEntryUserRel accountEntryUserRel : accountEntryUserRels) {
+			_accountEntryUserRelLocalService.deleteAccountEntryUserRel(
+				accountEntryUserRel);
+		}
+	}
+
+	@Reference
+	private AccountEntryOrganizationRelLocalService
+		_accountEntryOrganizationRelLocalService;
+
+	@Reference
+	private AccountEntryUserRelLocalService _accountEntryUserRelLocalService;
+
+	@Reference
+	private AccountRoleLocalService _accountRoleLocalService;
+
+}

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/internal/model/listener/test/AccountEntryModelListenerWhenDeletingAccountEntryTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/internal/model/listener/test/AccountEntryModelListenerWhenDeletingAccountEntryTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.account.internal.model.listener.test;
+
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.model.AccountRole;
+import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
+import com.liferay.account.service.AccountEntryUserRelLocalService;
+import com.liferay.account.service.AccountRoleLocalService;
+import com.liferay.account.service.test.AccountEntryTestUtil;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@RunWith(Arquillian.class)
+public class AccountEntryModelListenerWhenDeletingAccountEntryTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_accountEntry = AccountEntryTestUtil.addAccountEntry(
+			_accountEntryLocalService);
+	}
+
+	@Test
+	public void testAccountEntryOrganizationRelDeleted() throws Exception {
+		_organization = OrganizationTestUtil.addOrganization();
+
+		_accountEntryOrganizationRelLocalService.addAccountEntryOrganizationRel(
+			_accountEntry.getAccountEntryId(),
+			_organization.getOrganizationId());
+
+		Assert.assertTrue(
+			_accountEntryOrganizationRelLocalService.
+				hasAccountEntryOrganizationRel(
+					_accountEntry.getAccountEntryId(),
+					_organization.getOrganizationId()));
+
+		_accountEntryLocalService.deleteAccountEntry(_accountEntry);
+
+		Assert.assertNull(
+			_accountEntryLocalService.fetchAccountEntry(
+				_accountEntry.getAccountEntryId()));
+
+		Assert.assertFalse(
+			_accountEntryOrganizationRelLocalService.
+				hasAccountEntryOrganizationRel(
+					_accountEntry.getAccountEntryId(),
+					_organization.getOrganizationId()));
+	}
+
+	@Test
+	public void testAccountEntryUserRelDeleted() throws Exception {
+		_user = UserTestUtil.addUser();
+
+		_accountEntryUserRelLocalService.addAccountEntryUserRel(
+			_accountEntry.getAccountEntryId(), _user.getUserId());
+
+		Assert.assertTrue(
+			_accountEntryUserRelLocalService.hasAccountEntryUserRel(
+				_accountEntry.getAccountEntryId(), _user.getUserId()));
+
+		_accountEntryLocalService.deleteAccountEntry(_accountEntry);
+
+		Assert.assertNull(
+			_accountEntryLocalService.fetchAccountEntry(
+				_accountEntry.getAccountEntryId()));
+
+		Assert.assertFalse(
+			_accountEntryUserRelLocalService.hasAccountEntryUserRel(
+				_accountEntry.getAccountEntryId(), _user.getUserId()));
+	}
+
+	@Test
+	public void testAccountRoleDeleted() throws Exception {
+		AccountRole accountRole = _accountRoleLocalService.addAccountRole(
+			TestPropsValues.getUserId(), _accountEntry.getAccountEntryId(),
+			RandomTestUtil.randomString(), null, null);
+
+		Assert.assertEquals(
+			_accountEntry.getAccountEntryId(), accountRole.getAccountEntryId());
+
+		_accountEntryLocalService.deleteAccountEntry(_accountEntry);
+
+		Assert.assertNull(
+			_accountRoleLocalService.fetchAccountRole(
+				accountRole.getAccountRoleId()));
+	}
+
+	private AccountEntry _accountEntry;
+
+	@Inject
+	private AccountEntryLocalService _accountEntryLocalService;
+
+	@Inject
+	private AccountEntryOrganizationRelLocalService
+		_accountEntryOrganizationRelLocalService;
+
+	@Inject
+	private AccountEntryUserRelLocalService _accountEntryUserRelLocalService;
+
+	@Inject
+	private AccountRoleLocalService _accountRoleLocalService;
+
+	@DeleteAfterTestRun
+	private Organization _organization;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}


### PR DESCRIPTION
This is an update for [LPS-107841](https://issues.liferay.com/browse/LPS-107841).<br><br>/cc @pei-jung @alee8888 @ChrisKian @dejuknow @patriciajeanperez