### PR TITLE
LPS-108652 Update liferay-ckeditor to v4.13.1-liferay.3

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/build.gradle
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/build.gradle
@@ -5,8 +5,6 @@ import com.liferay.gradle.util.tasks.ConcatenateTask
 task buildCKEditor(type: Copy)
 task buildCKEditorBBCode(type: ConcatenateTask)
 task buildCKEditorPlugins(type: Copy)
-task buildCKEditorScayt(type: Copy)
-task buildCKEditorWsc(type: Copy)
 
 String ckEditorVersion = "4.13.1"
 
@@ -57,32 +55,8 @@ buildCKEditorPlugins {
 	into ckEditorDestinationDir
 }
 
-buildCKEditorScayt {
-	dependsOn buildCKEditor
-
-	from {
-		File ckEditorScaytFile = FileUtil.get(project, ckEditorScaytUrl)
-
-		zipTree(ckEditorScaytFile)
-	}
-
-	into new File(editorDestinationDir, "ckeditor/plugins")
-}
-
-buildCKEditorWsc {
-	dependsOn buildCKEditor
-
-	from {
-		File ckEditorWscFile = FileUtil.get(project, ckEditorWscUrl)
-
-		zipTree(ckEditorWscFile)
-	}
-
-	into new File(editorDestinationDir, "ckeditor/plugins")
-}
-
 classes {
-	dependsOn buildCKEditor, buildCKEditorPlugins, buildCKEditorScayt, buildCKEditorWsc
+	dependsOn buildCKEditor, buildCKEditorPlugins
 }
 
 clean {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -1,7 +1,7 @@
 {
 	"dependencies": {
 		"ckeditor4-react": "1.0.1",
-		"liferay-ckeditor": "4.13.1-liferay.2"
+		"liferay-ckeditor": "4.13.1-liferay.3"
 	},
 	"main": "index.js",
 	"name": "frontend-editor-ckeditor-web",

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -1,7 +1,7 @@
 {
 	"dependencies": {
 		"ckeditor4-react": "1.0.1",
-		"liferay-ckeditor": "4.13.1-liferay.1"
+		"liferay-ckeditor": "4.13.1-liferay.2"
 	},
 	"main": "index.js",
 	"name": "frontend-editor-ckeditor-web",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -11059,10 +11059,10 @@ liferay-amd-loader@4.2.0:
   resolved "https://registry.yarnpkg.com/liferay-amd-loader/-/liferay-amd-loader-4.2.0.tgz#c166fa3723a7cf760deefb8e580d8892c6bf436b"
   integrity sha512-q+b2oU6zy6gDe6uKqHPY2/L9eUjhZAVatCAC5HNrHd+tMIk+MDBSCiHmRvihoJnmPylT+RZ4gNvWxtVwIQBF/Q==
 
-liferay-ckeditor@4.13.1-liferay.2:
-  version "4.13.1-liferay.2"
-  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.13.1-liferay.2.tgz#04530e0970ffa906340c55dbd6fc4be15e6c4a43"
-  integrity sha512-s+5lHAqMNe7v73f+8kTGP17ViSGkBqTln6+3CSRLL2OlaUcK8FDtop7ZOLzA3Qg7sxhhLe6pqQOh8ld1TS1DJw==
+liferay-ckeditor@4.13.1-liferay.3:
+  version "4.13.1-liferay.3"
+  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.13.1-liferay.3.tgz#8036df7a2d934d926a120c73de552a2f614df87f"
+  integrity sha512-AiGMnsc1Oqfc6/MPGtLZAw7dyQe3X1NuMg1WUAjbyI8PM+p+DbrAF5y6zRM2pY4DXvJ2H0r60Dr2+SYbE2g58Q==
 
 liferay-css-parse@~1.7.1:
   version "1.7.1"

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -11059,10 +11059,10 @@ liferay-amd-loader@4.2.0:
   resolved "https://registry.yarnpkg.com/liferay-amd-loader/-/liferay-amd-loader-4.2.0.tgz#c166fa3723a7cf760deefb8e580d8892c6bf436b"
   integrity sha512-q+b2oU6zy6gDe6uKqHPY2/L9eUjhZAVatCAC5HNrHd+tMIk+MDBSCiHmRvihoJnmPylT+RZ4gNvWxtVwIQBF/Q==
 
-liferay-ckeditor@4.13.1-liferay.1:
-  version "4.13.1-liferay.1"
-  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.13.1-liferay.1.tgz#d2b9f865ac6553383c40c2a90561203b39329e59"
-  integrity sha512-TGgkYzkqBQukPClNJIMp4p+3PiETaGc8qVlqsVXQ2dWjFEuLuwBAxmF4+jlCsor6gXAkiYDkeRxCB749ZE+zKQ==
+liferay-ckeditor@4.13.1-liferay.2:
+  version "4.13.1-liferay.2"
+  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.13.1-liferay.2.tgz#04530e0970ffa906340c55dbd6fc4be15e6c4a43"
+  integrity sha512-s+5lHAqMNe7v73f+8kTGP17ViSGkBqTln6+3CSRLL2OlaUcK8FDtop7ZOLzA3Qg7sxhhLe6pqQOh8ld1TS1DJw==
 
 liferay-css-parse@~1.7.1:
   version "1.7.1"


### PR DESCRIPTION
The motivation here is to simplify our Gradle build by switching to a version that comes with the "scayt" and "wsc" plugins pre-bundled.

Originally suggested [here](https://github.com/brianchandotcom/liferay-portal/pull/84546#issuecomment-585232765).

Bundling occurred over [here](https://github.com/liferay/liferay-ckeditor/pull/39).

Tested [here](https://github.com/julien/liferay-portal/pull/224).
