### PR TITLE
LPS-107869 Bump CKEditor plugin versions to 4.13.1

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/build.gradle
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/build.gradle
@@ -8,7 +8,7 @@ task buildCKEditorPlugins(type: Copy)
 task buildCKEditorScayt(type: Copy)
 task buildCKEditorWsc(type: Copy)
 
-String ckEditorVersion = "4.11.3"
+String ckEditorVersion = "4.13.1"
 
 String ckEditorScaytUrl = "https://ckeditor.com/cke4/sites/default/files/scayt/releases/scayt_${ckEditorVersion}.zip"
 String ckEditorWscUrl = "https://ckeditor.com/cke4/sites/default/files/wsc/releases/wsc_${ckEditorVersion}.zip"


### PR DESCRIPTION
This should have been done as part of 7876e94f4845c, but I just noticed it was out-of-sync while an unrelated task led me to the build.gradle file.

We should rework this so that falling out of sync like this isn't possible (for example, maybe we could derive the version number from the one in the package.json file), but I will need to loop in some help from somebody who knows more about Gradle than I do, so just sending this immediate fix for now.