### PR TITLE
LPS-107799 Ignore modules that contain .lfrbuild-releng-ignore

### DIFF
--- a/modules/build-app.xml
+++ b/modules/build-app.xml
@@ -785,26 +785,48 @@
 					excludes="**/*-test*,${app.module.dirs.excludes}"
 					includes="apps/${app.name}/**,dxp/apps/${app.name}/**"
 				>
-					<present targetdir="${modules.dir}">
-						<mapper
-							from="*"
-							to="*/.lfrbuild-portal"
-							type="glob"
-						/>
-					</present>
+					<and>
+						<present targetdir="${modules.dir}">
+							<mapper
+								from="*"
+								to="*/.lfrbuild-portal"
+								type="glob"
+							/>
+						</present>
+						<not>
+							<present targetdir="${modules.dir}">
+								<mapper
+									from="*"
+									to="*/.lfrbuild-releng-ignore"
+									type="glob"
+								/>
+							</present>
+						</not>
+					</and>
 				</dirset>
 				<dirset
 					dir="${modules.dir}"
 					excludes="${app.module.dirs.excludes}"
 					includes="apps/${app.name}/**,dxp/apps/${app.name}/**"
 				>
-					<present targetdir="${modules.dir}">
-						<mapper
-							from="*"
-							to="*/.lfrbuild-portal-private"
-							type="glob"
-						/>
-					</present>
+					<and>
+						<present targetdir="${modules.dir}">
+							<mapper
+								from="*"
+								to="*/.lfrbuild-portal-private"
+								type="glob"
+							/>
+						</present>
+						<not>
+							<present targetdir="${modules.dir}">
+								<mapper
+									from="*"
+									to="*/.lfrbuild-releng-ignore"
+									type="glob"
+								/>
+							</present>
+						</not>
+					</and>
 				</dirset>
 			</path>
 		</pathconvert>
@@ -820,13 +842,24 @@
 					excludes="**/*-test*,${app.module.dirs.excludes}"
 					includes="apps/${app.name}/**"
 				>
-					<present targetdir="${modules.dir}">
-						<mapper
-							from="*"
-							to="*/.lfrbuild-portal"
-							type="glob"
-						/>
-					</present>
+					<and>
+						<present targetdir="${modules.dir}">
+							<mapper
+								from="*"
+								to="*/.lfrbuild-portal"
+								type="glob"
+							/>
+						</present>
+						<not>
+							<present targetdir="${modules.dir}">
+								<mapper
+									from="*"
+									to="*/.lfrbuild-releng-ignore"
+									type="glob"
+								/>
+							</present>
+						</not>
+					</and>
 				</dirset>
 			</path>
 		</pathconvert>


### PR DESCRIPTION
@brianchandotcom Don't worry, these modules were already being excluded from the bundles. This change simply makes it so that these modules aren't added to the list of module apps in builld-app.xml, instead of checking them for .lfrbuild-releng-ignore in build-app-module.xml right before the download process.