### PR TITLE
LPS-108271 Enable react editor

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/configuration/ContentPageEditorTypeConfiguration.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/configuration/ContentPageEditorTypeConfiguration.java
@@ -27,7 +27,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface ContentPageEditorTypeConfiguration {
 
-	@Meta.AD(deflt = "soy", required = false)
+	@Meta.AD(deflt = "react", required = false)
 	public String type();
 
 }


### PR DESCRIPTION
Hey @brianchandotcom,

After talking with @david-gutierrez-mesa, we've decided to enable the react editor, since they need more time to have the fixes, and we need to enable the react editor to continue with the backend work.

The idea is send the fixes for the failing tests tomorrow, if we cannot get those all fixes for tomorrow the idea is to disable the remaining failing tests for the moment.

Thanks!
Eudaldo.