### PR TITLE
LPS-112838 Update liferay-npm-scripts to v32.0.0

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/EditAdaptiveMediaConfig.es.js
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/js/EditAdaptiveMediaConfig.es.js
@@ -24,6 +24,7 @@ import dom from 'metal-dom';
  */
 
 class EditAdaptiveMediaConfig extends PortletBase {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -229,6 +230,7 @@ class EditAdaptiveMediaConfig extends PortletBase {
  * @type {!Object}
  */
 EditAdaptiveMediaConfig.STATE = {
+
 	/**
 	 * Node where errors will be rendered.
 	 * @instance

--- a/modules/apps/analytics/analytics-client-js/src/analytics.js
+++ b/modules/apps/analytics/analytics-client-js/src/analytics.js
@@ -43,6 +43,7 @@ let instance;
  * and flushes it to the defined endpoint at regular intervals.
  */
 class Analytics {
+
 	/**
 	 * Returns an Analytics instance and triggers the automatic flush loop
 	 * @param {Object} config object to instantiate the Analytics tool

--- a/modules/apps/analytics/analytics-client-js/src/client.js
+++ b/modules/apps/analytics/analytics-client-js/src/client.js
@@ -19,6 +19,7 @@ import middlewares from './middlewares/defaults';
  * and use methods as only valid entry points for sending and modifying requests.
  */
 class Client {
+
 	/**
 	 * Returns a Request object with all data from the analytics instance
 	 * including the batched event objects

--- a/modules/apps/analytics/analytics-client-js/src/plugins/defaults.js
+++ b/modules/apps/analytics/analytics-client-js/src/plugins/defaults.js
@@ -23,6 +23,7 @@ import webContents from './web-contents';
 
 export {blogs, documents, forms, resolution, scrolling, timing, webContents};
 export default [
+
 	// Resolution should come first, because it chages the context
 
 	resolution,

--- a/modules/apps/analytics/analytics-client-js/test/analytics.js
+++ b/modules/apps/analytics/analytics-client-js/test/analytics.js
@@ -151,6 +151,7 @@ describe('Analytics', () => {
 		sendDummyEvents(Analytics, 1);
 
 		setTimeout(async () => {
+
 			// flush should have happened at least once
 
 			const userId = getItem(STORAGE_KEY_USER_ID);

--- a/modules/apps/analytics/analytics-client-js/test/plugins/blogs.js
+++ b/modules/apps/analytics/analytics-client-js/test/plugins/blogs.js
@@ -39,6 +39,7 @@ describe('Blogs Plugin', () => {
 	let Analytics;
 
 	beforeEach(() => {
+
 		// Force attaching DOM Content Loaded event
 
 		Object.defineProperty(document, 'readyState', {

--- a/modules/apps/analytics/analytics-client-js/test/plugins/custom.js
+++ b/modules/apps/analytics/analytics-client-js/test/plugins/custom.js
@@ -60,6 +60,7 @@ describe('Custom Asset Plugin', () => {
 	let Analytics;
 
 	beforeEach(() => {
+
 		// Force attaching DOM Content Loaded event
 
 		Object.defineProperty(document, 'readyState', {

--- a/modules/apps/analytics/analytics-client-js/test/plugins/forms.js
+++ b/modules/apps/analytics/analytics-client-js/test/plugins/forms.js
@@ -23,6 +23,7 @@ describe('Forms Plugin', () => {
 	let duration;
 
 	beforeEach(() => {
+
 		// Force attaching DOM Content Loaded event
 
 		Object.defineProperty(document, 'readyState', {

--- a/modules/apps/analytics/analytics-client-js/test/utils/scroll.js
+++ b/modules/apps/analytics/analytics-client-js/test/utils/scroll.js
@@ -48,6 +48,7 @@ const getPage = () => {
 describe('ScrollTracker', () => {
 	describe('getDepth() from an element', () => {
 		beforeEach(() => {
+
 			// Avoid: "Error: Not implemented: window.scrollTo."
 
 			window.scrollTo = (_x, y) => {

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/hooks/useLoad.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/hooks/useLoad.es.js
@@ -44,6 +44,7 @@ export default function useLoad() {
 							},
 							(error) => {
 								if (isMounted()) {
+
 									// Reset to allow future retries.
 
 									modules.current.delete(key);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/InfoPanel.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/InfoPanel.es.js
@@ -19,6 +19,7 @@ import {PortletBase, openToast} from 'frontend-js-web';
  * @class InfoPanel
  */
 class InfoPanel extends PortletBase {
+
 	/**
 	 * @inheritdoc
 	 * @review

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FieldActionsDropDown.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FieldActionsDropDown.es.js
@@ -191,6 +191,7 @@ class FieldActionsDropDown extends Component {
 }
 
 FieldActionsDropDown.PROPS = {
+
 	/**
 	 * @default false
 	 * @instance
@@ -229,6 +230,7 @@ FieldActionsDropDown.PROPS = {
 };
 
 FieldActionsDropDown.STATE = {
+
 	/**
 	 * @default false
 	 * @instance

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilder.es.js
@@ -107,6 +107,7 @@ class FormBuilderBase extends Component {
 }
 
 FormBuilderBase.PROPS = {
+
 	/**
 	 * @default
 	 * @instance

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/props.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/props.es.js
@@ -17,6 +17,7 @@ import {Config} from 'metal-state';
 import {focusedFieldStructure, pageStructure} from '../../util/config.es';
 
 export default {
+
 	/**
 	 * @default
 	 * @instance

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withMultiplePages.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/withMultiplePages.es.js
@@ -250,6 +250,7 @@ const withMultiplePages = (ChildComponent) => {
 	}
 
 	MultiplePages.PROPS = {
+
 		/**
 		 * @instance
 		 * @memberof LayoutProvider
@@ -262,6 +263,7 @@ const withMultiplePages = (ChildComponent) => {
 	};
 
 	MultiplePages.STATE = {
+
 		/**
 		 * @default false
 		 * @instance

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/LayoutProvider.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/LayoutProvider.es.js
@@ -623,6 +623,7 @@ class LayoutProvider extends Component {
 }
 
 LayoutProvider.PROPS = {
+
 	/**
 	 * @instance
 	 * @memberof LayoutProvider
@@ -774,6 +775,7 @@ LayoutProvider.PROPS = {
 };
 
 LayoutProvider.STATE = {
+
 	/**
 	 * @instance
 	 * @memberof FormPage

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
@@ -1242,6 +1242,7 @@ class Sidebar extends Component {
 }
 
 Sidebar.STATE = {
+
 	/**
 	 * @default 0
 	 * @instance
@@ -1293,6 +1294,7 @@ Sidebar.STATE = {
 };
 
 Sidebar.PROPS = {
+
 	/**
 	 * @default undefined
 	 * @instance

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/__mock__/Modal.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/__mock__/Modal.js
@@ -13,6 +13,7 @@
  */
 
 module.exports = {
+
 	// Mock this because we can't evaluate React JSX from a Metal-using module
 	// like dynamic-data-mapping-form-builder.
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/FieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/FieldBase.es.js
@@ -38,6 +38,7 @@ class FieldBase extends Component {
 }
 
 FieldBase.STATE = {
+
 	/**
 	 * @default input
 	 * @memberof FieldBase

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Separator/Separator.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Separator/Separator.es.js
@@ -23,6 +23,7 @@ const Separator = ({style}) => {
 
 	useEffect(() => {
 		if (elRef.current) {
+
 			// The style is a string, to avoid creating a normalizer to generate compatibility
 			// with React, we can just add the raw value in the attribute, we don't need to
 			// worry about XSS here because it won't go to the server just for printing

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/components/FormPortal/FormPortal.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/components/FormPortal/FormPortal.es.js
@@ -22,6 +22,7 @@ import templates from './FormPortal.soy';
 class FormPortal extends Component {}
 
 FormPortal.STATE = {
+
 	/**
 	 * @default input
 	 * @instance

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/components/Tooltip/Tooltip.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/components/Tooltip/Tooltip.es.js
@@ -56,6 +56,7 @@ class Tooltip extends Component {
 Soy.register(Tooltip, templates);
 
 Tooltip.STATE = {
+
 	/**
 	 * @default undefined
 	 * @instance

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/hooks/useSyncValue.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/hooks/useSyncValue.es.js
@@ -20,6 +20,7 @@ import {useEffect, useRef, useState} from 'react';
  * values are different and when the value is not changed for more than ms.
  */
 export const useSyncValue = (newValue, isDelay = true) => {
+
 	// Maintains the reference of the last value to check in later renderings if the
 	// value is new or keeps the same, it covers cases where the value typed by
 	// the user is sent to LayoutProvider but it does not descend with the new changes.

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/ReactComponentAdapter.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/ReactComponentAdapter.es.js
@@ -90,6 +90,7 @@ const CONFIG_DEFAULT = ['displayErrors'];
 
 function getConnectedReactComponentAdapter(ReactComponent, variant) {
 	class ReactComponentAdapter extends JSXComponent {
+
 		/**
 		 * For Metal to track config changes, we need to declare the
 		 * configs in the static property so that willReceiveProps is
@@ -123,6 +124,7 @@ function getConnectedReactComponentAdapter(ReactComponent, variant) {
 		}
 
 		willReceiveProps(changes) {
+
 			// Delete the events and children properties to make it easier to
 			// check which values have been changed, events and children are
 			// properties that are changing all the time when new renderings

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/connectStore.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/connectStore.es.js
@@ -38,6 +38,7 @@ export const connectStore = (Component) => {
 
 		const emit = (name, event, value) =>
 			instance.emit(name, {
+
 				// A hacky to imitate an instance of a Metal+soy component
 
 				fieldInstance: {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/LocalizableText/LocalizableText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/LocalizableText/LocalizableText.es.js
@@ -66,6 +66,7 @@ const LocalizableTextWithContextMock = withContextMock(LocalizableText);
 
 describe('Field LocalizableText', () => {
 	beforeAll(() => {
+
 		// @ts-ignore
 
 		ReactDOM.createPortal = jest.fn((element) => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/FormRenderer/FormRenderer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/FormRenderer/FormRenderer.es.js
@@ -63,6 +63,7 @@ class FormRenderer extends Component {
 }
 
 FormRenderer.STATE = {
+
 	/**
 	 * @default
 	 * @instance

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/PageRenderer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/PageRenderer.es.js
@@ -113,6 +113,7 @@ class PageRenderer extends Component {
 }
 
 PageRenderer.STATE = {
+
 	/**
 	 * @instance
 	 * @memberof FormPage

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/store/actions/handleFieldEdited.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/store/actions/handleFieldEdited.es.js
@@ -62,6 +62,7 @@ export default (evaluatorContext, properties, updateState) => {
 			pages: editedPages,
 		}).then((evaluatedPages) => {
 			if (REVALIDATE_UPDATES.length > 0) {
+
 				// All non-evaluable operations that were performed after the request
 				// was sent are used here to revalidate the new data.
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/Popover/PopoverBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/Popover/PopoverBase.es.js
@@ -45,6 +45,7 @@ class PopoverBase extends Component {
 }
 
 PopoverBase.PROPS = {
+
 	/**
 	 * @type {string}
 	 * @default undefined

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/ShareFormPopover/ShareFormPopover.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/ShareFormPopover/ShareFormPopover.es.js
@@ -138,6 +138,7 @@ class ShareFormPopover extends Component {
 }
 
 ShareFormPopover.PROPS = {
+
 	/**
 	 * The element to align with.
 	 * @default ""

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
@@ -1076,6 +1076,7 @@ class Form extends Component {
 }
 
 Form.PROPS = {
+
 	/**
 	 * The context for rendering a layout that represents a form.
 	 * @default undefined
@@ -1299,6 +1300,7 @@ Form.PROPS = {
 };
 
 Form.STATE = {
+
 	/**
 	 * Current active tab index.
 	 * @default

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/__mock__/Modal.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/__mock__/Modal.js
@@ -13,6 +13,7 @@
  */
 
 module.exports = {
+
 	// Mock this because we can't evaluate React JSX from a Metal-using module
 	// like dynamic-data-mapping-form-web.
 

--- a/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/soy/Flags.es.js
+++ b/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/soy/Flags.es.js
@@ -29,6 +29,7 @@ import templates from './Flags.soy';
  */
 
 class Flags extends PortletBase {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -137,6 +138,7 @@ class Flags extends PortletBase {
  */
 
 Flags.STATE = {
+
 	/**
 	 * Flag to indicate if dialog should be open.
 	 * @default false

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionsView.es.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionsView.es.js
@@ -19,6 +19,7 @@ import {Config} from 'metal-state';
  * @class FragmentCollectionsView
  */
 class FragmentCollectionsView extends PortletBase {
+
 	/**
 	 * @inheritdoc
 	 * @review
@@ -182,6 +183,7 @@ class FragmentCollectionsView extends PortletBase {
 }
 
 FragmentCollectionsView.STATE = {
+
 	/**
 	 * Collections form used for updating backend
 	 * @default undefined

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/bbcode/bbcode_parser.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/bbcode/bbcode_parser.js
@@ -276,7 +276,9 @@
 							(token = lexer.getNextToken()) &&
 							token[3] != STR_TAG_CODE
 						) {
+
 							// Continue.
+
 						}
 
 						instance._handleData(token, data);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/bbcode/parser.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/bbcode/parser.js
@@ -233,7 +233,9 @@
 							(token = lexer.getNextToken()) &&
 							token[3] != STR_TAG_CODE
 						) {
+
 							// Continue.
+
 						}
 
 						instance._handleData(token, data);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
@@ -205,6 +205,7 @@
 		fallback: {
 			apply(node, data, options) {
 				if (options && options.forIE) {
+
 					// workaround for bad IE
 
 					data = data.replace(/\n/g, ' \r');

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/wikilink/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/wikilink/plugin.js
@@ -32,6 +32,7 @@ CKEDITOR.plugins.add('wikilink', {
 		CKEDITOR.dialog.add('link', instance.path + 'dialogs/link.js');
 
 		editor.on('selectionChange', (event) => {
+
 			// document.queryCommandEnabled does not work for this in Firefox.
 			// Use element paths to detect the state.
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/BrightnessComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/BrightnessComponent.es.js
@@ -28,6 +28,7 @@ import './BrightnessControls.soy';
  * Creates a Brightness component.
  */
 class BrightnessComponent extends Component {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -114,6 +115,7 @@ class BrightnessComponent extends Component {
  * @type {!Object}
  */
 BrightnessComponent.STATE = {
+
 	/**
 	 * Path of this module.
 	 *

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/BrightnessSlider.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/BrightnessSlider.es.js
@@ -22,6 +22,7 @@ import Soy from 'metal-soy';
 import templates from './BrightnessSlider.soy';
 
 class BrightnessSlider extends Component {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -190,6 +191,7 @@ Soy.register(BrightnessSlider, templates);
  */
 
 BrightnessSlider.STATE = {
+
 	/**
 	 * Name of the hidden input field that holds the BrightnessSlider value. Useful when BrightnessSlider is embedded
 	 * inside a form so it can automatically send its value.

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ContrastComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ContrastComponent.es.js
@@ -28,6 +28,7 @@ import './ContrastControls.soy';
  * Creates a Contrast component.
  */
 class ContrastComponent extends Component {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -113,6 +114,7 @@ class ContrastComponent extends Component {
  * @type {!Object}
  */
 ContrastComponent.STATE = {
+
 	/**
 	 * Path of this module.
 	 *

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ContrastSlider.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ContrastSlider.es.js
@@ -22,6 +22,7 @@ import Soy from 'metal-soy';
 import templates from './ContrastSlider.soy';
 
 class ContrastSlider extends Component {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -190,6 +191,7 @@ Soy.register(ContrastSlider, templates);
  */
 
 ContrastSlider.STATE = {
+
 	/**
 	 * Name of the hidden input field that holds the ContrastSlider value. Useful when ContrastSlider is embedded
 	 * inside a form so it can automatically send its value.

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/CropComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/CropComponent.es.js
@@ -24,6 +24,7 @@ import './CropControls.soy';
  * Creates a Crop component.
  */
 class CropComponent extends Component {
+
 	/**
 	 * Applies the brightness filter to generate a final version of the image.
 	 *
@@ -88,6 +89,7 @@ class CropComponent extends Component {
  * @type {!Object}
  */
 CropComponent.STATE = {
+
 	/**
 	 * Injected helper that retrieves the editor canvas.
 	 *

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/CropHandles.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/CropHandles.es.js
@@ -25,6 +25,7 @@ import handlesTemplates from './CropHandles.soy';
  * Creates a Crop Handles Component.
  */
 class CropHandles extends Component {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -260,6 +261,7 @@ class CropHandles extends Component {
  * @type {!Object}
  */
 CropHandles.STATE = {
+
 	/**
 	 * Injected helper that retrieves the editor canvas element.
 	 *

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/EffectsComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/EffectsComponent.es.js
@@ -24,6 +24,7 @@ import './EffectsControls.soy';
  * Creates an Effects component.
  */
 class EffectsComponent extends Component {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -276,6 +277,7 @@ class EffectsComponent extends Component {
  * @type {!Object}
  */
 EffectsComponent.STATE = {
+
 	/**
 	 * Offset in pixels (<code>px</code> postfix) for the carousel item.
 	 *

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
@@ -48,6 +48,7 @@ import ImageEditorHistoryEntry from './ImageEditorHistoryEntry.es';
  * </ul>
  */
 class ImageEditor extends PortletBase {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -516,6 +517,7 @@ class ImageEditor extends PortletBase {
  * @type {!Object}
  */
 ImageEditor.STATE = {
+
 	/**
 	 * Whether the editor is ready for user interaction.
 	 * @type {Object}

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditorHistoryEntry.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditorHistoryEntry.es.js
@@ -21,12 +21,14 @@
  * @review
  */
 class ImageEditorHistoryEntry {
+
 	/**
 	 * Constructor
 	 * @review
 	 */
 	constructor(image) {
 		this.dataPromise_ = new Promise((resolve) => {
+
 			// Preemtively fetch the imageData when all we have is the image url
 
 			if (image.url && !image.data) {

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ResizeComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ResizeComponent.es.js
@@ -24,6 +24,7 @@ import './ResizeControls.soy';
  * Creates a Resize component.
  */
 class ResizeComponent extends Component {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -124,6 +125,7 @@ class ResizeComponent extends Component {
  * @type {!Object}
  */
 ResizeComponent.STATE = {
+
 	/**
 	 * Injected helper that retrieves the editor image data.
 	 *

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/RotateComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/RotateComponent.es.js
@@ -24,6 +24,7 @@ import './RotateControls.soy';
  * Creates a Rotate component.
  */
 class RotateComponent extends Component {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -146,6 +147,7 @@ class RotateComponent extends Component {
  * @type {!Object}
  */
 RotateComponent.STATE = {
+
 	/**
 	 * Path of this module.
 	 *

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/SaturationComponent.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/SaturationComponent.es.js
@@ -28,6 +28,7 @@ import './SaturationControls.soy';
  * Creates a Saturation component.
  */
 class SaturationComponent extends Component {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -114,6 +115,7 @@ class SaturationComponent extends Component {
  * @type {!Object}
  */
 SaturationComponent.STATE = {
+
 	/**
 	 * Path of this module.
 	 *

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/SaturationSlider.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/SaturationSlider.es.js
@@ -22,6 +22,7 @@ import Soy from 'metal-soy';
 import templates from './SaturationSlider.soy';
 
 class SaturationSlider extends Component {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -190,6 +191,7 @@ Soy.register(SaturationSlider, templates);
  */
 
 SaturationSlider.STATE = {
+
 	/**
 	 * Name of the hidden input field that holds the SaturationSlider value. Useful when SaturationSlider is embedded
 	 * inside a form so it can automatically send its value.

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/browser_selectors.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/browser_selectors.js
@@ -91,6 +91,7 @@ YUI.add(
 
 		var BrowserSelectors = {
 			getSelectors() {
+
 				// The methods in this if block only run once across all instances
 
 				if (!UA.selectors) {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/social_bookmarks.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/social_bookmarks.js
@@ -42,6 +42,7 @@ AUI.add(
 		 */
 
 		var SocialBookmarks = A.Component.create({
+
 			/**
 			 * A static property used to define the default attribute
 			 * configuration for `SocialBookmarks`.
@@ -52,6 +53,7 @@ AUI.add(
 			 */
 
 			ATTRS: {
+
 				/**
 				 * The direct descendant of a widget's bounding box
 				 * and houses its content.
@@ -86,6 +88,7 @@ AUI.add(
 			NAME,
 
 			prototype: {
+
 				/**
 				 * Construction lifecycle implementation executed during
 				 * `SocialBookmarks` instantiation.

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/NodeList.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/NodeList.js
@@ -28,6 +28,7 @@ export default function NodeList({
 	const rootNodeId = nodes[0] && nodes[0].id;
 
 	if (!rootNodeId) {
+
 		// All nodes have been filtered.
 
 		return null;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/Treeview.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/Treeview.js
@@ -188,6 +188,7 @@ function updateNode(state, id, callback) {
 	let node = callback(nodeMap[id]);
 
 	if (node === nodeMap[id]) {
+
 		// Node didn't change, so leave state as-is.
 
 		return state.nodes;
@@ -242,6 +243,7 @@ function reducer(state, action) {
 			};
 
 		case 'COLLAPSE':
+
 			// eg double click
 
 			if (!filteredNodes) {
@@ -287,12 +289,14 @@ function reducer(state, action) {
 				else {
 					while (node) {
 						if (node.id !== action.nodeId) {
+
 							// Not the first iteration and we found a match: done.
 
 							break;
 						}
 
 						if (node.expanded && node.children.length) {
+
 							// Expanded, so go to first visible child.
 
 							node = node.children[0];
@@ -359,6 +363,7 @@ function reducer(state, action) {
 							break;
 						}
 						else {
+
 							// Go to parent.
 
 							node = nodeMap[node.parentId];
@@ -410,6 +415,7 @@ function reducer(state, action) {
 			break;
 
 		case 'TOGGLE_EXPANDED':
+
 			// Toggles the expanded or collapsed state of the selected
 			// parent node. eg. by double clicking; doesn't select a child.
 
@@ -470,6 +476,7 @@ function reducer(state, action) {
 
 		case 'COLLAPSE_PARENT':
 			{
+
 				// Collapse the currently selected parent node if it is
 				// expanded; otherwise move to the previous parent node
 				// (if possible).
@@ -500,6 +507,7 @@ function reducer(state, action) {
 
 		case 'EXPAND_AND_ENTER':
 			{
+
 				// Expand the currently selected parent node if it is closed;
 				// move to the first child list item if it was already expanded.
 
@@ -604,7 +612,9 @@ function reducer(state, action) {
 		}
 
 		case 'EXIT':
+
 			// Navigate away from tree.
+
 			break;
 
 		case 'UPDATE_NODES': {

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/TreeviewLabel.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/TreeviewLabel.js
@@ -24,7 +24,9 @@ export default function TreeviewLabel({node}) {
 				className="sr-only"
 				id={inputId}
 				onChange={() => {
+
 					// Let NodeListItem handle checked state.
+
 				}}
 				type="checkbox"
 			/>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/useKeyboardNavigation.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/useKeyboardNavigation.js
@@ -64,6 +64,7 @@ export default function useKeyboardNavigation(nodeId) {
 
 			if (focusedNodeId === nodeId && HANDLED_KEY_CODES.has(keyCode)) {
 				if (keyCode !== KEYS.TAB) {
+
 					// We intercept and manage all key presses internally,
 					// except for TAB, which is used to navigate away from the
 					// component (requires a `tabindex` of -1 on all internal

--- a/modules/apps/frontend-js/frontend-js-jquery-web/src/main/resources/META-INF/resources/jquery/fm.js
+++ b/modules/apps/frontend-js/frontend-js-jquery-web/src/main/resources/META-INF/resources/jquery/fm.js
@@ -13,6 +13,7 @@
  */
 
 (function ($) {
+
 	/*!
 	 * jQuery fm Plugin
 	 * version: 0.1

--- a/modules/apps/frontend-js/frontend-js-jquery-web/src/main/resources/META-INF/resources/jquery/form.js
+++ b/modules/apps/frontend-js/frontend-js-jquery-web/src/main/resources/META-INF/resources/jquery/form.js
@@ -13,6 +13,7 @@
  */
 
 (function (jQuery) {
+
 	/*!
 	 * jQuery Form Plugin
 	 * version: 3.51.0-2014.06.20
@@ -26,14 +27,19 @@
 	/*global ActiveXObject */
 
 	// AMD support
+
 	(function (factory) {
 		'use strict';
 		if (false && typeof define === 'function' && define.amd) {
+
 			// using AMD; register as anon module
+
 			define(['jquery'], factory);
 		}
 		else {
+
 			// no AMD; invoke directly
+
 			factory(typeof jQuery != 'undefined' ? jQuery : window.Zepto);
 		}
 	})(function ($) {
@@ -89,6 +95,7 @@
 		// an expected string.  this accounts for the case where a form
 		// contains inputs with names like "action" or "method"; in those
 		// cases "prop" returns the element
+
 		$.fn.attr2 = function () {
 			if (!hasProp) {
 				return this.attr.apply(this, arguments);
@@ -108,6 +115,7 @@
 			/*jshint scripturl:true */
 
 			// fast fail if nothing selected (http://dev.jquery.com/ticket/2752)
+
 			if (!this.length) {
 				log(
 					'ajaxSubmit: skipping submit process - no element selected'
@@ -133,7 +141,9 @@
 			url = typeof action === 'string' ? $.trim(action) : '';
 			url = url || window.location.href || '';
 			if (url) {
+
 				// clean url (don't include hash vaue)
+
 				url = (url.match(/^([^#]+)/) || [])[1];
 			}
 
@@ -152,6 +162,7 @@
 
 			// hook for manipulating the form data before it is extracted;
 			// convenient for use with rich editors like tinyMCE or FCKEditor
+
 			var veto = {};
 			this.trigger('form-pre-serialize', [this, options, veto]);
 			if (veto.veto) {
@@ -160,6 +171,7 @@
 			}
 
 			// provide opportunity to alter form data before it is serialized
+
 			if (
 				options.beforeSerialize &&
 				options.beforeSerialize(this, options) === false
@@ -182,6 +194,7 @@
 			}
 
 			// give pre-submit callback an opportunity to abort the submit
+
 			if (
 				options.beforeSubmit &&
 				options.beforeSubmit(a, this, options) === false
@@ -191,6 +204,7 @@
 			}
 
 			// fire vetoable 'validate' event
+
 			this.trigger('form-submit-validate', [a, this, options, veto]);
 			if (veto.veto) {
 				log(
@@ -224,6 +238,7 @@
 			}
 
 			// perform a load on the target only if dataType is not provided
+
 			if (!options.dataType && options.target) {
 				var oldSuccess = options.success || function () {};
 				callbacks.push(function (data) {
@@ -236,6 +251,7 @@
 			}
 
 			options.success = function (data, status, xhr) {
+
 				// jQuery 1.4+ passes xhr as 3rd arg
 				var context = options.context || this; // jQuery 1.4+ supports scope context
 				for (var i = 0, max = callbacks.length; i < max; i++) {
@@ -268,6 +284,7 @@
 
 			// [value] (issue #113), also see comment:
 			// https://github.com/malsup/form/commit/588306aedba1de01388032d5f42a60159eea9228#commitcomment-2180219
+
 			var fileInputs = $('input[type=file]:enabled', this).filter(
 				function () {
 					return $(this).val() !== '';
@@ -287,12 +304,15 @@
 
 			// options.iframe allows user to force iframe mode
 			// 06-NOV-09: now defaulting to iframe mode if file input is detected
+
 			if (
 				options.iframe !== false &&
 				(options.iframe || shouldUseFrame)
 			) {
+
 				// hack to fix Safari hang (thanks to Tim Molendijk for this)
 				// see:  http://groups.google.com/group/jquery-dev/browse_thread/thread/36395b7ab510dd5d
+
 				if (options.closeKeepAlive) {
 					$.get(options.closeKeepAlive, function () {
 						jqxhr = fileUploadIframe(a);
@@ -312,15 +332,18 @@
 			$form.removeData('jqxhr').data('jqxhr', jqxhr);
 
 			// clear element array
+
 			for (var k = 0; k < elements.length; k++) {
 				elements[k] = null;
 			}
 
 			// fire 'notify' event
+
 			this.trigger('form-submit-notify', [this, options]);
 			return this;
 
 			// utility fn for deep serialization
+
 			function deepSerialize(extraData) {
 				var serialized = $.param(extraData, options.traditional).split(
 					'&'
@@ -329,10 +352,14 @@
 				var result = [];
 				var i, part;
 				for (i = 0; i < len; i++) {
+
 					// #252; undo param space replacement
+
 					serialized[i] = serialized[i].replace(/\+/g, ' ');
 					part = serialized[i].split('=');
+
 					// #278; use array instead of object storage, favoring array serializations
+
 					result.push([
 						decodeURIComponent(part[0]),
 						decodeURIComponent(part[1]),
@@ -342,6 +369,7 @@
 			}
 
 			// XMLHttpRequest Level 2 file uploads (big hat tip to francois2metz)
+
 			function fileUploadXhr(a) {
 				var formdata = new FormData();
 
@@ -371,7 +399,9 @@
 				});
 
 				if (options.uploadProgress) {
+
 					// workaround because jqXHR does not expose upload property
+
 					s.xhr = function () {
 						var xhr = $.ajaxSettings.xhr();
 						if (xhr.upload) {
@@ -405,7 +435,9 @@
 				s.data = null;
 				var beforeSend = s.beforeSend;
 				s.beforeSend = function (xhr, o) {
+
 					//Send FormData() provided by user
+
 					if (options.formData) {
 						o.data = options.formData;
 					}
@@ -420,6 +452,7 @@
 			}
 
 			// private function for handling file uploads (hat tip to YAHOO!)
+
 			function fileUploadIframe(a) {
 				var form = $form[0],
 					el,
@@ -437,12 +470,15 @@
 				var deferred = $.Deferred();
 
 				// #341
+
 				deferred.abort = function (status) {
 					xhr.abort(status);
 				};
 
 				if (a) {
+
 					// ensure that every serialized input is still enabled
+
 					for (i = 0; i < elements.length; i++) {
 						el = $(elements[i]);
 						if (hasProp) {
@@ -480,7 +516,9 @@
 				io = $io[0];
 
 				xhr = {
+
 					// mock object
+
 					aborted: 0,
 					responseText: null,
 					responseXML: null,
@@ -495,7 +533,9 @@
 						this.aborted = 1;
 
 						try {
+
 							// #214, #257
+
 							if (io.contentWindow.document.execCommand) {
 								io.contentWindow.document.execCommand('Stop');
 							}
@@ -517,7 +557,9 @@
 				};
 
 				g = s.global;
+
 				// trigger ajax global events so that activity/block indicators work like normal
+
 				if (g && 0 === $.active++) {
 					$.event.trigger('ajaxStart');
 				}
@@ -541,6 +583,7 @@
 				}
 
 				// add submitting element to data if we know it
+
 				sub = form.clk;
 				if (sub) {
 					n = sub.name;
@@ -558,6 +601,7 @@
 				var SERVER_ABORT = 2;
 
 				function getDoc(frame) {
+
 					/* it looks like contentWindow or contentDocument do not
 					 * carry the protocol property in ie8, when running under ssl
 					 * frame.document is the only valid response document, since
@@ -568,29 +612,38 @@
 					var doc = null;
 
 					// IE8 cascading access check
+
 					try {
 						if (frame.contentWindow) {
 							doc = frame.contentWindow.document;
 						}
 					}
 					catch (err) {
+
 						// IE8 access denied under ssl & missing protocol
+
 						log('cannot get iframe.contentWindow document: ' + err);
 					}
 
 					if (doc) {
+
 						// successful getting content
+
 						return doc;
 					}
 
 					try {
+
 						// simply checking may throw in ie8 under ssl or mismatched protocol
+
 						doc = frame.contentDocument
 							? frame.contentDocument
 							: frame.document;
 					}
 					catch (err) {
+
 						// last attempt
+
 						log('cannot get iframe.contentDocument: ' + err);
 						doc = frame.document;
 					}
@@ -598,6 +651,7 @@
 				}
 
 				// Rails CSRF hack (thanks to Yvan Barthelemy)
+
 				var csrf_token = $('meta[name=csrf-token]').attr('content');
 				var csrf_param = $('meta[name=csrf-param]').attr('content');
 				if (csrf_param && csrf_token) {
@@ -606,8 +660,11 @@
 				}
 
 				// take a breath so that pending repaints get some cpu time before the upload starts
+
 				function doSubmit() {
+
 					// make sure form attrs are set
+
 					var t = $form.attr2('target'),
 						a = $form.attr2('action'),
 						mp = 'multipart/form-data',
@@ -617,6 +674,7 @@
 							mp;
 
 					// update form attrs in IE friendly way
+
 					form.setAttribute('target', id);
 					if (!method || /post/i.test(method)) {
 						form.setAttribute('method', 'POST');
@@ -626,6 +684,7 @@
 					}
 
 					// ie borks in some cases when setting encoding
+
 					if (
 						!s.skipEncodingOverride &&
 						(!method || /post/i.test(method))
@@ -637,6 +696,7 @@
 					}
 
 					// support timout
+
 					if (s.timeout) {
 						timeoutHandle = setTimeout(function () {
 							timedOut = true;
@@ -645,6 +705,7 @@
 					}
 
 					// look for server aborts
+
 					function checkState() {
 						try {
 							var state = getDoc(io).readyState;
@@ -667,12 +728,15 @@
 					}
 
 					// add "extra" data to form if provided in options
+
 					var extraInputs = [];
 					try {
 						if (s.extraData) {
 							for (var n in s.extraData) {
 								if (s.extraData.hasOwnProperty(n)) {
+
 									// if using the $.param format that allows for multiple values with the same name
+
 									if (
 										$.isPlainObject(s.extraData[n]) &&
 										s.extraData[n].hasOwnProperty('name') &&
@@ -704,7 +768,9 @@
 						}
 
 						if (!s.iframeTarget) {
+
 							// add iframe to doc and submit the form
+
 							$io.appendTo('body');
 						}
 						if (io.attachEvent) {
@@ -719,14 +785,18 @@
 							form.submit();
 						}
 						catch (err) {
+
 							// just in case form has element with name/id of 'submit'
+
 							var submitFn = document.createElement('form')
 								.submit;
 							submitFn.apply(form);
 						}
 					}
 					finally {
+
 						// reset attrs and remove "extra" input elements
+
 						form.setAttribute('action', a);
 						form.setAttribute('enctype', et); // #380
 						if (t) {
@@ -773,7 +843,9 @@
 					}
 
 					if (!doc || doc.location.href == s.iframeSrc) {
+
 						// response not received yet
+
 						if (!timedOut) {
 							return;
 						}
@@ -803,20 +875,25 @@
 							(doc.body === null || !doc.body.innerHTML)
 						) {
 							if (--domCheckCount) {
+
 								// in some browsers (Opera) the iframe DOM is not always traversable when
 								// the onload callback fires, so we loop a bit to accommodate
+
 								log(
 									'requeing onLoad callback, DOM not available'
 								);
 								setTimeout(cb, 250);
 								return;
 							}
+
 							// let this fall through because server response could be an empty document
 							//log('Could not access iframe DOM after mutiple tries.');
 							//throw 'DOMException: not available';
+
 						}
 
 						//log('response detected');
+
 						var docRoot = doc.body ? doc.body : doc.documentElement;
 						xhr.responseText = docRoot ? docRoot.innerHTML : null;
 						xhr.responseXML = doc.XMLDocument
@@ -829,7 +906,9 @@
 							var headers = {'content-type': s.dataType};
 							return headers[header.toLowerCase()];
 						};
+
 						// support for XHR 'status' & 'statusText' emulation :
+
 						if (docRoot) {
 							xhr.status =
 								Number(docRoot.getAttribute('status')) ||
@@ -842,11 +921,15 @@
 						var dt = (s.dataType || '').toLowerCase();
 						var scr = /(json|script|text)/.test(dt);
 						if (scr || s.textarea) {
+
 							// see if user embedded response in textarea
+
 							var ta = doc.getElementsByTagName('textarea')[0];
 							if (ta) {
 								xhr.responseText = ta.value;
+
 								// support for XHR 'status' & 'statusText' emulation :
+
 								xhr.status =
 									Number(ta.getAttribute('status')) ||
 									xhr.status;
@@ -855,7 +938,9 @@
 									xhr.statusText;
 							}
 							else if (scr) {
+
 								// account for browsers injecting pre around json response
+
 								var pre = doc.getElementsByTagName('pre')[0];
 								var b = doc.getElementsByTagName('body')[0];
 								if (pre) {
@@ -898,7 +983,9 @@
 					}
 
 					if (xhr.status) {
+
 						// we've set xhr.status
+
 						status =
 							(xhr.status >= 200 && xhr.status < 300) ||
 							xhr.status === 304
@@ -907,6 +994,7 @@
 					}
 
 					// ordering of these callbacks/triggers is odd, but that's how $.ajax does it
+
 					if (status === 'success') {
 						if (s.success) {
 							s.success.call(s.context, data, 'success', xhr);
@@ -947,12 +1035,15 @@
 					}
 
 					// clean up
+
 					setTimeout(function () {
 						if (!s.iframeTarget) {
 							$io.remove();
 						}
 						else {
+
 							//adding else to clean up existing iframe response.
+
 							$io.attr('src', s.iframeSrc);
 						}
 						xhr.responseXML = null;
@@ -962,7 +1053,9 @@
 				var toXml =
 					$.parseXML ||
 					function (s, doc) {
+
 						// use parseXML if available (jQuery 1.5+)
+
 						if (window.ActiveXObject) {
 							doc = new ActiveXObject('Microsoft.XMLDOM');
 							doc.async = 'false';
@@ -988,6 +1081,7 @@
 					};
 
 				var httpData = function (xhr, type, s) {
+
 					// mostly lifted from jq1.4.4
 
 					var ct = xhr.getResponseHeader('content-type') || '',
@@ -1047,6 +1141,7 @@
 			options.delegation = options.delegation && $.isFunction($.fn.on);
 
 			// in jQuery 1.3+ we can fix mistakes with the ready state
+
 			if (!options.delegation && this.length === 0) {
 				var o = {s: this.selector, c: this.context};
 				if (!$.isReady && o.s) {
@@ -1056,7 +1151,9 @@
 					});
 					return this;
 				}
+
 				// is your DOM ready?  http://docs.jquery.com/Tutorials:Introducing_$(document).ready()
+
 				log(
 					'terminating; zero elements found by selector' +
 						($.isReady ? '' : ' (DOM not ready)')
@@ -1093,11 +1190,14 @@
 		};
 
 		// private event handlers
+
 		function doAjaxSubmit(e) {
 			/*jshint validthis:true */
 			var options = e.data;
 			if (!e.isDefaultPrevented()) {
+
 				// if event has been canceled, don't proceed
+
 				e.preventDefault();
 				$(e.target).ajaxSubmit(options); // #365
 			}
@@ -1108,7 +1208,9 @@
 			var target = e.target;
 			var $el = $(target);
 			if (!$el.is('[type=submit],[type=image]')) {
+
 				// is this a child element of the submit el?  (ex: a span within a button)
+
 				var t = $el.closest('[type=submit]');
 				if (t.length === 0) {
 					return;
@@ -1132,13 +1234,16 @@
 					form.clk_y = e.pageY - target.offsetTop;
 				}
 			}
+
 			// clear form vars
+
 			setTimeout(function () {
 				form.clk = form.clk_x = form.clk_y = null;
 			}, 100);
 		}
 
 		// ajaxFormUnbind unbinds the event handlers that were bound by ajaxForm
+
 		$.fn.ajaxFormUnbind = function () {
 			return this.unbind('submit.form-plugin click.form-plugin');
 		};
@@ -1166,11 +1271,13 @@
 			var els2;
 
 			if (els && !/MSIE [678]/.test(navigator.userAgent)) {
+
 				// #390
 				els = $(els).get(); // convert to standard array
 			}
 
 			// #386; account for inputs outside the form which use the 'form' attribute
+
 			if (formId) {
 				els2 = $(':input[form="' + formId + '"]').get(); // hat tip @thet
 				if (els2.length) {
@@ -1191,7 +1298,9 @@
 				}
 
 				if (semantic && form.clk && el.type == 'image') {
+
 					// handle image inputs on the fly when semantic == true
+
 					if (form.clk == el) {
 						a.push({name: n, value: $(el).val(), type: el.type});
 						a.push(
@@ -1222,7 +1331,9 @@
 						}
 					}
 					else {
+
 						// #180
+
 						a.push({name: n, value: '', type: el.type});
 					}
 				}
@@ -1240,7 +1351,9 @@
 			}
 
 			if (!semantic && form.clk) {
+
 				// input type=='image' are not found in elements array! handle it here
+
 				var $input = $(form.clk),
 					input = $input[0];
 				n = input.name;
@@ -1260,7 +1373,9 @@
 		 * in the format: name1=value1&amp;name2=value2
 		 */
 		$.fn.formSerialize = function (semantic) {
+
 			//hand off to jQuery.param for proper encoding
+
 			return $.param(this.formToArray(semantic));
 		};
 
@@ -1285,7 +1400,9 @@
 					a.push({name: this.name, value: v});
 				}
 			});
+
 			//hand off to jQuery.param for proper encoding
+
 			return $.param(a);
 		};
 
@@ -1388,7 +1505,9 @@
 					if (op.selected) {
 						var v = op.value;
 						if (!v) {
+
 							// extra pain for IE...
+
 							v =
 								op.attributes &&
 								op.attributes.value &&
@@ -1447,10 +1566,12 @@
 					}
 				}
 				else if (includeHidden) {
+
 					// includeHidden can be the value true, or it can be a selector string
 					// indicating a special test; for example:
 					//  $('#myForm').clearForm('.special:hidden')
 					// the above would clean hidden inputs that have the class of 'special'
+
 					if (
 						(includeHidden === true && /hidden/.test(t)) ||
 						(typeof includeHidden == 'string' &&
@@ -1467,8 +1588,10 @@
 		 */
 		$.fn.resetForm = function () {
 			return this.each(function () {
+
 				// guard against an input with the name of 'reset'
 				// note that IE reports the reset function as an 'object'
+
 				if (
 					typeof this.reset == 'function' ||
 					(typeof this.reset == 'object' && !this.reset.nodeType)
@@ -1506,7 +1629,9 @@
 				else if (this.tagName.toLowerCase() == 'option') {
 					var $sel = $(this).parent('select');
 					if (select && $sel[0] && $sel[0].type == 'select-one') {
+
 						// deselect all other options
+
 						$sel.find('option').selected(false);
 					}
 					this.selected = select;
@@ -1515,9 +1640,11 @@
 		};
 
 		// expose debug var
+
 		$.fn.ajaxSubmit.debug = false;
 
 		// helper fn for console logging
+
 		function log() {
 			if (!$.fn.ajaxSubmit.debug) {
 				return;

--- a/modules/apps/frontend-js/frontend-js-jquery-web/src/main/resources/META-INF/resources/jquery/side_navigation.js
+++ b/modules/apps/frontend-js/frontend-js-jquery-web/src/main/resources/META-INF/resources/jquery/side_navigation.js
@@ -127,6 +127,7 @@
 		},
 
 		_focusElement(el) {
+
 			// ios 8 fixed element disappears when trying to scroll
 
 			el.focus();

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/app/App.es.js
@@ -38,6 +38,7 @@ const PROPAGATED_PARAMS = ['bodyCssClass'];
  */
 
 class LiferayApp extends App {
+
 	/**
 	 * @inheritDoc
 	 */

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/screen/ActionURLScreen.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/screen/ActionURLScreen.es.js
@@ -24,6 +24,7 @@ import EventScreen from './EventScreen.es';
  */
 
 class ActionURLScreen extends EventScreen {
+
 	/**
 	 * @inheritDoc
 	 */

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/screen/EventScreen.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/screen/EventScreen.es.js
@@ -24,6 +24,7 @@ import globals from 'senna/lib/globals/globals';
  */
 
 class EventScreen extends HtmlScreen {
+
 	/**
 	 * @inheritDoc
 	 */

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/screen/RenderURLScreen.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/screen/RenderURLScreen.es.js
@@ -22,6 +22,7 @@ import EventScreen from './EventScreen.es';
  */
 
 class RenderURLScreen extends EventScreen {
+
 	/**
 	 * @inheritDoc
 	 */

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/surface/Surface.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/surface/Surface.es.js
@@ -24,6 +24,7 @@ import Surface from 'senna/lib/surface/Surface';
  */
 
 class LiferaySurface extends Surface {
+
 	/**
 	 * @inheritDoc
 	 */

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/util/Utils.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/util/Utils.es.js
@@ -21,6 +21,7 @@ const MAX_TIMEOUT = Math.pow(2, 31) - 1;
  */
 
 class Utils {
+
 	/**
 	 * Returns the maximum number allowed by the `setTimeout` function
 	 * @return {!Number} The number

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/CompatibilityEventProxy.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/CompatibilityEventProxy.es.js
@@ -20,6 +20,7 @@ import State from 'metal-state';
  * and adding the capability of adding targets to bubble events to them.
  */
 class CompatibilityEventProxy extends State {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -79,7 +80,9 @@ class CompatibilityEventProxy extends State {
 						event.target = this.host;
 					}
 					catch (e) {
+
 						// Do nothing
+
 					}
 				}
 
@@ -131,6 +134,7 @@ class CompatibilityEventProxy extends State {
  * @type {!Object}
  */
 CompatibilityEventProxy.STATE = {
+
 	/**
 	 * Replaces event names with adapted YUI names.
 	 *

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
@@ -25,6 +25,7 @@ import PortletBase from './PortletBase.es';
  * @extends {Component}
  */
 class DynamicInlineScroll extends PortletBase {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -192,6 +193,7 @@ class DynamicInlineScroll extends PortletBase {
  * @type {!Object}
  */
 DynamicInlineScroll.STATE = {
+
 	/**
 	 * Current page index.
 	 *

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/ItemSelectorDialog.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/ItemSelectorDialog.es.js
@@ -19,6 +19,7 @@ import {Config} from 'metal-state';
  * Shows a dialog and handles the selected item.
  */
 class ItemSelectorDialog extends Component {
+
 	/**
 	 * Closes the dialog.
 	 */
@@ -146,6 +147,7 @@ class ItemSelectorDialog extends Component {
  * @type {!Object}
  */
 ItemSelectorDialog.STATE = {
+
 	/**
 	 * Label for the Add button.
 	 *

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/PortletBase.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/PortletBase.es.js
@@ -26,6 +26,7 @@ import objectToFormData from './util/form/object_to_form_data.es';
  * @extends {Component}
  */
 class PortletBase extends Component {
+
 	/**
 	 * Returns a Node List containing all the matching element nodes within the
 	 * subtrees of the root object, in tree order. If there are no matching
@@ -164,6 +165,7 @@ class PortletBase extends Component {
  * @type {!Object}
  */
 PortletBase.STATE = {
+
 	/**
 	 * Portlet's namespace.
 	 *

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/aop/AOP.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/aop/AOP.es.js
@@ -24,6 +24,7 @@ const PREVENT = 'prevent';
  * AOP class
  */
 class AOP {
+
 	/**
 	 * Constructor for AOP class.
 	 * @param {!Object} obj The object containing the displaced function.
@@ -31,6 +32,7 @@ class AOP {
 	 * @constructor
 	 */
 	constructor(obj, fnName) {
+
 		/**
 		 * Array of listeners that will invoke after the displaced function.
 		 * @type {!Array}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/compat/modal/Modal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/compat/modal/Modal.es.js
@@ -27,6 +27,7 @@ const KEY_CODE_ESC = 27;
  */
 
 class Modal extends Component {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -236,6 +237,7 @@ class Modal extends Component {
 }
 
 Modal.STATE = {
+
 	/**
 	 * A selector for the element that should be automatically focused when the modal
 	 * becomes visible, or `false` if no auto focus should happen. Defaults to the

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -512,6 +512,7 @@
 				// Functions to run on portlet load
 
 				if (canEditTitle) {
+
 					// https://github.com/yui/yui3/issues/1808
 
 					var events = 'focus';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/PortletInit.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/PortletInit.es.js
@@ -360,7 +360,9 @@ class PortletInit {
 						history.pushState(token, '', url);
 					}
 					catch (e) {
+
 						// Do nothing
+
 					}
 				}
 			});

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/portlet_constants.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/portlet_constants.es.js
@@ -15,6 +15,7 @@
 /* eslint-disable sort-keys */
 
 const PortletConstants = {
+
 	// Portlet mode
 
 	EDIT: 'edit',

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/portlet_util.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/portlet_util.es.js
@@ -82,7 +82,9 @@ const decodeUpdateString = function (pageRenderState, updateString) {
 		}
 	}
 	catch (e) {
+
 		// Do nothing
+
 	}
 
 	return portlets;
@@ -253,6 +255,7 @@ const generateParameterString = function (
 			const values = portletData.state.parameters[name];
 
 			if (values !== undefined) {
+
 				// If values are present, encode the mutlivalued parameter string
 
 				if (type === PUBLIC_RENDER_PARAM_KEY) {
@@ -381,6 +384,7 @@ const getUrl = function (
 	let url = '';
 
 	if (pageRenderState && pageRenderState.portlets) {
+
 		// If target portlet not defined for render URL, set it to null
 
 		if (type === 'RENDER' && portletId === undefined) {
@@ -440,6 +444,7 @@ const getUrl = function (
 			// Put the private & public parameters on the URL if cacheability != FULL
 
 			if (type !== 'RESOURCE' || cacheability !== 'cacheLevelFull') {
+
 				// Add the state for the target portlet, if there is one.
 				// (for the render URL, pid can be null, and the state will have
 				// been added previously)
@@ -678,6 +683,7 @@ const stateChanged = function (pageRenderState, newState, portletId) {
 				result = true;
 			}
 			else {
+
 				// Has a parameter changed or been added?
 
 				const newKeys = Object.keys(newState.parameters);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
@@ -24,6 +24,7 @@ const INSTANCE_MAP = new WeakMap();
  * component wrappers from a DOM element.
  */
 function getElement(element) {
+
 	// Remove jQuery wrapper, if any.
 
 	if (element && element.jquery) {
@@ -115,9 +116,11 @@ function setClasses(element, classes) {
 	element = getElement(element);
 
 	if (element) {
+
 		// One at a time because IE 11: https://caniuse.com/#feat=classlist
 
 		Object.entries(classes).forEach(([className, present]) => {
+
 			// Some callers use multiple space-separated classNames for
 			// `openClass`/`data-open-class`. (Looking at you,
 			// product-navigation-simulation-web...)
@@ -197,6 +200,7 @@ function handleEvent(eventName, event) {
 		let target = event.target;
 
 		while (target) {
+
 			// In IE11 SVG elements have no `parentElement`, only a
 			// `parentNode`, so we have to search up the DOM using
 			// the latter. This in turn requires us to check for the
@@ -226,6 +230,7 @@ function handleEvent(eventName, event) {
  */
 function subscribe(elementOrSelector, eventName, handler) {
 	if (elementOrSelector) {
+
 		// Add only one listener per `eventName`.
 
 		if (!eventNamesToSelectors[eventName]) {
@@ -941,6 +946,7 @@ SideNavigation.prototype = {
 			}
 
 			if (instance.mobile) {
+
 				// ios 8 fixed element disappears when trying to scroll
 
 				menu.focus();
@@ -1088,6 +1094,7 @@ function onReady() {
 }
 
 if (document.readyState !== 'loading') {
+
 	// readyState is "interactive" or "complete".
 
 	onReady();

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/misc/swfobject.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/misc/swfobject.js
@@ -47,6 +47,7 @@ deconcept.SWFObject = function (
 	}
 	this.installedVer = deconcept.SWFObjectUtil.getPlayerVersion();
 	if (!window.opera && document.all && this.installedVer.major > 7) {
+
 		// only add the onunload cleanup if the Flash Player version supports External Interface and we are in IE
 		// fixes bug in some fp9 versions see http://blog.deconcept.com/2006/07/28/swfobject-143-released/
 
@@ -120,7 +121,9 @@ deconcept.SWFObject.prototype = {
 			navigator.mimeTypes &&
 			navigator.mimeTypes.length
 		) {
+
 			// netscape plugin architecture
+
 			if (this.getAttribute('doExpressInstall')) {
 				this.addVariable('MMplayerType', 'PlugIn');
 				this.setAttribute('swf', this.xiSWFPath);
@@ -150,7 +153,9 @@ deconcept.SWFObject.prototype = {
 			swfNode += '/>';
 		}
 		else {
+
 			// PC IE
+
 			if (this.getAttribute('doExpressInstall')) {
 				this.addVariable('MMplayerType', 'ActiveX');
 				this.setAttribute('swf', this.xiSWFPath);
@@ -184,6 +189,7 @@ deconcept.SWFObject.prototype = {
 	},
 	write: function (elementId) {
 		if (this.getAttribute('useExpressInstall')) {
+
 			// check to see if we need to do an express install
 
 			var expressInstallReqVer = new deconcept.PlayerVersion([6, 0, 65]);
@@ -240,7 +246,9 @@ deconcept.SWFObjectUtil.getPlayerVersion = function () {
 		navigator.userAgent &&
 		navigator.userAgent.indexOf('Windows CE') >= 0
 	) {
+
 		// if Windows CE
+
 		var axo = 1;
 		var counter = 3;
 		while (axo) {
@@ -260,6 +268,7 @@ deconcept.SWFObjectUtil.getPlayerVersion = function () {
 		}
 	}
 	else {
+
 		// Win IE (non mobile)
 		// do minor version lookup in IE, but avoid fp6 crashing issues
 		// see http://blog.deconcept.com/2006/01/11/getvariable-setvariable-crash-internet-explorer-flash-6/

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/add_params.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/add_params.js
@@ -77,6 +77,7 @@ describe('Liferay.Util.addParams', () => {
 	});
 
 	it('gracefully handles a relative path as the second argument', () => {
+
 		// Invariant: Jest environment sets up location like so:
 
 		expect(location.href).toBe('http://localhost/');

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.es.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.es.js
@@ -29,6 +29,7 @@ import templates from './ManagementToolbar.soy';
  * Creates a Metal Management Toolbar component.
  */
 class ManagementToolbar extends ClayComponent {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -275,6 +276,7 @@ class ManagementToolbar extends ClayComponent {
  * @type {!Object}
  */
 ManagementToolbar.STATE = {
+
 	/**
 	 * List of items to display in the actions menu on active state.
 	 *

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -34,6 +34,7 @@ const statusCode = Liferay.STATUS_CODE;
  * @extends {PortletBase}
  */
 class ItemSelectorRepositoryEntryBrowser extends PortletBase {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -513,6 +514,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
  * @type {!Object}
  */
 ItemSelectorRepositoryEntryBrowser.STATE = {
+
 	/**
 	 * Text to show near the close icon in the Item Viewer
 	 *

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -30,6 +30,7 @@ const SIDEBAR_VISIBLE_CLASS = 'contextual-sidebar-visible';
  * @extends {PortletBase}
  */
 class JournalPortlet extends PortletBase {
+
 	/**
 	 * @inheritDoc
 	 */

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/MoveEntries.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/MoveEntries.es.js
@@ -22,6 +22,7 @@ import {Config} from 'metal-state';
  * @review
  */
 class MoveEntries extends PortletBase {
+
 	/**
 	 * @inheritdoc
 	 * @review
@@ -100,6 +101,7 @@ class MoveEntries extends PortletBase {
  * @static
  */
 MoveEntries.STATE = {
+
 	/**
 	 * @default undefined
 	 * @memberof MoveEntries

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumns.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumns.js
@@ -156,6 +156,7 @@ const MillerColumns = ({
 			const columnIndex = item.columnIndex;
 
 			if (item.columnIndex > prevColumnIndex) {
+
 				// Exit if source was active but not anymore and we are on the
 				// next column to where source used to live to avoid saving its
 				// children (which must not be shown anymore)

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Toolbar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Toolbar.js
@@ -97,6 +97,7 @@ function ToolbarBody() {
 	});
 
 	if (loading.current) {
+
 		// Do this once only.
 
 		loading.current();
@@ -310,6 +311,7 @@ export default function Toolbar() {
 	const isMounted = useIsMounted();
 
 	if (!isMounted()) {
+
 		// First time here, must empty JSP-rendered markup from container.
 
 		while (container.firstChild) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/selectors/selectAvailablePanels.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/selectors/selectAvailablePanels.js
@@ -18,6 +18,7 @@ export const AVAILABLE_PANELS = ['comments', 'contents', 'page-structure'];
  * @param {Array<Array<string>>} panels
  */
 export default function selectAvailablePanels(panels) {
+
 	/**
 	 * @param {{ permissions: import("../../types/ActionKeys").ActionKeysMap }} state
 	 */

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/selectors/selectAvailableSidebarPanels.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/selectors/selectAvailableSidebarPanels.js
@@ -18,6 +18,7 @@ import {AVAILABLE_PANELS} from './selectAvailablePanels';
  * @param {{ [panelId: string]: object }} sidebarPanels
  */
 export default function selectAvailableSidebarPanels(sidebarPanels) {
+
 	/**
 	 * @param {{ permissions: import("../../types/ActionKeys").ActionKeysMap }} state
 	 */

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/CollectionService.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/CollectionService.js
@@ -16,6 +16,7 @@ import {config} from '../config/index';
 import serviceFetch from './serviceFetch';
 
 export default {
+
 	/**
 	 * Get an asset's value
 	 * @param {object} options

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/ExperienceService.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/ExperienceService.js
@@ -30,6 +30,7 @@ function getExperienceUsedPortletIds({body, dispatch}) {
 }
 
 export default {
+
 	/**
 	 * Asks backend to create a new experience
 	 * @param {object} options

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/FragmentService.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/FragmentService.js
@@ -33,6 +33,7 @@ import serviceFetch from './serviceFetch';
  */
 
 export default {
+
 	/**
 	 * Adds a new Fragment to the current layout
 	 * @param {object} options

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/InfoItemService.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/InfoItemService.js
@@ -16,6 +16,7 @@ import {config} from '../config/index';
 import serviceFetch from './serviceFetch';
 
 export default {
+
 	/**
 	 * Get an asset's value
 	 * @param {object} options

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/LayoutService.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/LayoutService.js
@@ -16,6 +16,7 @@ import {config} from '../config/index';
 import serviceFetch from './serviceFetch';
 
 export default {
+
 	/**
 	 * Adds an item to layoutData
 	 * @param {object} options

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/WidgetService.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/WidgetService.js
@@ -16,6 +16,7 @@ import {config} from '../config/index';
 import serviceFetch from './serviceFetch';
 
 export default {
+
 	/**
 	 * Adds a Widget to the current layout
 	 * @param {object} options

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/Editor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/Editor.js
@@ -101,7 +101,9 @@ export default function Editor({
 				}
 			}
 			catch (_err) {
+
 				// https://github.com/liferay/alloy-editor/issues/1306
+
 			}
 		};
 	}, [autoFocus, editorConfig]);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/createDNDBackend.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/createDNDBackend.js
@@ -15,6 +15,7 @@
 import createBackend from 'react-dnd-html5-backend';
 
 export default function createDNDBackend(manager, mainContext) {
+
 	/**
 	 * @type {Set<Window>}
 	 */

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/hooks/useLoad.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/core/hooks/useLoad.js
@@ -44,6 +44,7 @@ export default function useLoad() {
 							},
 							(error) => {
 								if (isMounted()) {
+
 									// Reset to allow future retries.
 
 									modules.current.delete(key);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
@@ -233,7 +233,9 @@ const ExperienceSelector = ({
 				selectedExperienceId: selectedExperience.segmentsExperienceId,
 			})
 		).catch((_error) => {
+
 			// TODO handle error
+
 		});
 	};
 

--- a/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/GeoJSONBase.es.js
+++ b/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/GeoJSONBase.es.js
@@ -23,6 +23,7 @@ import State, {Config} from 'metal-state';
  * @review
  */
 class GeoJSONBase extends State {
+
 	/**
 	 * Receives an object with native features data and tries
 	 * to parse it with the implemented method _getNativeFeatures.
@@ -97,6 +98,7 @@ class GeoJSONBase extends State {
  * @type {!Object}
  */
 GeoJSONBase.STATE = {
+
 	/**
 	 * Map to be used
 	 * @review

--- a/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.es.js
+++ b/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.es.js
@@ -63,6 +63,7 @@ const pendingCallbacks = {};
  * @review
  */
 class MapBase extends State {
+
 	/**
 	 * MapBase constructor
 	 * @param  {Array} args List of arguments to be sent to State constructor
@@ -770,6 +771,7 @@ MapBase.POSITION_MAP = {};
  * @type {!Object}
  */
 MapBase.STATE = {
+
 	/**
 	 * DOM node selector identifying the element that will be used
 	 * for rendering the map

--- a/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MarkerBase.es.js
+++ b/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MarkerBase.es.js
@@ -23,6 +23,7 @@ import State, {Config} from 'metal-state';
  * @review
  */
 class MarkerBase extends State {
+
 	/**
 	 * Initializes the instance with a native marker which will handle all
 	 * the execution. This function may be moved to the class constructor in
@@ -109,6 +110,7 @@ class MarkerBase extends State {
  * @type {!Object}
  */
 MarkerBase.STATE = {
+
 	/**
 	 * Location to be used
 	 * @review

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsDialog.es.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsDialog.es.js
@@ -19,6 +19,7 @@ import State, {Config} from 'metal-state';
  * @review
  */
 class GoogleMapsDialog extends State {
+
 	/**
 	 * Creates a new map dialog using Google Map's API
 	 * @param  {Array} args List of arguments to be passed to State
@@ -50,6 +51,7 @@ class GoogleMapsDialog extends State {
  * @type {!Object}
  */
 GoogleMapsDialog.STATE = {
+
 	/**
 	 * Map used for creating the dialog content
 	 * @review

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsGeoJSON.es.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsGeoJSON.es.js
@@ -19,6 +19,7 @@ import GeoJSONBase from 'map-common/js/GeoJSONBase.es';
  * @review
  */
 class GoogleMapsGeoJSON extends GeoJSONBase {
+
 	/**
 	 * Creates a new geojson parser using Google Map's API
 	 * @param  {Array} args List of arguments to be passed to State

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsGeocoder.es.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsGeocoder.es.js
@@ -19,6 +19,7 @@ import State from 'metal-state';
  * @review
  */
 class GoogleMapsGeocoder extends State {
+
 	/**
 	 * Creates a new geocoder using Google Map's API
 	 * @param  {Array} args List of arguments to be passed to State

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsMarker.es.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsMarker.es.js
@@ -19,6 +19,7 @@ import MarkerBase from 'map-common/js/MarkerBase.es';
  * @review
  */
 class GoogleMapsMarker extends MarkerBase {
+
 	/**
 	 * If a marked has been created, sets the marker location to the given one
 	 * @param {Object} location Location to set the native marker in

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsSearch.es.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsSearch.es.js
@@ -21,6 +21,7 @@ import State, {Config} from 'metal-state';
  * @review
  */
 class GoogleMapsSearch extends State {
+
 	/**
 	 * Creates a new search handler using Google Map's API
 	 * @param  {Array} args List of arguments to be passed to State
@@ -94,6 +95,7 @@ class GoogleMapsSearch extends State {
  * @type {!Object}
  */
 GoogleMapsSearch.STATE = {
+
 	/**
 	 * Input element that will be used for searching addresses.
 	 * @review

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.es.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.es.js
@@ -26,6 +26,7 @@ import GoogleMapsSearch from './GoogleMapsSearch.es';
  * @review
  */
 class MapGoogleMaps extends MapBase {
+
 	/**
 	 * Creates a new map using Google Map's API
 	 * @param  {Array} args List of arguments to be passed to State

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.es.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.es.js
@@ -26,6 +26,7 @@ import OpenStreetMapMarker from './OpenStreetMapMarker.es';
  * @review
  */
 class MapOpenStreetMap extends MapBase {
+
 	/**
 	 * Creates a new map using OpenStreetMap's API
 	 * @param  {Array} args List of arguments to be passed to State

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapDialog.es.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapDialog.es.js
@@ -19,6 +19,7 @@ import State, {Config} from 'metal-state';
  * @review
  */
 class OpenStreetMapDialog extends State {
+
 	/**
 	 * Creates a new map dialog using OpenStreetMap's API
 	 * @param  {Array} args List of arguments to be passed to State
@@ -57,6 +58,7 @@ class OpenStreetMapDialog extends State {
  * @type {!Object}
  */
 OpenStreetMapDialog.STATE = {
+
 	/**
 	 * Map used for creating the dialog content
 	 * @review

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapGeoJSON.es.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapGeoJSON.es.js
@@ -19,6 +19,7 @@ import GeoJSONBase from 'map-common/js/GeoJSONBase.es';
  * @review
  */
 class OpenStreetMapGeoJSONBase extends GeoJSONBase {
+
 	/**
 	 * Creates a new map geojson parser using OpenStreetMap's API
 	 * @param {Array} args List of arguments to be passed to State

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapGeocoder.es.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapGeocoder.es.js
@@ -18,6 +18,7 @@ import State from 'metal-state';
  * OpenStreetMapGeocoder
  */
 class OpenStreetMapGeocoder extends State {
+
 	/**
 	 * Handles the server response of a successfull address forward
 	 * @param {Object} response Server response

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapMarker.es.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapMarker.es.js
@@ -19,6 +19,7 @@ import MarkerBase from 'map-common/js/MarkerBase.es';
  * @review
  */
 class OpenStreetMapMarker extends MarkerBase {
+
 	/**
 	 * @inheritDoc
 	 * @review

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/js/MBPortlet.es.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/js/MBPortlet.es.js
@@ -25,6 +25,7 @@ import {EventHandler} from 'metal-events';
  */
 
 class MBPortlet extends PortletBase {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -345,6 +346,7 @@ class MBPortlet extends PortletBase {
  */
 
 MBPortlet.STATE = {
+
 	/**
 	 * Portlet's constants
 	 * @instance

--- a/modules/apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/main/resources/META-INF/resources/router/SoyPortletRouter.js
+++ b/modules/apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/main/resources/META-INF/resources/router/SoyPortletRouter.js
@@ -30,6 +30,7 @@ import {RequestScreen, utils} from 'senna';
  *  - Global server error management
  */
 class SoyPortletRouter extends State {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -98,6 +99,7 @@ class SoyPortletRouter extends State {
 		 * way after retrieving the new renderState.
 		 */
 		class DeferredComponentScreen extends Router.defaultScreen {
+
 			/**
 			 * @inheritDoc
 			 */
@@ -560,6 +562,7 @@ class SoyPortletRouter extends State {
  * @static
  */
 SoyPortletRouter.STATE = {
+
 	/**
 	 * @instance
 	 * @memberof SoyPortletRouter

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorInputs.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorInputs.es.js
@@ -22,6 +22,7 @@ function ContributorInputs({contributors}) {
 	return contributors
 		.filter((criteria) => criteria.query)
 		.map((criteria, i) => {
+
 			/**
 			 * First criteria has to be preceded by a `AND` conjunction
 			 */

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/SiteNavigationMenuEditor.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/SiteNavigationMenuEditor.js
@@ -56,6 +56,7 @@ const KEYS = {
  * Provides the Site Navigation Menu Editor.
  */
 class SiteNavigationMenuEditor extends State {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -366,6 +367,7 @@ class SiteNavigationMenuEditor extends State {
  * @type {!Object}
  */
 SiteNavigationMenuEditor.STATE = {
+
 	/**
 	 * Control menu height.
 	 *

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/js/UserNameFields.es.js
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/js/UserNameFields.es.js
@@ -21,6 +21,7 @@ import {Config} from 'metal-state';
  * Handles actions to display user name field for a given locale.
  */
 class UserNameFields extends PortletBase {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -234,6 +235,7 @@ class UserNameFields extends PortletBase {
 }
 
 UserNameFields.STATE = {
+
 	/**
 	 * Uri to return the user name data.
 	 * @instance

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/js/WikiPortlet.es.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/js/WikiPortlet.es.js
@@ -23,6 +23,7 @@ import {EventHandler} from 'metal-events';
  * @extends {Component}
  */
 class WikiPortlet extends PortletBase {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -219,6 +220,7 @@ class WikiPortlet extends PortletBase {
  * @type {!Object}
  */
 WikiPortlet.STATE = {
+
 	/**
 	 * Portlet's constants
 	 * @instance

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/state/chartState.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/state/chartState.js
@@ -118,6 +118,7 @@ function reducer(state, action) {
  * Declares the state as loading and resets the dataSet histogram values
  */
 function setLoadingState(state) {
+
 	/**
 	 * The dataSet does not need to be reset
 	 */
@@ -255,6 +256,7 @@ function mergeDataSets({
  * }
  */
 function addDataSetItem(state, payload, validAnalyticsConnection) {
+
 	/**
 	 * The dataSetItem is recognized as substitutive when the
 	 * previous state was in loading state.

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/utils/APIService.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/utils/APIService.js
@@ -134,6 +134,7 @@ function APIService({endpoints, namespace, page}) {
 	}
 
 	function getTrafficSourceDetails(name) {
+
 		// TODO remove frontend mock
 
 		return new Promise((resolve) =>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/utils/dateFormat.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/utils/dateFormat.js
@@ -14,6 +14,7 @@
  * internationalized date related content.
  */
 export const generateDateFormatters = (key) => {
+
 	/**
 	 * Given 2 date objects it produces a user friendly date interval
 	 *

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/ResultRankingsForm.es.js
@@ -53,6 +53,7 @@ class ResultRankingsForm extends Component {
 	};
 
 	state = {
+
 		/**
 		 * Number of the active tab.
 		 * @type {number}
@@ -317,6 +318,7 @@ class ResultRankingsForm extends Component {
 					(state) => ({
 						dataLoadingVisible: false,
 						dataMap: {
+
 							// In the case when a previously added result is
 							// actually one of the results that loads in, its
 							// 'addedResult' property must be set to false.
@@ -350,6 +352,7 @@ class ResultRankingsForm extends Component {
 				);
 			})
 			.catch((error) => {
+
 				// Delay showing error message so the user has confirmation
 				// when attempting to reload the content after an error.
 
@@ -414,6 +417,7 @@ class ResultRankingsForm extends Component {
 				this.setState((state) => ({
 					dataLoadingHidden: false,
 					dataMap: {
+
 						// In the case when a previously added result is
 						// actually one of the results that loads in, its
 						// 'addedResult' property must be set to false.
@@ -433,6 +437,7 @@ class ResultRankingsForm extends Component {
 				}));
 			})
 			.catch((error) => {
+
 				// Delay showing error message so the user has confirmation
 				// when attempting to reload the content after an error.
 
@@ -568,6 +573,7 @@ class ResultRankingsForm extends Component {
 				(id) => !addedResultsIds.includes(id)
 			),
 			resultIdsPinned: [
+
 				// Place the addedResults at the top of the pinned list
 				// while removing any that are already part of the
 				// pinned list.

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/js/components/add_result/AddResultModal.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/test/js/components/add_result/AddResultModal.es.js
@@ -82,6 +82,7 @@ describe('AddResultModal', () => {
 	});
 
 	it('prompts a message to search in the modal', async () => {
+
 		// This is a temporary mock to get the initial message to display.
 		// There currently isn't a way to disable the initial fetch, so the
 		// current workaround is showing an initial message if a refetch

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/xml_definition.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/xml_definition.js
@@ -32,6 +32,7 @@ describe('liferay-kaleo-designer-xml-definition', () => {
 		require('../../../src/main/resources/META-INF/resources/designer/js/utils');
 
 		AUI().use(['liferay-kaleo-designer-utils'], (A) => {
+
 			// Stub for "aui-component", which refuses to load in test env.
 
 			A.Component = {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/xml_definition_serializer.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/xml_definition_serializer.js
@@ -33,6 +33,7 @@ describe('liferay-kaleo-designer-xml-definition-serializer', () => {
 		AUI().use(
 			['liferay-kaleo-designer-xml-util', 'liferay-kaleo-designer-utils'],
 			(A) => {
+
 				// Stub for "aui-component", which refuses to load in test env.
 
 				A.Component = {

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
@@ -209,6 +209,7 @@ function OverlayContainer({allowEdit, root}) {
 	// Before mount.
 
 	if (!targetableElements.current) {
+
 		// Apply CSS overrides.
 
 		const css = `
@@ -250,6 +251,7 @@ function OverlayContainer({allowEdit, root}) {
 
 	useEffect(() => {
 		return () => {
+
 			// Remove CSS overrides.
 
 			const style = document.getElementById(cssId);
@@ -273,6 +275,7 @@ function OverlayContainer({allowEdit, root}) {
 
 	const handleClick = useCallback(
 		(event) => {
+
 			// Clicking anywhere other than a target aborts target selection.
 
 			event.preventDefault();

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/reducer.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/reducer.es.js
@@ -57,6 +57,7 @@ export function getInitialState(target) {
 }
 
 const INITIAL_STATE = {
+
 	/**
 	 * The click goal target that is currently being edited.
 	 *

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/utils.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/utils.es.js
@@ -26,6 +26,7 @@ export const GeometryType = PropTypes.shape({
  */
 export function stopImmediatePropagation(event) {
 	if (event.nativeEvent) {
+
 		// This is a React synthetic event; must access nativeEvent instead.
 
 		event.nativeEvent.stopImmediatePropagation();

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/util/APIService.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/util/APIService.es.js
@@ -93,6 +93,7 @@ function APIService({contentPageEditorNamespace, endpoints, namespace}) {
 	}
 
 	function publishExperience(body) {
+
 		// TODO somehow type this
 
 		return _fetchWithError(editSegmentsExperimentStatusURL, {

--- a/modules/dxp/apps/segments/segments-experiment-web/test/js/components/SegmentsExperimentsSidebar.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/test/js/components/SegmentsExperimentsSidebar.es.js
@@ -553,6 +553,7 @@ describe('No Winner Declared', () => {
 	});
 
 	it('Variant publish action button when confirming in no winner declared status', async () => {
+
 		/**
 		 * The user accepts the confirmation message
 		 */
@@ -593,6 +594,7 @@ describe('No Winner Declared', () => {
 	});
 
 	it('Variant publish action button when not confirming in no winner declared status', async () => {
+
 		/**
 		 * The user rejects the confirmation message
 		 */
@@ -659,6 +661,7 @@ describe('Winner declared', () => {
 	});
 
 	it('Variant publish winner action button in alert in winner declared status', async () => {
+
 		/**
 		 * The user accepts the confirmation message
 		 */
@@ -699,6 +702,7 @@ describe('Winner declared', () => {
 	});
 
 	it('Variant publish action button when confirming in winner declared status', async () => {
+
 		/**
 		 * The user accepts the confirmation message
 		 */
@@ -739,6 +743,7 @@ describe('Winner declared', () => {
 	});
 
 	it('Variant publish action button when not confirming in winner declared status', async () => {
+
 		/**
 		 * The user rejects the confirmation message
 		 */

--- a/modules/package.json
+++ b/modules/package.json
@@ -5,7 +5,7 @@
 		"compass-mixins": "0.12.10",
 		"jsdoc": "3.6.3",
 		"liferay-frontend-common-css": "1.0.4",
-		"liferay-npm-scripts": "31.0.0",
+		"liferay-npm-scripts": "32.0.0",
 		"metal-jest-serializer": "2.0.0"
 	},
 	"private": true,

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -11444,10 +11444,10 @@ liferay-npm-bundler@3.0.0-snapshot.dda6cd1:
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-liferay-npm-scripts@31.0.0:
-  version "31.0.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-31.0.0.tgz#fda7780d215a4ef073c6c19aa31473d33f306f90"
-  integrity sha512-3aHE/t0tl4XWqdtx+temtUFYRe9mJxlsU+Upn2BcCArct4jk8VIgyYxv8uCI0gcwwgNbxTXs9I9OknW6im3oPg==
+liferay-npm-scripts@32.0.0:
+  version "32.0.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-32.0.0.tgz#eaeb00e4626ad1da88d1907181b59bb85ec6ec44"
+  integrity sha512-nFfrJ4mRyVT8ZgcAT+7cNK4SuKP3K0W865Td7qPAZgmTs5+4wPhi6XZ1C2w0crke/Zfqrl8y28ucXFmsnBymMQ==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"


### PR DESCRIPTION
Forwarding this manually because failure on [wincent#244](https://github.com/wincent/liferay-portal/pull/244) is almost certainly spurious; this change adds some blank lines to some JS files, so seems unlikely to be the cause of:

    com.liferay.headless.delivery.client.problem.Problem$ProblemException

---

Follow-up to [this request](https://github.com/brianchandotcom/liferay-portal/commit/1f085b085dd2b1260bb4da32229c060a08bb3363) on [#88193](https://github.com/brianchandotcom/liferay-portal/pull/88193).

Brings "blank-line-before-comments" behavior into line with Java. In the initial version I left these comments alone because ESLint and Prettier disagree about the rules; but this was a case where circumventing Prettier wasn't disproportionately hard or hacky.

Release notes:

https://github.com/liferay/liferay-npm-tools/releases/tag/liferay-npm-scripts%2Fv32.0.0
