### PR TITLE
LPS-109461 Avoid false positives for "tmp" files during frontend source formatting

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -5,7 +5,7 @@
 		"compass-mixins": "0.12.10",
 		"jsdoc": "3.6.3",
 		"liferay-frontend-common-css": "1.0.4",
-		"liferay-npm-scripts": "28.0.0",
+		"liferay-npm-scripts": "28.0.1",
 		"metal-jest-serializer": "2.0.0"
 	},
 	"private": true,

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -11458,10 +11458,10 @@ liferay-npm-bundler@2.18.2:
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-liferay-npm-scripts@28.0.0:
-  version "28.0.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-28.0.0.tgz#2e3325a67ffc48aa11e5921d08739525b3ba732d"
-  integrity sha512-I66fVNxmdKFLxY28Vg1Bdouj4IkDrfCravcoZuQeBJ8r8/fy+7mF9L1CmzMfb2GAOBlNfc8Uo2ZS3RgAPe/hUw==
+liferay-npm-scripts@28.0.1:
+  version "28.0.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-28.0.1.tgz#0aa09293813d062c0cda8dd311430946301931af"
+  integrity sha512-4E0yEl+HR68cwwF49vJeW/BmwpdNEj/Q7NRG0MjIe379REXsh2JdN3ORqXxoMTKDUG/fdlDRd90/rFWG9wa7xg==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"


### PR DESCRIPTION
**TL;DR:** Updates liferay-npm-scripts to v28.0.1 so as to tweak the default linting globs so that we don't erroneously check build artifacts like "tmp/META-INF/resources/aui/test/test-min.js" found in frontend-js-aui-web.

---

As reported [here](https://github.com/brianchandotcom/liferay-portal/pull/85415#issuecomment-592218863), Brian was seeing a bunch of lint errors in frontend-js-aui-web for files
that weren't even touched by the pull. My analysis is:

-   The files with errors were all under "tmp/".
-   You would not expect these files to be checked because we use [globs targeting files under "src/" and "test/", not "tmp/"](https://github.com/liferay/liferay-npm-tools/blob/eee51cbfa7a0ef6a558dc36f6132ea03f0595c5f/packages/liferay-npm-scripts/src/presets/standard/index.js#L10).
-   Any time you "clean" [the "tmp/" directory will get blown away](https://github.com/liferay/liferay-portal/blob/235df4cb7357fbc4116c0240ffef7e03fb0fd0f0/modules/apps/frontend-js/frontend-js-aui-web/build.gradle#L55).
-   By design, [globs match at any level](https://github.com/liferay/liferay-npm-tools/blob/eee51cbfa7a0ef6a558dc36f6132ea03f0595c5f/packages/liferay-npm-scripts/test/utils/getRegExpForGlob.js#L25-L31) (unless explicitly anchored).

All together, that means that when you SF from the top level, the "tmp/" files do not get formatted because the glob we are using [looks like this](https://github.com/liferay/liferay-portal/blob/235df4cb7357fbc4116c0240ffef7e03fb0fd0f0/modules/npmscripts.config.js#L18):

    /{,dxp/}apps/*/*/{src,test}/**/*.{js,scss}

If you run SF from frontend-js-aui-web, however, the "tmp/" files match because our glob looks like this:

    {src,test}/**/*.js

Which in turn means that files like these match (note the "test/*.js" at the end of each path):

-   tmp/META-INF/resources/aui/test/test-coverage.js
-   tmp/META-INF/resources/aui/test/test-debug.js
-   tmp/META-INF/resources/aui/test/test-min.js
-   tmp/META-INF/resources/aui/test/test.js

Two fixes which work:

-   We can either [edit the ignore files in liferay-portal like so](https://gist.github.com/wincent/30e5152d2adf1df9f27c4e1c307f2f38).
-   Or we can do what I am doing in this commit, which is to change the default globs. I think this one is the better solution, even though it means cutting a liferay-npm-scripts release, because it makes the configuration more exactly match our intent: there is nothing special about a directory named "src" or "test" unless it is at a specific location in the tree, so let's be explicit about that.

    And as a rule of thumb, whitelists are preferable to blacklists, because they tend to be more future-proof (the downside of them growing stale is generally more limited).

    Related change in liferay-npm-scripts was:

    https://github.com/liferay/liferay-npm-tools/pull/397