### PR TITLE
LPS-110730 (app.bnd) Set restart-required to "false" for Learning to Rank and Elasticsearch 7

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/app.bnd
+++ b/modules/apps/portal-search-elasticsearch7/app.bnd
@@ -9,7 +9,7 @@ Liferay-Releng-Labs: false
 Liferay-Releng-Marketplace: true
 Liferay-Releng-Portal-Required: false
 Liferay-Releng-Public: ${liferay.releng.public}
-Liferay-Releng-Restart-Required: true
+Liferay-Releng-Restart-Required: false
 Liferay-Releng-Suite:
 Liferay-Releng-Support-Url: http://www.liferay.com
 Liferay-Releng-Supported: ${liferay.releng.supported}

--- a/modules/dxp/apps/portal-search-learning-to-rank/app.bnd
+++ b/modules/dxp/apps/portal-search-learning-to-rank/app.bnd
@@ -9,7 +9,7 @@ Liferay-Releng-Labs: false
 Liferay-Releng-Marketplace: true
 Liferay-Releng-Portal-Required: false
 Liferay-Releng-Public: ${liferay.releng.public}
-Liferay-Releng-Restart-Required: true
+Liferay-Releng-Restart-Required: false
 Liferay-Releng-Suite:
 Liferay-Releng-Support-Url: http://www.liferay.com
 Liferay-Releng-Supported: ${liferay.releng.supported}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-110730

Follow-up to https://github.com/brianchandotcom/liferay-portal/pull/86677#issuecomment-602772395

:heavy_check_mark: Confirmed with @joshchong that we already have the tests here:
* [HotDeployElasticsearch7App](https://github.com/liferay/liferay-portal/blob/master/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase#L218)
* [HotDeployLearningToRankApp](https://github.com/liferay/liferay-portal/blob/master/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/Elasticsearch6EE.testcase#L684)