### PR TITLE
LPS-110730 (app.bnd) Set restart-required to "false" for Learning to Rank and Elasticsearch 7 (restore LPS-103843 that has been reverted by an Auto SF)

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/app.bnd
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd
@@ -9,7 +9,7 @@ Liferay-Releng-Labs: false
 Liferay-Releng-Marketplace: true
 Liferay-Releng-Portal-Required: false
 Liferay-Releng-Public: ${liferay.releng.public}
-Liferay-Releng-Restart-Required: true
+Liferay-Releng-Restart-Required: false
 Liferay-Releng-Suite:
 Liferay-Releng-Support-Url: http://www.liferay.com
 Liferay-Releng-Supported: ${liferay.releng.supported}

--- a/modules/apps/portal-search-elasticsearch7/source-formatter-suppressions.xml
+++ b/modules/apps/portal-search-elasticsearch7/source-formatter-suppressions.xml
@@ -2,6 +2,7 @@
 
 <suppressions>
 	<source-check>
+		<suppress checks="BNDBundleCheck" files="app\.bnd" />
 		<suppress checks="JavaComponentActivateCheck" files="portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/IndexSynchronizationPortalInitializedListener\.java" />
 	</source-check>
 </suppressions>

--- a/modules/dxp/apps/portal-search-learning-to-rank/app.bnd
+++ b/modules/dxp/apps/portal-search-learning-to-rank/app.bnd
@@ -9,7 +9,7 @@ Liferay-Releng-Labs: false
 Liferay-Releng-Marketplace: true
 Liferay-Releng-Portal-Required: false
 Liferay-Releng-Public: ${liferay.releng.public}
-Liferay-Releng-Restart-Required: true
+Liferay-Releng-Restart-Required: false
 Liferay-Releng-Suite:
 Liferay-Releng-Support-Url: http://www.liferay.com
 Liferay-Releng-Supported: ${liferay.releng.supported}

--- a/modules/dxp/apps/portal-search-learning-to-rank/source-formatter-suppressions.xml
+++ b/modules/dxp/apps/portal-search-learning-to-rank/source-formatter-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<suppressions>
+	<source-check>
+		<suppress checks="BNDBundleCheck" files="app\.bnd" />
+	</source-check>
+</suppressions>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-110730

Hey Brian,

We have already done this before the initial app releases back in October 2019 on https://issues.liferay.com/browse/LPS-103843, though looks like later it got reverted back to "true" by an auto-sf. (This revert also caused the CE ES7 connector to be released with true.)

I'm restoring the intended state in the PR. Feel free to auto-backport it to 7.2.x too, otherwise I'll send a backport PR.

Thanks,
Tibor

/cc @xbrianlee 