### PR TITLE
LPS-106886 Create and update Headless Delivery entities with localized content in one request

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -476,7 +476,8 @@ public class TaxonomyCategoryResourceImpl
 
 		if ((add && (localizedNames == null)) ||
 			(!add && (localizedNames != null) &&
-			 !localizedNames.containsKey(defaultLocale.toLanguageTag()))) {
+			 !localizedNames.containsKey(
+				 LocaleUtil.toBCP47LanguageId(defaultLocale)))) {
 
 			String w3cLanguageId = LocaleUtil.toW3cLanguageId(defaultLocale);
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -548,7 +548,8 @@ public class TaxonomyVocabularyResourceImpl
 
 		if ((add && (localizedNames == null)) ||
 			((localizedNames != null) &&
-			 !localizedNames.containsKey(defaultLocale.toLanguageTag()))) {
+			 !localizedNames.containsKey(
+				 LocaleUtil.toBCP47LanguageId(defaultLocale)))) {
 
 			String w3cLanguageId = LocaleUtil.toW3cLanguageId(defaultLocale);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/OrganizationResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/OrganizationResourceDTOConverter.java
@@ -49,6 +49,7 @@ import com.liferay.portal.kernel.service.RegionService;
 import com.liferay.portal.kernel.service.WebsiteService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.webserver.WebServerServletTokenUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -160,7 +161,7 @@ public class OrganizationResourceDTOConverter
 
 								return localesStream.collect(
 									Collectors.toMap(
-										Locale::toLanguageTag,
+										LocaleUtil::toBCP47LanguageId,
 										country::getName));
 							});
 						setAddressRegion(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/PostalAddressUtil.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/PostalAddressUtil.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.ListType;
 import com.liferay.portal.kernel.model.Region;
+import com.liferay.portal.kernel.util.LocaleUtil;
 
 import java.util.Locale;
 import java.util.Set;
@@ -73,7 +74,8 @@ public class PostalAddressUtil {
 
 						return localesStream.collect(
 							Collectors.toMap(
-								Locale::toLanguageTag, country::getName));
+								LocaleUtil::toBCP47LanguageId,
+								country::getName));
 					});
 				setAddressRegion(
 					() -> {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 16.1.1
+Bundle-Version: 17.0.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.resource.v1_0

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ContentField.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ContentField.java
@@ -262,16 +262,18 @@ public class ContentField {
 
 	@Schema
 	@Valid
-	public Value getValue() {
+	public ContentFieldValue getValue() {
 		return value;
 	}
 
-	public void setValue(Value value) {
+	public void setValue(ContentFieldValue value) {
 		this.value = value;
 	}
 
 	@JsonIgnore
-	public void setValue(UnsafeSupplier<Value, Exception> valueUnsafeSupplier) {
+	public void setValue(
+		UnsafeSupplier<ContentFieldValue, Exception> valueUnsafeSupplier) {
+
 		try {
 			value = valueUnsafeSupplier.get();
 		}
@@ -285,21 +287,21 @@ public class ContentField {
 
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected Value value;
+	protected ContentFieldValue value;
 
 	@Schema
 	@Valid
-	public Map<String, Object> getValue_i18n() {
+	public Map<String, ContentFieldValue> getValue_i18n() {
 		return value_i18n;
 	}
 
-	public void setValue_i18n(Map<String, Object> value_i18n) {
+	public void setValue_i18n(Map<String, ContentFieldValue> value_i18n) {
 		this.value_i18n = value_i18n;
 	}
 
 	@JsonIgnore
 	public void setValue_i18n(
-		UnsafeSupplier<Map<String, Object>, Exception>
+		UnsafeSupplier<Map<String, ContentFieldValue>, Exception>
 			value_i18nUnsafeSupplier) {
 
 		try {
@@ -315,7 +317,7 @@ public class ContentField {
 
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected Map<String, Object> value_i18n;
+	protected Map<String, ContentFieldValue> value_i18n;
 
 	@Override
 	public boolean equals(Object object) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ContentFieldValue.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ContentFieldValue.java
@@ -41,10 +41,10 @@ import javax.xml.bind.annotation.XmlRootElement;
  * @generated
  */
 @Generated("")
-@GraphQLName("Value")
+@GraphQLName("ContentFieldValue")
 @JsonFilter("Liferay.Vulcan")
-@XmlRootElement(name = "Value")
-public class Value {
+@XmlRootElement(name = "ContentFieldValue")
+public class ContentFieldValue {
 
 	@Schema(description = "The field's content for simple types.")
 	public String getData() {
@@ -225,13 +225,13 @@ public class Value {
 			return true;
 		}
 
-		if (!(object instanceof Value)) {
+		if (!(object instanceof ContentFieldValue)) {
 			return false;
 		}
 
-		Value value = (Value)object;
+		ContentFieldValue contentFieldValue = (ContentFieldValue)object;
 
-		return Objects.equals(toString(), value.toString());
+		return Objects.equals(toString(), contentFieldValue.toString());
 	}
 
 	@Override
@@ -320,7 +320,7 @@ public class Value {
 	}
 
 	@Schema(
-		defaultValue = "com.liferay.headless.delivery.dto.v1_0.Value",
+		defaultValue = "com.liferay.headless.delivery.dto.v1_0.ContentFieldValue",
 		name = "x-class-name"
 	)
 	public String xClassName;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 9.0.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/ContentField.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/ContentField.java
@@ -176,15 +176,17 @@ public class ContentField implements Cloneable {
 
 	protected Boolean repeatable;
 
-	public Value getValue() {
+	public ContentFieldValue getValue() {
 		return value;
 	}
 
-	public void setValue(Value value) {
+	public void setValue(ContentFieldValue value) {
 		this.value = value;
 	}
 
-	public void setValue(UnsafeSupplier<Value, Exception> valueUnsafeSupplier) {
+	public void setValue(
+		UnsafeSupplier<ContentFieldValue, Exception> valueUnsafeSupplier) {
+
 		try {
 			value = valueUnsafeSupplier.get();
 		}
@@ -193,18 +195,18 @@ public class ContentField implements Cloneable {
 		}
 	}
 
-	protected Value value;
+	protected ContentFieldValue value;
 
-	public Map<String, Object> getValue_i18n() {
+	public Map<String, ContentFieldValue> getValue_i18n() {
 		return value_i18n;
 	}
 
-	public void setValue_i18n(Map<String, Object> value_i18n) {
+	public void setValue_i18n(Map<String, ContentFieldValue> value_i18n) {
 		this.value_i18n = value_i18n;
 	}
 
 	public void setValue_i18n(
-		UnsafeSupplier<Map<String, Object>, Exception>
+		UnsafeSupplier<Map<String, ContentFieldValue>, Exception>
 			value_i18nUnsafeSupplier) {
 
 		try {
@@ -215,7 +217,7 @@ public class ContentField implements Cloneable {
 		}
 	}
 
-	protected Map<String, Object> value_i18n;
+	protected Map<String, ContentFieldValue> value_i18n;
 
 	@Override
 	public ContentField clone() throws CloneNotSupportedException {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/ContentFieldValue.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/ContentFieldValue.java
@@ -15,7 +15,7 @@
 package com.liferay.headless.delivery.client.dto.v1_0;
 
 import com.liferay.headless.delivery.client.function.UnsafeSupplier;
-import com.liferay.headless.delivery.client.serdes.v1_0.ValueSerDes;
+import com.liferay.headless.delivery.client.serdes.v1_0.ContentFieldValueSerDes;
 
 import java.util.Objects;
 
@@ -26,7 +26,7 @@ import javax.annotation.Generated;
  * @generated
  */
 @Generated("")
-public class Value implements Cloneable {
+public class ContentFieldValue implements Cloneable {
 
 	public String getData() {
 		return data;
@@ -152,8 +152,8 @@ public class Value implements Cloneable {
 	protected StructuredContentLink structuredContentLink;
 
 	@Override
-	public Value clone() throws CloneNotSupportedException {
-		return (Value)super.clone();
+	public ContentFieldValue clone() throws CloneNotSupportedException {
+		return (ContentFieldValue)super.clone();
 	}
 
 	@Override
@@ -162,13 +162,13 @@ public class Value implements Cloneable {
 			return true;
 		}
 
-		if (!(object instanceof Value)) {
+		if (!(object instanceof ContentFieldValue)) {
 			return false;
 		}
 
-		Value value = (Value)object;
+		ContentFieldValue contentFieldValue = (ContentFieldValue)object;
 
-		return Objects.equals(toString(), value.toString());
+		return Objects.equals(toString(), contentFieldValue.toString());
 	}
 
 	@Override
@@ -179,7 +179,7 @@ public class Value implements Cloneable {
 	}
 
 	public String toString() {
-		return ValueSerDes.toJSON(this);
+		return ContentFieldValueSerDes.toJSON(this);
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentFieldSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentFieldSerDes.java
@@ -330,7 +330,8 @@ public class ContentFieldSerDes {
 			else if (Objects.equals(jsonParserFieldName, "value")) {
 				if (jsonParserFieldValue != null) {
 					contentField.setValue(
-						ValueSerDes.toDTO((String)jsonParserFieldValue));
+						ContentFieldValueSerDes.toDTO(
+							(String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "value_i18n")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentFieldValueSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentFieldValueSerDes.java
@@ -14,7 +14,7 @@
 
 package com.liferay.headless.delivery.client.serdes.v1_0;
 
-import com.liferay.headless.delivery.client.dto.v1_0.Value;
+import com.liferay.headless.delivery.client.dto.v1_0.ContentFieldValue;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
 
 import java.util.Iterator;
@@ -30,22 +30,24 @@ import javax.annotation.Generated;
  * @generated
  */
 @Generated("")
-public class ValueSerDes {
+public class ContentFieldValueSerDes {
 
-	public static Value toDTO(String json) {
-		ValueJSONParser valueJSONParser = new ValueJSONParser();
+	public static ContentFieldValue toDTO(String json) {
+		ContentFieldValueJSONParser contentFieldValueJSONParser =
+			new ContentFieldValueJSONParser();
 
-		return valueJSONParser.parseToDTO(json);
+		return contentFieldValueJSONParser.parseToDTO(json);
 	}
 
-	public static Value[] toDTOs(String json) {
-		ValueJSONParser valueJSONParser = new ValueJSONParser();
+	public static ContentFieldValue[] toDTOs(String json) {
+		ContentFieldValueJSONParser contentFieldValueJSONParser =
+			new ContentFieldValueJSONParser();
 
-		return valueJSONParser.parseToDTOs(json);
+		return contentFieldValueJSONParser.parseToDTOs(json);
 	}
 
-	public static String toJSON(Value value) {
-		if (value == null) {
+	public static String toJSON(ContentFieldValue contentFieldValue) {
+		if (contentFieldValue == null) {
 			return "null";
 		}
 
@@ -53,7 +55,7 @@ public class ValueSerDes {
 
 		sb.append("{");
 
-		if (value.getData() != null) {
+		if (contentFieldValue.getData() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
@@ -62,42 +64,42 @@ public class ValueSerDes {
 
 			sb.append("\"");
 
-			sb.append(_escape(value.getData()));
+			sb.append(_escape(contentFieldValue.getData()));
 
 			sb.append("\"");
 		}
 
-		if (value.getDocument() != null) {
+		if (contentFieldValue.getDocument() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
 			sb.append("\"document\": ");
 
-			sb.append(String.valueOf(value.getDocument()));
+			sb.append(String.valueOf(contentFieldValue.getDocument()));
 		}
 
-		if (value.getGeo() != null) {
+		if (contentFieldValue.getGeo() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
 			sb.append("\"geo\": ");
 
-			sb.append(String.valueOf(value.getGeo()));
+			sb.append(String.valueOf(contentFieldValue.getGeo()));
 		}
 
-		if (value.getImage() != null) {
+		if (contentFieldValue.getImage() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
 			sb.append("\"image\": ");
 
-			sb.append(String.valueOf(value.getImage()));
+			sb.append(String.valueOf(contentFieldValue.getImage()));
 		}
 
-		if (value.getLink() != null) {
+		if (contentFieldValue.getLink() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
@@ -106,19 +108,20 @@ public class ValueSerDes {
 
 			sb.append("\"");
 
-			sb.append(_escape(value.getLink()));
+			sb.append(_escape(contentFieldValue.getLink()));
 
 			sb.append("\"");
 		}
 
-		if (value.getStructuredContentLink() != null) {
+		if (contentFieldValue.getStructuredContentLink() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
 			sb.append("\"structuredContentLink\": ");
 
-			sb.append(String.valueOf(value.getStructuredContentLink()));
+			sb.append(
+				String.valueOf(contentFieldValue.getStructuredContentLink()));
 		}
 
 		sb.append("}");
@@ -127,116 +130,122 @@ public class ValueSerDes {
 	}
 
 	public static Map<String, Object> toMap(String json) {
-		ValueJSONParser valueJSONParser = new ValueJSONParser();
+		ContentFieldValueJSONParser contentFieldValueJSONParser =
+			new ContentFieldValueJSONParser();
 
-		return valueJSONParser.parseToMap(json);
+		return contentFieldValueJSONParser.parseToMap(json);
 	}
 
-	public static Map<String, String> toMap(Value value) {
-		if (value == null) {
+	public static Map<String, String> toMap(
+		ContentFieldValue contentFieldValue) {
+
+		if (contentFieldValue == null) {
 			return null;
 		}
 
 		Map<String, String> map = new TreeMap<>();
 
-		if (value.getData() == null) {
+		if (contentFieldValue.getData() == null) {
 			map.put("data", null);
 		}
 		else {
-			map.put("data", String.valueOf(value.getData()));
+			map.put("data", String.valueOf(contentFieldValue.getData()));
 		}
 
-		if (value.getDocument() == null) {
+		if (contentFieldValue.getDocument() == null) {
 			map.put("document", null);
 		}
 		else {
-			map.put("document", String.valueOf(value.getDocument()));
+			map.put(
+				"document", String.valueOf(contentFieldValue.getDocument()));
 		}
 
-		if (value.getGeo() == null) {
+		if (contentFieldValue.getGeo() == null) {
 			map.put("geo", null);
 		}
 		else {
-			map.put("geo", String.valueOf(value.getGeo()));
+			map.put("geo", String.valueOf(contentFieldValue.getGeo()));
 		}
 
-		if (value.getImage() == null) {
+		if (contentFieldValue.getImage() == null) {
 			map.put("image", null);
 		}
 		else {
-			map.put("image", String.valueOf(value.getImage()));
+			map.put("image", String.valueOf(contentFieldValue.getImage()));
 		}
 
-		if (value.getLink() == null) {
+		if (contentFieldValue.getLink() == null) {
 			map.put("link", null);
 		}
 		else {
-			map.put("link", String.valueOf(value.getLink()));
+			map.put("link", String.valueOf(contentFieldValue.getLink()));
 		}
 
-		if (value.getStructuredContentLink() == null) {
+		if (contentFieldValue.getStructuredContentLink() == null) {
 			map.put("structuredContentLink", null);
 		}
 		else {
 			map.put(
 				"structuredContentLink",
-				String.valueOf(value.getStructuredContentLink()));
+				String.valueOf(contentFieldValue.getStructuredContentLink()));
 		}
 
 		return map;
 	}
 
-	public static class ValueJSONParser extends BaseJSONParser<Value> {
+	public static class ContentFieldValueJSONParser
+		extends BaseJSONParser<ContentFieldValue> {
 
 		@Override
-		protected Value createDTO() {
-			return new Value();
+		protected ContentFieldValue createDTO() {
+			return new ContentFieldValue();
 		}
 
 		@Override
-		protected Value[] createDTOArray(int size) {
-			return new Value[size];
+		protected ContentFieldValue[] createDTOArray(int size) {
+			return new ContentFieldValue[size];
 		}
 
 		@Override
 		protected void setField(
-			Value value, String jsonParserFieldName,
+			ContentFieldValue contentFieldValue, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
 			if (Objects.equals(jsonParserFieldName, "data")) {
 				if (jsonParserFieldValue != null) {
-					value.setData((String)jsonParserFieldValue);
+					contentFieldValue.setData((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "document")) {
 				if (jsonParserFieldValue != null) {
-					value.setDocument(
+					contentFieldValue.setDocument(
 						ContentDocumentSerDes.toDTO(
 							(String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "geo")) {
 				if (jsonParserFieldValue != null) {
-					value.setGeo(GeoSerDes.toDTO((String)jsonParserFieldValue));
+					contentFieldValue.setGeo(
+						GeoSerDes.toDTO((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "image")) {
 				if (jsonParserFieldValue != null) {
-					value.setImage(
+					contentFieldValue.setImage(
 						ContentDocumentSerDes.toDTO(
 							(String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "link")) {
 				if (jsonParserFieldValue != null) {
-					value.setLink((String)jsonParserFieldValue);
+					contentFieldValue.setLink((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(
 						jsonParserFieldName, "structuredContentLink")) {
 
 				if (jsonParserFieldValue != null) {
-					value.setStructuredContentLink(
+					contentFieldValue.setStructuredContentLink(
 						StructuredContentLinkSerDes.toDTO(
 							(String)jsonParserFieldValue));
 				}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -367,62 +367,67 @@ components:
                     readOnly: true
                     type: boolean
                 value:
-                    properties:
-                        data:
-                            description:
-                                The field's content for simple types.
-                            type: string
-                        document:
-                            allOf:
-                                - $ref: "#/components/schemas/ContentDocument"
-                            description:
-                                A content document element.
-                        geo:
-                            description:
-                                A point determined by latitude and longitude.
-                            properties:
-                                latitude:
-                                    description:
-                                        The latitude of a point in space.
-                                    format: double
-                                    type: number
-                                longitude:
-                                    description:
-                                        The longitude of a point in space.
-                                    format: double
-                                    type: number
-                            type: object
-                        image:
-                            allOf:
-                                - $ref: "#/components/schemas/ContentDocument"
-                            description:
-                                A content document element that stores an image file.
-                        link:
-                            description:
-                                A link to a page on the server.
-                            format: uri
-                            type: string
-                        structuredContentLink:
-                            description:
-                                A link to structured content on the server.
-                            properties:
-                                contentType:
-                                    readOnly: true
-                                    type: string
-                                id:
-                                    description:
-                                        The resource's ID.
-                                    format: int64
-                                    type: integer
-                                title:
-                                    description:
-                                        The resource's title.
-                                    type: string
-                            type: object
-                    type: object
+                    $ref: "#/components/schemas/ContentFieldValue"
                 value_i18n:
                     additionalProperties:
-                        type: object
+                        $ref: "#/components/schemas/ContentFieldValue"
+                    type: object
+        ContentFieldValue:
+            description:
+                # @review
+                Represents the value of a content field. Can contain different information types
+                (e.g., geolocation, documents, etc.).
+            properties:
+                data:
+                    description:
+                        The field's content for simple types.
+                    type: string
+                document:
+                    allOf:
+                        - $ref: "#/components/schemas/ContentDocument"
+                    description:
+                        A content document element.
+                geo:
+                    description:
+                        A point determined by latitude and longitude.
+                    properties:
+                        latitude:
+                            description:
+                                The latitude of a point in space.
+                            format: double
+                            type: number
+                        longitude:
+                            description:
+                                The longitude of a point in space.
+                            format: double
+                            type: number
+                    type: object
+                image:
+                    allOf:
+                        - $ref: "#/components/schemas/ContentDocument"
+                    description:
+                        A content document element that stores an image file.
+                link:
+                    description:
+                        A link to a page on the server.
+                    format: uri
+                    type: string
+                structuredContentLink:
+                    description:
+                        A link to structured content on the server.
+                    properties:
+                        contentType:
+                            readOnly: true
+                            type: string
+                        id:
+                            description:
+                                The resource's ID.
+                            format: int64
+                            type: integer
+                        title:
+                            description:
+                                The resource's title.
+                            type: string
                     type: object
         ContentSetElement:
             description:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/StructuredContentDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/StructuredContentDTOConverter.java
@@ -25,17 +25,18 @@ import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMFormFieldType;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.LocalizedValue;
+import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.storage.Fields;
 import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
 import com.liferay.headless.delivery.dto.v1_0.ContentField;
+import com.liferay.headless.delivery.dto.v1_0.ContentFieldValue;
 import com.liferay.headless.delivery.dto.v1_0.Geo;
 import com.liferay.headless.delivery.dto.v1_0.RenderedContent;
 import com.liferay.headless.delivery.dto.v1_0.StructuredContent;
 import com.liferay.headless.delivery.dto.v1_0.StructuredContentLink;
 import com.liferay.headless.delivery.dto.v1_0.TaxonomyCategoryBrief;
-import com.liferay.headless.delivery.dto.v1_0.Value;
 import com.liferay.headless.delivery.internal.dto.v1_0.util.AggregateRatingUtil;
 import com.liferay.headless.delivery.internal.dto.v1_0.util.ContentDocumentUtil;
 import com.liferay.headless.delivery.internal.dto.v1_0.util.ContentStructureUtil;
@@ -68,6 +69,7 @@ import com.liferay.subscription.service.SubscriptionLocalService;
 
 import java.text.ParseException;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -187,7 +189,7 @@ public class StructuredContentDTOConverter
 		};
 	}
 
-	private Value _getValue(
+	private ContentFieldValue _getContentFieldValue(
 			DDMFormField ddmFormField, DLAppService dlAppService,
 			DLURLHelper dlURLHelper,
 			JournalArticleService journalArticleService,
@@ -196,7 +198,7 @@ public class StructuredContentDTOConverter
 		throws Exception {
 
 		if (Objects.equals(DDMFormFieldType.DATE, ddmFormField.getType())) {
-			return new Value() {
+			return new ContentFieldValue() {
 				{
 					data = _toDateString(locale, valueString);
 				}
@@ -212,10 +214,10 @@ public class StructuredContentDTOConverter
 			long classPK = jsonObject.getLong("classPK");
 
 			if (classPK == 0) {
-				return new Value();
+				return new ContentFieldValue();
 			}
 
-			return new Value() {
+			return new ContentFieldValue() {
 				{
 					document = ContentDocumentUtil.toContentDocument(
 						dlURLHelper, dlAppService.getFileEntry(classPK));
@@ -229,7 +231,7 @@ public class StructuredContentDTOConverter
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 				valueString);
 
-			return new Value() {
+			return new ContentFieldValue() {
 				{
 					geo = new Geo() {
 						{
@@ -248,10 +250,10 @@ public class StructuredContentDTOConverter
 			long fileEntryId = jsonObject.getLong("fileEntryId");
 
 			if (fileEntryId == 0) {
-				return new Value();
+				return new ContentFieldValue();
 			}
 
-			return new Value() {
+			return new ContentFieldValue() {
 				{
 					image = ContentDocumentUtil.toContentDocument(
 						dlURLHelper, dlAppService.getFileEntry(fileEntryId));
@@ -270,13 +272,13 @@ public class StructuredContentDTOConverter
 			long classPK = jsonObject.getLong("classPK");
 
 			if (classPK == 0) {
-				return new Value();
+				return new ContentFieldValue();
 			}
 
 			JournalArticle journalArticle =
 				journalArticleService.getLatestArticle(classPK);
 
-			return new Value() {
+			return new ContentFieldValue() {
 				{
 					structuredContentLink = new StructuredContentLink() {
 						{
@@ -298,7 +300,7 @@ public class StructuredContentDTOConverter
 			long layoutId = jsonObject.getLong("layoutId");
 
 			if (layoutId == 0) {
-				return new Value();
+				return new ContentFieldValue();
 			}
 
 			long groupId = jsonObject.getLong("groupId");
@@ -307,14 +309,14 @@ public class StructuredContentDTOConverter
 			Layout layoutByUuidAndGroupId = layoutLocalService.getLayout(
 				groupId, privateLayout, layoutId);
 
-			return new Value() {
+			return new ContentFieldValue() {
 				{
 					link = layoutByUuidAndGroupId.getFriendlyURL();
 				}
 			};
 		}
 
-		return new Value() {
+		return new ContentFieldValue() {
 			{
 				data = valueString;
 			}
@@ -350,7 +352,7 @@ public class StructuredContentDTOConverter
 						journalArticleService, layoutLocalService),
 					ContentField.class);
 				repeatable = ddmFormField.isRepeatable();
-				value = _toValue(
+				value = _toContentFieldValue(
 					ddmFormField, ddmFormFieldValue.getValue(), dlAppService,
 					dlURLHelper, journalArticleService, layoutLocalService,
 					dtoConverterContext.getLocale());
@@ -361,13 +363,18 @@ public class StructuredContentDTOConverter
 							return null;
 						}
 
-						Map<String, Object> map = new HashMap<>();
+						Map<String, ContentFieldValue> map = new HashMap<>();
 
-						com.liferay.dynamic.data.mapping.model.Value ddmValue =
-							ddmFormFieldValue.getValue();
+						Value ddmValue = ddmFormFieldValue.getValue();
 
 						Map<Locale, String> ddmValueValues =
-							ddmValue.getValues();
+							Optional.ofNullable(
+								ddmValue
+							).map(
+								Value::getValues
+							).orElse(
+								Collections.emptyMap()
+							);
 
 						for (Map.Entry<Locale, String> entry :
 								ddmValueValues.entrySet()) {
@@ -375,8 +382,8 @@ public class StructuredContentDTOConverter
 							Locale locale = entry.getKey();
 
 							map.put(
-								locale.toLanguageTag(),
-								_getValue(
+								LocaleUtil.toBCP47LanguageId(locale),
+								_getContentFieldValue(
 									ddmFormField, dlAppService, dlURLHelper,
 									journalArticleService, layoutLocalService,
 									entry.getKey(), entry.getValue()));
@@ -412,6 +419,24 @@ public class StructuredContentDTOConverter
 				ddmFormFieldValue, dlAppService, dlURLHelper,
 				dtoConverterContext, journalArticleService, layoutLocalService),
 			ContentField.class);
+	}
+
+	private ContentFieldValue _toContentFieldValue(
+			DDMFormField ddmFormField, Value value, DLAppService dlAppService,
+			DLURLHelper dlURLHelper,
+			JournalArticleService journalArticleService,
+			LayoutLocalService layoutLocalService, Locale locale)
+		throws Exception {
+
+		if (value == null) {
+			return new ContentFieldValue();
+		}
+
+		String valueString = String.valueOf(value.getString(locale));
+
+		return _getContentFieldValue(
+			ddmFormField, dlAppService, dlURLHelper, journalArticleService,
+			layoutLocalService, locale, valueString);
 	}
 
 	private String _toDateString(Locale locale, String valueString) {
@@ -458,25 +483,6 @@ public class StructuredContentDTOConverter
 				}
 			},
 			RenderedContent.class);
-	}
-
-	private Value _toValue(
-			DDMFormField ddmFormField,
-			com.liferay.dynamic.data.mapping.model.Value value,
-			DLAppService dlAppService, DLURLHelper dlURLHelper,
-			JournalArticleService journalArticleService,
-			LayoutLocalService layoutLocalService, Locale locale)
-		throws Exception {
-
-		if (value == null) {
-			return new Value();
-		}
-
-		String valueString = String.valueOf(value.getString(locale));
-
-		return _getValue(
-			ddmFormField, dlAppService, dlURLHelper, journalArticleService,
-			layoutLocalService, locale, valueString);
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -37,7 +37,6 @@ import java.lang.reflect.Array;
 import java.text.DateFormat;
 import java.text.ParseException;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -151,8 +150,8 @@ public class CustomFieldsUtil {
 					else if (ExpandoColumnConstants.STRING_LOCALIZED ==
 								attributeType) {
 
-						return (Serializable)Collections.singletonMap(
-							locale, data);
+						return (Serializable)LocalizedMapUtil.getLocalizedMap(
+							locale, (String)data, customValue.getData_i18n());
 					}
 
 					return (Serializable)data;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DDMValueUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DDMValueUtil.java
@@ -22,6 +22,7 @@ import com.liferay.dynamic.data.mapping.model.UnlocalizedValue;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.headless.delivery.dto.v1_0.ContentDocument;
 import com.liferay.headless.delivery.dto.v1_0.ContentField;
+import com.liferay.headless.delivery.dto.v1_0.ContentFieldValue;
 import com.liferay.headless.delivery.dto.v1_0.Geo;
 import com.liferay.headless.delivery.dto.v1_0.StructuredContentLink;
 import com.liferay.journal.model.JournalArticle;
@@ -37,12 +38,17 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.text.ParseException;
 
+import java.util.Collections;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiFunction;
 
 import javax.ws.rs.BadRequestException;
 
@@ -52,132 +58,74 @@ import javax.ws.rs.BadRequestException;
 public class DDMValueUtil {
 
 	public static Value toDDMValue(
-		ContentField contentFieldValue, DDMFormField ddmFormField,
+		ContentField contentField, DDMFormField ddmFormField,
 		DLAppService dlAppService, long groupId,
 		JournalArticleService journalArticleService,
 		LayoutLocalService layoutLocalService, Locale locale) {
 
-		com.liferay.headless.delivery.dto.v1_0.Value value =
-			contentFieldValue.getValue();
+		ContentFieldValue contentFieldValue = contentField.getValue();
 
-		if (value == null) {
+		if (contentFieldValue == null) {
 			throw new BadRequestException(
 				"No value is specified for field " + ddmFormField.getName());
 		}
 
 		if (ddmFormField.isLocalizable()) {
-			LocalizedValue localizedValue = new LocalizedValue(locale);
+			Map<String, ContentFieldValue> i18nValues =
+				contentField.getValue_i18n();
 
 			if (Objects.equals(DDMFormFieldType.DATE, ddmFormField.getType())) {
-				localizedValue.addString(
-					locale, _toDateString(value.getData(), locale));
+				return _getLocalizedValue(
+					locale, contentFieldValue, i18nValues,
+					DDMValueUtil::_toLocalizedDateString);
 			}
 			else if (Objects.equals(
 						DDMFormFieldType.DOCUMENT_LIBRARY,
 						ddmFormField.getType())) {
 
-				String valueString = StringPool.BLANK;
-
-				ContentDocument contentDocument = value.getDocument();
-
-				if ((contentDocument != null) &&
-					(contentDocument.getId() != null)) {
-
-					valueString = _toJSON(
-						dlAppService, StringPool.BLANK,
-						contentDocument.getId());
-				}
-
-				localizedValue.addString(locale, valueString);
+				return _getLocalizedValue(
+					locale, contentFieldValue, i18nValues,
+					(loc, value) -> _toLocalizedDocument(
+						dlAppService, contentFieldValue));
 			}
 			else if (Objects.equals(
 						DDMFormFieldType.IMAGE, ddmFormField.getType())) {
 
-				String valueString = StringPool.BLANK;
-
-				ContentDocument contentDocument = value.getImage();
-
-				if ((contentDocument != null) &&
-					(contentDocument.getId() != null)) {
-
-					valueString = _toJSON(
-						dlAppService, contentDocument.getDescription(),
-						contentDocument.getId());
-				}
-
-				localizedValue.addString(locale, valueString);
+				return _getLocalizedValue(
+					locale, contentFieldValue, i18nValues,
+					(loc, value) -> _toLocalizedImage(
+						dlAppService, contentFieldValue));
 			}
 			else if (Objects.equals(
 						DDMFormFieldType.JOURNAL_ARTICLE,
 						ddmFormField.getType())) {
 
-				String valueString = StringPool.BLANK;
-
-				StructuredContentLink structuredContentLink =
-					value.getStructuredContentLink();
-
-				if ((structuredContentLink != null) &&
-					(structuredContentLink.getId() != null)) {
-
-					JournalArticle journalArticle = null;
-
-					try {
-						journalArticle = journalArticleService.getLatestArticle(
-							structuredContentLink.getId());
-					}
-					catch (Exception exception) {
-						throw new BadRequestException(
-							"No structured content exists with ID " +
-								structuredContentLink.getId(),
-							exception);
-					}
-
-					valueString = JSONUtil.put(
-						"className", JournalArticle.class.getName()
-					).put(
-						"classPK", journalArticle.getResourcePrimKey()
-					).put(
-						"title", journalArticle.getTitle()
-					).toString();
-				}
-
-				localizedValue.addString(locale, valueString);
+				return _getLocalizedValue(
+					locale, contentFieldValue, i18nValues,
+					(loc, value) -> _toLocalizedJournalArticle(
+						journalArticleService, contentFieldValue));
 			}
 			else if (Objects.equals(
 						DDMFormFieldType.LINK_TO_PAGE,
 						ddmFormField.getType())) {
 
-				String valueString = StringPool.BLANK;
-
-				if (value.getLink() != null) {
-					Layout layout = _getLayout(
-						groupId, layoutLocalService, value.getLink());
-
-					valueString = JSONUtil.put(
-						"groupId", layout.getGroupId()
-					).put(
-						"label", layout.getFriendlyURL()
-					).put(
-						"layoutId", layout.getLayoutId()
-					).put(
-						"privateLayout", layout.isPrivateLayout()
-					).toString();
-				}
-
-				localizedValue.addString(locale, valueString);
+				return _getLocalizedValue(
+					locale, contentFieldValue, i18nValues,
+					(loc, value) -> _toLocalizedLinkToPage(
+						groupId, layoutLocalService, contentFieldValue));
 			}
 			else {
-				localizedValue.addString(
-					locale, GetterUtil.getString(value.getData()));
+				return _getLocalizedValue(
+					locale, contentFieldValue, i18nValues,
+					(loc, value) -> GetterUtil.getString(
+						contentFieldValue.getData()));
 			}
-
-			return localizedValue;
 		}
 
 		if (Objects.equals(
 				DDMFormFieldType.GEOLOCATION, ddmFormField.getType())) {
 
-			Geo geo = value.getGeo();
+			Geo geo = contentFieldValue.getGeo();
 
 			if (Objects.isNull(geo) || Objects.isNull(geo.getLatitude()) ||
 				Objects.isNull(geo.getLongitude())) {
@@ -193,7 +141,8 @@ public class DDMValueUtil {
 				).toString());
 		}
 
-		return new UnlocalizedValue(GetterUtil.getString(value.getData()));
+		return new UnlocalizedValue(
+			GetterUtil.getString(contentFieldValue.getData()));
 	}
 
 	private static Layout _getLayout(
@@ -225,22 +174,35 @@ public class DDMValueUtil {
 		return layout;
 	}
 
-	private static String _toDateString(String valueString, Locale locale) {
-		if (Validator.isNull(valueString)) {
-			return StringPool.BLANK;
-		}
+	private static LocalizedValue _getLocalizedValue(
+		Locale defaultLocale, ContentFieldValue defaultValue,
+		Map<String, ContentFieldValue> i18nValues,
+		BiFunction<Locale, ContentFieldValue, String> localizedValueFunction) {
 
-		try {
-			return DateUtil.getDate(
-				DateUtil.parseDate(
-					"yyyy-MM-dd'T'HH:mm:ss'Z'", valueString, locale),
-				"yyyy-MM-dd", locale);
-		}
-		catch (ParseException parseException) {
-			throw new BadRequestException(
-				"Unable to parse date that does not conform to ISO-8601",
-				parseException);
-		}
+		LocalizedValue localizedValue = new LocalizedValue(defaultLocale);
+
+		localizedValue.addString(
+			defaultLocale,
+			localizedValueFunction.apply(defaultLocale, defaultValue));
+
+		Optional.ofNullable(
+			i18nValues
+		).orElse(
+			Collections.emptyMap()
+		).forEach(
+			(languageId, languageValue) -> {
+				Locale locale = LocaleUtil.fromLanguageId(
+					languageId, true, false);
+
+				if (locale != null) {
+					localizedValue.addString(
+						locale,
+						localizedValueFunction.apply(locale, languageValue));
+				}
+			}
+		);
+
+		return localizedValue;
 	}
 
 	private static String _toJSON(
@@ -275,6 +237,119 @@ public class DDMValueUtil {
 		).put(
 			"uuid", fileEntry.getUuid()
 		).toString();
+	}
+
+	private static String _toLocalizedDateString(
+		Locale locale, ContentFieldValue contentFieldValue) {
+
+		if (Validator.isNull(contentFieldValue.getData())) {
+			return StringPool.BLANK;
+		}
+
+		try {
+			return DateUtil.getDate(
+				DateUtil.parseDate(
+					"yyyy-MM-dd'T'HH:mm:ss'Z'", contentFieldValue.getData(),
+					locale),
+				"yyyy-MM-dd", locale);
+		}
+		catch (ParseException parseException) {
+			throw new BadRequestException(
+				"Unable to parse date that does not conform to ISO-8601",
+				parseException);
+		}
+	}
+
+	private static String _toLocalizedDocument(
+		DLAppService dlAppService, ContentFieldValue contentFieldValue) {
+
+		String valueString = StringPool.BLANK;
+
+		ContentDocument contentDocument = contentFieldValue.getDocument();
+
+		if ((contentDocument != null) && (contentDocument.getId() != null)) {
+			valueString = _toJSON(
+				dlAppService, StringPool.BLANK, contentDocument.getId());
+		}
+
+		return valueString;
+	}
+
+	private static String _toLocalizedImage(
+		DLAppService dlAppService, ContentFieldValue contentFieldValue) {
+
+		String valueString = StringPool.BLANK;
+
+		ContentDocument contentDocument = contentFieldValue.getImage();
+
+		if ((contentDocument != null) && (contentDocument.getId() != null)) {
+			valueString = _toJSON(
+				dlAppService, contentDocument.getDescription(),
+				contentDocument.getId());
+		}
+
+		return valueString;
+	}
+
+	private static String _toLocalizedJournalArticle(
+		JournalArticleService journalArticleService,
+		ContentFieldValue contentFieldValue) {
+
+		String valueString = StringPool.BLANK;
+
+		StructuredContentLink structuredContentLink =
+			contentFieldValue.getStructuredContentLink();
+
+		if ((structuredContentLink != null) &&
+			(structuredContentLink.getId() != null)) {
+
+			JournalArticle journalArticle = null;
+
+			try {
+				journalArticle = journalArticleService.getLatestArticle(
+					structuredContentLink.getId());
+			}
+			catch (Exception exception) {
+				throw new BadRequestException(
+					"No structured content exists with ID " +
+						structuredContentLink.getId(),
+					exception);
+			}
+
+			valueString = JSONUtil.put(
+				"className", JournalArticle.class.getName()
+			).put(
+				"classPK", journalArticle.getResourcePrimKey()
+			).put(
+				"title", journalArticle.getTitle()
+			).toString();
+		}
+
+		return valueString;
+	}
+
+	private static String _toLocalizedLinkToPage(
+		long groupId, LayoutLocalService layoutLocalService,
+		ContentFieldValue contentFieldValue) {
+
+		String valueString = StringPool.BLANK;
+
+		if (contentFieldValue.getLink() != null) {
+			Layout layout = _getLayout(
+				groupId, layoutLocalService, contentFieldValue.getLink());
+
+			valueString = JSONUtil.put(
+				"groupId", layout.getGroupId()
+			).put(
+				"label", layout.getFriendlyURL()
+			).put(
+				"layoutId", layout.getLayoutId()
+			).put(
+				"privateLayout", layout.isPrivateLayout()
+			).toString();
+		}
+
+		return valueString;
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -103,7 +103,6 @@ import java.net.URI;
 
 import java.time.LocalDateTime;
 
-import java.util.AbstractMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -405,15 +404,18 @@ public class StructuredContentResourceImpl
 				LocalizedMapUtil.patch(
 					journalArticle.getTitleMap(),
 					contextAcceptLanguage.getPreferredLocale(),
-					structuredContent.getTitle()),
+					structuredContent.getTitle(),
+					structuredContent.getTitle_i18n()),
 				LocalizedMapUtil.patch(
 					journalArticle.getDescriptionMap(),
 					contextAcceptLanguage.getPreferredLocale(),
-					structuredContent.getDescription()),
+					structuredContent.getDescription(),
+					structuredContent.getDescription_i18n()),
 				LocalizedMapUtil.patch(
 					journalArticle.getFriendlyURLMap(),
 					contextAcceptLanguage.getPreferredLocale(),
-					structuredContent.getFriendlyUrlPath()),
+					structuredContent.getFriendlyUrlPath(),
+					structuredContent.getFriendlyUrlPath_i18n()),
 				_journalConverter.getContent(
 					ddmStructure,
 					_toPatchedFields(
@@ -478,6 +480,8 @@ public class StructuredContentResourceImpl
 
 		DDMStructure ddmStructure = journalArticle.getDDMStructure();
 
+		_validateI18n(false, structuredContent);
+
 		_validateContentFields(
 			structuredContent.getContentFields(), ddmStructure);
 
@@ -489,21 +493,21 @@ public class StructuredContentResourceImpl
 			_journalArticleService.updateArticle(
 				journalArticle.getGroupId(), journalArticle.getFolderId(),
 				journalArticle.getArticleId(), journalArticle.getVersion(),
-				LocalizedMapUtil.merge(
-					journalArticle.getTitleMap(),
-					new AbstractMap.SimpleEntry<>(
-						contextAcceptLanguage.getPreferredLocale(),
-						structuredContent.getTitle())),
-				LocalizedMapUtil.merge(
-					journalArticle.getDescriptionMap(),
-					new AbstractMap.SimpleEntry<>(
-						contextAcceptLanguage.getPreferredLocale(),
-						structuredContent.getDescription())),
-				LocalizedMapUtil.merge(
-					journalArticle.getFriendlyURLMap(),
-					new AbstractMap.SimpleEntry<>(
-						contextAcceptLanguage.getPreferredLocale(),
-						structuredContent.getFriendlyUrlPath())),
+				LocalizedMapUtil.getLocalizedMap(
+					contextAcceptLanguage.getPreferredLocale(),
+					structuredContent.getTitle(),
+					structuredContent.getTitle_i18n(),
+					journalArticle.getTitleMap()),
+				LocalizedMapUtil.getLocalizedMap(
+					contextAcceptLanguage.getPreferredLocale(),
+					structuredContent.getDescription(),
+					structuredContent.getDescription_i18n(),
+					journalArticle.getDescriptionMap()),
+				LocalizedMapUtil.getLocalizedMap(
+					contextAcceptLanguage.getPreferredLocale(),
+					structuredContent.getFriendlyUrlPath(),
+					structuredContent.getFriendlyUrlPath_i18n(),
+					journalArticle.getDescriptionMap()),
 				_journalConverter.getContent(
 					ddmStructure,
 					_toFields(
@@ -586,32 +590,29 @@ public class StructuredContentResourceImpl
 		LocalDateTime localDateTime = LocalDateTimeUtil.toLocalDateTime(
 			structuredContent.getDatePublished());
 
-		if (!LocaleUtil.equals(
-				LocaleUtil.fromLanguageId(ddmStructure.getDefaultLanguageId()),
-				contextAcceptLanguage.getPreferredLocale())) {
-
-			String w3cLanguageId = LocaleUtil.toW3cLanguageId(
-				ddmStructure.getDefaultLanguageId());
-
-			throw new BadRequestException(
-				"Structured contents can only be created with the default " +
-					"language " + w3cLanguageId);
-		}
+		_validateI18n(true, structuredContent);
 
 		_validateContentFields(
 			structuredContent.getContentFields(), ddmStructure);
 
+		Map<Locale, String> titleMap = LocalizedMapUtil.getLocalizedMap(
+			contextAcceptLanguage.getPreferredLocale(),
+			structuredContent.getTitle(), structuredContent.getTitle_i18n());
+
+		Map<Locale, String> friendlyUrlMap = LocalizedMapUtil.getLocalizedMap(
+			contextAcceptLanguage.getPreferredLocale(),
+			structuredContent.getFriendlyUrlPath(),
+			structuredContent.getFriendlyUrlPath_i18n(), titleMap);
+
 		return _toStructuredContent(
 			_journalArticleService.addArticle(
 				siteId, parentStructuredContentFolderId, 0, 0, null, true,
-				HashMapBuilder.put(
+				titleMap,
+				LocalizedMapUtil.getLocalizedMap(
 					contextAcceptLanguage.getPreferredLocale(),
-					structuredContent.getTitle()
-				).build(),
-				HashMapBuilder.put(
-					contextAcceptLanguage.getPreferredLocale(),
-					structuredContent.getDescription()
-				).build(),
+					structuredContent.getDescription(),
+					structuredContent.getDescription_i18n()),
+				friendlyUrlMap,
 				_createJournalArticleContent(
 					DDMFormValuesUtil.toDDMFormValues(
 						structuredContent.getContentFields(),
@@ -625,7 +626,8 @@ public class StructuredContentResourceImpl
 				localDateTime.getMonthValue() - 1,
 				localDateTime.getDayOfMonth(), localDateTime.getYear(),
 				localDateTime.getHour(), localDateTime.getMinute(), 0, 0, 0, 0,
-				0, true, 0, 0, 0, 0, 0, true, true, null,
+				0, true, 0, 0, 0, 0, 0, true, true, false, null, null, null,
+				null,
 				ServiceContextUtil.createServiceContext(
 					structuredContent.getTaxonomyCategoryIds(),
 					structuredContent.getKeywords(),
@@ -1058,6 +1060,32 @@ public class StructuredContentResourceImpl
 				"Validation error: " +
 					ddmFormValuesValidationException.getMessage(),
 				ddmFormValuesValidationException);
+		}
+	}
+
+	private void _validateI18n(
+		boolean add, StructuredContent structuredContent) {
+
+		Locale defaultLocale = LocaleUtil.getSiteDefault();
+
+		if (LocaleUtil.equals(
+				defaultLocale, contextAcceptLanguage.getPreferredLocale())) {
+
+			return;
+		}
+
+		Map<String, String> localizedTitles = structuredContent.getTitle_i18n();
+
+		if ((add && (localizedTitles == null)) ||
+			((localizedTitles != null) &&
+			 !localizedTitles.containsKey(
+				 LocaleUtil.toBCP47LanguageId(defaultLocale)))) {
+
+			String w3cLanguageId = LocaleUtil.toW3cLanguageId(defaultLocale);
+
+			throw new BadRequestException(
+				"Structured Content must include the title in the default " +
+					"language " + w3cLanguageId);
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -26,8 +26,8 @@ import com.liferay.dynamic.data.mapping.storage.StorageType;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestHelper;
 import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentField;
+import com.liferay.headless.delivery.client.dto.v1_0.ContentFieldValue;
 import com.liferay.headless.delivery.client.dto.v1_0.StructuredContent;
-import com.liferay.headless.delivery.client.dto.v1_0.Value;
 import com.liferay.headless.delivery.client.resource.v1_0.StructuredContentResource;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFolder;
@@ -35,6 +35,7 @@ import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -69,8 +70,13 @@ public class StructuredContentResourceTest
 	public void setUp() throws Exception {
 		super.setUp();
 
-		_ddmStructure = _addDDMStructure(testGroup);
-		_irrelevantDDMStructure = _addDDMStructure(irrelevantGroup);
+		_ddmStructure = _addDDMStructure(
+			testGroup, "test-structured-content-structure.json");
+		_ddmLocalizedStructure = _addDDMStructure(
+			testGroup, "test-localized-structured-content-structure.json");
+
+		_irrelevantDDMStructure = _addDDMStructure(
+			irrelevantGroup, "test-structured-content-structure.json");
 
 		_ddmTemplate = _addDDMTemplate(_ddmStructure);
 		_addDDMTemplate(_irrelevantDDMStructure);
@@ -134,10 +140,10 @@ public class StructuredContentResourceTest
 
 		ContentField[] contentFields = structuredContent.getContentFields();
 
-		Value value = contentFields[0].getValue();
+		ContentFieldValue contentFieldValue = contentFields[0].getValue();
 
 		Assert.assertEquals(
-			"<div>" + value.getData() + "</div>",
+			"<div>" + contentFieldValue.getData() + "</div>",
 			structuredContentResource.
 				getStructuredContentRenderedContentTemplate(
 					structuredContent.getId(), _ddmTemplate.getTemplateId()));
@@ -153,6 +159,19 @@ public class StructuredContentResourceTest
 	@Override
 	@Test
 	public void testGraphQLGetSiteStructuredContentByUuid() {
+	}
+
+	@Test
+	public void testPostSiteLocalizedStructuredContent() throws Exception {
+		StructuredContent randomLocalizedStructuredContent =
+			_randomLocalizedStructuredContent();
+
+		StructuredContent postStructuredContent =
+			testPostSiteStructuredContent_addStructuredContent(
+				randomLocalizedStructuredContent);
+
+		assertEquals(randomLocalizedStructuredContent, postStructuredContent);
+		assertValid(postStructuredContent);
 	}
 
 	@Override
@@ -186,7 +205,7 @@ public class StructuredContentResourceTest
 				new ContentField() {
 					{
 						name = "MyText";
-						value = new Value() {
+						value = new ContentFieldValue() {
 							{
 								data = RandomTestUtil.randomString(10);
 							}
@@ -231,7 +250,9 @@ public class StructuredContentResourceTest
 		return _journalFolder.getFolderId();
 	}
 
-	private DDMStructure _addDDMStructure(Group group) throws Exception {
+	private DDMStructure _addDDMStructure(Group group, String filename)
+		throws Exception {
+
 		DDMStructureTestHelper ddmStructureTestHelper =
 			new DDMStructureTestHelper(
 				PortalUtil.getClassNameId(JournalArticle.class), group);
@@ -239,8 +260,8 @@ public class StructuredContentResourceTest
 		return ddmStructureTestHelper.addStructure(
 			PortalUtil.getClassNameId(JournalArticle.class),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			_deserialize(_read("test-structured-content-structure.json")),
-			StorageType.JSON.getValue(), DDMStructureConstants.TYPE_DEFAULT);
+			_deserialize(_read(filename)), StorageType.JSON.getValue(),
+			DDMStructureConstants.TYPE_DEFAULT);
 	}
 
 	private DDMTemplate _addDDMTemplate(DDMStructure ddmStructure)
@@ -264,6 +285,46 @@ public class StructuredContentResourceTest
 		return ddmFormDeserializerDeserializeResponse.getDDMForm();
 	}
 
+	private StructuredContent _randomLocalizedStructuredContent()
+		throws Exception {
+
+		StructuredContent structuredContent = super.randomStructuredContent();
+
+		ContentFieldValue randomEnglishContentFieldValue =
+			new ContentFieldValue() {
+				{
+					data = RandomTestUtil.randomString(10);
+				}
+			};
+
+		ContentFieldValue randomSpanishContentFieldValue =
+			new ContentFieldValue() {
+				{
+					data = RandomTestUtil.randomString(10);
+				}
+			};
+
+		structuredContent.setContentFields(
+			new ContentField[] {
+				new ContentField() {
+					{
+						name = "MyText";
+						value = randomEnglishContentFieldValue;
+						value_i18n = HashMapBuilder.put(
+							"en-US", randomEnglishContentFieldValue
+						).put(
+							"es-ES", randomSpanishContentFieldValue
+						).build();
+					}
+				}
+			});
+
+		structuredContent.setContentStructureId(
+			_ddmLocalizedStructure.getStructureId());
+
+		return structuredContent;
+	}
+
 	private String _read(String fileName) throws Exception {
 		Class<?> clazz = getClass();
 
@@ -276,6 +337,7 @@ public class StructuredContentResourceTest
 	@Inject(filter = "ddm.form.deserializer.type=json")
 	private static DDMFormDeserializer _jsonDDMFormDeserializer;
 
+	private DDMStructure _ddmLocalizedStructure;
 	private DDMStructure _ddmStructure;
 	private DDMTemplate _ddmTemplate;
 	private DDMStructure _irrelevantDDMStructure;

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-localized-structured-content-structure.json
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-localized-structured-content-structure.json
@@ -1,0 +1,32 @@
+{
+	"availableLanguageIds": [
+		"en_US",
+		"es_ES"
+	],
+	"defaultLanguageId": "en_US",
+	"fields": [
+		{
+			"dataType": "string",
+			"indexType": "keyword",
+			"label": {
+				"en_US": "TextFieldNameLabel",
+				"es_ES": "NombreEtiquetaDelCampoDeTexto"
+			},
+			"localizable": true,
+			"name": "MyText",
+			"predefinedValue": {
+				"en_US": "",
+				"es_ES": ""
+			},
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": "",
+				"es_ES": ""
+			},
+			"type": "text"
+		}
+	]
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/LocalizedMapUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/LocalizedMapUtil.java
@@ -38,7 +38,7 @@ public class LocalizedMapUtil {
 		for (Map.Entry<Locale, String> entry : localizedMap.entrySet()) {
 			Locale locale = entry.getKey();
 
-			i18nMap.put(locale.toLanguageTag(), entry.getValue());
+			i18nMap.put(LocaleUtil.toBCP47LanguageId(locale), entry.getValue());
 		}
 
 		return i18nMap;


### PR DESCRIPTION
Tried to keep ContentField value embedded as we talked as first option but it got really complicated. Jackson doesn't know how to parse the localized values and starts making maps of maps of maps...

I went with option 2 giving a more meaningful name to the extracted schema, ContentFieldValue, and keeping the value name property to prevent a breaking change.

https://gist.github.com/brianchandotcom/8682e8c8462406910dc29150ad737349
