### PR TITLE
LPS-107189 & LPS-107415 - Create endpoints to retrieve historical views and reads

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/data/provider/AnalyticsReportsDataProvider.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/data/provider/AnalyticsReportsDataProvider.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.analytics.reports.web.internal.data.provider;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author David Arques
+ */
+@Component(immediate = true, service = AnalyticsReportsDataProvider.class)
+public class AnalyticsReportsDataProvider {
+
+	public Long getTotalReads(long plid) {
+		return 9999L;
+	}
+
+	public Long getTotalViews(long plid) {
+		return 9999L;
+	}
+
+}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/data/provider/AnalyticsReportsDataProvider.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/data/provider/AnalyticsReportsDataProvider.java
@@ -14,6 +14,14 @@
 
 package com.liferay.analytics.reports.web.internal.data.provider;
 
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -21,6 +29,21 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(immediate = true, service = AnalyticsReportsDataProvider.class)
 public class AnalyticsReportsDataProvider {
+
+	public JSONObject getHistoricalViews(long plid) throws PortalException {
+		try {
+			Class<?> clazz = getClass();
+
+			InputStream inputStream = clazz.getResourceAsStream(
+				"dependencies/analytics-reports-historical-views.json");
+
+			return JSONFactoryUtil.createJSONObject(
+				StringUtil.read(inputStream));
+		}
+		catch (IOException ioException) {
+			throw new PortalException(ioException);
+		}
+	}
 
 	public Long getTotalReads(long plid) {
 		return 9999L;

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/data/provider/AnalyticsReportsDataProvider.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/data/provider/AnalyticsReportsDataProvider.java
@@ -30,15 +30,20 @@ import org.osgi.service.component.annotations.Component;
 @Component(immediate = true, service = AnalyticsReportsDataProvider.class)
 public class AnalyticsReportsDataProvider {
 
+	public JSONObject getHistoricalReads(long plid) throws PortalException {
+		try {
+			return JSONFactoryUtil.createJSONObject(
+				_read("analytics-reports-historical-reads.json"));
+		}
+		catch (IOException ioException) {
+			throw new PortalException(ioException);
+		}
+	}
+
 	public JSONObject getHistoricalViews(long plid) throws PortalException {
 		try {
-			Class<?> clazz = getClass();
-
-			InputStream inputStream = clazz.getResourceAsStream(
-				"dependencies/analytics-reports-historical-views.json");
-
 			return JSONFactoryUtil.createJSONObject(
-				StringUtil.read(inputStream));
+				_read("analytics-reports-historical-views.json"));
 		}
 		catch (IOException ioException) {
 			throw new PortalException(ioException);
@@ -51,6 +56,15 @@ public class AnalyticsReportsDataProvider {
 
 	public Long getTotalViews(long plid) {
 		return 9999L;
+	}
+
+	private String _read(String fileName) throws IOException {
+		Class<?> clazz = getClass();
+
+		InputStream inputStream = clazz.getResourceAsStream(
+			"dependencies/" + fileName);
+
+		return StringUtil.read(inputStream);
 	}
 
 }

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/data/provider/AnalyticsReportsDataProvider.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/data/provider/AnalyticsReportsDataProvider.java
@@ -30,7 +30,9 @@ import org.osgi.service.component.annotations.Component;
 @Component(immediate = true, service = AnalyticsReportsDataProvider.class)
 public class AnalyticsReportsDataProvider {
 
-	public JSONObject getHistoricalReads(long plid) throws PortalException {
+	public JSONObject getHistoricalReadsJSONObject(long plid)
+		throws PortalException {
+
 		try {
 			return JSONFactoryUtil.createJSONObject(
 				_read("analytics-reports-historical-reads.json"));
@@ -40,7 +42,9 @@ public class AnalyticsReportsDataProvider {
 		}
 	}
 
-	public JSONObject getHistoricalViews(long plid) throws PortalException {
+	public JSONObject getHistoricalViewsJSONObject(long plid)
+		throws PortalException {
+
 		try {
 			return JSONFactoryUtil.createJSONObject(
 				_read("analytics-reports-historical-views.json"));

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/display/context/AnalyticsReportsDisplayContext.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/display/context/AnalyticsReportsDisplayContext.java
@@ -65,6 +65,17 @@ public class AnalyticsReportsDisplayContext {
 			HashMapBuilder.<String, Object>put(
 				"endpoints",
 				HashMapBuilder.<String, Object>put(
+					"getAnalyticsReportsHistoricalViewsURL",
+					() -> {
+						ResourceURL resourceURL =
+							_renderResponse.createResourceURL();
+
+						resourceURL.setResourceID(
+							"/analytics_reports/get_historical_views");
+
+						return resourceURL.toString();
+					}
+				).put(
 					"getAnalyticsReportsTotalReadsURL",
 					() -> {
 						ResourceURL resourceURL =

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/display/context/AnalyticsReportsDisplayContext.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/display/context/AnalyticsReportsDisplayContext.java
@@ -65,6 +65,17 @@ public class AnalyticsReportsDisplayContext {
 			HashMapBuilder.<String, Object>put(
 				"endpoints",
 				HashMapBuilder.<String, Object>put(
+					"getAnalyticsReportsHistoricalReadsURL",
+					() -> {
+						ResourceURL resourceURL =
+							_renderResponse.createResourceURL();
+
+						resourceURL.setResourceID(
+							"/analytics_reports/get_historical_reads");
+
+						return resourceURL.toString();
+					}
+				).put(
 					"getAnalyticsReportsHistoricalViewsURL",
 					() -> {
 						ResourceURL resourceURL =

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetAnalyticsReportsHistoricalReadsMVCResourceCommand.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetAnalyticsReportsHistoricalReadsMVCResourceCommand.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.analytics.reports.web.internal.portlet.action;
+
+import com.liferay.analytics.reports.web.internal.constants.AnalyticsReportsPortletKeys;
+import com.liferay.analytics.reports.web.internal.data.provider.AnalyticsReportsDataProvider;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author David Arques
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + AnalyticsReportsPortletKeys.ANALYTICS_REPORTS,
+		"mvc.command.name=/analytics_reports/get_historical_reads"
+	},
+	service = MVCResourceCommand.class
+)
+public class GetAnalyticsReportsHistoricalReadsMVCResourceCommand
+	extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+
+		try {
+			long plid = ParamUtil.getLong(resourceRequest, "plid");
+
+			jsonObject.put(
+				"analyticsReportsHistoricalReads",
+				_analyticsReportsDataProvider.getHistoricalReads(plid));
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)resourceRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			jsonObject.put(
+				"error",
+				LanguageUtil.get(
+					themeDisplay.getRequest(), "an-unexpected-error-occurred"));
+		}
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse, jsonObject);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GetAnalyticsReportsHistoricalReadsMVCResourceCommand.class);
+
+	@Reference
+	private AnalyticsReportsDataProvider _analyticsReportsDataProvider;
+
+}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetAnalyticsReportsHistoricalReadsMVCResourceCommand.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetAnalyticsReportsHistoricalReadsMVCResourceCommand.java
@@ -60,7 +60,8 @@ public class GetAnalyticsReportsHistoricalReadsMVCResourceCommand
 
 			jsonObject.put(
 				"analyticsReportsHistoricalReads",
-				_analyticsReportsDataProvider.getHistoricalReads(plid));
+				_analyticsReportsDataProvider.getHistoricalReadsJSONObject(
+					plid));
 		}
 		catch (Exception exception) {
 			_log.error(exception, exception);

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetAnalyticsReportsHistoricalViewsMVCResourceCommand.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetAnalyticsReportsHistoricalViewsMVCResourceCommand.java
@@ -60,7 +60,8 @@ public class GetAnalyticsReportsHistoricalViewsMVCResourceCommand
 
 			jsonObject.put(
 				"analyticsReportsHistoricalViews",
-				_analyticsReportsDataProvider.getHistoricalViews(plid));
+				_analyticsReportsDataProvider.getHistoricalViewsJSONObject(
+					plid));
 		}
 		catch (Exception exception) {
 			_log.error(exception, exception);

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetAnalyticsReportsHistoricalViewsMVCResourceCommand.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetAnalyticsReportsHistoricalViewsMVCResourceCommand.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.analytics.reports.web.internal.portlet.action;
+
+import com.liferay.analytics.reports.web.internal.constants.AnalyticsReportsPortletKeys;
+import com.liferay.analytics.reports.web.internal.data.provider.AnalyticsReportsDataProvider;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author David Arques
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + AnalyticsReportsPortletKeys.ANALYTICS_REPORTS,
+		"mvc.command.name=/analytics_reports/get_historical_views"
+	},
+	service = MVCResourceCommand.class
+)
+public class GetAnalyticsReportsHistoricalViewsMVCResourceCommand
+	extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+
+		try {
+			long plid = ParamUtil.getLong(resourceRequest, "plid");
+
+			jsonObject.put(
+				"analyticsReportsHistoricalViews",
+				_analyticsReportsDataProvider.getHistoricalViews(plid));
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)resourceRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			jsonObject.put(
+				"error",
+				LanguageUtil.get(
+					themeDisplay.getRequest(), "an-unexpected-error-occurred"));
+		}
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse, jsonObject);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GetAnalyticsReportsHistoricalViewsMVCResourceCommand.class);
+
+	@Reference
+	private AnalyticsReportsDataProvider _analyticsReportsDataProvider;
+
+}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetAnalyticsReportsTotalReadsMVCResourceCommand.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetAnalyticsReportsTotalReadsMVCResourceCommand.java
@@ -15,16 +15,19 @@
 package com.liferay.analytics.reports.web.internal.portlet.action;
 
 import com.liferay.analytics.reports.web.internal.constants.AnalyticsReportsPortletKeys;
+import com.liferay.analytics.reports.web.internal.data.provider.AnalyticsReportsDataProvider;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.util.ParamUtil;
 
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author David Arques
@@ -45,11 +48,17 @@ public class GetAnalyticsReportsTotalReadsMVCResourceCommand
 			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
 		throws Exception {
 
+		long plid = ParamUtil.getLong(resourceRequest, "plid");
+
 		JSONObject jsonObject = JSONUtil.put(
-			"analyticsReportsTotalReads", 9999);
+			"analyticsReportsTotalReads",
+			_analyticsReportsDataProvider.getTotalReads(plid));
 
 		JSONPortletResponseUtil.writeJSON(
 			resourceRequest, resourceResponse, jsonObject);
 	}
+
+	@Reference
+	private AnalyticsReportsDataProvider _analyticsReportsDataProvider;
 
 }

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetAnalyticsReportsTotalViewsMVCResourceCommand.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/action/GetAnalyticsReportsTotalViewsMVCResourceCommand.java
@@ -15,16 +15,19 @@
 package com.liferay.analytics.reports.web.internal.portlet.action;
 
 import com.liferay.analytics.reports.web.internal.constants.AnalyticsReportsPortletKeys;
+import com.liferay.analytics.reports.web.internal.data.provider.AnalyticsReportsDataProvider;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.util.ParamUtil;
 
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Sarai Díaz
@@ -45,11 +48,17 @@ public class GetAnalyticsReportsTotalViewsMVCResourceCommand
 			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
 		throws Exception {
 
+		long plid = ParamUtil.getLong(resourceRequest, "plid");
+
 		JSONObject jsonObject = JSONUtil.put(
-			"analyticsReportsTotalViews", 9999);
+			"analyticsReportsTotalViews",
+			_analyticsReportsDataProvider.getTotalViews(plid));
 
 		JSONPortletResponseUtil.writeJSON(
 			resourceRequest, resourceResponse, jsonObject);
 	}
+
+	@Reference
+	private AnalyticsReportsDataProvider _analyticsReportsDataProvider;
 
 }

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/com/liferay/analytics/reports/web/internal/data/provider/dependencies/analytics-reports-historical-reads.json
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/com/liferay/analytics/reports/web/internal/data/provider/dependencies/analytics-reports-historical-reads.json
@@ -1,0 +1,48 @@
+{
+	"histogram": [
+		{
+			"key": "2020-01-27T00:00",
+			"previousKey": "2020-01-20T00:00",
+			"previousValue": 22.0,
+			"value": 32.0
+		},
+		{
+			"key": "2020-01-28T00:00",
+			"previousKey": "2020-01-21T00:00",
+			"previousValue": 23.0,
+			"value": 33.0
+		},
+		{
+			"key": "2020-01-29T00:00",
+			"previousKey": "2020-01-22T00:00",
+			"previousValue": 24.0,
+			"value": 34.0
+		},
+		{
+			"key": "2020-01-30T00:00",
+			"previousKey": "2020-01-23T00:00",
+			"previousValue": 25.0,
+			"value": 33.0
+		},
+		{
+			"key": "2020-01-31T00:00",
+			"previousKey": "2020-01-24T00:00",
+			"previousValue": 26.0,
+			"value": 32.0
+		},
+		{
+			"key": "2020-02-01T00:00",
+			"previousKey": "2020-01-25T00:00",
+			"previousValue": 27.0,
+			"value": 31.0
+		},
+		{
+			"key": "2020-02-02T00:00",
+			"previousKey": "2020-01-26T00:00",
+			"previousValue": 28.0,
+			"value": 30.0
+		}
+	],
+	"previousValue": 175.0,
+	"value": 225.0
+}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/com/liferay/analytics/reports/web/internal/data/provider/dependencies/analytics-reports-historical-views.json
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/com/liferay/analytics/reports/web/internal/data/provider/dependencies/analytics-reports-historical-views.json
@@ -1,0 +1,48 @@
+{
+	"histogram": [
+		{
+			"key": "2020-01-27T00:00",
+			"previousKey": "2020-01-20T00:00",
+			"previousValue": 32.0,
+			"value": 42.0
+		},
+		{
+			"key": "2020-01-28T00:00",
+			"previousKey": "2020-01-21T00:00",
+			"previousValue": 33.0,
+			"value": 43.0
+		},
+		{
+			"key": "2020-01-29T00:00",
+			"previousKey": "2020-01-22T00:00",
+			"previousValue": 34.0,
+			"value": 44.0
+		},
+		{
+			"key": "2020-01-30T00:00",
+			"previousKey": "2020-01-23T00:00",
+			"previousValue": 35.0,
+			"value": 43.0
+		},
+		{
+			"key": "2020-01-31T00:00",
+			"previousKey": "2020-01-24T00:00",
+			"previousValue": 36.0,
+			"value": 42.0
+		},
+		{
+			"key": "2020-02-01T00:00",
+			"previousKey": "2020-01-25T00:00",
+			"previousValue": 37.0,
+			"value": 41.0
+		},
+		{
+			"key": "2020-02-02T00:00",
+			"previousKey": "2020-01-26T00:00",
+			"previousValue": 38.0,
+			"value": 40.0
+		}
+	],
+	"previousValue": 245.0,
+	"value": 295.0
+}


### PR DESCRIPTION
@brianchandotcom as we agreed we're using Mocks for Content-Performance for now. See `AnalyticsReportDataProvider`. In the near future, when the real **Analytics Cloud Client** is ready, we'll get rid of faked data.

CC: @ealonso, @dgarciasarai, @andresfulla