### PR TITLE
LPS-102573 last actions pull

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -36,7 +37,7 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
-import java.util.Collections;
+import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -76,7 +77,7 @@ public class KeywordResourceImpl
 		throws Exception {
 
 		return SearchUtil.search(
-			Collections.emptyMap(),
+			_getSiteListActions(siteId),
 			booleanQuery -> {
 			},
 			filter, AssetTag.class, search, pagination,
@@ -109,9 +110,43 @@ public class KeywordResourceImpl
 			_assetTagService.updateTag(keywordId, keyword.getName(), null));
 	}
 
+	private Map<String, Map<String, String>> _getActions(AssetTag assetTag) {
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"delete",
+			addAction(
+				"MANAGE_TAG", assetTag.getTagId(), "deleteKeyword",
+				"com.liferay.asset.tags", assetTag.getGroupId())
+		).put(
+			"get",
+			addAction(
+				"MANAGE_TAG", assetTag.getTagId(), "getKeyword",
+				"com.liferay.asset.tags", assetTag.getGroupId())
+		).put(
+			"replace",
+			addAction(
+				"MANAGE_TAG", assetTag.getTagId(), "putKeyword",
+				"com.liferay.asset.tags", assetTag.getGroupId())
+		).build();
+	}
+
+	private Map<String, Map<String, String>> _getSiteListActions(Long siteId) {
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"create",
+			addAction(
+				"MANAGE_TAG", "postSiteKeyword", "com.liferay.asset.tags",
+				siteId)
+		).put(
+			"get",
+			addAction(
+				"MANAGE_TAG", "getSiteKeywordsPage", "com.liferay.asset.tags",
+				siteId)
+		).build();
+	}
+
 	private Keyword _toKeyword(AssetTag assetTag) {
 		return new Keyword() {
 			{
+				actions = _getActions(assetTag);
 				dateCreated = assetTag.getCreateDate();
 				dateModified = assetTag.getModifiedDate();
 				id = assetTag.getTagId();

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -104,7 +104,7 @@ public class TaxonomyVocabularyResourceImpl
 		throws Exception {
 
 		return SearchUtil.search(
-			Collections.emptyMap(),
+			_getSiteListActions(siteId),
 			booleanQuery -> {
 			},
 			filter, AssetVocabulary.class, search, pagination,
@@ -240,6 +240,23 @@ public class TaxonomyVocabularyResourceImpl
 					taxonomyVocabulary.getAssetTypes(),
 					assetVocabulary.getGroupId()),
 				new ServiceContext()));
+	}
+
+	private Map<String, Map<String, String>> _getActions(
+		AssetVocabulary assetVocabulary) {
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"delete",
+			addAction("DELETE", assetVocabulary, "deleteTaxonomyVocabulary")
+		).put(
+			"get", addAction("VIEW", assetVocabulary, "getTaxonomyVocabulary")
+		).put(
+			"replace",
+			addAction("UPDATE", assetVocabulary, "putTaxonomyVocabulary")
+		).put(
+			"update",
+			addAction("UPDATE", assetVocabulary, "patchTaxonomyVocabulary")
+		).build();
 	}
 
 	private AssetType _getAssetType(
@@ -472,12 +489,27 @@ public class TaxonomyVocabularyResourceImpl
 		return assetVocabularySettingsHelper.toString();
 	}
 
+	private Map<String, Map<String, String>> _getSiteListActions(Long siteId) {
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"create",
+			addAction(
+				"ADD_VOCABULARY", "postSiteTaxonomyVocabulary",
+				"com.liferay.asset.categories", siteId)
+		).put(
+			"get",
+			addAction(
+				"VIEW", "getSiteTaxonomyVocabulariesPage",
+				"com.liferay.asset.categories", siteId)
+		).build();
+	}
+
 	private TaxonomyVocabulary _toTaxonomyVocabulary(
 			AssetVocabulary assetVocabulary)
 		throws Exception {
 
 		return new TaxonomyVocabulary() {
 			{
+				actions = _getActions(assetVocabulary);
 				assetTypes = _getAssetTypes(
 					new AssetVocabularySettingsHelper(
 						assetVocabulary.getSettings()),

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/helper/OrganizationResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/helper/OrganizationResourceDTOConverter.java
@@ -110,6 +110,7 @@ public class OrganizationResourceDTOConverter
 
 		return new Organization() {
 			{
+				actions = dtoConverterContext.getActions();
 				comment = organization.getComments();
 				customFields = CustomFieldsUtil.toCustomFields(
 					dtoConverterContext.isAcceptAllLanguages(),

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
@@ -368,12 +368,12 @@ public class OrganizationResourceImpl
 	}
 
 	private Page<Organization> _getOrganizationsPage(
-			Map<String, Map<String, String>> actions, String organizationId,
+			Map<String, Map<String, String>> actions, String parentOrganizationId,
 			Boolean flatten, String search, Filter filter,
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		long id = _getOrganizationId(organizationId);
+		long id = _getOrganizationId(parentOrganizationId);
 
 		return SearchUtil.search(
 			actions,
@@ -386,11 +386,11 @@ public class OrganizationResourceImpl
 						booleanFilter.add(
 							new QueryFilter(
 								new WildcardQueryImpl(
-									"treePath", "*" + organizationId + "*")));
+									"treePath", "*" + parentOrganizationId + "*")));
 						booleanFilter.add(
 							new TermFilter(
 								"organizationId",
-								String.valueOf(organizationId)),
+								String.valueOf(parentOrganizationId)),
 							BooleanClauseOccur.MUST_NOT);
 					}
 				}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
@@ -356,21 +356,19 @@ public class OrganizationResourceImpl
 	private Map<String, Map<String, String>> _getOrganizationListActions(
 		String parentOrganizationId) {
 
-		long groupId = _getOrganizationId(parentOrganizationId);
-
 		return HashMapBuilder.<String, Map<String, String>>put(
 			"get",
 			addAction(
 				"VIEW", "getOrganizationOrganizationsPage",
 				com.liferay.portal.kernel.model.Organization.class.getName(),
-				groupId)
+				_getOrganizationId(parentOrganizationId))
 		).build();
 	}
 
 	private Page<Organization> _getOrganizationsPage(
-			Map<String, Map<String, String>> actions, String parentOrganizationId,
-			Boolean flatten, String search, Filter filter,
-			Pagination pagination, Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			String parentOrganizationId, Boolean flatten, String search,
+			Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		long id = _getOrganizationId(parentOrganizationId);
@@ -386,7 +384,8 @@ public class OrganizationResourceImpl
 						booleanFilter.add(
 							new QueryFilter(
 								new WildcardQueryImpl(
-									"treePath", "*" + parentOrganizationId + "*")));
+									"treePath",
+									"*" + parentOrganizationId + "*")));
 						booleanFilter.add(
 							new TermFilter(
 								"organizationId",

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -59,6 +59,7 @@ import com.liferay.portal.kernel.service.RoleService;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -69,6 +70,7 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
 import java.util.Collections;
+import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -110,6 +112,7 @@ public class UserAccountResourceImpl
 			organizationId);
 
 		return _getUserAccountsPage(
+			_getOrganizationListActions(organization),
 			booleanQuery -> {
 				BooleanFilter booleanFilter =
 					booleanQuery.getPreBooleanFilter();
@@ -130,6 +133,7 @@ public class UserAccountResourceImpl
 		throws Exception {
 
 		return _getUserAccountsPage(
+			_getSiteListActions(siteId),
 			booleanQuery -> {
 				BooleanFilter booleanFilter =
 					booleanQuery.getPreBooleanFilter();
@@ -159,6 +163,7 @@ public class UserAccountResourceImpl
 		}
 
 		return _getUserAccountsPage(
+			Collections.emptyMap(),
 			booleanQuery -> {
 				BooleanFilter booleanFilter =
 					booleanQuery.getPreBooleanFilter();
@@ -168,6 +173,15 @@ public class UserAccountResourceImpl
 					BooleanClauseOccur.MUST_NOT);
 			},
 			search, filter, pagination, sorts);
+	}
+
+	private Map<String, Map<String, String>> _getActions(User user) {
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"get",
+			addAction(
+				"VIEW", user.getUserId(), "getUserAccount",
+				User.class.getName(), user.getGroupId())
+		).build();
 	}
 
 	private String _getListTypeMessage(long listTypeId) throws Exception {
@@ -181,6 +195,26 @@ public class UserAccountResourceImpl
 			contextAcceptLanguage.getPreferredLocale(), listType.getName());
 	}
 
+	private Map<String, Map<String, String>> _getOrganizationListActions(
+		Organization organization) {
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"get",
+			addAction(
+				"VIEW", organization.getOrganizationId(),
+				"getOrganizationUserAccountsPage", Organization.class.getName(),
+				organization.getGroupId())
+		).build();
+	}
+
+	private Map<String, Map<String, String>> _getSiteListActions(Long siteId) {
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"get",
+			addAction(
+				"VIEW", "getSiteUserAccountsPage", User.class.getName(), siteId)
+		).build();
+	}
+
 	private ThemeDisplay _getThemeDisplay(Group group) {
 		return new ThemeDisplay() {
 			{
@@ -191,13 +225,14 @@ public class UserAccountResourceImpl
 	}
 
 	private Page<UserAccount> _getUserAccountsPage(
+			Map<String, Map<String, String>> actions,
 			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
 			String search, Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(
-			Collections.emptyMap(), booleanQueryUnsafeConsumer, filter,
-			User.class, search, pagination,
+			actions, booleanQueryUnsafeConsumer, filter, User.class, search,
+			pagination,
 			queryConfig -> queryConfig.setSelectedFieldNames(
 				Field.ENTRY_CLASS_PK),
 			searchContext -> searchContext.setCompanyId(
@@ -248,6 +283,7 @@ public class UserAccountResourceImpl
 
 		return new UserAccount() {
 			{
+				actions = _getActions(user);
 				additionalName = user.getMiddleName();
 				alternateName = user.getScreenName();
 				birthDate = user.getBirthday();

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentFolderResourceImpl.java
@@ -87,8 +87,10 @@ public class DocumentFolderResourceImpl
 
 		return _getDocumentFoldersPage(
 			_getDocumentFolderListActions(parentDocumentFolder.getSiteId()),
-			parentDocumentFolder.getSiteId(), flatten, search, filter,
-			parentDocumentFolder.getId(), pagination, sorts);
+			parentDocumentFolder.getId(), parentDocumentFolder.getSiteId(),
+			flatten,
+			search, filter, pagination,
+			sorts);
 	}
 
 	@Override
@@ -113,8 +115,8 @@ public class DocumentFolderResourceImpl
 		}
 
 		return _getDocumentFoldersPage(
-			_getSiteListActions(siteId), siteId, flatten, search, filter,
-			documentFolderId, pagination, sorts);
+			_getSiteListActions(siteId), documentFolderId, siteId, flatten,
+			search, filter, pagination, sorts);
 	}
 
 	@Override
@@ -264,9 +266,9 @@ public class DocumentFolderResourceImpl
 	}
 
 	private Page<DocumentFolder> _getDocumentFoldersPage(
-			Map<String, Map<String, String>> actions, Long siteId,
-			Boolean flatten, String search, Filter filter,
-			Long parentDocumentFolderId, Pagination pagination, Sort[] sorts)
+		Map<String, Map<String, String>> actions, Long parentDocumentFolderId,
+		Long siteId, Boolean flatten, String search, Filter filter,
+		Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(
@@ -287,8 +289,8 @@ public class DocumentFolderResourceImpl
 					}
 
 					booleanFilter.add(
-						new TermFilter(
-							field, String.valueOf(parentDocumentFolderId)),
+						new TermFilter(field, String.valueOf(
+							parentDocumentFolderId)),
 						BooleanClauseOccur.MUST);
 				}
 			},

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentFolderResourceImpl.java
@@ -88,9 +88,7 @@ public class DocumentFolderResourceImpl
 		return _getDocumentFoldersPage(
 			_getDocumentFolderListActions(parentDocumentFolder.getSiteId()),
 			parentDocumentFolder.getId(), parentDocumentFolder.getSiteId(),
-			flatten,
-			search, filter, pagination,
-			sorts);
+			flatten, search, filter, pagination, sorts);
 	}
 
 	@Override
@@ -266,9 +264,9 @@ public class DocumentFolderResourceImpl
 	}
 
 	private Page<DocumentFolder> _getDocumentFoldersPage(
-		Map<String, Map<String, String>> actions, Long parentDocumentFolderId,
-		Long siteId, Boolean flatten, String search, Filter filter,
-		Pagination pagination, Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			Long parentDocumentFolderId, Long siteId, Boolean flatten,
+			String search, Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(
@@ -289,8 +287,8 @@ public class DocumentFolderResourceImpl
 					}
 
 					booleanFilter.add(
-						new TermFilter(field, String.valueOf(
-							parentDocumentFolderId)),
+						new TermFilter(
+							field, String.valueOf(parentDocumentFolderId)),
 						BooleanClauseOccur.MUST);
 				}
 			},

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
@@ -119,7 +119,7 @@ public class MessageBoardMessageResourceImpl
 
 		return _getMessageBoardMessagesPage(
 			_getMessageBoardListActions(mbMessage), parentMessageBoardMessageId,
-			search, filter, pagination, sorts, flatten, null);
+			null, flatten, search, filter, pagination, sorts);
 	}
 
 	@Override
@@ -143,8 +143,8 @@ public class MessageBoardMessageResourceImpl
 
 		return _getMessageBoardMessagesPage(
 			_getMessageBoardThreadListActions(mbThread),
-			mbThread.getRootMessageId(), search, filter, pagination, sorts,
-			false, null);
+			mbThread.getRootMessageId(), null, false, search, filter,
+			pagination, sorts);
 	}
 
 	@Override
@@ -154,8 +154,8 @@ public class MessageBoardMessageResourceImpl
 		throws Exception {
 
 		return _getMessageBoardMessagesPage(
-			_getSiteListActions(siteId), null, search, filter, pagination,
-			sorts, flatten, siteId);
+			_getSiteListActions(siteId), null, siteId, flatten, search, filter,
+			pagination, sorts);
 	}
 
 	@Override
@@ -340,9 +340,9 @@ public class MessageBoardMessageResourceImpl
 	}
 
 	private Page<MessageBoardMessage> _getMessageBoardMessagesPage(
-			Map<String, Map<String, String>> actions,
-			Long messageBoardMessageId, String search, Filter filter,
-			Pagination pagination, Sort[] sorts, Boolean flatten, Long siteId)
+		Map<String, Map<String, String>> actions,
+		Long messageBoardMessageId, Long siteId, Boolean flatten,
+		String search, Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		if (messageBoardMessageId != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
@@ -340,9 +340,9 @@ public class MessageBoardMessageResourceImpl
 	}
 
 	private Page<MessageBoardMessage> _getMessageBoardMessagesPage(
-		Map<String, Map<String, String>> actions,
-		Long messageBoardMessageId, Long siteId, Boolean flatten,
-		String search, Filter filter, Pagination pagination, Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			Long messageBoardMessageId, Long siteId, Boolean flatten,
+			String search, Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		if (messageBoardMessageId != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentFolderResourceImpl.java
@@ -95,8 +95,8 @@ public class StructuredContentFolderResourceImpl
 		}
 
 		return _getFoldersPage(
-			_getSiteListActions(siteId), siteId,
-			parentStructuredContentFolderId, search, filter, pagination, sorts);
+			_getSiteListActions(siteId), parentStructuredContentFolderId,
+			siteId, search, filter, pagination, sorts);
 	}
 
 	@Override
@@ -120,7 +120,7 @@ public class StructuredContentFolderResourceImpl
 
 		return _getFoldersPage(
 			_getStructuredContentFolderListActions(journalFolder),
-			journalFolder.getGroupId(), parentStructuredContentFolderId, search,
+			parentStructuredContentFolderId, journalFolder.getGroupId(), search,
 			filter, pagination, sorts);
 	}
 
@@ -248,9 +248,9 @@ public class StructuredContentFolderResourceImpl
 	}
 
 	private Page<StructuredContentFolder> _getFoldersPage(
-			Map<String, Map<String, String>> actions, Long siteId,
-			Long parentStructuredContentFolderId, String search, Filter filter,
-			Pagination pagination, Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			Long parentStructuredContentFolderId, Long siteId, String search,
+			Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(


### PR DESCRIPTION
Resending to talk about the conventions. Our idea was:

- Method that return actions can't just be called getListActions because we can have several in the same resource (several collections, usually a regular one and another with a different parent), so we scope them by the parent relationship (Site, TaxonomyCategory...)
- Parameters follow the order defined in the REST Builder: path parameters first, then query, lastly special parameters (Pagination, Filter, Sort).

I'm available any time in slack to discuss it :)