### PR TITLE
LPS-107863 Bump netty library version

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/bnd.bnd
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/bnd.bnd
@@ -24,6 +24,8 @@ Import-Package:\
 	\
 	!com.ning.compress.*,\
 	\
+	!com.oracle.svm.*,\
+	\
 	!com.puppycrawl.tools.checkstyle.*,\
 	\
 	!com.sun.jna.*,\
@@ -37,6 +39,8 @@ Import-Package:\
 	!gnu.io.*,\
 	\
 	!groovy.*,\
+	\
+	!io.netty.internal.*,\
 	\
 	!javassist.*,\
 	\

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 	compileInclude group: "commons-io", name: "commons-io", version: "2.6"
 	compileInclude group: "commons-lang", name: "commons-lang", version: "2.6"
 	compileInclude group: "commons-logging", name: "commons-logging", version: "1.2"
-	compileInclude group: "io.netty", name: "netty-all", version: "4.1.11.Final"
+	compileInclude group: "io.netty", name: "netty-all", version: "4.1.36.Final"
 	compileInclude group: "joda-time", name: "joda-time", version: "2.9.5"
 	compileInclude group: "log4j", name: "log4j", version: "1.2.17"
 	compileInclude group: "net.sf.jopt-simple", name: "jopt-simple", version: "5.0.2"


### PR DESCRIPTION
**ci:test:search-es7 - 40 out of 3 jobs passed** https://github.com/BryanEngler/liferay-portal/pull/473#issuecomment-580962728
✅ The only failures unique to this pull are not caused by this pr, confirmed by @xbrianlee

Author(s): @lipusz
Reviewer(s): @BryanEngler

---
*[Bug] NoNodeAvailableException using Elasticsearch 7 with SSL/TLS on JDK 11*
https://issues.liferay.com/browse/LPS-107863