### PR TITLE
LPS-111193 Mute the annoying search warning log. There is no need to …

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -7923,6 +7923,10 @@ osb.lcs.portlet.oauth.consumer.secret=${osb.lcs.portlet.oauth.consumer.secret}</
 		<priority value="DEBUG" />
 	</category>
 
+	<category name="com.liferay.portal.kernel.messaging.proxy.ProxyMessageListener">
+		<priority value="ERROR" />
+	</category>
+
 	<category name="com.liferay.portal.service.impl.ReleaseLocalServiceImpl">
 		<priority value="${release.local.service.impl.log.level}" />
 	</category>


### PR DESCRIPTION
…do both logging and rethrow on CI. Like this:

    [junit] 06:12:57,947 WARN  [com.liferay.company.test-executor-thread][ProxyMessageListener:88] java.lang.RuntimeException: org.elasticsearch.index.IndexNotFoundException: [liferay-60130] IndexNotFoundException[no such index]
    [junit] java.lang.RuntimeException: org.elasticsearch.index.IndexNotFoundException: [liferay-60130] IndexNotFoundException[no such index]
    [junit] 	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndices(IndexNameExpressionResolver.java:182)
    [junit] 	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteWriteIndex(IndexNameExpressionResolver.java:282)
    [junit] 	at org.elasticsearch.action.bulk.TransportBulkAction$ConcreteIndices.resolveIfAbsent(TransportBulkAction.java:516)
    [junit] 	at org.elasticsearch.action.bulk.TransportBulkAction$BulkOperation.addFailureIfIndexIsUnavailable(TransportBulkAction.java:470)
    [junit] 	at org.elasticsearch.action.bulk.TransportBulkAction$BulkOperation.doRun(TransportBulkAction.java:318)
    [junit] 	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
    [junit] 	at org.elasticsearch.action.bulk.TransportBulkAction.executeBulk(TransportBulkAction.java:496)
    [junit] 	at org.elasticsearch.action.bulk.TransportBulkAction.executeIngestAndBulk(TransportBulkAction.java:243)
    [junit] 	at org.elasticsearch.action.bulk.TransportBulkAction.doExecute(TransportBulkAction.java:203)
    [junit] 	at org.elasticsearch.action.bulk.TransportBulkAction.doExecute(TransportBulkAction.java:89)
    [junit] 	at org.elasticsearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:167)
    [junit] 	at org.elasticsearch.action.support.TransportAction.execute(TransportAction.java:139)
    [junit] 	at org.elasticsearch.action.bulk.TransportSingleItemBulkWriteAction.doExecute(TransportSingleItemBulkWriteAction.java:69)
    [junit] 	at org.elasticsearch.action.bulk.TransportSingleItemBulkWriteAction.doExecute(TransportSingleItemBulkWriteAction.java:44)
    [junit] 	at org.elasticsearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:167)
    [junit] 	at org.elasticsearch.action.support.TransportAction.execute(TransportAction.java:139)
    [junit] 	at org.elasticsearch.action.support.TransportAction.execute(TransportAction.java:81)
    [junit] 	at org.elasticsearch.client.node.NodeClient.executeLocally(NodeClient.java:87)
    [junit] 	at org.elasticsearch.client.node.NodeClient.doExecute(NodeClient.java:76)
    [junit] 	at org.elasticsearch.client.support.AbstractClient.execute(AbstractClient.java:395)
    [junit] 	at org.elasticsearch.client.support.AbstractClient.execute(AbstractClient.java:384)
    [junit] 	at org.elasticsearch.action.ActionRequestBuilder.execute(ActionRequestBuilder.java:46)
    [junit] 	at org.elasticsearch.action.ActionRequestBuilder.get(ActionRequestBuilder.java:53)
    [junit] 	at com.liferay.portal.search.elasticsearch6.internal.search.engine.adapter.document.DeleteDocumentRequestExecutorImpl.execute(DeleteDocumentRequestExecutorImpl.java:42)
    [junit] 	at com.liferay.portal.search.elasticsearch6.internal.search.engine.adapter.document.ElasticsearchDocumentRequestExecutor.executeDocumentRequest(ElasticsearchDocumentRequestExecutor.java:65)
    [junit] 	at com.liferay.portal.search.engine.adapter.document.DeleteDocumentRequest.accept(DeleteDocumentRequest.java:43)
    [junit] 	at com.liferay.portal.search.engine.adapter.document.DeleteDocumentRequest.accept(DeleteDocumentRequest.java:24)
    [junit] 	at com.liferay.portal.search.elasticsearch6.internal.search.engine.adapter.ElasticsearchSearchEngineAdapterImpl.execute(ElasticsearchSearchEngineAdapterImpl.java:75)
    [junit] 	at com.liferay.portal.search.elasticsearch6.internal.ElasticsearchIndexWriter.deleteDocument(ElasticsearchIndexWriter.java:166)
    [junit] 	at sun.reflect.GeneratedMethodAccessor420.invoke(Unknown Source)
    [junit] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    [junit] 	at java.lang.reflect.Method.invoke(Method.java:498)
    [junit] 	at com.liferay.portal.kernel.messaging.proxy.ProxyRequest.execute(ProxyRequest.java:82)
    [junit] 	at com.liferay.portal.kernel.messaging.proxy.ProxyMessageListener.receive(ProxyMessageListener.java:58)
    [junit] 	at com.liferay.portal.kernel.messaging.InvokerMessageListener.receive(InvokerMessageListener.java:74)
    [junit] 	at com.liferay.portal.messaging.internal.SynchronousDestination.send(SynchronousDestination.java:46)
    [junit] 	at com.liferay.portal.messaging.internal.DefaultMessageBus.sendMessage(DefaultMessageBus.java:237)
    [junit] 	at com.liferay.portal.kernel.messaging.MessageBusUtil.sendMessage(MessageBusUtil.java:81)
    [junit] 	at com.liferay.portal.kernel.messaging.proxy.BaseMultiDestinationProxyBean.send(BaseMultiDestinationProxyBean.java:34)
    [junit] 	at com.liferay.portal.messaging.proxy.MultiDestinationMessagingProxyInvocationHandler.invoke(MultiDestinationMessagingProxyInvocationHandler.java:53)
    [junit] 	at com.sun.proxy.$Proxy184.deleteDocument(Unknown Source)
    [junit] 	at com.liferay.portal.search.internal.IndexWriterHelperImpl.deleteDocument(IndexWriterHelperImpl.java:184)
    [junit] 	at com.liferay.portal.search.internal.indexer.IndexerWriterImpl.delete(IndexerWriterImpl.java:81)
    [junit] 	at com.liferay.portal.search.internal.indexer.IndexerWriterImpl.delete(IndexerWriterImpl.java:100)
    [junit] 	at com.liferay.portal.search.internal.indexer.DefaultIndexer.delete(DefaultIndexer.java:78)
    [junit] 	at com.liferay.portal.search.internal.indexer.DefaultIndexer.delete(DefaultIndexer.java:50)
    [junit] 	at com.liferay.portal.kernel.test.rule.DataGuardTestRule._smartDelete(DataGuardTestRule.java:541)
    [junit] 	at com.liferay.portal.kernel.test.rule.DataGuardTestRule._autoDeleteLeftovers(DataGuardTestRule.java:464)
    [junit] 	at com.liferay.portal.kernel.test.rule.DataGuardTestRule._autoDeleteAndAssert(DataGuardTestRule.java:364)
    [junit] 	at com.liferay.portal.kernel.test.rule.DataGuardTestRule.afterClass(DataGuardTestRule.java:109)
    [junit] 	at com.liferay.portal.kernel.test.rule.DataGuardTestRule.afterClass(DataGuardTestRule.java:69)
    [junit] 	at com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:66)
    [junit] 	at com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:59)
    [junit] 	at com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:59)
    [junit] 	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
    [junit] 	at com.liferay.arquillian.extension.junit.bridge.server.TestExecutorRunnable._execute(TestExecutorRunnable.java:181)
    [junit] 	at com.liferay.arquillian.extension.junit.bridge.server.TestExecutorRunnable.run(TestExecutorRunnable.java:95)
    [junit] 	at java.lang.Thread.run(Thread.java:745)