### PR TITLE
LPS-109077 Remove unnecessary "no-unused-var" lint suppressions

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/dynamic_include/ChangeTrackingIndicator.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/dynamic_include/ChangeTrackingIndicator.js
@@ -25,7 +25,7 @@ const Component = ({
 	items,
 	namespace,
 	selectURL,
-	title
+	title,
 }) => {
 	const onDestroyPortlet = function() {
 		Liferay.detach('destroyPortlet', onDestroyPortlet);
@@ -40,15 +40,15 @@ const Component = ({
 				dialog: {
 					constrain: true,
 					modal: true,
-					width: 900
+					width: 900,
 				},
 				id: namespace + 'selectChangeList',
 				title: Liferay.Language.get('select-a-publication'),
-				uri: selectURL
+				uri: selectURL,
 			},
 			event => {
 				const portletURL = createPortletURL(checkoutURL, {
-					ctCollectionId: event.ctcollectionid
+					ctCollectionId: event.ctcollectionid,
 				});
 
 				Liferay.Util.navigate(portletURL.toString());
@@ -83,7 +83,7 @@ Component.propTypes = {
 	iconName: PropTypes.string,
 	namespace: PropTypes.string,
 	selectURL: PropTypes.string,
-	title: PropTypes.string
+	title: PropTypes.string,
 };
 
 export default function(props) {

--- a/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/soy/Flags.es.js
+++ b/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/soy/Flags.es.js
@@ -110,7 +110,6 @@ class Flags extends PortletBase {
 
 		const formData = new FormData();
 
-		// eslint-disable-next-line no-unused-vars
 		for (const name in this.formData) {
 			formData.append(name, this.formData[name]);
 		}

--- a/modules/apps/journal/journal-article-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/JournalArticleSelector.js
+++ b/modules/apps/journal/journal-article-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/JournalArticleSelector.js
@@ -12,10 +12,7 @@
  * details.
  */
 
-/* eslint-disable no-unused-vars */
-import {FieldBase} from 'dynamic-data-mapping-form-field-type';
-
-/* eslint-enable no-unused-vars */
+import 'dynamic-data-mapping-form-field-type';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
 import {Config} from 'metal-state';

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumns.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumns.js
@@ -73,7 +73,7 @@ const MillerColumns = ({
 	const columns = useMemo(() => {
 		const columns = [];
 
-		// eslint-disable-next-line no-for-of-loops/no-for-of-loops, no-unused-vars
+		// eslint-disable-next-line no-for-of-loops/no-for-of-loops
 		for (const item of items.values()) {
 			if (!columns[item.columnIndex]) {
 				columns[item.columnIndex] = {
@@ -143,7 +143,7 @@ const MillerColumns = ({
 		let prevColumnIndex;
 		let itemIndex = 0;
 
-		// eslint-disable-next-line no-for-of-loops/no-for-of-loops, no-unused-vars
+		// eslint-disable-next-line no-for-of-loops/no-for-of-loops
 		for (let item of items.values()) {
 			const columnIndex = item.columnIndex;
 

--- a/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/LayoutSelector.js
+++ b/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/LayoutSelector.js
@@ -12,10 +12,7 @@
  * details.
  */
 
-/* eslint-disable no-unused-vars */
-import {FieldBase} from 'dynamic-data-mapping-form-field-type';
-
-/* eslint-enable no-unused-vars */
+import 'dynamic-data-mapping-form-field-type';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
 import {Config} from 'metal-state';


### PR DESCRIPTION
Two categories here:

-   Suppressions needed to work around bugs in older versions of ESLint and babel-eslint, no longer needed since https://github.com/liferay/liferay-npm-tools/pull/392
-   Suppressions that existed for modules that we were `import`-ing only for their side-effects (ie. calls to `Soy.register()` inside those modules); the correct solution is to just make them side-effect-only imports.
