### PR TITLE
LPS-105156 Revert Sort (breaks query)

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/custom-sql/default.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/custom-sql/default.xml
@@ -8,10 +8,10 @@
 		 	FROM
 			 	OAuth2Authorization
 			WHERE
-				(OAuth2Authorization.accessTokenExpirationDate < ?) AND
 				(OAuth2Authorization.refreshTokenExpirationDate IS NOT NULL) AND
 				(OAuth2Authorization.refreshTokenExpirationDate < ?) OR
-				(OAuth2Authorization.refreshTokenExpirationDate IS NULL)
+				(OAuth2Authorization.refreshTokenExpirationDate IS NULL) AND
+				(OAuth2Authorization.accessTokenExpirationDate < ?)
 		]]>
 	</sql>
 	<sql id="com.liferay.oauth2.provider.service.persistence.OAuth2ScopeGrantFinder.findByC_A_B_A">


### PR DESCRIPTION
Hi Brian. Following up on https://github.com/brianchandotcom/liferay-portal/pull/85309#issuecomment-591754410

We have tested that the ```OAuth2AuthorizationLocalServiceImpl``` gets re-activated as soon as the configuration changes, so no server reboot required.

However, sorting these SQL clauses ( f7627c520 ) changes the semantics. Because AND has higher precedence than OR.

The impact of the sort is that whenever there exists an ```OAuth2Authorization``` that has an access token but no refresh token, these are deleted from the DB immediately.

/cc @martamedio @csierra