### PR TITLE
LPS-108993 Document changed default value in legacy property files

### DIFF
--- a/portal-impl/src/portal-legacy-7.2.properties
+++ b/portal-impl/src/portal-legacy-7.2.properties
@@ -1,0 +1,1 @@
+company.security.strangers.verify=false

--- a/portal-impl/src/portal-legacy-7.3.0.properties
+++ b/portal-impl/src/portal-legacy-7.3.0.properties
@@ -1,0 +1,1 @@
+company.security.strangers.verify=false


### PR DESCRIPTION
Hi Brian,

I'm not sure what's the proper naming for these legacy properties files. The portal-legacy-7.3.0.properties is to account for the old property included in the 7.3 CE GA1 release.

/cc @drewbrokke @alee8888 @yxingwu