### PR TITLE
LPS-102609 portal-search-tuning-rankings-web: Create new ranking indices even if old ranking index does not exist.

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/application/list/ResultRankingsPanelApp.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/application/list/ResultRankingsPanelApp.java
@@ -16,9 +16,15 @@ package com.liferay.portal.search.tuning.rankings.web.internal.application.list;
 
 import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.search.engine.SearchEngineInformation;
 import com.liferay.portal.search.tuning.rankings.web.internal.constants.ResultRankingsPortletKeys;
 import com.liferay.portal.search.tuning.web.application.list.constants.SearchTuningPanelCategoryKeys;
+
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -42,6 +48,17 @@ public class ResultRankingsPanelApp extends BasePanelApp {
 	}
 
 	@Override
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
+		throws PortalException {
+
+		if (Objects.equals(searchEngineInformation.getVendorString(), "Solr")) {
+			return false;
+		}
+
+		return super.isShow(permissionChecker, group);
+	}
+
+	@Override
 	@Reference(
 		target = "(javax.portlet.name=" + ResultRankingsPortletKeys.RESULT_RANKINGS + ")",
 		unbind = "-"
@@ -49,5 +66,8 @@ public class ResultRankingsPanelApp extends BasePanelApp {
 	public void setPortlet(Portlet portlet) {
 		super.setPortlet(portlet);
 	}
+
+	@Reference
+	protected SearchEngineInformation searchEngineInformation;
 
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/background/task/RankingIndexCreationBackgroundTaskExecutor.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/background/task/RankingIndexCreationBackgroundTaskExecutor.java
@@ -15,11 +15,15 @@
 package com.liferay.portal.search.tuning.rankings.web.internal.background.task;
 
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskConstants;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
 import com.liferay.portal.kernel.backgroundtask.BaseBackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.display.BackgroundTaskDisplay;
+import com.liferay.portal.search.engine.SearchEngineInformation;
 import com.liferay.portal.search.tuning.rankings.web.internal.index.importer.SingleIndexToMultipleIndexImporter;
+
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -47,6 +51,13 @@ public class RankingIndexCreationBackgroundTaskExecutor
 	public BackgroundTaskResult execute(BackgroundTask backgroundTask)
 		throws Exception {
 
+		if (Objects.equals(
+				_searchEngineInformation.getVendorString(), "Solr")) {
+
+			return new BackgroundTaskResult(
+				BackgroundTaskConstants.STATUS_CANCELLED);
+		}
+
 		_singleIndexToMultipleIndexImporter.importRankings();
 
 		return BackgroundTaskResult.SUCCESS;
@@ -58,6 +69,9 @@ public class RankingIndexCreationBackgroundTaskExecutor
 
 		return null;
 	}
+
+	@Reference
+	private SearchEngineInformation _searchEngineInformation;
 
 	@Reference
 	private SingleIndexToMultipleIndexImporter

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/activator/RankingIndexCreationBundleActivator.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/index/creation/activator/RankingIndexCreationBundleActivator.java
@@ -22,9 +22,11 @@ import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.uuid.PortalUUID;
+import com.liferay.portal.search.engine.SearchEngineInformation;
 import com.liferay.portal.search.tuning.rankings.web.internal.background.task.RankingIndexCreationBackgroundTaskExecutor;
 
 import java.util.HashMap;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -41,8 +43,15 @@ public class RankingIndexCreationBundleActivator {
 
 	@Activate
 	protected void activate() {
+		if (Objects.equals(searchEngineInformation.getVendorString(), "Solr")) {
+			return;
+		}
+
 		_addBackgroundTask();
 	}
+
+	@Reference
+	protected SearchEngineInformation searchEngineInformation;
 
 	private void _addBackgroundTask() {
 		try {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/application/list/SynonymsPanelApp.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/application/list/SynonymsPanelApp.java
@@ -16,9 +16,15 @@ package com.liferay.portal.search.tuning.synonyms.web.internal.application.list;
 
 import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.search.engine.SearchEngineInformation;
 import com.liferay.portal.search.tuning.synonyms.web.internal.constants.SynonymsPortletKeys;
 import com.liferay.portal.search.tuning.web.application.list.constants.SearchTuningPanelCategoryKeys;
+
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -42,6 +48,17 @@ public class SynonymsPanelApp extends BasePanelApp {
 	}
 
 	@Override
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
+		throws PortalException {
+
+		if (Objects.equals(searchEngineInformation.getVendorString(), "Solr")) {
+			return false;
+		}
+
+		return super.isShow(permissionChecker, group);
+	}
+
+	@Override
 	@Reference(
 		target = "(javax.portlet.name=" + SynonymsPortletKeys.SYNONYMS + ")",
 		unbind = "-"
@@ -49,5 +66,8 @@ public class SynonymsPanelApp extends BasePanelApp {
 	public void setPortlet(Portlet portlet) {
 		super.setPortlet(portlet);
 	}
+
+	@Reference
+	protected SearchEngineInformation searchEngineInformation;
 
 }


### PR DESCRIPTION
<h3><g-emoji class="g-emoji" alias="x" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/274c.png"><img class="emoji" alt="x" src="https://github.githubassets.com/images/icons/emoji/unicode/274c.png" width="20" height="20"></g-emoji> ci:test:search - 45 out of 50 jobs passed in 1 hour 39 minutes 51 seconds 575 ms</h3>

All unique tests are known flaky tests.

https://github.com/brandizzi/liferay-portal/pull/988#issuecomment-594621969

Author: @brandizzi

https://issues.liferay.com/browse/LPS-102609
https://issues.liferay.com/browse/LPS-102611