### PR TITLE
LPS-110601 DEFLAKE AssetPublisherExportImportTest

### DIFF
--- a/modules/apps/asset/asset-publisher-test/build.gradle
+++ b/modules/apps/asset/asset-publisher-test/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
+	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	testIntegrationCompile group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	testIntegrationCompile project(":apps:asset:asset-publisher-api")
 	testIntegrationCompile project(":apps:asset:asset-test-util")
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/lar/test/AssetPublisherExportImportTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/lar/test/AssetPublisherExportImportTest.java
@@ -19,8 +19,8 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.model.AssetVocabulary;
-import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
-import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
 import com.liferay.asset.publisher.test.util.AssetPublisherTestUtil;
@@ -30,16 +30,18 @@ import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationConstants;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
+import com.liferay.exportimport.kernel.controller.ExportImportController;
 import com.liferay.exportimport.kernel.lar.ExportImportHelperUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
-import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalServiceUtil;
-import com.liferay.exportimport.kernel.service.ExportImportLocalServiceUtil;
+import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalService;
+import com.liferay.exportimport.kernel.service.ExportImportLocalService;
 import com.liferay.exportimport.test.util.lar.BasePortletExportImportTestCase;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleConstants;
@@ -56,9 +58,9 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
-import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
-import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -71,7 +73,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.Inject;
@@ -131,8 +133,7 @@ public class AssetPublisherExportImportTest
 
 	@Test
 	public void testAnyDLFileEntryType() throws Exception {
-		long dlFileEntryClassNameId = PortalUtil.getClassNameId(
-			DLFileEntry.class);
+		long dlFileEntryClassNameId = _portal.getClassNameId(DLFileEntry.class);
 
 		Map<String, String[]> preferenceMap = HashMapBuilder.put(
 			"anyAssetType",
@@ -161,7 +162,7 @@ public class AssetPublisherExportImportTest
 
 	@Test
 	public void testAnyJournalStructure() throws Exception {
-		long journalArticleClassNameId = PortalUtil.getClassNameId(
+		long journalArticleClassNameId = _portal.getClassNameId(
 			JournalArticle.class);
 
 		Map<String, String[]> preferenceMap = HashMapBuilder.put(
@@ -216,7 +217,7 @@ public class AssetPublisherExportImportTest
 			assetCategory.getCategoryId(), importedAssetCategoryId);
 
 		AssetCategory importedAssetCategory =
-			AssetCategoryLocalServiceUtil.fetchAssetCategory(
+			_assetCategoryLocalService.fetchAssetCategory(
 				importedAssetCategoryId);
 
 		Assert.assertNotNull(importedAssetCategory);
@@ -248,7 +249,7 @@ public class AssetPublisherExportImportTest
 				portletPreferences.getValue("scopeIds", null));
 		}
 		finally {
-			GroupLocalServiceUtil.deleteGroup(childGroup);
+			_groupLocalService.deleteGroup(childGroup);
 		}
 	}
 
@@ -373,7 +374,7 @@ public class AssetPublisherExportImportTest
 		Map<String, String[]> preferenceMap = HashMapBuilder.put(
 			"anyAssetType",
 			new String[] {
-				String.valueOf(PortalUtil.getClassNameId(JournalArticle.class))
+				String.valueOf(_portal.getClassNameId(JournalArticle.class))
 			}
 		).put(
 			"classTypeIds",
@@ -423,7 +424,7 @@ public class AssetPublisherExportImportTest
 		Map<String, String[]> preferenceMap = HashMapBuilder.put(
 			"anyAssetType",
 			new String[] {
-				String.valueOf(PortalUtil.getClassNameId(DLFileEntry.class))
+				String.valueOf(_portal.getClassNameId(DLFileEntry.class))
 			}
 		).build();
 
@@ -462,7 +463,7 @@ public class AssetPublisherExportImportTest
 	public void testExportImportSeveralScopedAssetEntries() throws Exception {
 		List<Group> groups = new ArrayList<>();
 
-		Company company = CompanyLocalServiceUtil.getCompany(
+		Company company = _companyLocalService.getCompany(
 			layout.getCompanyId());
 
 		Group companyGroup = company.getGroup();
@@ -492,7 +493,7 @@ public class AssetPublisherExportImportTest
 
 	@Test
 	public void testGlobalScopeId() throws Exception {
-		Company company = CompanyLocalServiceUtil.getCompany(
+		Company company = _companyLocalService.getCompany(
 			layout.getCompanyId());
 
 		Group companyGroup = company.getGroup();
@@ -583,8 +584,7 @@ public class AssetPublisherExportImportTest
 			importedGroup.getGroupId(), importedDDMStructure.getStructureId(),
 			serviceContext);
 
-		long dlFileEntryClassNameId = PortalUtil.getClassNameId(
-			DLFileEntry.class);
+		long dlFileEntryClassNameId = _portal.getClassNameId(DLFileEntry.class);
 
 		Map<String, String[]> preferenceMap = HashMapBuilder.put(
 			"anyAssetType",
@@ -634,7 +634,7 @@ public class AssetPublisherExportImportTest
 			importedGroup.getGroupId(), JournalArticle.class.getName(), 0,
 			ddmStructure.getDDMForm(), LocaleUtil.getDefault(), serviceContext);
 
-		long journalArticleClassNameId = PortalUtil.getClassNameId(
+		long journalArticleClassNameId = _portal.getClassNameId(
 			JournalArticle.class);
 
 		Map<String, String[]> preferenceMap = HashMapBuilder.put(
@@ -721,7 +721,7 @@ public class AssetPublisherExportImportTest
 		Map<String, String[]> preferenceMap = HashMapBuilder.put(
 			"anyAssetType",
 			new String[] {
-				String.valueOf(PortalUtil.getClassNameId(DLFileEntry.class))
+				String.valueOf(_portal.getClassNameId(DLFileEntry.class))
 			}
 		).put(
 			"anyClassTypeDLFileEntryAssetRendererFactory",
@@ -773,7 +773,7 @@ public class AssetPublisherExportImportTest
 		Map<String, String[]> preferenceMap = HashMapBuilder.put(
 			"anyAssetType",
 			new String[] {
-				String.valueOf(PortalUtil.getClassNameId(JournalArticle.class))
+				String.valueOf(_portal.getClassNameId(JournalArticle.class))
 			}
 		).put(
 			"anyClassTypeJournalArticleAssetRendererFactory",
@@ -799,7 +799,7 @@ public class AssetPublisherExportImportTest
 
 	@Test
 	public void testSeveralLayoutScopeIds() throws Exception {
-		Company company = CompanyLocalServiceUtil.getCompany(
+		Company company = _companyLocalService.getCompany(
 			layout.getCompanyId());
 
 		Layout secondLayout = LayoutTestUtil.addLayout(group);
@@ -826,7 +826,7 @@ public class AssetPublisherExportImportTest
 			preferenceMap);
 
 		Layout importedSecondLayout =
-			LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
+			_layoutLocalService.fetchLayoutByUuidAndGroupId(
 				secondLayout.getUuid(), importedGroup.getGroupId(),
 				importedLayout.isPrivateLayout());
 
@@ -870,7 +870,7 @@ public class AssetPublisherExportImportTest
 			preferenceMap);
 
 		Layout importedSecondLayout =
-			LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
+			_layoutLocalService.fetchLayoutByUuidAndGroupId(
 				secondLayout.getUuid(), importedGroup.getGroupId(),
 				importedLayout.isPrivateLayout());
 
@@ -919,7 +919,7 @@ public class AssetPublisherExportImportTest
 			long groupId, long ddmStructureId, ServiceContext serviceContext)
 		throws Exception {
 
-		return DLFileEntryTypeLocalServiceUtil.addFileEntryType(
+		return _dlFileEntryTypeLocalService.addFileEntryType(
 			serviceContext.getUserId(), groupId, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), new long[] {ddmStructureId},
 			serviceContext);
@@ -955,7 +955,7 @@ public class AssetPublisherExportImportTest
 
 	@Override
 	protected void exportImportPortlet(String portletId) throws Exception {
-		List<Layout> layouts = LayoutLocalServiceUtil.getLayouts(
+		List<Layout> layouts = _layoutLocalService.getLayouts(
 			layout.getGroupId(), layout.isPrivateLayout());
 
 		User user = TestPropsValues.getUser();
@@ -968,13 +968,13 @@ public class AssetPublisherExportImportTest
 					getExportParameterMap());
 
 		ExportImportConfiguration exportConfiguration =
-			ExportImportConfigurationLocalServiceUtil.
+			_exportImportConfigurationLocalService.
 				addDraftExportImportConfiguration(
 					user.getUserId(),
 					ExportImportConfigurationConstants.TYPE_EXPORT_LAYOUT,
 					exportLayoutSettingsMap);
 
-		larFile = ExportImportLocalServiceUtil.exportLayoutsAsFile(
+		larFile = _exportImportLocalService.exportLayoutsAsFile(
 			exportConfiguration);
 
 		// Import site LAR
@@ -986,20 +986,17 @@ public class AssetPublisherExportImportTest
 					null, getImportParameterMap());
 
 		ExportImportConfiguration importConfiguration =
-			ExportImportConfigurationLocalServiceUtil.
+			_exportImportConfigurationLocalService.
 				addDraftExportImportConfiguration(
 					user.getUserId(),
 					ExportImportConfigurationConstants.TYPE_IMPORT_LAYOUT,
 					importLayoutSettingsMap);
 
-		ExportImportLocalServiceUtil.importLayouts(
-			importConfiguration, larFile);
+		_exportImportLocalService.importLayouts(importConfiguration, larFile);
 
-		importedLayout = LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
+		importedLayout = _layoutLocalService.getLayoutByUuidAndGroupId(
 			layout.getUuid(), importedGroup.getGroupId(),
 			layout.isPrivateLayout());
-
-		Assert.assertNotNull(importedLayout);
 	}
 
 	protected String[] getAssetEntriesXmls(List<AssetEntry> assetEntries) {
@@ -1072,7 +1069,7 @@ public class AssetPublisherExportImportTest
 		PortletPreferences portletPreferences = getImportedPortletPreferences(
 			preferenceMap);
 
-		Company company = CompanyLocalServiceUtil.getCompany(
+		Company company = _companyLocalService.getCompany(
 			TestPropsValues.getCompanyId());
 
 		AssetEntryQuery assetEntryQuery =
@@ -1121,7 +1118,7 @@ public class AssetPublisherExportImportTest
 				// Creating structures and templates in layout scope group is
 				// not possible
 
-				Company company = CompanyLocalServiceUtil.getCompany(
+				Company company = _companyLocalService.getCompany(
 					layout.getCompanyId());
 
 				serviceContext.setAttribute("ddmGroupId", company.getGroupId());
@@ -1165,14 +1162,14 @@ public class AssetPublisherExportImportTest
 		long groupId = group.getGroupId();
 
 		if (globalVocabulary) {
-			Company company = CompanyLocalServiceUtil.getCompany(
+			Company company = _companyLocalService.getCompany(
 				layout.getCompanyId());
 
 			groupId = company.getGroupId();
 		}
 
 		AssetVocabulary assetVocabulary =
-			AssetVocabularyLocalServiceUtil.addVocabulary(
+			_assetVocabularyLocalService.addVocabulary(
 				TestPropsValues.getUserId(), groupId,
 				RandomTestUtil.randomString(),
 				ServiceContextTestUtil.getServiceContext(groupId));
@@ -1193,7 +1190,7 @@ public class AssetPublisherExportImportTest
 			portletPreferences.getValue("assetVocabularyId", null));
 
 		AssetVocabulary importedVocabulary =
-			AssetVocabularyLocalServiceUtil.fetchAssetVocabulary(
+			_assetVocabularyLocalService.fetchAssetVocabulary(
 				importedAssetVocabularyId);
 
 		Assert.assertNotNull(
@@ -1212,12 +1209,52 @@ public class AssetPublisherExportImportTest
 				" does not belong to group ", expectedGroupId),
 			expectedGroupId, importedVocabulary.getGroupId());
 
-		AssetVocabularyLocalServiceUtil.deleteAssetVocabulary(assetVocabulary);
+		_assetVocabularyLocalService.deleteAssetVocabulary(assetVocabulary);
 	}
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
 
 	@Inject
 	private AssetPublisherHelper _assetPublisherHelper;
 
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
+
+	@Inject
+	private ExportImportConfigurationLocalService
+		_exportImportConfigurationLocalService;
+
+	@Inject(filter = "model.class.name=com.liferay.portal.kernel.model.Layout")
+	private ExportImportController _exportImportController;
+
+	@Inject
+	private ExportImportLocalService _exportImportLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	@Inject(filter = "component.name=*.LayoutStagedModelDataHandler")
+	private StagedModelDataHandler _layoutStagedModelDataHandler;
+
 	private PermissionChecker _permissionChecker;
+
+	@Inject
+	private Portal _portal;
+
+	@Inject(filter = "component.name=*.StagedGroupStagedModelDataHandler")
+	private StagedModelDataHandler _stagedGroupStagedModelDataHandler;
+
+	@Inject(filter = "component.name=*.StagedLayoutSetStagedModelDataHandler")
+	private StagedModelDataHandler _stagedLayoutSetStagedModelDataHandler;
 
 }


### PR DESCRIPTION
(Started the Search test suite 9 hours ago, now running for the past 5 hours, still unfinished. Anyway this should be safe to merge: changed only one single test.)

https://github.com/arboliveira/liferay-portal/pull/814#issuecomment-603087919

----

@brianchandotcom @shuyangzhou I was able to confirm that the root cause in the overwhelming majority of flaky integration tests attributed to Search is actually an antipattern in test dependency initialization code that requires no changes in Search or Elasticsearch at all. This pull request demonstrates how to fix it in AssetPublisherExportImportTest, and I will send further pull requests to fix the other flukes assigned to Search presenting the same antipattern. Applying the best practice eliminated the 80%+ failure rate completely, across 25+ executions observed overnight in our controlled Search CI Server, using a branch cut last Friday March 20, non rebased since then, and no other changes applied. Please compare:

(Prior to fix)

https://search-ci.liferay.com/job/integration-flaky/116/testReport/junit/com.liferay.asset.publisher.lar.test/history/?start=25

(With fix applied)

https://search-ci.liferay.com/job/integration-flaky/116/testReport/com.liferay.asset.publisher.lar.test/history/

To the best of my analysis, LPS-110705 appears to be unnecessary to solve the Search flukes we’re diagnosing and fixing (with around-the-clock help from @xbrianlee and @joshchong) and my recommendation as best immediate course of action would be for it to be reverted. All the evidence I collected points to Elasticsearch behavior being just fine, and instead uninitialized component dependencies being the prevalent root cause. (As in, scenarios I analyzed with missing search results aren’t caused by Elasticsearch taking too long to index; instead the root cause is the test running in the absence of a dependency, which leads to data never even being created or sent to the search engine in the first place.)

----

_[Bug] AssetPublisherExportImportTest#testAnyDLFileEntryType failing inconsistently_
https://issues.liferay.com/browse/LPS-110601
