### PR TITLE
LPS-113556 Deprecate `aui_sandbox`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/aui_sandbox.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/aui_sandbox.js
@@ -12,6 +12,9 @@
  * details.
  */
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
 (function () {
 	var ALLOY = YUI();
 


### PR DESCRIPTION
Manual forward from https://github.com/wincent/liferay-portal/pull/300 because we have a [green CI run on that](https://github.com/wincent/liferay-portal/pull/300#issuecomment-634605171) and I edited the commit message but I don't want to have to run it all again for a comment-only change.

Original message follows:

---

`aui_sandbox` overrides the original `YUI.use` function as well as [defining an `AUI` global][0] on the `window` object.

In this change we're marking the module as deprecated, because both [the `use()` function][1] (which is the basic dependency loading mechanism in AUI), and the `AUI` global itself will eventually become unused as we work through [LPS-98564][2] ("Remove AUI / YUI from Liferay Portal").

[0]: https://github.com/liferay/liferay-portal/blob/9617f95b39dbb47f032785f08b71932038e1bb9e/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/aui_sandbox.js#L42-L44
[1]: https://yuilibrary.com/yui/docs/yui/#dynamic-loading-with-use
[2]: https://issues.liferay.com/browse/LPS-98564
