### PR TITLE
Lps 109121 2

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -182,15 +182,18 @@ message.
 	</target>
 
 	<target name="compile">
-		<setup-sdk />
-
 		<if>
 			<equals arg1="${org.gradle.daemon}" arg2="true" />
 			<then>
+				<setup-sdk setupbinariescache="false" />
+
 				<gradle-execute dir="." forcedcacheenabled="false" task="">
 					<arg value="--stop" />
 				</gradle-execute>
 			</then>
+			<else>
+				<setup-sdk />
+			</else>
 		</if>
 
 		<setup-libs />

--- a/build.xml
+++ b/build.xml
@@ -182,20 +182,7 @@ message.
 	</target>
 
 	<target name="compile">
-		<if>
-			<equals arg1="${org.gradle.daemon}" arg2="true" />
-			<then>
-				<setup-sdk setupbinariescache="false" />
-
-				<gradle-execute dir="." forcedcacheenabled="false" task="">
-					<arg value="--stop" />
-				</gradle-execute>
-			</then>
-			<else>
-				<setup-sdk />
-			</else>
-		</if>
-
+		<setup-sdk />
 		<setup-libs />
 		<setup-yarn />
 


### PR DESCRIPTION
@brianchandotcom Lily's daily monitoring caught this regression, the original problem was unclear. But it seems https://github.com/brianchandotcom/liferay-portal/commit/4376ee2486e31db6df10cc7a2cd6b229a2d55762 is needed if you want to auto clean up the gradle daemon "on certain platform, for certain people". but doing it in compile is actually slowing thing down, which is defeating the whole purpose of making this daemon changes in the first place. So I am just dropping it for now.
Once peter is back, if he can revisit and figure out why https://github.com/brianchandotcom/liferay-portal/commit/4376ee2486e31db6df10cc7a2cd6b229a2d55762 was needed, we might be able to add it back in a different way.