### PR TITLE
Revert "LPS-107799 Ignore modules that contain .lfrbuild-releng-ignore"

### DIFF
--- a/modules/build-app.xml
+++ b/modules/build-app.xml
@@ -785,48 +785,26 @@
 					excludes="**/*-test*,${app.module.dirs.excludes}"
 					includes="apps/${app.name}/**,dxp/apps/${app.name}/**"
 				>
-					<and>
-						<present targetdir="${modules.dir}">
-							<mapper
-								from="*"
-								to="*/.lfrbuild-portal"
-								type="glob"
-							/>
-						</present>
-						<not>
-							<present targetdir="${modules.dir}">
-								<mapper
-									from="*"
-									to="*/.lfrbuild-releng-ignore"
-									type="glob"
-								/>
-							</present>
-						</not>
-					</and>
+					<present targetdir="${modules.dir}">
+						<mapper
+							from="*"
+							to="*/.lfrbuild-portal"
+							type="glob"
+						/>
+					</present>
 				</dirset>
 				<dirset
 					dir="${modules.dir}"
 					excludes="${app.module.dirs.excludes}"
 					includes="apps/${app.name}/**,dxp/apps/${app.name}/**"
 				>
-					<and>
-						<present targetdir="${modules.dir}">
-							<mapper
-								from="*"
-								to="*/.lfrbuild-portal-private"
-								type="glob"
-							/>
-						</present>
-						<not>
-							<present targetdir="${modules.dir}">
-								<mapper
-									from="*"
-									to="*/.lfrbuild-releng-ignore"
-									type="glob"
-								/>
-							</present>
-						</not>
-					</and>
+					<present targetdir="${modules.dir}">
+						<mapper
+							from="*"
+							to="*/.lfrbuild-portal-private"
+							type="glob"
+						/>
+					</present>
 				</dirset>
 			</path>
 		</pathconvert>
@@ -842,24 +820,13 @@
 					excludes="**/*-test*,${app.module.dirs.excludes}"
 					includes="apps/${app.name}/**"
 				>
-					<and>
-						<present targetdir="${modules.dir}">
-							<mapper
-								from="*"
-								to="*/.lfrbuild-portal"
-								type="glob"
-							/>
-						</present>
-						<not>
-							<present targetdir="${modules.dir}">
-								<mapper
-									from="*"
-									to="*/.lfrbuild-releng-ignore"
-									type="glob"
-								/>
-							</present>
-						</not>
-					</and>
+					<present targetdir="${modules.dir}">
+						<mapper
+							from="*"
+							to="*/.lfrbuild-portal"
+							type="glob"
+						/>
+					</present>
 				</dirset>
 			</path>
 		</pathconvert>


### PR DESCRIPTION
This reverts commit cd2b15b8e72a11dcd6b835a83e1336e471d7eee0.
@CAustin582 this commit completely broke static lpkg creation, missing tons of jar in it. May affect other lpkgs too, did not do a full scan and compare.