### PR TITLE
LPS-101643 Deprecate Liferay.Util.escapeCDATA

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -392,6 +392,9 @@
 			Util.toggleDisabled(inputs, false);
 		},
 
+		/**
+		 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+		 */
 		escapeCDATA(str) {
 			return str.replace(/<!\[CDATA\[|\]\]>/gi, match => {
 				var str = '';


### PR DESCRIPTION
Forwarding this manually [from here](https://github.com/wincent/liferay-portal/pull/226) because CI is showing signs of instability:

- CI [was unresponsive for 21 hours](https://github.com/wincent/liferay-portal/pull/226#issuecomment-618326630).
- On retry, CI [reported 2 failures](https://github.com/wincent/liferay-portal/pull/226#issuecomment-618358196) but "upstream comparison is not available".
- This is a comment-only change, so doesn't seem worth fighting to get it through via the normal channel for something so trivial (and would be a waste of strained CI resources anyway).

Original message follows:

---

The goal of this change is to mark the `Liferay.Util.escapeCDATA` function as deprecated. Based on the conversations we've had in https://github.com/wincent/liferay-portal/pulls/210, we're still keeping the function to avoid breaking changes in case it's being used externally. I couldn't find any internal usages (I searched using `git grep escapeCDATA`), but here is a list of commits that are related: 37ae29c, be13362