### PR TITLE
LPS-109025 Update react-dnd to v10.0.1

### DIFF
--- a/modules/apps/app-builder/app-builder-web/package.json
+++ b/modules/apps/app-builder/app-builder-web/package.json
@@ -22,8 +22,8 @@
 		"moment": "^2.24.0",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
-		"react-dnd": "7.7.0",
-		"react-dnd-html5-backend": "7.7.0",
+		"react-dnd": "10.0.1",
+		"react-dnd-html5-backend": "10.0.1",
 		"react-router-dom": "^5.0.1"
 	},
 	"description": "",

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/App.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/App.es.js
@@ -14,7 +14,7 @@
 
 import {ClayModalProvider} from '@clayui/modal';
 import React from 'react';
-import {DragDropContext as dragDropContext} from 'react-dnd';
+import {DndProvider} from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import {HashRouter as Router, Route, Switch} from 'react-router-dom';
 
@@ -23,8 +23,8 @@ import {ToastContextProvider} from './components/toast/ToastContext.es';
 import ListCustomObjects from './pages/custom-object/ListCustomObjects.es';
 import ViewCustomObject from './pages/custom-object/ViewCustomObject.es';
 
-export default dragDropContext(HTML5Backend)(props => {
-	return (
+export default props => (
+	<DndProvider backend={HTML5Backend}>
 		<AppContextProvider {...props}>
 			<ToastContextProvider>
 				<ClayModalProvider>
@@ -47,5 +47,5 @@ export default dragDropContext(HTML5Backend)(props => {
 				</ClayModalProvider>
 			</ToastContextProvider>
 		</AppContextProvider>
-	);
-});
+	</DndProvider>
+);

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormView.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormView.es.js
@@ -12,8 +12,9 @@
  * details.
  */
 
-import {withDragAndDropContext} from 'data-engine-taglib';
 import React, {useContext, useState} from 'react';
+import {DndProvider} from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
 import {createPortal} from 'react-dom';
 
 import {AppContext} from '../../AppContext.es';
@@ -40,7 +41,7 @@ const FormViewControlMenu = ({backURL, dataLayoutId}) => {
 	);
 };
 
-const EditFormView = withDragAndDropContext(props => {
+const EditFormView = props => {
 	const {
 		customObjectSidebarElementId,
 		dataDefinitionId,
@@ -57,25 +58,27 @@ const EditFormView = withDragAndDropContext(props => {
 	}
 
 	return (
-		<FormViewContextProvider
-			dataDefinitionId={dataDefinitionId}
-			dataLayoutBuilder={dataLayoutBuilder}
-			dataLayoutId={dataLayoutId}
-		>
-			<FormViewControlMenu
-				backURL={backURL}
+		<DndProvider backend={HTML5Backend}>
+			<FormViewContextProvider
+				dataDefinitionId={dataDefinitionId}
+				dataLayoutBuilder={dataLayoutBuilder}
 				dataLayoutId={dataLayoutId}
-			/>
+			>
+				<FormViewControlMenu
+					backURL={backURL}
+					dataLayoutId={dataLayoutId}
+				/>
 
-			<FormViewUpperToolbar newCustomObject={newCustomObject} />
+				<FormViewUpperToolbar newCustomObject={newCustomObject} />
 
-			{createPortal(
-				<CustomObjectSidebar />,
-				document.querySelector(`#${customObjectSidebarElementId}`)
-			)}
-		</FormViewContextProvider>
+				{createPortal(
+					<CustomObjectSidebar />,
+					document.querySelector(`#${customObjectSidebarElementId}`)
+				)}
+			</FormViewContextProvider>
+		</DndProvider>
 	);
-});
+};
 
 export default ({dataLayoutBuilderId, ...props}) => {
 	const [dataLayoutBuilder, setDataLayoutBuilder] = useState();

--- a/modules/apps/data-engine/data-engine-taglib/package.json
+++ b/modules/apps/data-engine/data-engine-taglib/package.json
@@ -16,7 +16,6 @@
 		"@clayui/sticker": "3.0.5",
 		"@clayui/table": "3.0.6",
 		"classnames": "2.2.6",
-		"dnd-core": "^7.7.0",
 		"dynamic-data-mapping-form-renderer": "*",
 		"frontend-js-react-web": "*",
 		"frontend-js-web": "*",
@@ -27,8 +26,8 @@
 		"moment": "^2.24.0",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
-		"react-dnd": "7.7.0",
-		"react-dnd-html5-backend": "7.7.0",
+		"react-dnd": "10.0.1",
+		"react-dnd-html5-backend": "10.0.1",
 		"react-router-dom": "^5.0.1"
 	},
 	"main": "data_layout_builder/js/index.es.js",

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/App.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/App.es.js
@@ -14,6 +14,8 @@
 
 import {ClayModalProvider} from '@clayui/modal';
 import React, {useContext, useEffect, useState} from 'react';
+import {DndProvider} from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
 
 import AppContext from './AppContext.es';
 import AppContextProvider from './AppContextProvider.es';
@@ -21,7 +23,6 @@ import DataLayoutBuilder from './data-layout-builder/DataLayoutBuilder.es';
 import DataLayoutBuilderContextProvider from './data-layout-builder/DataLayoutBuilderContextProvider.es';
 import DataLayoutBuilderSidebar from './data-layout-builder/DataLayoutBuilderSidebar.es';
 import DataLayoutBuilderDragAndDrop from './drag-and-drop/DataLayoutBuilderDragAndDrop.es';
-import withDragAndDropContext from './drag-and-drop/withDragAndDropContext.es';
 
 const parseProps = ({
 	dataDefinitionId,
@@ -69,7 +70,7 @@ const AppContent = ({dataLayoutBuilder, setDataLayoutBuilder, ...props}) => {
 	);
 };
 
-const App = withDragAndDropContext(props => {
+const App = props => {
 	const {dataDefinitionId, dataLayoutId, fieldTypesModules} = parseProps(
 		props
 	);
@@ -84,23 +85,25 @@ const App = withDragAndDropContext(props => {
 	}, [fieldTypesModules]);
 
 	return (
-		<ClayModalProvider>
-			{loaded && (
-				<AppContextProvider
-					dataDefinitionId={dataDefinitionId}
-					dataLayoutBuilder={dataLayoutBuilder}
-					dataLayoutId={dataLayoutId}
-				>
-					<AppContent
+		<DndProvider backend={HTML5Backend}>
+			<ClayModalProvider>
+				{loaded && (
+					<AppContextProvider
+						dataDefinitionId={dataDefinitionId}
 						dataLayoutBuilder={dataLayoutBuilder}
-						setDataLayoutBuilder={setDataLayoutBuilder}
-						{...props}
-					/>
-				</AppContextProvider>
-			)}
-		</ClayModalProvider>
+						dataLayoutId={dataLayoutId}
+					>
+						<AppContent
+							dataLayoutBuilder={dataLayoutBuilder}
+							setDataLayoutBuilder={setDataLayoutBuilder}
+							{...props}
+						/>
+					</AppContextProvider>
+				)}
+			</ClayModalProvider>
+		</DndProvider>
 	);
-});
+};
 
 export default function(props) {
 	return <App {...props} />;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/drag-and-drop/withDragAndDropContext.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/drag-and-drop/withDragAndDropContext.es.js
@@ -12,7 +12,13 @@
  * details.
  */
 
-import {DragDropContext} from 'react-dnd';
+import {DndProvider} from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 
-export default DragDropContext(HTML5Backend);
+export default function withDragAndDropContext(Component) {
+	return props => (
+		<DndProvider backend={HTML5Backend}>
+			<Component {...props} />
+		</DndProvider>
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-react-web/.npmbundlerrc
+++ b/modules/apps/frontend-js/frontend-js-react-web/.npmbundlerrc
@@ -27,12 +27,6 @@
 		"react": [
 			"umd/**/*"
 		],
-		"react-dnd": [
-			"dist/**/*"
-		],
-		"react-dnd-html5-backend": [
-			"dist/**/*"
-		],
 		"react-dom": [
 			"**/*profiling*",
 			"**/*server*",

--- a/modules/apps/frontend-js/frontend-js-react-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-react-web/package.json
@@ -5,13 +5,13 @@
 		"formik": "1.4.3",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
-		"react-dnd": "7.7.0",
-		"react-dnd-html5-backend": "7.7.0",
+		"react-dnd": "10.0.1",
+		"react-dnd-html5-backend": "10.0.1",
 		"react-dom": "16.12.0"
 	},
 	"devDependencies": {
-		"react-dnd-test-backend": "7.7.0",
-		"react-dnd-test-utils": "7.7.0"
+		"react-dnd-test-backend": "10.0.1",
+		"react-dnd-test-utils": "10.0.1"
 	},
 	"main": "js/index.es.js",
 	"name": "frontend-js-react-web",

--- a/modules/apps/layout/layout-content-page-editor-web/package.json
+++ b/modules/apps/layout/layout-content-page-editor-web/package.json
@@ -16,8 +16,8 @@
 		"metal-position": "2.1.2",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
-		"react-dnd": "7.7.0",
-		"react-dnd-html5-backend": "7.7.0",
+		"react-dnd": "10.0.1",
+		"react-dnd-html5-backend": "10.0.1",
 		"react-dom": "16.12.0"
 	},
 	"name": "layout-content-page-editor-web",

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/index.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/index.js
@@ -13,7 +13,7 @@
  */
 
 import React from 'react';
-import {DragDropContextProvider} from 'react-dnd';
+import {DndProvider} from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 
 import App from './components/App';
@@ -52,8 +52,8 @@ export default function(data) {
 	initializeConfig(data.config);
 
 	return (
-		<DragDropContextProvider backend={HTML5Backend}>
+		<DndProvider backend={HTML5Backend}>
 			<Container state={data.state} />
-		</DragDropContextProvider>
+		</DndProvider>
 	);
 }

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/fragments/components/FragmentsSidebar.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/fragments/components/FragmentsSidebar.test.js
@@ -56,11 +56,11 @@ jest.mock(
 
 const renderFragmentsSidebar = () =>
 	render(
-		<DragDropContextProvider backend={HTML5Backend}>
+		<DndProvider backend={HTML5Backend}>
 			<StoreAPIContextProvider>
 				<FragmentsSidebar />
 			</StoreAPIContextProvider>
-		</DragDropContextProvider>
+		</DndProvider>
 	);
 
 describe('FragmentsSidebar', () => {

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/fragments/components/FragmentsSidebar.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/fragments/components/FragmentsSidebar.test.js
@@ -15,7 +15,7 @@
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import {DragDropContextProvider} from 'react-dnd';
+import {DndProvider} from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 
 import {StoreAPIContextProvider} from '../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/widgets/components/WidgetsSidebar.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/widgets/components/WidgetsSidebar.test.js
@@ -15,7 +15,7 @@
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import {DragDropContextProvider} from 'react-dnd';
+import {DndProvider} from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 
 import {StoreAPIContextProvider} from '../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
@@ -68,11 +68,11 @@ const widgets = [
 
 const RenderWidgetsSidebar = () => {
 	return (
-		<DragDropContextProvider backend={HTML5Backend}>
+		<DndProvider backend={HTML5Backend}>
 			<StoreAPIContextProvider getState={() => ({widgets})}>
 				<WidgetsSidebar />
 			</StoreAPIContextProvider>
-		</DragDropContextProvider>
+		</DndProvider>
 	);
 };
 

--- a/modules/apps/segments/segments-web/package.json
+++ b/modules/apps/segments/segments-web/package.json
@@ -15,8 +15,8 @@
 		"odata-v4-parser": "^0.1.29",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
-		"react-dnd": "7.7.0",
-		"react-dnd-html5-backend": "7.7.0"
+		"react-dnd": "10.0.1",
+		"react-dnd-html5-backend": "10.0.1"
 	},
 	"description": "",
 	"jest": {

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
@@ -17,7 +17,7 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import getCN from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {DragDropContext as dragDropContext} from 'react-dnd';
+import {DndProvider} from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 
 import {
@@ -111,157 +111,163 @@ class ContributorBuilder extends React.Component {
 		});
 
 		return (
-			<div className={rootClasses}>
-				<div className="criteria-builder-section-sidebar">
-					<CriteriaSidebar
-						onTitleClicked={this._handleCriteriaEdit}
-						propertyGroups={propertyGroups}
-						propertyKey={editingId}
-					/>
-				</div>
+			<DndProvider backend={HTML5Backend}>
+				<div className={rootClasses}>
+					<div className="criteria-builder-section-sidebar">
+						<CriteriaSidebar
+							onTitleClicked={this._handleCriteriaEdit}
+							propertyGroups={propertyGroups}
+							propertyKey={editingId}
+						/>
+					</div>
 
-				<div className="criteria-builder-section-main">
-					<div className="contributor-container">
-						<div className="container-fluid container-fluid-max-xl">
-							<div className="content-wrapper">
-								<div className="sheet">
-									<div className="d-flex flex-wrap justify-content-between mb-4">
-										<h2 className="mb-2 sheet-title">
-											{Liferay.Language.get('conditions')}
-										</h2>
+					<div className="criteria-builder-section-main">
+						<div className="contributor-container">
+							<div className="container-fluid container-fluid-max-xl">
+								<div className="content-wrapper">
+									<div className="sheet">
+										<div className="d-flex flex-wrap justify-content-between mb-4">
+											<h2 className="mb-2 sheet-title">
+												{Liferay.Language.get(
+													'conditions'
+												)}
+											</h2>
 
-										<div className="criterion-string">
-											<div className="btn-group">
-												<div className="btn-group-item inline-item">
-													{membersCountLoading && (
-														<ClayLoadingIndicator
-															className="mr-4"
-															small
-														/>
-													)}
-
-													{!membersCountLoading && (
-														<span className="mr-4">
-															{Liferay.Language.get(
-																'conditions-match'
-															)}
-															<b className="ml-2 text-dark">
-																{getPluralMessage(
-																	Liferay.Language.get(
-																		'x-member'
-																	),
-																	Liferay.Language.get(
-																		'x-members'
-																	),
-																	membersCount
-																)}
-															</b>
-														</span>
-													)}
-
-													<ClayButton
-														displayType="secondary"
-														onClick={
-															onPreviewMembers
-														}
-														small
-														type="button"
-													>
-														{Liferay.Language.get(
-															'view-members'
+											<div className="criterion-string">
+												<div className="btn-group">
+													<div className="btn-group-item inline-item">
+														{membersCountLoading && (
+															<ClayLoadingIndicator
+																className="mr-4"
+																small
+															/>
 														)}
-													</ClayButton>
+
+														{!membersCountLoading && (
+															<span className="mr-4">
+																{Liferay.Language.get(
+																	'conditions-match'
+																)}
+																<b className="ml-2 text-dark">
+																	{getPluralMessage(
+																		Liferay.Language.get(
+																			'x-member'
+																		),
+																		Liferay.Language.get(
+																			'x-members'
+																		),
+																		membersCount
+																	)}
+																</b>
+															</span>
+														)}
+
+														<ClayButton
+															displayType="secondary"
+															onClick={
+																onPreviewMembers
+															}
+															small
+															type="button"
+														>
+															{Liferay.Language.get(
+																'view-members'
+															)}
+														</ClayButton>
+													</div>
 												</div>
 											</div>
 										</div>
+
+										{emptyContributors &&
+											(editingId === undefined ||
+												!editing) && (
+												<EmptyPlaceholder />
+											)}
+
+										{contributors
+											.filter(criteria => {
+												const editingCriteria =
+													editingId ===
+														criteria.propertyKey &&
+													editing;
+												const emptyCriteriaQuery =
+													criteria.query === '';
+
+												return (
+													editingCriteria ||
+													!emptyCriteriaQuery
+												);
+											})
+											.map((criteria, i) => {
+												return (
+													<React.Fragment key={i}>
+														{i !== 0 && (
+															<>
+																<Conjunction
+																	className="mb-4 ml-0 mt-4"
+																	conjunctionName={
+																		criteria.conjunctionId
+																	}
+																	editing={
+																		editing
+																	}
+																	onSelect={
+																		onConjunctionChange
+																	}
+																	supportedConjunctions={
+																		supportedConjunctions
+																	}
+																/>
+															</>
+														)}
+
+														<CriteriaBuilder
+															criteria={
+																criteria.criteriaMap
+															}
+															editing={editing}
+															emptyContributors={
+																emptyContributors
+															}
+															entityName={
+																criteria.entityName
+															}
+															modelLabel={
+																criteria.modelLabel
+															}
+															onChange={
+																this
+																	._handleCriteriaChange
+															}
+															propertyKey={
+																criteria.propertyKey
+															}
+															supportedConjunctions={
+																supportedConjunctions
+															}
+															supportedOperators={
+																supportedOperators
+															}
+															supportedProperties={
+																criteria.properties
+															}
+															supportedPropertyTypes={
+																supportedPropertyTypes
+															}
+														/>
+													</React.Fragment>
+												);
+											})}
 									</div>
-
-									{emptyContributors &&
-										(editingId === undefined ||
-											!editing) && <EmptyPlaceholder />}
-
-									{contributors
-										.filter(criteria => {
-											const editingCriteria =
-												editingId ===
-													criteria.propertyKey &&
-												editing;
-											const emptyCriteriaQuery =
-												criteria.query === '';
-
-											return (
-												editingCriteria ||
-												!emptyCriteriaQuery
-											);
-										})
-										.map((criteria, i) => {
-											return (
-												<React.Fragment key={i}>
-													{i !== 0 && (
-														<>
-															<Conjunction
-																className="mb-4 ml-0 mt-4"
-																conjunctionName={
-																	criteria.conjunctionId
-																}
-																editing={
-																	editing
-																}
-																onSelect={
-																	onConjunctionChange
-																}
-																supportedConjunctions={
-																	supportedConjunctions
-																}
-															/>
-														</>
-													)}
-
-													<CriteriaBuilder
-														criteria={
-															criteria.criteriaMap
-														}
-														editing={editing}
-														emptyContributors={
-															emptyContributors
-														}
-														entityName={
-															criteria.entityName
-														}
-														modelLabel={
-															criteria.modelLabel
-														}
-														onChange={
-															this
-																._handleCriteriaChange
-														}
-														propertyKey={
-															criteria.propertyKey
-														}
-														supportedConjunctions={
-															supportedConjunctions
-														}
-														supportedOperators={
-															supportedOperators
-														}
-														supportedProperties={
-															criteria.properties
-														}
-														supportedPropertyTypes={
-															supportedPropertyTypes
-														}
-													/>
-												</React.Fragment>
-											);
-										})}
 								</div>
 							</div>
 						</div>
 					</div>
 				</div>
-			</div>
+			</DndProvider>
 		);
 	}
 }
 
-export default dragDropContext(HTML5Backend)(ContributorBuilder);
+export default ContributorBuilder;

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/package.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/package.json
@@ -19,8 +19,8 @@
 		"lodash.times": "^4.3.2",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
-		"react-dnd": "7.7.0",
-		"react-dnd-html5-backend": "7.7.0",
+		"react-dnd": "10.0.1",
+		"react-dnd-html5-backend": "10.0.1",
 		"react-dom": "16.12.0"
 	},
 	"jest": {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/List.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/List.es.js
@@ -13,7 +13,7 @@ import ClayButton from '@clayui/button';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {PropTypes} from 'prop-types';
 import React, {PureComponent} from 'react';
-import {DragDropContext as dragDropContext} from 'react-dnd';
+import {DndProvider} from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 
 import {KEY_CODES} from '../../utils/constants.es';
@@ -230,81 +230,87 @@ class List extends PureComponent {
 		const {selectedIds} = this.state;
 
 		return (
-			<div className="result-ranking-list-root">
-				<ItemDragLayer />
+			<DndProvider backend={HTML5Backend}>
+				<div className="result-ranking-list-root">
+					<ItemDragLayer />
 
-				<SearchBar
-					dataMap={dataMap}
-					fetchDocumentsSearchUrl={fetchDocumentsSearchUrl}
-					onAddResultSubmit={onAddResultSubmit}
-					onClickHide={onClickHide}
-					onClickPin={onClickPin}
-					onRemoveSelect={this._handleRemoveSelect}
-					onSelectAll={this._handleSelectAll}
-					onSelectClear={this._handleSelectClear}
-					resultIds={resultIds}
-					selectedIds={selectedIds}
-				/>
+					<SearchBar
+						dataMap={dataMap}
+						fetchDocumentsSearchUrl={fetchDocumentsSearchUrl}
+						onAddResultSubmit={onAddResultSubmit}
+						onClickHide={onClickHide}
+						onClickPin={onClickPin}
+						onRemoveSelect={this._handleRemoveSelect}
+						onSelectAll={this._handleSelectAll}
+						onSelectClear={this._handleSelectClear}
+						resultIds={resultIds}
+						selectedIds={selectedIds}
+					/>
 
-				<ErrorBoundary toast>
-					{!!resultIds.length && (
-						<ul
-							className="list-group show-quick-actions-on-hover"
-							onKeyDown={this._handleKeyDown}
-						>
-							{resultIds.map((id, index, arr) =>
-								this._renderItem(id, index, arr)
-							)}
-						</ul>
-					)}
+					<ErrorBoundary toast>
+						{!!resultIds.length && (
+							<ul
+								className="list-group show-quick-actions-on-hover"
+								onKeyDown={this._handleKeyDown}
+							>
+								{resultIds.map((id, index, arr) =>
+									this._renderItem(id, index, arr)
+								)}
+							</ul>
+						)}
 
-					{dataLoading && (
-						<div className="load-more-container">
-							<ClayLoadingIndicator />
-						</div>
-					)}
+						{dataLoading && (
+							<div className="load-more-container">
+								<ClayLoadingIndicator />
+							</div>
+						)}
 
-					{!dataLoading && (
-						<>
-							{!displayError && !resultIds.length && (
-								<ClayEmptyState />
-							)}
+						{!dataLoading && (
+							<>
+								{!displayError && !resultIds.length && (
+									<ClayEmptyState />
+								)}
 
-							{displayError && (
-								<ClayEmptyState
-									actionLabel={Liferay.Language.get(
-										'try-again'
-									)}
-									description={Liferay.Language.get(
-										'an-error-has-occurred-and-we-were-unable-to-load-the-results'
-									)}
-									displayState={DISPLAY_STATES.EMPTY}
-									onClickAction={this._handleLoadMoreResults}
-									title={Liferay.Language.get(
-										'unable-to-load-content'
-									)}
-								/>
-							)}
-
-							{showLoadMore && (
-								<div className="load-more-container">
-									<ClayButton
-										className="load-more-button"
-										displayType="secondary"
-										onClick={this._handleLoadMoreResults}
-									>
-										{Liferay.Language.get(
-											'load-more-results'
+								{displayError && (
+									<ClayEmptyState
+										actionLabel={Liferay.Language.get(
+											'try-again'
 										)}
-									</ClayButton>
-								</div>
-							)}
-						</>
-					)}
-				</ErrorBoundary>
-			</div>
+										description={Liferay.Language.get(
+											'an-error-has-occurred-and-we-were-unable-to-load-the-results'
+										)}
+										displayState={DISPLAY_STATES.EMPTY}
+										onClickAction={
+											this._handleLoadMoreResults
+										}
+										title={Liferay.Language.get(
+											'unable-to-load-content'
+										)}
+									/>
+								)}
+
+								{showLoadMore && (
+									<div className="load-more-container">
+										<ClayButton
+											className="load-more-button"
+											displayType="secondary"
+											onClick={
+												this._handleLoadMoreResults
+											}
+										>
+											{Liferay.Language.get(
+												'load-more-results'
+											)}
+										</ClayButton>
+									</div>
+								)}
+							</>
+						)}
+					</ErrorBoundary>
+				</div>
+			</DndProvider>
 		);
 	}
 }
 
-export default dragDropContext(HTML5Backend)(List);
+export default List;

--- a/modules/package.json
+++ b/modules/package.json
@@ -9,6 +9,9 @@
 		"metal-jest-serializer": "2.0.0"
 	},
 	"private": true,
+	"resolutions": {
+		"dnd-core": "10.0.1"
+	},
 	"scripts": {
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1776,6 +1776,16 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
+"@react-dnd/invariant@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@react-dnd/invariant/-/invariant-2.0.0.tgz#09d2e81cd39e0e767d7da62df9325860f24e517e"
+  integrity sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==
+
+"@react-dnd/shallowequal@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz#a3031eb54129f2c66b2753f8404266ec7bf67f0a"
+  integrity sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==
+
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
@@ -2601,6 +2611,11 @@
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-4.2.4.tgz#9029bdf35d7f0557954452916f22ba0e9f11eff9"
   integrity sha512-Hi74+nCCjTM+HFRmN1CASq3Y1DC8XZk/oF0Ov/sIRXS5izvXCXtjxJcpPNzyi7YL5jGjWuldzsQTiPPtYbudwg==
+
+"@types/asap@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/asap/-/asap-2.0.0.tgz#d529e9608c83499a62ae08c871c5e62271aa2963"
+  integrity sha512-upIS0Gt9Mc8eEpCbYMZ1K8rhNosfKUtimNcINce+zLwJF5UpM3Vv7yz3S5l/1IX+DxTa8lTkUjqynvjRXyJzsg==
 
 "@types/babel__core@^7.1.0":
   version "7.1.0"
@@ -6804,14 +6819,15 @@ discontinuous-range@1.0.0:
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
   integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
 
-dnd-core@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-7.7.0.tgz#3166aefc8c5b85ca4ade4ae836712a3108975fab"
-  integrity sha512-+YqwflWEY1MEAEl2QiEiRaglYkCwIZryyQwximQGuTOm/ns7fS6Lg/i7OCkrtjM10D5FhArf/VUHIL4ZaRBK0g==
+dnd-core@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-10.0.1.tgz#151d95cd3a7fa47b210905c301364c0828203029"
+  integrity sha512-PokpWzFSKbpmJSWbSIfVJtIsRdx3DP5e3//agNNzV8L1k9T4/IFKtgjjwKeLKmP9qMuTXdZZGSS40w+eZ8MmUg==
   dependencies:
+    "@react-dnd/invariant" "^2.0.0"
+    "@types/asap" "^2.0.0"
     asap "^2.0.6"
-    invariant "^2.2.4"
-    redux "^4.0.1"
+    redux "^4.0.4"
 
 dns-equal@^1.0.0:
   version "1.0.0"
@@ -9848,7 +9864,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@2.2.4, invariant@^2.1.0, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -14951,35 +14967,34 @@ react-dev-utils@^9.0.0:
     strip-ansi "5.2.0"
     text-table "0.2.0"
 
-react-dnd-html5-backend@7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-7.7.0.tgz#e2b8ea61a1bc34ba743b89cafcda6213b006c06a"
-  integrity sha512-JgKmWOxqorFyfGPeWV+SAPhVGFe6+LrOR24jETE9rrYZU5hCppzwK9ujjS508kWibeDvbfEgi9j5qC2wB1/MoQ==
+react-dnd-html5-backend@10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-10.0.1.tgz#422c274a3007a86a7a64ddbab4a53e514211a907"
+  integrity sha512-llaw2bvSimBTFYLU479VPLtQgH+cR/kZajXjF6y4f/B9nijJW4IF8DJ2HN6wYXaVZnqaZQWdXBjf8RCOul+ZNQ==
   dependencies:
-    dnd-core "^7.7.0"
+    dnd-core "^10.0.1"
 
-react-dnd-test-backend@7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-dnd-test-backend/-/react-dnd-test-backend-7.7.0.tgz#c823f4d05b6e4b208eac73ec7e4c1c53fb814290"
-  integrity sha512-ELX2b6mBcgpVUuS9K74h+ldlHdsb1ZEVhJUm5vv7ZL+9l+xmpz+6IikiSdh7MmEGGrGLb2FCdXReeMPOblaCnQ==
+react-dnd-test-backend@10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-test-backend/-/react-dnd-test-backend-10.0.1.tgz#a311d4928657b3f7ab70151843bb6ef74bbbfef4"
+  integrity sha512-n4StfUoSgQlbLwgFSbN6PQtk8Az41D8Ao8pFYkpgaW/ZlTmuy2xM2MvwBKXRm3NiAi3YUWcuj2TIv4p5VhEwCA==
   dependencies:
-    dnd-core "^7.7.0"
+    dnd-core "^10.0.1"
 
-react-dnd-test-utils@7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-dnd-test-utils/-/react-dnd-test-utils-7.7.0.tgz#627dbc7f35bfe9db73148bf8c1f438bbd7b2bdae"
-  integrity sha512-OZAMws/26P6Jo5lVomxU3RZ9BEKyshG4szrkBK0ibF6SrfJ1ysEp4HOPtpeE0hVFdy3RG0eCsVDHXQSMY+6EBg==
+react-dnd-test-utils@10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-test-utils/-/react-dnd-test-utils-10.0.1.tgz#1283eeba7037af65c583715cf05cc20150ec2726"
+  integrity sha512-9zS5+Nz9SMWgIMtTHOR3f/kPX/KGEbchbkYvXJR0hvSLyOI47j10hnV7GklJzQe10zS0Y0c1H9SlSRgjdkkGiw==
 
-react-dnd@7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-7.7.0.tgz#9d983331ecf87ba33d058d861e6ca9adb8253a2e"
-  integrity sha512-anpJDKMgdXE6kXvtBFmIAe1fuaexpVy7meUyNjiTfCnjQ1mRvnttGTVvcW9fMKijsUQYadiyvzd3BRxteFuVXg==
+react-dnd@10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-10.0.1.tgz#fe9989f3b8aed2f237df090a382a1a309367be76"
+  integrity sha512-9GqK9j2s0+eUQiwIbni2m6/fv6L6Sq2WhPtpJmb5w2Ec+EIUSZLFo4/AZFmG8Nvck9AihavOTz/4nQiDq128DQ==
   dependencies:
+    "@react-dnd/shallowequal" "^2.0.0"
     "@types/hoist-non-react-statics" "^3.3.1"
-    dnd-core "^7.7.0"
+    dnd-core "^10.0.1"
     hoist-non-react-statics "^3.3.0"
-    invariant "^2.1.0"
-    shallowequal "^1.1.0"
 
 react-docgen@^4.1.0:
   version "4.1.1"
@@ -15530,10 +15545,10 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-redux@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
-  integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==
+redux@^4.0.1, redux@^4.0.4:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"


### PR DESCRIPTION
Changes to `.npmbundlerrc` are needed because react-dnd updated
its "main" field to point at `dist` rather than `lib` about seven months
ago, in:

https://github.com/react-dnd/react-dnd/commit/86a13e9e822ad70370c9886cd00d529bd2ed0b67

Without this, we wind up stripping the CommonJS files that we need
from the output JAR, causing our require calls to fail at runtime.

Additionally, we need to use "resolutions" to force the use of 10.0.1
instead of the latest, 10.0.2, in order to avoid this problematic commit
which forces the use of a fork of the `asap` module:

https://github.com/react-dnd/react-dnd/commit/ada65550b758a5de44b810a7b68753e7eaee24ac

Which leads to an untransformed `require('domain')` call winding up
in the build output and breaking everything:

https://github.com/react-dnd/asap/blob/b6bebeb73428474aefa8250ac79cf0f81fd146d9/src/node/raw.ts#L87