### PR TITLE
LRCI-1074 Further separate 'stable' suite batches as a subset of 'relevant' batches

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -4099,11 +4099,11 @@ log.sanitizer.enabled=false</echo>
 		<run-functional-test app.server.type="tomcat" database.type="mysql" database.version="5.7" />
 	</target>
 
-	<target name="functional-upgrade-tomcat90-mysql57-jdk11_open">
+	<target name="functional-upgrade-tomcat90-mysql57-jdk8_stable">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" database.version="5.7" />
 	</target>
 
-	<target name="functional-upgrade-tomcat90-mysql57-jdk8_stable">
+	<target name="functional-upgrade-tomcat90-mysql57-jdk11_open">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" database.version="5.7" />
 	</target>
 
@@ -4814,11 +4814,11 @@ log.sanitizer.enabled=false</echo>
 		<run-modules-integration-test database.type="mysql" database.version="5.7" />
 	</target>
 
-	<target name="modules-integration-mysql57-jdk11_open">
+	<target name="modules-integration-mysql57-jdk8_stable">
 		<run-modules-integration-test database.type="mysql" database.version="5.7" />
 	</target>
 
-	<target name="modules-integration-mysql57-jdk8_stable">
+	<target name="modules-integration-mysql57-jdk11_open">
 		<run-modules-integration-test database.type="mysql" database.version="5.7" />
 	</target>
 

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -3863,6 +3863,10 @@ log.sanitizer.enabled=false</echo>
 		<run-functional-test app.server.type="tomcat" database.type="mysql" database.version="5.7" test.portal.log.assert="true" />
 	</target>
 
+	<target name="functional-smoke-tomcat90-mysql57-jdk8_stable">
+		<run-functional-test app.server.type="tomcat" database.type="mysql" database.version="5.7" test.portal.log.assert="true" />
+	</target>
+
 	<target name="functional-smoke-tomcat90-mysql57-jdk8_zulu">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" database.version="5.7" test.portal.log.assert="true" />
 	</target>
@@ -4096,6 +4100,10 @@ log.sanitizer.enabled=false</echo>
 	</target>
 
 	<target name="functional-upgrade-tomcat90-mysql57-jdk11_open">
+		<run-functional-test app.server.type="tomcat" database.type="mysql" database.version="5.7" />
+	</target>
+
+	<target name="functional-upgrade-tomcat90-mysql57-jdk8_stable">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" database.version="5.7" />
 	</target>
 
@@ -4810,6 +4818,10 @@ log.sanitizer.enabled=false</echo>
 		<run-modules-integration-test database.type="mysql" database.version="5.7" />
 	</target>
 
+	<target name="modules-integration-mysql57-jdk8_stable">
+		<run-modules-integration-test database.type="mysql" database.version="5.7" />
+	</target>
+
 	<target name="modules-integration-oracle122-jdk8">
 		<run-modules-integration-test database.type="oracle" />
 	</target>
@@ -5016,6 +5028,10 @@ log.sanitizer.enabled=false</echo>
 				<stop-suite-search-engine />
 			</test-tear-down>
 		</run-batch-test>
+	</target>
+
+	<target name="modules-unit-jdk8_stable">
+		<antcall target="modules-unit-jdk8" />
 	</target>
 
 	<target name="modules-unit-project-templates-jdk8">
@@ -6234,6 +6250,10 @@ ${output.content}</echo>
 				<delete file="${app.server.lib.portal.dir}/util-taglib.jar" />
 			</test-set-up>
 		</run-batch-test>
+	</target>
+
+	<target name="unit-jdk8_stable">
+		<antcall target="unit-jdk8" />
 	</target>
 
 	<target name="wsdd-builder-jdk8">

--- a/test.properties
+++ b/test.properties
@@ -2717,26 +2717,14 @@
     # Stable
     #
 
-    test.batch.class.names.includes[modules-integration-*-jdk8][stable]=\
-        **/portal-dao-test/**/*Test.java,\
-        **/portal-upgrade-test/**/*Test.java,\
-        **/portlet-title-localization-test/**/*Test.java
-
-    test.batch.class.names.includes[modules-unit-jdk8][stable]=\
-        **/portal-upgrade-impl/**/*Test.java
-
-    test.batch.class.names.includes[unit-jdk8][stable]=\
-        **/test/**/DBInspectorUnitTest.java,\
-        **/test/**/UpgradeProcessTest.java
-
     test.batch.dist.app.servers[stable]=tomcat
 
     test.batch.names[stable]=\
-        functional-smoke-tomcat90-mysql57-jdk8,\
-        functional-upgrade-tomcat90-mysql57-jdk8,\
-        modules-integration-mysql57-jdk8,\
-        modules-unit-jdk8,\
-        unit-jdk8
+        functional-smoke-tomcat90-mysql57-jdk8_stable,\
+        functional-upgrade-tomcat90-mysql57-jdk8_stable,\
+        modules-integration-mysql57-jdk8_stable,\
+        modules-unit-jdk8_stable,\
+        unit-jdk8_stable
 
     #
     # Staging

--- a/test.properties
+++ b/test.properties
@@ -2403,16 +2403,16 @@
     #
 
     test.batch.class.names.includes.required[modules-integration-*-jdk8][relevant]=\
-        ${test.batch.class.names.includes[modules-integration-*-jdk8][stable]},\
+        ${test.batch.class.names.includes[modules-integration-*-jdk8_stable]},\
         **/src/testIntegration/**/DeclarativeServiceDependencyManagerTest.java,\
         **/src/testIntegration/**/SpringExtenderDependencyManagerTest.java
 
-    test.batch.class.names.includes.required[modules-unit-jdk8][relevant]=${test.batch.class.names.includes[modules-unit-jdk8][stable]}
+    test.batch.class.names.includes.required[modules-unit-jdk8][relevant]=${test.batch.class.names.includes[modules-unit-jdk8_stable]}
 
     test.batch.class.names.includes.required[modules-unit-project-templates-jdk8][relevant]=\
         **/project-templates/**/src/test/**/*Test.java
 
-    test.batch.class.names.includes.required[unit-jdk8][relevant]=${test.batch.class.names.includes[unit-jdk8][stable]}
+    test.batch.class.names.includes.required[unit-jdk8][relevant]=${test.batch.class.names.includes[unit-jdk8_stable]}
 
     test.batch.dist.app.servers[relevant]=tomcat
 

--- a/test.properties
+++ b/test.properties
@@ -1102,6 +1102,7 @@
 
     test.batch.class.names.includes[junit-test-csv-report-jdk8]=${test.batch.class.names.includes}
     test.batch.class.names.includes[modules-integration-*-jdk8]=**/src/testIntegration/**/*Test.java
+
     test.batch.class.names.includes[modules-integration-*-jdk8_stable]=\
         **/portal-dao-test/**/*Test.java,\
         **/portal-upgrade-test/**/*Test.java,\
@@ -1109,6 +1110,7 @@
 
     test.batch.class.names.includes[modules-integration-*-jdk11_open]=**/src/testIntegration/**/*Test.java
     test.batch.class.names.includes[modules-unit-jdk8]=**/src/test/**/*Test.java
+
     test.batch.class.names.includes[modules-unit-jdk8_stable]=\
         **/portal-upgrade-impl/**/*Test.java
 
@@ -1116,6 +1118,7 @@
 
     test.batch.class.names.includes[tck-jdk8]=deploy/target/deploy-files/tck-*.war
     test.batch.class.names.includes[unit-jdk8]=**/test/unit/**/*Test.java
+
     test.batch.class.names.includes[unit-jdk8_stable]=\
         **/test/**/DBInspectorUnitTest.java,\
         **/test/**/UpgradeProcessTest.java

--- a/test.properties
+++ b/test.properties
@@ -2421,11 +2421,14 @@
         central-requirements-jdk8,\
         functional-smoke-tomcat90-mysql57-jdk11_open,\
         functional-tomcat90-mysql57-jdk8,\
+        functional-upgrade-tomcat90-mysql57-jdk8,\
         js-unit-jdk8,\
         lpkg-base-jdk8,\
         lpkg-controller-jdk8,\
         modules-compile-jdk8,\
+        modules-integration-mysql57-jdk8,\
         modules-semantic-versioning-jdk8,\
+        modules-unit-jdk8,\
         modules-unit-project-templates-jdk8,\
         pmd-jdk8,\
         semantic-versioning-jdk8,\

--- a/test.properties
+++ b/test.properties
@@ -1274,8 +1274,8 @@
     test.batch.run.property.query[functional-upgrade-tomcat90-mariadb102-jdk8]=(portal.upgrades == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types ~ mariadb)
     test.batch.run.property.query[functional-upgrade-tomcat90-mariadb102-jdk11_open]=(portal.upgrades == true) AND (app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mariadb)
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8]=(portal.upgrades == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mysql)
-    test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk11_open]=(portal.upgrades == true) AND (app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mysql)
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8_stable]=${test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8]}
+    test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk11_open]=(portal.upgrades == true) AND (app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mysql)
     test.batch.run.property.query[functional-upgrade-tomcat90-oracle122-jdk8]=(portal.upgrades == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types ~ oracle)
     test.batch.run.property.query[functional-upgrade-tomcat90-oracle122-jdk11_open]=(portal.upgrades == true) AND (app.server.types ~ tomcat) AND (database.types == null OR database.types ~ oracle)
     test.batch.run.property.query[functional-upgrade-tomcat90-oracle193-jdk8]=(portal.upgrades == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types ~ oracle)

--- a/test.properties
+++ b/test.properties
@@ -1102,12 +1102,23 @@
 
     test.batch.class.names.includes[junit-test-csv-report-jdk8]=${test.batch.class.names.includes}
     test.batch.class.names.includes[modules-integration-*-jdk8]=**/src/testIntegration/**/*Test.java
+    test.batch.class.names.includes[modules-integration-*-jdk8_stable]=\
+        **/portal-dao-test/**/*Test.java,\
+        **/portal-upgrade-test/**/*Test.java,\
+        **/portlet-title-localization-test/**/*Test.java
+
     test.batch.class.names.includes[modules-integration-*-jdk11_open]=**/src/testIntegration/**/*Test.java
     test.batch.class.names.includes[modules-unit-jdk8]=**/src/test/**/*Test.java
+    test.batch.class.names.includes[modules-unit-jdk8_stable]=\
+        **/portal-upgrade-impl/**/*Test.java
+
     test.batch.class.names.includes[modules-unit-project-templates-jdk8]=**/project-templates/**/src/test/**/*Test.java
 
     test.batch.class.names.includes[tck-jdk8]=deploy/target/deploy-files/tck-*.war
     test.batch.class.names.includes[unit-jdk8]=**/test/unit/**/*Test.java
+    test.batch.class.names.includes[unit-jdk8_stable]=\
+        **/test/**/DBInspectorUnitTest.java,\
+        **/test/**/UpgradeProcessTest.java
 
     test.batch.class.names.includes.required[modules-integration-*-jdk11_open]=\
         **/src/testIntegration/**/DeclarativeServiceDependencyManagerTest.java,\
@@ -1192,6 +1203,7 @@
     test.batch.run.property.query[functional-smoke-tomcat90-mariadb102-jdk11_open]=(portal.smoke == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types ~ mariadb)
     test.batch.run.property.query[functional-smoke-tomcat90-mysql57-jdk8]=(portal.smoke == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mysql)
     test.batch.run.property.query[functional-smoke-tomcat90-mysql57-jdk8_redhat]=(portal.smoke == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mysql)
+    test.batch.run.property.query[functional-smoke-tomcat90-mysql57-jdk8_stable]=${test.batch.run.property.query[functional-smoke-tomcat90-mysql57-jdk8]}
     test.batch.run.property.query[functional-smoke-tomcat90-mysql57-jdk8_zulu]=(portal.smoke == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mysql)
     test.batch.run.property.query[functional-smoke-tomcat90-mysql57-jdk11_open]=(portal.smoke == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mysql)
     test.batch.run.property.query[functional-smoke-tomcat90-mysql57-jdk11_oracle]=(portal.smoke == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mysql)
@@ -1263,6 +1275,7 @@
     test.batch.run.property.query[functional-upgrade-tomcat90-mariadb102-jdk11_open]=(portal.upgrades == true) AND (app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mariadb)
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8]=(portal.upgrades == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mysql)
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk11_open]=(portal.upgrades == true) AND (app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mysql)
+    test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8_stable]=${test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8]}
     test.batch.run.property.query[functional-upgrade-tomcat90-oracle122-jdk8]=(portal.upgrades == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types ~ oracle)
     test.batch.run.property.query[functional-upgrade-tomcat90-oracle122-jdk11_open]=(portal.upgrades == true) AND (app.server.types ~ tomcat) AND (database.types == null OR database.types ~ oracle)
     test.batch.run.property.query[functional-upgrade-tomcat90-oracle193-jdk8]=(portal.upgrades == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types ~ oracle)


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1074

@brianchandotcom, we're making this change because of the way we split out the subset of 'stable' results in the PR tester when 'relevant' is run. This is to avoid some of the inconsistent groups of tests that we've been seeing that were designated as 'stable'. I.e., sometimes there'd be 7, 10, or 20 batches in 'stable'. This isn't the final solution, but so we can get some consistency in what runs right now, this is the simplest approach.

@pyoo47, @yichenroy