### PR TITLE
LPS-110127 | master

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/display/ReindexBackgroundTaskDisplay.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/display/ReindexBackgroundTaskDisplay.java
@@ -34,7 +34,7 @@ public class ReindexBackgroundTaskDisplay extends BaseBackgroundTaskDisplay {
 	@Override
 	public int getPercentage() {
 		return GetterUtil.getInteger(
-			getBackgroundTaskStatusAttributeString("percentage"),
+			getBackgroundTaskStatusAttributeLong("percentage"),
 			PERCENTAGE_NONE);
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-110127

Hey @brianchandotcom, we had to revert ee18e35 since it causes [LPS-110966](https://issues.liferay.com/browse/LPS-110966) which the team considers to be a 7.3 blocker due to it's visibility. @wcao20170619 tested this revert locally already and it resolves the issue in the LPS ticket. Thanks!