### PR TITLE
LPS-113026 Deprecate `liferay-toggler-interaction`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/toggler_interaction.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/toggler_interaction.js
@@ -12,6 +12,9 @@
  * details.
  */
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
 AUI.add(
 	'liferay-toggler-interaction',
 	(A) => {


### PR DESCRIPTION
Original review: https://github.com/wincent/liferay-portal/pull/284

Doing a manual forward because [unique test failure](https://github.com/wincent/liferay-portal/pull/284#issuecomment-633525002) in `ci:test:relevant` is obviously spurious (this is a comment-only change).

Original description:

---

The only usage of the `liferay-toggler-interaction` AUI component was in the [`liferay-product-navigation-control-menu-add-application`](https://github.com/liferay/liferay-portal/blob/8abc9337c7f4acd55e8ef803632f26090cafe3be/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_application.js) component - but the `togglerDelegate` variable declared [here](https://github.com/liferay/liferay-portal/blob/8abc9337c7f4acd55e8ef803632f26090cafe3be/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_application.js#L108) is always `undefined` because the `addApplicationPanelContainer` is no longer present in the markup (last instantiation removed in [efaf1f6105](https://github.com/liferay/liferay-portal/commit/efaf1f61051ef7a4b968b08628879dcee460452e), "LPS-62073 Adapt add aplication panel styles to new design", Jan 2016).