### PR TITLE
LPS-109847 Update liferay-npm-scripts to v28.0.2

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -5,7 +5,7 @@
 		"compass-mixins": "0.12.10",
 		"jsdoc": "3.6.3",
 		"liferay-frontend-common-css": "1.0.4",
-		"liferay-npm-scripts": "28.0.1",
+		"liferay-npm-scripts": "28.0.2",
 		"metal-jest-serializer": "2.0.0"
 	},
 	"private": true,

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -11458,10 +11458,10 @@ liferay-npm-bundler@2.18.2:
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-liferay-npm-scripts@28.0.1:
-  version "28.0.1"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-28.0.1.tgz#0aa09293813d062c0cda8dd311430946301931af"
-  integrity sha512-4E0yEl+HR68cwwF49vJeW/BmwpdNEj/Q7NRG0MjIe379REXsh2JdN3ORqXxoMTKDUG/fdlDRd90/rFWG9wa7xg==
+liferay-npm-scripts@28.0.2:
+  version "28.0.2"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-28.0.2.tgz#da329311fb0d28f5cb5c6f5dc44d2febf4bdad33"
+  integrity sha512-EeowxTEyRoAzBovLWAD6+zB/pSnwzMFyvK+m9c0Q0zkLeNDExQLIi9+B7JYgQ7/mPpktGcgaMeAmVZXjgpdanA==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"


### PR DESCRIPTION
New version updates the default globs that are used at project-level to match the ones used at the top-level.

Means that the kind of thing that happened in [this PR](https://github.com/brianchandotcom/liferay-portal/pull/85713) (developer runs SF at project-level and all is good, but CI runs SF at top-level and rejects) won't happen any more.

See: [v28.0.2 release notes](https://github.com/liferay/liferay-npm-tools/releases/tag/liferay-npm-scripts%2Fv28.0.2).

