### PR TITLE
LPS-107382 Return empty SearchHits instead of null

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/SearchResponseImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/SearchResponseImpl.java
@@ -24,6 +24,9 @@ import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.groupby.GroupByResponse;
 import com.liferay.portal.search.hits.SearchHit;
 import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.hits.SearchHitsBuilder;
+import com.liferay.portal.search.hits.SearchHitsBuilderFactory;
+import com.liferay.portal.search.internal.hits.SearchHitsBuilderFactoryImpl;
 import com.liferay.portal.search.internal.legacy.searcher.FacetContextImpl;
 import com.liferay.portal.search.searcher.FacetContext;
 import com.liferay.portal.search.searcher.SearchRequest;
@@ -140,6 +143,13 @@ public class SearchResponseImpl implements SearchResponse, Serializable {
 
 	@Override
 	public SearchHits getSearchHits() {
+		if (_searchHits == null) {
+			SearchHitsBuilder searchHitsBuilder =
+				_searchHitsBuilderFactory.getSearchHitsBuilder();
+
+			return searchHitsBuilder.build();
+		}
+
 		return _searchHits;
 	}
 
@@ -252,6 +262,8 @@ public class SearchResponseImpl implements SearchResponse, Serializable {
 	private String _responseString = StringPool.BLANK;
 	private final SearchContext _searchContext;
 	private SearchHits _searchHits;
+	private SearchHitsBuilderFactory _searchHitsBuilderFactory =
+		new SearchHitsBuilderFactoryImpl();
 	private SearchRequest _searchRequest;
 	private final Map<String, StatsResponse> _statsResponseMap =
 		new LinkedHashMap<>();

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/searcher/SearchResponseImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/searcher/SearchResponseImplTest.java
@@ -16,6 +16,7 @@ package com.liferay.portal.search.internal.searcher;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.search.hits.SearchHits;
 import com.liferay.portal.search.searcher.SearchResponse;
 
 import java.util.List;
@@ -52,7 +53,7 @@ public class SearchResponseImplTest {
 		assertIs(searchResponse.getRequest(), nullValue());
 		assertIs(searchResponse.getRequestString(), blank());
 		assertIs(searchResponse.getResponseString(), blank());
-		assertIs(searchResponse.getSearchHits(), nullValue());
+		assertIs(searchResponse.getSearchHits(), instanceOf(SearchHits.class));
 		assertIs(searchResponse.getStatsResponseMap(), emptyMap());
 		assertIs(searchResponse.getTotalHits(), zeroInt());
 	}
@@ -82,6 +83,10 @@ public class SearchResponseImplTest {
 				).collect(
 					Collectors.toList()
 				)));
+	}
+
+	protected static Consumer instanceOf(Class clazz) {
+		return object -> Assert.assertTrue(clazz.isInstance(object));
 	}
 
 	protected static Consumer nullValue() {


### PR DESCRIPTION
**ci:test:search - 46 out of 50 jobs passed** https://github.com/BryanEngler/liferay-portal/pull/475#issuecomment-582614838
✅ The only failures unique to this pull are also failing on the upstream canary https://github.com/xbrianlee/liferay-portal/pull/369#issuecomment-582963839

Author(s): @joshuacords
Reviewer(s): @BryanEngler
Cc: @arboliveira

---
*[Bug] searchResponse.getSearchHits() can return null*
https://issues.liferay.com/browse/LPS-107382