### PR TITLE
LPS-108492 Fix warnings, infos and errors that can't be closed by the user

### DIFF
--- a/modules/apps/frontend-js/frontend-js-alert-support-web/bnd.bnd
+++ b/modules/apps/frontend-js/frontend-js-alert-support-web/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Frontend JS Alert Support Web
+Bundle-SymbolicName: com.liferay.frontend.js.alert.support.web
+Bundle-Version: 1.0.0
+Web-ContextPath: /frontend-js-alert-support-web

--- a/modules/apps/frontend-js/frontend-js-alert-support-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-alert-support-web/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
+}

--- a/modules/apps/frontend-js/frontend-js-alert-support-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-alert-support-web/package.json
@@ -1,0 +1,13 @@
+{
+	"dependencies": {
+		"metal-dom": "2.16.8"
+	},
+	"name": "frontend-js-alert-support-web",
+	"private": true,
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "1.0.0"
+}

--- a/modules/apps/frontend-js/frontend-js-alert-support-web/src/main/java/com/liferay/frontend/js/alert/support/web/internal/servlet/taglib/AlertBottomDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-alert-support-web/src/main/java/com/liferay/frontend/js/alert/support/web/internal/servlet/taglib/AlertBottomDynamicInclude.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.alert.support.web.internal.servlet.taglib;
+
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
+import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.servlet.taglib.aui.ScriptData;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Marko Cikos
+ */
+@Component(service = DynamicInclude.class)
+public class AlertBottomDynamicInclude implements DynamicInclude {
+
+	@Override
+	public void include(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String key)
+		throws IOException {
+
+		ScriptData scriptData = new ScriptData();
+
+		String initModuleName = _npmResolver.resolveModuleName(
+			"frontend-js-alert-support-web/index");
+
+		scriptData.append(
+			null, "AlertProvider.default()",
+			initModuleName + " as AlertProvider", ScriptData.ModulesType.ES6);
+
+		scriptData.writeTo(httpServletResponse.getWriter());
+	}
+
+	@Override
+	public void register(
+		DynamicInclude.DynamicIncludeRegistry dynamicIncludeRegistry) {
+
+		dynamicIncludeRegistry.register("/html/common/themes/bottom.jsp#post");
+	}
+
+	@Reference
+	private NPMResolver _npmResolver;
+
+}

--- a/modules/apps/frontend-js/frontend-js-alert-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-alert-support-web/src/main/resources/META-INF/resources/index.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import dom from 'metal-dom';
+
+let handle;
+
+export default () => {
+	if (!handle) {
+		handle = dom.delegate(
+			document.body,
+			'click',
+			'[data-dismiss="liferay-alert"]',
+			event => {
+				event.preventDefault();
+
+				const container = dom.closest(event.delegateTarget, '.alert');
+
+				if (container) {
+					container.parentNode.removeChild(container);
+				}
+			}
+		);
+	}
+};

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/orphan_portlets.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/orphan_portlets.jsp
@@ -57,7 +57,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "orphan-widgets"));
 			</c:otherwise>
 		</c:choose>
 
-		<button aria-label="<%= LanguageUtil.get(request, "close") %>" class="close" data-dismiss="alert" type="button">
+		<button aria-label="<%= LanguageUtil.get(request, "close") %>" class="close" data-dismiss="liferay-alert" type="button">
 			<aui:icon image="times" markupView="lexicon" />
 		</button>
 	</div>

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/alert/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/alert/page.jsp
@@ -55,7 +55,7 @@
 	if (dismissible) {
 	%>
 
-		<button aria-label="<%= LanguageUtil.get(request, "close") %>" class="close" data-dismiss="alert" type="button">
+		<button aria-label="<%= LanguageUtil.get(request, "close") %>" class="close" data-dismiss="liferay-alert" type="button">
 			<svg aria-hidden="true" class="icon-monospaced lexicon-icon lexicon-icon-times">
 				<use xlink:href="<%= themeDisplayPath %>/lexicon/icons.svg#times" />
 			</svg>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/SLAForm.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/SLAForm.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayAlert from '@clayui/alert';
 import React from 'react';
 import {Redirect} from 'react-router-dom';
 import MaskedInput from 'react-text-mask';
@@ -98,31 +99,24 @@ const AlertMessage = () => {
 };
 
 const AlertWorkflowDefinitionChange = () => {
+	const [visible, setVisible] = useState(true);
+
 	return (
-		<div className="alert-container">
-			<div className="alert alert-danger alert-dismissible" role="alert">
-				<span className="alert-indicator">
-					<Icon iconName="exclamation-full" />
-				</span>
-
-				<strong className="lead">
-					{Liferay.Language.get('error')}
-				</strong>
-
-				{Liferay.Language.get(
-					'the-time-frame-options-changed-in-the-workflow-definition'
-				)}
-
-				<button
-					aria-label="Close"
-					className="close"
-					data-dismiss="alert"
-					type="button"
+		visible && (
+			<div className="alert-container">
+				<ClayAlert
+					displayType="danger"
+					onClose={() => {
+						setVisible(false);
+					}}
+					title={Liferay.Language.get('error')}
 				>
-					<Icon iconName="times" />
-				</button>
+					{Liferay.Language.get(
+						'the-time-frame-options-changed-in-the-workflow-definition'
+					)}
+				</ClayAlert>
 			</div>
-		</div>
+		)
 	);
 };
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/SLAListCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/SLAListCard.es.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import ClayAlert from '@clayui/alert';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 
@@ -36,7 +37,8 @@ class SLAListCard extends React.Component {
 			requestError: false,
 			showConfirmDialog: false,
 			showSLAsUpdatingAlert: false,
-			totalCount: 0
+			totalCount: 0,
+			visibleBlockedSLAAlert: true
 		};
 
 		this.slaContextState = {
@@ -166,7 +168,8 @@ class SLAListCard extends React.Component {
 			requestError,
 			showConfirmDialog,
 			showSLAsUpdatingAlert,
-			totalCount
+			totalCount,
+			visibleBlockedSLAAlert
 		} = this.state;
 		const {page, pageSize, processId} = this.props;
 		const emptyMessageText = Liferay.Language.get(
@@ -214,47 +217,32 @@ class SLAListCard extends React.Component {
 				)}
 
 				<div className="container-fluid-1280">
-					{blockedSLACount > 0 && (
-						<div
-							className="alert alert-danger alert-dismissible"
-							role="alert"
+					{blockedSLACount > 0 && visibleBlockedSLAAlert && (
+						<ClayAlert
+							displayType="danger"
+							onClose={() => {
+								this.setState({
+									visibleBlockedSLAAlert: false
+								});
+							}}
+							title={Liferay.Language.get('error')}
 						>
-							<span className="alert-indicator">
-								<Icon iconName="exclamation-full" />
-							</span>
-
-							<strong className="lead">
-								{Liferay.Language.get('error')}
-							</strong>
-
 							{Liferay.Language.get(
 								'fix-blocked-slas-to-resume-accurate-reporting'
 							)}
-
-							<button
-								aria-label="Close"
-								className="close"
-								data-dismiss="alert"
-								type="button"
-							>
-								<Icon iconName="times" />
-							</button>
-						</div>
+						</ClayAlert>
 					)}
 
 					{showSLAsUpdatingAlert && (
-						<div
-							className="alert alert-dismissible alert-info"
-							role="alert"
+						<ClayAlert
+							displayType="info"
+							onClose={() => {
+								this.setState({
+									showSLAsUpdatingAlert: false
+								});
+							}}
+							title={Liferay.Language.get('error')}
 						>
-							<span className="alert-indicator">
-								<Icon iconName="exclamation-full" />
-							</span>
-
-							<strong className="lead">
-								{Liferay.Language.get('info')}
-							</strong>
-
 							<span>
 								{`${Liferay.Language.get(
 									'one-or-more-slas-are-being-updated'
@@ -262,16 +250,7 @@ class SLAListCard extends React.Component {
 									'there-may-be-a-delay-before-sla-changes-are-fully-propagated'
 								)}`}
 							</span>
-
-							<button
-								aria-label="Close"
-								className="close"
-								data-dismiss="alert"
-								type="button"
-							>
-								<Icon iconName="times" />
-							</button>
-						</div>
+						</ClayAlert>
 					)}
 
 					<ListView

--- a/portal-web/docroot/html/taglib/ui/error/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/error/page.jsp
@@ -28,7 +28,7 @@ String rowBreak = (String)request.getAttribute("liferay-ui:error:rowBreak");
 <c:choose>
 	<c:when test="<%= embed %>">
 		<div class="alert alert-dismissible alert-<%= alertStyle %>" role="alert">
-			<button aria-label="<%= LanguageUtil.get(request, "close") %>" class="close" data-dismiss="alert" type="button">
+			<button aria-label="<%= LanguageUtil.get(request, "close") %>" class="close" data-dismiss="liferay-alert" type="button">
 				<aui:icon image="times" markupView="lexicon" />
 
 				<span class="sr-only"><%= LanguageUtil.get(request, "close") %></span>


### PR DESCRIPTION
When we turned off jQuery by default, these lingering, subtle usages of [the "Bootstrap Alert" utility](https://github.com/twbs/bootstrap/blob/master/js/src/alert.js), which relies on jQuery,  slipped under the radar and stopped working.

Previously reviewed/tested at:

- https://github.com/wincent/liferay-portal/pull/148
- https://github.com/wincent/liferay-portal/pull/147