### PR TITLE
LPS-112769 Service Builder Enhancement #1: Resource Attribute

### DIFF
--- a/definitions/liferay-service-builder_7_3_0.dtd
+++ b/definitions/liferay-service-builder_7_3_0.dtd
@@ -116,6 +116,17 @@ the name of the entity.
 >
 
 <!--
+If the resources value is true, the service populates the -LocalBaseImpl class with 
+calls to the resource service so they are added to Liferay's resource tables at the 
+same time as the entity. It also generates ModelResourcePermissionRegistrar 
+class so that permission checks may be run on this entity. The default value 
+is false. 
+-->
+<!ATTLIST entity
+	resources CDATA #IMPLIED
+>
+
+<!--
 If the uuid value is true, then the service will generate a UUID column for the
 service. This column will automatically be populated with a UUID. Developers
 will also be able to find and remove based on that UUID. The default value is


### PR DESCRIPTION
 For this week's Service Builder attribute, I would change the DTD to have a new attribute inside the element Entity:
 
 ```
 <!ELEMENT entity (column*, localized-entity?, order?, finder*, reference*, tx-required*)>
 <!--
 If the resources value is true, the service populates the -LocalBaseImpl class with 
 calls to the resource service to they are added to Liferay's resource tables at the 
 same time as the entity. It also generates ModelResourcePermissionRegistrar 
 class so that permission checks may be run on this entity. The default value 
 is false. 
 -->
 
 <!ATTLIST entity
 	resources CDATA #IMPLIED
 >
 ```
 
 The declaration for something like `BlogsEntry`, therefore, would look like this:
 
 ```
 <entity local-service="true" name="BlogsEntry" remote-service="true" trash-enabled="true" uuid="true" resources="true">
 ```
 
 After looking at the permissions registrar classes, I think in Service Builder it's only appropriate to generate the `ModelResourcePermissionRegistrar` classes, as the portlet permissions are defined by that front-end.
 
 Another concern I have is that the registrars seem to have coupled resources/permissions with other things in some cases (i.e., we have not separated our concerns well). For example, if the application supports Staging and Workflow, you'll see this in the registrar:
 
 ```java
 public void registerModelResourcePermissionLogics(
 	ModelResourcePermission<BlogsEntry> modelResourcePermission,
 	Consumer<ModelResourcePermissionLogic<BlogsEntry>>
 		modelResourcePermissionLogicConsumer) {
 
 	modelResourcePermissionLogicConsumer.accept(
 		new StagedModelPermissionLogic<>(
 			_stagingPermission, BlogsPortletKeys.BLOGS,
 			BlogsEntry::getEntryId));
 	modelResourcePermissionLogicConsumer.accept(
 		new WorkflowedModelPermissionLogic<>(
 			_workflowPermission, modelResourcePermission,
 			_groupLocalService, BlogsEntry::getEntryId));
 
 	if (_sharingModelResourcePermissionConfigurator != null) {
 		_sharingModelResourcePermissionConfigurator.configure(
 			modelResourcePermission, modelResourcePermissionLogicConsumer);
 	}
 }
 ```
 
 We can handle this in the documentation by modifying the permissions registrars when we get to implementing these things, and moving from Staging to Change Lists might also change this logic. You would know better than I. :-)
 
 I don't understand these classes very well, because they use features of Java > 5, which I think is the last version of Java I used on a daily basis when I was a developer.


@jpince