### PR TITLE
LPS-109023 Update liferay-npm-scripts to v27.0.0

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/css/_pages.scss
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/css/_pages.scss
@@ -1,5 +1,5 @@
-@import 'edit_app_body';
 @import 'edit_app';
+@import 'edit_app_body';
 @import 'edit_entry';
 @import 'form_view';
 @import 'table_view';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
@@ -1,9 +1,9 @@
 @import 'atlas-variables';
 
-@import 'utilities';
 @import 'date-picker';
 @import 'field-type-checkbox-switch';
 @import 'image_picker';
+@import 'utilities';
 
 %flex-space-between {
 	align-items: center;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/App.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/App.scss
@@ -1,17 +1,17 @@
-@import './AllowedFragments.scss';
 @import 'variables';
 
+@import './AllowedFragments';
 @import './DisabledArea';
 @import './DragPreview';
 @import './DropZone';
 @import './MasterLayout';
-@import './layout-data-items/ColumnOverlayGrid';
-@import './layout-data-items/FragmentsEditorShim';
 @import './PageEditor';
 @import './Sidebar';
 @import './Toolbar';
 @import './Topper';
 @import './Translation';
+@import './layout-data-items/ColumnOverlayGrid';
+@import './layout-data-items/FragmentsEditorShim';
 
 @import './floating-toolbar/FloatingToolbar';
 @import './floating-toolbar/SaveFragmentCompositionModal';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments/components/FragmentCard.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments/components/FragmentCard.scss
@@ -1,5 +1,5 @@
-@import './variables';
 @import '../../../app/components/variables';
+@import './variables';
 
 .page-editor__fragments__fragment-card {
 	box-shadow: 0 0 0 1px $fragmentsLightColor;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments/components/LayoutElements.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments/components/LayoutElements.scss
@@ -1,5 +1,5 @@
-@import './variables';
 @import '../../../app/components/variables';
+@import './variables';
 
 .page-editor__fragments__layout-element-card-preview {
 	box-shadow: 0 0 0 1px $fragmentsLightColor;

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,4 +1,4 @@
+@import 'search-results/search_results';
 @import 'search_bar';
 @import 'search_facet';
-@import 'search-results/search_results';
 @import 'suggestions';

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/css/main.scss
@@ -13,6 +13,6 @@
 	@import 'criteria_sidebar';
 	@import 'drop_zone';
 	@import 'empty_drop_zone';
-	@import 'segment_edit';
 	@import 'localized_title';
+	@import 'segment_edit';
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/css/main.scss
@@ -4,9 +4,9 @@
 .result-rankings-root,
 .result-ranking-modal-root {
 	@import 'empty_state';
-	@import 'loading';
 	@import 'list';
 	@import 'list_item';
+	@import 'loading';
 	@import 'modal';
 	@import 'page';
 	@import 'page_toolbar';

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,6 +1,6 @@
 @import 'app';
-@import 'dropdown';
 @import 'clay_chart';
+@import 'dropdown';
 @import 'empty-content';
 @import 'global-colors';
 @import 'multi-select';

--- a/modules/package.json
+++ b/modules/package.json
@@ -5,7 +5,7 @@
 		"compass-mixins": "0.12.10",
 		"jsdoc": "3.6.3",
 		"liferay-frontend-common-css": "1.0.4",
-		"liferay-npm-scripts": "26.0.0",
+		"liferay-npm-scripts": "27.0.0",
 		"metal-jest-serializer": "2.0.0"
 	},
 	"private": true,

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -11450,10 +11450,10 @@ liferay-npm-bundler@2.18.2:
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-liferay-npm-scripts@26.0.0:
-  version "26.0.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-26.0.0.tgz#7f3cfab2c1770b7f3a4f6f11b38259c2c1decad5"
-  integrity sha512-+vj+VG08F9FMhMf9LZf6RxxPqQ+Hdjlww9rsj9QkMKCCxtu8kKR04vvd2qsz70ufthkfhZt/UCoAdvC26hcgcA==
+liferay-npm-scripts@27.0.0:
+  version "27.0.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-27.0.0.tgz#ae61f0d30fa79621de68dc84ff379cb67d5d53a8"
+  integrity sha512-U+YfZjSfs8Oh35QeSD+25LNMigCi37W23lWY3YkWc4g+fHQkyOxMD9v/fzYecRZJAlRFuuHZKSaWF7jvB3IYTQ==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"


### PR DESCRIPTION
Brings auto-sorting of import statements in SCSS files. To enforce manual sorting, use a blank line as a separator.