### PR TITLE
LPS-112136 Update jQuery to v3.5.0

### DIFF
--- a/modules/apps/frontend-js/frontend-js-jquery-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-jquery-web/package.json
@@ -1,7 +1,7 @@
 {
 	"dependencies": {
 		"bootstrap": "4.3.1",
-		"jquery": "3.4.1",
+		"jquery": "3.5.0",
 		"popper.js": "1.14.7"
 	},
 	"name": "frontend-js-jquery-web",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -10910,10 +10910,10 @@ jest@^25.1.0:
     import-local "^3.0.2"
     jest-cli "^25.1.0"
 
-jquery@3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
-  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+jquery@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
+  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
 
 js-base64@^2.1.8:
   version "2.5.1"


### PR DESCRIPTION
This is a manual forward of https://github.com/wincent/liferay-portal/pull/217

That pull [contains no unique failures](https://github.com/wincent/liferay-portal/pull/217#issuecomment-617510974).  Once [LRCI-1208](https://issues.liferay.com/browse/LRCI-1208) is implemented, we will be able to forward such pulls using `ci:forward`, but for now, @john-co [suggests](https://github.com/wincent/liferay-portal/pull/211#issuecomment-617321115) that we forward manually, so I'm trying to do that now.

Original PR message follows:

---

Needed for a security fix

Release notes: [https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/](https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/) 

Since this is a security fix, we (frontend infra) will also need to backport this to `7.2.x` once it's merged into `master` and support will backport to `7.1.x` and `7.0.x`

According to the release notes, 

> The main change in this release is a security fix, and it’s possible you will need to change your own code to adapt. 

This doesn't directly affect DXP, because jQuery is no longer used internally, but it may require code changes in customer code in the unlikely event that they rely on the old behavior of `jQuery.htmlPrefilter`.

---

cc @julien