### PR TITLE
LPS-108400 Create AccountOrganizationRel GET and POST endpoints

### DIFF
--- a/modules/apps/account/account-api/bnd.bnd
+++ b/modules/apps/account/account-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Account API
 Bundle-SymbolicName: com.liferay.account.api
-Bundle-Version: 1.4.2
+Bundle-Version: 1.5.0
 Export-Package:\
 	com.liferay.account.constants,\
 	com.liferay.account.exception,\

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryOrganizationRelLocalService.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryOrganizationRelLocalService.java
@@ -274,6 +274,21 @@ public interface AccountEntryOrganizationRelLocalService
 		long accountEntryId, long organizationId);
 
 	/**
+	 * Creates an AccountEntryOrganizationRel for each given organizationId,
+	 * unless it already exists, and removes existing
+	 * AccountEntryOrganizationRels if their organizationId is not present in
+	 * the given organizationIds.
+	 *
+	 * @param accountEntryId
+	 * @param organizationIds
+	 * @throws PortalException
+	 * @review
+	 */
+	public void setAccountEntryOrganizationRels(
+			long accountEntryId, long[] organizationIds)
+		throws PortalException;
+
+	/**
 	 * Updates the account entry organization rel in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	 *
 	 * @param accountEntryOrganizationRel the account entry organization rel

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryOrganizationRelLocalServiceUtil.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryOrganizationRelLocalServiceUtil.java
@@ -348,6 +348,25 @@ public class AccountEntryOrganizationRelLocalServiceUtil {
 	}
 
 	/**
+	 * Creates an AccountEntryOrganizationRel for each given organizationId,
+	 * unless it already exists, and removes existing
+	 * AccountEntryOrganizationRels if their organizationId is not present in
+	 * the given organizationIds.
+	 *
+	 * @param accountEntryId
+	 * @param organizationIds
+	 * @throws PortalException
+	 * @review
+	 */
+	public static void setAccountEntryOrganizationRels(
+			long accountEntryId, long[] organizationIds)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		getService().setAccountEntryOrganizationRels(
+			accountEntryId, organizationIds);
+	}
+
+	/**
 	 * Updates the account entry organization rel in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	 *
 	 * @param accountEntryOrganizationRel the account entry organization rel

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryOrganizationRelLocalServiceWrapper.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryOrganizationRelLocalServiceWrapper.java
@@ -376,6 +376,26 @@ public class AccountEntryOrganizationRelLocalServiceWrapper
 	}
 
 	/**
+	 * Creates an AccountEntryOrganizationRel for each given organizationId,
+	 * unless it already exists, and removes existing
+	 * AccountEntryOrganizationRels if their organizationId is not present in
+	 * the given organizationIds.
+	 *
+	 * @param accountEntryId
+	 * @param organizationIds
+	 * @throws PortalException
+	 * @review
+	 */
+	@Override
+	public void setAccountEntryOrganizationRels(
+			long accountEntryId, long[] organizationIds)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_accountEntryOrganizationRelLocalService.
+			setAccountEntryOrganizationRels(accountEntryId, organizationIds);
+	}
+
+	/**
 	 * Updates the account entry organization rel in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	 *
 	 * @param accountEntryOrganizationRel the account entry organization rel

--- a/modules/apps/account/account-api/src/main/resources/com/liferay/account/service/packageinfo
+++ b/modules/apps/account/account-api/src/main/resources/com/liferay/account/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0

--- a/modules/apps/account/account-rest-api/src/main/java/com/liferay/account/rest/dto/v1_0/Account.java
+++ b/modules/apps/account/account-rest-api/src/main/java/com/liferay/account/rest/dto/v1_0/Account.java
@@ -157,6 +157,34 @@ public class Account {
 	protected String name;
 
 	@Schema
+	public Long[] getOrganizationIds() {
+		return organizationIds;
+	}
+
+	public void setOrganizationIds(Long[] organizationIds) {
+		this.organizationIds = organizationIds;
+	}
+
+	@JsonIgnore
+	public void setOrganizationIds(
+		UnsafeSupplier<Long[], Exception> organizationIdsUnsafeSupplier) {
+
+		try {
+			organizationIds = organizationIdsUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long[] organizationIds;
+
+	@Schema
 	public Long getParentAccountId() {
 		return parentAccountId;
 	}
@@ -299,6 +327,26 @@ public class Account {
 			sb.append(_escape(name));
 
 			sb.append("\"");
+		}
+
+		if (organizationIds != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"organizationIds\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < organizationIds.length; i++) {
+				sb.append(organizationIds[i]);
+
+				if ((i + 1) < organizationIds.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		if (parentAccountId != null) {

--- a/modules/apps/account/account-rest-client/src/main/java/com/liferay/account/rest/client/dto/v1_0/Account.java
+++ b/modules/apps/account/account-rest-client/src/main/java/com/liferay/account/rest/client/dto/v1_0/Account.java
@@ -108,6 +108,27 @@ public class Account implements Cloneable {
 
 	protected String name;
 
+	public Long[] getOrganizationIds() {
+		return organizationIds;
+	}
+
+	public void setOrganizationIds(Long[] organizationIds) {
+		this.organizationIds = organizationIds;
+	}
+
+	public void setOrganizationIds(
+		UnsafeSupplier<Long[], Exception> organizationIdsUnsafeSupplier) {
+
+		try {
+			organizationIds = organizationIdsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long[] organizationIds;
+
 	public Long getParentAccountId() {
 		return parentAccountId;
 	}

--- a/modules/apps/account/account-rest-client/src/main/java/com/liferay/account/rest/client/serdes/v1_0/AccountSerDes.java
+++ b/modules/apps/account/account-rest-client/src/main/java/com/liferay/account/rest/client/serdes/v1_0/AccountSerDes.java
@@ -115,6 +115,26 @@ public class AccountSerDes {
 			sb.append("\"");
 		}
 
+		if (account.getOrganizationIds() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"organizationIds\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < account.getOrganizationIds().length; i++) {
+				sb.append(account.getOrganizationIds()[i]);
+
+				if ((i + 1) < account.getOrganizationIds().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (account.getParentAccountId() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -181,6 +201,15 @@ public class AccountSerDes {
 			map.put("name", String.valueOf(account.getName()));
 		}
 
+		if (account.getOrganizationIds() == null) {
+			map.put("organizationIds", null);
+		}
+		else {
+			map.put(
+				"organizationIds",
+				String.valueOf(account.getOrganizationIds()));
+		}
+
 		if (account.getParentAccountId() == null) {
 			map.put("parentAccountId", null);
 		}
@@ -236,6 +265,12 @@ public class AccountSerDes {
 			else if (Objects.equals(jsonParserFieldName, "name")) {
 				if (jsonParserFieldValue != null) {
 					account.setName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "organizationIds")) {
+				if (jsonParserFieldValue != null) {
+					account.setOrganizationIds(
+						toLongs((Object[])jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "parentAccountId")) {

--- a/modules/apps/account/account-rest-impl/rest-openapi.yaml
+++ b/modules/apps/account/account-rest-impl/rest-openapi.yaml
@@ -23,6 +23,11 @@ components:
                     type: integer
                 name:
                     type: string
+                organizationIds:
+                    items:
+                        format: int64
+                        type: integer
+                    type: array
                 parentAccountId:
                     format: int64
                     type: integer

--- a/modules/apps/account/account-rest-impl/src/main/java/com/liferay/account/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/account/account-rest-impl/src/main/java/com/liferay/account/rest/internal/graphql/query/v1_0/Query.java
@@ -104,7 +104,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {account(accountId: ___){description, domains, id, name, parentAccountId, status}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {account(accountId: ___){description, domains, id, name, organizationIds, parentAccountId, status}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "")
 	public Account account(@GraphQLName("accountId") Long accountId)

--- a/modules/apps/account/account-rest-impl/src/main/java/com/liferay/account/rest/internal/resource/v1_0/AccountResourceImpl.java
+++ b/modules/apps/account/account-rest-impl/src/main/java/com/liferay/account/rest/internal/resource/v1_0/AccountResourceImpl.java
@@ -110,7 +110,7 @@ public class AccountResourceImpl
 			account.getName(), account.getDescription(), _getDomains(account),
 			null, _getStatus(account));
 
-		_updateAccountOrganizations(
+		_setAccountEntryOrganizationRels(
 			accountEntry.getAccountEntryId(), account.getOrganizationIds());
 
 		return _toAccount(accountEntry);
@@ -120,7 +120,8 @@ public class AccountResourceImpl
 	public Account putAccount(Long accountId, Account account)
 		throws Exception {
 
-		_updateAccountOrganizations(accountId, account.getOrganizationIds());
+		_setAccountEntryOrganizationRels(
+			accountId, account.getOrganizationIds());
 
 		return _toAccount(
 			_accountEntryLocalService.updateAccountEntry(
@@ -153,25 +154,7 @@ public class AccountResourceImpl
 		);
 	}
 
-	private Account _toAccount(AccountEntry accountEntry) throws Exception {
-		return new Account() {
-			{
-				description = accountEntry.getDescription();
-				domains = StringUtil.split(accountEntry.getDomains());
-				id = accountEntry.getAccountEntryId();
-				name = accountEntry.getName();
-				organizationIds = transformToArray(
-					_accountEntryOrganizationRelLocalService.
-						getAccountEntryOrganizationRels(
-							accountEntry.getAccountEntryId()),
-					AccountEntryOrganizationRel::getOrganizationId, Long.class);
-				parentAccountId = accountEntry.getParentAccountEntryId();
-				status = accountEntry.getStatus();
-			}
-		};
-	}
-
-	private void _updateAccountOrganizations(
+	private void _setAccountEntryOrganizationRels(
 			long accountId, Long[] organizationIds)
 		throws Exception {
 
@@ -203,6 +186,24 @@ public class AccountResourceImpl
 		_accountEntryOrganizationRelLocalService.
 			addAccountEntryOrganizationRels(
 				accountId, ArrayUtil.toLongArray(addOrganizationIdsSet));
+	}
+
+	private Account _toAccount(AccountEntry accountEntry) throws Exception {
+		return new Account() {
+			{
+				description = accountEntry.getDescription();
+				domains = StringUtil.split(accountEntry.getDomains());
+				id = accountEntry.getAccountEntryId();
+				name = accountEntry.getName();
+				organizationIds = transformToArray(
+					_accountEntryOrganizationRelLocalService.
+						getAccountEntryOrganizationRels(
+							accountEntry.getAccountEntryId()),
+					AccountEntryOrganizationRel::getOrganizationId, Long.class);
+				parentAccountId = accountEntry.getParentAccountEntryId();
+				status = accountEntry.getStatus();
+			}
+		};
 	}
 
 	@Reference

--- a/modules/apps/account/account-rest-impl/src/main/java/com/liferay/account/rest/internal/resource/v1_0/AccountResourceImpl.java
+++ b/modules/apps/account/account-rest-impl/src/main/java/com/liferay/account/rest/internal/resource/v1_0/AccountResourceImpl.java
@@ -27,8 +27,6 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -38,9 +36,7 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -110,8 +106,10 @@ public class AccountResourceImpl
 			account.getName(), account.getDescription(), _getDomains(account),
 			null, _getStatus(account));
 
-		_setAccountEntryOrganizationRels(
-			accountEntry.getAccountEntryId(), account.getOrganizationIds());
+		_accountEntryOrganizationRelLocalService.
+			setAccountEntryOrganizationRels(
+				accountEntry.getAccountEntryId(),
+				ArrayUtil.toArray(account.getOrganizationIds()));
 
 		return _toAccount(accountEntry);
 	}
@@ -120,8 +118,9 @@ public class AccountResourceImpl
 	public Account putAccount(Long accountId, Account account)
 		throws Exception {
 
-		_setAccountEntryOrganizationRels(
-			accountId, account.getOrganizationIds());
+		_accountEntryOrganizationRelLocalService.
+			setAccountEntryOrganizationRels(
+				accountId, ArrayUtil.toArray(account.getOrganizationIds()));
 
 		return _toAccount(
 			_accountEntryLocalService.updateAccountEntry(
@@ -152,40 +151,6 @@ public class AccountResourceImpl
 		).orElse(
 			WorkflowConstants.STATUS_APPROVED
 		);
-	}
-
-	private void _setAccountEntryOrganizationRels(
-			long accountId, Long[] organizationIds)
-		throws Exception {
-
-		if (organizationIds == null) {
-			return;
-		}
-
-		Set<Long> organizationIdsSet = SetUtil.fromArray(organizationIds);
-
-		List<Long> currentOrganizationIds = ListUtil.toList(
-			_accountEntryOrganizationRelLocalService.
-				getAccountEntryOrganizationRels(accountId),
-			AccountEntryOrganizationRel::getOrganizationId);
-
-		Set<Long> deleteOrganizationIdsSet = SetUtil.fromCollection(
-			currentOrganizationIds);
-
-		deleteOrganizationIdsSet.removeAll(organizationIdsSet);
-
-		_accountEntryOrganizationRelLocalService.
-			deleteAccountEntryOrganizationRels(
-				accountId, ArrayUtil.toLongArray(deleteOrganizationIdsSet));
-
-		Set<Long> addOrganizationIdsSet = SetUtil.fromCollection(
-			organizationIdsSet);
-
-		addOrganizationIdsSet.removeAll(currentOrganizationIds);
-
-		_accountEntryOrganizationRelLocalService.
-			addAccountEntryOrganizationRels(
-				accountId, ArrayUtil.toLongArray(addOrganizationIdsSet));
 	}
 
 	private Account _toAccount(AccountEntry accountEntry) throws Exception {

--- a/modules/apps/account/account-rest-impl/src/main/java/com/liferay/account/rest/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/account/account-rest-impl/src/main/java/com/liferay/account/rest/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -116,7 +116,7 @@ public abstract class BaseAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/account-rest/v1.0/accounts' -d $'{"description": ___, "domains": ___, "name": ___, "parentAccountId": ___, "status": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/account-rest/v1.0/accounts' -d $'{"description": ___, "domains": ___, "name": ___, "organizationIds": ___, "parentAccountId": ___, "status": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@Override
 	@Consumes({"application/json", "application/xml"})
@@ -242,7 +242,7 @@ public abstract class BaseAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/account-rest/v1.0/accounts/{accountId}' -d $'{"description": ___, "domains": ___, "name": ___, "parentAccountId": ___, "status": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/account-rest/v1.0/accounts/{accountId}' -d $'{"description": ___, "domains": ___, "name": ___, "organizationIds": ___, "parentAccountId": ___, "status": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@Override
 	@Consumes({"application/json", "application/xml"})
@@ -274,6 +274,10 @@ public abstract class BaseAccountResourceImpl
 			existingAccount.setName(account.getName());
 		}
 
+		if (account.getOrganizationIds() != null) {
+			existingAccount.setOrganizationIds(account.getOrganizationIds());
+		}
+
 		if (account.getParentAccountId() != null) {
 			existingAccount.setParentAccountId(account.getParentAccountId());
 		}
@@ -290,7 +294,7 @@ public abstract class BaseAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/account-rest/v1.0/accounts/{accountId}' -d $'{"description": ___, "domains": ___, "name": ___, "parentAccountId": ___, "status": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/account-rest/v1.0/accounts/{accountId}' -d $'{"description": ___, "domains": ___, "name": ___, "organizationIds": ___, "parentAccountId": ___, "status": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@Override
 	@Consumes({"application/json", "application/xml"})

--- a/modules/apps/account/account-rest-test/src/testIntegration/java/com/liferay/account/rest/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/account/account-rest-test/src/testIntegration/java/com/liferay/account/rest/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -736,6 +736,14 @@ public abstract class BaseAccountResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("organizationIds", additionalAssertFieldName)) {
+				if (account.getOrganizationIds() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("parentAccountId", additionalAssertFieldName)) {
 				if (account.getParentAccountId() == null) {
 					valid = false;
@@ -836,6 +844,17 @@ public abstract class BaseAccountResourceTestCase {
 			if (Objects.equals("name", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						account1.getName(), account2.getName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("organizationIds", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						account1.getOrganizationIds(),
+						account2.getOrganizationIds())) {
 
 					return false;
 				}
@@ -1007,6 +1026,11 @@ public abstract class BaseAccountResourceTestCase {
 			sb.append("'");
 
 			return sb.toString();
+		}
+
+		if (entityFieldName.equals("organizationIds")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
 		}
 
 		if (entityFieldName.equals("parentAccountId")) {

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryOrganizationRelLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryOrganizationRelLocalServiceImpl.java
@@ -23,8 +23,12 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 
 import java.util.List;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -131,6 +135,46 @@ public class AccountEntryOrganizationRelLocalServiceImpl
 		}
 
 		return false;
+	}
+
+	/**
+	 * Creates an AccountEntryOrganizationRel for each given organizationId,
+	 * unless it already exists, and removes existing
+	 * AccountEntryOrganizationRels if their organizationId is not present in
+	 * the given organizationIds.
+	 *
+	 * @param accountEntryId
+	 * @param organizationIds
+	 * @throws PortalException
+	 * @review
+	 */
+	@Override
+	public void setAccountEntryOrganizationRels(
+			long accountEntryId, long[] organizationIds)
+		throws PortalException {
+
+		if (organizationIds == null) {
+			return;
+		}
+
+		List<Long> currentOrganizationIds = ListUtil.toList(
+			getAccountEntryOrganizationRels(accountEntryId),
+			AccountEntryOrganizationRel::getOrganizationId);
+
+		Set<Long> deleteOrganizationIdsSet = SetUtil.fromCollection(
+			currentOrganizationIds);
+
+		deleteOrganizationIdsSet.removeAll(ListUtil.fromArray(organizationIds));
+
+		deleteAccountEntryOrganizationRels(
+			accountEntryId, ArrayUtil.toLongArray(deleteOrganizationIdsSet));
+
+		Set<Long> addOrganizationIdsSet = SetUtil.fromArray(organizationIds);
+
+		addOrganizationIdsSet.removeAll(currentOrganizationIds);
+
+		addAccountEntryOrganizationRels(
+			accountEntryId, ArrayUtil.toLongArray(addOrganizationIdsSet));
 	}
 
 	@Reference

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryOrganizationRelLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryOrganizationRelLocalServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -157,24 +158,25 @@ public class AccountEntryOrganizationRelLocalServiceImpl
 			return;
 		}
 
-		List<Long> currentOrganizationIds = ListUtil.toList(
-			getAccountEntryOrganizationRels(accountEntryId),
-			AccountEntryOrganizationRel::getOrganizationId);
+		Set<Long> newOrganizationIdsSet = SetUtil.fromArray(organizationIds);
 
-		Set<Long> deleteOrganizationIdsSet = SetUtil.fromCollection(
-			currentOrganizationIds);
+		Set<Long> oldOrganizationIdsSet = SetUtil.fromCollection(
+			ListUtil.toList(
+				getAccountEntryOrganizationRels(accountEntryId),
+				AccountEntryOrganizationRel::getOrganizationId));
 
-		deleteOrganizationIdsSet.removeAll(ListUtil.fromArray(organizationIds));
+		Set<Long> removeOrganizationIdsSet = new HashSet<>(
+			oldOrganizationIdsSet);
+
+		removeOrganizationIdsSet.removeAll(newOrganizationIdsSet);
 
 		deleteAccountEntryOrganizationRels(
-			accountEntryId, ArrayUtil.toLongArray(deleteOrganizationIdsSet));
+			accountEntryId, ArrayUtil.toLongArray(removeOrganizationIdsSet));
 
-		Set<Long> addOrganizationIdsSet = SetUtil.fromArray(organizationIds);
-
-		addOrganizationIdsSet.removeAll(currentOrganizationIds);
+		newOrganizationIdsSet.removeAll(oldOrganizationIdsSet);
 
 		addAccountEntryOrganizationRels(
-			accountEntryId, ArrayUtil.toLongArray(addOrganizationIdsSet));
+			accountEntryId, ArrayUtil.toLongArray(newOrganizationIdsSet));
 	}
 
 	@Reference

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryOrganizationRelLocalServiceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryOrganizationRelLocalServiceTest.java
@@ -24,6 +24,7 @@ import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.exception.NoSuchOrganizationException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
@@ -239,6 +240,43 @@ public class AccountEntryOrganizationRelLocalServiceTest {
 			ArrayUtil.containsAll(expectedAccountEntryIds, accountEntryIds));
 		Assert.assertTrue(
 			ArrayUtil.containsAll(accountEntryIds, expectedAccountEntryIds));
+	}
+
+	@Test
+	public void testSetAccountEntryOrganizationRels() throws Exception {
+		for (int i = 0; i < 10; i++) {
+			_organizations.add(OrganizationTestUtil.addOrganization());
+		}
+
+		_assertSet(_organizations.subList(0, 4));
+		_assertSet(_organizations.subList(5, 9));
+		_assertSet(_organizations.subList(3, 7));
+	}
+
+	private void _assertSet(List<Organization> organizations)
+		throws PortalException {
+
+		_accountEntryOrganizationRelLocalService.
+			setAccountEntryOrganizationRels(
+				_accountEntry.getAccountEntryId(),
+				ListUtil.toLongArray(
+					organizations, Organization.ORGANIZATION_ID_ACCESSOR));
+
+		List<Long> expectedOrganizationIdsList = ListUtil.toList(
+			organizations, Organization.ORGANIZATION_ID_ACCESSOR);
+		List<Long> actualOrganizationIdsList = ListUtil.toList(
+			_accountEntryOrganizationRelLocalService.
+				getAccountEntryOrganizationRels(
+					_accountEntry.getAccountEntryId()),
+			AccountEntryOrganizationRel::getOrganizationId);
+
+		Assert.assertEquals(
+			actualOrganizationIdsList.toString(),
+			expectedOrganizationIdsList.size(),
+			actualOrganizationIdsList.size());
+
+		Assert.assertTrue(
+			expectedOrganizationIdsList.containsAll(actualOrganizationIdsList));
 	}
 
 	@DeleteAfterTestRun


### PR DESCRIPTION
This is an update for [LPS-108400](https://issues.liferay.com/browse/LPS-108400).

Hi Brian,

This pull moves the logic for updating organizationIds to the service layer.

The logic inside the body of `UserLocalServiceImpl.setRoleUsers` is for reindexing purposes, which is taken care of for me in the service layer. Finding the symmetric difference between the new userIds and the oldUserIds will include ids that are being removed and added, so I'm not able to use that for what I'm doing.

Instead, I "copied" the logic found in `rolePersistence.setUsers` (which is what ends up being called from `UserLocalServiceImpl.setRoleUsers`). It is more or less the same idea as what I was doing before, but more concise.

Please let me know if you have any questions.

/cc @pei-jung @alee8888 @ChrisKian @dejuknow @patriciajeanperez