### PR TITLE
LPS-110163 Improve usability of <react:component> taglib

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/AdaptiveMediaProgress.es.js
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/AdaptiveMediaProgress.es.js
@@ -193,6 +193,4 @@ AdaptiveMediaProgress.propTypes = {
 	uuid: PropTypes.string,
 };
 
-export default function(props) {
-	return <AdaptiveMediaProgress {...props} />;
-}
+export default AdaptiveMediaProgress;

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormViewApp.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/EditFormViewApp.es.js
@@ -31,6 +31,4 @@ const EditFormViewApp = ({basePortletURL, ...props}) => {
 	);
 };
 
-export default function(props) {
-	return <EditFormViewApp {...props} />;
-}
+export default EditFormViewApp;

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -124,6 +124,4 @@ function SelectCategory({
 	);
 }
 
-export default function(props) {
-	return <SelectCategory {...props} />;
-}
+export default SelectCategory;

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/auto_field/index.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/auto_field/index.js
@@ -376,6 +376,4 @@ AutoField.propTypes = {
 	vocabularyIds: PropTypes.arrayOf(PropTypes.string),
 };
 
-export default function(props) {
-	return <AutoField {...props} />;
-}
+export default AutoField;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/App.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/App.es.js
@@ -114,6 +114,4 @@ const App = props => {
 	);
 };
 
-export default function(props) {
-	return <App {...props} />;
-}
+export default App;

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/Languages.es.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/Languages.es.js
@@ -212,6 +212,4 @@ Languages.propTypes = {
 	translatedLanguages: PropTypes.object,
 };
 
-export default function(props) {
-	return <Languages {...props} />;
-}
+export default Languages;

--- a/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/js/DocumentPreviewer.es.js
+++ b/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/js/DocumentPreviewer.es.js
@@ -301,6 +301,4 @@ DocumentPreviewer.propTypes = {
 	totalPages: PropTypes.number,
 };
 
-export default function(props) {
-	return <DocumentPreviewer {...props} />;
-}
+export default DocumentPreviewer;

--- a/modules/apps/document-library/document-library-preview-image/src/main/resources/META-INF/resources/preview/js/ImagePreviewer.es.js
+++ b/modules/apps/document-library/document-library-preview-image/src/main/resources/META-INF/resources/preview/js/ImagePreviewer.es.js
@@ -230,6 +230,4 @@ ImagePreviewer.propTypes = {
 	imageURL: PropTypes.string,
 };
 
-export default function(props) {
-	return <ImagePreviewer {...props} />;
-}
+export default ImagePreviewer;

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/bulk/BulkStatus.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/bulk/BulkStatus.es.js
@@ -114,4 +114,4 @@ BulkStatus.propTypes = {
 	waitingTime: PropTypes.number,
 };
 
-export default props => <BulkStatus {...props} />;
+export default BulkStatus;

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js
@@ -23,15 +23,19 @@ let counter = 0;
  *
  * - Provides commonly-needed context (for example, the Clay spritemap).
  * - Unmounts when portlets are destroyed based on the received
- *   `portletId` value inside renderData. If none is passed, the
+ *   `portletId` value inside `renderData`. If none is passed, the
  *   component will be automatically unmounted before the next navigation.
+ *
+ * @param {Function|React.Element} renderable Component, or function that returns an Element, to be rendered.
+ * @param {object} renderData Data to be passed to the component as props.
+ * @param {HTMLElement} container DOM node where the component is to be mounted.
  *
  * The React docs advise not to rely on the render return value, so we
  * don't propagate it.
  *
  * @see https://reactjs.org/docs/react-dom.html#render
  */
-export default function render(renderFunction, renderData, container) {
+export default function render(renderable, renderData, container) {
 	if (!Liferay.SPA || Liferay.SPA.app) {
 		const {portletId} = renderData;
 		const spritemap =
@@ -58,17 +62,19 @@ export default function render(renderFunction, renderData, container) {
 			}
 		);
 
+		const Component = typeof renderable === 'function' ? renderable : null;
+
 		// eslint-disable-next-line liferay-portal/no-react-dom-render
 		ReactDOM.render(
 			<ClayIconSpriteContext.Provider value={spritemap}>
-				{renderFunction(renderData)}
+				{Component ? <Component {...renderData} /> : renderable}
 			</ClayIconSpriteContext.Provider>,
 			container
 		);
 	}
 	else {
 		Liferay.once('SPAReady', () => {
-			render(renderFunction, renderData, container);
+			render(renderable, renderData, container);
 		});
 	}
 }

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.js
@@ -235,5 +235,5 @@ const TooltipProvider = () => {
 };
 
 export default () => {
-	render(() => <TooltipProvider />, {}, getDefaultTooltipContainer());
+	render(<TooltipProvider />, {}, getDefaultTooltipContainer());
 };

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/commands/OpenSimpleInputModal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/commands/OpenSimpleInputModal.es.js
@@ -40,7 +40,7 @@ function dispose() {
 	unmountComponentAtNode(getDefaultModalContainer());
 }
 
-function SimpleInputModalComponent({
+function openSimpleInputModalImplementation({
 	alert,
 	checkboxFieldLabel,
 	checkboxFieldName,
@@ -55,7 +55,9 @@ function SimpleInputModalComponent({
 	onFormSuccess,
 	placeholder,
 }) {
-	return (
+	dispose();
+
+	render(
 		<SimpleInputModal
 			alert={alert}
 			checkboxFieldLabel={checkboxFieldLabel}
@@ -72,18 +74,8 @@ function SimpleInputModalComponent({
 			namespace={namespace}
 			onFormSuccess={onFormSuccess}
 			placeholder={placeholder}
-		/>
-	);
-}
-
-function openSimpleInputModalImplementation(data) {
-	dispose();
-
-	const renderData = DEFAULT_RENDER_DATA;
-
-	render(
-		SimpleInputModalComponent,
-		{...data, ...renderData},
+		/>,
+		DEFAULT_RENDER_DATA,
 		getDefaultModalContainer()
 	);
 }

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -37,23 +37,6 @@ const getDefaultAlertContainer = () => {
 	return container;
 };
 
-const Toast = ({displayType, message, onClose, title, toastProps, variant}) => {
-	return (
-		<ClayAlert.ToastContainer>
-			<ClayAlert
-				autoClose={TOAST_AUTO_CLOSE_INTERVAL}
-				displayType={displayType}
-				onClose={onClose}
-				title={title}
-				variant={variant}
-				{...toastProps}
-			>
-				{message}
-			</ClayAlert>
-		</ClayAlert.ToastContainer>
-	);
-};
-
 /**
  * Function that implements the Toast pattern, which allows to present feedback
  * to user actions as a toast message in the lower left corner of the page
@@ -82,18 +65,22 @@ function openToast({
 
 	const onClose = () => unmountComponentAtNode(container);
 
-	const ToastComponent = () => (
-		<Toast
-			displayType={type}
-			message={message}
-			onClose={onClose}
-			title={title}
-			toastProps={toastProps}
-			variant={variant}
-		/>
+	render(
+		<ClayAlert.ToastContainer>
+			<ClayAlert
+				autoClose={TOAST_AUTO_CLOSE_INTERVAL}
+				displayType={type}
+				onClose={onClose}
+				title={title}
+				variant={variant}
+				{...toastProps}
+			>
+				{message}
+			</ClayAlert>
+		</ClayAlert.ToastContainer>,
+		renderData,
+		container
 	);
-
-	render(ToastComponent, renderData, container);
 }
 
 export {openToast};

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff_version_comparator/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff_version_comparator/index.js
@@ -254,6 +254,4 @@ function Comparator({
 	);
 }
 
-export default function(props) {
-	return <Comparator {...props} />;
-}
+export default Comparator;

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -18,7 +18,6 @@ import {PortletBase} from 'frontend-js-web';
 import dom from 'metal-dom';
 import {EventHandler} from 'metal-events';
 import {Config} from 'metal-state';
-import React from 'react';
 import ReactDOM from 'react-dom';
 
 import ItemSelectorPreview from '../../item_selector_preview/js/ItemSelectorPreview.es';
@@ -94,7 +93,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 			uploadItemURL: this.uploadItemURL,
 		};
 
-		render(props => <ItemSelectorPreview {...props} />, data, container);
+		render(ItemSelectorPreview, data, container);
 	}
 
 	closeItemSelectorPreview() {

--- a/modules/apps/item-selector/item-selector-url-web/src/main/resources/META-INF/resources/js/ItemSelectorUrl.es.js
+++ b/modules/apps/item-selector/item-selector-url-web/src/main/resources/META-INF/resources/js/ItemSelectorUrl.es.js
@@ -144,6 +144,4 @@ ItemSelectorUrl.propTypes = {
 	eventName: PropTypes.string.isRequired,
 };
 
-export default function(props) {
-	return <ItemSelectorUrl {...props} />;
-}
+export default ItemSelectorUrl;

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ChangeDefaultLanguage.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ChangeDefaultLanguage.es.js
@@ -106,6 +106,4 @@ ChangeDefaultLanguage.propTypes = {
 	strings: PropTypes.object.isRequired,
 };
 
-export default function(props) {
-	return <ChangeDefaultLanguage {...props} />;
-}
+export default ChangeDefaultLanguage;

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectFolder.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectFolder.es.js
@@ -87,6 +87,4 @@ const SelectFolder = ({itemSelectorSaveEvent, nodes}) => {
 	);
 };
 
-export default function(props) {
-	return <SelectFolder {...props} />;
-}
+export default SelectFolder;

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayout.es.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayout.es.js
@@ -154,6 +154,4 @@ SelectLayout.propTypes = {
 	nodes: PropTypes.array.isRequired,
 };
 
-export default function(props) {
-	return <SelectLayout {...props} />;
-}
+export default SelectLayout;

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/js/FieldMappings.es.js
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/js/FieldMappings.es.js
@@ -220,6 +220,4 @@ FieldMappings.propTypes = {
 	selectedIndexName: PropTypes.string,
 };
 
-export default function(props) {
-	return <FieldMappings {...props} />;
-}
+export default FieldMappings;

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/ColorPickerInput.es.js
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/ColorPickerInput.es.js
@@ -38,6 +38,4 @@ const ColorPicker = ({color, label, name}) => {
 	);
 };
 
-export default function(props) {
-	return <ColorPicker {...props} />;
-}
+export default ColorPicker;

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/LayoutFinder.es.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/LayoutFinder.es.js
@@ -207,6 +207,4 @@ LayoutFinder.propTypes = {
 	viewInPageAdministrationURL: PropTypes.string,
 };
 
-export default function(props) {
-	return <LayoutFinder {...props} />;
-}
+export default LayoutFinder;

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.es.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.es.js
@@ -118,6 +118,4 @@ PageTypeSelector.propTypes = {
 	privateLayout: PropTypes.bool,
 };
 
-export default function(props) {
-	return <PageTypeSelector {...props} />;
-}
+export default PageTypeSelector;

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
@@ -98,6 +98,4 @@ PersonalMenu.propTypes = {
 	itemsURL: PropTypes.string,
 };
 
-export default function(props) {
-	return <PersonalMenu {...props} />;
-}
+export default PersonalMenu;

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsLike.es.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsLike.es.js
@@ -115,6 +115,4 @@ RatingsLike.propTypes = {
 	url: PropTypes.string.isRequired,
 };
 
-export default function(props) {
-	return <RatingsLike {...props} />;
-}
+export default RatingsLike;

--- a/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/collaborators/js/index.es.js
+++ b/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/collaborators/js/index.es.js
@@ -12,10 +12,4 @@
  * details.
  */
 
-import React from 'react';
-
-import Collaborators from './components/Collaborators.es';
-
-export default function(props) {
-	return <Collaborators {...props} />;
-}
+export {default} from './components/Collaborators.es';

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/manage_collaborators/js/ManageCollaborators.es.js
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/manage_collaborators/js/ManageCollaborators.es.js
@@ -583,6 +583,4 @@ ManageCollaborators.propTypes = {
 	portletNamespace: PropTypes.string,
 };
 
-export default function(props) {
-	return <ManageCollaborators {...props} />;
-}
+export default ManageCollaborators;

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/sharing/js/Sharing.es.js
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/sharing/js/Sharing.es.js
@@ -411,6 +411,4 @@ const SharingAutocomplete = ({onItemClick = () => {}, sourceItems}) => {
 	);
 };
 
-export default function(props) {
-	return <Sharing {...props} />;
-}
+export default Sharing;

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/ContextualSidebar.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/ContextualSidebar.js
@@ -264,6 +264,4 @@ class SidebarBody extends React.Component {
 	}
 }
 
-export default function(props) {
-	return <ContextualSidebar {...props} />;
-}
+export default ContextualSidebar;

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/add_menu/index.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/add_menu/index.js
@@ -90,6 +90,4 @@ function AddMenu({dropdownItems, portletId}) {
 	);
 }
 
-export default function(props) {
-	return <AddMenu {...props} />;
-}
+export default AddMenu;

--- a/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/js/SelectSiteNavigationMenuItem.es.js
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/js/SelectSiteNavigationMenuItem.es.js
@@ -77,6 +77,4 @@ const SelectSiteNavigationMenuItem = ({itemSelectorSaveEvent, nodes}) => {
 	);
 };
 
-export default function(props) {
-	return <SelectSiteNavigationMenuItem {...props} />;
-}
+export default SelectSiteNavigationMenuItem;


### PR DESCRIPTION
Originally reviewed [here](https://github.com/jbalsas/liferay-portal/pull/2153).

---

When we originally made the `render` wrapper in `frontend-js-react-web` in 31f9beca59c7ac9b1c42d3e34a842167cb8313d7 we tried to keep the API relatively close to [the `ReactDOM.render` API](https://reactjs.org/docs/react-dom.html#render) that we're wrapping:

    render(reactElement, container, callback)

Later on (e77295d3d2e6ebf0010fdaccf21d09a5d5d6a2d4) we changed the signature to:

    render(renderFunction, renderData, container)

ie. instead of a React Element (eg. `<Foo />`), you would pass a function that returns an element.

All of this was motivated by a desire to make it easy to mount React components from JSP files using the `<react:component>` taglib, as [explained here](https://github.com/brianchandotcom/liferay-portal/pull/77801).

However, in practice, people are frequently confused by this pattern, running into errors like "Invalid hook call" if they pass a function that uses hooks:

    render(FunctionThatUsesHooks, renderData, container)

They can avoid this by adding a layer of indirection, but it is not intuitive to do so:

    render(() => <FunctionThatUsesHooks />, renderData, container)

And note that if the want to actually make use of the `renderData` in an example like that, they have to propagate it through manually in a repetitive way (if they are calling `render` directly instead of using the `<react:component>` taglib):

    render(data => {
        return (
          <FunctionThatUsesHooks
            someProp={data.foo}
          />
        );
      },
      renderData,
      container
    );

or (if they are being called from the taglib):

    export default function(props) {
      return <FunctionThatUsesHooks someProp={props.foo} />;
    }

I think we can get rid of this confusion and reduce the indirection by making `render` a little more liberal in what it accepts. Now in addition to accepting:

- A "render function" (a function that returns an element).

It also accepts:

- A component function (ie. no layer of indirection); or:
- An element (again, no layer of indirection).

In other words, given a functional component, `FooComponent`, all of these are now valid:

    render(FooComponent, data, container);
    render(() => <FooComponent />, {}, container);
    render(<FooComponent />, data, container);

To show the improvement, in this commit I remove indirection from all the call sites where it wasn't needed. There are still places where it is useful, and I left those untouched; in all of those they do some kind of prop-massaging before calling the actual component -- ie. things like this:

    export default function(({props, context}) {
      return (
        <Context.Provider value={context}>
          <App {...props} />
        </Context.Provider>
    }