### PR TITLE
LPS-110752 Create new openModal utility and apply it to segments-web

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -36,6 +36,8 @@ export {default as PortletBase} from './liferay/PortletBase.es';
 
 // Modal API
 
+export {openModal} from './liferay/modal/Modal.es';
+
 export {default as openSimpleInputModal} from './liferay/modal/commands/OpenSimpleInputModal.es';
 
 // PortletURL API

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.es.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayModal, {useModal} from '@clayui/modal';
+import {render} from 'frontend-js-react-web';
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+
+const openModal = props => {
+	// Mount in detached node; Clay will take care of appending to `document.body`.
+	// See: https://github.com/liferay/clay/blob/master/packages/clay-shared/src/Portal.tsx
+	render(Modal, props, document.createElement('div'));
+};
+
+const Modal = ({id, size, title, url}) => {
+	const [visible, setVisible] = useState(true);
+
+	const {observer} = useModal({
+		onClose: () => {
+			setVisible(false);
+		},
+	});
+
+	return (
+		<>
+			{visible && (
+				<ClayModal id={id} observer={observer} size={size}>
+					<ClayModal.Header>{title}</ClayModal.Header>
+					<ClayModal.Body url={url} />
+				</ClayModal>
+			)}
+		</>
+	);
+};
+
+Modal.propTypes = {
+	id: PropTypes.string,
+	size: PropTypes.oneOf(['full-screen', 'lg', 'sm']),
+	title: PropTypes.string,
+	url: PropTypes.string,
+};
+
+export {Modal, openModal};

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.es.js
@@ -32,12 +32,29 @@ const Modal = ({id, size, title, url}) => {
 		},
 	});
 
+	const getIframeUrl = () => {
+		if (!url) {
+			return null;
+		}
+
+		const iframeURL = new URL(url);
+
+		const namespace = iframeURL.searchParams.get('p_p_id');
+
+		iframeURL.searchParams.set(
+			`_${namespace}_bodyCssClass`,
+			'dialog-iframe-popup'
+		);
+
+		return iframeURL.toString();
+	};
+
 	return (
 		<>
 			{visible && (
 				<ClayModal id={id} observer={observer} size={size}>
 					<ClayModal.Header>{title}</ClayModal.Header>
-					<ClayModal.Body url={url} />
+					<ClayModal.Body url={getIframeUrl()} />
 				</ClayModal>
 			)}
 		</>

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/Modal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/Modal.es.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {render} from '@testing-library/react';
+import React from 'react';
+import {act} from 'react-dom/test-utils';
+
+import {Modal} from '../../../src/main/resources/META-INF/resources/liferay/modal/Modal.es';
+
+describe('Modal', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+
+	it('renders markup based on given configuration', () => {
+		const {baseElement} = render(
+			<Modal
+				id="abcd"
+				size="lg"
+				title="My Modal"
+				url="https://www.sample.url"
+			/>
+		);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		expect(baseElement).toMatchSnapshot();
+	});
+});

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/Modal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/Modal.es.js
@@ -29,7 +29,7 @@ describe('Modal', () => {
 				id="abcd"
 				size="lg"
 				title="My Modal"
-				url="https://www.sample.url"
+				url="https://www.sample.url?p_p_id=com_liferay_MyPortlet"
 			/>
 		);
 

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/__snapshots__/Modal.es.js.snap
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/__snapshots__/Modal.es.js.snap
@@ -51,8 +51,8 @@ exports[`Modal renders markup based on given configuration 1`] = `
               class="modal-body modal-body-iframe"
             >
               <iframe
-                src="https://www.sample.url"
-                title="https://www.sample.url"
+                src="https://www.sample.url/?p_p_id=com_liferay_MyPortlet&_com_liferay_MyPortlet_bodyCssClass=dialog-iframe-popup"
+                title="https://www.sample.url/?p_p_id=com_liferay_MyPortlet&_com_liferay_MyPortlet_bodyCssClass=dialog-iframe-popup"
               />
             </div>
           </div>

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/__snapshots__/Modal.es.js.snap
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/__snapshots__/Modal.es.js.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Modal renders markup based on given configuration 1`] = `
+<body
+  class="modal-open"
+>
+  <div />
+  <div>
+    <div
+      class="modal-backdrop fade show"
+    />
+    <div
+      class="fade modal d-block show"
+      id="abcd"
+    >
+      <div
+        class="modal-lg"
+        style="margin: auto;"
+      >
+        <div
+          class="modal-dialog modal-lg"
+          tabindex="-1"
+        >
+          <div
+            class="modal-content"
+          >
+            <div
+              class="modal-header"
+            >
+              <div
+                class="modal-title"
+              >
+                My Modal
+              </div>
+              <button
+                aria-label="close"
+                class="close btn btn-unstyled"
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-times"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="#times"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div
+              class="modal-body modal-body-iframe"
+            >
+              <iframe
+                src="https://www.sample.url"
+                title="https://www.sample.url"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/segment_edit/SegmentEdit.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/segment_edit/SegmentEdit.es.js
@@ -278,6 +278,7 @@ class SegmentEdit extends Component {
 
 		openModal({
 			id: 'segment-members-dialog',
+			size: 'full-screen',
 			title: sub(Liferay.Language.get('x-members'), [
 				Liferay.Util.escape(segmentLocalizedName),
 			]),

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/segment_edit/SegmentEdit.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/segment_edit/SegmentEdit.es.js
@@ -14,7 +14,7 @@
 
 import ClayButton from '@clayui/button';
 import {FieldArray, withFormik} from 'formik';
-import {debounce, fetch} from 'frontend-js-web';
+import {debounce, fetch, openModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 
@@ -276,15 +276,12 @@ class SegmentEdit extends Component {
 		const {name} = values;
 		const segmentLocalizedName = name[locale];
 
-		Liferay.Util.openWindow({
-			dialog: {
-				destroyOnHide: true,
-			},
+		openModal({
 			id: 'segment-members-dialog',
 			title: sub(Liferay.Language.get('x-members'), [
 				Liferay.Util.escape(segmentLocalizedName),
 			]),
-			uri: previewMembersURL,
+			url: previewMembersURL,
 		});
 	};
 


### PR DESCRIPTION
Hey @brianchandotcom, sending this directly after several days struggling to see green in tests. Everytime we quarantine one, another 3 fail...

This PR:
- Creates a new `openModal` utility to update Modal patterns in DXP
- It applies it only to one place in `segments-web` module (so only tests there or in `frontend-js-web` should be suspects...)

See analysis [here](https://github.com/wincent/liferay-portal/pull/190)

Could you please push this directly? That's what @manoelcyreno suggested.

/cc @john-co, @manoelcyreno, @dgarciasarai, @markocikos, @wincent