### PR TITLE
LPS-109492 Uses allowSuccessPage instead of successPageSettings.enabled (which was meant for actually displaying or not a success page on the form instead of controlling wether it's possible or not to add one)

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/java/com/liferay/app/builder/web/internal/servlet/taglib/definition/AppBuilderDataLayoutBuilderDefinition.java
+++ b/modules/apps/app-builder/app-builder-web/src/main/java/com/liferay/app/builder/web/internal/servlet/taglib/definition/AppBuilderDataLayoutBuilderDefinition.java
@@ -15,9 +15,6 @@
 package com.liferay.app.builder.web.internal.servlet.taglib.definition;
 
 import com.liferay.data.engine.taglib.servlet.taglib.definition.DataLayoutBuilderDefinition;
-import com.liferay.portal.kernel.util.HashMapBuilder;
-
-import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -32,10 +29,8 @@ public class AppBuilderDataLayoutBuilderDefinition
 	implements DataLayoutBuilderDefinition {
 
 	@Override
-	public Map<String, Object> getSuccessPageSettings() {
-		return HashMapBuilder.<String, Object>put(
-			"enabled", false
-		).build();
+	public boolean allowSuccessPage() {
+		return false;
 	}
 
 }

--- a/modules/apps/data-engine/data-engine-taglib/src/main/java/com/liferay/data/engine/taglib/servlet/taglib/definition/DataLayoutBuilderDefinition.java
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/java/com/liferay/data/engine/taglib/servlet/taglib/definition/DataLayoutBuilderDefinition.java
@@ -15,9 +15,6 @@
 package com.liferay.data.engine.taglib.servlet.taglib.definition;
 
 import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
-import com.liferay.portal.kernel.util.HashMapBuilder;
-
-import java.util.Map;
 
 /**
  * @author Eudaldo Alonso
@@ -32,6 +29,10 @@ public interface DataLayoutBuilderDefinition {
 		return false;
 	}
 
+	public default boolean allowSuccessPage() {
+		return false;
+	}
+
 	public default String[] getDisabledProperties() {
 		return new String[0];
 	}
@@ -42,12 +43,6 @@ public interface DataLayoutBuilderDefinition {
 
 	public default String getPaginationMode() {
 		return DDMFormLayout.WIZARD_MODE;
-	}
-
-	public default Map<String, Object> getSuccessPageSettings() {
-		return HashMapBuilder.<String, Object>put(
-			"enabled", true
-		).build();
 	}
 
 	public default String[] getUnimplementedProperties() {

--- a/modules/apps/data-engine/data-engine-taglib/src/main/java/com/liferay/data/engine/taglib/servlet/taglib/util/DataLayoutTaglibUtil.java
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/java/com/liferay/data/engine/taglib/servlet/taglib/util/DataLayoutTaglibUtil.java
@@ -136,6 +136,8 @@ public class DataLayoutTaglibUtil {
 		).put(
 			"allowRules", dataLayoutBuilderDefinition.allowRules()
 		).put(
+			"allowSuccessPage", dataLayoutBuilderDefinition.allowSuccessPage()
+		).put(
 			"disabledProperties",
 			dataLayoutBuilderDefinition.getDisabledProperties()
 		).put(
@@ -159,12 +161,8 @@ public class DataLayoutTaglibUtil {
 		}
 
 		dataLayoutConfigJSONObject.put(
-			"successPageSettings",
-			dataLayoutBuilderDefinition.getSuccessPageSettings()
-		).put(
 			"unimplementedProperties",
-			dataLayoutBuilderDefinition.getUnimplementedProperties()
-		);
+			dataLayoutBuilderDefinition.getUnimplementedProperties());
 
 		return dataLayoutConfigJSONObject;
 	}

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/data-layout-builder/DataLayoutBuilder.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/data-layout-builder/DataLayoutBuilder.es.js
@@ -65,12 +65,12 @@ class DataLayoutBuilder extends React.Component {
 				},
 				layoutProviderProps: {
 					...this.props,
+					allowSuccessPage: config.allowSuccessPage,
 					context,
 					defaultLanguageId: themeDisplay.getDefaultLanguageId(),
 					editingLanguageId: themeDisplay.getDefaultLanguageId(),
 					initialPages: context.pages,
 					initialPaginationMode: paginationMode,
-					initialSuccessPageSettings: config.successPageSettings,
 					ref: 'layoutProvider',
 				},
 			},

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withMultiplePages.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withMultiplePages.es.js
@@ -154,7 +154,7 @@ const withMultiplePages = ChildComponent => {
 				});
 			}
 
-			if (successPageSettings.enabled) {
+			if (!successPageSettings.enabled) {
 				pageSettingsItems.push({
 					label: Liferay.Language.get('add-success-page'),
 					settingsItem: 'add-success-page',

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withMultiplePages.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withMultiplePages.es.js
@@ -133,7 +133,12 @@ const withMultiplePages = ChildComponent => {
 		}
 
 		_getPageSettingsItems() {
-			const {pages, paginationMode, successPageSettings} = this.props;
+			const {
+				allowSuccessPage,
+				pages,
+				paginationMode,
+				successPageSettings,
+			} = this.props;
 			const pageSettingsItems = [
 				{
 					label: Liferay.Language.get('add-new-page'),
@@ -154,7 +159,7 @@ const withMultiplePages = ChildComponent => {
 				});
 			}
 
-			if (!successPageSettings.enabled) {
+			if (allowSuccessPage && !successPageSettings.enabled) {
 				pageSettingsItems.push({
 					label: Liferay.Language.get('add-success-page'),
 					settingsItem: 'add-success-page',
@@ -245,6 +250,14 @@ const withMultiplePages = ChildComponent => {
 	}
 
 	MultiplePages.PROPS = {
+		/**
+		 * @instance
+		 * @memberof LayoutProvider
+		 * @type {boolean}
+		 */
+
+		allowSuccessPage: Config.bool().value(true),
+
 		...formBuilderProps,
 	};
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/LayoutProvider.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/LayoutProvider.es.js
@@ -239,6 +239,7 @@ class LayoutProvider extends Component {
 
 	render() {
 		const {
+			allowSuccessPage,
 			children,
 			defaultLanguageId,
 			editingLanguageId,
@@ -259,6 +260,7 @@ class LayoutProvider extends Component {
 				Object.assign(child.props, {
 					...this.otherProps(),
 					activePage,
+					allowSuccessPage,
 					defaultLanguageId,
 					editingLanguageId,
 					fieldActions,
@@ -609,6 +611,14 @@ class LayoutProvider extends Component {
 }
 
 LayoutProvider.PROPS = {
+	/**
+	 * @instance
+	 * @memberof LayoutProvider
+	 * @type {boolean}
+	 */
+
+	allowSuccessPage: Config.bool().value(true),
+
 	/**
 	 * @default undefined
 	 * @instance


### PR DESCRIPTION
From @brunobasto:

> It seems that the regression was caused by a confusion on what `successPageSettings.enabled` actually does. The `successPageSettings` configuration of the Form Builder has the following structure:
> ```
> {
>     body: "A success message to the end user",
>     title: "A success message title to the end user",
>     enabled: true // or false
> }
> ```
> The `enabled` property tells the Form Builder if the success page feature is currently enabled in the form. That is: When a user (**End User**) submits a response to a form he/she will be redirected to this success page.
> 
> Recently we needed a feature that would say if the **Form Builder User** (the user that actually creates the form) is able to define a success page to a form or not. That feature was added by reusing the `successPageSettings.enabled` flag and that is what caused the confusion.
> 
> I've now added a new configuration called `allowSuccessPage` that's meant to remove the "Add Success Page" option from the Form Builder when set to `false`.

@brunobasto, I re-based your fix for the LPS-109492 and now I'm sending it again to see if we win this arm-wrestle against the CI unrelated failures. 🙂 

Best.