### PR TITLE
LPS-110469 Temporarily expose com.liferay.portal.kernel.service.persi…

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8116,6 +8116,7 @@
         com.liferay.aspectj,\
         com.liferay.aspectj.*,\
         com.liferay.expando.kernel.model,\
+        com.liferay.portal.kernel.service.persistence,\
         com.liferay.portal.servlet.delegate,\
         com.liferay.portal.servlet.delegate*,\
         com.sun.ccpp,\


### PR DESCRIPTION
…stence via bootdelegation. This is fixing release blocker caused by 6cd88061c455de707d0c83eba644b0b55b8745e1. That commit introduced a hidden dependency from com.liferay.portal.kernel.service to com.liferay.portal.kernel.service.persistence, which is not allowed by jdk11 during dynamic proxy creation. A proper right fix is simply to re-run the bnd processes for all modules to update the package imports, but considering we are already published all modules, using this hack as a workaround. Befcore next release publication, this MUST be reverted.