### PR TITLE
LPS-110186 Use aui:select to make sure the language keys in the selection list are resolved

### DIFF
--- a/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
+++ b/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
@@ -634,19 +634,19 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 
 								</c:when>
 								<c:when test="<%= propertyDisplayType.equals(ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_SELECTION_LIST) %>">
-									<select class="form-control" id="<portlet:namespace /><%= randomNamespace %><%= HtmlUtil.getAUICompatibleId(name) %>" name="<portlet:namespace />ExpandoAttribute--<%= HtmlUtil.escapeAttribute(name) %>--">
+									<aui:select id="<%= randomNamespace + HtmlUtil.escapeAttribute(name) %>" label="" name='<%= "ExpandoAttribute--" + HtmlUtil.escapeAttribute(name) + "--" %>'>
 
 										<%
 										for (String curDefaultValue : (String[])defaultValue) {
 										%>
 
-											<option <%= ((curValue.length > 0) && ArrayUtil.contains(curValue, curDefaultValue)) ? "selected" : "" %> value="<%= HtmlUtil.escape(curDefaultValue) %>"><%= HtmlUtil.escape(curDefaultValue) %></option>
+											<aui:option label="<%= HtmlUtil.escape(curDefaultValue) %>" selected="<%= (curValue.length > 0) && ArrayUtil.contains(curValue, curDefaultValue) %>" value="<%= HtmlUtil.escape(curDefaultValue) %>" />
 
 										<%
 										}
 										%>
 
-									</select>
+									</aui:select>
 								</c:when>
 								<c:when test="<%= propertyDisplayType.equals(ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_TEXT_BOX) %>">
 


### PR DESCRIPTION
Originally reviewed [here](https://github.com/wincent/liferay-portal/pull/176).

Verified that this works according to the description in the LPS:

1. Go to to Control Panel → Configuration → Custom Fields → Calendar Event
2. Add a dropdown selection list, containing some random language keys e.g.: `add-sample-data`, `edit-action`, `message-list`
3. Add a radio button selection list with the same values
4. Add a Calendar portlet to an arbitrary page
5. Add an event and edit it
6. Check the details tab

Result:

- Before this PR: the dropdown menu contains the keys.
- After this PR: the dropdown menu contains the translated human-readable text.