### PR TITLE
LPS-112628 Replace usages of div class="container" with clay:container in JSPs

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/view.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/view.jsp
@@ -26,7 +26,7 @@ ViewAccountEntriesManagementToolbarDisplayContext viewAccountEntriesManagementTo
 	displayContext="<%= viewAccountEntriesManagementToolbarDisplayContext %>"
 />
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<aui:form method="post" name="fm">
 		<aui:input name="accountEntryIds" type="hidden" />
 
@@ -100,7 +100,7 @@ ViewAccountEntriesManagementToolbarDisplayContext viewAccountEntriesManagementTo
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <liferay-frontend:component
 	componentId="<%= viewAccountEntriesManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/view.jsp
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/view.jsp
@@ -35,7 +35,10 @@ AMManagementToolbarDisplayContext amManagementToolbarDisplayContext = new AMMana
 PortletURL portletURL = renderResponse.createRenderURL();
 %>
 
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/adaptive_media/info_panel" var="sidebarPanelURL" />
 
 	<liferay-frontend:sidebar-panel
@@ -209,7 +212,7 @@ PortletURL portletURL = renderResponse.createRenderURL();
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />adaptRemaining(uuid, backgroundTaskUrl) {

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/add_channel.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/add_channel.jsp
@@ -33,7 +33,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 
 <portlet:actionURL name="/analytics/add_channel" var="addChannelURL" />
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:row>
 		<clay:col
 			size="12"
@@ -48,7 +48,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <aui:form action="<%= addChannelURL %>" method="post" name="fm">
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_channel.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_channel.jsp
@@ -36,7 +36,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 
 <portlet:actionURL name="/analytics/edit_channel" var="editChannelURL" />
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:row>
 		<clay:col
 			size="12"
@@ -51,7 +51,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <aui:form action="<%= editChannelURL %>" method="post" name="fm">
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts_groups.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts_groups.jsp
@@ -33,7 +33,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 
 <portlet:actionURL name="/analytics/edit_synced_contacts" var="editSyncedContactsURL" />
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:row>
 		<clay:col
 			size="12"
@@ -48,7 +48,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <div class="sheet sheet-lg">
 	<h2 class="autofit-row">

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts_organizations.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts_organizations.jsp
@@ -33,7 +33,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 
 <portlet:actionURL name="/analytics/edit_synced_contacts" var="editSyncedContactsURL" />
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:row>
 		<clay:col
 			size="12"
@@ -48,7 +48,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <div class="sheet sheet-lg">
 	<h2 class="autofit-row">

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements_admin/view.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements_admin/view.jsp
@@ -82,7 +82,7 @@ AnnouncementsAdminViewManagementToolbarDisplayContext announcementsAdminViewMana
 	showSearch="false"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= currentURL %>" method="get" name="fm">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
@@ -154,7 +154,7 @@ AnnouncementsAdminViewManagementToolbarDisplayContext announcementsAdminViewMana
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	var deleteEntries = function () {

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/edit_entry.jsp
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/edit_entry.jsp
@@ -21,7 +21,9 @@ AppBuilderApp appBuilderApp = (AppBuilderApp)request.getAttribute(AppBuilderWebK
 %>
 
 <div class="app-builder-root">
-	<div class="container edit-entry">
+	<clay:container
+		className="edit-entry"
+	>
 		<div id="<%= renderResponse.getNamespace() %>-control-menu"></div>
 
 		<clay:row
@@ -80,5 +82,5 @@ AppBuilderApp appBuilderApp = (AppBuilderApp)request.getAttribute(AppBuilderWebK
 				</div>
 			</clay:col>
 		</clay:row>
-	</div>
+	</clay:container>
 </div>

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/layout/init.jsp
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/layout/init.jsp
@@ -14,7 +14,8 @@
  */
 --%>
 
-<%@ taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/layout/view.jsp
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/layout/view.jsp
@@ -32,7 +32,9 @@ if (mvcPath.startsWith("/edit_entry.jsp")) {
 
 <div class="app-builder-standalone">
 	<header class="app-builder-standalone-header">
-		<div class="container p-0">
+		<clay:container
+			className="p-0"
+		>
 			<div class="app-builder-standalone-menu autofit-row">
 				<div class="autofit-col autofit-col-expand">
 					<a class="company-link" href="<%= PortalUtil.addPreservedParameters(themeDisplay, themeDisplay.getURLPortal(), false, true) %>">
@@ -59,12 +61,14 @@ if (mvcPath.startsWith("/edit_entry.jsp")) {
 			</div>
 
 			<h1 class="app-builder-standalone-name <%= editEntryCssClass %>"><%= HtmlUtil.escape(appName) %></h1>
-		</div>
+		</clay:container>
 	</header>
 
-	<div class="app-builder-standalone-content container <%= editEntryCssClass %> sheet">
+	<clay:container
+		className="app-builder-standalone-content <%= editEntryCssClass %> sheet"
+	>
 		<liferay-portlet:runtime
 			portletName="<%= portletName %>"
 		/>
-	</div>
+	</clay:container>
 </div>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/select_structure_field.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/select_structure_field.jsp
@@ -41,7 +41,9 @@ portletURL.setParameter("eventName", eventName);
 	<span class="error-message"><liferay-ui:message key="the-field-value-is-invalid" /></span>
 </div>
 
-<div class="container-fluid-1280" id="<portlet:namespace />selectDDMStructureFieldForm">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "selectDDMStructureFieldForm" %>'
+>
 	<liferay-ui:search-container
 		iteratorURL="<%= portletURL %>"
 		total="<%= classType.getClassTypeFieldsCount() %>"
@@ -117,7 +119,7 @@ portletURL.setParameter("eventName", eventName);
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script use="aui-base">
 	var Util = Liferay.Util;

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
@@ -31,7 +31,9 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 %>
 
-<div class="container-fluid container-fluid-max-xl container-view">
+<clay:container
+	className="container-view"
+>
 	<clay:row>
 		<clay:col
 			lg="3"
@@ -136,7 +138,7 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 			</c:choose>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <script>
 	<portlet:actionURL name="/asset_list/add_asset_list_entry_variation" var="addAssetListEntryVariationURL">

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_asset_list_entry_usages.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_asset_list_entry_usages.jsp
@@ -33,7 +33,9 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 %>
 
-<div class="container-fluid container-fluid-max-xl container-form-lg">
+<clay:container
+	className="container-form-lg"
+>
 	<clay:row>
 		<clay:col
 			lg="3"
@@ -164,4 +166,4 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -16,7 +16,9 @@
 
 <%@ include file="/init.jsp" %>
 
-<div class="container-fluid-1280 pt-3">
+<clay:container
+	className="pt-3"
+>
 	<liferay-ui:search-container
 		id="assetEntries"
 		searchContainer="<%= assetListDisplayContext.getAssetListContentSearchContainer() %>"
@@ -48,7 +50,7 @@
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:button-row>
 	<aui:button type="cancel" value="close" />

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/add_asset_selector.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/add_asset_selector.jsp
@@ -20,7 +20,7 @@
 String redirect = PortalUtil.getLayoutFullURL(layout, themeDisplay);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:fieldset-group markupView="lexicon">
 		<aui:fieldset>
 
@@ -105,7 +105,7 @@ String redirect = PortalUtil.getLayoutFullURL(layout, themeDisplay);
 
 		<aui:button href="<%= redirect %>" type="cancel" />
 	</aui:button-row>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />addAssetEntry() {

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/select_structure_field.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/select_structure_field.jsp
@@ -43,7 +43,9 @@ portletURL.setParameter("eventName", eventName);
 	<span class="error-message"><liferay-ui:message key="the-field-value-is-invalid" /></span>
 </div>
 
-<div class="container-fluid-1280" id="<portlet:namespace />selectDDMStructureFieldForm">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "selectDDMStructureFieldForm" %>'
+>
 	<liferay-ui:search-container
 		iteratorURL="<%= portletURL %>"
 		total="<%= classType.getClassTypeFieldsCount() %>"
@@ -127,7 +129,7 @@ portletURL.setParameter("eventName", eventName);
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script use="aui-base">
 	var Util = Liferay.Util;

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_entry_usages/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_entry_usages/page.jsp
@@ -23,7 +23,9 @@ String className = GetterUtil.getString(request.getAttribute("liferay-asset:asse
 AssetEntryUsagesDisplayContext assetEntryUsagesDisplayContext = new AssetEntryUsagesDisplayContext(renderRequest, renderResponse, className, classPK);
 %>
 
-<div class="container-fluid container-fluid-max-xl container-form-lg">
+<clay:container
+	className="container-form-lg"
+>
 	<clay:row>
 		<clay:col
 			lg="3"
@@ -179,4 +181,4 @@ AssetEntryUsagesDisplayContext assetEntryUsagesDisplayContext = new AssetEntryUs
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>

--- a/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -20,7 +20,7 @@
 	displayContext="<%= new AssetTagsSelectorManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetTagsSelectorDisplayContext) %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-container
 		id="tags"
 		searchContainer="<%= assetTagsSelectorDisplayContext.getTagsSearchContainer() %>"
@@ -43,7 +43,7 @@
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get('<portlet:namespace />tags');

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
@@ -56,7 +56,9 @@ renderResponse.setTitle((entry != null) ? BlogsEntryUtil.getDisplayTitle(resourc
 
 <portlet:actionURL name="/blogs/edit_entry" var="editEntryURL" />
 
-<div class="container-fluid-1280 entry-body">
+<clay:container
+	className="entry-body"
+>
 	<aui:form action="<%= editEntryURL %>" cssClass="edit-entry" enctype="multipart/form-data" method="post" name="fm" onSubmit="event.preventDefault();">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
@@ -407,7 +409,7 @@ renderResponse.setTitle((entry != null) ? BlogsEntryUtil.getDisplayTitle(resourc
 			<aui:button href="<%= redirect %>" name="cancelButton" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <portlet:actionURL name="/blogs/edit_entry" var="editEntryURL" windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>">
 	<portlet:param name="ajax" value="<%= Boolean.TRUE.toString() %>" />

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry.jsp
@@ -82,7 +82,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 	</div>
 </aui:form>
 
-<div class="container-fluid">
+<clay:container>
 	<c:if test="<%= PropsValues.BLOGS_ENTRY_PREVIOUS_AND_NEXT_NAVIGATION_ENABLED %>">
 
 		<%
@@ -152,7 +152,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 			</c:if>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <%
 PortalUtil.setPageTitle(BlogsEntryUtil.getDisplayTitle(resourceBundle, entry), request);

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content_detail.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content_detail.jsp
@@ -42,7 +42,9 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 			</c:choose>
 		</portlet:renderURL>
 
-		<div class="container widget-mode-detail-header">
+		<clay:container
+			className="widget-mode-detail-header"
+		>
 			<liferay-asset:asset-categories-available
 				className="<%= BlogsEntry.class.getName() %>"
 				classPK="<%= entry.getEntryId() %>"
@@ -153,7 +155,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 					</div>
 				</clay:col>
 			</clay:row>
-		</div>
+		</clay:container>
 
 		<%
 		String coverImageURL = entry.getCoverImageURL(themeDisplay);
@@ -165,7 +167,10 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 
 		<!-- text resume -->
 
-		<div class="container widget-mode-detail-header" id="<portlet:namespace /><%= entry.getEntryId() %>">
+		<clay:container
+			className="widget-mode-detail-header"
+			id="<%= renderResponse.getNamespace() + entry.getEntryId() %>"
+		>
 			<c:if test="<%= Validator.isNotNull(coverImageURL) %>">
 
 				<%
@@ -232,9 +237,9 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 					</clay:col>
 				</clay:row>
 			</liferay-asset:asset-tags-available>
-		</div>
+		</clay:container>
 
-		<div class="container">
+		<clay:container>
 			<clay:row>
 				<clay:col
 					className="mx-auto widget-mode-detail-text"
@@ -272,7 +277,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 					</clay:col>
 				</clay:row>
 			</c:if>
-		</div>
+		</clay:container>
 	</c:when>
 	<c:otherwise>
 

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_entries.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_entries.jsp
@@ -44,7 +44,9 @@ BlogEntriesManagementToolbarDisplayContext blogEntriesManagementToolbarDisplayCo
 	portletURL="<%= restoreTrashEntriesURL %>"
 />
 
-<div class="container-fluid container-fluid-max-xl main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<aui:form action="<%= portletURL.toString() %>" method="get" name="fm">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
@@ -91,7 +93,7 @@ BlogEntriesManagementToolbarDisplayContext blogEntriesManagementToolbarDisplayCo
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <liferay-frontend:component
 	componentId="<%= blogEntriesManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
@@ -67,7 +67,9 @@ String displayStyle = blogImagesManagementToolbarDisplayContext.getDisplayStyle(
 	viewTypeItems="<%= blogImagesManagementToolbarDisplayContext.getViewTypes() %>"
 />
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<portlet:actionURL name="/blogs/edit_image" var="editImageURL" />
 
 	<aui:form action="<%= editImageURL %>" name="fm">
@@ -106,7 +108,7 @@ String displayStyle = blogImagesManagementToolbarDisplayContext.getDisplayStyle(
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	var deleteImages = function () {

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_entry.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_entry.jsp
@@ -53,7 +53,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(headerTitle);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<portlet:actionURL name="/bookmarks/edit_entry" var="editEntryURL">
 		<portlet:param name="mvcRenderCommandName" value="/bookmarks/edit_entry" />
 	</portlet:actionURL>
@@ -199,7 +199,7 @@ renderResponse.setTitle(headerTitle);
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />saveEntry() {

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_folder.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_folder.jsp
@@ -55,7 +55,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(headerTitle);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<portlet:actionURL name="/bookmarks/edit_folder" var="editFolderURL">
 		<portlet:param name="mvcRenderCommandName" value="/bookmarks/edit_folder" />
 	</portlet:actionURL>
@@ -185,7 +185,7 @@ renderResponse.setTitle(headerTitle);
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />saveFolder() {

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/select_folder.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/select_folder.jsp
@@ -32,7 +32,7 @@ if (folder != null) {
 }
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form method="post" name="selectFolderFm">
 		<liferay-ui:breadcrumb
 			showCurrentGroup="<%= false %>"
@@ -139,7 +139,7 @@ if (folder != null) {
 			<liferay-ui:search-iterator />
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/view.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/view.jsp
@@ -171,7 +171,10 @@ BookmarksUtil.addPortletBreadcrumbEntries(folder, request, renderResponse);
 	<liferay-util:param name="searchContainerId" value="entries" />
 </liferay-util:include>
 
-<div class="closed container-fluid container-fluid-max-xl sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/bookmarks/info_panel" var="sidebarPanelURL">
 		<portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" />
 	</liferay-portlet:resourceURL>
@@ -209,7 +212,7 @@ BookmarksUtil.addPortletBreadcrumbEntries(folder, request, renderResponse);
 			</liferay-util:include>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <%
 if (navigation.equals("all") && !defaultFolderView && (folder != null) && (portletName.equals(BookmarksPortletKeys.BOOKMARKS) || portletName.equals(BookmarksPortletKeys.BOOKMARKS_ADMIN))) {

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_booking.jsp
@@ -38,7 +38,7 @@ java.util.Calendar endTimeJCalendar = JCalendarUtil.getJCalendar(endTime, userTi
 AssetEntry layoutAssetEntry = AssetEntryLocalServiceUtil.getEntry(CalendarBooking.class.getName(), calendarBooking.getCalendarBookingId());
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<div class="panel panel-default">
 		<liferay-ui:header
 			backURL="<%= backURL %>"
@@ -306,4 +306,4 @@ AssetEntry layoutAssetEntry = AssetEntryLocalServiceUtil.getEntry(CalendarBookin
 			}
 		}
 	</aui:script>
-</div>
+</clay:container>

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_resources.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_resources.jsp
@@ -38,7 +38,7 @@ CalendarResourceDisplayTerms displayTerms = new CalendarResourceDisplayTerms(ren
 	<portlet:param name="tabs1" value="resources" />
 </liferay-portlet:renderURL>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:choose>
 		<c:when test="<%= displayTerms.getScope() == themeDisplay.getCompanyGroupId() %>">
 			<h3><liferay-ui:message key="users" /></h3>
@@ -53,4 +53,4 @@ CalendarResourceDisplayTerms displayTerms = new CalendarResourceDisplayTerms(ren
 			<%@ include file="/calendar_resource_search_container.jspf" %>
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:container>

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendars.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendars.jsp
@@ -47,7 +47,7 @@ portletURL.setParameter("calendarResourceId", String.valueOf(calendarResource.ge
 	</aui:button-row>
 </c:if>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-container
 		emptyResultsMessage="there-are-no-calendars-for-the-selected-resource"
 		iteratorURL="<%= renderResponse.createRenderURL() %>"
@@ -103,7 +103,7 @@ portletURL.setParameter("calendarResourceId", String.valueOf(calendarResource.ge
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <div class="calendar-portlet-import-container hide" id="<portlet:namespace />importCalendarContainer">
 	<div class="hide portlet-msg-error" id="<portlet:namespace />portletErrorMessage"></div>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/select_change_list.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/select_change_list.jsp
@@ -36,7 +36,9 @@ SelectChangeListManagementToolbarDisplayContext selectChangeListManagementToolba
 	</div>
 </c:if>
 
-<div class="container container-fluid-1280" id="<portlet:namespace />selectChangeListContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "selectChangeListContainer" %>'
+>
 	<div class="table-responsive">
 		<table class="change-lists-table select-change-list-table table table-autofit">
 			<tbody>
@@ -94,7 +96,7 @@ SelectChangeListManagementToolbarDisplayContext selectChangeListManagementToolba
 		markupView="lexicon"
 		searchContainer="<%= searchContainer %>"
 	/>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view.jsp
@@ -31,7 +31,7 @@ ChangeListsManagementToolbarDisplayContext changeListsManagementToolbarDisplayCo
 	displayContext="<%= changeListsManagementToolbarDisplayContext %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-container
 		cssClass="change-lists-table"
 		searchContainer="<%= searchContainer %>"
@@ -127,4 +127,4 @@ ChangeListsManagementToolbarDisplayContext changeListsManagementToolbarDisplayCo
 			searchContainer="<%= searchContainer %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_changes.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_changes.jsp
@@ -34,7 +34,7 @@ portletDisplay.setShowBackIcon(true);
 %>
 
 <nav class="change-lists-tbar component-tbar subnav-tbar-light tbar ">
-	<div class="container-fluid container-fluid-max-xl">
+	<clay:container>
 		<ul class="tbar-nav">
 			<c:choose>
 				<c:when test="<%= ctCollection.getStatus() == WorkflowConstants.STATUS_APPROVED %>">
@@ -141,7 +141,7 @@ portletDisplay.setShowBackIcon(true);
 				</c:otherwise>
 			</c:choose>
 		</ul>
-	</div>
+	</clay:container>
 </nav>
 
 <clay:management-toolbar
@@ -149,7 +149,7 @@ portletDisplay.setShowBackIcon(true);
 	id="viewChangesManagementToolbar"
 />
 
-<div class="container container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-container
 		cssClass="change-lists-changes-table change-lists-table"
 		searchContainer="<%= searchContainer %>"
@@ -204,4 +204,4 @@ portletDisplay.setShowBackIcon(true);
 			searchContainer="<%= searchContainer %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_conflicts.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_conflicts.jsp
@@ -33,7 +33,9 @@ portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(backURL);
 %>
 
-<div class="container-fluid container-fluid-max-xl container-form-lg">
+<clay:container
+	className="container-form-lg"
+>
 	<div class="sheet-lg table-responsive">
 		<table class="change-lists-conflicts-table table table-autofit table-list">
 			<tr>
@@ -267,4 +269,4 @@ portletDisplay.setURLBack(backURL);
 			</td></tr>
 		</table>
 	</div>
-</div>
+</clay:container>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_entry.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_entry.jsp
@@ -16,7 +16,7 @@
 
 <%@ include file="/change_lists/init.jsp" %>
 
-<div class="container-fluid">
+<clay:container>
 
 	<%
 	long ctEntryId = ParamUtil.getLong(request, "ctEntryId");
@@ -26,4 +26,4 @@
 	ctDisplayRendererRegistry.renderCTEntry(request, response, ctEntry, ctEntry.getCtCollectionId());
 	%>
 
-</div>
+</clay:container>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_history.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_history.jsp
@@ -35,7 +35,7 @@ Format format = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 	displayContext="<%= viewHistoryManagementToolbarDisplayContext %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-container
 		cssClass="change-lists-table"
 		searchContainer="<%= searchContainer %>"
@@ -159,4 +159,4 @@ Format format = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 			searchContainer="<%= searchContainer %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/view.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/view.jsp
@@ -21,7 +21,9 @@
 	navigationItems="<%= changeListsConfigurationDisplayContext.getViewNavigationItems() %>"
 />
 
-<div class="container-fluid container-fluid-max-xl container-form-lg">
+<clay:container
+	className="container-form-lg"
+>
 	<aui:form action="<%= changeListsConfigurationDisplayContext.getActionURL() %>" method="post" name="fm">
 		<aui:input name="navigation" type="hidden" value="<%= changeListsConfigurationDisplayContext.getNavigation() %>" />
 		<aui:input name="redirectToOverview" type="hidden" value="<%= false %>" />
@@ -30,4 +32,4 @@
 			<%@ include file="/change_lists_configuration/global_settings.jspf" %>
 		</div>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/apps/comment/comment-web/build.gradle
+++ b/modules/apps/comment/comment-web/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly project(":apps:comment:comment-api")
 	compileOnly project(":apps:frontend-editor:frontend-editor-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/comment/comment-web/src/main/resources/META-INF/resources/edit_discussion.jsp
+++ b/modules/apps/comment/comment-web/src/main/resources/META-INF/resources/edit_discussion.jsp
@@ -55,7 +55,7 @@ if (comment instanceof WorkflowableComment) {
 	title='<%= (comment == null) ? "new-message" : "edit-message" %>'
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action='<%= themeDisplay.getPathMain() + "/portal/comment/discussion/edit" %>' enctype="multipart/form-data" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "saveComment();" %>'>
 		<input name="p_auth" type="hidden" value="<%= AuthTokenUtil.getToken(request) %>" />
 		<input name="namespace" type="hidden" value="<%= renderResponse.getNamespace() %>" />
@@ -121,7 +121,7 @@ if (comment instanceof WorkflowableComment) {
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />saveComment() {

--- a/modules/apps/comment/comment-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/comment/comment-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
@@ -81,7 +81,7 @@ renderResponse.setTitle(categoryDisplayName);
 <portlet:actionURL name="bindConfiguration" var="bindConfigurationActionURL" />
 <portlet:actionURL name="deleteConfiguration" var="deleteConfigurationActionURL" />
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:col
 		size="12"
 	>
@@ -92,9 +92,9 @@ renderResponse.setTitle(categoryDisplayName);
 			showParentGroups="<%= false %>"
 		/>
 	</clay:col>
-</div>
+</clay:container>
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:row>
 		<clay:col
 			md="3"
@@ -246,4 +246,4 @@ renderResponse.setTitle(categoryDisplayName);
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/search_results.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/search_results.jsp
@@ -47,7 +47,9 @@ renderResponse.setTitle(LanguageUtil.get(request, "search-results"));
 	showSearch="<%= true %>"
 />
 
-<div class="container-fluid container-fluid-max-xl container-view">
+<clay:container
+	className="container-view"
+>
 	<liferay-ui:search-container
 		emptyResultsMessage="no-configurations-were-found"
 		iteratorURL="<%= searchURL %>"
@@ -178,4 +180,4 @@ renderResponse.setTitle(LanguageUtil.get(request, "search-results"));
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -35,7 +35,9 @@ ConfigurationScopeDisplayContext configurationScopeDisplayContext = Configuratio
 	showSearch="<%= true %>"
 />
 
-<div class="container-fluid container-fluid-max-xl container-view">
+<clay:container
+	className="container-view"
+>
 	<c:if test="<%= configurationCategorySectionDisplays.isEmpty() %>">
 		<liferay-ui:empty-result-message
 			message="no-configurations-were-found"
@@ -92,4 +94,4 @@ ConfigurationScopeDisplayContext configurationScopeDisplayContext = Configuratio
 		%>
 
 	</ul>
-</div>
+</clay:container>

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view_configuration_screen.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view_configuration_screen.jsp
@@ -45,7 +45,7 @@ portletDisplay.setURLBack(portletURL.toString());
 renderResponse.setTitle(categoryDisplayName);
 %>
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:col
 		size="12"
 	>
@@ -56,9 +56,9 @@ renderResponse.setTitle(categoryDisplayName);
 			showParentGroups="<%= false %>"
 		/>
 	</clay:col>
-</div>
+</clay:container>
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:row>
 		<clay:col
 			md="3"
@@ -76,4 +76,4 @@ renderResponse.setTitle(categoryDisplayName);
 
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view_factory_instances.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view_factory_instances.jsp
@@ -50,7 +50,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(categoryDisplayName);
 %>
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:col
 		size="12"
 	>
@@ -61,9 +61,9 @@ renderResponse.setTitle(categoryDisplayName);
 			showParentGroups="<%= false %>"
 		/>
 	</clay:col>
-</div>
+</clay:container>
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:row>
 		<clay:col
 			md="3"
@@ -226,4 +226,4 @@ renderResponse.setTitle(categoryDisplayName);
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>

--- a/modules/apps/data-engine/data-engine-taglib/build.gradle
+++ b/modules/apps/data-engine/data-engine-taglib/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	compileOnly project(":apps:frontend-editor:frontend-editor-taglib")
 	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_renderer/page.jsp
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_renderer/page.jsp
@@ -17,7 +17,9 @@
 <%@ include file="/data_layout_renderer/init.jsp" %>
 
 <div class="sheet">
-	<div class="container-fluid-1280 ddm-form-builder-app">
+	<clay:container
+		className="ddm-form-builder-app"
+	>
 		<%= content %>
-	</div>
+	</clay:container>
 </div>

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -35,4 +35,5 @@
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.Set" %>
 
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/item/selector/application_disabled.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/item/selector/application_disabled.jsp
@@ -20,7 +20,9 @@
 DepotApplicationDisplayContext depotApplicationDisplayContext = (DepotApplicationDisplayContext)request.getAttribute(DepotAdminWebKeys.DEPOT_APPLICATION_DISPLAY_CONTEXT);
 %>
 
-<div class="container-fluid container-fluid-max-xl pt-4">
+<clay:container
+	className="pt-4"
+>
 	<div class="alert alert-info">
 		<span class="alert-indicator">
 			<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
@@ -30,4 +32,4 @@ DepotApplicationDisplayContext depotApplicationDisplayContext = (DepotApplicatio
 
 		<strong class="lead">Info:</strong><%= depotApplicationDisplayContext.getMessage() %>
 	</div>
-</div>
+</clay:container>

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/view.jsp
@@ -26,7 +26,9 @@ DepotAdminManagementToolbarDisplayContext depotAdminManagementToolbarDisplayCont
 	displayContext="<%= depotAdminManagementToolbarDisplayContext %>"
 />
 
-<div class="closed container-fluid-1280 sidenav-container sidenav-right">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+>
 	<div class="sidenav-content">
 		<portlet:actionURL name="deleteGroups" var="deleteGroupsURL" />
 
@@ -118,7 +120,7 @@ DepotAdminManagementToolbarDisplayContext depotAdminManagementToolbarDisplayCont
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <liferay-frontend:component
 	componentId="<%= DepotAdminWebKeys.DEPOT_ENTRY_DROPDOWN_DEFAULT_EVENT_HANDLER %>"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure.jsp
@@ -49,7 +49,7 @@ renderResponse.setTitle(title);
 
 <portlet:actionURL name="/document_library/ddm/update_ddm_structure" var="updateDDMStructureURL" />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= (ddmStructure == null) ? addDDMStructureURL : updateDDMStructureURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "saveDDMStructure();" %>'>
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 		<aui:input name="ddmStructureId" type="hidden" value="<%= ddmStructureId %>" />
@@ -208,7 +208,7 @@ renderResponse.setTitle(title);
 
 		<aui:button href="<%= redirect %>" type="cancel" />
 	</aui:button-row>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />openParentDDMStructureSelector() {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -137,7 +137,7 @@ renderResponse.setTitle(headerTitle);
 	</liferay-frontend:info-bar>
 </c:if>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:if test="<%= checkedOut %>">
 
 		<%
@@ -555,7 +555,7 @@ renderResponse.setTitle(headerTitle);
 		id="<%= uploadProgressId %>"
 		message="uploading"
 	/>
-</div>
+</clay:container>
 
 <c:if test="<%= (fileEntry != null) && checkedOut && dlAdminDisplayContext.isVersioningStrategyOverridable() %>">
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_type_data_layout_builder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_type_data_layout_builder.jsp
@@ -64,7 +64,7 @@ renderResponse.setTitle((fileEntryType == null) ? LanguageUtil.get(request, "new
 	<aui:model-context bean="<%= fileEntryType %>" model="<%= DLFileEntryType.class %>" />
 
 	<nav class="component-tbar subnav-tbar-light tbar tbar-metadata-type">
-		<div class="container-fluid container-fluid-max-xl">
+		<clay:container>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand"></li>
 				<li class="tbar-item">
@@ -75,10 +75,12 @@ renderResponse.setTitle((fileEntryType == null) ? LanguageUtil.get(request, "new
 					</div>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 
-	<div class="container-fluid container-fluid-max-xl container-view">
+	<clay:container
+		className="container-view"
+	>
 
 		<%
 		DLEditFileEntryTypeDisplayContext dlEditFileEntryTypeDisplayContext = (DLEditFileEntryTypeDisplayContext)request.getAttribute(DLWebKeys.DOCUMENT_LIBRARY_EDIT_EDIT_FILE_ENTRY_TYPE_DISPLAY_CONTEXT);
@@ -94,7 +96,7 @@ renderResponse.setTitle((fileEntryType == null) ? LanguageUtil.get(request, "new
 			localizable="<%= true %>"
 			namespace="<%= renderResponse.getNamespace() %>"
 		/>
-	</div>
+	</clay:container>
 </aui:form>
 
 <aui:script>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_type_form_builder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_type_form_builder.jsp
@@ -33,7 +33,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle((fileEntryType == null) ? LanguageUtil.get(request, "new-document-type") : fileEntryType.getName(locale));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<portlet:actionURL name="/document_library/edit_file_entry_type" var="editFileEntryTypeURL">
 		<portlet:param name="mvcRenderCommandName" value="/document_library/edit_file_entry_type" />
 	</portlet:actionURL>
@@ -81,7 +81,7 @@ renderResponse.setTitle((fileEntryType == null) ? LanguageUtil.get(request, "new
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />saveStructure() {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
@@ -24,7 +24,7 @@ DLEditFileShortcutDisplayContext dlEditFileShortcutDisplayContext = (DLEditFileS
 renderResponse.setTitle(dlEditFileShortcutDisplayContext.getTitle());
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= dlEditFileShortcutDisplayContext.getEditFileShortcutURL() %>" method="post" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 		<aui:input name="fileShortcutId" type="hidden" value="<%= dlEditFileShortcutDisplayContext.getFileShortcutId() %>" />
@@ -63,7 +63,7 @@ renderResponse.setTitle(dlEditFileShortcutDisplayContext.getTitle());
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
 	var selectToFileEntryButton = document.getElementById(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
@@ -63,18 +63,18 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(headerTitle);
 %>
 
-<div class="container-fluid-1280">
-	<liferay-util:buffer
-		var="removeFileEntryTypeIcon"
-	>
-		<liferay-ui:icon
-			icon="times"
-			label="<%= true %>"
-			markupView="lexicon"
-			message="remove"
-		/>
-	</liferay-util:buffer>
+<liferay-util:buffer
+	var="removeFileEntryTypeIcon"
+>
+	<liferay-ui:icon
+		icon="times"
+		label="<%= true %>"
+		markupView="lexicon"
+		message="remove"
+	/>
+</liferay-util:buffer>
 
+<clay:container>
 	<portlet:actionURL name="/document_library/edit_folder" var="editFolderURL">
 		<portlet:param name="mvcRenderCommandName" value="/document_library/edit_folder" />
 	</portlet:actionURL>
@@ -307,7 +307,7 @@ renderResponse.setTitle(headerTitle);
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <liferay-util:buffer
 	var="workflowDefinitionsBuffer"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_repository.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_repository.jsp
@@ -33,7 +33,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(headerTitle);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<portlet:actionURL name="/document_library/edit_repository" var="editRepositoryURL">
 		<portlet:param name="mvcRenderCommandName" value="/document_library/edit_repository" />
 	</portlet:actionURL>
@@ -169,7 +169,7 @@ renderResponse.setTitle(headerTitle);
 		%>
 
 	</div>
-</div>
+</clay:container>
 
 <aui:script require="metal-dom/src/dom as dom">
 	var settingsParametersContainer = document.getElementById(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_upper_tbar.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_upper_tbar.jsp
@@ -25,7 +25,7 @@ FileVersion fileVersion = (FileVersion)request.getAttribute("file_entry_upper_tb
 
 <div class="upper-tbar-container-fixed">
 	<div class="tbar upper-tbar">
-		<div class="container-fluid container-fluid-max-xl">
+		<clay:container>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 					<div class="tbar-section text-left">
@@ -94,6 +94,6 @@ FileVersion fileVersion = (FileVersion)request.getAttribute("file_entry_upper_tb
 					/>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</div>
 </div>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_entry.jsp
@@ -45,7 +45,7 @@ List<Object> foldersAndFileEntriesAndFileShortcuts = DLAppServiceUtil.getFolders
 dlSearchContainer.setResults(foldersAndFileEntriesAndFileShortcuts);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form method="post" name="selectFileEntryFm">
 		<liferay-ui:breadcrumb
 			showGuestGroup="<%= false %>"
@@ -131,7 +131,7 @@ dlSearchContainer.setResults(foldersAndFileEntriesAndFileShortcuts);
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_version.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_version.jsp
@@ -36,7 +36,7 @@ if ((user.getUserId() == fileEntry.getUserId()) || permissionChecker.isContentRe
 	<portlet:param name="version" value="<%= String.valueOf(fileVersion.getVersion()) %>" />
 </liferay-portlet:renderURL>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="selectFileVersionFm">
 		<liferay-ui:search-container
 			id="fileVersionSearchContainer"
@@ -92,7 +92,7 @@ if ((user.getUserId() == fileEntry.getUserId()) || permissionChecker.isContentRe
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_folder.jsp
@@ -36,7 +36,7 @@ if (folder != null) {
 DLVisualizationHelper dlVisualizationHelper = new DLVisualizationHelper(dlRequestHelper);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form method="post" name="selectFolderFm">
 		<liferay-ui:breadcrumb
 			showCurrentGroup="<%= false %>"
@@ -176,7 +176,7 @@ DLVisualizationHelper dlVisualizationHelper = new DLVisualizationHelper(dlReques
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_group.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_group.jsp
@@ -24,7 +24,7 @@ PortletURL portletURL = renderResponse.createRenderURL();
 portletURL.setParameter("mvcPath", "/document_library/select_group.jsp");
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<clay:management-toolbar
 		clearResultsURL="<%= portletURL.toString() %>"
 		searchActionURL="<%= portletURL.toString() %>"
@@ -141,7 +141,7 @@ portletURL.setParameter("mvcPath", "/document_library/select_group.jsp");
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -97,15 +97,10 @@ if (portletTitleBasedNavigation) {
 	<liferay-util:include page="/document_library/file_entry_upper_tbar.jsp" servletContext="<%= application %>" />
 </c:if>
 
-<c:choose>
-	<c:when test="<%= portletTitleBasedNavigation %>">
-<div class="container-fluid-1280" id="<portlet:namespace />FileEntry">
-	</c:when>
-	<c:otherwise>
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
-	</c:otherwise>
-</c:choose>
-
+<clay:container
+	className='<%= portletTitleBasedNavigation ? StringPool.BLANK : "closed sidenav-container sidenav-right" %>'
+	id='<%= renderResponse.getNamespace() + (portletTitleBasedNavigation ? "FileEntry" : "infoPanelId") %>'
+>
 	<portlet:actionURL name="/document_library/edit_file_entry" var="editFileEntry" />
 
 	<aui:form action="<%= editFileEntry %>" method="post" name="fm">
@@ -131,9 +126,9 @@ if (portletTitleBasedNavigation) {
 			<div class="contextual-sidebar sidebar-light sidebar-preview">
 
 				<%
-					request.setAttribute("info_panel.jsp-fileEntry", fileEntry);
-					request.setAttribute("info_panel.jsp-fileVersion", fileVersion);
-					request.setAttribute("info_panel_file_entry.jsp-hideActions", true);
+				request.setAttribute("info_panel.jsp-fileEntry", fileEntry);
+				request.setAttribute("info_panel.jsp-fileVersion", fileVersion);
+				request.setAttribute("info_panel_file_entry.jsp-hideActions", true);
 				%>
 
 				<liferay-util:include page="/document_library/info_panel_file_entry.jsp" servletContext="<%= application %>" />
@@ -143,8 +138,8 @@ if (portletTitleBasedNavigation) {
 			<liferay-frontend:sidebar-panel>
 
 				<%
-					request.setAttribute("info_panel.jsp-fileEntry", fileEntry);
-					request.setAttribute("info_panel.jsp-fileVersion", fileVersion);
+				request.setAttribute("info_panel.jsp-fileEntry", fileEntry);
+				request.setAttribute("info_panel.jsp-fileVersion", fileVersion);
 				%>
 
 				<liferay-util:include page="/document_library/info_panel_file_entry.jsp" servletContext="<%= application %>" />
@@ -164,15 +159,15 @@ if (portletTitleBasedNavigation) {
 				<c:if test="<%= dlPortletInstanceSettingsHelper.isShowActions() %>">
 
 					<%
-						for (ToolbarItem toolbarItem : dlViewFileVersionDisplayContext.getToolbarItems()) {
+					for (ToolbarItem toolbarItem : dlViewFileVersionDisplayContext.getToolbarItems()) {
 					%>
 
-					<liferay-ui:toolbar-item
-						toolbarItem="<%= toolbarItem %>"
-					/>
+						<liferay-ui:toolbar-item
+							toolbarItem="<%= toolbarItem %>"
+						/>
 
 					<%
-						}
+					}
 					%>
 
 				</c:if>
@@ -231,7 +226,7 @@ if (portletTitleBasedNavigation) {
 			</c:if>
 		</div>
 	</div>
-</div>
+</clay:container>
 
 <c:if test="<%= dlPortletInstanceSettingsHelper.isShowActions() && dlAdminDisplayContext.isVersioningStrategyOverridable() %>">
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_metadata_sets.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_metadata_sets.jsp
@@ -26,7 +26,9 @@ DLViewFileEntryMetadataSetsDisplayContext dLViewFileEntryMetadataSetsDisplayCont
 	displayContext="<%= new DLViewFileEntryMetadataSetsManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, dLViewFileEntryMetadataSetsDisplayContext) %>"
 />
 
-<div class="container-fluid container-fluid-max-xl main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureReferencedByStructureLinks.class %>" message="the-structure-cannot-be-deleted-because-it-is-required-by-one-or-more-structure-links" />
 	<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureReferencedByTemplates.class %>" message="the-structure-cannot-be-deleted-because-it-is-required-by-one-or-more-templates" />
 	<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureThatHasChild.class %>" message="the-structure-cannot-be-deleted-because-it-has-one-or-more-substructures" />
@@ -106,4 +108,4 @@ DLViewFileEntryMetadataSetsDisplayContext dLViewFileEntryMetadataSetsDisplayCont
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_types.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_types.jsp
@@ -32,7 +32,9 @@ DLViewFileEntryTypesDisplayContext dlViewFileEntryTypesDisplayContext = new DLVi
 	selectable="<%= false %>"
 />
 
-<div class="container-fluid container-fluid-max-xl main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<liferay-ui:error exception="<%= RequiredFileEntryTypeException.class %>" message="cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents" />
 
 	<liferay-ui:search-container
@@ -86,4 +88,4 @@ DLViewFileEntryTypesDisplayContext dlViewFileEntryTypesDisplayContext = new DLVi
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -55,7 +55,7 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 			<aui:input name="redirect" type="hidden" value="<%= configurationRenderURL.toString() %>" />
 
 			<liferay-ui:section>
-				<div class="container-fluid-1280">
+				<clay:container>
 					<div class="alert alert-info">
 						<span class="displaying-help-message-holder <%= (selRecordSet == null) ? StringPool.BLANK : "hide" %>">
 							<liferay-ui:message key="please-select-a-list-entry-from-the-list-below" />
@@ -140,7 +140,7 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 							</div>
 						</div>
 					</aui:fieldset>
-				</div>
+				</clay:container>
 			</liferay-ui:section>
 		</aui:form>
 
@@ -151,7 +151,7 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 
 			<c:if test="<%= selRecordSet != null %>">
 				<liferay-ui:section>
-					<div class="container-fluid-1280">
+					<clay:container>
 						<div class="alert alert-info">
 							<span class="displaying-record-set-id-holder <%= (selRecordSet == null) ? "hide" : StringPool.BLANK %>">
 								<liferay-ui:message key="displaying-list" />: <span class="displaying-record-set-id"><%= (selRecordSet != null) ? HtmlUtil.escape(selRecordSet.getName(locale)) : StringPool.BLANK %></span>
@@ -233,7 +233,7 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 								</div>
 							</div>
 						</aui:fieldset>
-					</div>
+					</clay:container>
 				</liferay-ui:section>
 			</c:if>
 		</aui:form>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record.jsp
@@ -96,7 +96,10 @@ else {
 	/>
 </c:if>
 
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<c:if test="<%= recordVersion != null %>">
 		<div class="sidenav-menu-slider">
 			<div class="sidebar sidebar-default sidenav-menu">
@@ -264,7 +267,7 @@ else {
 			</aui:button-row>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />setWorkflowAction(draft) {

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view.jsp
@@ -26,7 +26,9 @@ String displayStyle = ddlDisplayContext.getDisplayStyle();
 
 <liferay-util:include page="/management_bar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid-1280" id="<portlet:namespace />formContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "formContainer" %>'
+>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
 		<aui:input name="recordSetIds" type="hidden" />
@@ -94,6 +96,6 @@ String displayStyle = ddlDisplayContext.getDisplayStyle();
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <%@ include file="/export_record_set.jspf" %>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_record.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_record.jsp
@@ -49,7 +49,7 @@ else {
 }
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:if test="<%= recordVersion != null %>">
 		<aui:model-context bean="<%= recordVersion %>" model="<%= DDLRecordVersion.class %>" />
 
@@ -100,7 +100,7 @@ else {
 			<aui:button href="<%= redirect %>" name="cancelButton" type="cancel" />
 		</aui:button-row>
 	</aui:fieldset>
-</div>
+</clay:container>
 
 <%
 PortletURL portletURL = renderResponse.createRenderURL();

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_records.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_records.jsp
@@ -54,7 +54,10 @@ if (!ddlDisplayContext.isAdminPortlet()) {
 	sortingURL="<%= ddlViewRecordsDisplayContext.getSortingURL() %>"
 />
 
-<div class="container-fluid-1280 view-records-container" id="<portlet:namespace />formContainer">
+<clay:container
+	className="view-records-container"
+	id='<%= renderResponse.getNamespace() + "formContainer" %>'
+>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="fm">
 		<aui:input name="recordIds" type="hidden" />
 
@@ -156,7 +159,7 @@ if (!ddlDisplayContext.isAdminPortlet()) {
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <%@ include file="/export_record_set.jspf" %>
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_spreadsheet_records.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_spreadsheet_records.jsp
@@ -28,7 +28,9 @@ if (editable || ddlDisplayContext.isAdminPortlet()) {
 DDMStructure ddmStructure = recordSet.getDDMStructure();
 %>
 
-<div class="container-fluid-1280 lfr-spreadsheet-container">
+<clay:container
+	className="lfr-spreadsheet-container"
+>
 	<div id="<portlet:namespace />spreadsheet">
 		<div class="table-striped yui3-datatable yui3-widget" id="<portlet:namespace />dataTable">
 			<div class="yui3-datatable-content yui3-datatable-scrollable" id="<portlet:namespace />dataTableContent"></div>
@@ -48,7 +50,7 @@ DDMStructure ddmStructure = recordSet.getDDMStructure();
 			<aui:button inlineField="<%= true %>" name="addRecords" value="add" />
 		</div>
 	</c:if>
-</div>
+</clay:container>
 
 <%@ include file="/custom_spreadsheet_editors.jspf" %>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/edit_data_provider.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/edit_data_provider.jsp
@@ -49,7 +49,9 @@ renderResponse.setTitle((ddmDataProviderInstance == null) ? LanguageUtil.get(req
 
 	<%@ include file="/exceptions.jspf" %>
 
-	<div class="container-fluid-1280 lfr-ddm-edit-data-provider">
+	<clay:container
+		className="lfr-ddm-edit-data-provider"
+	>
 		<aui:fieldset-group markupView="lexicon">
 			<aui:fieldset>
 				<liferay-util:buffer
@@ -83,16 +85,16 @@ renderResponse.setTitle((ddmDataProviderInstance == null) ? LanguageUtil.get(req
 				</aui:fieldset>
 			</c:if>
 		</aui:fieldset-group>
-	</div>
+	</clay:container>
 
 	<c:if test="<%= !windowState.equals(LiferayWindowState.POP_UP) %>">
-		<div class="container-fluid-1280">
+		<clay:container>
 			<aui:button-row>
 				<aui:button id="submit" label="save" type="submit" />
 
 				<aui:button href="<%= redirect %>" name="cancelButton" type="cancel" />
 			</aui:button-row>
-		</div>
+		</clay:container>
 	</c:if>
 
 	<aui:button cssClass="hide" type="submit" />

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/view.jsp
@@ -35,7 +35,9 @@ renderResponse.setTitle(ddmDataProviderDisplayContext.getTitle());
 
 <liferay-util:include page="/management_bar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid-1280" id="<portlet:namespace />formContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "formContainer" %>'
+>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="searchContainerForm">
 		<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
 		<aui:input name="deleteDataProviderInstanceIds" type="hidden" />
@@ -107,4 +109,4 @@ renderResponse.setTitle(ddmDataProviderDisplayContext.getTitle());
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
@@ -22,7 +22,7 @@ int totalItems = ddmFormReportDisplayContext.getTotalItems();
 
 <div class="ddm-form-report hide">
 	<div class="ddm-form-report-header">
-		<div class="container-fluid container-fluid-max-xl">
+		<clay:container>
 			<div class="align-items-center autofit-row">
 				<span class="ddm-form-report-header-title text-truncate">
 					<liferay-ui:message arguments="<%= totalItems %>" key="x-entries" />
@@ -41,7 +41,7 @@ int totalItems = ddmFormReportDisplayContext.getTotalItems();
 					</c:choose>
 				</span>
 			</div>
-		</div>
+		</clay:container>
 	</div>
 
 	<clay:navigation-bar

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_renderer/init.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_renderer/init.jsp
@@ -30,3 +30,5 @@ Map<String, Object> dynamicAttributes = (Map<String, Object>)request.getAttribut
 %>
 
 <%@ include file="/ddm_form_renderer/init-ext.jspf" %>
+
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_renderer/page.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_renderer/page.jsp
@@ -85,7 +85,7 @@ if (ddmFormInstance != null) {
 
 					<c:if test="<%= showFormBasicInfo %>">
 						<div class="ddm-form-basic-info">
-							<div class="container-fluid-1280">
+							<clay:container>
 								<h1 class="ddm-form-name"><%= HtmlUtil.escape(ddmFormInstance.getName(displayLocale)) %></h1>
 
 								<%
@@ -95,15 +95,17 @@ if (ddmFormInstance != null) {
 								<c:if test="<%= Validator.isNotNull(description) %>">
 									<h5 class="ddm-form-description"><%= description %></h5>
 								</c:if>
-							</div>
+							</clay:container>
 						</div>
 					</c:if>
 
-					<div class="container-fluid-1280 ddm-form-builder-app">
+					<clay:container
+						className="ddm-form-builder-app"
+					>
 						<%= ddmFormHTML %>
 
 						<aui:input name="empty" type="hidden" value="" />
-					</div>
+					</clay:container>
 				</div>
 			</c:when>
 			<c:when test="<%= !hasViewFormInstancePermission %>">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
@@ -47,7 +47,9 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 	/>
 
 	<nav class="management-bar management-bar-light navbar navbar-expand-md toolbar-group-field">
-		<div class="container toolbar">
+		<clay:container
+			className="toolbar"
+		>
 			<ul class="navbar-nav toolbar-group-field"></ul>
 			<ul class="navbar-nav toolbar-group-field">
 				<li class="nav-item">
@@ -58,17 +60,19 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 					</button>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 
-	<div class="container-fluid-1280 ddm-translation-manager">
+	<clay:container
+		className="ddm-translation-manager"
+	>
 		<liferay-frontend:translation-manager
 			availableLocales="<%= ddmFormAdminDisplayContext.getAvailableLocales() %>"
 			changeableDefaultLanguage="<%= false %>"
 			defaultLanguageId="<%= ddmFormAdminDisplayContext.getDefaultLanguageId() %>"
 			id="translationManager"
 		/>
-	</div>
+	</clay:container>
 
 	<aui:form action="<%= saveStructureURL %>" cssClass="ddm-form-builder-form" method="post" name="editForm">
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
@@ -81,7 +85,7 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 		<%@ include file="/admin/exceptions.jspf" %>
 
 		<div class="ddm-form-basic-info">
-			<div class="container-fluid-1280">
+			<clay:container>
 				<h1>
 					<liferay-editor:editor
 						autoCreate="<%= false %>"
@@ -109,7 +113,7 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 				</h5>
 
 				<aui:input name="description" type="hidden" />
-			</div>
+			</clay:container>
 		</div>
 
 		<div id="<portlet:namespace />-container"></div>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -42,7 +42,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 </portlet:actionURL>
 
 <div class="lfr-alert-container">
-	<div class="container-fluid-1280 lfr-alert-wrapper"></div>
+	<clay:container className="lfr-alert-wrapper"></clay:container>
 </div>
 
 <div class="portlet-forms" id="<portlet:namespace />formContainer">
@@ -54,7 +54,9 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 	/>
 
 	<nav class="management-bar management-bar-light navbar navbar-expand-md toolbar-group-field" id="<portlet:namespace />managementToolbar">
-		<div class="autosave-bar container toolbar">
+		<clay:container
+			className="autosave-bar toolbar"
+		>
 			<div class="navbar-form navbar-form-autofit navbar-overlay toolbar-group-content">
 				<span class="autosave-feedback management-bar-text" id="<portlet:namespace />autosaveMessage"></span>
 			</div>
@@ -75,17 +77,19 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 					</button>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 
-	<div class="container-fluid-1280 ddm-translation-manager">
+	<clay:container
+		className="ddm-translation-manager"
+	>
 		<liferay-frontend:translation-manager
 			availableLocales="<%= ddmFormAdminDisplayContext.getAvailableLocales() %>"
 			changeableDefaultLanguage="<%= false %>"
 			defaultLanguageId="<%= ddmFormAdminDisplayContext.getDefaultLanguageId() %>"
 			id="translationManager"
 		/>
-	</div>
+	</clay:container>
 
 	<aui:form action="<%= saveFormInstanceURL %>" cssClass="ddm-form-builder-form" enctype="multipart/form-data" method="post" name="editForm">
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
@@ -100,7 +104,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 		<%@ include file="/admin/exceptions.jspf" %>
 
 		<div class="ddm-form-basic-info">
-			<div class="container-fluid-1280">
+			<clay:container>
 				<h1>
 					<liferay-editor:editor
 						autoCreate="<%= false %>"
@@ -124,15 +128,18 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 						showSource="<%= false %>"
 					/>
 				</h5>
-			</div>
+			</clay:container>
 		</div>
 
 		<div id="<portlet:namespace />-container"></div>
 	</aui:form>
 
-	<div class="container-fluid-1280 ddm-form-instance-settings hide" id="<portlet:namespace />settings">
+	<clay:container
+		className="ddm-form-instance-settings hide"
+		id='<%= renderResponse.getNamespace() + "settings" %>'
+	>
 		<%= ddmFormAdminDisplayContext.serializeSettingsForm(pageContext) %>
-	</div>
+	</clay:container>
 </div>
 
 <portlet:actionURL name="publishFormInstance" var="publishFormInstanceURL">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance_record.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance_record.jsp
@@ -29,14 +29,16 @@ String title = ParamUtil.getString(request, "title");
 renderResponse.setTitle(GetterUtil.get(title, LanguageUtil.get(request, "view-form")));
 %>
 
-<div class="container-fluid-1280 ddm-form-builder-app editing-form-entry">
+<clay:container
+	className="ddm-form-builder-app editing-form-entry"
+>
 	<div class="portlet-forms">
 		<div class="ddm-form-basic-info ddm-form-success-page">
-			<div class="container-fluid-1280">
+			<clay:container>
 				<h1 class="ddm-form-name"><%= ddmFormAdminDisplayContext.getFormName() %></h1>
 
 				<h5 class="ddm-form-description"><%= ddmFormAdminDisplayContext.getFormDescription() %></h5>
-			</div>
+			</clay:container>
 		</div>
 	</div>
 
@@ -49,4 +51,4 @@ renderResponse.setTitle(GetterUtil.get(title, LanguageUtil.get(request, "view-fo
 
 		<%= ddmFormAdminDisplayContext.getDDMFormHTML(renderRequest, false) %>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/form_instance_records_search_container.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/form_instance_records_search_container.jsp
@@ -37,7 +37,9 @@ PortletURL portletURL = ddmFormViewFormInstanceRecordsDisplayContext.getPortletU
 	sortingURL="<%= ddmFormViewFormInstanceRecordsDisplayContext.getSortingURL() %>"
 />
 
-<div class="container-fluid-1280" id="<portlet:namespace />viewEntriesContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "viewEntriesContainer" %>'
+>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="searchContainerForm">
 		<aui:input name="deleteFormInstanceRecordIds" type="hidden" />
 
@@ -113,13 +115,13 @@ PortletURL portletURL = ddmFormViewFormInstanceRecordsDisplayContext.getPortletU
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-paginator
 		searchContainer="<%= ddmFormViewFormInstanceRecordsDisplayContext.getSearch() %>"
 	/>
-</div>
+</clay:container>
 
 <%@ include file="/admin/export_form_instance.jspf" %>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_element_set.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_element_set.jsp
@@ -26,7 +26,9 @@ portletURL.setParameter("displayStyle", displayStyle);
 FieldSetPermissionCheckerHelper fieldSetPermissionCheckerHelper = ddmFormAdminDisplayContext.getPermissionCheckerHelper();
 %>
 
-<div class="container-fluid-1280" id="<portlet:namespace />formContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "formContainer" %>'
+>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="searchContainerForm">
 		<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
 		<aui:input name="deleteStructureIds" type="hidden" />
@@ -104,6 +106,6 @@ FieldSetPermissionCheckerHelper fieldSetPermissionCheckerHelper = ddmFormAdminDi
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script use="liferay-ddm-form-portlet"></aui:script>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance.jsp
@@ -23,7 +23,9 @@ PortletURL portletURL = ddmFormAdminDisplayContext.getPortletURL();
 FormInstancePermissionCheckerHelper formInstancePermissionCheckerHelper = ddmFormAdminDisplayContext.getPermissionCheckerHelper();
 %>
 
-<div class="container-fluid-1280" id="<portlet:namespace />formContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "formContainer" %>'
+>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="searchContainerForm">
 		<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
 		<aui:input name="deleteFormInstanceIds" type="hidden" />
@@ -102,7 +104,7 @@ FormInstancePermissionCheckerHelper formInstancePermissionCheckerHelper = ddmFor
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script require='<%= mainRequire + "/admin/js/components/ShareFormPopover/ShareFormPopover.es as ShareFormPopover" %>'>
 	var spritemap = themeDisplay.getPathThemeImages() + '/lexicon/icons.svg';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance_record.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance_record.jsp
@@ -27,7 +27,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(LanguageUtil.get(request, "view-form"));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:if test="<%= formInstanceRecordVersion != null %>">
 		<aui:model-context bean="<%= formInstanceRecordVersion %>" model="<%= DDMFormInstanceRecordVersion.class %>" />
 
@@ -35,8 +35,10 @@ renderResponse.setTitle(LanguageUtil.get(request, "view-form"));
 			<aui:workflow-status markupView="lexicon" model="<%= DDMFormInstanceRecord.class %>" showHelpMessage="<%= false %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= formInstanceRecordVersion.getStatus() %>" version="<%= formInstanceRecordVersion.getVersion() %>" />
 		</div>
 	</c:if>
-</div>
+</clay:container>
 
-<div class="container-fluid-1280 ddm-form-builder-app form-entry">
+<clay:container
+	className="ddm-form-builder-app form-entry"
+>
 	<%= ddmFormAdminDisplayContext.getDDMFormHTML(renderRequest) %>
-</div>
+</clay:container>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/asset/full_content.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/asset/full_content.jsp
@@ -20,6 +20,6 @@
 DDMFormViewFormInstanceRecordDisplayContext ddmFormViewFormInstanceRecordDisplayContext = (DDMFormViewFormInstanceRecordDisplayContext)request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<%= ddmFormViewFormInstanceRecordDisplayContext.getDDMFormHTML(renderRequest) %>
-</div>
+</clay:container>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/asset/init.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/asset/init.jsp
@@ -16,7 +16,8 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %>
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
 
 <%@ page import="com.liferay.dynamic.data.mapping.form.web.internal.display.context.DDMFormViewFormInstanceRecordDisplayContext" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/browser/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/browser/view.jsp
@@ -34,7 +34,9 @@
 	sortingURL="<%= ddmFormBrowserDisplayContext.getSortingURL() %>"
 />
 
-<div class="container-fluid-1280" id="<portlet:namespace />formContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "formContainer" %>'
+>
 	<aui:form action="<%= String.valueOf(ddmFormBrowserDisplayContext.getPortletURL()) %>" method="post" name="selectDDMFormFm">
 		<liferay-ui:search-container
 			id="<%= ddmFormBrowserDisplayContext.getSearchContainerId() %>"
@@ -85,7 +87,7 @@
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/configuration.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/configuration.jsp
@@ -40,7 +40,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 	<aui:input name="redirect" type="hidden" value="<%= configurationRenderURL.toString() %>" />
 
 	<div class="portlet-configuration-body-content">
-		<div class="container-fluid-1280">
+		<clay:container>
 			<div class="alert alert-info">
 				<span class="displaying-help-message-holder <%= (selFormInstance == null) ? StringPool.BLANK : "hide" %>">
 					<liferay-ui:message key="please-select-a-form-from-the-list-below" />
@@ -126,7 +126,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 					</div>
 				</div>
 			</aui:fieldset>
-		</div>
+		</clay:container>
 	</div>
 </aui:form>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
@@ -30,24 +30,24 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 	</c:when>
 	<c:when test="<%= !ddmFormDisplayContext.hasAddFormInstanceRecordPermission() && !ddmFormDisplayContext.hasViewPermission() %>">
 		<div class="ddm-form-basic-info">
-			<div class="container-fluid-1280">
+			<clay:container>
 				<clay:alert
 					message='<%= LanguageUtil.get(resourceBundle, "you-do-not-have-the-permission-to-view-this-form") %>'
 					style="warning"
 					title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
 				/>
-			</div>
+			</clay:container>
 		</div>
 	</c:when>
 	<c:when test="<%= ddmFormDisplayContext.isRequireAuthentication() %>">
 		<div class="ddm-form-basic-info">
-			<div class="container-fluid-1280">
+			<clay:container>
 				<clay:alert
 					message='<%= LanguageUtil.get(resourceBundle, "you-need-to-be-signed-in-to-view-this-form") %>'
 					style="warning"
 					title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
 				/>
-			</div>
+			</clay:container>
 		</div>
 	</c:when>
 	<c:otherwise>
@@ -70,11 +70,11 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 
 				<div class="portlet-forms">
 					<div class="ddm-form-basic-info ddm-form-success-page">
-						<div class="container-fluid-1280">
+						<clay:container>
 							<h1 class="ddm-form-name"><%= HtmlUtil.escape(GetterUtil.getString(title.getString(displayLocale), title.getString(title.getDefaultLocale()))) %></h1>
 
 							<h5 class="ddm-form-description"><%= HtmlUtil.escape(GetterUtil.getString(body.getString(displayLocale), body.getString(body.getDefaultLocale()))) %></h5>
-						</div>
+						</clay:container>
 					</div>
 				</div>
 			</c:when>
@@ -133,7 +133,7 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 						<liferay-ui:error-principal />
 
 						<c:if test="<%= ddmFormDisplayContext.isFormShared() %>">
-							<div class="container-fluid-1280">
+							<clay:container>
 								<div class="locale-actions">
 									<liferay-ui:language
 										formAction="<%= currentURL %>"
@@ -141,23 +141,23 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 										languageIds="<%= ddmFormDisplayContext.getAvailableLanguageIds() %>"
 									/>
 								</div>
-							</div>
+							</clay:container>
 						</c:if>
 
 						<c:if test="<%= !ddmFormDisplayContext.hasAddFormInstanceRecordPermission() %>">
 							<div class="ddm-form-basic-info">
-								<div class="container-fluid-1280">
+								<clay:container>
 									<clay:alert
 										message='<%= LanguageUtil.get(resourceBundle, "you-do-not-have-the-permission-to-submit-this-form") %>'
 										style="warning"
 										title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
 									/>
-								</div>
+								</clay:container>
 							</div>
 						</c:if>
 
 						<div class="ddm-form-basic-info">
-							<div class="container-fluid-1280">
+							<clay:container>
 								<h1 class="ddm-form-name"><%= HtmlUtil.escape(formInstance.getName(displayLocale)) %></h1>
 
 								<%
@@ -167,14 +167,17 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 								<c:if test="<%= Validator.isNotNull(description) %>">
 									<h5 class="ddm-form-description"><%= description %></h5>
 								</c:if>
-							</div>
+							</clay:container>
 						</div>
 
-						<div class="container-fluid-1280 ddm-form-builder-app ddm-form-builder-app-not-ready" id="<%= ddmFormDisplayContext.getContainerId() %>container">
+						<clay:container
+							className="ddm-form-builder-app ddm-form-builder-app-not-ready"
+							id='<%= ddmFormDisplayContext.getContainerId() + "container" %>'
+						>
 							<%= ddmFormDisplayContext.getDDMFormHTML() %>
 
 							<aui:input name="empty" type="hidden" value="" />
-						</div>
+						</clay:container>
 					</aui:form>
 				</div>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_structure.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_structure.jsp
@@ -90,7 +90,7 @@ if (Validator.isNotNull(requestUpdateStructureURL)) {
 }
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= (structure == null) ? addStructureURL : updateStructureURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "saveStructure();" %>'>
 		<aui:input name="redirect" type="hidden" value="<%= ddmDisplay.getViewTemplatesBackURL(liferayPortletRequest, liferayPortletResponse, classPK) %>" />
 		<aui:input name="closeRedirect" type="hidden" value="<%= closeRedirect %>" />
@@ -344,7 +344,7 @@ if (Validator.isNotNull(requestUpdateStructureURL)) {
 
 		<aui:button href="<%= PortalUtil.escapeRedirect(ddmDisplay.getViewTemplatesBackURL(liferayPortletRequest, liferayPortletResponse, classPK)) %>" type="cancel" />
 	</aui:button-row>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />openParentStructureSelector() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_template.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_template.jsp
@@ -88,7 +88,7 @@ DDMNavigationHelper ddmNavigationHelper = ddmDisplay.getDDMNavigationHelper();
 	<portlet:param name="mvcPath" value="/edit_template.jsp" />
 </portlet:actionURL>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= (template == null) ? addTemplateURL : updateTemplateURL %>" cssClass="container-fluid-1280" enctype="multipart/form-data" method="post" name="fm" onSubmit='<%= "event.preventDefault();" %>'>
 		<aui:input name="redirect" type="hidden" value="<%= ddmDisplay.getEditTemplateBackURL(liferayPortletRequest, liferayPortletResponse, classNameId, classPK, resourceClassNameId, portletResource) %>" />
 		<aui:input name="closeRedirect" type="hidden" value="<%= closeRedirect %>" />
@@ -490,4 +490,4 @@ DDMNavigationHelper ddmNavigationHelper = ddmDisplay.getDDMNavigationHelper();
 
 		<aui:button href="<%= ddmDisplay.getEditTemplateBackURL(liferayPortletRequest, liferayPortletResponse, classNameId, classPK, resourceClassNameId, portletResource) %>" type="cancel" />
 	</aui:button-row>
-</div>
+</clay:container>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_template.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_template.jsp
@@ -51,7 +51,7 @@ SearchContainer<DDMTemplate> templateSearch = ddmDisplayContext.getTemplateSearc
 />
 
 <aui:form action="<%= ddmDisplayContext.getSelectTemplateSearchActionURL() %>" method="post" name="selectTemplateFm">
-	<div class="container-fluid-1280">
+	<clay:container>
 		<liferay-ui:search-container
 			searchContainer="<%= templateSearch %>"
 		>
@@ -113,7 +113,7 @@ SearchContainer<DDMTemplate> templateSearch = ddmDisplayContext.getTemplateSearc
 				markupView="lexicon"
 			/>
 		</liferay-ui:search-container>
-	</div>
+	</clay:container>
 </aui:form>
 
 <aui:script>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/view.jsp
@@ -53,7 +53,9 @@ List<DDMDisplayTabItem> ddmDisplayTabItems = ddmDisplay.getTabItems();
 	<aui:input name="redirect" type="hidden" value="<%= ddmDisplayContext.getStructureSearchActionURL() %>" />
 	<aui:input name="deleteStructureIds" type="hidden" />
 
-	<div class="container-fluid container-fluid-max-xl" id="<portlet:namespace />entriesContainer">
+	<clay:container
+		id='<%= renderResponse.getNamespace() + "entriesContainer" %>'
+	>
 		<liferay-ui:search-container
 			id="ddmStructures"
 			rowChecker="<%= new DDMStructureRowChecker(renderResponse) %>"
@@ -148,5 +150,5 @@ List<DDMDisplayTabItem> ddmDisplayTabItems = ddmDisplay.getTabItems();
 				markupView="lexicon"
 			/>
 		</liferay-ui:search-container>
-	</div>
+	</clay:container>
 </aui:form>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/view_structure.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/view_structure.jsp
@@ -46,7 +46,7 @@ backURL.setParameter("redirect", redirect);
 backURL.setParameter("structureId", String.valueOf(structureVersion.getStructureId()));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:choose>
 		<c:when test="<%= ddmDisplay.isShowBackURLInTitleBar() %>">
 
@@ -78,4 +78,4 @@ backURL.setParameter("structureId", String.valueOf(structureVersion.getStructure
 	<aui:button-row>
 		<aui:button href="<%= backURL.toString() %>" type="cancel" />
 	</aui:button-row>
-</div>
+</clay:container>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/view_template.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/view_template.jsp
@@ -74,7 +74,9 @@ if (layout != null) {
 	<aui:input name="redirect" type="hidden" value="<%= ddmDisplayContext.getTemplateSearchActionURL() %>" />
 	<aui:input name="deleteTemplateIds" type="hidden" />
 
-	<div class="container-fluid container-fluid-max-xl" id="<portlet:namespace />entriesContainer">
+	<clay:container
+		id='<%= renderResponse.getNamespace() + "entriesContainer" %>'
+	>
 		<liferay-ui:search-container
 			id="<%= ddmDisplayContext.getTemplateSearchContainerId() %>"
 			rowChecker="<%= new DDMTemplateRowChecker(renderResponse) %>"
@@ -218,5 +220,5 @@ if (layout != null) {
 				markupView="lexicon"
 			/>
 		</liferay-ui:search-container>
-	</div>
+	</clay:container>
 </aui:form>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/view_template_version.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/view_template_version.jsp
@@ -34,7 +34,7 @@ backURL.setParameter("redirect", redirect);
 backURL.setParameter("templateId", String.valueOf(template.getTemplateId()));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:choose>
 		<c:when test="<%= ddmDisplay.isShowBackURLInTitleBar() %>">
 
@@ -88,4 +88,4 @@ backURL.setParameter("templateId", String.valueOf(template.getTemplateId()));
 	<aui:button-row>
 		<aui:button href="<%= backURL.toString() %>" type="cancel" />
 	</aui:button-row>
-</div>
+</clay:container>

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/expando.jsp
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/expando.jsp
@@ -115,14 +115,14 @@ else {
 	<portlet:param name="mvcPath" value="/edit/expando.jsp" />
 </portlet:actionURL>
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<liferay-ui:breadcrumb
 		showCurrentGroup="<%= false %>"
 		showGuestGroup="<%= false %>"
 		showLayout="<%= false %>"
 		showPortletBreadcrumb="<%= true %>"
 	/>
-</div>
+</clay:container>
 
 <liferay-frontend:edit-form
 	action="<%= editExpandoURL %>"

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/select_field_type.jsp
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/select_field_type.jsp
@@ -49,14 +49,14 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "view-at
 PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "new-custom-field"), null);
 %>
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<liferay-ui:breadcrumb
 		showCurrentGroup="<%= false %>"
 		showGuestGroup="<%= false %>"
 		showLayout="<%= false %>"
 		showPortletBreadcrumb="<%= true %>"
 	/>
-</div>
+</clay:container>
 
 <liferay-frontend:edit-form>
 	<liferay-frontend:edit-form-body>

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/view.jsp
@@ -29,7 +29,9 @@ List<CustomAttributesDisplay> customAttributesDisplays = PortletLocalServiceUtil
 Collections.sort(customAttributesDisplays, new CustomAttributesDisplayComparator(locale));
 %>
 
-<div class="container-fluid container-fluid-max-xl container-view">
+<clay:container
+	className="container-view"
+>
 	<liferay-ui:search-container
 		emptyResultsMessage='<%= LanguageUtil.get(request, "custom-fields-are-not-enabled-for-any-resource") %>'
 		iteratorURL="<%= portletURL %>"
@@ -78,4 +80,4 @@ Collections.sort(customAttributesDisplays, new CustomAttributesDisplayComparator
 			paginate="<%= false %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/view_attributes.jsp
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/view_attributes.jsp
@@ -64,14 +64,14 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "view-at
 	<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
 	<aui:input name="columnIds" type="hidden" />
 
-	<div class="container-fluid container-fluid-max-xl">
+	<clay:container>
 		<liferay-ui:breadcrumb
 			showCurrentGroup="<%= false %>"
 			showGuestGroup="<%= false %>"
 			showLayout="<%= false %>"
 			showPortletBreadcrumb="<%= true %>"
 		/>
-	</div>
+	</clay:container>
 
 	<liferay-ui:search-container
 		emptyResultsMessage='<%= LanguageUtil.format(request, "no-custom-fields-are-defined-for-x", HtmlUtil.escape(modelResourceName), false) %>'

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/export_templates/edit_template.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/export_templates/edit_template.jsp
@@ -82,7 +82,7 @@ portletDisplay.setURLBack(portletURL.toString());
 renderResponse.setTitle((exportImportConfiguration == null) ? LanguageUtil.get(request, "new-export-template") : exportImportConfiguration.getName());
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<portlet:actionURL name="editExportConfiguration" var="updateExportConfigurationURL">
 		<portlet:param name="mvcRenderCommandName" value="editExportConfiguration" />
 	</portlet:actionURL>
@@ -147,7 +147,7 @@ renderResponse.setTitle((exportImportConfiguration == null) ? LanguageUtil.get(r
 			<aui:button href="<%= portletURL.toString() %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script use="liferay-export-import-export-import">
 	var exportImport = new Liferay.ExportImport({

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/export_templates/view.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/export_templates/view.jsp
@@ -67,7 +67,7 @@ ExportTemplatesToolbarDisplayContext exportTemplatesToolbarDisplayContext = new 
 	showSearch="<%= true %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= portletURL %>">
 		<liferay-ui:search-container
 			searchContainer="<%= exportTemplatesToolbarDisplayContext.getSearchContainer() %>"
@@ -133,4 +133,4 @@ ExportTemplatesToolbarDisplayContext exportTemplatesToolbarDisplayContext = new 
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/new_export/export_layouts.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/new_export/export_layouts.jsp
@@ -88,7 +88,7 @@ portletDisplay.setURLBack(backURL);
 renderResponse.setTitle(!configuredExport ? LanguageUtil.get(request, "new-custom-export") : LanguageUtil.format(request, "new-export-based-on-x", exportImportConfiguration.getName(), false));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<portlet:actionURL name="editExportConfiguration" var="restoreTrashEntriesURL">
 		<portlet:param name="mvcRenderCommandName" value="exportLayouts" />
 		<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.RESTORE %>" />
@@ -182,7 +182,7 @@ renderResponse.setTitle(!configuredExport ? LanguageUtil.get(request, "new-custo
 			<aui:button href="<%= backURL %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script use="liferay-export-import-export-import">
 	var exportImport = new Liferay.ExportImport({

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/processes_list/view.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/processes_list/view.jsp
@@ -27,7 +27,9 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 %>
 
 <div id="<portlet:namespace />exportProcessesSearchContainer">
-	<div class="container-fluid-1280" id="<portlet:namespace />processesContainer">
+	<clay:container
+		id='<%= renderResponse.getNamespace() + "processesContainer" %>'
+	>
 		<liferay-util:include page="/export/processes_list/export_layouts_processes.jsp" servletContext="<%= application %>">
 			<liferay-util:param name="groupId" value="<%= String.valueOf(liveGroupId) %>" />
 			<liferay-util:param name="privateLayout" value="<%= String.valueOf(privateLayout) %>" />
@@ -37,5 +39,5 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 			<liferay-util:param name="orderByType" value="<%= orderByType %>" />
 			<liferay-util:param name="searchContainerId" value="<%= searchContainerId %>" />
 		</liferay-util:include>
-	</div>
+	</clay:container>
 </div>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/processes_list/view.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/processes_list/view.jsp
@@ -28,7 +28,7 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 
 <div id="<portlet:namespace />exportProcessesSearchContainer">
 	<clay:container
-		id='<%= renderResponse.getNamespace() + "processesContainer" %>'
+		id='<%= portletResponse.getNamespace() + "processesContainer" %>'
 	>
 		<liferay-util:include page="/export/processes_list/export_layouts_processes.jsp" servletContext="<%= application %>">
 			<liferay-util:param name="groupId" value="<%= String.valueOf(liveGroupId) %>" />

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet.jsp
@@ -89,7 +89,7 @@ portletURL.setParameter("portletResource", portletResource);
 			<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.EXPORT %>" />
 
 			<div class="export-dialog-tree">
-				<div class="container-fluid-1280">
+				<clay:container>
 					<aui:fieldset-group markupView="lexicon">
 						<aui:fieldset>
 							<aui:input label="export-the-selected-data-to-the-given-lar-file-name" name="exportFileName" required="<%= true %>" showRequiredLabel="<%= false %>" size="50" value="<%= ExportImportHelperUtil.getPortletExportFileName(selPortlet) %>" />
@@ -452,7 +452,7 @@ portletURL.setParameter("portletResource", portletResource);
 							/>
 						</c:if>
 					</aui:fieldset-group>
-				</div>
+				</clay:container>
 			</div>
 
 			<aui:button-row>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet_processes.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet_processes.jsp
@@ -40,7 +40,7 @@ else {
 OrderByComparator<BackgroundTask> orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-container
 		emptyResultsMessage="no-export-processes-were-found"
 		iteratorURL="<%= portletURL %>"
@@ -174,4 +174,4 @@ OrderByComparator<BackgroundTask> orderByComparator = BackgroundTaskComparatorFa
 			<liferay-util:param name="incompleteBackgroundTaskCount" value="<%= String.valueOf(incompleteBackgroundTaskCount) %>" />
 		</liferay-util:include>
 	</div>
-</div>
+</clay:container>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts.jsp
@@ -33,7 +33,10 @@ portletDisplay.setURLBack(importProcessesURL.toString());
 renderResponse.setTitle(LanguageUtil.get(request, "new-import-process"));
 %>
 
-<div class="container-fluid-1280 container-view" id="<portlet:namespace />exportImportOptions">
+<clay:container
+	className="container-view"
+	id='<%= renderResponse.getNamespace() + "exportImportOptions" %>'
+>
 
 	<%
 	int incompleteBackgroundTaskCount = BackgroundTaskManagerUtil.getBackgroundTasksCount(groupId, BackgroundTaskExecutorNames.LAYOUT_IMPORT_BACKGROUND_TASK_EXECUTOR, false);
@@ -53,4 +56,4 @@ renderResponse.setTitle(LanguageUtil.get(request, "new-import-process"));
 			<liferay-util:include page="/import/new_import/import_layouts_validation.jsp" servletContext="<%= application %>" />
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:container>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_validation.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_validation.jsp
@@ -23,9 +23,9 @@ boolean privateLayout = ParamUtil.getBoolean(request, "privateLayout");
 
 <aui:form cssClass="lfr-export-dialog" method="post" name="fm1">
 	<div class="lfr-dynamic-uploader">
-		<div class="container-fluid-1280">
+		<clay:container>
 			<div class="lfr-upload-container" id="<portlet:namespace />fileUpload"></div>
-		</div>
+		</clay:container>
 	</div>
 
 	<%

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/processes_list/view.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/processes_list/view.jsp
@@ -28,7 +28,7 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 
 <div id="<portlet:namespace />importProcessesSearchContainer">
 	<clay:container
-		id='<%= renderResponse.getNamespace() + "processesContainer" %>'
+		id='<%= portletResponse.getNamespace() + "processesContainer" %>'
 	>
 		<liferay-util:include page="/import/processes_list/import_layouts_processes.jsp" servletContext="<%= application %>">
 			<liferay-util:param name="groupId" value="<%= String.valueOf(groupId) %>" />

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/processes_list/view.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/processes_list/view.jsp
@@ -27,7 +27,9 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 %>
 
 <div id="<portlet:namespace />importProcessesSearchContainer">
-	<div class="container-fluid-1280" id="<portlet:namespace />processesContainer">
+	<clay:container
+		id='<%= renderResponse.getNamespace() + "processesContainer" %>'
+	>
 		<liferay-util:include page="/import/processes_list/import_layouts_processes.jsp" servletContext="<%= application %>">
 			<liferay-util:param name="groupId" value="<%= String.valueOf(groupId) %>" />
 			<liferay-util:param name="privateLayout" value="<%= String.valueOf(privateLayout) %>" />
@@ -38,5 +40,5 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 			<liferay-util:param name="orderByType" value="<%= orderByType %>" />
 			<liferay-util:param name="searchContainerId" value="<%= searchContainerId %>" />
 		</liferay-util:include>
-	</div>
+	</clay:container>
 </div>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_processes.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_processes.jsp
@@ -38,7 +38,7 @@ else {
 OrderByComparator<BackgroundTask> orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-container
 		emptyResultsMessage="no-import-processes-were-found"
 		iteratorURL="<%= portletURL %>"
@@ -138,4 +138,4 @@ OrderByComparator<BackgroundTask> orderByComparator = BackgroundTaskComparatorFa
 			<liferay-util:param name="incompleteBackgroundTaskCount" value="<%= String.valueOf(incompleteBackgroundTaskCount) %>" />
 		</liferay-util:include>
 	</div>
-</div>
+</clay:container>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_resources.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_resources.jsp
@@ -50,7 +50,7 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(them
 	<aui:input name="portletResource" type="hidden" value="<%= portletResource %>" />
 
 	<div class="export-dialog-tree">
-		<div class="container-fluid-1280">
+		<clay:container>
 			<aui:fieldset-group markupView="lexicon">
 				<aui:fieldset cssClass="options-group" label="file">
 					<dl class="import-file-details options">
@@ -340,7 +340,7 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(them
 					<aui:input data-name='<%= LanguageUtil.get(request, "always-use-my-user-id") %>' id="alwaysCurrentUserId" label="<%= taglibUseTheCurrentUserAsAuthorLabel %>" name="<%= PortletDataHandlerKeys.USER_ID_STRATEGY %>" type="radio" value="<%= UserIdStrategy.ALWAYS_CURRENT_USER_ID %>" />
 				</aui:fieldset>
 			</aui:fieldset-group>
-		</div>
+		</clay:container>
 	</div>
 
 	<aui:button-row>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_validation.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_validation.jsp
@@ -35,9 +35,9 @@ String redirect = ParamUtil.getString(request, "redirect");
 	%>
 
 	<div class="lfr-dynamic-uploader <%= (fileEntry == null) ? "hide-dialog-footer" : StringPool.BLANK %>">
-		<div class="container-fluid-1280">
+		<clay:container>
 			<div class="lfr-upload-container" id="<portlet:namespace />fileUpload"></div>
-		</div>
+		</clay:container>
 	</div>
 
 	<aui:button-row>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/init.jsp
@@ -135,6 +135,7 @@ page import="com.liferay.portal.kernel.util.FastDateFormatFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
+page import="com.liferay.portal.kernel.util.JavaConstants" %><%@
 page import="com.liferay.portal.kernel.util.ListUtil" %><%@
 page import="com.liferay.portal.kernel.util.MapUtil" %><%@
 page import="com.liferay.portal.kernel.util.OrderByComparator" %><%@
@@ -173,6 +174,7 @@ page import="java.util.Set" %>
 
 <%@ page import="javax.portlet.ActionRequest" %><%@
 page import="javax.portlet.PortletRequest" %><%@
+page import="javax.portlet.PortletResponse" %><%@
 page import="javax.portlet.PortletURL" %>
 
 <liferay-frontend:defineObjects />
@@ -184,6 +186,8 @@ page import="javax.portlet.PortletURL" %>
 <portlet:defineObjects />
 
 <%
+PortletResponse portletResponse = (PortletResponse)request.getAttribute(JavaConstants.JAVAX_PORTLET_RESPONSE);
+
 PortalPreferences portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(request);
 
 String portletResource = ParamUtil.getString(request, "portletResource");

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/process_summary/view.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/process_summary/view.jsp
@@ -16,7 +16,7 @@
 
 <%@ include file="/process_summary/init.jsp" %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<%@ include file="/process_summary/process_summary_pages.jspf" %>
 
 	<%@ include file="/process_summary/process_summary_dates.jspf" %>
@@ -26,4 +26,4 @@
 	<%@ include file="/process_summary/process_summary_deletions.jspf" %>
 
 	<%@ include file="/process_summary/process_summary_permissions.jspf" %>
-</div>
+</clay:container>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/publish_layouts.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/publish_layouts.jsp
@@ -110,7 +110,7 @@ redirectURL.setParameter("privateLayout", String.valueOf(privateLayout));
 response.setHeader("Ajax-ID", request.getHeader("Ajax-ID"));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:if test='<%= SessionMessages.contains(renderRequest, "requestProcessed") %>'>
 
 		<%
@@ -190,7 +190,7 @@ response.setHeader("Ajax-ID", request.getHeader("Ajax-ID"));
 
 		<div id="<portlet:namespace />publishOptions">
 			<div class="export-dialog-tree">
-				<div class="container-fluid-1280">
+				<clay:container>
 
 					<%
 					String taskExecutorClassName = localPublishing ? BackgroundTaskExecutorNames.LAYOUT_STAGING_BACKGROUND_TASK_EXECUTOR : BackgroundTaskExecutorNames.LAYOUT_REMOTE_STAGING_BACKGROUND_TASK_EXECUTOR;
@@ -289,7 +289,7 @@ response.setHeader("Ajax-ID", request.getHeader("Ajax-ID"));
 							</aui:fieldset>
 						</c:if>
 					</aui:fieldset-group>
-				</div>
+				</clay:container>
 			</div>
 
 			<aui:button-row>
@@ -303,7 +303,7 @@ response.setHeader("Ajax-ID", request.getHeader("Ajax-ID"));
 			</aui:button-row>
 		</div>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />publishPages() {

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/publish_templates/view.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/publish_templates/view.jsp
@@ -55,7 +55,7 @@ clearResultsURL.setParameter("keywords", StringPool.BLANK);
 %>
 
 <div class="export-dialog-tree">
-	<div class="container-fluid-1280">
+	<clay:container>
 		<div class="alert alert-info">
 			<liferay-ui:message key="publish-templates-can-be-administered-in-the-control-menu" />
 		</div>
@@ -130,5 +130,5 @@ clearResultsURL.setParameter("keywords", StringPool.BLANK);
 				/>
 			</liferay-ui:search-container>
 		</aui:form>
-	</div>
+	</clay:container>
 </div>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/simple/publish_layouts_simple.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/simple/publish_layouts_simple.jsp
@@ -54,14 +54,16 @@ advancedPublishURL.setParameter("selPlid", String.valueOf(selPlid));
 advancedPublishURL.setParameter("privateLayout", String.valueOf(privateLayout));
 %>
 
-<div class="container-fluid-1280 mt-2 publish-navbar text-right">
+<clay:container
+	className="mt-2 publish-navbar text-right"
+>
 	<clay:link
 		buttonStyle="link"
 		elementClasses="btn-sm"
 		href="<%= advancedPublishURL.toString() %>"
 		label='<%= LanguageUtil.get(request, "switch-to-advanced-publication") %>'
 	/>
-</div>
+</clay:container>
 
 <portlet:actionURL name="editPublishConfiguration" var="confirmedActionURL">
 	<portlet:param name="mvcRenderCommandName" value="editPublishConfigurationSimple" />
@@ -92,7 +94,7 @@ advancedPublishURL.setParameter("privateLayout", String.valueOf(privateLayout));
 		}
 		%>
 
-		<div class="container-fluid-1280">
+		<clay:container>
 			<div class="<%= (incompleteBackgroundTaskCount == 0) ? "hide" : "in-progress" %>" id="<portlet:namespace />incompleteProcessMessage">
 				<liferay-util:include page="/incomplete_processes_message.jsp" servletContext="<%= application %>">
 					<liferay-util:param name="incompleteBackgroundTaskCount" value="<%= String.valueOf(incompleteBackgroundTaskCount) %>" />
@@ -235,7 +237,7 @@ advancedPublishURL.setParameter("privateLayout", String.valueOf(privateLayout));
 					<liferay-ui:message key="simple-publication-help" />
 				</span>
 			</ul>
-		</div>
+		</clay:container>
 	</div>
 
 	<aui:button-row>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/view.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/view.jsp
@@ -124,7 +124,9 @@ simplePublishURL.setParameter("targetGroupId", String.valueOf(liveGroupId));
 %>
 
 <c:if test='<%= !publishConfigurationButtons.equals("template") %>'>
-	<div class="container-fluid-1280 publish-navbar">
+	<clay:container
+		className="publish-navbar"
+	>
 		<div class="autofit-row autofit-row-center">
 			<div class="autofit-col autofit-col-expand">
 				<clay:navigation-bar
@@ -160,7 +162,7 @@ simplePublishURL.setParameter("targetGroupId", String.valueOf(liveGroupId));
 				/>
 			</div>
 		</div>
-	</div>
+	</clay:container>
 </c:if>
 
 <c:choose>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish_portlet_processes.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish_portlet_processes.jsp
@@ -39,7 +39,7 @@ else {
 OrderByComparator<BackgroundTask> orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-container
 		emptyResultsMessage="no-publication-processes-were-found"
 		iteratorURL="<%= portletURL %>"
@@ -131,4 +131,4 @@ OrderByComparator<BackgroundTask> orderByComparator = BackgroundTaskComparatorFa
 			<liferay-util:param name="incompleteBackgroundTaskCount" value="<%= String.valueOf(incompleteBackgroundTaskCount) %>" />
 		</liferay-util:include>
 	</div>
-</div>
+</clay:container>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish_portlet_publish_or_copy.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish_portlet_publish_or_copy.jsp
@@ -56,7 +56,7 @@ else {
 	<aui:input name="portletResource" type="hidden" value="<%= portletResource %>" />
 
 	<div class="export-dialog-tree portlet-export-import-publish-processes">
-		<div class="container-fluid-1280">
+		<clay:container>
 
 			<%
 			int incompleteBackgroundTaskCount = BackgroundTaskManagerUtil.getBackgroundTasksCount(StagingUtil.getStagingAndLiveGroupIds(themeDisplay.getScopeGroupId()), selPortlet.getPortletId(), BackgroundTaskExecutorNames.PORTLET_STAGING_BACKGROUND_TASK_EXECUTOR, false);
@@ -411,7 +411,7 @@ else {
 					/>
 				</c:if>
 			</aui:fieldset-group>
-		</div>
+		</clay:container>
 	</div>
 
 	<aui:button-row>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/view.jsp
@@ -36,7 +36,7 @@ String rootNodeName = liveGroup.getLayoutRootNodeName(privateLayout, themeDispla
 	<portlet:param name="mvcPath" value="/view.jsp" />
 </liferay-portlet:renderURL>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:tabs
 		names="public-pages,private-pages"
 		param="tabs1"
@@ -69,4 +69,4 @@ String rootNodeName = liveGroup.getLayoutRootNodeName(privateLayout, themeDispla
 			<aui:nav-item href="<%= importPagesURL %>" label="import" />
 		</aui:nav>
 	</aui:nav-bar>
-</div>
+</clay:container>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/view_export_import.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/view_export_import.jsp
@@ -31,9 +31,11 @@ if (Validator.isNotNull(backURL)) {
 renderResponse.setTitle(LanguageUtil.get(request, "process-details"));
 %>
 
-<div class="container-fluid-1280" id="<portlet:namespace />exportImportProcessContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "exportImportProcessContainer" %>'
+>
 	<liferay-util:include page="/export_import_process.jsp" servletContext="<%= application %>" />
-</div>
+</clay:container>
 
 <aui:script use="liferay-export-import-export-import">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="exportImport" var="exportImportProcessURL">

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
@@ -24,7 +24,9 @@ List<FragmentCollection> systemFragmentCollections = (List<FragmentCollection>)r
 List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDisplayContext.getFragmentCollectionContributors(locale);
 %>
 
-<div class="container-fluid container-fluid-max-xl container-view">
+<clay:container
+	className="container-view"
+>
 	<clay:row>
 		<clay:col
 			lg="3"
@@ -272,7 +274,7 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 			</c:if>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <aui:form cssClass="hide" name="fragmentCollectionsFm">
 </aui:form>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_entry_usages.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_entry_usages.jsp
@@ -25,14 +25,13 @@ portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(fragmentEntryLinkDisplayContext.getRedirect());
 
 renderResponse.setTitle(LanguageUtil.format(request, "usages-and-propagation-x", fragmentEntry.getName()));
+
+FragmentEntryUsageManagementToolbarDisplayContext fragmentEntryUsageManagementToolbarDisplayContext = new FragmentEntryUsageManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, fragmentEntryLinkDisplayContext.getSearchContainer());
 %>
 
-<div class="container-fluid container-fluid-max-xl container-form-lg">
-
-	<%
-	FragmentEntryUsageManagementToolbarDisplayContext fragmentEntryUsageManagementToolbarDisplayContext = new FragmentEntryUsageManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, fragmentEntryLinkDisplayContext.getSearchContainer());
-	%>
-
+<clay:container
+	className="container-form-lg"
+>
 	<clay:row>
 		<clay:col
 			lg="3"
@@ -176,7 +175,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "usages-and-propagation-x",
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <liferay-frontend:component
 	componentId="<%= fragmentEntryUsageManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_group_fragment_entry_usages.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_group_fragment_entry_usages.jsp
@@ -25,15 +25,14 @@ portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(groupFragmentEntryLinkDisplayContext.getRedirect());
 
 renderResponse.setTitle(LanguageUtil.format(request, "usages-and-propagation-x", fragmentEntry.getName()));
+
+GroupFragmentEntryUsageManagementToolbarDisplayContext groupFragmentEntryUsageManagementToolbarDisplayContext = new GroupFragmentEntryUsageManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, groupFragmentEntryLinkDisplayContext.getSearchContainer());
 %>
 
-<div class="container-fluid container-fluid-max-xl container-form-lg">
+<clay:container
+	className="container-form-lg"
+>
 	<div class="sheet">
-
-		<%
-		GroupFragmentEntryUsageManagementToolbarDisplayContext groupFragmentEntryUsageManagementToolbarDisplayContext = new GroupFragmentEntryUsageManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, groupFragmentEntryLinkDisplayContext.getSearchContainer());
-		%>
-
 		<clay:row>
 			<clay:col
 				lg="12"
@@ -79,7 +78,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "usages-and-propagation-x",
 			</clay:col>
 		</clay:row>
 	</div>
-</div>
+</clay:container>
 
 <liferay-frontend:component
 	componentId="<%= groupFragmentEntryUsageManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/frontend-taglib/frontend-taglib-chart-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-chart-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -27,7 +27,7 @@
 	}
 </style>
 
-<div class="container-fluid">
+<clay:container>
 	<clay:row>
 		<clay:col>
 			<chart:area-spline
@@ -43,9 +43,9 @@
 			/>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
-<div class="container-fluid">
+<clay:container>
 	<clay:row>
 		<clay:col>
 			<chart:line
@@ -75,9 +75,9 @@
 			/>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
-<div class="container-fluid">
+<clay:container>
 	<clay:row>
 		<clay:col>
 			<chart:bar
@@ -93,9 +93,9 @@
 			/>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
-<div class="container-fluid">
+<clay:container>
 	<clay:row>
 		<clay:col>
 			<chart:donut
@@ -111,9 +111,9 @@
 			/>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
-<div class="container-fluid">
+<clay:container>
 	<clay:row>
 		<clay:col>
 			<chart:gauge
@@ -122,9 +122,9 @@
 			/>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
-<div class="container-fluid">
+<clay:container>
 	<clay:row>
 		<clay:col
 			className="geomap"
@@ -144,9 +144,9 @@
 			/>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
-<div class="container-fluid">
+<clay:container>
 	<clay:row>
 		<clay:col
 			className="polling-interval"
@@ -158,9 +158,9 @@
 			/>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
-<div class="container-fluid">
+<clay:container>
 	<clay:row>
 		<clay:col
 			className="predictive"
@@ -172,7 +172,7 @@
 			/>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.componentReady('polling-interval-line-chart').then(function (chart) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -29,9 +29,9 @@
 	%>
 
 		<liferay-ui:section>
-			<div class="container-fluid-1280">
+			<clay:container>
 				<liferay-util:include page="<%= partial %>" servletContext="<%= application %>" />
-			</div>
+			</clay:container>
 		</liferay-ui:section>
 
 	<%

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff/page.jsp
@@ -25,7 +25,7 @@ List<DiffResult> sourceResults = diffResults[0];
 List<DiffResult> targetResults = diffResults[1];
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:choose>
 		<c:when test="<%= !sourceResults.isEmpty() %>">
 			<table class="table table-bordered table-hover table-striped" id="taglib-diff-results">
@@ -99,7 +99,7 @@ List<DiffResult> targetResults = diffResults[1];
 			<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(sourceName), HtmlUtil.escape(targetName)} %>" key="there-are-no-differences-between-x-and-x" translateArguments="<%= false %>" />
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:container>
 
 <%!
 private static String _processColumn(String changedLine) {

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/management_bar/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/management_bar/page.jsp
@@ -18,7 +18,7 @@
 
 <div class="management-bar-container" data-qa-id="managementBar" id="<%= namespace %>managementBarContainerId">
 	<div class="management-bar management-bar-default">
-		<div class="container-fluid-1280">
+		<clay:container>
 			<div class="management-bar-header">
 				<c:if test="<%= includeCheckBox %>">
 					<div class="checkbox">
@@ -50,12 +50,12 @@
 					<%= buttons %>
 				</div>
 			</c:if>
-		</div>
+		</clay:container>
 	</div>
 
 	<c:if test="<%= Validator.isNotNull(actionButtons) || includeCheckBox %>">
 		<div class="management-bar management-bar-default management-bar-no-collapse management-bar-secondary-bar" id="<%= namespace %>actionButtons">
-			<div class="container-fluid-1280">
+			<clay:container>
 				<div class="management-bar-header">
 					<c:if test="<%= includeCheckBox %>">
 						<div class="checkbox">
@@ -81,7 +81,7 @@
 						<%= actionButtons %>
 					</c:if>
 				</div>
-			</div>
+			</clay:container>
 		</div>
 	</c:if>
 </div>

--- a/modules/apps/gogo-shell/gogo-shell-web/build.gradle
+++ b/modules/apps/gogo-shell/gogo-shell-web/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 }

--- a/modules/apps/gogo-shell/gogo-shell-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/gogo-shell/gogo-shell-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>

--- a/modules/apps/gogo-shell/gogo-shell-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/gogo-shell/gogo-shell-web/src/main/resources/META-INF/resources/view.jsp
@@ -24,7 +24,7 @@ String prompt = (String)SessionMessages.get(renderRequest, "prompt");
 
 <portlet:actionURL name="executeCommand" var="executeCommandURL" />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= executeCommandURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "executeCommand();" %>'>
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
@@ -53,7 +53,7 @@ String prompt = (String)SessionMessages.get(renderRequest, "prompt");
 			<pre><%= commandOutput %></pre>
 		</c:if>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />executeCommand() {

--- a/modules/apps/image-uploader/image-uploader-web/build.gradle
+++ b/modules/apps/image-uploader/image-uploader-web/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/image-uploader/image-uploader-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/image-uploader/image-uploader-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/image-uploader/image-uploader-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/image-uploader/image-uploader-web/src/main/resources/META-INF/resources/view.jsp
@@ -66,7 +66,7 @@ String randomNamespace = ParamUtil.getString(request, "randomNamespace");
 			<aui:input name="imageUploaded" type="hidden" value='<%= SessionMessages.contains(renderRequest, "imageUploaded") %>' />
 
 			<div class="dialog-body">
-				<div class="container-fluid-1280">
+				<clay:container>
 
 					<%
 					DLConfiguration dlConfiguration = ConfigurationProviderUtil.getSystemConfiguration(DLConfiguration.class);
@@ -114,7 +114,7 @@ String randomNamespace = ParamUtil.getString(request, "randomNamespace");
 							</div>
 						</aui:fieldset>
 					</aui:fieldset-group>
-				</div>
+				</clay:container>
 			</div>
 
 			<aui:button-row>

--- a/modules/apps/invitation/invitation-invite-members-web/build.gradle
+++ b/modules/apps/invitation/invitation-invite-members-web/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:invitation:invitation-invite-members-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:portal:portal-upgrade-api")

--- a/modules/apps/invitation/invitation-invite-members-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/invitation/invitation-invite-members-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 

--- a/modules/apps/invitation/invitation-invite-members-web/src/main/resources/META-INF/resources/invite_members/view_invite.jsp
+++ b/modules/apps/invitation/invitation-invite-members-web/src/main/resources/META-INF/resources/invite_members/view_invite.jsp
@@ -36,7 +36,9 @@ Group group = GroupLocalServiceUtil.getGroup(scopeGroupId);
 		<aui:input name="invitedTeamId" type="hidden" value="" />
 
 		<div class="dialog-body">
-			<div class="container-fluid main-content-body">
+			<clay:container
+				className="main-content-body"
+			>
 				<aui:fieldset-group markupView="lexicon">
 					<aui:fieldset>
 						<label><liferay-ui:message key="find-members" /></label>
@@ -118,7 +120,7 @@ Group group = GroupLocalServiceUtil.getGroup(scopeGroupId);
 						</c:if>
 					</aui:fieldset>
 				</aui:fieldset-group>
-			</div>
+			</clay:container>
 		</div>
 
 		<aui:button-row>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
@@ -23,7 +23,7 @@ Set<String> groupTypes = groupSelectorDisplayContext.getGroupTypes();
 %>
 
 <c:if test="<%= groupTypes.size() > 1 %>">
-	<div class="container-fluid-1280">
+	<clay:container>
 		<div class="btn-group btn-group-sm my-3" role="group">
 
 			<%
@@ -37,10 +37,12 @@ Set<String> groupTypes = groupSelectorDisplayContext.getGroupTypes();
 			%>
 
 		</div>
-	</div>
+	</clay:container>
 </c:if>
 
-<div class="container-fluid-1280 lfr-item-viewer">
+<clay:container
+	className="lfr-item-viewer"
+>
 	<liferay-ui:search-container
 		searchContainer="<%= groupSelectorDisplayContext.getSearchContainer() %>"
 		var="listSearchContainer"
@@ -82,4 +84,4 @@ Set<String> groupTypes = groupSelectorDisplayContext.getGroupTypes();
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/init.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/init.jsp
@@ -16,7 +16,5 @@
 
 <%@ include file="/init.jsp" %>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
-
 <%@ page import="com.liferay.document.library.util.DLURLHelperUtil" %><%@
 page import="com.liferay.portal.kernel.servlet.BrowserSnifferUtil" %>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/document-library" prefix="liferay-document-library" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/init.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/init.jsp
@@ -16,8 +16,6 @@
 
 <%@ include file="/init.jsp" %>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
-
 <%@ page import="com.liferay.document.library.util.DLURLHelperUtil" %><%@
 page import="com.liferay.item.selector.ItemSelectorReturnType" %><%@
 page import="com.liferay.item.selector.taglib.internal.display.context.ItemSelectorRepositoryEntryManagementToolbarDisplayContext" %><%@

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -70,7 +70,10 @@ ItemSelectorRepositoryEntryManagementToolbarDisplayContext itemSelectorRepositor
 	viewTypeItems="<%= itemSelectorRepositoryEntryManagementToolbarDisplayContext.getViewTypes() %>"
 />
 
-<div class="container-fluid container-fluid-max-xl item-selector lfr-item-viewer" id="<%= randomNamespace %>ItemSelectorContainer">
+<clay:container
+	className="item-selector lfr-item-viewer"
+	id='<%= randomNamespace + "ItemSelectorContainer" %>'
+>
 	<c:if test="<%= showSearchInfo %>">
 		<liferay-util:include page="/repository_entry_browser/search_info.jsp" servletContext="<%= application %>" />
 	</c:if>
@@ -508,7 +511,7 @@ ItemSelectorRepositoryEntryManagementToolbarDisplayContext itemSelectorRepositor
 	</c:if>
 
 	<div class="item-selector-preview-container"></div>
-</div>
+</clay:container>
 
 <aui:script require='<%= npmResolvedPackageName + "/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es as ItemSelectorRepositoryEntryBrowser" %>'>
 	var itemSelector = new ItemSelectorRepositoryEntryBrowser.default({

--- a/modules/apps/item-selector/item-selector-upload-web/build.gradle
+++ b/modules/apps/item-selector/item-selector-upload-web/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:item-selector:item-selector-taglib")

--- a/modules/apps/item-selector/item-selector-upload-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/item-selector/item-selector-upload-web/src/main/resources/META-INF/resources/init.jsp
@@ -18,7 +18,8 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 

--- a/modules/apps/item-selector/item-selector-upload-web/src/main/resources/META-INF/resources/upload.jsp
+++ b/modules/apps/item-selector/item-selector-upload-web/src/main/resources/META-INF/resources/upload.jsp
@@ -48,7 +48,10 @@ Map<String, Object> context = HashMapBuilder.<String, Object>put(
 ).build();
 %>
 
-<div class="container-fluid-1280 lfr-item-viewer" id="itemSelectorUploadContainer">
+<clay:container
+	className="lfr-item-viewer"
+	id="itemSelectorUploadContainer"
+>
 	<div class="drop-enabled drop-zone item-selector upload-view">
 		<div id="uploadDescription">
 			<c:if test="<%= !BrowserSnifferUtil.isMobile(request) %>">
@@ -70,7 +73,7 @@ Map<String, Object> context = HashMapBuilder.<String, Object>put(
 	/>
 
 	<div class="item-selector-preview-container"></div>
-</div>
+</clay:container>
 
 <liferay-frontend:component
 	context="<%= context %>"

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -30,7 +30,10 @@ SearchContainer searchContainer = itemSelectorViewDescriptor.getSearchContainer(
 	/>
 </c:if>
 
-<div class="container-fluid container-fluid-max-xl item-selector lfr-item-viewer" id="<portlet:namespace />entriesContainer">
+<clay:container
+	className="item-selector lfr-item-viewer"
+	id='<%= renderResponse.getNamespace() + "entriesContainer" %>'
+>
 	<c:if test="<%= itemSelectorViewDescriptor.isShowBreadcrumb() %>">
 		<liferay-site-navigation:breadcrumb
 			breadcrumbEntries="<%= itemSelectorViewDescriptorRendererDisplayContext.getBreadcrumbEntries(currentURLObj) %>"
@@ -136,7 +139,7 @@ SearchContainer searchContainer = itemSelectorViewDescriptor.getSearchContainer(
 			searchContainer="<%= searchContainer %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script require="metal-dom/src/all/dom as dom">
 	var selectItemHandler = dom.delegate(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/compare_versions.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/compare_versions.jsp
@@ -47,7 +47,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "compare-versions"));
 	<portlet:param name="articleId" value="<%= articleId %>" />
 </liferay-portlet:resourceURL>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-frontend:diff-version-comparator
 		availableLocales="<%= availableLocales %>"
 		diffHtmlResults="<%= diffHtmlResults %>"
@@ -58,4 +58,4 @@ renderResponse.setTitle(LanguageUtil.get(request, "compare-versions"));
 		sourceVersion="<%= sourceVersion %>"
 		targetVersion="<%= targetVersion %>"
 	/>
-</div>
+</clay:container>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -53,14 +53,14 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 	<aui:input name="workflowAction" type="hidden" value="<%= String.valueOf(WorkflowConstants.ACTION_SAVE_DRAFT) %>" />
 
 	<nav class="component-tbar subnav-tbar-light tbar tbar-article">
-		<div class="container-fluid container-fluid-max-xl">
+
+		<%
+		DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
+		%>
+
+		<clay:container>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
-
-					<%
-					DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
-					%>
-
 					<aui:input autoFocus="<%= (article == null) || article.isNew() %>" cssClass="form-control-inline" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" label="" localized="<%= true %>" name="titleMapAsXML" placeholder='<%= LanguageUtil.format(request, "untitled-x", HtmlUtil.escape(ddmStructure.getName(locale))) %>' required="<%= journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT %>" selectedLanguageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>" type="text" wrapperCssClass="article-content-title mb-0" />
 				</li>
 				<li class="tbar-item">
@@ -97,7 +97,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 					</div>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 
 	<div class="contextual-sidebar edit-article-sidebar sidebar-light sidebar-sm" id="<portlet:namespace />contextualSidebarContainer">
@@ -138,7 +138,9 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 	</div>
 
 	<div class="contextual-sidebar-content">
-		<div class="container-fluid container-fluid-max-xl container-view">
+		<clay:container
+			className="container-view"
+		>
 			<div class="sheet sheet-lg">
 				<aui:model-context bean="<%= article %>" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" model="<%= JournalArticle.class %>" />
 
@@ -275,7 +277,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 					</c:choose>
 				</div>
 			</div>
-		</div>
+		</clay:container>
 	</div>
 </aui:form>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_data_layout_builder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_data_layout_builder.jsp
@@ -60,7 +60,7 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 	<aui:model-context bean="<%= ddmStructure %>" model="<%= DDMStructure.class %>" />
 
 	<nav class="component-tbar subnav-tbar-light tbar tbar-article">
-		<div class="container-fluid container-fluid-max-xl">
+		<clay:container>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 					<aui:input cssClass="form-control-inline" defaultLanguageId="<%= (ddmForm == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): LocaleUtil.toLanguageId(ddmForm.getDefaultLocale()) %>" label="" name="name" placeholder='<%= LanguageUtil.format(request, "untitled-x", "structure") %>' wrapperCssClass="article-content-title mb-0" />
@@ -73,10 +73,12 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 					</div>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 
-	<div class="container-fluid container-fluid-max-xl container-view">
+	<clay:container
+		className="container-view"
+	>
 		<c:if test="<%= (ddmStructure != null) && (DDMStorageLinkLocalServiceUtil.getStructureStorageLinksCount(journalEditDDMStructuresDisplayContext.getDDMStructureId()) > 0) %>">
 			<div class="alert alert-warning">
 				<liferay-ui:message key="there-are-content-references-to-this-structure.-you-may-lose-data-if-a-field-name-is-renamed-or-removed" />
@@ -105,7 +107,7 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 			namespace="<%= renderResponse.getNamespace() %>"
 			singlePage="<%= true %>"
 		/>
-	</div>
+	</clay:container>
 </aui:form>
 
 <aui:script>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_form_builder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_form_builder.jsp
@@ -58,7 +58,7 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 	<aui:model-context bean="<%= ddmStructure %>" model="<%= DDMStructure.class %>" />
 
 	<nav class="component-tbar subnav-tbar-light tbar tbar-article">
-		<div class="container-fluid container-fluid-max-xl">
+		<clay:container>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 					<aui:input cssClass="form-control-inline" defaultLanguageId="<%= (ddmForm == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): LocaleUtil.toLanguageId(ddmForm.getDefaultLocale()) %>" label="" name="name" placeholder='<%= LanguageUtil.format(request, "untitled-x", "structure") %>' wrapperCssClass="article-content-title mb-0" />
@@ -79,7 +79,7 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 					</div>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 
 	<div class="contextual-sidebar edit-article-sidebar sidebar-light sidebar-sm" id="<portlet:namespace />contextualSidebarContainer">
@@ -100,7 +100,9 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 	</div>
 
 	<div class="contextual-sidebar-content">
-		<div class="container-fluid container-fluid-max-xl container-view">
+		<clay:container
+			className="container-view"
+		>
 			<liferay-ui:error exception="<%= DDMFormLayoutValidationException.class %>" message="please-enter-a-valid-form-layout" />
 
 			<liferay-ui:error exception="<%= DDMFormLayoutValidationException.MustNotDuplicateFieldName.class %>">
@@ -179,7 +181,7 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 			<div class="sheet">
 				<%@ include file="/ddm_form_builder.jspf" %>
 			</div>
-		</div>
+		</clay:container>
 	</div>
 </aui:form>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
@@ -45,7 +45,7 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 	<aui:model-context bean="<%= ddmTemplate %>" model="<%= DDMTemplate.class %>" />
 
 	<nav class="component-tbar subnav-tbar-light tbar tbar-article">
-		<div class="container-fluid container-fluid-max-xl">
+		<clay:container>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 					<aui:input cssClass="form-control-inline" defaultLanguageId="<%= (ddmTemplate == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): ddmTemplate.getDefaultLanguageId() %>" label="" name="name" placeholder='<%= LanguageUtil.format(request, "untitled-x", "template") %>' wrapperCssClass="article-content-title mb-0" />
@@ -76,7 +76,7 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 					</div>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 
 	<div class="contextual-sidebar edit-article-sidebar sidebar-light sidebar-sm" id="<portlet:namespace />contextualSidebarContainer">
@@ -97,7 +97,9 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 	</div>
 
 	<div class="contextual-sidebar-content">
-		<div class="container-fluid container-fluid-max-xl container-view">
+		<clay:container
+			className="container-view"
+		>
 			<div class="sheet">
 				<liferay-ui:error exception="<%= TemplateNameException.class %>" message="please-enter-a-valid-name" />
 				<liferay-ui:error exception="<%= TemplateScriptException.class %>" message="please-enter-a-valid-script" />
@@ -110,7 +112,7 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 
 				<liferay-util:include page="/edit_ddm_template_display.jsp" servletContext="<%= application %>" />
 			</div>
-		</div>
+		</clay:container>
 	</div>
 </aui:form>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
@@ -24,7 +24,10 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 	displayContext="<%= new JournalArticleItemSelectorViewManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, journalArticleItemSelectorViewDisplayContext) %>"
 />
 
-<div class="container-fluid container-fluid-max-xl item-selector lfr-item-viewer" id="<portlet:namespace />articlesContainer">
+<clay:container
+	className="item-selector lfr-item-viewer"
+	id='<%= renderResponse.getNamespace() + "articlesContainer" %>'
+>
 	<liferay-site-navigation:breadcrumb
 		breadcrumbEntries="<%= journalArticleItemSelectorViewDisplayContext.getPortletBreadcrumbEntries() %>"
 	/>
@@ -282,7 +285,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 			searchContainer="<%= searchContainer %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script require="metal-dom/src/all/dom as dom">
 	var selectArticleHandler = dom.delegate(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content.jsp
@@ -20,9 +20,11 @@
 JournalArticleDisplay articleDisplay = journalDisplayContext.getArticleDisplay();
 %>
 
-<div class="container-fluid-1280 mt-2">
+<clay:container
+	className="mt-2"
+>
 	<%= articleDisplay.getContent() %>
-</div>
+</clay:container>
 
 <c:if test="<%= articleDisplay.isPaginate() %>">
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
@@ -60,7 +60,10 @@ if (Validator.isNotNull(title)) {
 	module="js/ManagementToolbarDefaultEventHandler.es"
 />
 
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<c:if test="<%= journalDisplayContext.isShowInfoButton() %>">
 		<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/journal/info_panel" var="sidebarPanelURL">
 			<portlet:param name="folderId" value="<%= String.valueOf(journalDisplayContext.getFolderId()) %>" />
@@ -143,4 +146,4 @@ if (Validator.isNotNull(title)) {
 			</c:choose>
 		</aui:form>
 	</div>
-</div>
+</clay:container>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/compare_versions.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/compare_versions.jsp
@@ -56,7 +56,7 @@ if (portletTitleBasedNavigation) {
 	<portlet:param name="resourcePrimKey" value="<%= String.valueOf(kbArticle.getResourcePrimKey()) %>" />
 </liferay-portlet:resourceURL>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-frontend:diff-version-comparator
 		diffHtmlResults="<%= diffHtmlResults %>"
 		diffVersionsInfo="<%= AdminUtil.getDiffVersionsInfo(scopeGroupId, kbArticle.getResourcePrimKey(), GetterUtil.getInteger(sourceVersion), GetterUtil.getInteger(targetVersion)) %>"
@@ -65,4 +65,4 @@ if (portletTitleBasedNavigation) {
 		sourceVersion="<%= sourceVersion %>"
 		targetVersion="<%= targetVersion %>"
 	/>
-</div>
+</clay:container>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_folder.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_folder.jsp
@@ -41,7 +41,7 @@ renderResponse.setTitle((kbFolder == null) ? LanguageUtil.get(resourceBundle, "n
 
 <liferay-portlet:actionURL name="updateKBFolder" var="updateKBFolderURL" />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= updateKBFolderURL %>" method="post" name="fm">
 		<aui:input name="mvcPath" type="hidden" value="/admin/common/edit_folder.jsp" />
 		<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= (kbFolder == null) ? Constants.ADD : Constants.UPDATE %>" />
@@ -92,4 +92,4 @@ renderResponse.setTitle((kbFolder == null) ? LanguageUtil.get(resourceBundle, "n
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_template.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_template.jsp
@@ -32,7 +32,7 @@ renderResponse.setTitle((kbTemplate == null) ? LanguageUtil.get(request, "new-te
 
 <liferay-portlet:actionURL name="updateKBTemplate" var="updateKBTemplateURL" />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= updateKBTemplateURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "updateKBTemplate();" %>'>
 		<aui:input name="mvcPath" type="hidden" value='<%= templatePath + "edit_template.jsp" %>' />
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
@@ -75,7 +75,7 @@ renderResponse.setTitle((kbTemplate == null) ? LanguageUtil.get(request, "new-te
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />updateKBTemplate() {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/select_parent.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/select_parent.jsp
@@ -76,7 +76,7 @@ else {
 }
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form method="post" name="fm">
 
 		<%
@@ -275,7 +275,7 @@ else {
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/select_version.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/select_version.jsp
@@ -33,7 +33,7 @@ portletURL.setParameter("resourcePrimKey", String.valueOf(kbArticle.getResourceP
 portletURL.setParameter("sourceVersion", String.valueOf(sourceVersion));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="selectVersionFm">
 		<liferay-ui:search-container
 			id="articleVersionSearchContainer"
@@ -93,7 +93,7 @@ portletURL.setParameter("sourceVersion", String.valueOf(sourceVersion));
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/import.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/import.jsp
@@ -29,7 +29,7 @@ renderResponse.setTitle(LanguageUtil.get(resourceBundle, "import"));
 	<portlet:param name="redirect" value="<%= redirect %>" />
 </portlet:actionURL>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= importFileURL %>" class="lfr-dynamic-form" enctype="multipart/form-data" method="post" name="fm">
 		<aui:input name="mvcPath" type="hidden" value="/admin/import.jsp" />
 		<aui:input name="parentKBFolderId" type="hidden" value="<%= String.valueOf(parentKBFolderId) %>" />
@@ -71,4 +71,4 @@ renderResponse.setTitle(LanguageUtil.get(resourceBundle, "import"));
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -67,7 +67,10 @@ if (parentResourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 	sortingURL="<%= String.valueOf(kbAdminManagementToolbarDisplayContext.getSortingURL()) %>"
 />
 
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="infoPanel" var="sidebarPanelURL">
 		<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(parentResourceClassNameId) %>" />
 		<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(parentResourcePrimKey) %>" />
@@ -315,7 +318,7 @@ if (parentResourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <aui:script>
 	var deleteEntries = function () {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_suggestion.jsp
@@ -16,6 +16,8 @@
 
 <%@ include file="/admin/init.jsp" %>
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
-</div>
+</clay:container>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_suggestions.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_suggestions.jsp
@@ -77,7 +77,7 @@ request.setAttribute("view_suggestions.jsp-searchContainer", kbCommentsSearchCon
 	sortingURL="<%= String.valueOf(kbSuggestionListManagementToolbarDisplayContext.getSortingURL()) %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:success key="suggestionDeleted" message="suggestion-deleted-successfully" />
 
 	<liferay-ui:success key="suggestionsDeleted" message="suggestions-deleted-successfully" />
@@ -87,7 +87,7 @@ request.setAttribute("view_suggestions.jsp-searchContainer", kbCommentsSearchCon
 	<liferay-ui:success key="suggestionSaved" message="suggestion-saved-successfully" />
 
 	<liferay-util:include page="/admin/common/view_suggestions_by_status.jsp" servletContext="<%= application %>" />
-</div>
+</clay:container>
 
 <aui:script>
 	var deleteKBComments = function () {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_templates.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_templates.jsp
@@ -37,7 +37,7 @@ KBTemplatesManagementToolbarDisplayContext kbTemplatesManagementToolbarDisplayCo
 	sortingURL="<%= String.valueOf(kbTemplatesManagementToolbarDisplayContext.getSortingURL()) %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-portlet:renderURL varImpl="searchURL">
 		<portlet:param name="mvcPath" value="/admin/view_templates.jsp" />
 	</liferay-portlet:renderURL>
@@ -110,7 +110,7 @@ KBTemplatesManagementToolbarDisplayContext kbTemplatesManagementToolbarDisplayCo
 			</liferay-ui:search-container>
 		</aui:fieldset>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	var deleteKBTemplates = function () {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/view_suggestion.jsp
@@ -16,6 +16,8 @@
 
 <%@ include file="/admin/init.jsp" %>
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
-</div>
+</clay:container>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/view_suggestion.jsp
@@ -16,6 +16,8 @@
 
 <%@ include file="/admin/init.jsp" %>
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
-</div>
+</clay:container>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/search/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/search/view_suggestion.jsp
@@ -16,6 +16,8 @@
 
 <%@ include file="/admin/init.jsp" %>
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
-</div>
+</clay:container>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/section/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/section/view_suggestion.jsp
@@ -16,6 +16,8 @@
 
 <%@ include file="/admin/init.jsp" %>
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
-</div>
+</clay:container>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
@@ -22,7 +22,9 @@ long sourcePlid = ParamUtil.getLong(request, "sourcePlid");
 List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.getAutoSiteNavigationMenus();
 %>
 
-<div class="container-fluid-1280 pt-2">
+<clay:container
+	className="pt-2"
+>
 	<liferay-frontend:edit-form
 		action="<%= (sourcePlid <= 0) ? layoutsAdminDisplayContext.getAddLayoutURL() : layoutsAdminDisplayContext.getCopyLayoutURL(sourcePlid) %>"
 		method="post"
@@ -38,7 +40,9 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 
 					<liferay-ui:message key="add-this-page-to-the-following-menus" />
 
-					<div class="auto-site-navigation-menus container my-3">
+					<clay:container
+						className="auto-site-navigation-menus mt-3"
+					>
 						<clay:row>
 
 							<%
@@ -56,7 +60,7 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 							%>
 
 						</clay:row>
-					</div>
+					</clay:container>
 				</c:when>
 				<c:when test="<%= autoSiteNavigationMenus.size() == 1 %>">
 
@@ -64,11 +68,13 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 					SiteNavigationMenu autoSiteNavigationMenu = autoSiteNavigationMenus.get(0);
 					%>
 
-					<div class="auto-site-navigation-menus container mt-3">
+					<clay:container
+						className="auto-site-navigation-menus mt-3"
+					>
 						<clay:row>
 							<aui:input id='<%= "menu_" + autoSiteNavigationMenu.getSiteNavigationMenuId() %>' label='<%= LanguageUtil.format(request, "add-this-page-to-x", HtmlUtil.escape(autoSiteNavigationMenu.getName())) %>' name="TypeSettingsProperties--siteNavigationMenuId--" type="checkbox" value="<%= autoSiteNavigationMenu.getSiteNavigationMenuId() %>" />
 						</clay:row>
-					</div>
+					</clay:container>
 				</c:when>
 			</c:choose>
 
@@ -106,7 +112,7 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 			/>
 		</liferay-frontend:edit-form-footer>
 	</liferay-frontend:edit-form>
-</div>
+</clay:container>
 
 <aui:script use="liferay-alert">
 	var form = document.<portlet:namespace />fm;

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/customization_settings.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/customization_settings.jsp
@@ -28,7 +28,7 @@ Map<String, Object> data = HashMapBuilder.<String, Object>put(
 
 <div id="<%= portletNamespace %>customizationBar">
 	<div class="control-menu-level-2">
-		<div class="container-fluid container-fluid-max-xl">
+		<clay:container>
 			<div class="control-menu-level-2-heading d-block d-md-none">
 				<liferay-ui:message key="customization-options" />
 
@@ -181,6 +181,6 @@ Map<String, Object> data = HashMapBuilder.<String, Object>put(
 					}
 				</aui:script>
 			</ul>
-		</div>
+		</clay:container>
 	</div>
 </div>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
@@ -17,6 +17,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
@@ -33,7 +33,10 @@ portletDisplay.setURLBack(backURL);
 renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 %>
 
-<div class="container-fluid container-fluid-max-xl container-view" id="<portlet:namespace />layoutPageTemplateEntries">
+<clay:container
+	className="container-view"
+	id='<%= renderResponse.getNamespace() + "layoutPageTemplateEntries" %>'
+>
 	<clay:row>
 		<clay:col
 			lg="3"
@@ -156,7 +159,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <aui:script require="metal-dom/src/all/dom as dom">
 	var layoutPageTemplateEntries = document.getElementById(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/init.jsp
@@ -18,7 +18,8 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/layout" prefix="liferay-layout" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/view_toolbar.jsp
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/view_toolbar.jsp
@@ -21,7 +21,7 @@ ContentPageEditorDisplayContext contentPageEditorDisplayContext = (ContentPageEd
 %>
 
 <div class="management-bar navbar navbar-expand-md page-editor__toolbar <%= contentPageEditorDisplayContext.isMasterLayout() ? "page-editor__toolbar--master-layout" : StringPool.BLANK %>" id="<%= contentPageEditorDisplayContext.getPortletNamespace() %>pageEditorToolbar">
-	<div class="container-fluid container-fluid-max-xl">
+	<clay:container>
 		<ul class="navbar-nav">
 		</ul>
 
@@ -60,5 +60,5 @@ ContentPageEditorDisplayContext contentPageEditorDisplayContext = (ContentPageEd
 				</button>
 			</li>
 		</ul>
-	</div>
+	</clay:container>
 </div>

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_display_page_master_layout.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_display_page_master_layout.jsp
@@ -27,7 +27,9 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 %>
 
-<div class="container-fluid-1280 mt-4">
+<clay:container
+	className="mt-4"
+>
 	<div class="lfr-search-container-wrapper">
 		<ul class="card-page card-page-equal-height">
 
@@ -47,7 +49,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 
 		</ul>
 	</div>
-</div>
+</clay:container>
 
 <%
 StringBundler sb = new StringBundler(3);

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry_master_layout.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry_master_layout.jsp
@@ -36,7 +36,9 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 %>
 
-<div class="container-fluid-1280 mt-4">
+<clay:container
+	className="mt-4"
+>
 	<div class="lfr-search-container-wrapper">
 		<ul class="card-page card-page-equal-height">
 
@@ -56,7 +58,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 
 		</ul>
 	</div>
-</div>
+</clay:container>
 
 <aui:script require="metal-dom/src/all/dom as dom,frontend-js-web/liferay/modal/commands/OpenSimpleInputModal.es as openSimpleInputModal" sandbox="<%= true %>">
 	var addPageTemplateClickHandler = dom.delegate(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
@@ -29,7 +29,9 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 
 <liferay-ui:success key="layoutPageTemplatePublished" message="the-page-template-was-published-succesfully" />
 
-<div class="container-fluid container-fluid-max-xl container-view">
+<clay:container
+	className="container-view"
+>
 	<clay:row>
 		<clay:col
 			lg="3"
@@ -149,7 +151,7 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 			</c:if>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <aui:form cssClass="hide" name="layoutPageTemplateCollectionsFm">
 </aui:form>

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_admin/page.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_admin/page.jsp
@@ -23,7 +23,9 @@ String className = GetterUtil.getString(request.getAttribute("liferay-layout:lay
 LayoutClassedModelUsagesDisplayContext layoutClassedModelUsagesDisplayContext = new LayoutClassedModelUsagesDisplayContext(renderRequest, renderResponse, className, classPK);
 %>
 
-<div class="container-fluid container-fluid-max-xl container-form-lg">
+<clay:container
+	className="container-form-lg"
+>
 	<clay:row>
 		<clay:col
 			lg="3"
@@ -179,4 +181,4 @@ LayoutClassedModelUsagesDisplayContext layoutClassedModelUsagesDisplayContext = 
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_fragment_layout/render_layout_structure.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_fragment_layout/render_layout_structure.jsp
@@ -224,7 +224,9 @@ for (String childrenItemId : childrenItemIds) {
 
 			<c:choose>
 				<c:when test="<%= includeContainer %>">
-					<div class="container-fluid p-0">
+					<clay:container
+						className="p-0"
+					>
 						<clay:row
 							className="<%= ResponsiveLayoutStructureUtil.getRowCssClass(rowLayoutStructureItem) %>"
 						>
@@ -235,7 +237,7 @@ for (String childrenItemId : childrenItemIds) {
 
 							<liferay-util:include page="/render_fragment_layout/render_layout_structure.jsp" servletContext="<%= application %>" />
 						</clay:row>
-					</div>
+					</clay:container>
 				</c:when>
 				<c:otherwise>
 					<clay:row

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/init.jsp
@@ -16,7 +16,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/layout" prefix="liferay-layout" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/layout/view/display_page.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/layout/view/display_page.jsp
@@ -64,11 +64,13 @@ String ppid = ParamUtil.getString(request, "p_p_id");
 		<c:choose>
 			<c:when test="<%= (assetRendererFactory != null) && !assetRendererFactory.hasPermission(permissionChecker, infoDisplayObjectProvider.getClassPK(), ActionKeys.VIEW) %>">
 				<div class="layout-content" id="main-content" role="main">
-					<div class="container-fluid-1280 pt-3">
+					<clay:container
+						className="pt-3"
+					>
 						<div class="alert alert-danger">
 							<liferay-ui:message key="you-do-not-have-permission-to-view-this-page" />
 						</div>
-					</div>
+					</clay:container>
 				</div>
 			</c:when>
 			<c:when test="<%= infoDisplayObjectProvider != null %>">

--- a/modules/apps/license-manager/license-manager-web/build.gradle
+++ b/modules/apps/license-manager/license-manager-web/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:application-list:application-list-api")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/license-manager/license-manager-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/license-manager/license-manager-web/src/main/resources/META-INF/resources/init.jsp
@@ -17,6 +17,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <liferay-theme:defineObjects />

--- a/modules/apps/license-manager/license-manager-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/license-manager/license-manager-web/src/main/resources/META-INF/resources/view.jsp
@@ -22,9 +22,9 @@
 	</aui:nav>
 </aui:nav-bar>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<iframe allowTransparency="true" frameborder="0" id="<portlet:namespace />iframe" scrolling="no" src="<%= themeDisplay.getPathMain() %>/portal/license?p_l_id=<%= themeDisplay.getPlid() %>&p_p_state=pop_up" style="border: none; width: 100%;"></iframe>
-</div>
+</clay:container>
 
 <aui:script use="aui-autosize-iframe">
 	var iframe = A.one('#<portlet:namespace />iframe');

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view.jsp
@@ -43,7 +43,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "app-man
 	sortingURL="<%= viewAppsManagerManagementToolbarDisplayContext.getSortingURL() %>"
 />
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<liferay-ui:breadcrumb
 		showCurrentGroup="<%= false %>"
 		showGuestGroup="<%= false %>"
@@ -69,4 +69,4 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "app-man
 			resultRowSplitter="<%= new MarketplaceAppManagerResultRowSplitter() %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_module.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_module.jsp
@@ -74,7 +74,7 @@ else {
 	sortingURL="<%= viewModuleManagementToolbarDisplayContext.getSortingURL() %>"
 />
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<liferay-ui:breadcrumb
 		showCurrentGroup="<%= false %>"
 		showGuestGroup="<%= false %>"
@@ -147,4 +147,4 @@ else {
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_modules.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_modules.jsp
@@ -58,7 +58,7 @@ MarketplaceAppManagerUtil.addPortletBreadcrumbEntry(appDisplay, request, renderR
 	sortingURL="<%= viewModulesManagementToolbarDisplayContext.getSortingURL() %>"
 />
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<liferay-ui:breadcrumb
 		showCurrentGroup="<%= false %>"
 		showGuestGroup="<%= false %>"
@@ -83,4 +83,4 @@ MarketplaceAppManagerUtil.addPortletBreadcrumbEntry(appDisplay, request, renderR
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_search_results.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_search_results.jsp
@@ -56,7 +56,7 @@ SearchContainer searchContainer = appManagerSearchResultsManagementToolbarDispla
 	sortingURL="<%= appManagerSearchResultsManagementToolbarDisplayContext.getSortingURL() %>"
 />
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<liferay-ui:breadcrumb
 		showCurrentGroup="<%= false %>"
 		showGuestGroup="<%= false %>"
@@ -101,4 +101,4 @@ SearchContainer searchContainer = appManagerSearchResultsManagementToolbarDispla
 			resultRowSplitter="<%= new MarketplaceAppManagerResultRowSplitter() %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
@@ -112,7 +112,9 @@ if (portletTitleBasedNavigation) {
 }
 %>
 
-<div class="container-fluid-1280" id="<%= renderResponse.getNamespace() + "mbEditPageContainer" %>">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "mbEditPageContainer" %>'
+>
 	<c:if test="<%= !portletTitleBasedNavigation %>">
 		<h3><%= headerTitle %></h3>
 	</c:if>
@@ -449,7 +451,7 @@ if (portletTitleBasedNavigation) {
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script require='<%= npmResolvedPackageName + "/message_boards/js/MBPortlet.es as MBPortlet" %>'>
 	new MBPortlet.default({

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/select_category.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/select_category.jsp
@@ -38,7 +38,7 @@ else {
 }
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form method="post" name="selectCategoryFm">
 		<liferay-ui:breadcrumb
 			showGuestGroup="<%= false %>"
@@ -140,7 +140,7 @@ else {
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_deleted_message_attachments.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_deleted_message_attachments.jsp
@@ -37,7 +37,7 @@ iteratorURL.setParameter("messageId", String.valueOf(messageId));
 String trashEntriesMaxAgeTimeDescription = LanguageUtil.getTimeDescription(locale, trashHelper.getMaxAge(themeDisplay.getScopeGroup()) * Time.MINUTE, true);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-trash:empty
 		confirmMessage="are-you-sure-you-want-to-remove-the-attachments-for-this-message"
 		emptyMessage="remove-the-attachments-for-this-message"
@@ -103,4 +103,4 @@ String trashEntriesMaxAgeTimeDescription = LanguageUtil.getTimeDescription(local
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_banned_users.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_banned_users.jsp
@@ -43,7 +43,7 @@ int totalBannedUsers = MBBanLocalServiceUtil.getBansCount(scopeGroupId);
 	showSearch="<%= false %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= portletURL.toString() %>" method="get" name="fm">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
@@ -129,7 +129,7 @@ int totalBannedUsers = MBBanLocalServiceUtil.getBansCount(scopeGroupId);
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <%
 PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, TextFormatter.format("banned-users", TextFormatter.O)), portletURL.toString());

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_statistics.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_statistics.jsp
@@ -32,7 +32,7 @@ long categoryId = GetterUtil.getLong(request.getAttribute("view.jsp-categoryId")
 MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, categoryId);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<div class="statistics-panel">
 		<h3><liferay-ui:message key="overview" /></h3>
 
@@ -113,7 +113,7 @@ MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, category
 			/>
 		</liferay-ui:search-container>
 	</div>
-</div>
+</clay:container>
 
 <%
 PortalUtil.setPageSubtitle(LanguageUtil.get(request, "statistics"), request);

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/edit_action.jsp
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/edit_action.jsp
@@ -47,7 +47,7 @@ MDRRuleGroupInstance ruleGroupInstance = (MDRRuleGroupInstance)renderRequest.get
 	<aui:model-context bean="<%= action %>" model="<%= MDRAction.class %>" />
 
 	<div class="portlet-configuration-body-content">
-		<div class="container-fluid-1280">
+		<clay:container>
 			<aui:fieldset-group markupView="lexicon">
 				<aui:fieldset>
 					<c:if test="<%= action == null %>">
@@ -81,7 +81,7 @@ MDRRuleGroupInstance ruleGroupInstance = (MDRRuleGroupInstance)renderRequest.get
 					</div>
 				</aui:fieldset>
 			</aui:fieldset-group>
-		</div>
+		</clay:container>
 	</div>
 
 	<aui:button-row>

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/view_rules.jsp
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/view_rules.jsp
@@ -126,7 +126,7 @@ renderResponse.setTitle(ruleGroup.getName(locale));
 	</liferay-frontend:management-bar-filters>
 </liferay-frontend:management-bar>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-container
 		searchContainer="<%= rulesSearchContainer %>"
 	>
@@ -206,4 +206,4 @@ renderResponse.setTitle(ruleGroup.getName(locale));
 			type="more"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/view.jsp
@@ -62,7 +62,7 @@ sortingURL.setParameter("orderByType", orderByType.equals("asc") ? "desc" : "asc
 	sortingURL="<%= sortingURL.toString() %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:choose>
 		<c:when test="<%= userTrackers != null %>">
 			<liferay-ui:search-container
@@ -147,4 +147,4 @@ sortingURL.setParameter("orderByType", orderByType.equals("asc") ? "desc" : "asc
 			<liferay-ui:message arguments="<%= PropsKeys.SESSION_TRACKER_MEMORY_ENABLED %>" key="display-of-live-session-data-is-disabled" translateArguments="<%= false %>" />
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:container>

--- a/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/view.jsp
@@ -34,7 +34,7 @@ int subscriptionsCount = mySubscriptionsManagementToolbarDisplayContext.getTotal
 	showSearch="<%= mySubscriptionsManagementToolbarDisplayContext.isShowSearch() %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= unsubscribeURL %>" method="get" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "unsubscribe();" %>'>
 		<liferay-portlet:renderURLParams varImpl="portletURL" />
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
@@ -111,7 +111,7 @@ int subscriptionsCount = mySubscriptionsManagementToolbarDisplayContext.getTotal
 			</liferay-ui:search-container>
 		</aui:fieldset>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.provide(

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
@@ -85,7 +85,9 @@ navigationURL.setParameter(SearchContainer.DEFAULT_CUR_PARAM, "0");
 	sortingURL="<%= String.valueOf(notificationsManagementToolbarDisplayContext.getSortingURL()) %>"
 />
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<aui:form action="<%= currentURL %>" method="get" name="fm">
 		<div class="user-notifications">
 			<liferay-ui:search-container
@@ -120,7 +122,7 @@ navigationURL.setParameter(SearchContainer.DEFAULT_CUR_PARAM, "0");
 			</liferay-ui:search-container>
 		</div>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script sandbox="<%= true %>">
 	var deleteNotifications = function () {

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/application_authorizations.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/application_authorizations.jsp
@@ -48,7 +48,7 @@ OAuth2AuthorizationsManagementToolbarDisplayContext oAuth2AuthorizationsManageme
 	<portlet:param name="oAuth2ApplicationId" value="<%= String.valueOf(oAuth2ApplicationId) %>" />
 </portlet:actionURL>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= revokeOAuth2AuthorizationsURL %>" name="fm">
 		<aui:input name="oAuth2ApplicationId" type="hidden" value="<%= oAuth2ApplicationId %>" />
 		<aui:input name="oAuth2AuthorizationIds" type="hidden" />
@@ -118,7 +118,7 @@ OAuth2AuthorizationsManagementToolbarDisplayContext oAuth2AuthorizationsManageme
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />revokeOAuth2Authorizations() {

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes.jsp
@@ -24,7 +24,9 @@ OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2
 AssignScopesDisplayContext assignScopesDisplayContext = (AssignScopesDisplayContext)oAuth2AdminPortletDisplayContext;
 %>
 
-<div class="container-fluid container-fluid-max-xl container-view">
+<clay:container
+	className="container-view"
+>
 	<liferay-ui:error exception="<%= OAuth2ApplicationClientCredentialUserIdException.class %>">
 
 		<%
@@ -88,7 +90,7 @@ AssignScopesDisplayContext assignScopesDisplayContext = (AssignScopesDisplayCont
 			</aui:form>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <aui:script require="metal-dom/src/dom as dom">
 	AUI().use('node', 'aui-modal', function (A) {

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tree.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tree.jsp
@@ -32,132 +32,115 @@ pageContext.setAttribute("assignedScopeAliases", assignedScopeAliases);
 pageContext.setAttribute("scopeAliasesDescriptionsMap", scopeAliasesDescriptionsMap);
 %>
 
-<div class="container-fluid container-fluid-max-xl container-view">
+<clay:container
+	className="container-view"
+>
+	<div class="sheet">
+		<div class="sheet-header">
+			<h2 class="sheet-title"><liferay-ui:message key="scopes" /></h2>
 
-<div class="sheet">
-	<div class="sheet-header">
-		<h2 class="sheet-title"><liferay-ui:message key="scopes" /></h2>
+			<div class="sheet-text"><liferay-ui:message key="scopes-description" /></div>
+		</div>
 
-		<div class="sheet-text"><liferay-ui:message key="scopes-description" /></div>
+		<div class="sheet-section">
+			<liferay-ui:error exception="<%= OAuth2ApplicationClientCredentialUserIdException.class %>">
+
+				<%
+				OAuth2ApplicationClientCredentialUserIdException oAuth2ApplicationClientCredentialUserIdException = (OAuth2ApplicationClientCredentialUserIdException)errorException;
+				%>
+
+				<c:choose>
+					<c:when test="<%= Validator.isNotNull(oAuth2ApplicationClientCredentialUserIdException.getClientCredentialUserScreenName()) %>">
+						<liferay-ui:message arguments="<%= oAuth2ApplicationClientCredentialUserIdException.getClientCredentialUserScreenName() %>" key="this-operation-cannot-be-performed-because-you-cannot-impersonate-x" />
+					</c:when>
+					<c:otherwise>
+						<liferay-ui:message arguments="<%= oAuth2ApplicationClientCredentialUserIdException.getClientCredentialUserId() %>" key="this-operation-cannot-be-performed-because-you-cannot-impersonate-x" />
+					</c:otherwise>
+				</c:choose>
+			</liferay-ui:error>
+
+			<clay:row>
+				<div class="col-lg-12">
+					<portlet:actionURL name="/admin/assign_scopes" var="assignScopesURL">
+						<portlet:param name="mvcRenderCommandName" value="/admin/assign_scopes" />
+						<portlet:param name="navigation" value="assign_scopes" />
+						<portlet:param name="backURL" value="<%= redirect %>" />
+						<portlet:param name="oAuth2ApplicationId" value="<%= String.valueOf(oAuth2Application.getOAuth2ApplicationId()) %>" />
+					</portlet:actionURL>
+
+					<aui:form action="<%= assignScopesURL %>" name="fm">
+						<ul class="list-group">
+							<oauth2-tree:tree
+								trees="<%= (Collection)scopeAliasTreeNode.getTrees() %>"
+							>
+								<jsp:attribute
+									name="nodeJspFragment"
+								>
+								<li class="borderless list-group-item<c:if test="${assignedDeletedScopeAliases.contains(tree.value)}"> removed-scope</c:if>" id="${tree.value}-container">
+									<clay:row>
+											<c:choose>
+												<c:when test="${parentNodes.size() > 0}">
+												<div class="col-md-6">
+													<div class="scope-children-${parentNodes.size()}">
+														<aui:input checked="${assignedScopeAliases.contains(tree.value)}" data-has-childrens="true" data-parent="${parentNodes.getFirst().value}" disabled="${assignedDeletedScopeAliases.contains(tree.value)}" id="${tree.value}" label="${tree.value}" name="scopeAliases" type="checkbox" value="${tree.value}" />
+													</div>
+												</div>
+												</c:when>
+												<c:otherwise>
+												<div class="col-md-6">
+													<aui:input checked="${assignedScopeAliases.contains(tree.value)}" data-has-childrens="true" disabled="${assignedDeletedScopeAliases.contains(tree.value)}" id="${tree.value}" label="${tree.value}" name="scopeAliases" type="checkbox" value="${tree.value}" />
+												</div>
+												</c:otherwise>
+											</c:choose>
+										<div class="col-md-6 text-left">
+											${scopeAliasesDescriptionsMap.get(tree.value)}
+										</div>
+									</clay:row>
+								</li>
+
+								<oauth2-tree:render-children />
+								</jsp:attribute>
+
+								<jsp:attribute
+									name="leafJspFragment"
+								>
+								<li class="borderless list-group-item<c:if test="${assignedDeletedScopeAliases.contains(tree.value)}"> removed-scope</c:if>" id="${tree.value}-container">
+									<clay:row>
+											<c:choose>
+												<c:when test="${parentNodes.size() > 0}">
+												<div class="col-md-6">
+													<div class="scope-children-${parentNodes.size()}">
+														<aui:input checked="${assignedScopeAliases.contains(tree.value)}" data-parent="${parentNodes.getFirst().value}" disabled="${assignedDeletedScopeAliases.contains(tree.value)}" id="${tree.value}" label="${tree.value}" name="scopeAliases" type="checkbox" value="${tree.value}" />
+													</div>
+												</div>
+												</c:when>
+												<c:otherwise>
+												<div class="col-md-6">
+													<aui:input checked="${assignedScopeAliases.contains(tree.value)}" disabled="${assignedDeletedScopeAliases.contains(tree.value)}" id="${tree.value}" label="${tree.value}" name="scopeAliases" type="checkbox" value="${tree.value}" />
+												</div>
+												</c:otherwise>
+											</c:choose>
+										<div class="col-md-6 text-left">
+											${scopeAliasesDescriptionsMap.get(tree.value)}
+										</div>
+									</clay:row>
+								</li>
+								</jsp:attribute>
+							</oauth2-tree:tree>
+							</li>
+						</ul>
+
+						<aui:button-row>
+							<aui:button id="save" type="submit" value="save" />
+
+							<aui:button href="<%= PortalUtil.escapeRedirect(redirect) %>" type="cancel" />
+						</aui:button-row>
+					</aui:form>
+				</div>
+			</clay:row>
+		</div>
 	</div>
-
-<div class="sheet-section">
-	<liferay-ui:error exception="<%= OAuth2ApplicationClientCredentialUserIdException.class %>">
-
-		<%
-		OAuth2ApplicationClientCredentialUserIdException oAuth2ApplicationClientCredentialUserIdException = (OAuth2ApplicationClientCredentialUserIdException)errorException;
-		%>
-
-		<c:choose>
-			<c:when test="<%= Validator.isNotNull(oAuth2ApplicationClientCredentialUserIdException.getClientCredentialUserScreenName()) %>">
-				<liferay-ui:message arguments="<%= oAuth2ApplicationClientCredentialUserIdException.getClientCredentialUserScreenName() %>" key="this-operation-cannot-be-performed-because-you-cannot-impersonate-x" />
-			</c:when>
-			<c:otherwise>
-				<liferay-ui:message arguments="<%= oAuth2ApplicationClientCredentialUserIdException.getClientCredentialUserId() %>" key="this-operation-cannot-be-performed-because-you-cannot-impersonate-x" />
-			</c:otherwise>
-		</c:choose>
-	</liferay-ui:error>
-
-	<clay:row>
-		<clay:col
-			lg="12"
-		>
-			<portlet:actionURL name="/admin/assign_scopes" var="assignScopesURL">
-				<portlet:param name="mvcRenderCommandName" value="/admin/assign_scopes" />
-				<portlet:param name="navigation" value="assign_scopes" />
-				<portlet:param name="backURL" value="<%= redirect %>" />
-				<portlet:param name="oAuth2ApplicationId" value="<%= String.valueOf(oAuth2Application.getOAuth2ApplicationId()) %>" />
-			</portlet:actionURL>
-
-			<aui:form action="<%= assignScopesURL %>" name="fm">
-				<ul class="list-group">
-					<oauth2-tree:tree
-						trees="<%= (Collection)scopeAliasTreeNode.getTrees() %>"
-					>
-						<jsp:attribute
-							name="nodeJspFragment"
-						>
-						<li class="borderless list-group-item<c:if test="${assignedDeletedScopeAliases.contains(tree.value)}"> removed-scope</c:if>" id="${tree.value}-container">
-							<clay:row>
-								<c:choose>
-									<c:when test="${parentNodes.size() > 0}">
-										<clay:col
-											md="6"
-										>
-											<div class="scope-children-${parentNodes.size()}">
-												<aui:input checked="${assignedScopeAliases.contains(tree.value)}" data-has-childrens="true" data-parent="${parentNodes.getFirst().value}" disabled="${assignedDeletedScopeAliases.contains(tree.value)}" id="${tree.value}" label="${tree.value}" name="scopeAliases" type="checkbox" value="${tree.value}" />
-											</div>
-										</clay:col>
-									</c:when>
-									<c:otherwise>
-										<clay:col
-											md="6"
-										>
-											<aui:input checked="${assignedScopeAliases.contains(tree.value)}" data-has-childrens="true" disabled="${assignedDeletedScopeAliases.contains(tree.value)}" id="${tree.value}" label="${tree.value}" name="scopeAliases" type="checkbox" value="${tree.value}" />
-										</clay:col>
-									</c:otherwise>
-								</c:choose>
-
-								<clay:col
-									className="text-left"
-									md="6"
-								>
-									${scopeAliasesDescriptionsMap.get(tree.value)}
-								</clay:col>
-							</clay:row>
-						</li>
-
-						<oauth2-tree:render-children />
-						</jsp:attribute>
-
-						<jsp:attribute
-							name="leafJspFragment"
-						>
-						<li class="borderless list-group-item<c:if test="${assignedDeletedScopeAliases.contains(tree.value)}"> removed-scope</c:if>" id="${tree.value}-container">
-							<clay:row>
-								<c:choose>
-									<c:when test="${parentNodes.size() > 0}">
-										<clay:col
-											md="6"
-										>
-											<div class="scope-children-${parentNodes.size()}">
-												<aui:input checked="${assignedScopeAliases.contains(tree.value)}" data-parent="${parentNodes.getFirst().value}" disabled="${assignedDeletedScopeAliases.contains(tree.value)}" id="${tree.value}" label="${tree.value}" name="scopeAliases" type="checkbox" value="${tree.value}" />
-											</div>
-										</clay:col>
-									</c:when>
-									<c:otherwise>
-										<clay:col
-											md="6"
-										>
-											<aui:input checked="${assignedScopeAliases.contains(tree.value)}" disabled="${assignedDeletedScopeAliases.contains(tree.value)}" id="${tree.value}" label="${tree.value}" name="scopeAliases" type="checkbox" value="${tree.value}" />
-										</clay:col>
-									</c:otherwise>
-								</c:choose>
-
-								<clay:col
-									className="text-left"
-									md="6"
-								>
-									${scopeAliasesDescriptionsMap.get(tree.value)}
-								</clay:col>
-							</clay:row>
-						</li>
-						</jsp:attribute>
-					</oauth2-tree:tree>
-					</li>
-				</ul>
-
-				<aui:button-row>
-					<aui:button id="save" type="submit" value="save" />
-
-					<aui:button href="<%= PortalUtil.escapeRedirect(redirect) %>" type="cancel" />
-				</aui:button-row>
-			</aui:form>
-		</clay:col>
-	</clay:row>
-</div>
-</div>
-</div>
+</clay:container>
 
 <aui:script require="metal-dom/src/dom as dom">
 	AUI().use('node', 'aui-modal', function (A) {

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
@@ -32,7 +32,9 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 </portlet:actionURL>
 
 <aui:form action="<%= updateOAuth2ApplicationURL %>" id="oauth2-application-fm" method="post" name="oauth2-application-fm">
-	<div class="container-fluid container-fluid-max-xl container-view">
+	<clay:container
+		className="container-view"
+	>
 		<div class="sheet">
 			<clay:row>
 				<clay:col
@@ -168,7 +170,7 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 				</clay:col>
 			</clay:row>
 		</div>
-	</div>
+	</clay:container>
 </aui:form>
 
 <div class="hidden">

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -40,7 +40,9 @@ String displayStyle = oAuth2ApplicationsManagementToolbarDisplayContext.getDispl
 	viewTypeItems="<%= oAuth2ApplicationsManagementToolbarDisplayContext.getViewTypes() %>"
 />
 
-<div class="closed container-fluid-1280">
+<clay:container
+	className="closed"
+>
 	<aui:form action="<%= currentURLObj %>" method="get" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 		<aui:input name="oAuth2ApplicationIds" type="hidden" />
@@ -144,7 +146,7 @@ String displayStyle = oAuth2ApplicationsManagementToolbarDisplayContext.getDispl
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <script>
 	function <portlet:namespace />deleteOAuth2Applications() {

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
@@ -30,7 +30,9 @@ if (Validator.isNotNull(replyTo) && !replyTo.startsWith(PortalUtil.getPortalURL(
 }
 %>
 
-<div class="closed consent container-fluid-1280">
+<clay:container
+	className="closed consent"
+>
 	<aui:form action="<%= replyTo %>" data-senna-off="true" method="post" name="fm">
 		<aui:fieldset-group markupView="lexicon">
 			<div class="panel-body">
@@ -157,4 +159,4 @@ if (Validator.isNotNull(replyTo) && !replyTo.startsWith(PortalUtil.getPortalURL(
 			</div>
 		</aui:fieldset-group>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view.jsp
@@ -35,7 +35,7 @@ int userOAuth2AuthorizationsCount = OAuth2AuthorizationServiceUtil.getUserOAuth2
 	sortingURL="<%= String.valueOf(oAuth2ConnectedApplicationsManagementToolbarDisplayContext.getSortingURL()) %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= currentURLObj %>" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 		<aui:input name="oAuth2AuthorizationIds" type="hidden" />
@@ -99,7 +99,7 @@ int userOAuth2AuthorizationsCount = OAuth2AuthorizationServiceUtil.getUserOAuth2
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <script>
 	function <portlet:namespace />removeAccess() {

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view_application.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view_application.jsp
@@ -30,7 +30,9 @@ OAuth2Application oAuth2Application = oAuth2ConnectedApplicationsPortletDisplayC
 renderResponse.setTitle(oAuth2Application.getName());
 %>
 
-<div class="container-fluid-1280 view-application">
+<clay:container
+	className="view-application"
+>
 	<portlet:actionURL name="/connected_applications/revoke_oauth2_authorizations" var="revokeOAuth2AuthorizationURL" />
 
 	<aui:form action="<%= revokeOAuth2AuthorizationURL %>" method="post" name="fm">
@@ -141,7 +143,7 @@ renderResponse.setTitle(oAuth2Application.getName());
 			</div>
 		</aui:fieldset-group>
 	</aui:form>
-</div>
+</clay:container>
 
 <script>
 	var removeAccessButton = document.getElementById(

--- a/modules/apps/organizations/organizations-item-selector-web/build.gradle
+++ b/modules/apps/organizations/organizations-item-selector-web/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:item-selector:item-selector-taglib")

--- a/modules/apps/organizations/organizations-item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/organizations/organizations-item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -17,6 +17,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/item-selector" prefix="liferay-item-selector" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/organizations/organizations-item-selector-web/src/main/resources/META-INF/resources/organization_item_selector.jsp
+++ b/modules/apps/organizations/organizations-item-selector-web/src/main/resources/META-INF/resources/organization_item_selector.jsp
@@ -55,7 +55,9 @@ PortletURL portletURL = organizationItemSelectorViewDisplayContext.getPortletURL
 	</liferay-frontend:management-bar-filters>
 </liferay-frontend:management-bar>
 
-<div class="container-fluid-1280" id="<portlet:namespace />organizationSelectorWrapper">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "organizationSelectorWrapper" %>'
+>
 	<liferay-ui:search-container
 		id="organizations"
 		searchContainer="<%= organizationItemSelectorViewDisplayContext.getSearchContainer() %>"
@@ -100,7 +102,7 @@ PortletURL portletURL = organizationItemSelectorViewDisplayContext.getPortletURL
 			searchContainer="<%= organizationItemSelectorViewDisplayContext.getSearchContainer() %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get(

--- a/modules/apps/plugins-admin/plugins-admin-web/src/main/resources/META-INF/resources/edit_plugin.jsp
+++ b/modules/apps/plugins-admin/plugins-admin-web/src/main/resources/META-INF/resources/edit_plugin.jsp
@@ -49,7 +49,7 @@ renderResponse.setTitle(title);
 
 <portlet:actionURL name="/plugins_admin/edit_plugin" var="editPluginURL" />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= editPluginURL %>" method="post" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 		<aui:input name="pluginId" type="hidden" value="<%= pluginId %>" />
@@ -228,7 +228,7 @@ renderResponse.setTitle(title);
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <%!
 private List<Role> _filterRoles(List<Role> roles, String portletId, String actionId) throws Exception {

--- a/modules/apps/plugins-admin/plugins-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/plugins-admin/plugins-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -59,7 +59,7 @@ boolean showEditPluginHREF = true;
 	%>'
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:choose>
 		<c:when test='<%= tabs2.equals("themes") %>'>
 			<%@ include file="/themes.jspf" %>
@@ -75,4 +75,4 @@ boolean showEditPluginHREF = true;
 			<%@ include file="/portlets.jspf" %>
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:container>

--- a/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/view.jsp
+++ b/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/view.jsp
@@ -20,7 +20,9 @@
 
 <liferay-util:include page="/polls/management_bar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid container-fluid-max-xl main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<aui:form method="post" name="fm">
 		<aui:input name="deleteQuestionIds" type="hidden" />
 
@@ -124,4 +126,4 @@
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls_display/configuration.jsp
+++ b/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls_display/configuration.jsp
@@ -43,7 +43,7 @@ if (scopeGroupId != themeDisplay.getCompanyGroupId()) {
 	<aui:input name="redirect" type="hidden" value="<%= configurationRenderURL %>" />
 
 	<div class="portlet-configuration-body-content">
-		<div class="container-fluid-1280">
+		<clay:container>
 			<liferay-ui:error exception="<%= NoSuchQuestionException.class %>" message="the-question-could-not-be-found" />
 
 			<c:choose>
@@ -74,7 +74,7 @@ if (scopeGroupId != themeDisplay.getCompanyGroupId()) {
 					</div>
 				</c:otherwise>
 			</c:choose>
-		</div>
+		</clay:container>
 	</div>
 
 	<aui:button-row>

--- a/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/build.gradle
+++ b/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:asset:asset-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:portal-rules-engine:portal-rules-engine-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -34,7 +34,7 @@ long[] classNameIdValues = StringUtil.split(ParamUtil.getString(request, "classN
 	<liferay-ui:error key="rules" message="please-enter-valid-rules" />
 	<liferay-ui:error key="rulesEngineException" message="please-check-the-syntax-of-your-rules" />
 
-	<div class="container-fluid-1280">
+	<clay:container>
 		<aui:fieldset>
 			<aui:input name="domainName" value="<%= domainNameValue %>" wrapperCssClass="lfr-input-text-container" />
 
@@ -82,7 +82,7 @@ long[] classNameIdValues = StringUtil.split(ParamUtil.getString(request, "classN
 				<aui:button type="submit" />
 			</aui:button-row>
 		</aui:fieldset>
-	</div>
+	</clay:container>
 </aui:form>
 
 <aui:script>

--- a/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -20,6 +20,7 @@
 
 <%@ taglib uri="http://liferay.com/tld/asset" prefix="liferay-asset" %><%@
 taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/connections.jsp
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/connections.jsp
@@ -35,7 +35,9 @@ SearchEngineDisplayContext
 	searchEngineDisplayContext = (SearchEngineDisplayContext)request.getAttribute(SearchAdminWebKeys.SEARCH_ENGINE_DISPLAY_CONTEXT);
 %>
 
-<div class="container-fluid container-fluid-max-xl container-form-lg search-engine-page-container">
+<clay:container
+	className="container-form-lg search-engine-page-container"
+>
 	<c:choose>
 		<c:when test="<%= searchEngineDisplayContext.isMissingSearchEngine() %>">
 			<div class="alert alert-warning">
@@ -201,4 +203,4 @@ SearchEngineDisplayContext
 			</c:choose>
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:container>

--- a/modules/apps/portal-security-wedeploy-auth/portal-security-wedeploy-auth-web/src/main/resources/META-INF/resources/wedeploy_auth/view.jsp
+++ b/modules/apps/portal-security-wedeploy-auth/portal-security-wedeploy-auth-web/src/main/resources/META-INF/resources/wedeploy_auth/view.jsp
@@ -24,7 +24,7 @@ String clientId = ParamUtil.getString(request, "clientId");
 WeDeployAuthApp weDeployAuthApp = WeDeployAuthAppLocalServiceUtil.fetchWeDeployAuthApp(redirectURI, clientId);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:choose>
 		<c:when test="<%= weDeployAuthApp == null %>">
 			<div class="alert alert-info">
@@ -64,4 +64,4 @@ WeDeployAuthApp weDeployAuthApp = WeDeployAuthAppLocalServiceUtil.fetchWeDeployA
 			</div>
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:container>

--- a/modules/apps/portal-security-wedeploy-auth/portal-security-wedeploy-auth-web/src/main/resources/META-INF/resources/wedeploy_auth_admin/view.jsp
+++ b/modules/apps/portal-security-wedeploy-auth/portal-security-wedeploy-auth-web/src/main/resources/META-INF/resources/wedeploy_auth_admin/view.jsp
@@ -36,7 +36,9 @@ weDeployAuthAppsSearchContainer.setResults(weDeployAuthApps);
 	displayContext="<%= new WeDeployAuthAppsManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, weDeployAuthAppsSearchContainer) %>"
 />
 
-<div class="container-fluid container-fluid-max-xl container-view">
+<clay:container
+	className="container-view"
+>
 	<liferay-ui:search-container
 		id="weDeployAuthApps"
 		searchContainer="<%= weDeployAuthAppsSearchContainer %>"
@@ -91,4 +93,4 @@ weDeployAuthAppsSearchContainer.setResults(weDeployAuthApps);
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/portal-security/portal-security-service-access-policy-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portal-security/portal-security-service-access-policy-web/src/main/resources/META-INF/resources/view.jsp
@@ -61,7 +61,7 @@ sortingURL.setParameter("orderByType", orderByAsc ? "desc" : "asc");
 	sortingURL="<%= sortingURL.toString() %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-container
 		emptyResultsMessage="there-are-no-service-access-policies"
 		iteratorURL="<%= portletURL %>"
@@ -116,4 +116,4 @@ sortingURL.setParameter("orderByType", orderByAsc ? "desc" : "asc");
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/edit_workflow_task.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/edit_workflow_task.jsp
@@ -65,7 +65,7 @@ portletDisplay.setURLBack(backURL);
 renderResponse.setTitle(headerTitle);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<clay:col
 		className="lfr-asset-column lfr-asset-column-details"
 	>
@@ -292,7 +292,7 @@ renderResponse.setTitle(headerTitle);
 			</liferay-ui:panel-container>
 		</aui:fieldset-group>
 	</clay:col>
-</div>
+</clay:container>
 
 <aui:script use="liferay-workflow-tasks">
 	var onTaskClickFn = A.rbind('onTaskClick', Liferay.WorkflowTasks, '');

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view.jsp
@@ -26,6 +26,8 @@ portletDisplay.setShowBackIcon(false);
 
 <liferay-util:include page="/toolbar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<%@ include file="/workflow_tasks.jspf" %>
-</div>
+</clay:container>

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -43,7 +43,9 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(title);
 %>
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<clay:col
 		className="lfr-asset-column lfr-asset-column-details"
 		md="12"
@@ -78,4 +80,4 @@ renderResponse.setTitle(title);
 			</div>
 		</div>
 	</clay:col>
-</div>
+</clay:container>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
@@ -56,7 +56,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 
 <c:if test="<%= workflowDefinition != null %>">
 	<liferay-frontend:info-bar>
-		<div class="container-fluid-1280">
+		<clay:container>
 			<div class="info-bar-item">
 				<c:choose>
 					<c:when test="<%= active %>">
@@ -86,7 +86,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 					</c:otherwise>
 				</c:choose>
 			</span>
-		</div>
+		</clay:container>
 
 		<liferay-frontend:info-bar-buttons>
 			<liferay-frontend:info-bar-sidenav-toggler-button
@@ -104,13 +104,13 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 			<div class="sidebar sidebar-light">
 				<div class="tbar-visible-xs">
 					<nav class="component-tbar tbar">
-						<div class="container-fluid">
+						<clay:container>
 							<ul class="tbar-nav">
 								<li class="tbar-item">
 									<aui:icon cssClass="component-action sidenav-close" image="times" markupView="lexicon" url="javascript:;" />
 								</li>
 							</ul>
-						</div>
+						</clay:container>
 					</nav>
 				</div>
 
@@ -190,7 +190,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 		</div>
 	</c:if>
 
-	<div class="container-fluid-1280">
+	<clay:container>
 		<div class="sidenav-content">
 			<aui:form method="post" name="fm">
 				<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
@@ -280,7 +280,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 				</aui:button-row>
 			</aui:form>
 		</div>
-	</div>
+	</clay:container>
 </div>
 
 <div class="hide" id="<%= randomNamespace %>titleInputLocalized">

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view.jsp
@@ -49,7 +49,9 @@ WorkflowDefinitionSearch workflowDefinitionSearch = new WorkflowDefinitionSearch
 	sortingURL="<%= workflowDefinitionDisplayContext.getSortingURL(request) %>"
 />
 
-<div class="container-fluid-1280 workflow-definition-container">
+<clay:container
+	className="workflow-definition-container"
+>
 	<liferay-ui:error exception="<%= RequiredWorkflowDefinitionException.class %>">
 		<liferay-ui:message arguments="<%= workflowDefinitionDisplayContext.getMessageArguments((RequiredWorkflowDefinitionException)errorException) %>" key="<%= workflowDefinitionDisplayContext.getMessageKey((RequiredWorkflowDefinitionException)errorException) %>" translateArguments="<%= false %>" />
 	</liferay-ui:error>
@@ -116,4 +118,4 @@ WorkflowDefinitionSearch workflowDefinitionSearch = new WorkflowDefinitionSearch
 			searchContainer="<%= workflowDefinitionSearch %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view_workflow_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view_workflow_definition.jsp
@@ -41,7 +41,7 @@ boolean previewBeforeRestore = WorkflowWebKeys.WORKFLOW_PREVIEW_BEFORE_RESTORE_S
 </liferay-portlet:renderURL>
 
 <liferay-frontend:info-bar>
-	<div class="container-fluid-1280">
+	<clay:container>
 		<c:if test="<%= !previewBeforeRestore %>">
 			<div class="info-bar-item">
 				<c:choose>
@@ -76,7 +76,7 @@ boolean previewBeforeRestore = WorkflowWebKeys.WORKFLOW_PREVIEW_BEFORE_RESTORE_S
 				</c:otherwise>
 			</c:choose>
 		</span>
-	</div>
+	</clay:container>
 </liferay-frontend:info-bar>
 
 <div class="<%= previewBeforeRestore ? "" : "container-fluid-1280" %>" id="container">

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition_link/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition_link/view.jsp
@@ -24,7 +24,10 @@ boolean showStripeMessage = workflowDefinitionLinkDisplayContext.showStripeMessa
 
 <liferay-util:include page="/definition_link/management_bar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid-1280 workflow-definition-link-container" id="<portlet:namespace />Container">
+<clay:container
+	className="workflow-definition-link-container"
+	id='<%= renderResponse.getNamespace() + "Container" %>'
+>
 	<c:if test="<%= showStripeMessage %>">
 		<clay:alert
 			closeable="true"
@@ -85,4 +88,4 @@ boolean showStripeMessage = workflowDefinitionLinkDisplayContext.showStripeMessa
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/edit_workflow_instance.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/edit_workflow_instance.jsp
@@ -34,7 +34,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(workflowInstanceEditDisplayContext.getHeaderTitle());
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<clay:col
 		className="lfr-asset-column lfr-asset-column-details"
 	>
@@ -201,4 +201,4 @@ renderResponse.setTitle(workflowInstanceEditDisplayContext.getHeaderTitle());
 			</liferay-ui:panel-container>
 		</aui:fieldset-group>
 	</clay:col>
-</div>
+</clay:container>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/view.jsp
@@ -28,6 +28,8 @@ PortletURL portletURL = workflowInstanceViewDisplayContext.getViewPortletURL();
 	<liferay-util:include page="/instance/toolbar.jsp" servletContext="<%= application %>" />
 </aui:form>
 
-<div class="container-fluid-1280 main-content-body workflow-instance-container">
+<clay:container
+	className="main-content-body workflow-instance-container"
+>
 	<%@ include file="/instance/workflow_instance.jspf" %>
-</div>
+</clay:container>

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/add_configuration_template.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/add_configuration_template.jsp
@@ -31,7 +31,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 		<aui:input name="portletResource" type="hidden" value="<%= portletResource %>" />
 
 		<div class="portlet-configuration-body-content">
-			<div class="container-fluid-1280">
+			<clay:container>
 				<liferay-ui:error exception="<%= PortletItemNameException.class %>" message="please-enter-a-valid-setup-name" />
 
 				<aui:fieldset-group markupView="lexicon">
@@ -52,7 +52,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 						</aui:input>
 					</aui:fieldset>
 				</aui:fieldset-group>
-			</div>
+			</clay:container>
 		</div>
 
 		<aui:button-row>

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_configuration_templates.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_configuration_templates.jsp
@@ -36,7 +36,7 @@ PortletConfigurationTemplatesManagementToolbarDisplayContext portletConfiguratio
 				displayContext="<%= portletConfigurationTemplatesManagementToolbarDisplayContext %>"
 			/>
 
-			<div class="container-fluid-1280">
+			<clay:container>
 				<liferay-ui:error exception="<%= NoSuchPortletItemException.class %>" message="the-setup-could-not-be-found" />
 
 				<div class="button-holder text-center">
@@ -130,7 +130,7 @@ PortletConfigurationTemplatesManagementToolbarDisplayContext portletConfiguratio
 						markupView="lexicon"
 					/>
 				</liferay-ui:search-container>
-			</div>
+			</clay:container>
 		</div>
 	</aui:form>
 </div>

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_supported_clients.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_supported_clients.jsp
@@ -38,7 +38,7 @@ Set<String> allPortletModes = selPortlet.getAllPortletModes();
 				<liferay-util:param name="tabs1" value="supported-clients" />
 			</liferay-util:include>
 
-			<div class="container-fluid-1280">
+			<clay:container>
 				<aui:fieldset-group markupView="lexicon">
 
 					<%
@@ -63,7 +63,7 @@ Set<String> allPortletModes = selPortlet.getAllPortletModes();
 					%>
 
 				</aui:fieldset-group>
-			</div>
+			</clay:container>
 		</div>
 
 		<aui:button-row>

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/init.jsp
@@ -27,3 +27,5 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 <liferay-frontend:defineObjects />
 
 <liferay-theme:defineObjects />
+
+<portlet:defineObjects />

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
@@ -18,7 +18,9 @@
 
 <div id="<portlet:namespace />simulationDeviceContainer">
 	<div class="list-group-panel">
-		<div class="container-fluid devices">
+		<clay:container
+			className="devices"
+		>
 			<clay:row
 				className="default-devices"
 			>
@@ -59,13 +61,13 @@
 
 			<clay:row
 				className="custom-devices d-lg-flex d-none hide"
-				id="<portlet:namespace />customDeviceContainer"
+				id='<%= renderResponse.getNamespace() + "customDeviceContainer" %>'
 			>
 				<aui:input cssClass="input-sm" inlineField="<%= true %>" label='<%= LanguageUtil.get(request, "height") + " (px):" %>' name="height" size="4" value="600" wrapperCssClass="col-6" />
 
 				<aui:input cssClass="input-sm" inlineField="<%= true %>" label='<%= LanguageUtil.get(request, "width") + " (px):" %>' name="width" size="4" value="600" wrapperCssClass="col-6" />
 			</clay:row>
-		</div>
+		</clay:container>
 	</div>
 </div>
 

--- a/modules/apps/product-navigation/product-navigation-taglib/build.gradle
+++ b/modules/apps/product-navigation/product-navigation-taglib/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:product-navigation:product-navigation-control-menu-api")
 	compileOnly project(":apps:product-navigation:product-navigation-personal-menu-api")

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
@@ -42,7 +42,7 @@ for (ProductNavigationControlMenuCategory productNavigationControlMenuCategory :
 		<liferay-util:dynamic-include key="com.liferay.product.navigation.taglib#/page.jsp#pre" />
 
 		<div class="control-menu control-menu-level-1 d-print-none" data-qa-id="controlMenu" id="<portlet:namespace />ControlMenu">
-			<div class="container-fluid container-fluid-max-xl">
+			<clay:container>
 				<h1 class="sr-only"><liferay-ui:message key="admin-header" /></h1>
 
 				<ul class="control-menu-level-1-nav control-menu-nav" data-namespace="<portlet:namespace />" data-qa-id="header" id="<portlet:namespace />controlMenu">
@@ -87,7 +87,7 @@ for (ProductNavigationControlMenuCategory productNavigationControlMenuCategory :
 					%>
 
 				</ul>
-			</div>
+			</clay:container>
 
 			<div class="control-menu-body">
 

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@

--- a/modules/apps/push-notifications/push-notifications-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/push-notifications/push-notifications-web/src/main/resources/META-INF/resources/view.jsp
@@ -47,7 +47,7 @@ portletURL.setParameter("tabs1", tabs1);
 	%>'
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:choose>
 		<c:when test='<%= tabs1.equals("test") %>'>
 			<%@ include file="/test.jspf" %>
@@ -56,4 +56,4 @@ portletURL.setParameter("tabs1", tabs1);
 			<%@ include file="/devices.jspf" %>
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:container>

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
@@ -28,7 +28,10 @@ RedirectManagementToolbarDisplayContext redirectManagementToolbarDisplayContext 
 	displayContext="<%= redirectManagementToolbarDisplayContext %>"
 />
 
-<div class="closed container-fluid-1280 redirect-entries sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed redirect-entries sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/redirect/info_panel" var="sidebarPanelURL" />
 
 	<liferay-frontend:sidebar-panel
@@ -122,7 +125,7 @@ RedirectManagementToolbarDisplayContext redirectManagementToolbarDisplayContext 
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <liferay-frontend:component
 	componentId="<%= redirectManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions.jsp
@@ -66,7 +66,7 @@ if (!portletName.equals(PortletKeys.SERVER_ADMIN)) {
 </c:if>
 
 <clay:container
-	className="c-pt-md-5"
+	className="container-form-lg"
 	id='<%= renderResponse.getNamespace() + "permissionContainer" %>'
 >
 	<clay:row>

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/view_segments_entry_users.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/view_segments_entry_users.jsp
@@ -20,7 +20,9 @@
 long segmentsEntryId = ParamUtil.getLong(request, "segmentsEntryId");
 %>
 
-<div class="container-fluid container-fluid-max-sm">
+<clay:container
+	size="sm"
+>
 	<liferay-ui:search-container
 		emptyResultsMessage="no-users-have-been-assigned-to-this-segment"
 		iteratorURL="<%= currentURLObj %>"
@@ -55,4 +57,4 @@ long segmentsEntryId = ParamUtil.getLong(request, "segmentsEntryId");
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/roles/roles-item-selector-web/src/main/resources/META-INF/resources/role_item_selector.jsp
+++ b/modules/apps/roles/roles-item-selector-web/src/main/resources/META-INF/resources/role_item_selector.jsp
@@ -25,7 +25,7 @@ RoleItemSelectorViewDisplayContext roleItemSelectorViewDisplayContext = (RoleIte
 />
 
 <clay:container
-	className="container-form-lg"
+	className="container-form-lg container-view"
 	id='<%= renderResponse.getNamespace() + "roleSelectorWrapper" %>'
 >
 	<liferay-ui:search-container

--- a/modules/apps/roles/roles-item-selector-web/src/main/resources/META-INF/resources/role_item_selector.jsp
+++ b/modules/apps/roles/roles-item-selector-web/src/main/resources/META-INF/resources/role_item_selector.jsp
@@ -24,7 +24,10 @@ RoleItemSelectorViewDisplayContext roleItemSelectorViewDisplayContext = (RoleIte
 	displayContext="<%= roleItemSelectorViewDisplayContext %>"
 />
 
-<div class="container-fluid container-fluid-max-xl container-form-lg container-view" id="<portlet:namespace />roleSelectorWrapper">
+<clay:container
+	className="container-form-lg"
+	id='<%= renderResponse.getNamespace() + "roleSelectorWrapper" %>'
+>
 	<liferay-ui:search-container
 		searchContainer="<%= roleItemSelectorViewDisplayContext.getSearchContainer() %>"
 	>
@@ -61,7 +64,7 @@ RoleItemSelectorViewDisplayContext roleItemSelectorViewDisplayContext = (RoleIte
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script require="metal-dom/src/all/dom as dom">
 	var selectItemHandler = dom.delegate(

--- a/modules/apps/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -153,7 +153,7 @@ else {
 	%>
 
 	<div class="roles-selector-body">
-		<div class="container-fluid-1280">
+		<clay:container>
 			<c:choose>
 				<c:when test="<%= role == null %>">
 					<liferay-util:include page="/edit_roles.jsp" servletContext="<%= application %>" />
@@ -179,7 +179,7 @@ else {
 					</c:choose>
 				</c:otherwise>
 			</c:choose>
-		</div>
+		</clay:container>
 	</div>
 
 	<aui:button-row>

--- a/modules/apps/segments/segments-context-vocabulary/src/main/resources/META-INF/resources/edit_segments_context_vocabulary_configuration.jsp
+++ b/modules/apps/segments/segments-context-vocabulary/src/main/resources/META-INF/resources/edit_segments_context_vocabulary_configuration.jsp
@@ -31,20 +31,22 @@ segmentsContextVocabularyConfigurationDisplayContext.addPortletBreadcrumbEntries
 	<liferay-ui:message key="<%= cmle.causeMessage %>" localizeKey="<%= false %>" />
 </liferay-ui:error>
 
-<div class="container-fluid container-fluid-max-xl">
-	<clay:col
-		size="12"
-	>
-		<liferay-ui:breadcrumb
-			showCurrentGroup="<%= false %>"
-			showGuestGroup="<%= false %>"
-			showLayout="<%= false %>"
-			showParentGroups="<%= false %>"
-		/>
-	</clay:col>
-</div>
+<clay:container>
+	<clay:row>
+		<clay:col
+			size="12"
+		>
+			<liferay-ui:breadcrumb
+				showCurrentGroup="<%= false %>"
+				showGuestGroup="<%= false %>"
+				showLayout="<%= false %>"
+				showParentGroups="<%= false %>"
+			/>
+		</clay:col>
+	</clay:row>
+</clay:container>
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:row>
 		<clay:col
 			md="3"
@@ -155,4 +157,4 @@ segmentsContextVocabularyConfigurationDisplayContext.addPortletBreadcrumbEntries
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>

--- a/modules/apps/segments/segments-simulation-web/build.gradle
+++ b/modules/apps/segments/segments-simulation-web/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:product-navigation:product-navigation-simulation-api")
 	compileOnly project(":apps:segments:segments-api")
 	compileOnly project(":apps:staging:staging-api")

--- a/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>

--- a/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
@@ -20,7 +20,10 @@
 SegmentsSimulationDisplayContext segmentsSimulationDisplayContext = new SegmentsSimulationDisplayContext(request, renderResponse);
 %>
 
-<div class="container-fluid segments-simulation" id="<portlet:namespace />segmentsSimulationContainer">
+<clay:container
+	className="segments-simulation"
+	id='<%= renderResponse.getNamespace() + "segmentsSimulationContainer" %>'
+>
 	<c:choose>
 		<c:when test="<%= segmentsSimulationDisplayContext.isShowEmptyMessage() %>">
 			<p class="mb-4 mt-1 small">
@@ -69,4 +72,4 @@ SegmentsSimulationDisplayContext segmentsSimulationDisplayContext = new Segments
 			</aui:script>
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:container>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/preview_segments_entry_users.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/preview_segments_entry_users.jsp
@@ -20,7 +20,9 @@
 PreviewSegmentsEntryUsersDisplayContext previewSegmentsEntryUsersDisplayContext = (PreviewSegmentsEntryUsersDisplayContext)request.getAttribute(SegmentsWebKeys.PREVIEW_SEGMENTS_ENTRY_USERS_DISPLAY_CONTEXT);
 %>
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<liferay-ui:search-container
 		searchContainer="<%= previewSegmentsEntryUsersDisplayContext.getSearchContainer() %>"
 	>
@@ -50,4 +52,4 @@ PreviewSegmentsEntryUsersDisplayContext previewSegmentsEntryUsersDisplayContext 
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/log_levels.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/log_levels.jsp
@@ -92,7 +92,7 @@ CreationMenu creationMenu = new CreationMenu() {
 	showSearch="<%= true %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-container
 		searchContainer="<%= loggerSearchContainer %>"
 	>
@@ -144,4 +144,4 @@ CreationMenu creationMenu = new CreationMenu() {
 	<aui:button-row>
 		<aui:button cssClass="save-server-button" data-cmd="updateLogLevels" value="save" />
 	</aui:button-row>
-</div>
+</clay:container>

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/portal_properties.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/portal_properties.jsp
@@ -94,7 +94,7 @@ propertiesSearchContainer.setTotal(filteredPropertiesList.size());
 	showSearch="<%= true %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-container
 		emptyResultsMessage='<%= tabs2.equals("portal-properties") ? "no-portal-properties-were-found-that-matched-the-keywords" : "no-system-properties-were-found-that-matched-the-keywords" %>'
 		iteratorURL="<%= serverURL %>"
@@ -152,4 +152,4 @@ propertiesSearchContainer.setTotal(filteredPropertiesList.size());
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/system_properties.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/system_properties.jsp
@@ -72,7 +72,7 @@ propertiesSearchContainer.setTotal(filteredPropertiesList.size());
 	showSearch="<%= true %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-container
 		emptyResultsMessage='<%= tabs2.equals("portal-properties") ? "no-portal-properties-were-found-that-matched-the-keywords" : "no-system-properties-were-found-that-matched-the-keywords" %>'
 		iteratorURL="<%= serverURL %>"
@@ -121,4 +121,4 @@ propertiesSearchContainer.setTotal(filteredPropertiesList.size());
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/shared_assets/view.jsp
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/shared_assets/view.jsp
@@ -44,7 +44,9 @@ SearchContainer sharingEntriesSearchContainer = new SearchContainer(renderReques
 sharedAssetsViewDisplayContext.populateResults(sharingEntriesSearchContainer);
 %>
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<liferay-ui:search-container
 		id="sharingEntries"
 		searchContainer="<%= sharingEntriesSearchContainer %>"
@@ -105,7 +107,7 @@ sharedAssetsViewDisplayContext.populateResults(sharingEntriesSearchContainer);
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <%
 PortletURL viewAssetTypeURL = PortletURLUtil.clone(currentURLObj, liferayPortletResponse);

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/shared_assets/view_asset_entry_sharing_entry.jsp
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/shared_assets/view_asset_entry_sharing_entry.jsp
@@ -48,7 +48,7 @@ else {
 %>
 
 <div class="tbar upper-tbar">
-	<div class="container-fluid container-fluid-max-xl">
+	<clay:container>
 		<ul class="tbar-nav">
 			<c:if test="<%= !scopeGroup.equals(themeDisplay.getControlPanelGroup()) %>">
 				<li class="d-none d-sm-flex tbar-item">
@@ -73,7 +73,7 @@ else {
 				/>
 			</li>
 		</ul>
-	</div>
+	</clay:container>
 </div>
 
 <liferay-util:buffer
@@ -95,7 +95,7 @@ else {
 	</c:if>
 </liferay-util:buffer>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:choose>
 		<c:when test="<%= scopeGroup.equals(themeDisplay.getControlPanelGroup()) %>">
 			<aui:fieldset-group markupView="lexicon">
@@ -108,4 +108,4 @@ else {
 			<%= assetContent %>
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:container>

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/edit_site_navigation_menu.jsp
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/edit_site_navigation_menu.jsp
@@ -27,7 +27,7 @@ renderResponse.setTitle(siteNavigationAdminDisplayContext.getSiteNavigationMenuN
 
 <c:if test="<%= siteNavigationAdminDisplayContext.hasUpdatePermission() %>">
 	<nav class="management-bar management-bar-light navbar navbar-expand-md site-navigation-management-bar">
-		<div class="container">
+		<clay:container>
 			<ul class="navbar-nav"></ul>
 
 			<ul class="navbar-nav">
@@ -65,11 +65,13 @@ renderResponse.setTitle(siteNavigationAdminDisplayContext.getSiteNavigationMenuN
 					</div>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 </c:if>
 
-<div class="container-fluid-1280 contextual-sidebar-content site-navigation-content">
+<clay:container
+	className="contextual-sidebar-content site-navigation-content"
+>
 	<div class="lfr-search-container-wrapper site-navigation-menu-container">
 		<liferay-ui:error embed="<%= false %>" key="<%= InvalidSiteNavigationMenuItemOrderException.class.getName() %>" message="the-order-of-site-navigation-menu-items-is-invalid" />
 
@@ -109,7 +111,7 @@ renderResponse.setTitle(siteNavigationAdminDisplayContext.getSiteNavigationMenuN
 			</c:otherwise>
 		</c:choose>
 	</div>
-</div>
+</clay:container>
 
 <c:if test="<%= siteNavigationAdminDisplayContext.hasUpdatePermission() %>">
 	<div>

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/site_url.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/site_url.jsp
@@ -153,7 +153,9 @@ if (privateVirtualHostnames.isEmpty()) {
 			String virtualHostLanguageId = Validator.isNotNull(entry.getValue()) ? entry.getValue() : StringPool.BLANK;
 		%>
 
-			<div class="container-fluid lfr-form-row">
+			<clay:container
+				className="lfr-form-row"
+			>
 				<clay:row>
 					<aui:input inlineField="<%= true %>" label="public-pages" maxlength="200" name="publicVirtualHostname[]" placeholder="virtual-host" type="text" value="<%= virtualHostname %>" wrapperCssClass="col-sm-6" />
 
@@ -173,7 +175,7 @@ if (privateVirtualHostnames.isEmpty()) {
 
 					</aui:select>
 				</clay:row>
-			</div>
+			</clay:container>
 
 		<%
 		}
@@ -190,7 +192,9 @@ if (privateVirtualHostnames.isEmpty()) {
 			String virtualHostLanguageId = Validator.isNotNull(entry.getValue()) ? entry.getValue() : StringPool.BLANK;
 		%>
 
-			<div class="container-fluid lfr-form-row">
+			<clay:container
+				className="lfr-form-row"
+			>
 				<clay:row>
 					<aui:input inlineField="<%= true %>" label="private-pages" maxlength="200" name="privateVirtualHostname[]" placeholder="virtual-host" type="text" value="<%= virtualHostname %>" wrapperCssClass="col-sm-6" />
 
@@ -210,7 +214,7 @@ if (privateVirtualHostnames.isEmpty()) {
 
 					</aui:select>
 				</clay:row>
-			</div>
+			</clay:container>
 
 		<%
 		}
@@ -241,7 +245,9 @@ if (privateVirtualHostnames.isEmpty()) {
 				String virtualHostLanguageId = Validator.isNotNull(entry.getValue()) ? entry.getValue() : StringPool.BLANK;
 			%>
 
-				<div class="container-fluid lfr-form-row">
+				<clay:container
+					className="lfr-form-row"
+				>
 					<clay:row>
 						<aui:input inlineField="<%= true %>" label="staging-public-pages" maxlength="200" name="stagingPublicVirtualHostname[]" placeholder="virtual-host" type="text" value="<%= virtualHostname %>" wrapperCssClass="col-sm-6" />
 
@@ -261,7 +267,7 @@ if (privateVirtualHostnames.isEmpty()) {
 
 						</aui:select>
 					</clay:row>
-				</div>
+				</clay:container>
 
 			<%
 			}
@@ -290,7 +296,9 @@ if (privateVirtualHostnames.isEmpty()) {
 				String virtualHostLanguageId = Validator.isNotNull(entry.getValue()) ? entry.getValue() : StringPool.BLANK;
 			%>
 
-				<div class="container-fluid lfr-form-row">
+				<clay:container
+					className="lfr-form-row"
+				>
 					<clay:row>
 						<aui:input inlineField="<%= true %>" label="staging-private-pages" maxlength="200" name="stagingPrivateVirtualHostname[]" placeholder="virtual-host" type="text" value="<%= virtualHostname %>" wrapperCssClass="col-sm-6" />
 
@@ -310,7 +318,7 @@ if (privateVirtualHostnames.isEmpty()) {
 
 						</aui:select>
 					</clay:row>
-				</div>
+				</clay:container>
 
 			<%
 			}

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -37,7 +37,10 @@ if (group != null) {
 	displayContext="<%= siteAdminManagementToolbarDisplayContext %>"
 />
 
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/site/info_panel" var="sidebarPanelURL" />
 
 	<liferay-frontend:sidebar-panel
@@ -87,7 +90,7 @@ if (group != null) {
 			<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <liferay-frontend:component
 	componentId="<%= siteAdminManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organizations.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organizations.jsp
@@ -31,7 +31,10 @@ OrganizationsManagementToolbarDisplayContext organizationsManagementToolbarDispl
 	displayContext="<%= organizationsManagementToolbarDisplayContext %>"
 />
 
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/organization/info_panel" var="sidebarPanelURL">
 		<portlet:param name="groupId" value="<%= String.valueOf(siteMembershipsDisplayContext.getGroupId()) %>" />
 	</liferay-portlet:resourceURL>
@@ -79,7 +82,7 @@ OrganizationsManagementToolbarDisplayContext organizationsManagementToolbarDispl
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <portlet:actionURL name="addGroupOrganizations" var="addGroupOrganizationsURL">
 	<portlet:param name="redirect" value="<%= currentURL %>" />

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/preview_membership_request.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/preview_membership_request.jsp
@@ -39,7 +39,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(userName);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:fieldset-group markupView="lexicon">
 		<aui:fieldset>
 			<h4 class="text-default">
@@ -126,4 +126,4 @@ renderResponse.setTitle(userName);
 			</c:choose>
 		</aui:fieldset>
 	</aui:fieldset-group>
-</div>
+</clay:container>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users.jsp
@@ -35,7 +35,10 @@ Role role = usersDisplayContext.getRole();
 
 <liferay-ui:error embed="<%= false %>" exception="<%= RequiredUserException.class %>" message="one-or-more-users-were-not-removed-since-they-belong-to-a-user-group" />
 
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/user/info_panel" var="sidebarPanelURL">
 		<portlet:param name="groupId" value="<%= String.valueOf(siteMembershipsDisplayContext.getGroupId()) %>" />
 	</liferay-portlet:resourceURL>
@@ -94,7 +97,7 @@ Role role = usersDisplayContext.getRole();
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <portlet:actionURL name="addGroupUsers" var="addGroupUsersURL">
 	<portlet:param name="redirect" value="<%= currentURL %>" />

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests.jsp
@@ -37,7 +37,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "membership-requests"));
 
 <liferay-ui:success key="membershipReplySent" message="your-reply-will-be-sent-to-the-user-by-email" />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-container
 		searchContainer="<%= viewMembershipRequestsDisplayContext.getSiteMembershipSearchContainer() %>"
 	>
@@ -65,4 +65,4 @@ renderResponse.setTitle(LanguageUtil.get(request, "membership-requests"));
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/edit_layout_branch.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/edit_layout_branch.jsp
@@ -65,7 +65,9 @@ if (layoutBranch != null) {
 	<liferay-util:param name="navigationName" value="<%= title %>" />
 </liferay-util:include>
 
-<div class="container-fluid-1280" data-namespace="<portlet:namespace />" id="<portlet:namespace /><%= (layoutBranch != null) ? "updateBranch" : "addBranch" %>">
+<clay:container
+	id='<%= renderResponse.getNamespace() + ((layoutBranch != null) ? "updateBranch" : "addBranch") %>'
+>
 	<aui:model-context bean="<%= layoutBranch %>" model="<%= LayoutBranch.class %>" />
 
 	<portlet:actionURL name="editLayoutBranch" var="editLayoutBranchURL">
@@ -89,4 +91,4 @@ if (layoutBranch != null) {
 			<aui:button href="<%= redirect %>" value="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/edit_layout_set_branch.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/edit_layout_set_branch.jsp
@@ -64,6 +64,7 @@ if (layoutSetBranch != null) {
 </liferay-util:include>
 
 <clay:container
+	className="container-view"
 	id='<%= renderResponse.getNamespace() + ((layoutSetBranch != null) ? "updateBranch" : "addBranch") %>'
 >
 	<aui:model-context bean="<%= layoutSetBranch %>" model="<%= LayoutSetBranch.class %>" />

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/edit_layout_set_branch.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/edit_layout_set_branch.jsp
@@ -63,7 +63,9 @@ if (layoutSetBranch != null) {
 	<liferay-util:param name="navigationName" value="<%= title %>" />
 </liferay-util:include>
 
-<div class="container-fluid-1280 container-view" data-namespace="<portlet:namespace />" id="<portlet:namespace /><%= (layoutSetBranch != null) ? "updateBranch" : "addBranch" %>">
+<clay:container
+	id='<%= renderResponse.getNamespace() + ((layoutSetBranch != null) ? "updateBranch" : "addBranch") %>'
+>
 	<aui:model-context bean="<%= layoutSetBranch %>" model="<%= LayoutSetBranch.class %>" />
 
 	<portlet:actionURL name="editLayoutSetBranch" var="editLayoutSetBranchURL">
@@ -112,4 +114,4 @@ if (layoutSetBranch != null) {
 			<aui:button href="<%= redirect %>" value="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/merge_layout_set_branch.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/merge_layout_set_branch.jsp
@@ -32,7 +32,7 @@ if (layoutSetBranches.contains(layoutSetBranch)) {
 }
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<div class="site-pages-variation taglib-header">
 		<a class="icon-monospaced list-unstyled portlet-icon-back text-default" href="<%= HtmlUtil.escapeAttribute(redirect) %>" title="<%= HtmlUtil.escapeAttribute(LanguageUtil.get(resourceBundle, "back")) %>">
 			<liferay-ui:icon
@@ -100,7 +100,7 @@ if (layoutSetBranches.contains(layoutSetBranch)) {
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <script>
 	function <portlet:namespace />selectLayoutSetBranch(layoutSetBranchId) {

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -35,7 +35,7 @@ if (liveLayout != null) {
 <c:if test="<%= themeDisplay.isShowStagingIcon() %>">
 	<c:if test="<%= liveGroup != null %>">
 		<nav class="navbar navbar-collapse-absolute navbar-expand navbar-underline navigation-bar navigation-bar-secondary staging-navbar">
-			<div class="container-fluid container-fluid-max-xl">
+			<clay:container>
 				<ul class="navbar-nav">
 					<c:choose>
 						<c:when test="<%= group.isStagingGroup() || group.isStagedRemotely() %>">
@@ -134,12 +134,12 @@ if (liveLayout != null) {
 						markupView="lexicon"
 					/>
 				</button>
-			</div>
+			</clay:container>
 		</nav>
 
 		<c:if test="<%= !layout.isSystem() || layout.isTypeControlPanel() || !Objects.equals(layout.getFriendlyURL(), PropsValues.CONTROL_PANEL_LAYOUT_FRIENDLY_URL) %>">
 			<div class="staging-bar">
-				<div class="container-fluid container-fluid-max-xl">
+				<clay:container>
 					<clay:row>
 						<c:choose>
 							<c:when test="<%= group.isStagingGroup() || group.isStagedRemotely() %>">
@@ -223,7 +223,7 @@ if (liveLayout != null) {
 							</c:otherwise>
 						</c:choose>
 					</clay:row>
-				</div>
+				</clay:container>
 			</div>
 		</c:if>
 	</c:if>

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_branches.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_branches.jsp
@@ -43,7 +43,7 @@ request.setAttribute("view_layout_branches.jsp-currenttLayoutBranchId", String.v
 	<liferay-util:param name="navigationName" value="page-variations" />
 </liferay-util:include>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:success key="pageVariationAdded" message="page-variation-was-added" />
 	<liferay-ui:success key="pageVariationDeleted" message="page-variation-was-deleted" />
 	<liferay-ui:success key="pageVariationUpdated" message="page-variation-was-updated" />
@@ -118,7 +118,7 @@ request.setAttribute("view_layout_branches.jsp-currenttLayoutBranchId", String.v
 			/>
 		</liferay-ui:search-container>
 	</div>
-</div>
+</clay:container>
 
 <aui:script position="inline" use="liferay-staging-branch">
 	Liferay.StagingBar.init({

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_status.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_status.jsp
@@ -70,7 +70,9 @@ else {
 	<div class="staging-bar-level-3-message">
 		<div class="staging-bar-level-3-message-container">
 			<div class="alert alert-fluid alert-info" role="alert">
-				<div class="container-fluid container-fluid-max-xl staging-alert-container">
+				<clay:container
+					className="staging-alert-container"
+				>
 					<span class="alert-indicator">
 						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-info-circle">
 							<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#info-circle" />
@@ -78,7 +80,7 @@ else {
 					</span>
 
 					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(layoutRevision.getName(locale)), layoutSetBranchName} %>" key="the-page-x-is-not-enabled-in-x,-but-is-available-in-other-pages-variations" translateArguments="<%= false %>" />
-				</div>
+				</clay:container>
 			</div>
 		</div>
 	</div>

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
@@ -39,7 +39,7 @@ List<LayoutRevision> rootLayoutRevisions = LayoutRevisionLocalServiceUtil.getChi
 	<liferay-util:param name="navigationName" value="history" />
 </liferay-util:include>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:if test="<%= !rootLayoutRevisions.isEmpty() %>">
 		<c:if test="<%= rootLayoutRevisions.size() > 1 %>">
 			<aui:select cssClass="variation-selector" inlineLabel="left" label="" name="variationsSelector">
@@ -169,7 +169,7 @@ List<LayoutRevision> rootLayoutRevisions = LayoutRevisionLocalServiceUtil.getChi
 
 		</div>
 	</c:if>
-</div>
+</clay:container>
 
 <script>
 function <portlet:namespace />selectRevision(

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_set_branches.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_set_branches.jsp
@@ -28,7 +28,7 @@ request.setAttribute("view_layout_set_branches.jsp-currentLayoutSetBranchId", St
 	<liferay-util:param name="navigationName" value="site-pages-variation" />
 </liferay-util:include>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:success key="sitePageVariationAdded" message="site-page-variation-was-added" />
 	<liferay-ui:success key="sitePageVariationDeleted" message="site-page-variation-was-deleted" />
 	<liferay-ui:success key="sitePageVariationMerged" message="site-page-variation-was-merged" />
@@ -97,7 +97,7 @@ request.setAttribute("view_layout_set_branches.jsp-currentLayoutSetBranchId", St
 			/>
 		</liferay-ui:search-container>
 	</div>
-</div>
+</clay:container>
 
 <aui:script use="liferay-staging-branch">
 	Liferay.StagingBar.init({

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/init.jsp
@@ -65,6 +65,7 @@ page import="com.liferay.portal.kernel.util.CalendarFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
+page import="com.liferay.portal.kernel.util.JavaConstants" %><%@
 page import="com.liferay.portal.kernel.util.ListUtil" %><%@
 page import="com.liferay.portal.kernel.util.MapUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
@@ -95,6 +96,7 @@ page import="java.util.Map" %>
 <%@ page import="javax.portlet.ActionRequest" %><%@
 page import="javax.portlet.PortletMode" %><%@
 page import="javax.portlet.PortletRequest" %><%@
+page import="javax.portlet.PortletResponse" %><%@
 page import="javax.portlet.PortletURL" %>
 
 <liferay-frontend:defineObjects />
@@ -108,6 +110,8 @@ page import="javax.portlet.PortletURL" %>
 <portlet:defineObjects />
 
 <%
+PortletResponse portletResponse = (PortletResponse)request.getAttribute(JavaConstants.JAVAX_PORTLET_RESPONSE);
+
 PortalPreferences portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(liferayPortletRequest);
 
 Calendar calendar = CalendarFactoryUtil.getCalendar(timeZone, locale);

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/new_publication/view.jsp
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/new_publication/view.jsp
@@ -16,6 +16,8 @@
 
 <%@ include file="/init.jsp" %>
 
-<div class="container-fluid-1280" id="<portlet:namespace />newPublicationContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "newPublicationContainer" %>'
+>
 	<liferay-util:include page="/new_publication/publish_layouts.jsp" servletContext="<%= application %>" />
-</div>
+</clay:container>

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/processes_list/view.jsp
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/processes_list/view.jsp
@@ -41,7 +41,9 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 		<liferay-util:param name="searchContainerId" value="<%= searchContainerId %>" />
 	</liferay-util:include>
 
-	<div class="container-fluid-1280" id="<portlet:namespace />processesContainer">
+	<clay:container
+		id='<%= renderResponse.getNamespace() + "processesContainer" %>'
+	>
 		<liferay-util:include page="/processes_list/publish_layouts_processes.jsp" servletContext="<%= application %>" />
-	</div>
+	</clay:container>
 </div>

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/processes_list/view.jsp
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/processes_list/view.jsp
@@ -42,7 +42,7 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 	</liferay-util:include>
 
 	<clay:container
-		id='<%= renderResponse.getNamespace() + "processesContainer" %>'
+		id='<%= portletResponse.getNamespace() + "processesContainer" %>'
 	>
 		<liferay-util:include page="/processes_list/publish_layouts_processes.jsp" servletContext="<%= application %>" />
 	</clay:container>

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/publish_templates/edit_template.jsp
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/publish_templates/edit_template.jsp
@@ -104,7 +104,7 @@ renderResponse.setTitle((exportImportConfiguration == null) ? LanguageUtil.get(r
 	</c:if>
 </c:if>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<div id="<portlet:namespace />customConfiguration">
 		<portlet:actionURL name="editPublishConfiguration" var="updatePublishConfigurationURL">
 			<portlet:param name="mvcRenderCommandName" value="editPublishConfiguration" />
@@ -188,7 +188,7 @@ renderResponse.setTitle((exportImportConfiguration == null) ? LanguageUtil.get(r
 			</div>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />publishPages() {

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/publish_templates/view.jsp
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/publish_templates/view.jsp
@@ -65,7 +65,10 @@ StagingProcessesWebPublishTemplatesToolbarDisplayContext stagingProcessesWebPubl
 	showSearch="<%= true %>"
 />
 
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<aui:form action="<%= portletURL %>">
 		<liferay-ui:search-container
 			searchContainer="<%= stagingProcessesWebPublishTemplatesToolbarDisplayContext.getSearchContainer() %>"
@@ -130,4 +133,4 @@ StagingProcessesWebPublishTemplatesToolbarDisplayContext stagingProcessesWebPubl
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/scheduled_list/view.jsp
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/scheduled_list/view.jsp
@@ -16,6 +16,8 @@
 
 <%@ include file="/init.jsp" %>
 
-<div class="container-fluid-1280" id="<portlet:namespace />scheduledProcessesContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "scheduledProcessesContainer" %>'
+>
 	<liferay-util:include page="/scheduled_list/scheduled_publish_processes.jsp" servletContext="<%= application %>" />
-</div>
+</clay:container>

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/alert/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/alert/page.jsp
@@ -70,11 +70,11 @@
 </liferay-util:buffer>
 
 <div class="alert alert-<%= type %><%= dismissible ? " alert-dismissible" : "" %><%= fluid ? " alert-fluid" : "" %>">
-	<div class="container-fluid container-fluid-max-xl">
+	<clay:container>
 		<%= icon %>
 
 		<span><%= bodyContentString %></span>
 
 		<%= close %>
-	</div>
+	</clay:container>
 </div>

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/alert/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/alert/page.jsp
@@ -70,7 +70,7 @@
 </liferay-util:buffer>
 
 <div class="alert alert-<%= type %><%= dismissible ? " alert-dismissible" : "" %><%= fluid ? " alert-fluid" : "" %>">
-	<div class="container">
+	<div class="container-fluid container-fluid-max-xl">
 		<%= icon %>
 
 		<span><%= bodyContentString %></span>

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_info/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_info/page.jsp
@@ -16,61 +16,50 @@
 
 <%@ include file="/process_info/init.jsp" %>
 
-<div class="container text-secondary">
-	<clay:row>
-		<clay:col
-			sm=""
-		>
+<div class="container-fluid container-fluid-max-xl text-secondary">
+	<div class="row">
+		<div class="col-sm">
 			<liferay-staging:process-title
 				backgroundTask="<%= backgroundTask %>"
 				listView="<%= false %>"
 			/>
-		</clay:col>
-	</clay:row>
+		</div>
+	</div>
 
-	<clay:row>
-		<clay:col
-			sm=""
-		>
-			<%= HtmlUtil.escape(userName) %>
-		</clay:col>
-
-		<clay:col
-			sm=""
-		>
+	<div class="row">
+		<div class="col-sm"><%= HtmlUtil.escape(userName) %></div>
+		<div class="col-sm">
 			<liferay-staging:process-date
 				date="<%= backgroundTask.getCreateDate() %>"
 				labelKey="start-date"
 				listView="<%= false %>"
 			/>
-		</clay:col>
+		</div>
 
-		<clay:col
-			sm=""
-		>
+		<div class="col-sm">
 			<liferay-staging:process-date
 				date="<%= backgroundTask.getCompletionDate() %>"
 				labelKey="completion-date"
 				listView="<%= false %>"
 			/>
-		</clay:col>
-	</clay:row>
+		</div>
+	</div>
 
-	<clay:row>
-		<clay:col>
+	<div class="row">
+		<div class="col">
 			<liferay-staging:process-in-progress
 				backgroundTask="<%= backgroundTask %>"
 				listView="<%= false %>"
 			/>
-		</clay:col>
-	</clay:row>
+		</div>
+	</div>
 
-	<clay:row>
-		<clay:col>
+	<div class="row">
+		<div class="col">
 			<liferay-staging:process-status
 				backgroundTaskStatus="<%= backgroundTask.getStatus() %>"
 				backgroundTaskStatusLabel="<%= backgroundTask.getStatusLabel() %>"
 			/>
-		</clay:col>
-	</clay:row>
+		</div>
+	</div>
 </div>

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_info/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_info/page.jsp
@@ -16,50 +16,63 @@
 
 <%@ include file="/process_info/init.jsp" %>
 
-<div class="container-fluid container-fluid-max-xl text-secondary">
-	<div class="row">
-		<div class="col-sm">
+<clay:container
+	className="text-secondary"
+>
+	<clay:row>
+		<clay:col
+			sm=""
+		>
 			<liferay-staging:process-title
 				backgroundTask="<%= backgroundTask %>"
 				listView="<%= false %>"
 			/>
-		</div>
-	</div>
+		</clay:col>
+	</clay:row>
 
-	<div class="row">
-		<div class="col-sm"><%= HtmlUtil.escape(userName) %></div>
-		<div class="col-sm">
+	<clay:row>
+		<clay:col
+			sm=""
+		>
+			<%= HtmlUtil.escape(userName) %>
+		</clay:col>
+
+		<clay:col
+			sm=""
+		>
 			<liferay-staging:process-date
 				date="<%= backgroundTask.getCreateDate() %>"
 				labelKey="start-date"
 				listView="<%= false %>"
 			/>
-		</div>
+		</clay:col>
 
-		<div class="col-sm">
+		<clay:col
+			sm=""
+		>
 			<liferay-staging:process-date
 				date="<%= backgroundTask.getCompletionDate() %>"
 				labelKey="completion-date"
 				listView="<%= false %>"
 			/>
-		</div>
-	</div>
+		</clay:col>
+	</clay:row>
 
-	<div class="row">
-		<div class="col">
+	<clay:row>
+		<clay:col>
 			<liferay-staging:process-in-progress
 				backgroundTask="<%= backgroundTask %>"
 				listView="<%= false %>"
 			/>
-		</div>
-	</div>
+		</clay:col>
+	</clay:row>
 
-	<div class="row">
-		<div class="col">
+	<clay:row>
+		<clay:col>
 			<liferay-staging:process-status
 				backgroundTaskStatus="<%= backgroundTask.getStatus() %>"
 				backgroundTaskStatusLabel="<%= backgroundTask.getStatusLabel() %>"
 			/>
-		</div>
-	</div>
-</div>
+		</clay:col>
+	</clay:row>
+</clay:container>

--- a/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/devices.jsp
+++ b/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/devices.jsp
@@ -72,7 +72,7 @@ portletURL.setParameter("delta", String.valueOf(delta));
 	</c:if>
 </liferay-frontend:management-bar>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form method="post" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
@@ -163,4 +163,4 @@ portletURL.setParameter("delta", String.valueOf(delta));
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/sites.jsp
+++ b/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/sites.jsp
@@ -86,7 +86,7 @@ portletURL.setParameter("delta", String.valueOf(delta));
 	</liferay-frontend:management-bar-action-buttons>
 </liferay-frontend:management-bar>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form method="post" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 		<aui:input name="enabled" type="hidden" />
@@ -204,7 +204,7 @@ portletURL.setParameter("delta", String.valueOf(delta));
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />disableSites() {

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view.jsp
@@ -26,7 +26,10 @@ TrashManagementToolbarDisplayContext trashManagementToolbarDisplayContext = new 
 
 <liferay-util:include page="/restore_path.jsp" servletContext="<%= application %>" />
 
-<div class="closed container-fluid container-fluid-max-xl sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/trash/info_panel" var="sidebarPanelURL" />
 
 	<liferay-frontend:sidebar-panel
@@ -286,7 +289,7 @@ TrashManagementToolbarDisplayContext trashManagementToolbarDisplayContext = new 
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <liferay-frontend:component
 	componentId="<%= trashManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -28,7 +28,10 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 			displayContext="<%= new TrashContainerManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, trashDisplayContext) %>"
 		/>
 
-		<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+		<clay:container
+			className="closed sidenav-container sidenav-right"
+			id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+		>
 			<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/trash/info_panel" var="sidebarPanelURL" />
 
 			<liferay-frontend:sidebar-panel
@@ -141,7 +144,7 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 					/>
 				</liferay-ui:search-container>
 			</div>
-		</div>
+		</clay:container>
 	</c:when>
 	<c:otherwise>
 
@@ -154,7 +157,7 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 		renderResponse.setTitle(trashRenderer.getTitle(locale));
 		%>
 
-		<div class="container-fluid-1280">
+		<clay:container>
 			<aui:fieldset-group markupView="lexicon">
 				<aui:fieldset>
 					<liferay-asset:asset-display
@@ -162,7 +165,7 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 					/>
 				</aui:fieldset>
 			</aui:fieldset-group>
-		</div>
+		</clay:container>
 	</c:otherwise>
 </c:choose>
 

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
@@ -32,7 +32,9 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 	<portlet:param name="mvcRenderCommandName" value="/view_uad_export_processes" />
 </portlet:renderURL>
 
-<div class="container-fluid container-fluid-max-xl container-form-lg">
+<clay:container
+	className="container-form-lg"
+>
 	<aui:form method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "exportApplicationData();" %>'>
 		<aui:input name="p_u_i_d" type="hidden" value="<%= String.valueOf(selectedUser.getUserId()) %>" />
 		<aui:input name="redirect" type="hidden" value="<%= viewUADExportProcesses.toString() %>" />
@@ -129,7 +131,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 			</div>
 		</div>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />exportApplicationData() {

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/anonymize_nonreviewable_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/anonymize_nonreviewable_uad_data.jsp
@@ -31,7 +31,9 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 
 <liferay-util:include page="/uad_data_navigation_bar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid container-fluid-max-xl container-form-lg">
+<clay:container
+	className="container-form-lg"
+>
 	<aui:form method="post" name="nonreviewableUADDataForm">
 		<aui:input name="p_u_i_d" type="hidden" value="<%= String.valueOf(selectedUser.getUserId()) %>" />
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
@@ -118,6 +120,6 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 			</div>
 		</div>
 	</aui:form>
-</div>
+</clay:container>
 
 <%@ include file="/action/confirm_action_js.jspf" %>

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/completed_data_erasure.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/completed_data_erasure.jsp
@@ -26,11 +26,13 @@ portletDisplay.setURLBack(usersAdminURL.toString());
 renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", LanguageUtil.get(request, "personal-data-erasure")));
 %>
 
-<div class="container-fluid container-fluid-max-xl container-form-lg">
+<clay:container
+	className="container-form-lg"
+>
 	<liferay-ui:empty-result-message
 		message="you-have-successfully-anonymized-all-remaining-data"
 	/>
-</div>
+</clay:container>
 
 <portlet:actionURL name="/delete_user" var="deleteUserURL">
 	<portlet:param name="p_u_i_d" value="<%= String.valueOf(selectedUser.getUserId()) %>" />

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
@@ -37,7 +37,9 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 
 <liferay-util:include page="/uad_data_navigation_bar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid container-fluid-max-xl container-form-lg">
+<clay:container
+	className="container-form-lg"
+>
 	<clay:row>
 		<clay:col
 			lg="3"
@@ -213,7 +215,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <portlet:renderURL var="reviewUADDataURL">
 	<portlet:param name="p_u_i_d" value="<%= String.valueOf(selectedUser.getUserId()) %>" />

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_entities.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_entities.jsp
@@ -70,7 +70,10 @@ long[] groupIds = viewUADEntitiesDisplay.getGroupIds();
 		</c:otherwise>
 	</c:choose>
 
-	<div class="closed container-fluid container-fluid-max-xl sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+	<clay:container
+		className="closed sidenav-container sidenav-right"
+		id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+	>
 		<div id="breadcrumb">
 			<liferay-ui:breadcrumb
 				showCurrentGroup="<%= false %>"
@@ -180,7 +183,7 @@ long[] groupIds = viewUADEntitiesDisplay.getGroupIds();
 				/>
 			</liferay-ui:search-container>
 		</div>
-	</div>
+	</clay:container>
 </aui:form>
 
 <aui:script>

--- a/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/build.gradle
+++ b/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:item-selector:item-selector-taglib")

--- a/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -17,6 +17,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/item-selector" prefix="liferay-item-selector" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/resources/META-INF/resources/user_group_item_selector.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/resources/META-INF/resources/user_group_item_selector.jsp
@@ -55,7 +55,9 @@ PortletURL portletURL = userGroupItemSelectorViewDisplayContext.getPortletURL();
 	</liferay-frontend:management-bar-filters>
 </liferay-frontend:management-bar>
 
-<div class="container-fluid-1280" id="<portlet:namespace />userGroupSelectorWrapper">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "userGroupSelectorWrapper" %>'
+>
 	<liferay-ui:search-container
 		id="userGroups"
 		searchContainer="<%= userGroupItemSelectorViewDisplayContext.getSearchContainer() %>"
@@ -94,7 +96,7 @@ PortletURL portletURL = userGroupItemSelectorViewDisplayContext.getPortletURL();
 			searchContainer="<%= userGroupItemSelectorViewDisplayContext.getSearchContainer() %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get(

--- a/modules/apps/users-admin/users-admin-item-selector-web/build.gradle
+++ b/modules/apps/users-admin/users-admin-item-selector-web/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:item-selector:item-selector-taglib")

--- a/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -17,6 +17,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/item-selector" prefix="liferay-item-selector" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/user_item_selector.jsp
+++ b/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/user_item_selector.jsp
@@ -55,7 +55,9 @@ PortletURL portletURL = userItemSelectorViewDisplayContext.getPortletURL();
 	</liferay-frontend:management-bar-filters>
 </liferay-frontend:management-bar>
 
-<div class="container-fluid-1280" id="<portlet:namespace />userSelectorWrapper">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "userSelectorWrapper" %>'
+>
 	<liferay-ui:search-container
 		id="users"
 		searchContainer="<%= userItemSelectorViewDisplayContext.getSearchContainer() %>"
@@ -98,7 +100,7 @@ PortletURL portletURL = userItemSelectorViewDisplayContext.getPortletURL();
 			searchContainer="<%= userItemSelectorViewDisplayContext.getSearchContainer() %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get('<portlet:namespace />users');

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_address.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_address.jsp
@@ -49,7 +49,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 	<aui:input name="listType" type="hidden" value="<%= ListTypeConstants.ADDRESS %>" />
 	<aui:input name="primaryKey" type="hidden" value="<%= String.valueOf(editContactInformationDisplayContext.getPrimaryKey()) %>" />
 
-	<div class="container-fluid container-fluid-max-xl">
+	<clay:container>
 		<div class="sheet-lg" id="breadcrumb">
 			<liferay-ui:breadcrumb
 				showCurrentGroup="<%= false %>"
@@ -118,7 +118,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 				<aui:button href="<%= editContactInformationDisplayContext.getRedirect() %>" type="cancel" />
 			</div>
 		</div>
-	</div>
+	</clay:container>
 
 	<aui:script use="liferay-dynamic-select">
 		new Liferay.DynamicSelect([

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_email_address.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_email_address.jsp
@@ -43,7 +43,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 	<aui:input name="listType" type="hidden" value="<%= ListTypeConstants.EMAIL_ADDRESS %>" />
 	<aui:input name="primaryKey" type="hidden" value="<%= String.valueOf(editContactInformationDisplayContext.getPrimaryKey()) %>" />
 
-	<div class="container-fluid container-fluid-max-xl">
+	<clay:container>
 		<div class="sheet-lg" id="breadcrumb">
 			<liferay-ui:breadcrumb
 				showCurrentGroup="<%= false %>"
@@ -78,5 +78,5 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 				<aui:button href="<%= editContactInformationDisplayContext.getRedirect() %>" type="cancel" />
 			</div>
 		</div>
-	</div>
+	</clay:container>
 </aui:form>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_phone_number.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_phone_number.jsp
@@ -43,7 +43,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 	<aui:input name="listType" type="hidden" value="<%= ListTypeConstants.PHONE %>" />
 	<aui:input name="primaryKey" type="hidden" value="<%= String.valueOf(editContactInformationDisplayContext.getPrimaryKey()) %>" />
 
-	<div class="container-fluid container-fluid-max-xl">
+	<clay:container>
 		<div class="sheet-lg" id="breadcrumb">
 			<liferay-ui:breadcrumb
 				showCurrentGroup="<%= false %>"
@@ -90,5 +90,5 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 				<aui:button href="<%= editContactInformationDisplayContext.getRedirect() %>" type="cancel" />
 			</div>
 		</div>
-	</div>
+	</clay:container>
 </aui:form>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_website.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_website.jsp
@@ -43,7 +43,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 	<aui:input name="listType" type="hidden" value="<%= ListTypeConstants.WEBSITE %>" />
 	<aui:input name="primaryKey" type="hidden" value="<%= String.valueOf(editContactInformationDisplayContext.getPrimaryKey()) %>" />
 
-	<div class="container-fluid container-fluid-max-xl">
+	<clay:container>
 		<div class="sheet-lg" id="breadcrumb">
 			<liferay-ui:breadcrumb
 				showCurrentGroup="<%= false %>"
@@ -84,5 +84,5 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 				<aui:button href="<%= editContactInformationDisplayContext.getRedirect() %>" type="cancel" />
 			</div>
 		</div>
-	</div>
+	</clay:container>
 </aui:form>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/edit_opening_hours.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/edit_opening_hours.jsp
@@ -43,7 +43,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 	<aui:input name="listType" type="hidden" value="<%= ListTypeConstants.ORGANIZATION_SERVICE %>" />
 	<aui:input name="primaryKey" type="hidden" value="<%= String.valueOf(editContactInformationDisplayContext.getPrimaryKey()) %>" />
 
-	<div class="container-fluid container-fluid-max-xl">
+	<clay:container>
 		<div class="sheet-lg" id="breadcrumb">
 			<liferay-ui:breadcrumb
 				showCurrentGroup="<%= false %>"
@@ -127,5 +127,5 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 				<aui:button href="<%= editContactInformationDisplayContext.getRedirect() %>" type="cancel" />
 			</div>
 		</div>
-	</div>
+	</clay:container>
 </aui:form>

--- a/modules/apps/wiki/wiki-engine-creole/build.gradle
+++ b/modules/apps/wiki/wiki-engine-creole/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:wiki:wiki-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/wiki/wiki-engine-creole/src/main/resources/META-INF/resources/help_page.jsp
+++ b/modules/apps/wiki/wiki-engine-creole/src/main/resources/META-INF/resources/help_page.jsp
@@ -16,7 +16,7 @@
 
 <%@ include file="/init.jsp" %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<h4>
 		<liferay-ui:message key="text-styles" />
 	</h4>
@@ -79,4 +79,4 @@
 	%>
 
 	<aui:a href="<%= baseWikiEngine.getHelpURL() %>" target="_blank"><liferay-ui:message key="learn-more" /> &raquo;</aui:a>
-</div>
+</clay:container>

--- a/modules/apps/wiki/wiki-engine-creole/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/wiki/wiki-engine-creole/src/main/resources/META-INF/resources/init.jsp
@@ -15,6 +15,7 @@
 --%>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.wiki.engine.BaseWikiEngine" %>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/wiki_pages.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/wiki_pages.jsp
@@ -80,7 +80,10 @@ String searchURL = HttpUtil.removeParameter(searchBaseURL.toString(), liferayPor
 	showCreationMenu="<%= false %>"
 />
 
-<div class="container-fluid-1280 lfr-item-viewer" id="<portlet:namespace />wikiPagesSelectorContainer">
+<clay:container
+	className="lfr-item-viewer"
+	id='<%= renderResponse.getNamespace() + "wikiPagesSelectorContainer" %>'
+>
 	<liferay-ui:search-container
 		id="wikiPagesSearchContainer"
 		searchContainer="<%= wikiPagesSearchContainer %>"
@@ -143,7 +146,7 @@ String searchURL = HttpUtil.removeParameter(searchBaseURL.toString(), liferayPor
 			searchContainer="<%= wikiPagesSearchContainer %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script use="liferay-search-container">
 	var Util = Liferay.Util;

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/select_version.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/select_version.jsp
@@ -31,7 +31,7 @@ portletURL.setParameter("title", HtmlUtil.unescape(wikiPage.getTitle()));
 portletURL.setParameter("sourceVersion", String.valueOf(sourceVersion));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="selectVersionFm">
 		<liferay-ui:search-container
 			id="wikiPageVersionSearchContainer"
@@ -91,7 +91,7 @@ portletURL.setParameter("sourceVersion", String.valueOf(sourceVersion));
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view_trash_page_attachments.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view_trash_page_attachments.jsp
@@ -25,7 +25,7 @@ WikiNode node = (WikiNode)request.getAttribute(WikiWebKeys.WIKI_NODE);
 	<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.RESTORE %>" />
 </portlet:actionURL>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-trash:undo
 		portletURL="<%= undoTrashURL %>"
 	/>
@@ -69,4 +69,4 @@ WikiNode node = (WikiNode)request.getAttribute(WikiWebKeys.WIKI_NODE);
 	%>
 
 	<%@ include file="/wiki/attachments_list.jspf" %>
-</div>
+</clay:container>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/edit_node.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/edit_node.jsp
@@ -31,7 +31,7 @@ renderResponse.setTitle((node == null) ? LanguageUtil.get(request, "new-wiki-nod
 
 <portlet:actionURL name="/wiki/edit_node" var="editNodeURL" />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= editNodeURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "saveNode();" %>'>
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
@@ -70,7 +70,7 @@ renderResponse.setTitle((node == null) ? LanguageUtil.get(request, "new-wiki-nod
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />saveNode() {

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/import_pages.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/import_pages.jsp
@@ -55,7 +55,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "import-pages"));
 
 <portlet:actionURL name="/wiki/import_pages" var="importPagesURL" />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= importPagesURL %>" enctype="multipart/form-data" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "importPages();" %>'>
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
@@ -92,7 +92,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "import-pages"));
 		id="<%= importProgressId %>"
 		message="importing"
 	/>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />importPages() {

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view.jsp
@@ -92,7 +92,10 @@ WikiNodesManagementToolbarDisplayContext wikiNodesManagementToolbarDisplayContex
 	viewTypeItems="<%= wikiNodesManagementToolbarDisplayContext.getViewTypes() %>"
 />
 
-<div class="closed container-fluid container-fluid-max-xl sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/wiki/node_info_panel" var="sidebarPanelURL" />
 
 	<liferay-frontend:sidebar-panel
@@ -225,7 +228,7 @@ WikiNodesManagementToolbarDisplayContext wikiNodesManagementToolbarDisplayContex
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <script>
 	var deleteNodes = function () {

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_node_deleted_attachments.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_node_deleted_attachments.jsp
@@ -43,7 +43,7 @@ portletDisplay.setURLBack(backToNodeURL.toString());
 renderResponse.setTitle(LanguageUtil.get(request, "removed-attachments"));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<portlet:actionURL name="/wiki/edit_node_attachment" var="emptyTrashURL">
 		<portlet:param name="nodeId" value="<%= String.valueOf(node.getPrimaryKey()) %>" />
 	</portlet:actionURL>
@@ -77,4 +77,4 @@ renderResponse.setTitle(LanguageUtil.get(request, "removed-attachments"));
 	%>
 
 	<%@ include file="/wiki/attachments_list.jspf" %>
-</div>
+</clay:container>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_pages.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_pages.jsp
@@ -102,7 +102,10 @@ WikiPagesManagementToolbarDisplayContext wikiPagesManagementToolbarDisplayContex
 	viewTypeItems="<%= wikiPagesManagementToolbarDisplayContext.getViewTypes() %>"
 />
 
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/wiki/page_info_panel" var="sidebarPanelURL">
 		<portlet:param name="nodeId" value="<%= String.valueOf(node.getNodeId()) %>" />
 		<portlet:param name="showSidebarHeader" value="<%= Boolean.TRUE.toString() %>" />
@@ -289,7 +292,7 @@ WikiPagesManagementToolbarDisplayContext wikiPagesManagementToolbarDisplayContex
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <script>
 	var deletePages = function () {

--- a/modules/dxp/apps/akismet/akismet-web/build.gradle
+++ b/modules/dxp/apps/akismet/akismet-web/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:application-list:application-list-api")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:message-boards:message-boards-service")
 	compileOnly project(":apps:message-boards:message-boards-web")

--- a/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>

--- a/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view_thread_message.jsp
+++ b/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view_thread_message.jsp
@@ -32,7 +32,7 @@ if (messageId > 0) {
 
 <a id="<portlet:namespace />message_<%= message.getMessageId() %>"></a>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<div class="spam" style="margin: 10px;">
 		<portlet:actionURL name="markNotSpamMBMessages" var="markAsHamURL" windowState="<%= WindowState.MAXIMIZED.toString() %>">
 			<portlet:param name="redirect" value="<%= portletURL.toString() %>" />
@@ -146,4 +146,4 @@ if (messageId > 0) {
 			</div>
 		</div>
 	</div>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/configuration.jsp
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/configuration.jsp
@@ -52,7 +52,7 @@ Map<String, String> emailDefinitionTerms = EmailConfigurationUtil.getEmailDefini
 			<liferay-ui:error key="emailNotificationsSubject" message="please-enter-a-valid-subject" />
 
 			<liferay-ui:section>
-				<div class="container-fluid-1280">
+				<clay:container>
 					<aui:fieldset-group markupView="lexicon">
 						<aui:fieldset>
 							<aui:input cssClass="lfr-input-text-container" label="name" name="preferences--emailFromName--" type="text" value="<%= emailFromName %>" />
@@ -60,11 +60,11 @@ Map<String, String> emailDefinitionTerms = EmailConfigurationUtil.getEmailDefini
 							<aui:input cssClass="lfr-input-text-container" label="address" name="preferences--emailFromAddress--" type="text" value="<%= emailFromAddress %>" />
 						</aui:fieldset>
 					</aui:fieldset-group>
-				</div>
+				</clay:container>
 			</liferay-ui:section>
 
 			<liferay-ui:section>
-				<div class="container-fluid-1280">
+				<clay:container>
 					<aui:fieldset-group markupView="lexicon">
 						<liferay-frontend:email-notification-settings
 							emailBodyLocalizedValuesMap="<%= reportsGroupServiceEmailConfiguration.emailDeliveryBody() %>"
@@ -74,11 +74,11 @@ Map<String, String> emailDefinitionTerms = EmailConfigurationUtil.getEmailDefini
 							emailSubjectLocalizedValuesMap="<%= reportsGroupServiceEmailConfiguration.emailDeliverySubject() %>"
 						/>
 					</aui:fieldset-group>
-				</div>
+				</clay:container>
 			</liferay-ui:section>
 
 			<liferay-ui:section>
-				<div class="container-fluid-1280">
+				<clay:container>
 					<aui:fieldset-group markupView="lexicon">
 						<liferay-frontend:email-notification-settings
 							emailBodyLocalizedValuesMap="<%= reportsGroupServiceEmailConfiguration.emailNotificationsBody() %>"
@@ -88,7 +88,7 @@ Map<String, String> emailDefinitionTerms = EmailConfigurationUtil.getEmailDefini
 							emailSubjectLocalizedValuesMap="<%= reportsGroupServiceEmailConfiguration.emailNotificationsSubject() %>"
 						/>
 					</aui:fieldset-group>
-				</div>
+				</clay:container>
 			</liferay-ui:section>
 		</liferay-ui:tabs>
 	</div>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/report/requested_report_detail.jsp
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/report/requested_report_detail.jsp
@@ -36,7 +36,7 @@ portletDisplay.setURLBack(searchRequestURL.toString());
 renderResponse.setTitle(definition.getName(locale));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:choose>
 		<c:when test="<%= status.equals(ReportStatus.ERROR.getValue()) %>">
 			<div class="portlet-msg-error">
@@ -226,4 +226,4 @@ renderResponse.setTitle(definition.getName(locale));
 			</liferay-ui:search-container>
 		</aui:fieldset>
 	</aui:fieldset-group>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -18,7 +18,9 @@
 
 <liferay-util:include page="/admin/toolbar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<c:choose>
 		<c:when test="<%= hasAddSourcePermission && reportsEngineDisplayContext.isSourcesTabSelected() %>">
 			<liferay-util:include page="/admin/data_source/sources.jsp" servletContext="<%= application %>" />
@@ -30,4 +32,4 @@
 			<liferay-util:include page="/admin/report/entries.jsp" servletContext="<%= application %>" />
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/asset" prefix="liferay-asset" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
@@ -51,7 +52,9 @@ rankingResultContentDisplayBuilder.setRenderResponse(renderResponse);
 RankingResultContentDisplayContext rankingResultContentDisplayContext = rankingResultContentDisplayBuilder.build();
 %>
 
-<div class="container container-no-gutters-sm-down container-view">
+<clay:container
+	className="container-no-gutters-sm-down container-view"
+>
 	<c:choose>
 		<c:when test="<%= rankingResultContentDisplayContext.isVisible() %>">
 			<div class="result-rankings-view-content-container sheet sheet-lg">
@@ -105,4 +108,4 @@ RankingResultContentDisplayContext rankingResultContentDisplayContext = rankingR
 			</div>
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view.jsp
@@ -18,7 +18,9 @@
 
 <liferay-portlet:renderURL varImpl="searchURL" />
 
-<div class="container-fluid container-fluid-max-xl container-view">
+<clay:container
+	className="container-view"
+>
 	<aui:form action="<%= searchURL %>" method="get" name="fm">
 		<liferay-portlet:renderURLParams varImpl="searchURL" />
 
@@ -108,4 +110,4 @@
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -83,7 +83,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 			<aui:model-context bean="<%= kaleoDefinitionVersion %>" model="<%= KaleoDefinitionVersion.class %>" />
 
 			<liferay-frontend:info-bar>
-				<div class="container-fluid-1280">
+				<clay:container>
 					<c:if test="<%= !Objects.equals(state, WorkflowWebKeys.WORKFLOW_PREVIEW_BEFORE_RESTORE_STATE) %>">
 						<div class="info-bar-item">
 							<c:choose>
@@ -118,7 +118,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 							</c:otherwise>
 						</c:choose>
 					</span>
-				</div>
+				</clay:container>
 
 				<c:if test='<%= !Objects.equals(state, WorkflowWebKeys.WORKFLOW_PREVIEW_BEFORE_RESTORE_STATE) && !Objects.equals(state, "view") %>'>
 					<liferay-frontend:info-bar-buttons>
@@ -138,13 +138,13 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 					<div class="sidebar sidebar-light">
 						<div class="tbar-visible-xs">
 							<nav class="component-tbar tbar">
-								<div class="container-fluid">
+								<clay:container>
 									<ul class="tbar-nav">
 										<li class="tbar-item">
 											<aui:icon cssClass="component-action sidenav-close" image="times" markupView="lexicon" url="javascript:;" />
 										</li>
 									</ul>
-								</div>
+								</clay:container>
 							</nav>
 						</div>
 
@@ -230,7 +230,9 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 				</div>
 			</c:if>
 
-			<div class="<%= Objects.equals(renderRequest.getWindowState(), LiferayWindowState.POP_UP) ? "" : "container-fluid-1280" %>">
+			<clay:container
+				size='<%= Objects.equals(renderRequest.getWindowState(), LiferayWindowState.POP_UP) ? "xl" : "lg" %>'
+			>
 				<div class="sidenav-content">
 					<aui:form method="post" name="fm" onSubmit="event.preventDefault();">
 						<aui:model-context bean="<%= kaleoDefinitionVersion %>" model="<%= KaleoDefinitionVersion.class %>" />
@@ -777,7 +779,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 						</c:choose>
 					</aui:form>
 				</div>
-			</div>
+			</clay:container>
 		</div>
 
 		<c:if test="<%= kaleoDefinition != null %>">

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/view_workflow_definitions.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/view_workflow_definitions.jsp
@@ -24,7 +24,9 @@ KaleoDefinitionVersionSearch kaleoDefinitionVersionSearch = kaleoDesignerDisplay
 
 <liferay-util:include page="/designer/management_bar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<liferay-ui:error exception="<%= RequiredWorkflowDefinitionException.class %>">
 		<liferay-ui:message arguments="<%= kaleoDesignerDisplayContext.getMessageArguments((RequiredWorkflowDefinitionException)errorException) %>" key="<%= kaleoDesignerDisplayContext.getMessageKey((RequiredWorkflowDefinitionException)errorException) %>" translateArguments="<%= false %>" />
 	</liferay-ui:error>
@@ -89,4 +91,4 @@ KaleoDefinitionVersionSearch kaleoDefinitionVersionSearch = kaleoDesignerDisplay
 			searchContainer="<%= kaleoDefinitionVersionSearch %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_kaleo_process.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_kaleo_process.jsp
@@ -64,9 +64,11 @@ renderResponse.setTitle(title);
 %>
 
 <c:if test="<%= kaleoProcessStarted %>">
-	<div class="alert alert-info container-fluid-1280">
+	<clay:container
+		className="alert alert-info"
+	>
 		<liferay-ui:message key="updating-the-field-set-or-workflow-will-cause-loss-of-data" />
-	</div>
+	</clay:container>
 </c:if>
 
 <portlet:actionURL name="updateKaleoProcess" var="editKaleoProcessURL">

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_record.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_record.jsp
@@ -56,7 +56,9 @@ renderResponse.setTitle((ddlRecord != null) ? LanguageUtil.format(request, "edit
 	<portlet:param name="kaleoProcessId" value="<%= String.valueOf(kaleoProcessId) %>" />
 </portlet:actionURL>
 
-<div class="container-fluid-1280 sidenav-container sidenav-right">
+<clay:container
+	className="sidenav-container sidenav-right"
+>
 	<div class="lfr-form-content">
 		<aui:form action="<%= updateDDLRecordURL %>" cssClass="lfr-dynamic-form" enctype="multipart/form-data" onSubmit='<%= "event.preventDefault(); submitForm(event.target);" %>'>
 			<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
@@ -104,7 +106,7 @@ renderResponse.setTitle((ddlRecord != null) ? LanguageUtil.format(request, "edit
 			</aui:button-row>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <%
 if (ddlRecord != null) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_request.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_request.jsp
@@ -33,7 +33,9 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(LanguageUtil.format(request, "new-x", kaleoProcess.getName(locale), false));
 %>
 
-<div class="container-fluid-1280 sidenav-container sidenav-right">
+<clay:container
+	className="sidenav-container sidenav-right"
+>
 	<portlet:actionURL name="startWorkflowInstance" var="startWorkflowInstanceURL" />
 
 	<aui:form action="<%= startWorkflowInstanceURL %>" cssClass="lfr-dynamic-form" enctype="multipart/form-data" method="post" name="fm1">
@@ -66,7 +68,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "new-x", kaleoProcess.getNa
 			<aui:button cssClass="btn-lg" href="<%= redirect %>" name="cancelButton" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <%
 PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.format(request, "add-x", kaleoProcess.getName(locale), false), currentURL);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/init.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/init.jsp
@@ -16,8 +16,6 @@
 
 <%@ include file="/init.jsp" %>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
-
 <%@ page import="com.liferay.dynamic.data.lists.exception.RecordSetDDMStructureIdException" %><%@
 page import="com.liferay.dynamic.data.lists.exception.RecordSetNameException" %><%@
 page import="com.liferay.dynamic.data.lists.model.DDLRecordConstants" %><%@

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -26,7 +26,9 @@ KaleoProcessSearch kaleoProcessSearch = kaleoFormsAdminDisplayContext.getKaleoPr
 
 <liferay-util:include page="/admin/management_bar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid-1280" id="<portlet:namespace />formContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "formContainer" %>'
+>
 	<aui:form action="<%= kaleoFormsAdminDisplayContext.getSearchActionURL() %>" method="post" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= kaleoFormsAdminDisplayContext.getSearchActionURL() %>" />
 		<aui:input name="kaleoProcessIds" type="hidden" />
@@ -90,7 +92,7 @@ KaleoProcessSearch kaleoProcessSearch = kaleoFormsAdminDisplayContext.getKaleoPr
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <%@ include file="/admin/export_kaleo_process.jspf" %>
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view_kaleo_process.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view_kaleo_process.jsp
@@ -60,7 +60,9 @@ portletURL.setParameter("kaleoProcessId", String.valueOf(kaleoProcess.getKaleoPr
 	sortingURL="<%= kaleoFormsViewRecordsDisplayContext.getSortingURL() %>"
 />
 
-<div class="container-fluid-1280" id="<portlet:namespace />formContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "formContainer" %>'
+>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="searchContainerForm">
 		<aui:input name="ddlRecordIds" type="hidden" />
 
@@ -146,13 +148,13 @@ portletURL.setParameter("kaleoProcessId", String.valueOf(kaleoProcess.getKaleoPr
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-paginator
 		searchContainer="<%= kaleoFormsViewRecordsDisplayContext.getSearch() %>"
 	/>
-</div>
+</clay:container>
 
 <%@ include file="/admin/export_kaleo_process.jspf" %>
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view_record.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view_record.jsp
@@ -37,7 +37,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(LanguageUtil.format(request, "view-x", kaleoProcess.getName(locale), false));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:if test="<%= ddlRecordVersion != null %>">
 		<aui:model-context bean="<%= ddlRecordVersion %>" model="<%= DDLRecordVersion.class %>" />
 
@@ -72,4 +72,4 @@ renderResponse.setTitle(LanguageUtil.format(request, "view-x", kaleoProcess.getN
 			<aui:button cssClass="btn-lg" href="<%= redirect %>" name="cancelButton" type="cancel" />
 		</aui:button-row>
 	</aui:fieldset>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/asset/full_content.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/asset/full_content.jsp
@@ -26,7 +26,9 @@ DDLRecordVersion ddlRecordVersion = (DDLRecordVersion)request.getAttribute(DDLWe
 KaleoProcessLink kaleoProcessLink = (KaleoProcessLink)request.getAttribute(KaleoFormsWebKeys.KALEO_PROCESS_LINK);
 %>
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<aui:fieldset>
 
 		<%
@@ -53,4 +55,4 @@ KaleoProcessLink kaleoProcessLink = (KaleoProcessLink)request.getAttribute(Kaleo
 			requestedLocale="<%= locale %>"
 		/>
 	</aui:fieldset>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/asset/init.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/asset/init.jsp
@@ -15,6 +15,7 @@
 --%>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/ddm" prefix="liferay-ddm" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/ddm" prefix="liferay-ddm" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/security" prefix="liferay-security" %><%@

--- a/modules/dxp/apps/saml/saml-web/build.gradle
+++ b/modules/dxp/apps/saml/saml-web/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "xml-apis", name: "xml-apis", version: "1.4.01"
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_identity_provider_connection.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_identity_provider_connection.jsp
@@ -24,12 +24,12 @@ SamlSpIdpConnection samlSpIdpConnection = (SamlSpIdpConnection)request.getAttrib
 long clockSkew = GetterUtil.getLong(request.getAttribute(SamlWebKeys.SAML_CLOCK_SKEW), samlProviderConfiguration.clockSkew());
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:header
 		backURL="<%= redirect %>"
 		title='<%= (samlSpIdpConnection != null) ? samlSpIdpConnection.getName() : "new-identity-provider" %>'
 	/>
-</div>
+</clay:container>
 
 <portlet:actionURL name="/admin/updateIdentityProviderConnection" var="updateIdentityProviderConnectionURL">
 	<portlet:param name="mvcRenderCommandName" value="/admin/edit_identity_provider_connection" />

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_service_provider_connection.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_service_provider_connection.jsp
@@ -24,12 +24,12 @@ SamlIdpSpConnection samlIdpSpConnection = (SamlIdpSpConnection)request.getAttrib
 long assertionLifetime = GetterUtil.getLong(request.getAttribute(SamlWebKeys.SAML_ASSERTION_LIFETIME), samlProviderConfiguration.defaultAssertionLifetime());
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:header
 		backURL="<%= redirect %>"
 		title='<%= (samlIdpSpConnection != null) ? samlIdpSpConnection.getName() : "new-service-provider" %>'
 	/>
-</div>
+</clay:container>
 
 <portlet:actionURL name="/admin/updateServiceProviderConnection" var="updateServiceProviderConnectionURL">
 	<portlet:param name="mvcRenderCommandName" value="/admin/edit_service_provider_connection" />

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -37,7 +37,7 @@ else if (samlProviderConfigurationHelper.isRoleSp()) {
 	names="<%= tabs1Names %>"
 	url="<%= portletURL.toString() %>"
 >
-	<div class="container-fluid-1280">
+	<clay:container>
 		<c:choose>
 			<c:when test='<%= tabs1.equals("general") %>'>
 				<liferay-util:include page="/admin/general.jsp" servletContext="<%= pageContext.getServletContext() %>" />
@@ -55,5 +55,5 @@ else if (samlProviderConfigurationHelper.isRoleSp()) {
 				<liferay-util:include page="/admin/view_service_provider_connections.jsp" servletContext="<%= pageContext.getServletContext() %>" />
 			</c:when>
 		</c:choose>
-	</div>
+	</clay:container>
 </liferay-ui:tabs>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>


### PR DESCRIPTION
Manual foward from: https://github.com/wincent/liferay-portal/pull/258 (only [remaining CI failures](https://github.com/wincent/liferay-portal/pull/258#issuecomment-627418640) are marked as not unique).

Original message follows:

---

Hey @wincent, picking up from @eduardoallegrini here...

### In this PR

- As it stands from the Title, replace all occurrences of `div class="container*"` with our new `clay:container` tag.

### Context

Followup of https://github.com/brianchandotcom/liferay-portal/pull/88326 which was in itself https://github.com/wincent/liferay-portal/pull/245 and contained these key parts:

- [Implement clay:container tag](https://issues.liferay.com/browse/LPS-112620). Up to the final specs discussed at https://github.com/marcoscv-work/liferay-portal/pull/316#issuecomment-621905296 and based on [Define clay:container tag](https://issues.liferay.com/browse/LPS-112361)
- [Replace usages of aui:container with clay:container](https://issues.liferay.com/browse/LPS-112626).

#### History

Older than the universe, in fact, but here's a summary 😂 

- **Initial attempts**
    - https://github.com/eduardoallegrini/liferay-portal/pull/64
    - https://github.com/eduardoallegrini/liferay-portal/pull/65
    - https://github.com/eduardoallegrini/liferay-portal/pull/66
    - https://github.com/eduardoallegrini/liferay-portal/pull/67
    - https://github.com/eduardoallegrini/liferay-portal/pull/68
    - https://github.com/eduardoallegrini/liferay-portal/pull/69
    - https://github.com/eduardoallegrini/liferay-portal/pull/70
- **Split into modules**
    - [Part 1](https://github.com/eduardoallegrini/liferay-portal/pull/71)
    - [Part 2](https://github.com/eduardoallegrini/liferay-portal/pull/72)
