### PR TITLE
LPS-107538 portal-search: Test: the model indexer writer document helper should treat eceptions from the index document builder.

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/index/contributor/helper/ModelIndexerWriterDocumentHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/index/contributor/helper/ModelIndexerWriterDocumentHelperImpl.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.index.contributor.helper;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.search.indexer.IndexerDocumentBuilder;
+import com.liferay.portal.search.spi.model.index.contributor.helper.ModelIndexerWriterDocumentHelper;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class ModelIndexerWriterDocumentHelperImpl
+	implements ModelIndexerWriterDocumentHelper {
+
+	public ModelIndexerWriterDocumentHelperImpl(
+		String className, IndexerDocumentBuilder indexerDocumentBuilder) {
+
+		_className = className;
+		_indexerDocumentBuilder = indexerDocumentBuilder;
+	}
+
+	@Override
+	public Document getDocument(BaseModel baseModel) {
+		try {
+			return _indexerDocumentBuilder.getDocument(baseModel);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Error indexing ", _className, " with primaryKey=",
+						baseModel.getPrimaryKeyObj()),
+					exception);
+			}
+
+			return null;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ModelIndexerWriterDocumentHelperImpl.class);
+
+	private final String _className;
+	private final IndexerDocumentBuilder _indexerDocumentBuilder;
+
+}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
@@ -195,8 +195,23 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 
 						@Override
 						public Document getDocument(BaseModel baseModel) {
-							return _indexerDocumentBuilder.getDocument(
-								baseModel);
+							try {
+								return _indexerDocumentBuilder.getDocument(
+									baseModel);
+							}
+							catch (Exception exception) {
+								if (_log.isWarnEnabled()) {
+									_log.warn(
+										StringBundler.concat(
+											"Error indexing ",
+											_modelSearchSettings.getClassName(),
+											" with primaryKey=",
+											baseModel.getPrimaryKeyObj()),
+										exception);
+								}
+
+								return null;
+							}
 						}
 
 					});

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
@@ -35,10 +35,10 @@ import com.liferay.portal.search.index.UpdateDocumentIndexWriter;
 import com.liferay.portal.search.indexer.BaseModelRetriever;
 import com.liferay.portal.search.indexer.IndexerDocumentBuilder;
 import com.liferay.portal.search.indexer.IndexerWriter;
+import com.liferay.portal.search.internal.index.contributor.helper.ModelIndexerWriterDocumentHelperImpl;
 import com.liferay.portal.search.permission.SearchPermissionIndexWriter;
 import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
 import com.liferay.portal.search.spi.model.index.contributor.helper.IndexerWriterMode;
-import com.liferay.portal.search.spi.model.index.contributor.helper.ModelIndexerWriterDocumentHelper;
 import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
 
 import java.util.Collection;
@@ -191,30 +191,9 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 
 				_modelIndexerWriterContributor.customize(
 					batchIndexingActionable,
-					new ModelIndexerWriterDocumentHelper() {
-
-						@Override
-						public Document getDocument(BaseModel baseModel) {
-							try {
-								return _indexerDocumentBuilder.getDocument(
-									baseModel);
-							}
-							catch (Exception exception) {
-								if (_log.isWarnEnabled()) {
-									_log.warn(
-										StringBundler.concat(
-											"Error indexing ",
-											_modelSearchSettings.getClassName(),
-											" with primaryKey=",
-											baseModel.getPrimaryKeyObj()),
-										exception);
-								}
-
-								return null;
-							}
-						}
-
-					});
+					new ModelIndexerWriterDocumentHelperImpl(
+						_modelSearchSettings.getClassName(),
+						_indexerDocumentBuilder));
 
 				try {
 					batchIndexingActionable.performActions();

--- a/modules/apps/portal-search/portal-search/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/portal-search/portal-search/src/main/resources/META-INF/module-log4j.xml
@@ -5,4 +5,8 @@
 	<category name="com.liferay.portal.search.internal.IndexerRegistryImpl">
 		<priority value="WARN" />
 	</category>
+
+	<category name="com.liferay.portal.search.internal.indexer.IndexerWriterImpl">
+		<priority value="WARN" />
+	</category>
 </log4j:configuration>

--- a/modules/apps/portal-search/portal-search/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/portal-search/portal-search/src/main/resources/META-INF/module-log4j.xml
@@ -6,6 +6,10 @@
 		<priority value="WARN" />
 	</category>
 
+	<category name="com.liferay.portal.search.internal.index.contributor.helper.ModelIndexerWriterDocumentHelperImpl">
+		<priority value="WARN" />
+	</category>
+
 	<category name="com.liferay.portal.search.internal.indexer.IndexerWriterImpl">
 		<priority value="WARN" />
 	</category>

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/index/contributor/helper/ModelIndexerWriterDocumentHelperTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/index/contributor/helper/ModelIndexerWriterDocumentHelperTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.index.contributor.helper;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.indexer.IndexerDocumentBuilder;
+import com.liferay.portal.search.spi.model.index.contributor.helper.ModelIndexerWriterDocumentHelper;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class ModelIndexerWriterDocumentHelperTest {
+
+	@Before
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void testException() throws PortalException {
+		throwIndexNameBuilderException(new SystemException());
+
+		ModelIndexerWriterDocumentHelper modelIndexerWriterDocumentHelper =
+			new ModelIndexerWriterDocumentHelperImpl(
+				RandomTestUtil.randomString(), indexDocumentBuilder);
+
+		modelIndexerWriterDocumentHelper.getDocument(baseModel);
+	}
+
+	protected void throwIndexNameBuilderException(Exception exception) {
+		Mockito.when(
+			indexDocumentBuilder.getDocument(Matchers.any())
+		).thenThrow(
+			exception
+		);
+	}
+
+	@Mock
+	protected BaseModel<?> baseModel;
+
+	@Mock
+	protected IndexerDocumentBuilder indexDocumentBuilder;
+
+}


### PR DESCRIPTION
<h3><g-emoji class="g-emoji" alias="x" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/274c.png"><img class="emoji" alt="x" src="https://github.githubassets.com/images/icons/emoji/unicode/274c.png" width="20" height="20"></g-emoji> ci:test:search - 46 out of 51 jobs passed in 1 hour 32 minutes 5 seconds 256 ms</h3>

https://github.com/brandizzi/liferay-portal/pull/991#issuecomment-595592485

The only unique failure is a known fluke.

Author: @jorgediaz-lr
Reviewer: @brandizzi

https://issues.liferay.com/browse/LPS-107538