### PR TITLE
LPS-109974 Reorder params to match SearchUtil search method

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -167,7 +167,7 @@ public class TaxonomyCategoryResourceImpl
 						String.valueOf(assetCategory.getCategoryId())),
 					BooleanClauseOccur.MUST);
 			},
-			search, filter, pagination, sorts);
+			filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -207,7 +207,7 @@ public class TaxonomyCategoryResourceImpl
 						String.valueOf(taxonomyVocabularyId)),
 					BooleanClauseOccur.MUST);
 			},
-			search, filter, pagination, sorts);
+			filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -372,9 +372,10 @@ public class TaxonomyCategoryResourceImpl
 	}
 
 	private Page<TaxonomyCategory> _getCategoriesPage(
-			Map<String, Map<String, String>> actions,
-			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
-			String search, Filter filter, Pagination pagination, Sort[] sorts)
+		Map<String, Map<String, String>> actions,
+		UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
+		Filter filter, String search, Pagination pagination,
+		Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -372,10 +372,9 @@ public class TaxonomyCategoryResourceImpl
 	}
 
 	private Page<TaxonomyCategory> _getCategoriesPage(
-		Map<String, Map<String, String>> actions,
-		UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
-		Filter filter, String search, Pagination pagination,
-		Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
+			Filter filter, String search, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
@@ -133,7 +133,7 @@ public class OrganizationResourceImpl
 						getName(),
 					_getServiceBuilderOrganizationId(parentOrganizationId))
 			).build(),
-			parentOrganizationId, flatten, search, filter, pagination, sorts);
+			parentOrganizationId, flatten, filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -158,7 +158,7 @@ public class OrganizationResourceImpl
 						getName(),
 					0L)
 			).build(),
-			null, flatten, search, filter, pagination, sorts);
+			null, flatten, filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -345,9 +345,10 @@ public class OrganizationResourceImpl
 	}
 
 	private Page<Organization> _getOrganizationsPage(
-			Map<String, Map<String, String>> actions,
-			String parentOrganizationId, Boolean flatten, String search,
-			Filter filter, Pagination pagination, Sort[] sorts)
+		Map<String, Map<String, String>> actions,
+		String parentOrganizationId, Boolean flatten, Filter filter,
+		String search,
+		Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		long serviceBuilderOrganizationId = _getServiceBuilderOrganizationId(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
@@ -345,10 +345,9 @@ public class OrganizationResourceImpl
 	}
 
 	private Page<Organization> _getOrganizationsPage(
-		Map<String, Map<String, String>> actions,
-		String parentOrganizationId, Boolean flatten, Filter filter,
-		String search,
-		Pagination pagination, Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			String parentOrganizationId, Boolean flatten, Filter filter,
+			String search, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		long serviceBuilderOrganizationId = _getServiceBuilderOrganizationId(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentFolderResourceImpl.java
@@ -101,7 +101,7 @@ public class DocumentFolderResourceImpl
 					"com.liferay.document.library", folder.getGroupId())
 			).build(),
 			parentDocumentFolder.getId(), parentDocumentFolder.getSiteId(),
-			flatten, search, filter, pagination, sorts);
+			flatten, filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -137,7 +137,7 @@ public class DocumentFolderResourceImpl
 					"VIEW", "getSiteDocumentFoldersPage",
 					"com.liferay.document.library", siteId)
 			).build(),
-			documentFolderId, siteId, flatten, search, filter, pagination,
+			documentFolderId, siteId, flatten, filter, search, pagination,
 			sorts);
 	}
 
@@ -231,9 +231,10 @@ public class DocumentFolderResourceImpl
 	}
 
 	private Page<DocumentFolder> _getDocumentFoldersPage(
-			Map<String, Map<String, String>> actions,
-			Long parentDocumentFolderId, Long siteId, Boolean flatten,
-			String search, Filter filter, Pagination pagination, Sort[] sorts)
+		Map<String, Map<String, String>> actions,
+		Long parentDocumentFolderId, Long siteId, Boolean flatten,
+		Filter filter, String search, Pagination pagination,
+		Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentFolderResourceImpl.java
@@ -231,10 +231,9 @@ public class DocumentFolderResourceImpl
 	}
 
 	private Page<DocumentFolder> _getDocumentFoldersPage(
-		Map<String, Map<String, String>> actions,
-		Long parentDocumentFolderId, Long siteId, Boolean flatten,
-		Filter filter, String search, Pagination pagination,
-		Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			Long parentDocumentFolderId, Long siteId, Boolean flatten,
+			Filter filter, String search, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -136,7 +136,7 @@ public class DocumentResourceImpl
 						BooleanClauseOccur.MUST);
 				}
 			},
-			search, filter, pagination, sorts);
+			filter, search, pagination, sorts);
 	}
 
 	public Rating getDocumentMyRating(Long documentId) throws Exception {
@@ -191,7 +191,7 @@ public class DocumentResourceImpl
 						BooleanClauseOccur.MUST);
 				}
 			},
-			search, filter, pagination, sorts);
+			filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -408,9 +408,10 @@ public class DocumentResourceImpl
 	}
 
 	private Page<Document> _getDocumentsPage(
-			Map<String, Map<String, String>> actions,
-			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
-			String search, Filter filter, Pagination pagination, Sort[] sorts)
+		Map<String, Map<String, String>> actions,
+		UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
+		Filter filter, String search, Pagination pagination,
+		Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -408,10 +408,9 @@ public class DocumentResourceImpl
 	}
 
 	private Page<Document> _getDocumentsPage(
-		Map<String, Map<String, String>> actions,
-		UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
-		Filter filter, String search, Pagination pagination,
-		Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
+			Filter filter, String search, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseArticleResourceImpl.java
@@ -395,11 +395,10 @@ public class KnowledgeBaseArticleResourceImpl
 	}
 
 	private Page<KnowledgeBaseArticle> _getKnowledgeBaseArticlesPage(
-		Map<String, Map<String, String>> actions,
-		UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
-		Long siteId, Filter filter, String search,
-		Pagination pagination,
-		Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
+			Long siteId, Filter filter, String search, Pagination pagination,
+			Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseArticleResourceImpl.java
@@ -144,7 +144,7 @@ public class KnowledgeBaseArticleResourceImpl
 						String.valueOf(kbArticle.getResourcePrimKey())),
 					BooleanClauseOccur.MUST);
 			},
-			kbArticle.getGroupId(), search, filter, pagination, sorts);
+			kbArticle.getGroupId(), filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -196,7 +196,7 @@ public class KnowledgeBaseArticleResourceImpl
 						BooleanClauseOccur.MUST);
 				}
 			},
-			kbFolder.getGroupId(), search, filter, pagination, sorts);
+			kbFolder.getGroupId(), filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -240,7 +240,7 @@ public class KnowledgeBaseArticleResourceImpl
 						BooleanClauseOccur.MUST);
 				}
 			},
-			siteId, search, filter, pagination, sorts);
+			siteId, filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -395,10 +395,11 @@ public class KnowledgeBaseArticleResourceImpl
 	}
 
 	private Page<KnowledgeBaseArticle> _getKnowledgeBaseArticlesPage(
-			Map<String, Map<String, String>> actions,
-			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
-			Long siteId, String search, Filter filter, Pagination pagination,
-			Sort[] sorts)
+		Map<String, Map<String, String>> actions,
+		UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
+		Long siteId, Filter filter, String search,
+		Pagination pagination,
+		Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
@@ -358,10 +358,9 @@ public class MessageBoardMessageResourceImpl
 	}
 
 	private Page<MessageBoardMessage> _getMessageBoardMessagesPage(
-		Map<String, Map<String, String>> actions,
-		Long messageBoardMessageId, Long siteId, Boolean flatten, Filter filter,
-		String search,
-		Pagination pagination, Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			Long messageBoardMessageId, Long siteId, Boolean flatten,
+			Filter filter, String search, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		if (messageBoardMessageId != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
@@ -134,7 +134,7 @@ public class MessageBoardMessageResourceImpl
 					mbMessage.getUserId(), "com.liferay.message.boards",
 					mbMessage.getGroupId())
 			).build(),
-			parentMessageBoardMessageId, flatten, search, null, filter,
+			parentMessageBoardMessageId, null, flatten, filter, search,
 			pagination, sorts);
 	}
 
@@ -173,7 +173,7 @@ public class MessageBoardMessageResourceImpl
 					mbThread.getUserId(), "com.liferay.message.boards",
 					mbThread.getGroupId())
 			).build(),
-			mbThread.getRootMessageId(), false, search, null, filter,
+			mbThread.getRootMessageId(), null, false, filter, search,
 			pagination, sorts);
 	}
 
@@ -200,7 +200,7 @@ public class MessageBoardMessageResourceImpl
 					"VIEW", "getSiteMessageBoardMessagesPage",
 					"com.liferay.message.boards", siteId)
 			).build(),
-			null, flatten, search, siteId, filter, pagination, sorts);
+			null, siteId, flatten, filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -358,9 +358,10 @@ public class MessageBoardMessageResourceImpl
 	}
 
 	private Page<MessageBoardMessage> _getMessageBoardMessagesPage(
-			Map<String, Map<String, String>> actions,
-			Long messageBoardMessageId, Boolean flatten, String search,
-			Long siteId, Filter filter, Pagination pagination, Sort[] sorts)
+		Map<String, Map<String, String>> actions,
+		Long messageBoardMessageId, Long siteId, Boolean flatten, Filter filter,
+		String search,
+		Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		if (messageBoardMessageId != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardSectionResourceImpl.java
@@ -247,11 +247,10 @@ public class MessageBoardSectionResourceImpl
 	}
 
 	private Page<MessageBoardSection> _getMessageBoardSectionsPage(
-		Map<String, Map<String, String>> actions,
-		UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
-		Long siteId, Filter filter, String search,
-		Pagination pagination,
-		Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
+			Long siteId, Filter filter, String search, Pagination pagination,
+			Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardSectionResourceImpl.java
@@ -124,7 +124,7 @@ public class MessageBoardSectionResourceImpl
 						String.valueOf(mbCategory.getCategoryId())),
 					BooleanClauseOccur.MUST);
 			},
-			mbCategory.getGroupId(), search, filter, pagination, sorts);
+			mbCategory.getGroupId(), filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -155,7 +155,7 @@ public class MessageBoardSectionResourceImpl
 						BooleanClauseOccur.MUST);
 				}
 			},
-			siteId, search, filter, pagination, sorts);
+			siteId, filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -247,10 +247,11 @@ public class MessageBoardSectionResourceImpl
 	}
 
 	private Page<MessageBoardSection> _getMessageBoardSectionsPage(
-			Map<String, Map<String, String>> actions,
-			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
-			Long siteId, String search, Filter filter, Pagination pagination,
-			Sort[] sorts)
+		Map<String, Map<String, String>> actions,
+		UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
+		Long siteId, Filter filter, String search,
+		Pagination pagination,
+		Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
@@ -179,7 +179,7 @@ public class MessageBoardThreadResourceImpl
 					new TermFilter("parentMessageId", "0"),
 					BooleanClauseOccur.MUST);
 			},
-			mbCategory.getGroupId(), search, filter, pagination, sorts);
+			mbCategory.getGroupId(), filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -263,7 +263,7 @@ public class MessageBoardThreadResourceImpl
 					new TermFilter("parentMessageId", "0"),
 					BooleanClauseOccur.MUST);
 			},
-			siteId, search, filter, pagination, sorts);
+			siteId, filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -480,10 +480,11 @@ public class MessageBoardThreadResourceImpl
 	}
 
 	private Page<MessageBoardThread> _getSiteMessageBoardThreadsPage(
-			Map<String, Map<String, String>> actions,
-			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
-			Long siteId, String search, Filter filter, Pagination pagination,
-			Sort[] sorts)
+		Map<String, Map<String, String>> actions,
+		UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
+		Long siteId, Filter filter, String search,
+		Pagination pagination,
+		Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
@@ -480,11 +480,10 @@ public class MessageBoardThreadResourceImpl
 	}
 
 	private Page<MessageBoardThread> _getSiteMessageBoardThreadsPage(
-		Map<String, Map<String, String>> actions,
-		UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
-		Long siteId, Filter filter, String search,
-		Pagination pagination,
-		Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
+			Long siteId, Filter filter, String search, Pagination pagination,
+			Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentFolderResourceImpl.java
@@ -106,7 +106,7 @@ public class StructuredContentFolderResourceImpl
 					"VIEW", "getSiteStructuredContentFoldersPage",
 					"com.liferay.journal", siteId)
 			).build(),
-			parentStructuredContentFolderId, siteId, search, filter, pagination,
+			parentStructuredContentFolderId, siteId, filter, search, pagination,
 			sorts);
 	}
 
@@ -151,8 +151,9 @@ public class StructuredContentFolderResourceImpl
 					"SUBSCRIBE", journalFolder,
 					"putStructuredContentFolderUnsubscribe")
 			).build(),
-			parentStructuredContentFolderId, journalFolder.getGroupId(), search,
-			filter, pagination, sorts);
+			parentStructuredContentFolderId, journalFolder.getGroupId(), filter,
+			search,
+			pagination, sorts);
 	}
 
 	@Override
@@ -249,9 +250,10 @@ public class StructuredContentFolderResourceImpl
 	}
 
 	private Page<StructuredContentFolder> _getFoldersPage(
-			Map<String, Map<String, String>> actions,
-			Long parentStructuredContentFolderId, Long siteId, String search,
-			Filter filter, Pagination pagination, Sort[] sorts)
+		Map<String, Map<String, String>> actions,
+		Long parentStructuredContentFolderId, Long siteId, Filter filter,
+		String search,
+		Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentFolderResourceImpl.java
@@ -152,8 +152,7 @@ public class StructuredContentFolderResourceImpl
 					"putStructuredContentFolderUnsubscribe")
 			).build(),
 			parentStructuredContentFolderId, journalFolder.getGroupId(), filter,
-			search,
-			pagination, sorts);
+			search, pagination, sorts);
 	}
 
 	@Override
@@ -250,10 +249,9 @@ public class StructuredContentFolderResourceImpl
 	}
 
 	private Page<StructuredContentFolder> _getFoldersPage(
-		Map<String, Map<String, String>> actions,
-		Long parentStructuredContentFolderId, Long siteId, Filter filter,
-		String search,
-		Pagination pagination, Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			Long parentStructuredContentFolderId, Long siteId, Filter filter,
+			String search, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -180,7 +180,7 @@ public class StructuredContentResourceImpl
 						BooleanClauseOccur.MUST);
 				}
 			},
-			ddmStructure.getGroupId(), search, filter, pagination, sorts);
+			ddmStructure.getGroupId(), filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -266,7 +266,7 @@ public class StructuredContentResourceImpl
 						BooleanClauseOccur.MUST);
 				}
 			},
-			siteId, search, filter, pagination, sorts);
+			siteId, filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -323,7 +323,7 @@ public class StructuredContentResourceImpl
 						BooleanClauseOccur.MUST);
 				}
 			},
-			journalFolder.getGroupId(), search, filter, pagination, sorts);
+			journalFolder.getGroupId(), filter, search, pagination, sorts);
 	}
 
 	@Override
@@ -792,10 +792,11 @@ public class StructuredContentResourceImpl
 	}
 
 	private Page<StructuredContent> _getStructuredContentsPage(
-			Map<String, Map<String, String>> actions,
-			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
-			Long siteId, String search, Filter filter, Pagination pagination,
-			Sort[] sorts)
+		Map<String, Map<String, String>> actions,
+		UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
+		Long siteId, Filter filter, String search,
+		Pagination pagination,
+		Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -792,11 +792,10 @@ public class StructuredContentResourceImpl
 	}
 
 	private Page<StructuredContent> _getStructuredContentsPage(
-		Map<String, Map<String, String>> actions,
-		UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
-		Long siteId, Filter filter, String search,
-		Pagination pagination,
-		Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
+			Long siteId, Filter filter, String search, Pagination pagination,
+			Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(


### PR DESCRIPTION
Worried about this refactor.

We already discussed this order and the parameter order applied matches the REST Builder order for public get*Page methods, which was about first Path parameters and then Query parameters with he following order: flatten, search, filter, pagination and sort.

We may swap the search and filter param to be consistent with SearchUtil search method but we will create an inconsistency with the get*Page public methods generated from REST Builder.

This is the approach taken in this PR. Waiting for your validation before notifying @hhuijser to enforce this approach in SourceFormatter. I left the "UserAccountResourceImpl" class without applying this pattern to be tested by the new SourceFormatter rule.