### PR TITLE
LPS-107725 We can reuse the path 1.1.7 to 1.1.8 because the upgradeUrlTitle does not need to be backported. See LPS-100925

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/JournalServiceUpgrade.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/JournalServiceUpgrade.java
@@ -52,7 +52,7 @@ import com.liferay.journal.internal.upgrade.v1_1_3.UpgradeResourcePermissions;
 import com.liferay.journal.internal.upgrade.v1_1_4.UpgradeUrlTitle;
 import com.liferay.journal.internal.upgrade.v1_1_5.UpgradeContentImages;
 import com.liferay.journal.internal.upgrade.v1_1_6.UpgradeAssetDisplayPageEntry;
-import com.liferay.journal.internal.upgrade.v1_1_9.UpgradeJournalArticle;
+import com.liferay.journal.internal.upgrade.v1_1_8.UpgradeJournalArticle;
 import com.liferay.journal.internal.upgrade.v2_0_0.util.JournalArticleTable;
 import com.liferay.journal.internal.upgrade.v2_0_0.util.JournalFeedTable;
 import com.liferay.journal.internal.upgrade.v2_0_0.util.JournalFolderTable;
@@ -202,12 +202,10 @@ public class JournalServiceUpgrade implements UpgradeStepRegistrator {
 				_subscriptionLocalService, JournalArticle.class.getName(),
 				UpgradeDiscussionSubscriptionClassName.DeletionMode.ADD_NEW));
 
-		registry.register("1.1.7", "1.1.8", new DummyUpgradeStep());
-
-		registry.register("1.1.8", "1.1.9", new UpgradeJournalArticle());
+		registry.register("1.1.7", "1.1.8", new UpgradeJournalArticle());
 
 		registry.register(
-			"1.1.9", "2.0.0",
+			"1.1.8", "2.0.0",
 			new BaseUpgradeSQLServerDatetime(
 				new Class<?>[] {
 					JournalArticleTable.class, JournalFeedTable.class,

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_8/UpgradeJournalArticle.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_8/UpgradeJournalArticle.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.journal.internal.upgrade.v1_1_9;
+package com.liferay.journal.internal.upgrade.v1_1_8;
 
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;


### PR DESCRIPTION
cc/ @ctampoya @balazssk