### PR TITLE
LPS-105972 Remove configuration property for using initials for user portrait

### DIFF
--- a/modules/apps/users-admin/users-admin-api/src/main/java/com/liferay/users/admin/configuration/UserFileUploadsConfiguration.java
+++ b/modules/apps/users-admin/users-admin-api/src/main/java/com/liferay/users/admin/configuration/UserFileUploadsConfiguration.java
@@ -53,6 +53,10 @@ public interface UserFileUploadsConfiguration {
 	)
 	public boolean imageCheckToken();
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x)
+	 */
+	@Deprecated
 	@Meta.AD(
 		deflt = "true",
 		description = "use-initials-for-default-user-portrait-help",

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/configuration/settings/UserFileUploadsSettingsImpl.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/configuration/settings/UserFileUploadsSettingsImpl.java
@@ -53,9 +53,13 @@ public class UserFileUploadsSettingsImpl implements UserFileUploadsSettings {
 		return _userFileUploadsConfiguration.imageCheckToken();
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x)
+	 */
+	@Deprecated
 	@Override
 	public boolean isImageDefaultUseInitials() {
-		return _userFileUploadsConfiguration.imageDefaultUseInitials();
+		return false;
 	}
 
 	@Activate

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 6.1.1
+Bundle-Version: 6.1.2
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.test.*,\

--- a/portal-kernel/src/com/liferay/users/admin/kernel/file/uploads/UserFileUploadsSettings.java
+++ b/portal-kernel/src/com/liferay/users/admin/kernel/file/uploads/UserFileUploadsSettings.java
@@ -30,6 +30,10 @@ public interface UserFileUploadsSettings {
 
 	public boolean isImageCheckToken();
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x)
+	 */
+	@Deprecated
 	public boolean isImageDefaultUseInitials();
 
 }


### PR DESCRIPTION
This is an update for [LPS-105972](https://issues.liferay.com/browse/LPS-105972).<br><br>/cc @pei-jung @alee8888 @ChrisKian @dejuknow @patriciajeanperez