### PR TITLE
LPS-108231 Set restart-required to false for CCR

### DIFF
--- a/modules/dxp/apps/portal-search-elasticsearch-cross-cluster-replication/app.bnd
+++ b/modules/dxp/apps/portal-search-elasticsearch-cross-cluster-replication/app.bnd
@@ -9,7 +9,7 @@ Liferay-Releng-Labs: false
 Liferay-Releng-Marketplace: true
 Liferay-Releng-Portal-Required: false
 Liferay-Releng-Public: ${liferay.releng.public}
-Liferay-Releng-Restart-Required: true
+Liferay-Releng-Restart-Required: false
 Liferay-Releng-Suite:
 Liferay-Releng-Support-Url: http://www.liferay.com
 Liferay-Releng-Supported: ${liferay.releng.supported}


### PR DESCRIPTION
From tibor:
The SF error is expected: it happened on the previous PRs too where we set this property to false, we just need to tell Brian that we are confirming it's safe to set to false when sending to him.

See https://github.com/BryanEngler/liferay-portal/pull/477#issuecomment-583310684

Cc: @lipusz @xbrianlee @joshchong @dejuknow

---
*[Task] Set restart-required to false for Cross Cluster Replication and Similar Results*
https://issues.liferay.com/browse/LPS-108231