### PR TITLE
LRQA-57011 Quarantine search upgrade tests from relevant

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchUpgrade.testcase
@@ -4,7 +4,7 @@ definition {
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
 	property portal.release = "true";
 	property portal.suite.search.engine = "elasticsearch6,elasticsearch7,solr";
-	property portal.upstream = "true";
+	property portal.upstream = "quarantine";
 	property testray.main.component.name = "Upgrades Search";
 
 	setUp {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-57011

Hey @brianchandotcom is it okay if we let this one through? Our team realized that these tests are failing pretty consistently due to [LPS-110124](https://issues.liferay.com/browse/LPS-110124) and will prevent anyone from making changes to ANY of the search modules while using `ci:forward`. I didn't use `ci:forward` for this change myself since that would require all 300+ Poshi acceptance tests to pass just for this one low risk change, which I don't believe is very likely nor would it be a good use of our already limited CI resources.

cc @xbrianlee @arboliveira @jpince