### PR TITLE
LRCI-1013 Change compatibility to 1.8

### DIFF
--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -1,5 +1,5 @@
-sourceCompatibility = "1.7"
-targetCompatibility = "1.7"
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
 
 dependencies {
 	compile group: "com.amazonaws", name: "aws-java-sdk-core", version: "1.11.220"


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1013

https://github.com/liferay/liferay-portal/commit/1d22d20e31733bd5450197274b463d8527af70fc#diff-559ad7a5e301968f04e69314b1d68f72

Has introduced a lambda expression into jenkins results parser. This necessitates a change from 1.7 to 1.8 compatibility.

@adolfopa