### PR TITLE
LPS-108259 Use entity class name for reindex logging

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchEngineInitializer.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchEngineInitializer.java
@@ -188,7 +188,9 @@ public class SearchEngineInitializer implements Runnable {
 		stopWatch.start();
 
 		if (_log.isInfoEnabled()) {
-			_log.info("Reindexing with " + indexer.getClass() + " started");
+			_log.info(
+				"Reindexing of " + indexer.getClassName() +
+					" className started");
 		}
 
 		indexer.reindex(new String[] {String.valueOf(_companyId)});
@@ -198,8 +200,9 @@ public class SearchEngineInitializer implements Runnable {
 		if (_log.isInfoEnabled()) {
 			_log.info(
 				StringBundler.concat(
-					"Reindexing with ", indexer.getClass(), " completed in ",
-					stopWatch.getTime() / Time.SECOND, " seconds"));
+					"Reindexing of ", indexer.getClassName(), " className ",
+					"completed in ", stopWatch.getTime() / Time.SECOND,
+					" seconds"));
 		}
 	}
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchEngineInitializer.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchEngineInitializer.java
@@ -190,7 +190,7 @@ public class SearchEngineInitializer implements Runnable {
 		if (_log.isInfoEnabled()) {
 			_log.info(
 				"Reindexing of " + indexer.getClassName() +
-					" className started");
+					" entities started");
 		}
 
 		indexer.reindex(new String[] {String.valueOf(_companyId)});
@@ -200,9 +200,9 @@ public class SearchEngineInitializer implements Runnable {
 		if (_log.isInfoEnabled()) {
 			_log.info(
 				StringBundler.concat(
-					"Reindexing of ", indexer.getClassName(), " className ",
-					"completed in ", stopWatch.getTime() / Time.SECOND,
-					" seconds"));
+					"Reindexing of ", indexer.getClassName(),
+					" entities completed in ",
+					stopWatch.getTime() / Time.SECOND, " seconds"));
 		}
 	}
 


### PR DESCRIPTION
**ci:test:search - 43 out of 49 jobs passed** https://github.com/BryanEngler/liferay-portal/pull/481#issuecomment-585421789
✅ The only failures unique to this pull are also failing on the upstream canary https://github.com/xbrianlee/liferay-portal/pull/369#issuecomment-585239996

Author(s): @jorgediaz-lr
Reviewer(s): @BryanEngler

---
*[Regression Bug] Entities moved to new architecture are traced as "DefaultIndexer" during full reindex in case you activate DEBUG traces*
https://issues.liferay.com/browse/LPS-108259