### PR TITLE
LRCI-1147 Add global query for functional upgrade batch

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -2916,6 +2916,9 @@
     test.batch.run.property.global.query[functional-tomcat*-mysql*-jdk8][relevant]=\
         (portal.upstream != quarantine)
 
+    test.batch.run.property.global.query[functional-upgrade-tomcat*-mysql*-jdk8][relevant]=\
+        (portal.upstream != quarantine)
+
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
         false
     test.relevant.changes[relevant]=true


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1147

As a follow up to https://github.com/brianchandotcom/liferay-portal/pull/86785, we need this to quarantine functional tests that normally run on the upgrade batches.

cc @kenjiheigel