### PR TITLE
LPS-112763 | master

### DIFF
--- a/modules/apps/analytics/analytics-client-js/test/analytics.js
+++ b/modules/apps/analytics/analytics-client-js/test/analytics.js
@@ -152,6 +152,7 @@ describe('Analytics', () => {
 
 		setTimeout(async () => {
 			// flush should have happened at least once
+
 			const userId = getItem(STORAGE_KEY_USER_ID);
 
 			await Analytics.setIdentity({
@@ -187,6 +188,7 @@ describe('Analytics', () => {
 	// Skipping this test because it was broken in the old
 	// Karma-based implementation (the `expect` was failing but it
 	// did so asynchronously after the test has "finished").
+
 	it.skip('regenerates the user id on logouts or session expirations ', async () => {
 		fetchMock.mock(/ac-server/i, () => Promise.resolve(200));
 		fetchMock.mock(/identity$/, () => Promise.resolve(200));

--- a/modules/apps/analytics/analytics-client-js/test/eventQueue.js
+++ b/modules/apps/analytics/analytics-client-js/test/eventQueue.js
@@ -25,6 +25,7 @@ import {
 } from './helpers';
 
 // We don't need any of the timing callbacks to run during these tests.
+
 jest.mock('../src/plugins/timing');
 
 jest.mock('../src/messageQueue', () => {

--- a/modules/apps/analytics/analytics-client-js/test/plugins/blogs.js
+++ b/modules/apps/analytics/analytics-client-js/test/plugins/blogs.js
@@ -40,6 +40,7 @@ describe('Blogs Plugin', () => {
 
 	beforeEach(() => {
 		// Force attaching DOM Content Loaded event
+
 		Object.defineProperty(document, 'readyState', {
 			value: 'loading',
 			writable: false,

--- a/modules/apps/analytics/analytics-client-js/test/plugins/custom.js
+++ b/modules/apps/analytics/analytics-client-js/test/plugins/custom.js
@@ -61,6 +61,7 @@ describe('Custom Asset Plugin', () => {
 
 	beforeEach(() => {
 		// Force attaching DOM Content Loaded event
+
 		Object.defineProperty(document, 'readyState', {
 			value: 'loading',
 			writable: false,

--- a/modules/apps/analytics/analytics-client-js/test/plugins/forms.js
+++ b/modules/apps/analytics/analytics-client-js/test/plugins/forms.js
@@ -24,6 +24,7 @@ describe('Forms Plugin', () => {
 
 	beforeEach(() => {
 		// Force attaching DOM Content Loaded event
+
 		Object.defineProperty(document, 'readyState', {
 			value: 'loading',
 			writable: false,
@@ -195,6 +196,7 @@ describe('Forms Plugin', () => {
 			field.dispatchEvent(new Event('focus'));
 
 			// Fake timing.
+
 			duration = 1500;
 
 			field.dispatchEvent(new Event('blur'));

--- a/modules/apps/analytics/analytics-client-js/test/plugins/web-content.js
+++ b/modules/apps/analytics/analytics-client-js/test/plugins/web-content.js
@@ -40,6 +40,7 @@ describe('WebContent Plugin', () => {
 
 	beforeEach(() => {
 		// Force attaching DOM Content Loaded event
+
 		Object.defineProperty(document, 'readyState', {
 			value: 'loading',
 			writable: false,

--- a/modules/apps/analytics/analytics-client-js/test/utils/scroll.js
+++ b/modules/apps/analytics/analytics-client-js/test/utils/scroll.js
@@ -49,6 +49,7 @@ describe('ScrollTracker', () => {
 	describe('getDepth() from an element', () => {
 		beforeEach(() => {
 			// Avoid: "Error: Not implemented: window.scrollTo."
+
 			window.scrollTo = (_x, y) => {
 				window.pageYOffset = y;
 			};

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -46,6 +46,7 @@ function SelectCategory({
 		const data = {};
 
 		// Mark newly selected nodes as selected.
+
 		visit(nodes, (node) => {
 			if (selectedNodes.has(node.id)) {
 				data[node.id] = {
@@ -58,6 +59,7 @@ function SelectCategory({
 		});
 
 		// Mark unselected nodes as unchecked.
+
 		if (selectedNodesRef.current) {
 			Object.entries(selectedNodesRef.current).forEach(([id, node]) => {
 				if (!selectedNodes.has(id)) {

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/initializeSidebarConfig.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/initializeSidebarConfig.es.js
@@ -28,6 +28,7 @@ export default function initializeSidebarConfig(backendInfo) {
 	const toolbarId = `${backendInfo.portletNamespace}${DEFAULT_CONFIG.toolbarId}`;
 
 	// Special items requiring augmentation, creation, or transformation.
+
 	const augmentedPanels = augmentPanelData(
 		Object.values(backendInfo.sidebarPanels)
 	);

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/hooks/useLoad.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/hooks/useLoad.es.js
@@ -45,6 +45,7 @@ export default function useLoad() {
 							(error) => {
 								if (isMounted()) {
 									// Reset to allow future retries.
+
 									modules.current.delete(key);
 									reject(error);
 								}

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/hooks/usePlugins.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/hooks/usePlugins.es.js
@@ -38,6 +38,7 @@ export default function usePlugins() {
 							console.error(error);
 
 							// Reset to allow future retries.
+
 							plugins.current.delete(key);
 						}
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/categorization/tags/EditTagsModal.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/categorization/tags/EditTagsModal.es.js
@@ -47,6 +47,7 @@ const EditTagsModal = ({
 
 	// Flag that indicates whether new selected items must be added to old ones
 	// or replace them.
+
 	const [append, setAppend] = useState(true);
 	const [description, setDescription] = useState('');
 	const [loading, setLoading] = useState(true);
@@ -54,10 +55,12 @@ const EditTagsModal = ({
 
 	// Selected items received from the server and saved to compare with new
 	// ones.
+
 	const [initialSelectedItems, setInitialSelectedItems] = useState([]);
 	const [inputValue, setInputValue] = useState();
 
 	// Current selected items.
+
 	const [selectedItems, setSelectedItems] = useState([]);
 	const [selectedRadioGroupValue, setSelectedRadioGroupValue] = useState(
 		'add'
@@ -67,6 +70,7 @@ const EditTagsModal = ({
 
 	// This makes the component fetch selected items only after mounting it
 	// (a.k.a. first render).
+
 	useEffect(() => {
 		const selection = {
 			documentIds: fileEntries,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/__mock__/Modal.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/__mock__/Modal.js
@@ -15,5 +15,6 @@
 module.exports = {
 	// Mock this because we can't evaluate React JSX from a Metal-using module
 	// like dynamic-data-mapping-form-builder.
+
 	openModal: () => {},
 };

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/LayoutProvider.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/components/LayoutProvider/LayoutProvider.es.js
@@ -471,6 +471,7 @@ describe('LayoutProvider', () => {
 								// Overrides the instanceId because it is generated when a field is duplicated,
 								// toMatchSnapshot has problems with deep arrays so we override it here to
 								// avoid this.
+
 								instanceId: 'Any<String>',
 								name: `name${fieldIndex}${columnIndex}${rowIndex}${pageIndex}`,
 							};

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldSet/FieldSet.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldSet/FieldSet.es.js
@@ -35,6 +35,7 @@ class NoRender extends React.Component {
 // being able to call page renderer rows. This should probably be removed
 // by a more friendly implementation when we remove the implementation of
 // calling the fields dynamically through soy.
+
 const PageRendererAdapter = ({
 	activePage,
 	context,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Separator/Separator.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Separator/Separator.es.js
@@ -27,6 +27,7 @@ const Separator = ({style}) => {
 			// with React, we can just add the raw value in the attribute, we don't need to
 			// worry about XSS here because it won't go to the server just for printing
 			// on the screen.
+
 			elRef.current.setAttribute('style', style);
 		}
 	}, [style]);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/hooks/useSyncValue.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/hooks/useSyncValue.es.js
@@ -23,6 +23,7 @@ export const useSyncValue = (newValue, isDelay = true) => {
 	// Maintains the reference of the last value to check in later renderings if the
 	// value is new or keeps the same, it covers cases where the value typed by
 	// the user is sent to LayoutProvider but it does not descend with the new changes.
+
 	const previousValueRef = useRef(newValue);
 
 	const [value, setValue] = useState(newValue);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/ReactComponentAdapter.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/ReactComponentAdapter.es.js
@@ -127,6 +127,7 @@ function getConnectedReactComponentAdapter(ReactComponent, variant) {
 			// check which values have been changed, events and children are
 			// properties that are changing all the time when new renderings
 			// happen, a new reference is created all the time.
+
 			delete changes.events;
 			delete changes.children;
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/SoyRegisterAdapter.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/SoyRegisterAdapter.es.js
@@ -57,6 +57,7 @@ export const SoyRegisterAdapter = (ComponentAdapter, variant) => {
 
 		// We call the template created above so that Metal
 		// can take care of the rest.
+
 		const templateAlias = Soy.getTemplate(
 			variant + 'Adapter.incrementaldom',
 			'render'

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/connectStore.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/connectStore.es.js
@@ -33,17 +33,20 @@ export const connectStore = (Component) => {
 		// for cases where you want to propagate the emit event (e.g FieldSet).
 		// The implementation of the event must correspond to the use of the
 		// function `emit` below.
+
 		const propagate = (name, event) => instance.emit(name, event);
 
 		const emit = (name, event, value) =>
 			instance.emit(name, {
 				// A hacky to imitate an instance of a Metal+soy component
+
 				fieldInstance: {
 					...instance,
 					...instance.props,
 
 					// Explicitly declare the element, because it will get lost
 					// in the destructuring above because the element is a getter.
+
 					element: instance.element,
 					isDisposed: instance.isDisposed,
 				},

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Grid/Grid.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Grid/Grid.es.js
@@ -186,6 +186,7 @@ describe('Grid', () => {
 	// This test needs to be investigated further, it is failing at metal-events because it
 	// has no events adding, strange that we are adding but only this one is failing.
 	// This is not reproducible in manual tests.
+
 	it.skip('emits a fieldEdited event when changing the state of radio input', (done) => {
 		const handleFieldEdited = (data) => {
 			expect(data).toEqual(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/LocalizableText/LocalizableText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/LocalizableText/LocalizableText.es.js
@@ -67,6 +67,7 @@ const LocalizableTextWithContextMock = withContextMock(LocalizableText);
 describe('Field LocalizableText', () => {
 	beforeAll(() => {
 		// @ts-ignore
+
 		ReactDOM.createPortal = jest.fn((element) => {
 			return element;
 		});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/store/actions/handleFieldEdited.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/store/actions/handleFieldEdited.es.js
@@ -64,6 +64,7 @@ export default (evaluatorContext, properties, updateState) => {
 			if (REVALIDATE_UPDATES.length > 0) {
 				// All non-evaluable operations that were performed after the request
 				// was sent are used here to revalidate the new data.
+
 				REVALIDATE_UPDATES.forEach((item) => {
 					evaluatedPages = getEditedPages({
 						...item,
@@ -73,6 +74,7 @@ export default (evaluatorContext, properties, updateState) => {
 
 				// Redefine the list of updates to avoid leaking memory and avoid
 				// more expensive operations in the next interactions
+
 				REVALIDATE_UPDATES = [];
 			}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/__mock__/Modal.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/__mock__/Modal.js
@@ -15,5 +15,6 @@
 module.exports = {
 	// Mock this because we can't evaluate React JSX from a Metal-using module
 	// like dynamic-data-mapping-form-web.
+
 	openModal: () => {},
 };

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
@@ -206,6 +206,7 @@
 			apply(node, data, options) {
 				if (options && options.forIE) {
 					// workaround for bad IE
+
 					data = data.replace(/\n/g, ' \r');
 				}
 				node.appendChild(document.createTextNode(data));

--- a/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.js
+++ b/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.js
@@ -79,6 +79,7 @@ class CollapseProvider {
 
 		// Reflow to make sure dimention is set, without this transition may
 		// not trigger.
+
 		panel.getBoundingClientRect();
 
 		panel.classList.remove(CssClass.COLLAPSE);

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/NodeList.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/NodeList.js
@@ -29,6 +29,7 @@ export default function NodeList({
 
 	if (!rootNodeId) {
 		// All nodes have been filtered.
+
 		return null;
 	}
 

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/Treeview.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/Treeview.js
@@ -189,12 +189,14 @@ function updateNode(state, id, callback) {
 
 	if (node === nodeMap[id]) {
 		// Node didn't change, so leave state as-is.
+
 		return state.nodes;
 	}
 
 	nodeMap[id] = node;
 
 	// Walk back to root updating subtrees.
+
 	while (node.parentId) {
 		const parent = nodeMap[node.parentId];
 
@@ -241,6 +243,7 @@ function reducer(state, action) {
 
 		case 'COLLAPSE':
 			// eg double click
+
 			if (!filteredNodes) {
 				return {
 					...state,
@@ -285,22 +288,26 @@ function reducer(state, action) {
 					while (node) {
 						if (node.id !== action.nodeId) {
 							// Not the first iteration and we found a match: done.
+
 							break;
 						}
 
 						if (node.expanded && node.children.length) {
 							// Expanded, so go to first visible child.
+
 							node = node.children[0];
 							break;
 						}
 
 						// No visible children, so go to first visible sibling.
+
 						if (node.nextSiblingId) {
 							node = nodeMap[node.nextSiblingId];
 							continue;
 						}
 
 						// As last resort, go to parent's sibling.
+
 						if (node.parentId) {
 							const nextId = nodeMap[node.parentId].nextSiblingId;
 
@@ -311,6 +318,7 @@ function reducer(state, action) {
 						}
 
 						// Give up.
+
 						node = null;
 						break;
 					}
@@ -352,6 +360,7 @@ function reducer(state, action) {
 						}
 						else {
 							// Go to parent.
+
 							node = nodeMap[node.parentId];
 							break;
 						}
@@ -403,6 +412,7 @@ function reducer(state, action) {
 		case 'TOGGLE_EXPANDED':
 			// Toggles the expanded or collapsed state of the selected
 			// parent node. eg. by double clicking; doesn't select a child.
+
 			if (!filteredNodes) {
 				return {
 					...state,
@@ -463,6 +473,7 @@ function reducer(state, action) {
 				// Collapse the currently selected parent node if it is
 				// expanded; otherwise move to the previous parent node
 				// (if possible).
+
 				if (!filteredNodes) {
 					const node = nodeMap[action.nodeId];
 
@@ -491,6 +502,7 @@ function reducer(state, action) {
 			{
 				// Expand the currently selected parent node if it is closed;
 				// move to the first child list item if it was already expanded.
+
 				if (!filteredNodes) {
 					const node = nodeMap[action.nodeId];
 
@@ -759,6 +771,7 @@ function Treeview({
 		// immediately after this "blur" (eg. when moving around inside
 		// the treeview); so, we defer this state update until the next
 		// tick, giving us a chance to cancel it if needed.
+
 		focusTimer.current = delay(() => {
 			setHasFocus((hadFocus) => {
 				if (hadFocus) {

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/useKeyboardNavigation.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/useKeyboardNavigation.js
@@ -68,6 +68,7 @@ export default function useKeyboardNavigation(nodeId) {
 					// except for TAB, which is used to navigate away from the
 					// component (requires a `tabindex` of -1 on all internal
 					// components).
+
 					event.preventDefault();
 				}
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -34,6 +34,7 @@ const openModal = (props) => {
 
 	// Mount in detached node; Clay will take care of appending to `document.body`.
 	// See: https://github.com/liferay/clay/blob/master/packages/clay-shared/src/Portal.tsx
+
 	render(Modal, props, document.createElement('div'));
 };
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
@@ -25,6 +25,7 @@ const INSTANCE_MAP = new WeakMap();
  */
 function getElement(element) {
 	// Remove jQuery wrapper, if any.
+
 	if (element && element.jquery) {
 		if (element.length > 1) {
 			throw new Error(
@@ -35,6 +36,7 @@ function getElement(element) {
 	}
 
 	// Remove Metal wrapper, if any.
+
 	if (element && !(element instanceof HTMLElement)) {
 		element = element.element;
 	}
@@ -114,10 +116,12 @@ function setClasses(element, classes) {
 
 	if (element) {
 		// One at a time because IE 11: https://caniuse.com/#feat=classlist
+
 		Object.entries(classes).forEach(([className, present]) => {
 			// Some callers use multiple space-separated classNames for
 			// `openClass`/`data-open-class`. (Looking at you,
 			// product-navigation-simulation-web...)
+
 			className.split(/\s+/).forEach((name) => {
 				if (present) {
 					element.classList.add(name);
@@ -134,6 +138,7 @@ function hasClass(element, className) {
 	element = getElement(element);
 
 	// Again, product-navigation-simulation-web passes multiple classNames.
+
 	return className.split(/\s+/).every((name) => {
 		return element.classList.contains(name);
 	});
@@ -198,6 +203,7 @@ function handleEvent(eventName, event) {
 			// existence of `target.matches` before using it.
 			//
 			// See: https://stackoverflow.com/a/36270354/2103996
+
 			matches = target.matches && target.matches(selector);
 
 			if (matches) {
@@ -221,6 +227,7 @@ function handleEvent(eventName, event) {
 function subscribe(elementOrSelector, eventName, handler) {
 	if (elementOrSelector) {
 		// Add only one listener per `eventName`.
+
 		if (!eventNamesToSelectors[eventName]) {
 			eventNamesToSelectors[eventName] = {};
 
@@ -372,6 +379,7 @@ SideNavigation.prototype = {
 					range.selectNode(sidebar);
 
 					// Unlike `.innerHTML`, this will eval scripts.
+
 					const fragment = range.createContextualFragment(text);
 
 					sidebar.removeChild(loading);
@@ -452,6 +460,7 @@ SideNavigation.prototype = {
 		}
 
 		// Force Reflow for IE11 Browser Bug
+
 		setStyles(container, {
 			display: '',
 		});
@@ -933,6 +942,7 @@ SideNavigation.prototype = {
 
 			if (instance.mobile) {
 				// ios 8 fixed element disappears when trying to scroll
+
 				menu.focus();
 			}
 		});
@@ -1079,6 +1089,7 @@ function onReady() {
 
 if (document.readyState !== 'loading') {
 	// readyState is "interactive" or "complete".
+
 	onReady();
 }
 else {

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/add_params.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/add_params.js
@@ -78,6 +78,7 @@ describe('Liferay.Util.addParams', () => {
 
 	it('gracefully handles a relative path as the second argument', () => {
 		// Invariant: Jest environment sets up location like so:
+
 		expect(location.href).toBe('http://localhost/');
 
 		expect(addParams('something=other', '/hello-there')).toEqual(

--- a/modules/apps/frontend-theme/frontend-theme-classic/.eslintrc.js
+++ b/modules/apps/frontend-theme/frontend-theme-classic/.eslintrc.js
@@ -12,22 +12,8 @@
  * details.
  */
 
-/*
- * This function gets loaded when all the HTML, not including the portlets, is
- * loaded.
- */
-AUI().ready(function () {});
-
-/*
- * This function gets loaded after each and every portlet on the page.
- *
- * portletId: the current portlet's id
- * node: the Alloy Node object of the current portlet
- */
-Liferay.Portlet.ready(function (_portletId, _node) {});
-
-/*
- * This function gets loaded when everything, including the portlets, is on
- * the page.
- */
-Liferay.on('allPortletsReady', function () {});
+module.exports = {
+	rules: {
+		'prefer-arrow-callback': 'off',
+	},
+};

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/.eslintrc.js
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/.eslintrc.js
@@ -12,22 +12,8 @@
  * details.
  */
 
-/*
- * This function gets loaded when all the HTML, not including the portlets, is
- * loaded.
- */
-AUI().ready(function () {});
-
-/*
- * This function gets loaded after each and every portlet on the page.
- *
- * portletId: the current portlet's id
- * node: the Alloy Node object of the current portlet
- */
-Liferay.Portlet.ready(function (_portletId, _node) {});
-
-/*
- * This function gets loaded when everything, including the portlets, is on
- * the page.
- */
-Liferay.on('allPortletsReady', function () {});
+module.exports = {
+	rules: {
+		'prefer-arrow-callback': 'off',
+	},
+};

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumns.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumns.js
@@ -73,6 +73,7 @@ const MillerColumns = ({
 	const [items, setItems] = useState(() => getItemsMap(initialColumns));
 
 	// Transform items map into a columns-like array.
+
 	const columns = useMemo(() => {
 		const columns = [];
 
@@ -91,6 +92,7 @@ const MillerColumns = ({
 		}
 
 		// Add empty column in the end if last column has an active item
+
 		const lastColumnActiveItem = columns[columns.length - 1].items.find(
 			(item) => item.active
 		);
@@ -134,6 +136,7 @@ const MillerColumns = ({
 		const parent = itemsArray.find((item) => item.id === newParentId);
 
 		// If no newIndex is provided set it as the last of the siblings.
+
 		if (typeof newIndex !== 'number') {
 			newIndex = parent.childrenCount || 0;
 		}
@@ -156,6 +159,7 @@ const MillerColumns = ({
 				// Exit if source was active but not anymore and we are on the
 				// next column to where source used to live to avoid saving its
 				// children (which must not be shown anymore)
+
 				if (
 					source.active &&
 					!newSource.active &&
@@ -165,10 +169,12 @@ const MillerColumns = ({
 				}
 
 				// Reset itemIndex counter on each column
+
 				itemIndex = 0;
 			}
 
 			// Skip the source item iteration
+
 			if (item.id === sourceId) {
 				itemIndex++;
 				prevColumnIndex = item.columnIndex;
@@ -215,6 +221,7 @@ const MillerColumns = ({
 		// If source parent is active (children are visible) set (again or not)
 		// the newSource in the map in case it's being placed as the last
 		// element (so won't reach that position in the loop).
+
 		if (parent.active) {
 			newItems.set(newSource.id, newSource);
 		}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/constants.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/constants.js
@@ -18,4 +18,5 @@ export const ACCEPTING_TYPES = {
 
 // Defines the distance in px from the border to the center of an item where
 // dropZone changes from TOP/BOTTOM to ELEMENT
+
 export const ITEM_HOVER_BORDER_LIMIT = 20;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Sidebar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Sidebar.js
@@ -237,6 +237,7 @@ export default function Sidebar() {
 						});
 
 						// Add separator between groups.
+
 						if (groupIndex === panels.length - 1) {
 							return elements.concat(buttons);
 						}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Toolbar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Toolbar.js
@@ -95,6 +95,7 @@ function ToolbarBody() {
 
 	if (loading.current) {
 		// Do this once only.
+
 		loading.current();
 		loading.current = null;
 	}
@@ -295,6 +296,7 @@ export default function Toolbar() {
 
 	if (!isMounted()) {
 		// First time here, must empty JSP-rendered markup from container.
+
 		while (container.firstChild) {
 			container.removeChild(container.firstChild);
 		}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/TopperEmpty.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/TopperEmpty.js
@@ -114,6 +114,7 @@ function TopperEmpty({children, item, layoutData}) {
 						drop(node);
 
 						// Call the original ref, if any.
+
 						if (typeof child.ref === 'function') {
 							child.ref(node);
 						}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/config/index.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/config/index.js
@@ -30,6 +30,7 @@ export function initializeConfig(backendConfig) {
 	const toolbarId = `${portletNamespace}${DEFAULT_CONFIG.toolbarId}`;
 
 	// Special items requiring augmentation, creation, or transformation.
+
 	const augmentedPanels = augmentPanelData(pluginsRootPath, sidebarPanels);
 
 	const syntheticItems = {
@@ -71,6 +72,7 @@ function augmentPanelData(pluginsRootPath, sidebarPanels) {
 			...panel,
 
 			// https://github.com/liferay/liferay-js-toolkit/issues/324
+
 			pluginEntryPoint: `${pluginsRootPath}/${sidebarPanelId}/index`,
 
 			sidebarPanelId,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/store/index.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/store/index.js
@@ -123,6 +123,7 @@ export const useSelector = (selector, compareEqual = (a, b) => a === b) => {
 
 	const initialState = useMemo(
 		() => selector(storeRef.current.getState()),
+
 		// We really want to call selector here just on component mount.
 		// This provides an initial value that will be recalculated when
 		// store suscription has been called.

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/useDragAndDrop.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/useDragAndDrop.js
@@ -251,16 +251,20 @@ export default function useDragAndDrop({
 			}
 
 			// Determine rectangle on screen
+
 			const hoverBoundingRect = containerRef.current.getBoundingClientRect();
 
 			// Get vertical middle
+
 			const hoverMiddleY =
 				(hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
 
 			// Determine mouse position
+
 			const clientOffset = _monitor.getClientOffset();
 
 			// Get pixels to the top
+
 			const hoverClientY = clientOffset.y - hoverBoundingRect.top;
 
 			const [
@@ -679,6 +683,7 @@ function getParentItemIdAndPositon({
 				: dropTargetItemIndex + 1;
 
 		// Moving an item in the same parent
+
 		if (parent.children.includes(dropItem.itemId)) {
 			const itemIndex = parent.children.indexOf(dropItem.itemId);
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/hooks/useLoad.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/hooks/useLoad.js
@@ -45,6 +45,7 @@ export default function useLoad() {
 							(error) => {
 								if (isMounted()) {
 									// Reset to allow future retries.
+
 									modules.current.delete(key);
 									reject(error);
 								}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/hooks/usePlugins.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/hooks/usePlugins.js
@@ -38,6 +38,7 @@ export default function usePlugins() {
 							console.error(error);
 
 							// Reset to allow future retries.
+
 							plugins.current.delete(key);
 						}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/hooks/useThunk.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/hooks/useThunk.js
@@ -27,6 +27,7 @@ export default function useThunk([state, dispatch]) {
 
 	// Use a ref to ensure our `dispatch` is stable across renders, just
 	// like the React-provided `dispatch` that we're wrapping.
+
 	const thunkDispatch = useRef((action) => {
 		if (isMounted()) {
 			if (typeof action === 'function') {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceToolbarSection.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceToolbarSection.js
@@ -20,6 +20,7 @@ import {useDispatch, useSelector} from '../../../app/store/index';
 import ExperienceSelector from './ExperienceSelector';
 
 // TODO: show how to colocate CSS with plugins (may use loaders)
+
 export default function ExperienceToolbarSection({selectId}) {
 	const availableSegmentsExperiences = useSelector(
 		(state) => state.availableSegmentsExperiences

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments/index.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments/index.js
@@ -16,6 +16,7 @@ import React from 'react';
 
 import {Component} from '../../core/AppContext';
 import FragmentsSidebar from './components/FragmentsSidebar';
+
 /**
  * Entry-point for "Fragments" (sidebar pane) functionality.
  */

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/ContainerConfigurationPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/ContainerConfigurationPanel.test.js
@@ -161,6 +161,7 @@ describe('ContainerConfigurationPanel', () => {
 			});
 
 			// debug();
+
 			expect(getByLabelText('image-source').value).toBe(
 				'manual_selection'
 			);

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/experience/components/ExperienceToolbarSection.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/experience/components/ExperienceToolbarSection.test.js
@@ -221,6 +221,7 @@ describe('ExperienceToolbarSection', () => {
 		//      "TypeError: Cannot read property '_defaultView' of undefined"
 		//
 		// Caused by: https://github.com/jsdom/jsdom/issues/2499
+
 		document.activeElement.blur = () => {};
 
 		userEvent.click(lockIcon);
@@ -436,6 +437,7 @@ describe('ExperienceToolbarSection', () => {
 
 		// Grab parentElement here to work around jsdom v13 issue.
 		// "TypeError: Cannot read property '_defaultView' of undefined"
+
 		userEvent.click(getByText('save').parentElement);
 
 		await wait(() => expect(serviceFetch).toHaveBeenCalledTimes(2));
@@ -517,6 +519,7 @@ describe('ExperienceToolbarSection', () => {
 
 		// Grab parentElement here to work around jsdom v13 issue.
 		// "TypeError: Cannot read property '_defaultView' of undefined"
+
 		userEvent.click(getByText('save').parentElement);
 
 		await wait(() => expect(serviceFetch).toHaveBeenCalledTimes(1));

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Rating.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Rating.es.js
@@ -77,8 +77,6 @@ export default ({aggregateRating, entityId, myRating, ratingChange, type}) => {
 					'text-reset' + (userRating === -1 ? ' text-primary' : '')
 				}
 				displayType="unstyled"
-				// small={if-it-is-a-sub-comment}
-
 				monospaced
 				onClick={() => voteChange(-1)}
 			>

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Rating.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Rating.es.js
@@ -78,6 +78,7 @@ export default ({aggregateRating, entityId, myRating, ratingChange, type}) => {
 				}
 				displayType="unstyled"
 				// small={if-it-is-a-sub-comment}
+
 				monospaced
 				onClick={() => voteChange(-1)}
 			>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/CustomTooltip.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/CustomTooltip.js
@@ -11,6 +11,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+
 /**
  * Component to customize the content of recharts Tooltip
  * http://recharts.org/en-US/api/Tooltip#content

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/utils/APIService.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/utils/APIService.js
@@ -135,6 +135,7 @@ function APIService({endpoints, namespace, page}) {
 
 	function getTrafficSourceDetails(name) {
 		// TODO remove frontend mock
+
 		return new Promise((resolve) =>
 			setTimeout(() => {
 				resolve(MOCK_TRAFFIC_SOURCES_DETAILS[name]);

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
@@ -288,12 +288,14 @@ class ResultRankingsForm extends Component {
 				const fetchedItems = items || {};
 
 				// Get existing results to update its addedResult property.
+
 				const existingFetchedIds = fetchedItems
 					.filter(({id}) => this.state.resultIds.includes(id))
 					.map(({id}) => id);
 
 				// Remove duplicate results from the new list of results to
 				// avoid duplicate key errors.
+
 				const newItems = fetchedItems.filter(
 					({id}) => !this.state.resultIds.includes(id)
 				);
@@ -305,6 +307,7 @@ class ResultRankingsForm extends Component {
 
 				// Keep history of all initially pinned results to update the
 				// end index of pinned results.
+
 				this._initialResultIdsPinned = [
 					...this._initialResultIdsPinned,
 					...newPinnedIds,
@@ -320,6 +323,7 @@ class ResultRankingsForm extends Component {
 							// This prevents confusion since unpinning or
 							// un-hiding added results removes it from results
 							// list entirely.
+
 							...updateDataMap(
 								state.dataMap,
 								existingFetchedIds,
@@ -385,12 +389,14 @@ class ResultRankingsForm extends Component {
 
 				// Get already existing results in order to set addedResult
 				// property to false in setState.
+
 				const existingFetchedIds = fetchedItems
 					.filter(({id}) => this.state.resultIds.includes(id))
 					.map(({id}) => id);
 
 				// Remove duplicate results from the new list of results to
 				// avoid duplicate key errors.
+
 				const newItems = fetchedItems.filter(
 					({id}) => !this.state.resultIds.includes(id)
 				);
@@ -399,6 +405,7 @@ class ResultRankingsForm extends Component {
 
 				// Keep history of all initial results, to get the difference
 				// for addedResults and for all added/removed hidden/pinned
+
 				this._initialResultIdsHidden = [
 					...this._initialResultIdsHidden,
 					...newIds,
@@ -413,6 +420,7 @@ class ResultRankingsForm extends Component {
 						// This prevents confusion since unpinning or
 						// un-hiding added results removes it from results
 						// list entirely.
+
 						...updateDataMap(state.dataMap, existingFetchedIds, {
 							addedResult: false,
 						}),

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/js/components/add_result/AddResultModal.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/js/components/add_result/AddResultModal.es.js
@@ -88,6 +88,7 @@ describe('AddResultModal', () => {
 		// hasn't been called.
 		//
 		// This should be removed after disabling the initial fetch.
+
 		fetch.mockResponse(JSON.stringify({}));
 
 		const {getByTestId} = render(<AddResultModalWithModalMock />);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/xml_definition.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/xml_definition.js
@@ -33,6 +33,7 @@ describe('liferay-kaleo-designer-xml-definition', () => {
 
 		AUI().use(['liferay-kaleo-designer-utils'], (A) => {
 			// Stub for "aui-component", which refuses to load in test env.
+
 			A.Component = {
 				create({ATTRS, prototype, ...properties}) {
 					const constructor = function (config) {
@@ -103,6 +104,7 @@ describe('liferay-kaleo-designer-xml-definition', () => {
 			//
 			//      https://github.com/yui/yui3/blob/25264e3629/src/dataschema/js/dataschema-xml.js#L182
 			//
+
 			xmlDefinition.definitionDoc.evaluate = undefined;
 
 			xmlDefinition.forEachField((_tagName, fieldData) => {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/xml_definition_serializer.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/xml_definition_serializer.js
@@ -34,6 +34,7 @@ describe('liferay-kaleo-designer-xml-definition-serializer', () => {
 			['liferay-kaleo-designer-xml-util', 'liferay-kaleo-designer-utils'],
 			(A) => {
 				// Stub for "aui-component", which refuses to load in test env.
+
 				A.Component = {
 					create({ATTRS, prototype, ...properties}) {
 						const constructor = function () {};

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
@@ -103,6 +103,7 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 			target.scrollIntoView();
 
 			// Make sure nothing slides under the top nav.
+
 			window.scrollBy(0, -100);
 		}
 
@@ -206,8 +207,10 @@ function OverlayContainer({allowEdit, root}) {
 	const targetableElements = useRef();
 
 	// Before mount.
+
 	if (!targetableElements.current) {
 		// Apply CSS overrides.
+
 		const css = `
 			#banner {
 				cursor: not-allowed;
@@ -239,13 +242,16 @@ function OverlayContainer({allowEdit, root}) {
 		head.appendChild(style);
 
 		// This must happen after hiding the toppers.
+
 		targetableElements.current = getTargetableElements(root);
 	}
 
 	// On unmount.
+
 	useEffect(() => {
 		return () => {
 			// Remove CSS overrides.
+
 			const style = document.getElementById(cssId);
 
 			if (style) {
@@ -268,6 +274,7 @@ function OverlayContainer({allowEdit, root}) {
 	const handleClick = useCallback(
 		(event) => {
 			// Clicking anywhere other than a target aborts target selection.
+
 			event.preventDefault();
 			stopImmediatePropagation(event);
 			dispatch({type: 'deactivate'});
@@ -311,11 +318,13 @@ function Overlay({allowEdit, root, targetableElements}) {
 	);
 
 	// For now, treat scrolling just like resizing.
+
 	const handleScroll = handleResize;
 
 	useEventListener('resize', handleResize, false, window);
 
 	// TODO: also consider scrolling of elements with "overflow: auto/scroll";
+
 	useEventListener('scroll', handleScroll, false, window);
 
 	return (
@@ -395,6 +404,7 @@ function Target({allowEdit, element, geometry, mode, selector}) {
 	// At this point we don't know the dimensions of our children, but we do
 	// know whether we have more space on the left or right of our target, so we
 	// flip based on that.
+
 	const spaceOnLeft = left - geometry.left;
 	const spaceOnRight = geometry.right - right;
 	const spaceOnTop = top - geometry.top;
@@ -403,6 +413,7 @@ function Target({allowEdit, element, geometry, mode, selector}) {
 	return (
 		// TODO: make tooltip match mock and switch to Clay v3 tooltips directly
 		// instead of using lfr-portal-tooltip.
+
 		<div
 			className="lfr-segments-experiment-click-goal-target"
 			style={{
@@ -550,6 +561,7 @@ function TargetPopover({selector}) {
 	}, []);
 
 	// The +1 here is to avoid unwanted wrapping of the button.
+
 	const maxWidth = buttonWidth
 		? `${buttonWidth + POPOVER_PADDING * 2 + 1}px`
 		: 'none';

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
@@ -410,10 +410,10 @@ function Target({allowEdit, element, geometry, mode, selector}) {
 	const spaceOnTop = top - geometry.top;
 	const align = spaceOnRight > spaceOnLeft ? 'left' : 'right';
 
-	return (
-		// TODO: make tooltip match mock and switch to Clay v3 tooltips directly
-		// instead of using lfr-portal-tooltip.
+	// TODO: make tooltip match mock and switch to Clay v3 tooltips directly
+	// instead of using lfr-portal-tooltip.
 
+	return (
 		<div
 			className="lfr-segments-experiment-click-goal-target"
 			style={{

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/utils.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/utils.es.js
@@ -27,6 +27,7 @@ export const GeometryType = PropTypes.shape({
 export function stopImmediatePropagation(event) {
 	if (event.nativeEvent) {
 		// This is a React synthetic event; must access nativeEvent instead.
+
 		event.nativeEvent.stopImmediatePropagation();
 	}
 	else {
@@ -44,6 +45,7 @@ export function getTargetableElements(element) {
 	const elements = element.querySelectorAll('a, button');
 
 	// As first cut, only deal with items that have an id.
+
 	return Array.from(elements).filter((element) => {
 		return element.id && _isVisible(element);
 	});

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/util/APIService.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/util/APIService.es.js
@@ -94,6 +94,7 @@ function APIService({contentPageEditorNamespace, endpoints, namespace}) {
 
 	function publishExperience(body) {
 		// TODO somehow type this
+
 		return _fetchWithError(editSegmentsExperimentStatusURL, {
 			body: _getFormDataRequest(body, namespace),
 			credentials: 'include',

--- a/modules/dxp/apps/segments/segments-experiment-web/test/js/components/SegmentsExperimentsSidebar.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/test/js/components/SegmentsExperimentsSidebar.es.js
@@ -374,6 +374,7 @@ describe('Review and Run test', () => {
 		expect(queryAllByLabelText('traffic-split').length).toBe(
 			segmentsVariants.length
 		);
+
 		/*
 		 * There is no show action button
 		 */

--- a/modules/package.json
+++ b/modules/package.json
@@ -5,7 +5,7 @@
 		"compass-mixins": "0.12.10",
 		"jsdoc": "3.6.3",
 		"liferay-frontend-common-css": "1.0.4",
-		"liferay-npm-scripts": "30.0.0",
+		"liferay-npm-scripts": "31.0.0",
 		"metal-jest-serializer": "2.0.0"
 	},
 	"private": true,

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1167,7 +1167,7 @@
     "@clayui/link" "^3.1.1"
     classnames "^2.2.6"
 
-"@clayui/link@3.1.1", "@clayui/link@^3.1.0", "@clayui/link@^3.1.1":
+"@clayui/link@3.1.1", "@clayui/link@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@clayui/link/-/link-3.1.1.tgz#b4f454a0f9a45d132435f2168041eb2df2a77ba5"
   integrity sha512-9ITqLGZfw48E30/V/X2mJK5sK1FKL/p/QTkqZBf4NvUkP5ZuDR7fZGaT7GUCsyLFXWuumDe7+jJiMgUbzipu8g==
@@ -1187,7 +1187,7 @@
     "@clayui/sticker" "^3.1.1"
     classnames "^2.2.6"
 
-"@clayui/loading-indicator@3.0.2", "@clayui/loading-indicator@^3.0.1", "@clayui/loading-indicator@^3.0.2":
+"@clayui/loading-indicator@3.0.2", "@clayui/loading-indicator@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@clayui/loading-indicator/-/loading-indicator-3.0.2.tgz#4bdcc273f077ce83b818cf3b14ffd0b3de40c71d"
   integrity sha512-tJFqNsAgEQK20yHJtahtW7K/D/Z34syGE3TD/uEs5+tDPRjcpIi0zjPlay1QP5bBl5KoNvr8/qgTppWHzf/4wg==
@@ -7407,10 +7407,10 @@ escodegen@^1.11.0, escodegen@^1.11.1, escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-20.0.1.tgz#966b1c538d9af8a63685efadd8d9a81c1d7321f1"
-  integrity sha512-9SSavMhQhgaN4NUzEkoD4GGMdAeIBW+YonnRhIqosfa/rwed1twKWeR55s8yR0p2MOUsORl87bhb9UkD2UVKBg==
+eslint-config-liferay@21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-21.0.0.tgz#65749b5b2b58ffd1dd2395ad320720fd4b5909dc"
+  integrity sha512-FMXe/ajc2OWW5U+4nU2sWhYzDWJ/bleRXYzhJfXoJIU6MAutx8W/SLw4nnux1JxmhTXtNiZhPaKTAZivbo6sfw==
   dependencies:
     eslint-config-prettier "^6.5.0"
     eslint-plugin-no-for-of-loops "^1.0.0"
@@ -11444,10 +11444,10 @@ liferay-npm-bundler@3.0.0-snapshot.dda6cd1:
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-liferay-npm-scripts@30.0.0:
-  version "30.0.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-30.0.0.tgz#df80c616d056d49257349a69f271934e0111047c"
-  integrity sha512-477Kdd9SPiImvu22V+eQYNTpXOC9FSVm1Z08+wzy+1krNAcsM1YbsTEialr60lq+OzmXFnFJ1tA/C75A/k+vOQ==
+liferay-npm-scripts@31.0.0:
+  version "31.0.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-31.0.0.tgz#fda7780d215a4ef073c6c19aa31473d33f306f90"
+  integrity sha512-3aHE/t0tl4XWqdtx+temtUFYRe9mJxlsU+Upn2BcCArct4jk8VIgyYxv8uCI0gcwwgNbxTXs9I9OknW6im3oPg==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"
@@ -11476,7 +11476,7 @@ liferay-npm-scripts@30.0.0:
     css-loader "^3.0.0"
     deepmerge "^4.0.0"
     eslint "6.8.0"
-    eslint-config-liferay "20.0.1"
+    eslint-config-liferay "21.0.0"
     fs-extra "^8.1.0"
     globby "11.0.0"
     gulp "^4.0.2"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagesadmin/PagesFinder.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagesadmin/PagesFinder.testcase
@@ -88,7 +88,10 @@ definition {
 		}
 	}
 
+	// Ignore failing test because of ticket LPS-112763
+
 	@description = "This is the test for LPS-103104. Can add a child page via page tree panel."
+	@ignore = "true"
 	@priority = "5"
 	test AddChildPageViaPageFinder {
 		property portal.acceptance = "true";


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-112763

Forwarded from https://github.com/wincent/liferay-portal/pull/241

Notes from @wincent:
New version release notes.

Brings in new lints from latest eslint-liferay-config release, specifically:

feat!: require blank lines before and after line comments
feat!: enforce standard formatting for deprecation annotations
This gets up 99% of the way to where we want to go, by which I meant that:

We put blank lines before and after line comments (//); and:
Blank lines before but not after block comments (/* ... */)
in 95% of places. The remaining 5% consists of points where ESLint and Prettier disagree about how a comment should be formatted; this specifically occurs at the beginning of objects, arrays, blocks etc. The first 95% was cheap to get (configuration only); the remaining 5% would be expensive (requiring hacking Prettier) so I stopped at this point for now.

I'll apply the autofixes (a hundred or so) and manual fixes (a couple) in separate commits to make the automated part of this update clear.