### PR TITLE
LPS-109095 Promote bulk faliure logging from warn to error

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/util/LogUtil.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/util/LogUtil.java
@@ -49,8 +49,8 @@ public class LogUtil {
 	}
 
 	public static void logActionResponse(Log log, BulkResponse bulkResponse) {
-		if (bulkResponse.hasFailures() && log.isWarnEnabled()) {
-			log.warn(bulkResponse.buildFailureMessage());
+		if (bulkResponse.hasFailures()) {
+			log.error(bulkResponse.buildFailureMessage());
 		}
 
 		logActionResponse(log, (ActionResponse)bulkResponse);

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/util/LogUtil.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/util/LogUtil.java
@@ -56,8 +56,8 @@ public class LogUtil {
 	}
 
 	public static void logActionResponse(Log log, BulkResponse bulkResponse) {
-		if (bulkResponse.hasFailures() && log.isWarnEnabled()) {
-			log.warn(bulkResponse.buildFailureMessage());
+		if (bulkResponse.hasFailures()) {
+			log.error(bulkResponse.buildFailureMessage());
 		}
 
 		logActionResponse(log, (ActionResponse)bulkResponse);


### PR DESCRIPTION
**ci:test:search-es7 - 43 out of 52 jobs passed** https://github.com/BryanEngler/liferay-portal/pull/485#issuecomment-593460552
**ci:test:search - 42 out of 50 jobs passed** https://github.com/BryanEngler/liferay-portal/pull/485#issuecomment-593461603
✅ The only failures unique to this pull are also failing on the upstream canary https://github.com/xbrianlee/liferay-portal/pull/369

Author(s): @istvansajtos
Reviewer(s): @BryanEngler @lipusz

---
*[Bug] Elasticsearch bulk execution failures are not logged properly*
https://issues.liferay.com/browse/LPS-109095