### PR TITLE
LPS-109811 Unable to renavigate to widget configuration screens

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -92,10 +92,9 @@ Liferay.Portal = {
 	},
 };
 
-Liferay.Portlet = {
-	...Liferay.Portlet,
-	minimize: minimizePortlet,
-};
+Liferay.Portlet = Liferay.Portlet || {};
+
+Liferay.Portlet.minimize = minimizePortlet;
 
 Liferay.SideNavigation = SideNavigation;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -22,6 +22,8 @@
 	var TPL_NOT_AJAXABLE = '<div class="alert alert-info">{0}</div>';
 
 	var Portlet = {
+		...Liferay.Portlet,
+
 		_defCloseFn(event) {
 			event.portlet.remove(true);
 
@@ -743,8 +745,5 @@
 		});
 	};
 
-	Liferay.Portlet = {
-		...Liferay.Portlet,
-		...Portlet,
-	};
+	Liferay.Portlet = Portlet;
 })(AUI(), Liferay);


### PR DESCRIPTION
From the commit:

> We must not merge `Liferay.Portlet` object using spread operator after `Liferay.provide`. (`Liferay.provide` requires object persistence.)

More context here: https://github.com/wincent/liferay-portal/pull/165