### PR TITLE
LPS-100538 portal-search-elasticsearch7-impl: Realize the test case for Elasticsearch 6 and extractlogic from ES engine test to the fixture we need.

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchSearchEngineFixture.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchSearchEngineFixture.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal;
+
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.search.SearchEngine;
+import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchConnectionManager;
+import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.OperationMode;
+import com.liferay.portal.search.elasticsearch6.internal.index.CompanyIdIndexNameBuilder;
+import com.liferay.portal.search.elasticsearch6.internal.index.CompanyIndexFactory;
+import com.liferay.portal.search.elasticsearch6.internal.search.engine.adapter.ElasticsearchEngineAdapterFixture;
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.index.IndexNameBuilder;
+import com.liferay.portal.search.test.util.search.engine.SearchEngineFixture;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class ElasticsearchSearchEngineFixture implements SearchEngineFixture {
+
+	public ElasticsearchSearchEngineFixture(String tmpDir) {
+		_tmpDir = tmpDir;
+	}
+
+	public ElasticsearchConnectionManager getElasticsearchConnectionManager() {
+		return _elasticsearchConnectionManager;
+	}
+
+	public ElasticsearchFixture getElasticsearchFixture() {
+		return _elasticsearchFixture;
+	}
+
+	public ElasticsearchSearchEngine getElasticsearchSearchEngine() {
+		return _elasticsearchSearchEngine;
+	}
+
+	@Override
+	public IndexNameBuilder getIndexNameBuilder() {
+		return _indexNameBuilder;
+	}
+
+	@Override
+	public SearchEngine getSearchEngine() {
+		return _elasticsearchSearchEngine;
+	}
+
+	@Override
+	public void setUp() throws Exception {
+		setUpElasticsearchFixture();
+
+		setUpIndexNameBuilder();
+
+		setUpElasticsearchConnnectionManager();
+
+		setUpSearchEngineAdapter();
+
+		setUpElasticsearchSearchEngine();
+	}
+
+	@Override
+	public void tearDown() throws Exception {
+		_elasticsearchFixture.tearDown();
+	}
+
+	protected CompanyIndexFactory createCompanyIndexFactory() {
+		return new CompanyIndexFactory() {
+			{
+				indexNameBuilder = _indexNameBuilder;
+				jsonFactory = new JSONFactoryImpl();
+			}
+		};
+	}
+
+	protected void setUpElasticsearchConnnectionManager() {
+		_elasticsearchConnectionManager = new ElasticsearchConnectionManager();
+
+		_elasticsearchConnectionManager.setEmbeddedElasticsearchConnection(
+			_elasticsearchFixture.getEmbeddedElasticsearchConnection());
+
+		_elasticsearchConnectionManager.activate(OperationMode.EMBEDDED);
+	}
+
+	protected void setUpElasticsearchFixture() throws Exception {
+		_elasticsearchFixture = new ElasticsearchFixture(_tmpDir);
+
+		_elasticsearchFixture.setUp();
+	}
+
+	protected void setUpElasticsearchSearchEngine() {
+		_elasticsearchSearchEngine = new ElasticsearchSearchEngine() {
+			{
+				setIndexFactory(createCompanyIndexFactory());
+				setIndexNameBuilder(String::valueOf);
+				setElasticsearchConnectionManager(
+					_elasticsearchConnectionManager);
+				setSearchEngineAdapter(_searchEngineAdapter);
+			}
+		};
+	}
+
+	protected void setUpIndexNameBuilder() {
+		_indexNameBuilder = new CompanyIdIndexNameBuilder() {
+			{
+				setIndexNamePrefix(null);
+			}
+		};
+	}
+
+	protected void setUpSearchEngineAdapter() {
+		ElasticsearchEngineAdapterFixture elasticsearchEngineAdapterFixture =
+			new ElasticsearchEngineAdapterFixture() {
+				{
+					setElasticsearchClientResolver(_elasticsearchFixture);
+				}
+			};
+
+		elasticsearchEngineAdapterFixture.setUp();
+
+		_searchEngineAdapter =
+			elasticsearchEngineAdapterFixture.getSearchEngineAdapter();
+	}
+
+	private ElasticsearchConnectionManager _elasticsearchConnectionManager;
+	private ElasticsearchFixture _elasticsearchFixture;
+	private ElasticsearchSearchEngine _elasticsearchSearchEngine;
+	private IndexNameBuilder _indexNameBuilder;
+	private SearchEngineAdapter _searchEngineAdapter;
+	private final String _tmpDir;
+
+}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutorTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutorTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.background.task;
+
+import com.liferay.portal.search.elasticsearch6.internal.ElasticsearchSearchEngineFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch6.internal.index.FieldMappingAssert;
+import com.liferay.portal.search.elasticsearch6.internal.index.LiferayTypeMappingsConstants;
+import com.liferay.portal.search.test.util.background.task.BaseReindexSingleIndexerBackgroundTaskExecutorTestCase;
+import com.liferay.portal.search.test.util.search.engine.SearchEngineFixture;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class ReindexSingleIndexerBackgroundTaskExecutorTest
+	extends BaseReindexSingleIndexerBackgroundTaskExecutorTestCase {
+
+	@Override
+	protected void assertFieldType(String fieldName, String fieldType)
+		throws Exception {
+
+		ElasticsearchFixture elasticsearchFixture =
+			_elasticsearchSearchEngineFixture.getElasticsearchFixture();
+
+		FieldMappingAssert.assertType(
+			fieldType, fieldName,
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE, getIndexName(),
+			elasticsearchFixture.getIndicesAdminClient());
+	}
+
+	@Override
+	protected SearchEngineFixture getSearchEngineFixture() {
+		_elasticsearchSearchEngineFixture =
+			new ElasticsearchSearchEngineFixture(
+				ReindexSingleIndexerBackgroundTaskExecutorTest.class.
+					getSimpleName());
+
+		return _elasticsearchSearchEngineFixture;
+	}
+
+	private ElasticsearchSearchEngineFixture _elasticsearchSearchEngineFixture;
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchSearchEngineFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchSearchEngineFixture.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal;
+
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.search.SearchEngine;
+import com.liferay.portal.search.ccr.CrossClusterReplicationHelper;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionManager;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch7.internal.connection.OperationMode;
+import com.liferay.portal.search.elasticsearch7.internal.index.CompanyIdIndexNameBuilder;
+import com.liferay.portal.search.elasticsearch7.internal.index.CompanyIndexFactory;
+import com.liferay.portal.search.elasticsearch7.internal.search.engine.adapter.ElasticsearchEngineAdapterFixture;
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.index.IndexNameBuilder;
+import com.liferay.portal.search.test.util.search.engine.SearchEngineFixture;
+
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.SnapshotClient;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class ElasticsearchSearchEngineFixture implements SearchEngineFixture {
+
+	public ElasticsearchSearchEngineFixture(String tmpDir) {
+		_tmpDir = tmpDir;
+	}
+
+	public ElasticsearchConnectionManager getElasticsearchConnectionManager() {
+		return _elasticsearchConnectionManager;
+	}
+
+	public ElasticsearchFixture getElasticsearchFixture() {
+		return _elasticsearchFixture;
+	}
+
+	public ElasticsearchSearchEngine getElasticsearchSearchEngine() {
+		return _elasticsearchSearchEngine;
+	}
+
+	@Override
+	public IndexNameBuilder getIndexNameBuilder() {
+		return _indexNameBuilder;
+	}
+
+	@Override
+	public SearchEngine getSearchEngine() {
+		return getElasticsearchSearchEngine();
+	}
+
+	public SnapshotClient getSnapshotClient() {
+		RestHighLevelClient restHighLevelClient =
+			_elasticsearchConnectionManager.getRestHighLevelClient();
+
+		return restHighLevelClient.snapshot();
+	}
+
+	@Override
+	public void setUp() throws Exception {
+		setUpElasticsearchFixture();
+
+		setUpIndexNameBuilder();
+
+		setUpElasticsearchConnnectionManager();
+
+		setUpSearchEngineAdapter();
+
+		setUpElasticsearchSearchEngine();
+	}
+
+	@Override
+	public void tearDown() throws Exception {
+		_elasticsearchFixture.tearDown();
+	}
+
+	protected static CrossClusterReplicationHelper
+		createCrossClusterReplicationHelper() {
+
+		return new CrossClusterReplicationHelper() {
+
+			@Override
+			public void follow(String indexName) {
+			}
+
+			@Override
+			public void unfollow(String indexName) {
+			}
+
+		};
+	}
+
+	protected CompanyIndexFactory createCompanyIndexFactory() {
+		return new CompanyIndexFactory() {
+			{
+				indexNameBuilder = _indexNameBuilder;
+				jsonFactory = new JSONFactoryImpl();
+			}
+		};
+	}
+
+	protected void setUpElasticsearchConnnectionManager() {
+		_elasticsearchConnectionManager = new ElasticsearchConnectionManager();
+
+		_elasticsearchConnectionManager.setEmbeddedElasticsearchConnection(
+			_elasticsearchFixture.getEmbeddedElasticsearchConnection());
+
+		_elasticsearchConnectionManager.setOperationMode(
+			OperationMode.EMBEDDED);
+	}
+
+	protected void setUpElasticsearchFixture() throws Exception {
+		_elasticsearchFixture = new ElasticsearchFixture(_tmpDir);
+
+		_elasticsearchFixture.setUp();
+	}
+
+	protected void setUpElasticsearchSearchEngine() {
+		_elasticsearchSearchEngine = new ElasticsearchSearchEngine() {
+			{
+				setCrossClusterReplicationHelper(
+					createCrossClusterReplicationHelper());
+				setIndexFactory(createCompanyIndexFactory());
+				setIndexNameBuilder(String::valueOf);
+				setElasticsearchConnectionManager(
+					_elasticsearchConnectionManager);
+				setSearchEngineAdapter(_searchEngineAdapter);
+			}
+		};
+	}
+
+	protected void setUpIndexNameBuilder() {
+		_indexNameBuilder = new CompanyIdIndexNameBuilder() {
+			{
+				setIndexNamePrefix(null);
+			}
+		};
+	}
+
+	protected void setUpSearchEngineAdapter() {
+		ElasticsearchEngineAdapterFixture elasticsearchEngineAdapterFixture =
+			new ElasticsearchEngineAdapterFixture() {
+				{
+					setElasticsearchClientResolver(_elasticsearchFixture);
+				}
+			};
+
+		elasticsearchEngineAdapterFixture.setUp();
+
+		_searchEngineAdapter =
+			elasticsearchEngineAdapterFixture.getSearchEngineAdapter();
+	}
+
+	private ElasticsearchConnectionManager _elasticsearchConnectionManager;
+	private ElasticsearchFixture _elasticsearchFixture;
+	private ElasticsearchSearchEngine _elasticsearchSearchEngine;
+	private IndexNameBuilder _indexNameBuilder;
+	private SearchEngineAdapter _searchEngineAdapter;
+	private final String _tmpDir;
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchSearchEngineTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchSearchEngineTest.java
@@ -14,20 +14,10 @@
 
 package com.liferay.portal.search.elasticsearch7.internal;
 
-import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.search.ccr.CrossClusterReplicationHelper;
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnection;
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionManager;
-import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
-import com.liferay.portal.search.elasticsearch7.internal.connection.EmbeddedElasticsearchConnection;
-import com.liferay.portal.search.elasticsearch7.internal.connection.OperationMode;
-import com.liferay.portal.search.elasticsearch7.internal.index.CompanyIdIndexNameBuilder;
-import com.liferay.portal.search.elasticsearch7.internal.index.CompanyIndexFactory;
-import com.liferay.portal.search.elasticsearch7.internal.search.engine.adapter.ElasticsearchEngineAdapterFixture;
-import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
-import com.liferay.portal.search.index.IndexNameBuilder;
 
 import java.io.IOException;
 
@@ -38,13 +28,11 @@ import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotReq
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.SnapshotClient;
 import org.elasticsearch.snapshots.SnapshotInfo;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -55,43 +43,22 @@ public class ElasticsearchSearchEngineTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		_elasticsearchFixture = new ElasticsearchFixture(
-			ElasticsearchSearchEngineTest.class.getSimpleName());
+		_elasticsearchSearchEngineFixture =
+			new ElasticsearchSearchEngineFixture(
+				ElasticsearchSearchEngineTest.class.getSimpleName());
 
-		_elasticsearchFixture.setUp();
+		_elasticsearchSearchEngineFixture.setUp();
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		_elasticsearchFixture.tearDown();
-	}
-
-	@Before
-	public void setUp() throws Exception {
-		_elasticsearchConnectionManager = createElasticsearchConnectionManager(
-			_elasticsearchFixture.getEmbeddedElasticsearchConnection());
-
-		_elasticsearchConnectionManager.setOperationMode(
-			OperationMode.EMBEDDED);
-
-		ElasticsearchEngineAdapterFixture elasticsearchEngineAdapterFixture =
-			new ElasticsearchEngineAdapterFixture() {
-				{
-					setElasticsearchClientResolver(_elasticsearchFixture);
-				}
-			};
-
-		elasticsearchEngineAdapterFixture.setUp();
-
-		_searchEngineAdapter =
-			elasticsearchEngineAdapterFixture.getSearchEngineAdapter();
+		_elasticsearchSearchEngineFixture.tearDown();
 	}
 
 	@Test
 	public void testBackup() throws SearchException {
 		ElasticsearchSearchEngine elasticsearchSearchEngine =
-			createElasticsearchSearchEngine(
-				_elasticsearchConnectionManager, _searchEngineAdapter);
+			_elasticsearchSearchEngineFixture.getElasticsearchSearchEngine();
 
 		long companyId = RandomTestUtil.randomLong();
 
@@ -112,14 +79,15 @@ public class ElasticsearchSearchEngineTest {
 	@Test
 	public void testInitializeAfterReconnect() {
 		ElasticsearchSearchEngine elasticsearchSearchEngine =
-			createElasticsearchSearchEngine(
-				_elasticsearchConnectionManager, _searchEngineAdapter);
+			_elasticsearchSearchEngineFixture.getElasticsearchSearchEngine();
 
 		long companyId = RandomTestUtil.randomLong();
 
 		elasticsearchSearchEngine.initialize(companyId);
 
-		reconnect(_elasticsearchConnectionManager);
+		reconnect(
+			_elasticsearchSearchEngineFixture.
+				getElasticsearchConnectionManager());
 
 		elasticsearchSearchEngine.initialize(companyId);
 	}
@@ -127,8 +95,7 @@ public class ElasticsearchSearchEngineTest {
 	@Test
 	public void testRestore() throws SearchException {
 		ElasticsearchSearchEngine elasticsearchSearchEngine =
-			createElasticsearchSearchEngine(
-				_elasticsearchConnectionManager, _searchEngineAdapter);
+			_elasticsearchSearchEngineFixture.getElasticsearchSearchEngine();
 
 		long companyId = RandomTestUtil.randomLong();
 
@@ -144,69 +111,6 @@ public class ElasticsearchSearchEngineTest {
 		deleteSnapshot("liferay_backup", "restore_test");
 	}
 
-	protected static CompanyIndexFactory createCompanyIndexFactory() {
-		return new CompanyIndexFactory() {
-			{
-				indexNameBuilder = createIndexNameBuilder();
-				jsonFactory = new JSONFactoryImpl();
-			}
-		};
-	}
-
-	protected static CrossClusterReplicationHelper
-		createCrossClusterReplicationHelper() {
-
-		return new CrossClusterReplicationHelper() {
-
-			@Override
-			public void follow(String indexName) {
-			}
-
-			@Override
-			public void unfollow(String indexName) {
-			}
-
-		};
-	}
-
-	protected static IndexNameBuilder createIndexNameBuilder() {
-		return new CompanyIdIndexNameBuilder() {
-			{
-				setIndexNamePrefix(null);
-			}
-		};
-	}
-
-	protected ElasticsearchConnectionManager
-		createElasticsearchConnectionManager(
-			EmbeddedElasticsearchConnection embeddedElasticsearchConnection) {
-
-		ElasticsearchConnectionManager elasticsearchConnectionManager =
-			new ElasticsearchConnectionManager();
-
-		elasticsearchConnectionManager.setEmbeddedElasticsearchConnection(
-			embeddedElasticsearchConnection);
-
-		return elasticsearchConnectionManager;
-	}
-
-	protected ElasticsearchSearchEngine createElasticsearchSearchEngine(
-		final ElasticsearchConnectionManager elasticsearchConnectionManager,
-		final SearchEngineAdapter searchEngineAdapter) {
-
-		return new ElasticsearchSearchEngine() {
-			{
-				setCrossClusterReplicationHelper(
-					createCrossClusterReplicationHelper());
-				setIndexFactory(createCompanyIndexFactory());
-				setIndexNameBuilder(String::valueOf);
-				setElasticsearchConnectionManager(
-					elasticsearchConnectionManager);
-				setSearchEngineAdapter(searchEngineAdapter);
-			}
-		};
-	}
-
 	protected void createSnapshot(
 		String repositoryName, String snapshotName, boolean waitForCompletion,
 		String... indexNames) {
@@ -217,10 +121,8 @@ public class ElasticsearchSearchEngineTest {
 		createSnapshotRequest.indices(indexNames);
 		createSnapshotRequest.waitForCompletion(waitForCompletion);
 
-		RestHighLevelClient restHighLevelClient =
-			_elasticsearchConnectionManager.getRestHighLevelClient();
-
-		SnapshotClient snapshotClient = restHighLevelClient.snapshot();
+		SnapshotClient snapshotClient =
+			_elasticsearchSearchEngineFixture.getSnapshotClient();
 
 		try {
 			snapshotClient.create(
@@ -235,10 +137,8 @@ public class ElasticsearchSearchEngineTest {
 		DeleteSnapshotRequest deleteSnapshotRequest = new DeleteSnapshotRequest(
 			repository, snapshot);
 
-		RestHighLevelClient restHighLevelClient =
-			_elasticsearchConnectionManager.getRestHighLevelClient();
-
-		SnapshotClient snapshotClient = restHighLevelClient.snapshot();
+		SnapshotClient snapshotClient =
+			_elasticsearchSearchEngineFixture.getSnapshotClient();
 
 		try {
 			snapshotClient.delete(
@@ -258,10 +158,8 @@ public class ElasticsearchSearchEngineTest {
 		getSnapshotsRequest.repository(repository);
 		getSnapshotsRequest.snapshots(snapshots);
 
-		RestHighLevelClient restHighLevelClient =
-			_elasticsearchConnectionManager.getRestHighLevelClient();
-
-		SnapshotClient snapshotClient = restHighLevelClient.snapshot();
+		SnapshotClient snapshotClient =
+			_elasticsearchSearchEngineFixture.getSnapshotClient();
 
 		try {
 			return snapshotClient.get(
@@ -283,9 +181,7 @@ public class ElasticsearchSearchEngineTest {
 		elasticsearchConnection.connect();
 	}
 
-	private static ElasticsearchFixture _elasticsearchFixture;
-
-	private ElasticsearchConnectionManager _elasticsearchConnectionManager;
-	private SearchEngineAdapter _searchEngineAdapter;
+	private static ElasticsearchSearchEngineFixture
+		_elasticsearchSearchEngineFixture;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutorTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.background.task;
+
+import com.liferay.portal.search.elasticsearch7.internal.ElasticsearchSearchEngineFixture;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch7.internal.index.FieldMappingAssert;
+import com.liferay.portal.search.elasticsearch7.internal.index.LiferayTypeMappingsConstants;
+import com.liferay.portal.search.test.util.background.task.BaseReindexSingleIndexerBackgroundTaskExecutorTestCase;
+
+import org.elasticsearch.client.RestHighLevelClient;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class ReindexSingleIndexerBackgroundTaskExecutorTest
+	extends BaseReindexSingleIndexerBackgroundTaskExecutorTestCase {
+
+	@Override
+	protected void assertFieldType(String fieldName, String fieldType)
+		throws Exception {
+
+		ElasticsearchFixture elasticsearchFixture =
+			_elasticsearchSearchEngineFixture.getElasticsearchFixture();
+
+		RestHighLevelClient restHighLevelClient =
+			elasticsearchFixture.getRestHighLevelClient();
+
+		FieldMappingAssert.assertType(
+			fieldType, fieldName,
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE, getIndexName(),
+			restHighLevelClient.indices());
+	}
+
+	protected RestHighLevelClient getRestHighLevelClient() {
+		ElasticsearchFixture elasticsearchFixture =
+			_elasticsearchSearchEngineFixture.getElasticsearchFixture();
+
+		return elasticsearchFixture.getRestHighLevelClient();
+	}
+
+	@Override
+	protected ElasticsearchSearchEngineFixture getSearchEngineFixture() {
+		_elasticsearchSearchEngineFixture =
+			new ElasticsearchSearchEngineFixture(
+				ReindexSingleIndexerBackgroundTaskExecutorTest.class.
+					getSimpleName());
+
+		return _elasticsearchSearchEngineFixture;
+	}
+
+	private ElasticsearchSearchEngineFixture _elasticsearchSearchEngineFixture;
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/background/task/BaseReindexSingleIndexerBackgroundTaskExecutorTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/background/task/BaseReindexSingleIndexerBackgroundTaskExecutorTestCase.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.background.task;
+
+import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.IndexWriterHelper;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.search.background.task.ReindexBackgroundTaskConstants;
+import com.liferay.portal.kernel.search.background.task.ReindexStatusMessageSender;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.search.index.IndexNameBuilder;
+import com.liferay.portal.search.internal.SearchEngineHelperImpl;
+import com.liferay.portal.search.internal.background.task.ReindexSingleIndexerBackgroundTaskExecutor;
+import com.liferay.portal.search.test.util.search.engine.SearchEngineFixture;
+
+import java.io.Serializable;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Adam Brandizzi
+ */
+public abstract class BaseReindexSingleIndexerBackgroundTaskExecutorTestCase {
+
+	@Before
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
+
+		_companyId = RandomTestUtil.randomLong();
+
+		setUpIndexerRegistry();
+
+		setUpBackgroundTask();
+
+		setUpSearchEngineFixture();
+
+		setUpSearchEngineHelper();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		searchEngineFixture.tearDown();
+	}
+
+	@Test
+	public void testFieldMappings() throws Exception {
+		ReindexSingleIndexerBackgroundTaskExecutor
+			reindexSingleIndexerBackgroundTaskExecutor =
+				getReindexSingleIndexerBackgroundTaskExecutor();
+
+		reindexSingleIndexerBackgroundTaskExecutor.execute(_backgroundTask);
+
+		assertFieldType(Field.ENTRY_CLASS_NAME, "keyword");
+	}
+
+	protected abstract void assertFieldType(String fieldName, String fieldType)
+		throws Exception;
+
+	protected String getIndexName() {
+		IndexNameBuilder indexNameBuilder =
+			searchEngineFixture.getIndexNameBuilder();
+
+		return indexNameBuilder.getIndexName(_companyId);
+	}
+
+	protected ReindexSingleIndexerBackgroundTaskExecutor
+		getReindexSingleIndexerBackgroundTaskExecutor() {
+
+		return new ReindexSingleIndexerBackgroundTaskExecutor() {
+			{
+				indexerRegistry = _indexerRegistry;
+				indexWriterHelper = _indexWriterHelper;
+				reindexStatusMessageSender = _reindexStatusMessageSender;
+				searchEngineHelper = _searchEngineHelper;
+			}
+		};
+	}
+
+	protected abstract SearchEngineFixture getSearchEngineFixture();
+
+	protected void setUpBackgroundTask() {
+		Mockito.when(
+			_backgroundTask.getTaskContextMap()
+		).thenReturn(
+			HashMapBuilder.<String, Serializable>put(
+				ReindexBackgroundTaskConstants.CLASS_NAME,
+				RandomTestUtil.randomString()
+			).put(
+				ReindexBackgroundTaskConstants.COMPANY_IDS,
+				new long[] {_companyId}
+			).build()
+		);
+	}
+
+	protected void setUpIndexerRegistry() {
+		Mockito.when(
+			_indexerRegistry.getIndexer(Matchers.anyString())
+		).thenReturn(
+			_indexer
+		);
+	}
+
+	protected void setUpSearchEngineFixture() throws Exception {
+		searchEngineFixture = getSearchEngineFixture();
+
+		searchEngineFixture.setUp();
+	}
+
+	protected void setUpSearchEngineHelper() {
+		_searchEngineHelper = new SearchEngineHelperImpl();
+
+		_searchEngineHelper.setSearchEngine(
+			"test", searchEngineFixture.getSearchEngine());
+	}
+
+	protected SearchEngineFixture searchEngineFixture;
+
+	@Mock
+	private BackgroundTask _backgroundTask;
+
+	private long _companyId;
+
+	@Mock
+	private Indexer<Object> _indexer;
+
+	@Mock
+	private IndexerRegistry _indexerRegistry;
+
+	@Mock
+	private IndexWriterHelper _indexWriterHelper;
+
+	@Mock
+	private ReindexStatusMessageSender _reindexStatusMessageSender;
+
+	private SearchEngineHelper _searchEngineHelper;
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/search/engine/SearchEngineFixture.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/search/engine/SearchEngineFixture.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.search.engine;
+
+import com.liferay.portal.kernel.search.SearchEngine;
+import com.liferay.portal.search.index.IndexNameBuilder;
+
+/**
+ * @author Adam Brandizzi
+ */
+public interface SearchEngineFixture {
+
+	public IndexNameBuilder getIndexNameBuilder();
+
+	public SearchEngine getSearchEngine();
+
+	public void setUp() throws Exception;
+
+	public void tearDown() throws Exception;
+
+}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/BackgroundTaskExecutorConfigurator.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/BackgroundTaskExecutorConfigurator.java
@@ -44,11 +44,8 @@ public class BackgroundTaskExecutorConfigurator {
 		registerBackgroundTaskExecutor(
 			bundleContext, reindexPortalBackgroundTaskExecutor);
 
-		BackgroundTaskExecutor reindexSingleIndexerBackgroundTaskExecutor =
-			new ReindexSingleIndexerBackgroundTaskExecutor();
-
 		registerBackgroundTaskExecutor(
-			bundleContext, reindexSingleIndexerBackgroundTaskExecutor);
+			bundleContext, _reindexSingleIndexerBackgroundTaskExecutor);
 	}
 
 	@Deactivate
@@ -80,6 +77,10 @@ public class BackgroundTaskExecutorConfigurator {
 
 	@Reference
 	private PortalExecutorManager _portalExecutorManager;
+
+	@Reference
+	private ReindexSingleIndexerBackgroundTaskExecutor
+		_reindexSingleIndexerBackgroundTaskExecutor;
 
 	private final Set<ServiceRegistration<BackgroundTaskExecutor>>
 		_serviceRegistrations = new HashSet<>();

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutor.java
@@ -19,14 +19,13 @@ import com.liferay.portal.kernel.backgroundtask.BackgroundTaskConstants;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.search.IndexWriterHelperUtil;
+import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.search.Indexer;
-import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchEngine;
 import com.liferay.portal.kernel.search.SearchEngineHelper;
-import com.liferay.portal.kernel.search.SearchEngineHelperUtil;
 import com.liferay.portal.kernel.search.background.task.ReindexBackgroundTaskConstants;
-import com.liferay.portal.kernel.search.background.task.ReindexStatusMessageSenderUtil;
+import com.liferay.portal.kernel.search.background.task.ReindexStatusMessageSender;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
@@ -34,9 +33,20 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Andrew Betts
  */
+@Component(
+	immediate = true,
+	property = "background.task.executor.class.name=com.liferay.portal.search.internal.background.task.ReindexSingleIndexerBackgroundTaskExecutor",
+	service = {
+		BackgroundTaskExecutor.class,
+		ReindexSingleIndexerBackgroundTaskExecutor.class
+	}
+)
 public class ReindexSingleIndexerBackgroundTaskExecutor
 	extends ReindexBackgroundTaskExecutor {
 
@@ -46,7 +56,7 @@ public class ReindexSingleIndexerBackgroundTaskExecutor
 
 	@Override
 	public BackgroundTaskExecutor clone() {
-		return new ReindexSingleIndexerBackgroundTaskExecutor();
+		return this;
 	}
 
 	@Override
@@ -67,20 +77,17 @@ public class ReindexSingleIndexerBackgroundTaskExecutor
 	protected void reindex(String className, long[] companyIds)
 		throws Exception {
 
-		Indexer<?> indexer = IndexerRegistryUtil.getIndexer(className);
+		Indexer<?> indexer = indexerRegistry.getIndexer(className);
 
 		if (indexer == null) {
 			return;
 		}
 
-		SearchEngineHelper searchEngineHelper =
-			SearchEngineHelperUtil.getSearchEngineHelper();
-
 		Collection<SearchEngine> searchEngines =
 			searchEngineHelper.getSearchEngines();
 
 		for (long companyId : companyIds) {
-			ReindexStatusMessageSenderUtil.sendStatusMessage(
+			reindexStatusMessageSender.sendStatusMessage(
 				ReindexBackgroundTaskConstants.SINGLE_START, companyId,
 				companyIds);
 
@@ -89,7 +96,7 @@ public class ReindexSingleIndexerBackgroundTaskExecutor
 					searchEngine.initialize(companyId);
 				}
 
-				IndexWriterHelperUtil.deleteEntityDocuments(
+				indexWriterHelper.deleteEntityDocuments(
 					indexer.getSearchEngineId(), companyId, className, true);
 
 				indexer.reindex(new String[] {String.valueOf(companyId)});
@@ -98,12 +105,24 @@ public class ReindexSingleIndexerBackgroundTaskExecutor
 				_log.error(exception, exception);
 			}
 			finally {
-				ReindexStatusMessageSenderUtil.sendStatusMessage(
+				reindexStatusMessageSender.sendStatusMessage(
 					ReindexBackgroundTaskConstants.SINGLE_END, companyId,
 					companyIds);
 			}
 		}
 	}
+
+	@Reference
+	protected IndexerRegistry indexerRegistry;
+
+	@Reference
+	protected IndexWriterHelper indexWriterHelper;
+
+	@Reference
+	protected ReindexStatusMessageSender reindexStatusMessageSender;
+
+	@Reference
+	protected SearchEngineHelper searchEngineHelper;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ReindexSingleIndexerBackgroundTaskExecutor.class);

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutor.java
@@ -22,12 +22,16 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.IndexWriterHelperUtil;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.SearchEngine;
+import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.search.SearchEngineHelperUtil;
 import com.liferay.portal.kernel.search.background.task.ReindexBackgroundTaskConstants;
 import com.liferay.portal.kernel.search.background.task.ReindexStatusMessageSenderUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -69,12 +73,22 @@ public class ReindexSingleIndexerBackgroundTaskExecutor
 			return;
 		}
 
+		SearchEngineHelper searchEngineHelper =
+			SearchEngineHelperUtil.getSearchEngineHelper();
+
+		Collection<SearchEngine> searchEngines =
+			searchEngineHelper.getSearchEngines();
+
 		for (long companyId : companyIds) {
 			ReindexStatusMessageSenderUtil.sendStatusMessage(
 				ReindexBackgroundTaskConstants.SINGLE_START, companyId,
 				companyIds);
 
 			try {
+				for (SearchEngine searchEngine : searchEngines) {
+					searchEngine.initialize(companyId);
+				}
+
 				IndexWriterHelperUtil.deleteEntityDocuments(
 					indexer.getSearchEngineId(), companyId, className, true);
 


### PR DESCRIPTION
<h3><g-emoji class="g-emoji" alias="x" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/274c.png"><img class="emoji" alt="x" src="https://github.githubassets.com/images/icons/emoji/unicode/274c.png" width="20" height="20"></g-emoji> ci:test:search - 57 out of 63 jobs passed in 2 hours 11 minutes 46 seconds 581 ms</h3>

https://github.com/brandizzi/liferay-portal/pull/993#issuecomment-601496195

Unique failures are known flaky tests.

Author: @jorgediaz-lr
Reviewer: @brandizz

https://issues.liferay.com/browse/LPS-100538