### PR TITLE
LPS-108441 Use element because ClayDropdown doesn't have getAttribute method

### DIFF
--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/add_menu/index.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/add_menu/index.js
@@ -22,7 +22,7 @@ function AddMenu({dropdownItems, portletId}) {
 
 	const handleItemClick = useCallback(
 		event => {
-			event.currentTarget = event.target;
+			event.currentTarget = event.target.element || event.target;
 
 			const uri = event.data
 				? event.data.item.href


### PR DESCRIPTION
@ealonso @pavel-savinov