### PR TITLE
Partial revert LPS-111510 | master

### DIFF
--- a/portal-kernel/test/unit/com/liferay/portal/log/assertor/PortalLogAssertorTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/log/assertor/PortalLogAssertorTest.java
@@ -33,8 +33,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import jdk.nashorn.internal.ir.annotations.Ignore;
-
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -83,7 +81,6 @@ public class PortalLogAssertorTest {
 		Assert.assertTrue(sb.toString(), sb.index() == 0);
 	}
 
-	@Ignore
 	@Test
 	public void testScanXMLLog() throws IOException {
 		Files.walkFileTree(


### PR DESCRIPTION
@marcosapmf Please do not disable the log assertor test. This is a critical test since it is our method of catching errors on most other test executions on CI. @hhuijser Is it possible to enforce the special status of this test and keep it from being disabled?