### PR TITLE
LPS-108031 Enable scans for CI

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -837,6 +837,7 @@ information.
 						<arg value="--stacktrace" />
 						<arg value="-Dapp.server.parent.dir=${app.server.parent.dir}" />
 						<arg value="-Dforced.cache.enabled=@{forcedcacheenabled}" />
+						<arg if:set="env.JENKINS_HOME" value="-Dgradle.build.scan.enabled=true" />
 						<arg value="-Dliferay.home=${liferay.home}" />
 						<arg if:set="env.JENKINS_HOME" value="-Dorg.gradle.internal.http.connectionTimeout=${gradle.ci.http.connection.timeout}" />
 						<arg if:set="env.JENKINS_HOME" value="-Dorg.gradle.internal.http.socketTimeout=${gradle.ci.http.socket.timeout}" />
@@ -949,6 +950,7 @@ information.
 								<arg value="--stacktrace" />
 								<arg value="-Dapp.server.parent.dir=${app.server.parent.dir}" />
 								<arg value="-Dforced.cache.enabled=@{forcedcacheenabled}" />
+								<arg if:set="env.JENKINS_HOME" value="-Dgradle.build.scan.enabled=true" />
 								<arg value="-Dliferay.home=${liferay.home}" />
 								<arg if:set="env.JENKINS_HOME" value="-Dorg.gradle.internal.http.connectionTimeout=${gradle.ci.http.connection.timeout}" />
 								<arg if:set="env.JENKINS_HOME" value="-Dorg.gradle.internal.http.socketTimeout=${gradle.ci.http.socket.timeout}" />
@@ -985,6 +987,7 @@ information.
 									<arg value="--stacktrace" />
 									<arg value="-Dapp.server.parent.dir=${app.server.parent.dir}" />
 									<arg value="-Dforced.cache.enabled=@{forcedcacheenabled}" />
+									<arg if:set="env.JENKINS_HOME" value="-Dgradle.build.scan.enabled=true" />
 									<arg value="-Dliferay.home=${liferay.home}" />
 									<arg if:set="env.JENKINS_HOME" value="-Dorg.gradle.internal.http.connectionTimeout=${gradle.ci.http.connection.timeout}" />
 									<arg if:set="env.JENKINS_HOME" value="-Dorg.gradle.internal.http.socketTimeout=${gradle.ci.http.socket.timeout}" />

--- a/build.properties
+++ b/build.properties
@@ -344,6 +344,8 @@
     org.gradle.logging.level=lifecycle
     org.gradle.warning.mode=none
 
+    systemProp.gradle.build.scan.enabled=false
+    systemProp.gradle.build.scan.server.url=https://ec2-54-202-222-165.us-west-2.compute.amazonaws.com/
     systemProp.packageRunBuild.incremental.cache.enabled=true
 
 ##

--- a/build.properties
+++ b/build.properties
@@ -346,6 +346,7 @@
 
     systemProp.gradle.build.scan.enabled=false
     systemProp.gradle.build.scan.server.url=https://ec2-54-202-222-165.us-west-2.compute.amazonaws.com/
+    systemProp.gradle.build.scan.tag=
     systemProp.packageRunBuild.incremental.cache.enabled=true
 
 ##

--- a/modules/build-buildscript.gradle
+++ b/modules/build-buildscript.gradle
@@ -4,6 +4,10 @@ dependencies {
 	classpath group: "de.undercouch", name: "gradle-download-task", version: "3.3.0"
 	classpath group: "gradle.plugin.org.ysb33r.gradle", name: "gradletest", version: "2.0"
 	classpath group: "xalan", name: "xalan", version: "2.7.2"
+
+	if (System.getProperty("gradle.build.scan.server.url")) {
+		classpath group: "com.gradle", name: "gradle-enterprise-gradle-plugin", version: "3.1.1"
+	}
 }
 
 repositories {

--- a/modules/build-buildscript.gradle
+++ b/modules/build-buildscript.gradle
@@ -5,7 +5,7 @@ dependencies {
 	classpath group: "gradle.plugin.org.ysb33r.gradle", name: "gradletest", version: "2.0"
 	classpath group: "xalan", name: "xalan", version: "2.7.2"
 
-	if (System.getProperty("gradle.build.scan.server.url")) {
+	if (Boolean.getBoolean("gradle.build.scan.enabled")) {
 		classpath group: "com.gradle", name: "gradle-enterprise-gradle-plugin", version: "3.1.1"
 	}
 }

--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -46,6 +46,10 @@ if (Boolean.getBoolean("gradle.build.scan.enabled")) {
 
 		publishAlwaysIf true
 		tag System.getenv("JENKINS_HOME") ? "CI" : "LOCAL"
+
+		if (System.getProperty("gradle.build.scan.tag")) {
+			tag System.getProperty("gradle.build.scan.tag")
+		}
 	}
 }
 

--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -37,12 +37,12 @@ ext {
 	]
 }
 
-if (System.getProperty("gradle.build.scan.server.url")) {
+if (Boolean.getBoolean("gradle.build.scan.enabled")) {
 	apply plugin: "com.gradle.build-scan"
 
 	buildScan {
 		allowUntrustedServer = true
-		server = System.getProperty("gradle.build.scan.server.url")
+		server = System.getProperty("gradle.build.scan.server.url") ?: null
 
 		publishAlwaysIf true
 		tag System.getenv("JENKINS_HOME") ? "CI" : "LOCAL"

--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -37,6 +37,18 @@ ext {
 	]
 }
 
+if (System.getProperty("gradle.build.scan.server.url")) {
+	apply plugin: "com.gradle.build-scan"
+
+	buildScan {
+		allowUntrustedServer = true
+		server = System.getProperty("gradle.build.scan.server.url")
+
+		publishAlwaysIf true
+		tag System.getenv("JENKINS_HOME") ? "CI" : "LOCAL"
+	}
+}
+
 Set<File> bndPrintJarFiles = null
 
 if (Boolean.getBoolean("build.bnd.print.enabled")) {


### PR DESCRIPTION
@yichenroy - The CI `System` property that we discussed yesterday isn't needed anymore, its automatically set now.

For the CI memory tests, the `build.property` below can be set to make it easier to compare the data

```
systemProp.gradle.build.scan.tag=XMX4096M
```

@david-truong - After this pull is merged, the Gradle Enterprise trial server will automatically capture data from the CI