### PR TITLE
LRCI-1067 Revert jenkins-results-parser java 8 changes

### DIFF
--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/java/com/liferay/frontend/image/editor/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/java/com/liferay/frontend/image/editor/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -128,10 +128,14 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 				properties.get(
 					"com.liferay.frontend.image.editor.capability.category"));
 
+			if (!imageEditorCapabilityDescriptorsMap.containsKey(category)) {
+				imageEditorCapabilityDescriptorsMap.put(
+					category, new ArrayList<ImageEditorCapabilityDescriptor>());
+			}
+
 			List<ImageEditorCapabilityDescriptor>
 				curImageEditorCapabilityDescriptors =
-					imageEditorCapabilityDescriptorsMap.computeIfAbsent(
-						category, key -> new ArrayList<>());
+					imageEditorCapabilityDescriptorsMap.get(category);
 
 			curImageEditorCapabilityDescriptors.add(
 				imageEditorCapabilityDescriptor);

--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -1,5 +1,5 @@
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
+sourceCompatibility = "1.7"
+targetCompatibility = "1.7"
 
 dependencies {
 	compile group: "com.amazonaws", name: "aws-java-sdk-core", version: "1.11.220"

--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -1,3 +1,6 @@
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
 dependencies {
 	compile group: "com.amazonaws", name: "aws-java-sdk-core", version: "1.11.220"
 	compile group: "com.amazonaws", name: "aws-java-sdk-ec2", version: "1.11.220"

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubDevSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubDevSyncUtil.java
@@ -512,9 +512,13 @@ public class GitHubDevSyncUtil {
 				String baseCacheBranchName = remoteGitBranchName.replaceAll(
 					"(.*)-\\d+", "$1");
 
+				if (!remoteGitBranchesMap.containsKey(baseCacheBranchName)) {
+					remoteGitBranchesMap.put(
+						baseCacheBranchName, new ArrayList<RemoteGitBranch>());
+				}
+
 				List<RemoteGitBranch> timestampedRemoteGitBranches =
-					remoteGitBranchesMap.computeIfAbsent(
-						baseCacheBranchName, key -> new ArrayList<>());
+					remoteGitBranchesMap.get(baseCacheBranchName);
 
 				timestampedRemoteGitBranches.add(remoteGitBranch);
 			}


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1067

@pyoo47, @michaelhashimoto, @yichenroy. Switching us back to Java 7 compatibility. 6.2 jobs are failing, so this is the quickest fix. We'll work out how to get us back to Java 8 later on.