### PR TITLE
LPS-110685 | master

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-web/package.json
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/package.json
@@ -18,5 +18,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "1.0.0"
+	"version": "3.0.0"
 }


### PR DESCRIPTION
@brianchandotcom 
Central Requirements test now failing at head:
`Version must match the project version (3.0.0) modules/apps/headless/headless-discovery/headless-discovery-web/package.json`
https://test-1-14.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/387598/testReport/com.liferay.portal.modules/ModulesStructureTest/testScanBuildScripts/

Caused by https://github.com/liferay/liferay-portal/commit/592b064c552ecc029bd1c192bae1f20b33a5ce5f

I synced the versions based on the error message.

@nhpatt