### PR TITLE
LPS-112983 Deprecate liferay-browser-selectors

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/java/com/liferay/frontend/js/aui/web/internal/servlet/AUITopHeadResources.java
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/java/com/liferay/frontend/js/aui/web/internal/servlet/AUITopHeadResources.java
@@ -81,8 +81,7 @@ public class AUITopHeadResources implements TopHeadResources {
 	}
 
 	private static final String[] _FILE_NAMES_AUI_CORE = {
-		"/aui/aui/aui.js", "/liferay/modules.js",
-		"/liferay/browser_selectors.js", "/liferay/aui_sandbox.js",
+		"/aui/aui/aui.js", "/liferay/modules.js", "/liferay/aui_sandbox.js",
 		"/aui/attribute-base/attribute-base.js",
 		"/aui/attribute-complex/attribute-complex.js",
 		"/aui/attribute-core/attribute-core.js",
@@ -150,9 +149,9 @@ public class AUITopHeadResources implements TopHeadResources {
 		"/aui/aui-node-base/aui-node-base.js",
 		"/aui/aui-node-html5/aui-node-html5.js",
 		"/aui/aui-selector/aui-selector.js", "/aui/aui-timer/aui-timer.js",
-		"/liferay/language.js", "/liferay/form.js",
-		"/liferay/form_placeholders.js", "/liferay/icon.js", "/liferay/menu.js",
-		"/liferay/notice.js", "/liferay/poller.js"
+		"/liferay/browser_selectors.js", "/liferay/language.js",
+		"/liferay/form.js", "/liferay/form_placeholders.js", "/liferay/icon.js",
+		"/liferay/menu.js", "/liferay/notice.js", "/liferay/poller.js"
 	};
 
 	private static final String[] _FILE_NAMES_AUI_PRELOAD_AUTHENTICATED = {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/browser_selectors.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/browser_selectors.js
@@ -12,6 +12,9 @@
  * details.
  */
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
 YUI.add(
 	'liferay-browser-selectors',
 	(A) => {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/layout.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/layout.js
@@ -158,8 +158,7 @@ AUI.add(
 
 					if (!firstPortletStatic || firstPortletStatic == 'end') {
 						referencePortlet = firstPortlet;
-					}
-					else {
+					} else {
 						portlets.each((item) => {
 							var isStatic = item.isStatic;
 
@@ -533,12 +532,11 @@ AUI.add(
 			});
 
 			if (layoutContainer) {
-				if (!A.UA.touch) {
+				if (!A.UA.touchEnabled) {
 					layoutContainer.once('mousemove', () => {
 						Liferay.fire('initLayout');
 					});
-				}
-				else {
+				} else {
 					Liferay.fire('initLayout');
 				}
 			}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/layout.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/layout.js
@@ -158,7 +158,8 @@ AUI.add(
 
 					if (!firstPortletStatic || firstPortletStatic == 'end') {
 						referencePortlet = firstPortlet;
-					} else {
+					}
+					else {
 						portlets.each((item) => {
 							var isStatic = item.isStatic;
 
@@ -536,7 +537,8 @@ AUI.add(
 					layoutContainer.once('mousemove', () => {
 						Liferay.fire('initLayout');
 					});
-				} else {
+				}
+				else {
 					Liferay.fire('initLayout');
 				}
 			}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
@@ -274,8 +274,12 @@
 							'liferay-input-move-boxes-touch': {
 								condition: {
 									name: 'liferay-input-move-boxes-touch',
+									test(A) {
+										return (
+											A.UA.touchEnabled && !!A.UA.mobile
+										);
+									},
 									trigger: 'liferay-input-move-boxes',
-									ua: 'touchMobile',
 								},
 							},
 						},
@@ -390,8 +394,10 @@
 								condition: {
 									name:
 										'liferay-navigation-interaction-touch',
+									test(A) {
+										return A.UA.touchEnabled;
+									},
 									trigger: 'liferay-navigation-interaction',
-									ua: 'touch',
 								},
 							},
 						},

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -103,8 +103,7 @@
 						loadHTML(responseHTML);
 					},
 				});
-			}
-			else {
+			} else {
 				loadHTML(responseHTML);
 			}
 		},
@@ -173,8 +172,7 @@
 				placeHolder = A.Node.create(
 					'<div class="loading-animation" />'
 				);
-			}
-			else {
+			} else {
 				placeHolder = A.one(placeHolder);
 			}
 
@@ -239,8 +237,7 @@
 						nestedPortletOffset += nestedPortlet
 							.all('.portlet-boundary')
 							.size();
-					}
-					else if (nestedPortletIndex >= portletPosition) {
+					} else if (nestedPortletIndex >= portletPosition) {
 						return true;
 					}
 				});
@@ -273,8 +270,7 @@
 			if (!options.placeHolder && !options.plid) {
 				if (!hasStaticPortlet) {
 					container.prepend(placeHolder);
-				}
-				else {
+				} else {
 					firstPortlet.placeAfter(placeHolder);
 				}
 			}
@@ -362,8 +358,7 @@
 					if (onComplete) {
 						onComplete(portletBoundary, portletId);
 					}
-				}
-				else {
+				} else {
 					placeHolder.remove();
 				}
 
@@ -381,19 +376,16 @@
 				.then((response) => {
 					if (dataType === 'JSON') {
 						return response.json();
-					}
-					else {
+					} else {
 						return response.text();
 					}
 				})
 				.then((response) => {
 					if (dataType === 'HTML') {
 						addPortletReturn(response);
-					}
-					else if (response.refresh) {
+					} else if (response.refresh) {
 						addPortletReturn(response.portletHTML);
-					}
-					else {
+					} else {
 						Portlet._loadMarkupHeadElements(response);
 						Portlet._loadPortletFiles(response, addPortletReturn);
 					}
@@ -452,8 +444,7 @@
 				Liferay.fire('destroyPortlet', options);
 
 				Liferay.fire('closePortlet', options);
-			}
-			else {
+			} else {
 				A.config.win.focus();
 			}
 		},
@@ -512,12 +503,11 @@
 				// Functions to run on portlet load
 
 				if (canEditTitle) {
-
 					// https://github.com/yui/yui3/issues/1808
 
 					var events = 'focus';
 
-					if (!A.UA.touch) {
+					if (!A.UA.touchEnabled) {
 						events = ['focus', 'mousemove'];
 					}
 
@@ -617,8 +607,7 @@
 						placeHolder,
 						url,
 					});
-				}
-				else if (!portlet.getData('pendingRefresh')) {
+				} else if (!portlet.getData('pendingRefresh')) {
 					portlet.setData('pendingRefresh', true);
 
 					var nonAjaxableContentMessage = Lang.sub(TPL_NOT_AJAXABLE, [
@@ -648,8 +637,7 @@
 
 			if (Node && portletId instanceof Node) {
 				portletId = portletId.attr('id');
-			}
-			else if (portletId.id) {
+			} else if (portletId.id) {
 				portletId = portletId.id;
 			}
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -103,7 +103,8 @@
 						loadHTML(responseHTML);
 					},
 				});
-			} else {
+			}
+			else {
 				loadHTML(responseHTML);
 			}
 		},
@@ -172,7 +173,8 @@
 				placeHolder = A.Node.create(
 					'<div class="loading-animation" />'
 				);
-			} else {
+			}
+			else {
 				placeHolder = A.one(placeHolder);
 			}
 
@@ -237,7 +239,8 @@
 						nestedPortletOffset += nestedPortlet
 							.all('.portlet-boundary')
 							.size();
-					} else if (nestedPortletIndex >= portletPosition) {
+					}
+					else if (nestedPortletIndex >= portletPosition) {
 						return true;
 					}
 				});
@@ -270,7 +273,8 @@
 			if (!options.placeHolder && !options.plid) {
 				if (!hasStaticPortlet) {
 					container.prepend(placeHolder);
-				} else {
+				}
+				else {
 					firstPortlet.placeAfter(placeHolder);
 				}
 			}
@@ -358,7 +362,8 @@
 					if (onComplete) {
 						onComplete(portletBoundary, portletId);
 					}
-				} else {
+				}
+				else {
 					placeHolder.remove();
 				}
 
@@ -376,16 +381,19 @@
 				.then((response) => {
 					if (dataType === 'JSON') {
 						return response.json();
-					} else {
+					}
+					else {
 						return response.text();
 					}
 				})
 				.then((response) => {
 					if (dataType === 'HTML') {
 						addPortletReturn(response);
-					} else if (response.refresh) {
+					}
+					else if (response.refresh) {
 						addPortletReturn(response.portletHTML);
-					} else {
+					}
+					else {
 						Portlet._loadMarkupHeadElements(response);
 						Portlet._loadPortletFiles(response, addPortletReturn);
 					}
@@ -444,7 +452,8 @@
 				Liferay.fire('destroyPortlet', options);
 
 				Liferay.fire('closePortlet', options);
-			} else {
+			}
+			else {
 				A.config.win.focus();
 			}
 		},
@@ -503,6 +512,7 @@
 				// Functions to run on portlet load
 
 				if (canEditTitle) {
+
 					// https://github.com/yui/yui3/issues/1808
 
 					var events = 'focus';
@@ -607,7 +617,8 @@
 						placeHolder,
 						url,
 					});
-				} else if (!portlet.getData('pendingRefresh')) {
+				}
+				else if (!portlet.getData('pendingRefresh')) {
 					portlet.setData('pendingRefresh', true);
 
 					var nonAjaxableContentMessage = Lang.sub(TPL_NOT_AJAXABLE, [
@@ -637,7 +648,8 @@
 
 			if (Node && portletId instanceof Node) {
 				portletId = portletId.attr('id');
-			} else if (portletId.id) {
+			}
+			else if (portletId.id) {
 				portletId = portletId.id;
 			}
 

--- a/modules/apps/frontend-theme/frontend-theme-browser-support/bnd.bnd
+++ b/modules/apps/frontend-theme/frontend-theme-browser-support/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Frontend Theme Browser Support
+Bundle-SymbolicName: com.liferay.frontend.theme.browser.support
+Bundle-Version: 1.0.0

--- a/modules/apps/frontend-theme/frontend-theme-browser-support/build.gradle
+++ b/modules/apps/frontend-theme/frontend-theme-browser-support/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":core:petra:petra-string")
+}

--- a/modules/apps/frontend-theme/frontend-theme-browser-support/src/main/java/com/liferay/frontend/theme/browser/support/internal/theme/contributor/BrowserTemplateContextContributor.java
+++ b/modules/apps/frontend-theme/frontend-theme-browser-support/src/main/java/com/liferay/frontend/theme/browser/support/internal/theme/contributor/BrowserTemplateContextContributor.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.theme.browser.support.internal.theme.contributor;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
+import com.liferay.portal.kernel.template.TemplateContextContributor;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Chema Balsas
+ */
+@Component(
+	immediate = true,
+	property = "type=" + TemplateContextContributor.TYPE_THEME,
+	service = TemplateContextContributor.class
+)
+public class BrowserTemplateContextContributor
+	implements TemplateContextContributor {
+
+	@Override
+	public void prepare(
+		Map<String, Object> contextObjects,
+		HttpServletRequest httpServletRequest) {
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(GetterUtil.getString(contextObjects.get("bodyCssClass")));
+		sb.append(StringPool.SPACE);
+		sb.append(BrowserSnifferUtil.getBrowserId(httpServletRequest));
+
+		if (BrowserSnifferUtil.isMobile(httpServletRequest)) {
+			sb.append(StringPool.SPACE);
+			sb.append("mobile");
+		}
+
+		contextObjects.put("bodyCssClass", sb.toString());
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/servlet/BrowserSnifferImpl.java
+++ b/portal-impl/src/com/liferay/portal/servlet/BrowserSnifferImpl.java
@@ -51,7 +51,10 @@ public class BrowserSnifferImpl implements BrowserSniffer {
 		BrowserMetadata browserMetadata = getBrowserMetadata(
 			httpServletRequest);
 
-		if (browserMetadata.isEdge()) {
+		if (browserMetadata.isChrome()) {
+			return BROWSER_ID_CHROME;
+		}
+		else if (browserMetadata.isEdge()) {
 			return BROWSER_ID_EDGE;
 		}
 		else if (browserMetadata.isIe()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/BrowserSniffer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/BrowserSniffer.java
@@ -26,6 +26,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface BrowserSniffer {
 
+	public static final String BROWSER_ID_CHROME = "chrome";
+
 	public static final String BROWSER_ID_EDGE = "edge";
 
 	public static final String BROWSER_ID_FIREFOX = "firefox";

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/packageinfo
@@ -1,1 +1,1 @@
-version 8.2.0
+version 8.3.0

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -57,8 +57,6 @@
 			</c:if>
 		</c:otherwise>
 	</c:choose>
-
-	Liferay.BrowserSelectors.run();
 </aui:script>
 
 <aui:script>

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -618,3 +618,38 @@ archived. Skipping initialization by default streamlines page loads for the
 common case.
 
 ---------------------------------------
+
+### Liferay.BrowserSelectors.run Is No Longer called
+- **Date:** 2020-May-26
+- **JIRA Ticket:** [LPS-112983](https://issues.liferay.com/browse/LPS-112983)
+
+#### What changed?
+
+The `Liferay.BrowserSelectors.run` function is no longer been called and as a
+result some CSS classes are no longer present in the top `<html>` element,
+ now most of these are present in the `<body>` element.
+
+#### Who is affected?
+
+This affects any code that relies on having the following CSS classes set on
+the top `<html>` element: `aol`, `camino`, `edgeHTML` `edge`, `firefox`,
+`flock` `gecko`, `icab`, `ie11`, `ie6`, `ie7`, `ie9`, `ie`, `js` `konqueror`,
+`mac` `mozilla`, `netscape`, `opera`, `presto`, `safari` `secure`, `touch`,
+`trident`, `webkit`, `win`.
+
+Instead, depending on which browser is being used, the following classes are
+added to the `<body>` element: `chrome`, `edge`, `firefox`, `ie`, `mobile`
+and `other`.
+
+#### How should I update my code?
+
+There's no direct replacement for the `Liferay.BrowserSelectors.run` function,
+but you can adapt your CSS to target the `<body>` element.
+
+#### Why was this change made?
+
+The classes added to the top `<html>` element where being added via JavaScript,
+with this change it is now done on the server side to streamline page loads.
+Some CSS classes where targeting some older browsers and weren't needed anymore.
+
+---------------------------------------

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -619,37 +619,49 @@ common case.
 
 ---------------------------------------
 
-### Liferay.BrowserSelectors.run Is No Longer called
+### Liferay.BrowserSelectors.run Is No Longer Called
 - **Date:** 2020-May-26
 - **JIRA Ticket:** [LPS-112983](https://issues.liferay.com/browse/LPS-112983)
 
 #### What changed?
 
-The `Liferay.BrowserSelectors.run` function is no longer been called and as a
-result some CSS classes are no longer present in the top `<html>` element,
- now most of these are present in the `<body>` element.
+The `Liferay.BrowserSelectors.run()` function is no longer called on all pages
+and as a result some CSS classes are no longer present in the opening `<html>`
+tag. Many of these are now added to the `<body>` element instead.
 
 #### Who is affected?
 
-This affects any code that relies on having the following CSS classes set on
-the top `<html>` element: `aol`, `camino`, `edgeHTML` `edge`, `firefox`,
-`flock` `gecko`, `icab`, `ie11`, `ie6`, `ie7`, `ie9`, `ie`, `js` `konqueror`,
-`mac` `mozilla`, `netscape`, `opera`, `presto`, `safari` `secure`, `touch`,
-`trident`, `webkit`, `win`.
+This affects any code that relies on having the following CSS classes set on the
+`<html>` element: `aol`, `camino`, `edgeHTML` `edge`, `firefox`, `flock`
+`gecko`, `icab`, `ie11`, `ie6`, `ie7`, `ie9`, `ie`, `js` `konqueror`, `mac`
+`mozilla`, `netscape`, `opera`, `presto`, `safari` `secure`, `touch`, `trident`,
+`webkit`, and `win`.
 
 Instead, depending on which browser is being used, the following classes are
-added to the `<body>` element: `chrome`, `edge`, `firefox`, `ie`, `mobile`
+added to the `<body>` element: `chrome`, `edge`, `firefox`, `ie`, `mobile`,
 and `other`.
 
 #### How should I update my code?
 
-There's no direct replacement for the `Liferay.BrowserSelectors.run` function,
-but you can adapt your CSS to target the `<body>` element.
+There's no direct replacement for the `Liferay.BrowserSelectors.run()`
+function, but you can adapt your CSS and JS to target the new classes on
+the `<body>` element instead.
+
+Alternatively, you can still invoke `Liferay.BrowserSelectors.run()` to
+apply the old classes to the `<html>` element with the following code:
+
+```
+<aui:script use="liferay-browser-selectors">
+	Liferay.BrowserSelectors.run();
+</aui:script>
+```
 
 #### Why was this change made?
 
-The classes added to the top `<html>` element where being added via JavaScript,
-with this change it is now done on the server side to streamline page loads.
-Some CSS classes where targeting some older browsers and weren't needed anymore.
+The classes added to the top `<html>` element were being added via
+legacy JavaScript that depended on Alloy UI. With this change it is now
+done on the server side, streamlining page loads. Additionally, some of
+the previously added CSS classes were related to older browsers and are
+no longer relevant.
 
 ---------------------------------------


### PR DESCRIPTION
Manual forward from [wincent#296](https://github.com/wincent/liferay-portal/pull/296) because I don't want to waste CI resources re-running green tests after a trivial edit to a Markdown file (ci:test:sf passed on the edit).

Previous green test runs:

- [ci:test:relevant](https://github.com/wincent/liferay-portal/pull/296#issuecomment-634028594)
- [ci:test:sf](https://github.com/wincent/liferay-portal/pull/296#issuecomment-634101220)

Original message follows:

---

Previously:

- https://github.com/wincent/liferay-portal/pull/294
- https://github.com/wincent/liferay-portal/pull/291
- https://github.com/wincent/liferay-portal/pull/249

---

This is a follow up on #294, and is what I did since then:

- Fixed the source formatting for the files we mentioned [here](https://github.com/wincent/liferay-portal/pull/294#discussion_r430252746) 
- Deprecated the `liferay-browser-selectors` AUI module

I also checked for usages for the remaining css classes: 

For `.safari`:

I didn't find any usages in CSS, and for JavaScript usages, we have: 

https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js#L305

- This doesn't depend on the classes added to `document.documentElement` by `Liferay.BrowserSelectors.run`, it uses `A.UA.safari` which is defined [here](https://github.com/yui/yui3/blob/25264e3629b1c07fb779d203c4a25c0879ec862c/src/yui/js/yui-ua.js#L116), and get's modified [here](https://github.com/yui/yui3/blob/25264e3629b1c07fb779d203c4a25c0879ec862c/src/yui/js/yui-ua.js#L318), and "reset" [here](https://github.com/yui/yui3/blob/25264e3629b1c07fb779d203c4a25c0879ec862c/src/yui/js/yui-ua.js#L389)
	
- It's in `frontend-js-aui-web` and we'll end up migrating or deprecating this function as well

For `.secure` this is the only usage I found:

https://github.com/liferay/liferay-portal/blob/8abc9337c7f4acd55e8ef803632f26090cafe3be/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js#L362

- It doesn't depend on the classes added to `document.documentElement` by `Liferay.BrowserSelectors.run`, it uses `A.UA.secure` which is defined [here](https://github.com/yui/yui3/blob/25264e3629b1c07fb779d203c4a25c0879ec862c/src/yui/js/yui-ua.js#L231) and get's set [here](https://github.com/yui/yui3/blob/25264e3629b1c07fb779d203c4a25c0879ec862c/src/yui/js/yui-ua.js#L286) (and it looks like an "easy" replacement)
- It's in `frontend-js-aui-web` and we'll end up migrating or deprecating this function as well

For `.touch` as @jbalsas mentioned, we have 3 usages in CSS and the JS usages have been updated to use `UA.touchEnabled`.

Thanks again for your help on this one