### PR TITLE
LPS-108206 Remove bundler loaders from dynamic-data-mapping-form-field-type package.json

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
@@ -8,8 +8,6 @@
 		"clay-radio": "2.20.2",
 		"frontend-js-web": "*",
 		"leaflet": "1.2.0",
-		"liferay-npm-bundler-loader-css-loader": "^2.14.1",
-		"liferay-npm-bundler-loader-style-loader": "^2.14.1",
 		"map-google-maps": "*",
 		"map-openstreetmap": "*",
 		"metal-component": "2.16.8",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -10980,6 +10980,11 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
+leaflet@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.2.0.tgz#fd5d93d9cb00091f5f8a69206d0d6744c1c82697"
+  integrity sha512-Bold8phAE6WcRsuwhofrQ7cOK1REFHaYIkKuj7+TBYK3ONKRpGGIb5oXR5akYotFnrWN0TWKh6Svlhflm3dogg==
+
 left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"


### PR DESCRIPTION
These packages were incorrectly added in dfb71a9dce492, causing duplication in the yarn.lock. If you run `yarn`, you wind up with multiple versions of these packages in the lockfile, and you see this (trimmed for brevity) in the output of `yarn why babel-plugin-normalize-requires`:

```
=> Found "babel-plugin-normalize-requires@2.17.0"
info Reasons this module exists
   - "_project_#babel-preset-liferay-standard" depends on it
=> Found "liferay-npm-bundler-loader-css-loader#babel-plugin-normalize-requires@2.17.1"
   - "_project_#dynamic-data-mapping-form-field-type#liferay-npm-bundler-loader-css-loader#liferay-npm-build-tools-common#liferay-npm-bundler-preset-standard#babel-preset-liferay-standard" depends on it
=> Found "liferay-npm-bundler-loader-style-loader#babel-plugin-normalize-requires@2.17.1"
   - "_project_#dynamic-data-mapping-form-field-type#liferay-npm-bundler-loader-style-loader#liferay-npm-build-tools-common#liferay-npm-bundler-preset-standard#babel-preset-liferay-standard" depends on it
```

These are "devDependencies" anyway, and should not have been added to "dependencies". And as "devDependencies", they are available transitively, and should not be declared.

Note also that the "leaflet" package, also added in dfb71a9dce492, was missing from the lockfile; I suspect that due to merge conflicts and/or rebase errors, that change got lost between when the commit was prepared and when it was merged -- note the long gap between the author and commit dates:

    Author:     marcelabc <mbc3@cin.ufpe.br>
    AuthorDate: Mon Jan 20 16:49:33 2020 -0300
    Commit:     Brian Chan <brian.chan@liferay.com>
    CommitDate: Wed Feb 5 13:51:18 2020 -0800