### PR TITLE
LPS-108054 Documents Lodash not being served by default breaking change

### DIFF
--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -372,3 +372,36 @@ value has also changed to avoid the execution of new upgrade processes on
 startup in production environments.
 
 ---------------------------------------
+
+### JQuery is no longer included by default
+- **Date:** 2020-Feb-04
+- **JIRA Ticket:** [LPS-95726](https://issues.liferay.com/browse/LPS-95726)
+
+#### What changed?
+
+Previously, JQuery was being included in every page by default and made
+available through the global `window.$` and the scoped `AUI.$` variables. After
+this change, Lodash is no longer included by default and those variables will be
+`undefined`.
+
+#### Who is affected?
+
+This affects any developer who used `AUI.$` or `window.$` in their custom
+scripts.
+
+#### How should I update my code?
+
+You should provide your own version `JQuery` to be used by your custom
+developments following any of the possible strategies to add third party
+libraries.
+
+Additionally, as a temporary measure, you can bring back the old behaviour by
+setting the `Enable JQuery` property in `System Settings > Third Party > JQuery`
+to `true`.
+
+#### Why was this change made?
+
+This change was made to avoid bundling and serving additional library code on
+every page that was mostly unused and redundant.
+
+---------------------------------------


### PR DESCRIPTION
Hey @brianchandotcom!

We inadvertently merged a commit where we disable `JQuery` by default yesterday at https://github.com/brianchandotcom/liferay-portal/pull/84086. Here I'm just documenting the breaking change so it can be included in our next release notes. 

I know we want to avoid breaking changes, but in this case, I think we should go for it. If we don't, it means we'll basically have all of our pages slower for the next 2 years (until DXP 7.4 is released).

I've taken some screenshots of a rough measurement I just took on my machine. See the before and after the flag is swapped:

### Before (with JQuery), TTI: 15.1s

![Screen Shot 2020-02-04 at 14 47 25](https://user-images.githubusercontent.com/905006/73750707-ece23600-475d-11ea-97f6-ca9920fad1a9.png)

### After (without JQuery), TTI: 12.8s

![Screen Shot 2020-02-04 at 14 46 31](https://user-images.githubusercontent.com/905006/73750724-f2d81700-475d-11ea-8f18-b31bb57030af.png)

Re-enabling JQuery is just one checkbox away, so I'd say this is a worth breaking change we should do in this cycle. If you prefer, we could try to find ways to avoid it in CE bundles so we only deliver the new behaviour in DXP...

@ryanschuhler, could you verify if this could affect the web team and your ability to upgrade? I think that could be a good reality-check...

/cc @JorgeFerrer, @AngeloYoun, @david-truong