### PR TITLE
LRCI-925 Allow archived apps to deploy by using 'osgi.app.includes' in poshi tests

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6272,7 +6272,7 @@ go</echo>
 
 						<local name="app.dir.includes" />
 
-						<condition else="apps/${osgi.app.name}" property="app.dir.includes" value="apps/${osgi.app.name},dxp/apps/${osgi.app.name}">
+						<condition else="apps/${osgi.app.name},apps/archived/${osgi.app.name}" property="app.dir.includes" value="apps/${osgi.app.name},apps/archived/${osgi.app.name},dxp/apps/${osgi.app.name}">
 							<equals arg1="${build.profile}" arg2="dxp" />
 						</condition>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-925

Tested here (archived apps can deploy): https://github.com/yichenroy/liferay-portal/pull/290#issuecomment-594243313

Related:
7.0.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/29332
7.1.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/29330
7.2.x: https://github.com/brianchandotcom/liferay-portal-ee/pull/29331

cc @brianwulbern poshi-tests that require `archived` apps will need to specify them using the `osgi.app.includes` property.