### PR TITLE
LPS-112464 Clay 3.x IconTag, BadgeTag, LabelTag and StickerTag

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
@@ -40,8 +40,8 @@ if (accountEntryDisplay != null) {
 
 <clay:sheet-section>
 	<clay:content-row
-		className="sheet-subtitle"
 		containerElement="h3"
+		cssClass="sheet-subtitle"
 	>
 		<clay:content-col
 			expand="true"

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/parent_account_entry.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/parent_account_entry.jsp
@@ -40,8 +40,8 @@ if (accountEntryDisplay != null) {
 
 <clay:sheet-section>
 	<clay:content-row
-		className="sheet-subtitle"
 		containerElement="h3"
+		cssClass="sheet-subtitle"
 	>
 		<clay:content-col
 			expand="true"

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/view.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/view.jsp
@@ -85,8 +85,8 @@ ViewAccountEntriesManagementToolbarDisplayContext viewAccountEntriesManagementTo
 					name="status"
 				>
 					<clay:label
+						displayType="<%= accountEntryDisplay.getStatusLabelStyle() %>"
 						label="<%= StringUtil.toUpperCase(LanguageUtil.get(request, accountEntryDisplay.getStatusLabel()), locale) %>"
-						style="<%= accountEntryDisplay.getStatusLabelStyle() %>"
 					/>
 				</liferay-ui:search-container-column-text>
 

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/view.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/view.jsp
@@ -86,7 +86,7 @@ ViewAccountEntriesManagementToolbarDisplayContext viewAccountEntriesManagementTo
 				>
 					<clay:label
 						displayType="<%= accountEntryDisplay.getStatusLabelStyle() %>"
-						label="<%= StringUtil.toUpperCase(LanguageUtil.get(request, accountEntryDisplay.getStatusLabel()), locale) %>"
+						label="<%= accountEntryDisplay.getStatusLabel() %>"
 					/>
 				</liferay-ui:search-container-column-text>
 

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/account_user/account_entries.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/account_user/account_entries.jsp
@@ -56,8 +56,8 @@ portletDisplay.setURLBack(backURL);
 		</h2>
 
 		<clay:content-row
-			className="sheet-subtitle"
 			containerElement="h3"
+			cssClass="sheet-subtitle"
 		>
 			<clay:content-col
 				expand="true"

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entries.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entries.jsp
@@ -52,8 +52,8 @@ SelectAccountEntriesManagementToolbarDisplayContext selectAccountEntriesManageme
 				name="status"
 			>
 				<clay:label
+					displayType="<%= accountEntryDisplay.getStatusLabelStyle() %>"
 					label="<%= StringUtil.toUpperCase(LanguageUtil.get(request, accountEntryDisplay.getStatusLabel()), locale) %>"
-					style="<%= accountEntryDisplay.getStatusLabelStyle() %>"
 				/>
 			</liferay-ui:search-container-column-text>
 		</liferay-ui:search-container-row>

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entries.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entries.jsp
@@ -53,7 +53,7 @@ SelectAccountEntriesManagementToolbarDisplayContext selectAccountEntriesManageme
 			>
 				<clay:label
 					displayType="<%= accountEntryDisplay.getStatusLabelStyle() %>"
-					label="<%= StringUtil.toUpperCase(LanguageUtil.get(request, accountEntryDisplay.getStatusLabel()), locale) %>"
+					label="<%= accountEntryDisplay.getStatusLabel() %>"
 				/>
 			</liferay-ui:search-container-column-text>
 		</liferay-ui:search-container-row>

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/view.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/view.jsp
@@ -103,7 +103,7 @@ AccountUsersAdminManagementToolbarDisplayContext accountUsersAdminManagementTool
 				>
 					<clay:label
 						displayType="<%= accountUserDisplay.getStatusLabelStyle() %>"
-						label="<%= StringUtil.toUpperCase(LanguageUtil.get(request, accountUserDisplay.getStatusLabel()), locale) %>"
+						label="<%= accountUserDisplay.getStatusLabel() %>"
 					/>
 				</liferay-ui:search-container-column-text>
 

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/view.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/view.jsp
@@ -102,8 +102,8 @@ AccountUsersAdminManagementToolbarDisplayContext accountUsersAdminManagementTool
 					name="status"
 				>
 					<clay:label
+						displayType="<%= accountUserDisplay.getStatusLabelStyle() %>"
 						label="<%= StringUtil.toUpperCase(LanguageUtil.get(request, accountUserDisplay.getStatusLabel()), locale) %>"
-						style="<%= accountUserDisplay.getStatusLabelStyle() %>"
 					/>
 				</liferay-ui:search-container-column-text>
 

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/view.jsp
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/view.jsp
@@ -36,7 +36,7 @@ PortletURL portletURL = renderResponse.createRenderURL();
 %>
 
 <clay:container-fluid
-	className="closed sidenav-container sidenav-right"
+	cssClass="closed sidenav-container sidenav-right"
 	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 >
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/adaptive_media/info_panel" var="sidebarPanelURL" />

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts.jsp
@@ -88,12 +88,11 @@ Set<String> syncedUserGroupIds = SetUtil.fromArray(analyticsConfiguration.synced
 			</c:choose>
 
 				<div class="pr-3">
-					<div class="bg-light sticker sticker-light sticker-rounded">
-						<liferay-ui:icon
-							icon="users"
-							markupView="lexicon"
-						/>
-					</div>
+					<clay:sticker
+						className="sticker-light"
+						displayType="light"
+						icon="users"
+					/>
 				</div>
 
 				<div>
@@ -130,12 +129,11 @@ Set<String> syncedUserGroupIds = SetUtil.fromArray(analyticsConfiguration.synced
 			</c:choose>
 
 				<div class="pr-3">
-					<div class="bg-light sticker sticker-light sticker-rounded">
-						<liferay-ui:icon
-							icon="organizations"
-							markupView="lexicon"
-						/>
-					</div>
+					<clay:sticker
+						className="sticker-light"
+						displayType="light"
+						icon="organizations"
+					/>
 				</div>
 
 				<div>

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts.jsp
@@ -89,7 +89,7 @@ Set<String> syncedUserGroupIds = SetUtil.fromArray(analyticsConfiguration.synced
 
 				<div class="pr-3">
 					<clay:sticker
-						className="sticker-light"
+						cssClass="sticker-light"
 						displayType="light"
 						icon="users"
 					/>
@@ -130,7 +130,7 @@ Set<String> syncedUserGroupIds = SetUtil.fromArray(analyticsConfiguration.synced
 
 				<div class="pr-3">
 					<clay:sticker
-						className="sticker-light"
+						cssClass="sticker-light"
 						displayType="light"
 						icon="organizations"
 					/>

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/edit_entry.jsp
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/edit_entry.jsp
@@ -22,12 +22,12 @@ AppBuilderApp appBuilderApp = (AppBuilderApp)request.getAttribute(AppBuilderWebK
 
 <div class="app-builder-root">
 	<clay:container-fluid
-		className="edit-entry"
+		cssClass="edit-entry"
 	>
 		<div id="<%= renderResponse.getNamespace() %>-control-menu"></div>
 
 		<clay:row
-			className="justify-content-center"
+			cssClass="justify-content-center"
 		>
 			<clay:col
 				lg="12"

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/layout/view.jsp
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/layout/view.jsp
@@ -33,7 +33,7 @@ if (mvcPath.startsWith("/edit_entry.jsp")) {
 <div class="app-builder-standalone">
 	<header class="app-builder-standalone-header">
 		<clay:container-fluid
-			className="p-0"
+			cssClass="p-0"
 		>
 			<div class="app-builder-standalone-menu autofit-row">
 				<div class="autofit-col autofit-col-expand">
@@ -65,7 +65,7 @@ if (mvcPath.startsWith("/edit_entry.jsp")) {
 	</header>
 
 	<clay:container-fluid
-		className="app-builder-standalone-content <%= editEntryCssClass %> sheet"
+		cssClass="app-builder-standalone-content <%= editEntryCssClass %> sheet"
 	>
 		<liferay-portlet:runtime
 			portletName="<%= portletName %>"

--- a/modules/apps/application-list/application-list-taglib/build.gradle
+++ b/modules/apps/application-list/application-list-taglib/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.http.whiteboard", version: "1.0.0"
 	compileOnly project(":apps:application-list:application-list-api")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -18,6 +18,7 @@
 
 <%@ taglib uri="http://liferay.com/tld/application-list" prefix="liferay-application-list" %><%@
 taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 

--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel_app/page.jsp
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel_app/page.jsp
@@ -32,7 +32,7 @@ String url = (String)request.getAttribute("liferay-application-list:panel-app:ur
 
 			<c:if test="<%= notificationsCount > 0 %>">
 				<clay:badge
-					className="float-right"
+					cssClass="float-right"
 					displayType="danger"
 					label="<%= String.valueOf(notificationsCount) %>"
 				/>

--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel_app/page.jsp
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel_app/page.jsp
@@ -31,9 +31,11 @@ String url = (String)request.getAttribute("liferay-application-list:panel-app:ur
 			<%= label %>
 
 			<c:if test="<%= notificationsCount > 0 %>">
-				<span class="badge badge-danger float-right">
-					<span class="badge-item badge-item-expand"><%= notificationsCount %></span>
-				</span>
+				<clay:badge
+					className="float-right"
+					displayType="danger"
+					label="<%= String.valueOf(notificationsCount) %>"
+				/>
 			</c:if>
 		</aui:a>
 	</li>

--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel_category/start.jsp
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel_category/start.jsp
@@ -22,9 +22,12 @@
 			<%= panelCategory.getLabel(themeDisplay.getLocale()) %>
 
 			<c:if test="<%= notificationsCount > 0 %>">
-				<span class="badge badge-danger float-right panel-notifications-count">
-					<span class="badge-item badge-item-expand" data-qa-id="notificationsCount"><%= notificationsCount %></span>
-				</span>
+				<clay:badge
+					className="float-right panel-notifications-count"
+					data-qa-id="notificationsCount"
+					displayType="danger"
+					label="<%= String.valueOf(notificationsCount) %>"
+				/>
 			</c:if>
 		</c:if>
 

--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel_category/start.jsp
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel_category/start.jsp
@@ -23,7 +23,7 @@
 
 			<c:if test="<%= notificationsCount > 0 %>">
 				<clay:badge
-					className="float-right panel-notifications-count"
+					cssClass="float-right panel-notifications-count"
 					data-qa-id="notificationsCount"
 					displayType="danger"
 					label="<%= String.valueOf(notificationsCount) %>"

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
@@ -32,7 +32,7 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 %>
 
 <clay:container-fluid
-	className="container-view"
+	cssClass="container-view"
 >
 	<clay:row>
 		<clay:col

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_asset_list_entry_usages.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_asset_list_entry_usages.jsp
@@ -34,7 +34,7 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 %>
 
 <clay:container-fluid
-	className="container-form-lg"
+	cssClass="container-form-lg"
 >
 	<clay:row>
 		<clay:col

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/init.jsp" %>
 
 <clay:container-fluid
-	className="pt-3"
+	cssClass="pt-3"
 >
 	<liferay-ui:search-container
 		id="assetEntries"

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
@@ -360,7 +360,7 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 
 			<c:if test="<%= assetPublisherDisplayContext.isEnableComments() && assetRenderer.isCommentable() %>">
 				<clay:col
-					className="mt-4"
+					cssClass="mt-4"
 					md="12"
 				>
 					<liferay-comment:discussion

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -411,7 +411,7 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 
 	<c:if test="<%= assetPublisherDisplayContext.isEnableComments() && assetRenderer.isCommentable() %>">
 		<clay:col
-			className="mt-4"
+			cssClass="mt-4"
 			md="12"
 		>
 			<liferay-comment:discussion

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/page.jsp
@@ -78,7 +78,7 @@ List<Map<String, Object>> vocabularies = (List<Map<String, Object>>)data.get("vo
 										%>
 
 											<clay:label
-												closeable="<%= true %>"
+												dismissible="<%= true %>"
 												label="<%= selectedItemLabel %>"
 											/>
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_summary/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_summary/init.jsp
@@ -16,7 +16,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.asset.kernel.model.AssetCategory" %><%@
 page import="com.liferay.asset.kernel.model.AssetEntry" %><%@

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_summary/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_summary/page.jsp
@@ -62,9 +62,11 @@ for (AssetVocabulary vocabulary : vocabularies) {
 							for (AssetCategory category : curCategories) {
 							%>
 
-								<span class="label label-dark label-lg text-uppercase">
-									<%= HtmlUtil.escape(category.getTitle(themeDisplay.getLocale())) %>
-								</span>
+								<clay:label
+									displayType="dark"
+									label="<%= HtmlUtil.escape(category.getTitle(themeDisplay.getLocale())) %>"
+									large="true"
+								/>
 
 							<%
 							}

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_entry_usages/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_entry_usages/page.jsp
@@ -24,7 +24,7 @@ AssetEntryUsagesDisplayContext assetEntryUsagesDisplayContext = new AssetEntryUs
 %>
 
 <clay:container-fluid
-	className="container-form-lg"
+	cssClass="container-form-lg"
 >
 	<clay:row>
 		<clay:col

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_links/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_links/init.jsp
@@ -17,6 +17,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_links/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_links/page.jsp
@@ -48,9 +48,11 @@ List<Tuple> assetLinkEntries = (List<Tuple>)request.getAttribute("liferay-asset:
 						<c:choose>
 							<c:when test="<%= assetRenderer.getStatus() == WorkflowConstants.STATUS_SCHEDULED %>">
 								<%= HtmlUtil.escape(assetLinkEntry.getTitle(locale)) %>
-								<span class="label label-<%= WorkflowConstants.getStatusStyle(assetRenderer.getStatus()) %> ml-2 text-uppercase">
-									<liferay-ui:message key="<%= WorkflowConstants.getStatusLabel(assetRenderer.getStatus()) %>" />
-								</span>
+								<clay:label
+									className="ml-2"
+									displayType="%= WorkflowConstants.getStatusStyle(assetRenderer.getStatus()) %>"
+									label="<%= WorkflowConstants.getStatusLabel(assetRenderer.getStatus()) %>"
+								/>
 							</c:when>
 							<c:otherwise>
 								<aui:a cssClass="text-truncate" href="<%= (String)tuple.getObject(1) %>" target='<%= themeDisplay.isStatePopUp() ? "_blank" : "_self" %>'>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_links/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_links/page.jsp
@@ -35,11 +35,11 @@ List<Tuple> assetLinkEntries = (List<Tuple>)request.getAttribute("liferay-asset:
 
 		<li class="list-group-item list-group-item-flex">
 			<div class="autofit-col">
-				<div class="sticker sticker-secondary">
-					<span class="inline-item">
-						<aui:icon image="<%= assetRenderer.getIconCssClass() %>" markupView="lexicon" />
-					</span>
-				</div>
+				<clay:sticker
+					displayType="secondary"
+					icon="<%= assetRenderer.getIconCssClass() %>"
+					inline="true"
+				/>
 			</div>
 
 			<div class="autofit-col autofit-col-expand">

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_links/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_links/page.jsp
@@ -49,7 +49,7 @@ List<Tuple> assetLinkEntries = (List<Tuple>)request.getAttribute("liferay-asset:
 							<c:when test="<%= assetRenderer.getStatus() == WorkflowConstants.STATUS_SCHEDULED %>">
 								<%= HtmlUtil.escape(assetLinkEntry.getTitle(locale)) %>
 								<clay:label
-									className="ml-2"
+									cssClass="ml-2"
 									displayType="%= WorkflowConstants.getStatusStyle(assetRenderer.getStatus()) %>"
 									label="<%= WorkflowConstants.getStatusLabel(assetRenderer.getStatus()) %>"
 								/>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_metadata/metadata_entry.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_metadata/metadata_entry.jsp
@@ -113,7 +113,7 @@ else if (metadataField.equals("view-count")) {
 	</c:when>
 	<c:when test="<%= Validator.isNotNull(value) %>">
 		<clay:col
-			className="form-feedback-item"
+			cssClass="form-feedback-item"
 			md="3"
 			size="6"
 			sm="4"

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/page.jsp
@@ -50,7 +50,7 @@ List<Map<String, String>> selectedItems = (List<Map<String, String>>)data.get("s
 						%>
 
 							<clay:label
-								closeable="<%= true %>"
+								dismissible="<%= true %>"
 								label='<%= selectedItem.get("label") %>'
 							/>
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_summary/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_summary/init.jsp
@@ -16,7 +16,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %>
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %>
 
 <%@ page import="com.liferay.asset.kernel.model.AssetTag" %><%@
 page import="com.liferay.asset.kernel.service.AssetTagServiceUtil" %><%@

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_summary/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_summary/page.jsp
@@ -60,7 +60,11 @@ if (assetTagNames.length == 0) {
 				for (int i = 0; i < assetTagNames.length; i++) {
 				%>
 
-					<span class="label label-lg label-secondary text-uppercase"><%= assetTagNames[i] %></span>
+					<clay:label
+						displayType="secondary"
+						label="<%= assetTagNames[i] %>"
+						large="true"
+					/>
 
 				<%
 				}

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/categorization_filter/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/categorization_filter/init.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/categorization_filter/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/categorization_filter/page.jsp
@@ -67,7 +67,9 @@ if (assetCategoryId != 0) {
 
 			<clay:label-item-after>
 				<a href="<%= viewURLWithoutCategory %>" title='<liferay-ui:message key="remove" />'>
-					<clay:icon symbol="times-circle" />
+					<clay:icon
+						symbol="times-circle"
+					/>
 				</a>
 			</clay:label-item-after>
 		</clay:label>
@@ -91,7 +93,9 @@ if (assetCategoryId != 0) {
 
 			<clay:label-item-after>
 				<a href="<%= viewURLWithoutTag %>" title='<liferay-ui:message key="remove" />'>
-					<clay:icon symbol="times-circle" />
+					<clay:icon
+						symbol="times-circle"
+					/>
 				</a>
 			</clay:label-item-after>
 		</clay:label>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/categorization_filter/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/categorization_filter/page.jsp
@@ -58,15 +58,19 @@ if (assetCategoryId != 0) {
 			<portlet:param name="categoryId" value="0" />
 		</portlet:renderURL>
 
-		<span class="label label-dark label-dismissible label-lg text-uppercase">
-			<span class="label-item label-item-expand"><%= assetCategoryTitle %></span>
+		<clay:label
+			dismissible="true"
+			displayType="dark"
+			large="true"
+		>
+			<clay:label-item-expand><%= assetCategoryTitle %></clay:label-item-expand>
 
-			<span class="label-item label-item-after">
+			<clay:label-item-after>
 				<a href="<%= viewURLWithoutCategory %>" title='<liferay-ui:message key="remove" />'>
-					<aui:icon image="times-circle" markupView="lexicon" />
+					<clay:icon symbol="times-circle" />
 				</a>
-			</span>
-		</span>
+			</clay:label-item-after>
+		</clay:label>
 	</c:if>
 </liferay-util:buffer>
 
@@ -78,15 +82,19 @@ if (assetCategoryId != 0) {
 			<liferay-portlet:param name="tag" value="" />
 		</liferay-portlet:renderURL>
 
-		<span class="label label-dark label-dismissible label-lg text-uppercase">
-			<span class="label-item label-item-expand"><%= HtmlUtil.escape(assetTagName) %></span>
+		<clay:label
+			dismissible="true"
+			displayType="dark"
+			large="true"
+		>
+			<clay:label-item-expand><%= HtmlUtil.escape(assetTagName) %></clay:label-item-expand>
 
-			<span class="label-item label-item-after">
+			<clay:label-item-after>
 				<a href="<%= viewURLWithoutTag %>" title='<liferay-ui:message key="remove" />'>
-					<aui:icon image="times-circle" markupView="lexicon" />
+					<clay:icon symbol="times-circle" />
 				</a>
-			</span>
-		</span>
+			</clay:label-item-after>
+		</clay:label>
 	</c:if>
 </liferay-util:buffer>
 

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
@@ -57,7 +57,7 @@ renderResponse.setTitle((entry != null) ? BlogsEntryUtil.getDisplayTitle(resourc
 <portlet:actionURL name="/blogs/edit_entry" var="editEntryURL" />
 
 <clay:container-fluid
-	className="entry-body"
+	cssClass="entry-body"
 >
 	<aui:form action="<%= editEntryURL %>" cssClass="edit-entry" enctype="multipart/form-data" method="post" name="fm" onSubmit="event.preventDefault();">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
@@ -132,7 +132,7 @@ renderResponse.setTitle((entry != null) ? BlogsEntryUtil.getDisplayTitle(resourc
 					<aui:input name="coverImageCaption" type="hidden" />
 
 					<clay:col
-						className="col-md-offset-2"
+						cssClass="col-md-offset-2"
 						md="8"
 					>
 						<div class='cover-image-caption <%= (coverImageFileEntryId == 0) ? "invisible" : "" %>'>
@@ -149,7 +149,7 @@ renderResponse.setTitle((entry != null) ? BlogsEntryUtil.getDisplayTitle(resourc
 					</clay:col>
 
 					<clay:col
-						className="col-md-offset-2"
+						cssClass="col-md-offset-2"
 						md="8"
 					>
 						<div class="entry-title form-group">

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/entry_toolbar.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/entry_toolbar.jsp
@@ -28,7 +28,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 %>
 
 <clay:content-row
-	className="widget-toolbar"
+	cssClass="widget-toolbar"
 	floatElements="end"
 	verticalAlign="center"
 >
@@ -104,7 +104,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 	</c:if>
 
 	<clay:content-col
-		className="autofit-col-end"
+		cssClass="autofit-col-end"
 	>
 		<liferay-portlet:renderURL varImpl="bookmarkURL" windowState="<%= WindowState.NORMAL.toString() %>">
 			<portlet:param name="mvcRenderCommandName" value="/blogs/view_entry" />

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry.jsp
@@ -95,7 +95,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 		<c:if test="<%= (previousEntry != null) || (nextEntry != null) %>">
 			<clay:row>
 				<clay:col
-					className="col-md-offset-1 entry-navigation"
+					cssClass="col-md-offset-1 entry-navigation"
 					md="10"
 				>
 					<h2>
@@ -103,7 +103,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 					</h2>
 
 					<clay:row
-						className="widget-mode-card"
+						cssClass="widget-mode-card"
 					>
 
 						<%
@@ -125,7 +125,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 
 	<clay:row>
 		<clay:col
-			className="col-md-offset-2"
+			cssClass="col-md-offset-2"
 			md="8"
 		>
 			<c:if test="<%= blogsPortletInstanceConfiguration.enableComments() %>">

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content.jsp
@@ -42,7 +42,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 
 		<div class="widget-mode-simple-entry">
 			<clay:content-row
-				className="widget-topbar"
+				cssClass="widget-topbar"
 			>
 				<clay:content-col
 					expand="true"
@@ -61,7 +61,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 				</clay:content-col>
 
 				<clay:content-col
-					className="visible-interaction"
+					cssClass="visible-interaction"
 				>
 					<div class="dropdown dropdown-action">
 						<liferay-util:include page="/blogs/entry_action.jsp" servletContext="<%= application %>" />
@@ -70,7 +70,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 			</clay:content-row>
 
 			<clay:content-row
-				className="widget-metadata"
+				cssClass="widget-metadata"
 			>
 
 				<%
@@ -84,7 +84,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 				%>
 
 				<clay:content-col
-					className="inline-item-before"
+					cssClass="inline-item-before"
 				>
 					<liferay-ui:user-portrait
 						user="<%= entryUser %>"

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content_detail.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content_detail.jsp
@@ -43,7 +43,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 		</portlet:renderURL>
 
 		<clay:container-fluid
-			className="widget-mode-detail-header"
+			cssClass="widget-mode-detail-header"
 		>
 			<liferay-asset:asset-categories-available
 				className="<%= BlogsEntry.class.getName() %>"
@@ -51,7 +51,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 			>
 				<clay:row>
 					<clay:col
-						className="categories mx-auto widget-metadata"
+						cssClass="categories mx-auto widget-metadata"
 						md="8"
 					>
 						<liferay-asset:asset-categories-summary
@@ -66,7 +66,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 
 			<clay:row>
 				<clay:col
-					className="mx-auto"
+					cssClass="mx-auto"
 					md="8"
 				>
 					<clay:content-row>
@@ -85,7 +85,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 						</clay:content-col>
 
 						<clay:content-col
-							className="visible-interaction"
+							cssClass="visible-interaction"
 						>
 							<div class="dropdown dropdown-action">
 								<c:if test="<%= BlogsEntryPermission.contains(permissionChecker, entry, ActionKeys.UPDATE) %>">
@@ -112,7 +112,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 					</clay:content-row>
 
 					<clay:content-row
-						className="widget-metadata"
+						cssClass="widget-metadata"
 					>
 
 						<%
@@ -126,7 +126,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 						%>
 
 						<clay:content-col
-							className="inline-item-before"
+							cssClass="inline-item-before"
 						>
 							<liferay-ui:user-portrait
 								cssClass="sticker-lg"
@@ -180,7 +180,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 		<!-- text resume -->
 
 		<clay:container-fluid
-			className="widget-mode-detail-header"
+			cssClass="widget-mode-detail-header"
 			id="<%= renderResponse.getNamespace() + entry.getEntryId() %>"
 		>
 			<c:if test="<%= Validator.isNotNull(coverImageURL) %>">
@@ -192,7 +192,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 				<c:if test="<%= Validator.isNotNull(coverImageCaption) %>">
 					<clay:row>
 						<clay:col
-							className="mx-auto"
+							cssClass="mx-auto"
 							md="8"
 						>
 							<div class="cover-image-caption">
@@ -205,7 +205,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 
 			<clay:row>
 				<clay:col
-					className="mx-auto widget-mode-detail-text"
+					cssClass="mx-auto widget-mode-detail-text"
 					md="8"
 				>
 					<%= entry.getContent() %>
@@ -217,7 +217,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 			>
 				<clay:row>
 					<clay:col
-						className="mx-auto widget-mode-detail-text"
+						cssClass="mx-auto widget-mode-detail-text"
 						md="8"
 					>
 						<liferay-expando:custom-attribute-list
@@ -236,7 +236,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 			>
 				<clay:row>
 					<clay:col
-						className="mx-auto widget-mode-detail-text"
+						cssClass="mx-auto widget-mode-detail-text"
 						md="8"
 					>
 						<div class="entry-tags">
@@ -254,7 +254,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 		<clay:container-fluid>
 			<clay:row>
 				<clay:col
-					className="mx-auto widget-mode-detail-text"
+					cssClass="mx-auto widget-mode-detail-text"
 					md="8"
 				>
 
@@ -271,7 +271,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 			<c:if test="<%= blogsPortletInstanceConfiguration.enableRelatedAssets() %>">
 				<clay:row>
 					<clay:col
-						className="mx-auto widget-mode-detail-text"
+						cssClass="mx-auto widget-mode-detail-text"
 						md="8"
 					>
 

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_related.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_related.jsp
@@ -48,7 +48,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 
 			<div class="card-body widget-topbar">
 				<clay:content-row
-					className="card-title"
+					cssClass="card-title"
 				>
 					<clay:content-col
 						expand="true"
@@ -72,7 +72,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 				</clay:content-row>
 
 				<clay:content-row
-					className="widget-metadata"
+					cssClass="widget-metadata"
 				>
 
 					<%
@@ -86,7 +86,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 					%>
 
 					<clay:content-col
-						className="inline-item-before"
+						cssClass="inline-item-before"
 					>
 						<liferay-ui:user-portrait
 							user="<%= blogsEntryUser %>"
@@ -94,11 +94,11 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 					</clay:content-col>
 
 					<clay:content-col
-						className="inline-item-before"
+						cssClass="inline-item-before"
 					>
 						<clay:content-row>
 							<clay:content-col
-								className="inline-item-before"
+								cssClass="inline-item-before"
 							>
 								<div class="text-truncate-inline">
 									<a class="text-truncate username" href="<%= blogsEntryUserURL %>"><%= HtmlUtil.escape(blogsEntry.getUserName()) %></a>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_entries.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_entries.jsp
@@ -45,7 +45,7 @@ BlogEntriesManagementToolbarDisplayContext blogEntriesManagementToolbarDisplayCo
 />
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<aui:form action="<%= portletURL.toString() %>" method="get" name="fm">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
@@ -68,7 +68,7 @@ String displayStyle = blogImagesManagementToolbarDisplayContext.getDisplayStyle(
 />
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<portlet:actionURL name="/blogs/edit_image" var="editImageURL" />
 

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/asset/folder_full_content.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/asset/folder_full_content.jsp
@@ -35,7 +35,7 @@ BookmarksFolder folder = (BookmarksFolder)request.getAttribute(BookmarksWebKeys.
 
 	<clay:row>
 		<clay:col
-			className="lfr-asset-column lfr-asset-column-details"
+			cssClass="lfr-asset-column lfr-asset-column-details"
 		>
 			<c:if test="<%= Validator.isNotNull(folder.getDescription()) %>">
 				<div class="lfr-asset-description">

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/view.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/view.jsp
@@ -180,7 +180,7 @@ BookmarksUtil.addPortletBreadcrumbEntries(folder, request, renderResponse);
 </liferay-util:include>
 
 <clay:container-fluid
-	className="closed sidenav-container sidenav-right"
+	cssClass="closed sidenav-container sidenav-right"
 	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 >
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/bookmarks/info_panel" var="sidebarPanelURL">

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
@@ -386,7 +386,7 @@ while (manageableCalendarsIterator.hasNext()) {
 						</c:if>
 
 						<clay:row
-							className="calendar-booking-invitations"
+							cssClass="calendar-booking-invitations"
 						>
 							<clay:col
 								md="<%= (calendarBooking != null) ? String.valueOf(3) : String.valueOf(4) %>"

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar.jsp
@@ -82,7 +82,7 @@ boolean columnOptionsVisible = GetterUtil.getBoolean(SessionClicks.get(request, 
 </aui:script>
 
 <clay:container-fluid
-	className="calendar-portlet-column-parent"
+	cssClass="calendar-portlet-column-parent"
 >
 	<clay:row>
 		<c:if test="<%= !displaySchedulerOnly %>">
@@ -144,7 +144,7 @@ boolean columnOptionsVisible = GetterUtil.getBoolean(SessionClicks.get(request, 
 		</c:if>
 
 		<clay:col
-			className="calendar-portlet-column-grid"
+			cssClass="calendar-portlet-column-grid"
 			id='<%= renderResponse.getNamespace() + "columnGrid" %>'
 			md="<%= (columnOptionsVisible && !displaySchedulerOnly) ? String.valueOf(9) : String.valueOf(12) %>"
 		>

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar.jsp
@@ -87,7 +87,7 @@ boolean columnOptionsVisible = GetterUtil.getBoolean(SessionClicks.get(request, 
 	<clay:row>
 		<c:if test="<%= !displaySchedulerOnly %>">
 			<clay:col
-				className='<%= "calendar-portlet-column-options " + (columnOptionsVisible ? StringPool.BLANK : "hide") %>'
+				cssClass='<%= "calendar-portlet-column-options " + (columnOptionsVisible ? StringPool.BLANK : "hide") %>'
 				id='<%= renderResponse.getNamespace() + "columnOptions" %>'
 				md="3"
 			>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_changes.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_changes.jsp
@@ -39,8 +39,8 @@ portletDisplay.setShowBackIcon(true);
 							<span><%= HtmlUtil.escape(ctCollection.getName()) %></span>
 
 							<clay:label
+								displayType="<%= WorkflowConstants.getStatusStyle(ctCollection.getStatus()) %>"
 								label="<%= LanguageUtil.get(resourceBundle, viewChangesDisplayContext.getStatusLabel(ctCollection.getStatus())) %>"
-								style="<%= WorkflowConstants.getStatusStyle(ctCollection.getStatus()) %>"
 							/>
 						</div>
 
@@ -73,8 +73,8 @@ portletDisplay.setShowBackIcon(true);
 							<span><%= HtmlUtil.escape(ctCollection.getName()) %></span>
 
 							<clay:label
+								displayType="<%= WorkflowConstants.getStatusStyle(ctCollection.getStatus()) %>"
 								label="<%= LanguageUtil.get(resourceBundle, viewChangesDisplayContext.getStatusLabel(ctCollection.getStatus())) %>"
-								style="<%= WorkflowConstants.getStatusStyle(ctCollection.getStatus()) %>"
 							/>
 						</div>
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_changes.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_changes.jsp
@@ -40,7 +40,7 @@ portletDisplay.setShowBackIcon(true);
 
 							<clay:label
 								displayType="<%= WorkflowConstants.getStatusStyle(ctCollection.getStatus()) %>"
-								label="<%= LanguageUtil.get(resourceBundle, viewChangesDisplayContext.getStatusLabel(ctCollection.getStatus())) %>"
+								label="<%= viewChangesDisplayContext.getStatusLabel(ctCollection.getStatus()) %>"
 							/>
 						</div>
 
@@ -74,7 +74,7 @@ portletDisplay.setShowBackIcon(true);
 
 							<clay:label
 								displayType="<%= WorkflowConstants.getStatusStyle(ctCollection.getStatus()) %>"
-								label="<%= LanguageUtil.get(resourceBundle, viewChangesDisplayContext.getStatusLabel(ctCollection.getStatus())) %>"
+								label="<%= viewChangesDisplayContext.getStatusLabel(ctCollection.getStatus()) %>"
 							/>
 						</div>
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_conflicts.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_conflicts.jsp
@@ -34,7 +34,7 @@ portletDisplay.setURLBack(backURL);
 %>
 
 <clay:container-fluid
-	className="container-form-lg"
+	cssClass="container-form-lg"
 >
 	<div class="sheet-lg table-responsive">
 		<table class="change-lists-conflicts-table table table-autofit table-list">

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_history.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_history.jsp
@@ -85,7 +85,7 @@ Format format = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 						<div>
 							<clay:label
 								displayType="<%= viewHistoryDisplayContext.getStatusStyle(status) %>"
-								label="<%= LanguageUtil.get(resourceBundle, viewHistoryDisplayContext.getStatusLabel(status)) %>"
+								label="<%= viewHistoryDisplayContext.getStatusLabel(status) %>"
 							/>
 						</div>
 					</liferay-ui:search-container-column-text>
@@ -130,7 +130,7 @@ Format format = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 					>
 						<clay:label
 							displayType="<%= viewHistoryDisplayContext.getStatusStyle(status) %>"
-							label="<%= LanguageUtil.get(resourceBundle, viewHistoryDisplayContext.getStatusLabel(status)) %>"
+							label="<%= viewHistoryDisplayContext.getStatusLabel(status) %>"
 						/>
 					</liferay-ui:search-container-column-text>
 				</c:otherwise>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_history.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_history.jsp
@@ -84,8 +84,8 @@ Format format = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 
 						<div>
 							<clay:label
+								displayType="<%= viewHistoryDisplayContext.getStatusStyle(status) %>"
 								label="<%= LanguageUtil.get(resourceBundle, viewHistoryDisplayContext.getStatusLabel(status)) %>"
-								style="<%= viewHistoryDisplayContext.getStatusStyle(status) %>"
 							/>
 						</div>
 					</liferay-ui:search-container-column-text>
@@ -129,8 +129,8 @@ Format format = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 						name="status"
 					>
 						<clay:label
+							displayType="<%= viewHistoryDisplayContext.getStatusStyle(status) %>"
 							label="<%= LanguageUtil.get(resourceBundle, viewHistoryDisplayContext.getStatusLabel(status)) %>"
-							style="<%= viewHistoryDisplayContext.getStatusStyle(status) %>"
 						/>
 					</liferay-ui:search-container-column-text>
 				</c:otherwise>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/view.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/view.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/change_lists_configuration/init.jsp" %>
 
 <clay:container-fluid
-	className="container-form-lg"
+	cssClass="container-form-lg"
 >
 	<aui:form action="<%= changeListsConfigurationDisplayContext.getActionURL() %>" method="post" name="fm">
 		<aui:input name="navigation" type="hidden" value="<%= changeListsConfigurationDisplayContext.getNavigation() %>" />

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/search_results.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/search_results.jsp
@@ -48,7 +48,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "search-results"));
 />
 
 <clay:container-fluid
-	className="container-view"
+	cssClass="container-view"
 >
 	<liferay-ui:search-container
 		emptyResultsMessage="no-configurations-were-found"

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -36,7 +36,7 @@ ConfigurationScopeDisplayContext configurationScopeDisplayContext = Configuratio
 />
 
 <clay:container-fluid
-	className="container-view"
+	cssClass="container-view"
 >
 	<c:if test="<%= configurationCategorySectionDisplays.isEmpty() %>">
 		<liferay-ui:empty-result-message

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -72,7 +72,6 @@ ConfigurationScopeDisplayContext configurationScopeDisplayContext = Configuratio
 						<li class="list-group-card-item">
 							<a href="<%= viewCategoryHREF %>">
 								<clay:icon
-									elementClasses="user-icon-sm"
 									symbol="<%= configurationCategoryDisplay.getCategoryIcon() %>"
 								/>
 

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/asset/abstract.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/asset/abstract.jsp
@@ -26,7 +26,7 @@ request.setAttribute("view_user.jsp-user", user2);
 
 <clay:row>
 	<clay:col
-		className="contacts-container"
+		cssClass="contacts-container"
 	>
 		<div class="lfr-contact-thumb">
 			<img alt="<%= HtmlUtil.escapeAttribute(user2.getFullName()) %>" src="<%= user2.getPortraitURL(themeDisplay) %>" />

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/my_contacts/view.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/my_contacts/view.jsp
@@ -44,7 +44,7 @@
 			<c:otherwise>
 				<clay:row>
 					<clay:col
-						className="my-contacts"
+						cssClass="my-contacts"
 					>
 
 						<%
@@ -53,7 +53,7 @@
 
 							<clay:row>
 								<clay:col
-									className="lfr-contact-grid-item"
+									cssClass="lfr-contact-grid-item"
 								>
 									<div class="lfr-contact-thumb">
 										<a href="<%= user2.getDisplayURL(themeDisplay) %>"><img alt="<%= HtmlUtil.escapeAttribute(user2.getFullName()) %>" src="<%= user2.getPortraitURL(themeDisplay) %>" /></a>

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/profile/view.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/profile/view.jsp
@@ -27,7 +27,7 @@
 
 		<clay:row>
 			<clay:col
-				className="contacts-container"
+				cssClass="contacts-container"
 			>
 				<liferay-util:include page="/view_user.jsp" servletContext="<%= application %>" />
 			</clay:col>

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/view.jsp
@@ -141,7 +141,7 @@ portletURL.setWindowState(WindowState.NORMAL);
 		</aui:form>
 
 		<clay:row
-			className="contacts-result-container lfr-app-column-view"
+			cssClass="contacts-result-container lfr-app-column-view"
 		>
 			<aui:col cssClass="contacts-list" first="<%= true %>" width="<%= 30 %>">
 				<div class="toggle-user">

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/view_user.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/view_user.jsp
@@ -38,7 +38,7 @@ request.setAttribute("view_user.jsp-user", user2);
 		<c:if test="<%= (displayStyle == ContactsConstants.DISPLAY_STYLE_BASIC) || (displayStyle == ContactsConstants.DISPLAY_STYLE_FULL) %>">
 			<clay:row>
 				<clay:col
-					className="social-relations"
+					cssClass="social-relations"
 				>
 
 					<%
@@ -86,7 +86,7 @@ request.setAttribute("view_user.jsp-user", user2);
 
 					<clay:row>
 						<clay:col
-							className="contacts-action"
+							cssClass="contacts-action"
 						>
 							<c:choose>
 								<c:when test="<%= portletId.equals(ContactsPortletKeys.CONTACTS_CENTER) || portletId.equals(ContactsPortletKeys.MEMBERS) %>">
@@ -186,7 +186,7 @@ request.setAttribute("view_user.jsp-user", user2);
 					<clay:col>
 						<c:if test="<%= showUsersInformation %>">
 							<clay:col
-								className="user-information-column-1"
+								cssClass="user-information-column-1"
 								md="<%= showSites ? String.valueOf(9) : String.valueOf(12) %>"
 							>
 								<div class="user-information-title">
@@ -229,7 +229,7 @@ request.setAttribute("view_user.jsp-user", user2);
 
 						<c:if test="<%= showSites || showTags %>">
 							<clay:col
-								className="user-information-column-2"
+								cssClass="user-information-column-2"
 								md="<%= showUsersInformation ? String.valueOf(3) : String.valueOf(12) %>"
 							>
 								<c:if test="<%= showSites %>">

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/init.jsp" %>
 
 <clay:container
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<div class="sheet">
 		<h2 class="sheet-title">
@@ -37,7 +37,7 @@
 </clay:container>
 
 <clay:container
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<div class="sheet">
 		<h2 class="sheet-title">

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_renderer/page.jsp
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_renderer/page.jsp
@@ -18,7 +18,7 @@
 
 <div class="sheet">
 	<clay:container-fluid
-		className="ddm-form-builder-app"
+		cssClass="ddm-form-builder-app"
 	>
 		<%= content %>
 	</clay:container-fluid>

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/memberships/depot_groups.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/memberships/depot_groups.jsp
@@ -32,8 +32,8 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "asset-
 <liferay-ui:membership-policy-error />
 
 <clay:content-row
-	cssClass="sheet-subtitle"
 	containerElement="h3"
+	cssClass="sheet-subtitle"
 >
 	<clay:content-col
 		expand="true"

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/memberships/depot_groups.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/memberships/depot_groups.jsp
@@ -32,7 +32,7 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "asset-
 <liferay-ui:membership-policy-error />
 
 <clay:content-row
-	className="sheet-subtitle"
+	cssClass="sheet-subtitle"
 	containerElement="h3"
 >
 	<clay:content-col

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/roles/depot_roles.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/roles/depot_roles.jsp
@@ -23,7 +23,7 @@ DepotAdminRolesDisplayContext depotAdminRolesDisplayContext = (DepotAdminRolesDi
 <aui:input name="<%= ActionRequest.ACTION_NAME %>" type="hidden" value="/depot/update_roles" />
 
 <clay:content-row
-	className="sheet-subtitle"
+	cssClass="sheet-subtitle"
 	containerElement="h3"
 >
 	<clay:content-col

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/roles/depot_roles.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/roles/depot_roles.jsp
@@ -23,8 +23,8 @@ DepotAdminRolesDisplayContext depotAdminRolesDisplayContext = (DepotAdminRolesDi
 <aui:input name="<%= ActionRequest.ACTION_NAME %>" type="hidden" value="/depot/update_roles" />
 
 <clay:content-row
-	cssClass="sheet-subtitle"
 	containerElement="h3"
+	cssClass="sheet-subtitle"
 >
 	<clay:content-col
 		expand="true"

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/item/selector/application_disabled.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/item/selector/application_disabled.jsp
@@ -21,7 +21,7 @@ DepotApplicationDisplayContext depotApplicationDisplayContext = (DepotApplicatio
 %>
 
 <clay:container-fluid
-	className="pt-4"
+	cssClass="pt-4"
 >
 	<div class="alert alert-info">
 		<span class="alert-indicator">

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/sites.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/sites.jsp
@@ -24,7 +24,7 @@ List<DepotEntryGroupRel> depotEntryGroupRels = depotAdminSitesDisplayContext.get
 
 <clay:sheet-section>
 	<clay:content-row
-		className="sheet-subtitle"
+		cssClass="sheet-subtitle"
 		containerElement="h3"
 	>
 		<clay:content-col

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/sites.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/sites.jsp
@@ -24,8 +24,8 @@ List<DepotEntryGroupRel> depotEntryGroupRels = depotAdminSitesDisplayContext.get
 
 <clay:sheet-section>
 	<clay:content-row
-		cssClass="sheet-subtitle"
 		containerElement="h3"
+		cssClass="sheet-subtitle"
 	>
 		<clay:content-col
 			expand="true"

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/view.jsp
@@ -27,7 +27,7 @@ DepotAdminManagementToolbarDisplayContext depotAdminManagementToolbarDisplayCont
 />
 
 <clay:container-fluid
-	className="closed sidenav-container sidenav-right"
+	cssClass="closed sidenav-container sidenav-right"
 >
 	<div class="sidenav-content">
 		<portlet:actionURL name="deleteGroups" var="deleteGroupsURL" />

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/mime_type_sticker/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/mime_type_sticker/page.jsp
@@ -21,8 +21,7 @@ String cssClass = (String)request.getAttribute("liferay-document-library:mime-ty
 DLViewFileVersionDisplayContext dlViewFileVersionDisplayContext = (DLViewFileVersionDisplayContext)request.getAttribute("liferay-document-library:mime-type-sticker:dlViewFileVersionDisplayContext");
 %>
 
-<div class="sticker sticker-document <%= cssClass %> <%= dlViewFileVersionDisplayContext.getCssClassFileMimeType() %>">
-	<clay:icon
-		symbol="<%= dlViewFileVersionDisplayContext.getIconFileMimeType() %>"
-	/>
-</div>
+<clay:sticker
+	className='<%= "sticker-document " + cssClass + " " + dlViewFileVersionDisplayContext.getCssClassFileMimeType() %>'
+	icon="<%= dlViewFileVersionDisplayContext.getIconFileMimeType() %>"
+/>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/mime_type_sticker/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/mime_type_sticker/page.jsp
@@ -22,6 +22,6 @@ DLViewFileVersionDisplayContext dlViewFileVersionDisplayContext = (DLViewFileVer
 %>
 
 <clay:sticker
-	className='<%= "sticker-document " + cssClass + " " + dlViewFileVersionDisplayContext.getCssClassFileMimeType() %>'
+	cssClass='<%= "sticker-document " + cssClass + " " + dlViewFileVersionDisplayContext.getCssClassFileMimeType() %>'
 	icon="<%= dlViewFileVersionDisplayContext.getIconFileMimeType() %>"
 />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure_data_layout_builder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure_data_layout_builder.jsp
@@ -92,7 +92,7 @@ renderResponse.setTitle(title);
 						title='<%= LanguageUtil.get(request, "details") %>'
 					>
 						<clay:row
-							className="lfr-ddm-types-form-column"
+							cssClass="lfr-ddm-types-form-column"
 						>
 							<aui:input name="storageType" type="hidden" value="<%= StorageType.JSON.getValue() %>" />
 						</clay:row>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure_form_builder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure_form_builder.jsp
@@ -150,7 +150,7 @@ renderResponse.setTitle(title);
 						title='<%= LanguageUtil.get(request, "details") %>'
 					>
 						<clay:row
-							className="lfr-ddm-types-form-column"
+							cssClass="lfr-ddm-types-form-column"
 						>
 							<aui:input name="storageType" type="hidden" value="<%= StorageType.JSON.getValue() %>" />
 						</clay:row>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_type_data_layout_builder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_type_data_layout_builder.jsp
@@ -73,7 +73,7 @@ renderResponse.setTitle((fileEntryType == null) ? LanguageUtil.get(request, "new
 	</nav>
 
 	<clay:container-fluid
-		className="container-view"
+		cssClass="container-view"
 	>
 
 		<%

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -41,8 +41,8 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 
 	<c:if test="<%= dlViewFileVersionDisplayContext.isVersionInfoVisible() %>">
 		<clay:label
+			displayType="info"
 			label='<%= LanguageUtil.get(request, "version") + StringPool.SPACE + fileVersion.getVersion() %>'
-			style="info"
 		/>
 	</c:if>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -454,7 +454,7 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 									name="name"
 								>
 									<clay:sticker
-										className="sticker-document"
+										cssClass="sticker-document"
 										displayType="secondary"
 										icon='<%= curFolder.isMountPoint() ? "repository" : "folder" %>'
 									/>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -453,11 +453,11 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 									cssClass="table-cell-expand table-cell-minw-200 table-title"
 									name="name"
 								>
-									<div class="sticker sticker-document sticker-secondary">
-										<clay:icon
-											symbol='<%= curFolder.isMountPoint() ? "repository" : "folder" %>'
-										/>
-									</div>
+									<clay:sticker
+										className="sticker-document"
+										displayType="secondary"
+										icon='<%= curFolder.isMountPoint() ? "repository" : "folder" %>'
+									/>
 
 									<aui:a href="<%= rowURL.toString() %>"><%= HtmlUtil.escape(curFolder.getName()) %></aui:a>
 								</liferay-ui:search-container-column-text>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -98,7 +98,7 @@ if (portletTitleBasedNavigation) {
 </c:if>
 
 <clay:container-fluid
-	className='<%= portletTitleBasedNavigation ? StringPool.BLANK : "closed sidenav-container sidenav-right" %>'
+	cssClass='<%= portletTitleBasedNavigation ? StringPool.BLANK : "closed sidenav-container sidenav-right" %>'
 	id='<%= renderResponse.getNamespace() + (portletTitleBasedNavigation ? "FileEntry" : "infoPanelId") %>'
 >
 	<portlet:actionURL name="/document_library/edit_file_entry" var="editFileEntry" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_metadata_sets.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_metadata_sets.jsp
@@ -27,7 +27,7 @@ DLViewFileEntryMetadataSetsDisplayContext dLViewFileEntryMetadataSetsDisplayCont
 />
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureReferencedByStructureLinks.class %>" message="the-structure-cannot-be-deleted-because-it-is-required-by-one-or-more-structure-links" />
 	<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureReferencedByTemplates.class %>" message="the-structure-cannot-be-deleted-because-it-is-required-by-one-or-more-templates" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_types.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_types.jsp
@@ -33,7 +33,7 @@ DLViewFileEntryTypesDisplayContext dlViewFileEntryTypesDisplayContext = new DLVi
 />
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<liferay-ui:error exception="<%= RequiredFileEntryTypeException.class %>" message="cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents" />
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record.jsp
@@ -106,7 +106,7 @@ else {
 </c:if>
 
 <clay:container-fluid
-	className="closed sidenav-container sidenav-right"
+	cssClass="closed sidenav-container sidenav-right"
 	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 >
 	<c:if test="<%= recordVersion != null %>">

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_records.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_records.jsp
@@ -55,7 +55,7 @@ if (!ddlDisplayContext.isAdminPortlet()) {
 />
 
 <clay:container-fluid
-	className="view-records-container"
+	cssClass="view-records-container"
 	id='<%= renderResponse.getNamespace() + "formContainer" %>'
 >
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="fm">

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_spreadsheet_records.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_spreadsheet_records.jsp
@@ -29,7 +29,7 @@ DDMStructure ddmStructure = recordSet.getDDMStructure();
 %>
 
 <clay:container-fluid
-	className="lfr-spreadsheet-container"
+	cssClass="lfr-spreadsheet-container"
 >
 	<div id="<portlet:namespace />spreadsheet">
 		<div class="table-striped yui3-datatable yui3-widget" id="<portlet:namespace />dataTable">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/edit_data_provider.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/edit_data_provider.jsp
@@ -50,7 +50,7 @@ renderResponse.setTitle((ddmDataProviderInstance == null) ? LanguageUtil.get(req
 	<%@ include file="/exceptions.jspf" %>
 
 	<clay:container-fluid
-		className="lfr-ddm-edit-data-provider"
+		cssClass="lfr-ddm-edit-data-provider"
 	>
 		<aui:fieldset-group markupView="lexicon">
 			<aui:fieldset>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_renderer/page.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_renderer/page.jsp
@@ -100,7 +100,7 @@ if (ddmFormInstance != null) {
 					</c:if>
 
 					<clay:container-fluid
-						className="ddm-form-builder-app"
+						cssClass="ddm-form-builder-app"
 					>
 						<%= ddmFormHTML %>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
@@ -48,7 +48,7 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 
 	<nav class="management-bar management-bar-light navbar navbar-expand-md toolbar-group-field">
 		<clay:container-fluid
-			className="toolbar"
+			cssClass="toolbar"
 		>
 			<ul class="navbar-nav toolbar-group-field"></ul>
 			<ul class="navbar-nav toolbar-group-field">
@@ -64,7 +64,7 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 	</nav>
 
 	<clay:container-fluid
-		className="ddm-translation-manager"
+		cssClass="ddm-translation-manager"
 	>
 		<liferay-frontend:translation-manager
 			availableLocales="<%= ddmFormAdminDisplayContext.getAvailableLocales() %>"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -42,7 +42,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 </portlet:actionURL>
 
 <div class="lfr-alert-container">
-	<clay:container-fluid className="lfr-alert-wrapper"></clay:container-fluid>
+	<clay:container-fluid cssClass="lfr-alert-wrapper"></clay:container-fluid>
 </div>
 
 <div class="portlet-forms" id="<portlet:namespace />formContainer">
@@ -55,7 +55,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 
 	<nav class="management-bar management-bar-light navbar navbar-expand-md toolbar-group-field" id="<portlet:namespace />managementToolbar">
 		<clay:container-fluid
-			className="autosave-bar toolbar"
+			cssClass="autosave-bar toolbar"
 		>
 			<div class="navbar-form navbar-form-autofit navbar-overlay toolbar-group-content">
 				<span class="autosave-feedback management-bar-text" id="<portlet:namespace />autosaveMessage"></span>
@@ -81,7 +81,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 	</nav>
 
 	<clay:container-fluid
-		className="ddm-translation-manager"
+		cssClass="ddm-translation-manager"
 	>
 		<liferay-frontend:translation-manager
 			availableLocales="<%= ddmFormAdminDisplayContext.getAvailableLocales() %>"
@@ -135,7 +135,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 	</aui:form>
 
 	<clay:container-fluid
-		className="ddm-form-instance-settings hide"
+		cssClass="ddm-form-instance-settings hide"
 		id='<%= renderResponse.getNamespace() + "settings" %>'
 	>
 		<%= ddmFormAdminDisplayContext.serializeSettingsForm(pageContext) %>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance_record.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance_record.jsp
@@ -38,7 +38,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "view-form"));
 </clay:container-fluid>
 
 <clay:container-fluid
-	className="ddm-form-builder-app form-entry"
+	cssClass="ddm-form-builder-app form-entry"
 >
 	<%= ddmFormAdminDisplayContext.getDDMFormHTML(renderRequest) %>
 </clay:container-fluid>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/edit_form_instance_record.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/edit_form_instance_record.jsp
@@ -48,7 +48,7 @@ renderResponse.setTitle(GetterUtil.get(title, LanguageUtil.get(request, "view-fo
 </clay:container-fluid>
 
 <clay:container-fluid
-	className="ddm-form-builder-app editing-form-entry"
+	cssClass="ddm-form-builder-app editing-form-entry"
 >
 	<portlet:actionURL name="addFormInstanceRecord" var="editFormInstanceRecordActionURL" />
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
@@ -171,7 +171,7 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 						</div>
 
 						<clay:container-fluid
-							className="ddm-form-builder-app ddm-form-builder-app-not-ready"
+							cssClass="ddm-form-builder-app ddm-form-builder-app-not-ready"
 							id='<%= ddmFormDisplayContext.getContainerId() + "container" %>'
 						>
 							<%= ddmFormDisplayContext.getDDMFormHTML() %>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_structure.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_structure.jsp
@@ -270,7 +270,7 @@ if (Validator.isNotNull(requestUpdateStructureURL)) {
 						title='<%= LanguageUtil.get(request, "details") %>'
 					>
 						<clay:row
-							className="lfr-ddm-types-form-column"
+							cssClass="lfr-ddm-types-form-column"
 						>
 							<c:choose>
 								<c:when test="<%= Validator.isNull(storageTypeValue) %>">

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/select_field_type.jsp
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/select_field_type.jsp
@@ -67,7 +67,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "new-cus
 		</div>
 
 		<clay:row
-			className="clay-site-row-spacer"
+			cssClass="clay-site-row-spacer"
 		>
 			<clay:col
 				size="12"

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/view.jsp
@@ -30,7 +30,7 @@ Collections.sort(customAttributesDisplays, new CustomAttributesDisplayComparator
 %>
 
 <clay:container-fluid
-	className="container-view"
+	cssClass="container-view"
 >
 	<liferay-ui:search-container
 		emptyResultsMessage='<%= LanguageUtil.get(request, "custom-fields-are-not-enabled-for-any-resource") %>'

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts.jsp
@@ -34,7 +34,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "new-import-process"));
 %>
 
 <clay:container-fluid
-	className="container-view"
+	cssClass="container-view"
 	id='<%= renderResponse.getNamespace() + "exportImportOptions" %>'
 >
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/simple/publish_layouts_simple.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/simple/publish_layouts_simple.jsp
@@ -55,7 +55,7 @@ advancedPublishURL.setParameter("privateLayout", String.valueOf(privateLayout));
 %>
 
 <clay:container-fluid
-	className="mt-2 publish-navbar text-right"
+	cssClass="mt-2 publish-navbar text-right"
 >
 	<clay:link
 		buttonStyle="link"

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/view.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/view.jsp
@@ -125,7 +125,7 @@ simplePublishURL.setParameter("targetGroupId", String.valueOf(liveGroupId));
 
 <c:if test='<%= !publishConfigurationButtons.equals("template") %>'>
 	<clay:container-fluid
-		className="publish-navbar"
+		cssClass="publish-navbar"
 	>
 		<div class="autofit-row autofit-row-center">
 			<div class="autofit-col autofit-col-expand">

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
@@ -25,7 +25,7 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 %>
 
 <clay:container-fluid
-	className="container-view"
+	cssClass="container-view"
 >
 	<clay:row>
 		<clay:col

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_entry_usages.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_entry_usages.jsp
@@ -30,7 +30,7 @@ FragmentEntryUsageManagementToolbarDisplayContext fragmentEntryUsageManagementTo
 %>
 
 <clay:container-fluid
-	className="container-form-lg"
+	cssClass="container-form-lg"
 >
 	<clay:row>
 		<clay:col

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_group_fragment_entry_usages.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_group_fragment_entry_usages.jsp
@@ -30,7 +30,7 @@ GroupFragmentEntryUsageManagementToolbarDisplayContext groupFragmentEntryUsageMa
 %>
 
 <clay:container-fluid
-	className="container-form-lg"
+	cssClass="container-form-lg"
 >
 	<div class="sheet">
 		<clay:row>

--- a/modules/apps/frontend-taglib/frontend-taglib-chart-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-chart-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -127,7 +127,7 @@
 <clay:container-fluid>
 	<clay:row>
 		<clay:col
-			className="geomap"
+			cssClass="geomap"
 		>
 			<chart:geomap
 				config="<%= chartSampleDisplayContext.getGeomapConfig1() %>"
@@ -136,7 +136,7 @@
 		</clay:col>
 
 		<clay:col
-			className="geomap"
+			cssClass="geomap"
 		>
 			<chart:geomap
 				config="<%= chartSampleDisplayContext.getGeomapConfig2() %>"
@@ -149,7 +149,7 @@
 <clay:container-fluid>
 	<clay:row>
 		<clay:col
-			className="polling-interval"
+			cssClass="polling-interval"
 		>
 			<chart:line
 				componentId="polling-interval-line-chart"
@@ -163,7 +163,7 @@
 <clay:container-fluid>
 	<clay:row>
 		<clay:col
-			className="predictive"
+			cssClass="predictive"
 		>
 			<chart:predictive
 				componentId="predictive-chart"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/badges.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/badges.jsp
@@ -21,7 +21,7 @@
 </blockquote>
 
 <clay:row
-	className="text-center"
+	cssClass="text-center"
 >
 	<clay:col
 		md="1"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/buttons.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/buttons.jsp
@@ -34,14 +34,14 @@
 		<tr>
 			<td>
 				<clay:row
-					className="flex-md-nowrap mb-2"
+					cssClass="flex-md-nowrap mb-2"
 				>
 					<clay:col><clay:button label="Primary" /></clay:col>
 					<clay:col><clay:button ariaLabel="Workflow" icon="workflow" /></clay:col>
 				</clay:row>
 
 				<clay:row
-					className="flex-md-nowrap"
+					cssClass="flex-md-nowrap"
 				>
 					<clay:col><clay:button disabled="<%= true %>" label="Primary" /></clay:col>
 					<clay:col><clay:button ariaLabel="Workflow" disabled="<%= true %>" icon="workflow" /></clay:col>
@@ -54,14 +54,14 @@
 		<tr>
 			<td>
 				<clay:row
-					className="flex-md-nowrap mb-2"
+					cssClass="flex-md-nowrap mb-2"
 				>
 					<clay:col><clay:button label="Secondary" style="secondary" /></clay:col>
 					<clay:col><clay:button ariaLabel="Wiki" icon="wiki" style="secondary" /></clay:col>
 				</clay:row>
 
 				<clay:row
-					className="flex-md-nowrap"
+					cssClass="flex-md-nowrap"
 				>
 					<clay:col><clay:button disabled="<%= true %>" label="Secondary" style="secondary" /></clay:col>
 					<clay:col><clay:button ariaLabel="Wiki" disabled="<%= true %>" icon="wiki" style="secondary" /></clay:col>
@@ -74,14 +74,14 @@
 		<tr>
 			<td>
 				<clay:row
-					className="flex-md-nowrap mb-2"
+					cssClass="flex-md-nowrap mb-2"
 				>
 					<clay:col><clay:button label="Borderless" style="borderless" /></clay:col>
 					<clay:col><clay:button ariaLabel="Page Template" icon="page-template" style="borderless" /></clay:col>
 				</clay:row>
 
 				<clay:row
-					className="flex-md-nowrap"
+					cssClass="flex-md-nowrap"
 				>
 					<clay:col><clay:button disabled="<%= true %>" label="Borderless" style="borderless" /></clay:col>
 					<clay:col><clay:button ariaLabel="Page Template" disabled="<%= true %>" icon="page-template" style="borderless" /></clay:col>
@@ -94,14 +94,14 @@
 		<tr>
 			<td>
 				<clay:row
-					className="flex-md-nowrap mb-2"
+					cssClass="flex-md-nowrap mb-2"
 				>
 					<clay:col><clay:button label="Link" style="link" /></clay:col>
 					<clay:col><clay:button ariaLabel="Add Role" icon="add-role" style="link" /></clay:col>
 				</clay:row>
 
 				<clay:row
-					className="flex-md-nowrap"
+					cssClass="flex-md-nowrap"
 				>
 					<clay:col><clay:button disabled="<%= true %>" label="Link" style="link" /></clay:col>
 					<clay:col><clay:button ariaLabel="Add Role" disabled="<%= true %>" icon="add-role" style="link" /></clay:col>
@@ -117,7 +117,7 @@
 <h3>VARIATIONS</h3>
 
 <clay:row
-	className="text-center"
+	cssClass="text-center"
 >
 	<clay:col
 		md="2"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/icons.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/icons.jsp
@@ -23,7 +23,7 @@
 <h3>Liferay Icon Library</h3>
 
 <clay:row
-	className="mb-3"
+	cssClass="mb-3"
 >
 
 	<%
@@ -51,7 +51,7 @@
 <h3>Language Flags</h3>
 
 <clay:row
-	className="mb-3"
+	cssClass="mb-3"
 >
 
 	<%

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/labels.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/labels.jsp
@@ -27,11 +27,18 @@
 		size="2"
 	>
 		<div>
-			<clay:label label="Label text" displayType="info" />
+			<clay:label
+				displayType="info"
+				label="Label text"
+			/>
 		</div>
 
 		<div>
-			<clay:label label="Label text" large="true" displayType="info" />
+			<clay:label
+				displayType="info"
+				label="Label text"
+				large="true"
+			/>
 		</div>
 	</clay:col>
 
@@ -45,22 +52,22 @@
 	<clay:col
 		size="2"
 	>
-		<div><clay:label label="Pending" displayType="warning" /></div>
-		<div><clay:label label="Pending" large="true" displayType="warning" /></div>
+		<div><clay:label displayType="warning" label="Pending" /></div>
+		<div><clay:label displayType="warning" label="Pending" large="true" /></div>
 	</clay:col>
 
 	<clay:col
 		size="2"
 	>
-		<div><clay:label label="Rejected" displayType="danger" /></div>
-		<div><clay:label label="Rejected" large="true" displayType="danger" /></div>
+		<div><clay:label displayType="danger" label="Rejected" /></div>
+		<div><clay:label displayType="danger" label="Rejected" large="true" /></div>
 	</clay:col>
 
 	<clay:col
 		size="2"
 	>
-		<div><clay:label label="Approved" displayType="success" /></div>
-		<div><clay:label label="Approved" large="true" displayType="success" /></div>
+		<div><clay:label displayType="success" label="Approved" /></div>
+		<div><clay:label displayType="success" label="Approved" large="true" /></div>
 	</clay:col>
 </clay:row>
 
@@ -79,9 +86,9 @@
 
 		<clay:label
 			dismissible="<%= true %>"
+			displayType="success"
 			label="Large Label"
 			large="true"
-			displayType="success"
 		/>
 	</clay:col>
 </clay:row>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/labels.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/labels.jsp
@@ -21,7 +21,7 @@
 </blockquote>
 
 <clay:row
-	className="mb-3"
+	cssClass="mb-3"
 >
 	<clay:col
 		size="2"
@@ -74,7 +74,7 @@
 <h3>LABEL REMOVABLE</h3>
 
 <clay:row
-	className="row"
+	cssClass="row"
 >
 	<clay:col
 		size="12"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/labels.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/labels.jsp
@@ -26,36 +26,41 @@
 	<clay:col
 		size="2"
 	>
-		<div><clay:label label="Label text" style="info" /></div>
-		<div><clay:label label="Label text" size="lg" style="info" /></div>
+		<div>
+			<clay:label label="Label text" displayType="info" />
+		</div>
+
+		<div>
+			<clay:label label="Label text" large="true" displayType="info" />
+		</div>
 	</clay:col>
 
 	<clay:col
 		size="2"
 	>
 		<div><clay:label label="Status" /></div>
-		<div><clay:label label="Status" size="lg" /></div>
+		<div><clay:label label="Status" large="true" /></div>
 	</clay:col>
 
 	<clay:col
 		size="2"
 	>
-		<div><clay:label label="Pending" style="warning" /></div>
-		<div><clay:label label="Pending" size="lg" style="warning" /></div>
+		<div><clay:label label="Pending" displayType="warning" /></div>
+		<div><clay:label label="Pending" large="true" displayType="warning" /></div>
 	</clay:col>
 
 	<clay:col
 		size="2"
 	>
-		<div><clay:label label="Rejected" style="danger" /></div>
-		<div><clay:label label="Rejected" size="lg" style="danger" /></div>
+		<div><clay:label label="Rejected" displayType="danger" /></div>
+		<div><clay:label label="Rejected" large="true" displayType="danger" /></div>
 	</clay:col>
 
 	<clay:col
 		size="2"
 	>
-		<div><clay:label label="Approved" style="success" /></div>
-		<div><clay:label label="Approved" size="lg" style="success" /></div>
+		<div><clay:label label="Approved" displayType="success" /></div>
+		<div><clay:label label="Approved" large="true" displayType="success" /></div>
 	</clay:col>
 </clay:row>
 
@@ -68,15 +73,15 @@
 		size="12"
 	>
 		<clay:label
-			closeable="<%= true %>"
+			dismissible="<%= true %>"
 			label="Normal Label"
 		/>
 
 		<clay:label
-			closeable="<%= true %>"
+			dismissible="<%= true %>"
 			label="Large Label"
-			size="lg"
-			style="success"
+			large="true"
+			displayType="success"
 		/>
 	</clay:col>
 </clay:row>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/stickers.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/stickers.jsp
@@ -23,7 +23,7 @@
 <h3>SQUARE</h3>
 
 <clay:row
-	className="mb-3 text-center"
+	cssClass="mb-3 text-center"
 >
 	<clay:col
 		md="1"
@@ -45,7 +45,7 @@
 <h3>ROUND</h3>
 
 <clay:row
-	className="mb-3 text-center"
+	cssClass="mb-3 text-center"
 >
 	<clay:col
 		md="1"
@@ -69,7 +69,7 @@
 <h3>POSITION</h3>
 
 <clay:row
-	className="mb-3"
+	cssClass="mb-3"
 >
 	<clay:col
 		md="2"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 3.5.1
+Bundle-Version: 3.6.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.servlet.taglib,\
 	com.liferay.frontend.taglib.clay.servlet.taglib.contributor,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -83,5 +83,5 @@
 		"format": "liferay-npm-scripts fix",
 		"test": "liferay-npm-scripts test"
 	},
-	"version": "3.5.1"
+	"version": "3.6.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
@@ -23,6 +23,7 @@ import com.liferay.taglib.util.IncludeTag;
 import com.liferay.taglib.util.InlineUtil;
 
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.jsp.JspWriter;
@@ -37,8 +38,49 @@ public class BaseContainerTag extends IncludeTag {
 		return _className;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getComponentId() {
+		return _componentId;
+	}
+
 	public String getContainerElement() {
 		return _containerElement;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getContributorKey() {
+		return _contributorKey;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public Map<String, String> getData() {
+		return _data;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getDefaultEventHandler() {
+		return _defaultEventHandler;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getClassName()}
+	 */
+	@Deprecated
+	public String getElementClasses() {
+		return getClassName();
 	}
 
 	public String getId() {
@@ -49,8 +91,49 @@ public class BaseContainerTag extends IncludeTag {
 		_className = className;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setComponentId(String componentId) {
+		_componentId = componentId;
+	}
+
 	public void setContainerElement(String containerElement) {
 		_containerElement = containerElement;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setContributorKey(String contributorKey) {
+		_contributorKey = contributorKey;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setData(Map<String, String> data) {
+		_data = data;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setDefaultEventHandler(String defaultEventHandler) {
+		_defaultEventHandler = defaultEventHandler;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setClassName(String)}
+	 */
+	@Deprecated
+	public void setElementClasses(String elementClasses) {
+		setClassName(elementClasses);
 	}
 
 	public void setId(String id) {
@@ -69,7 +152,12 @@ public class BaseContainerTag extends IncludeTag {
 		super.cleanUp();
 
 		_className = null;
+		_componentId = null;
 		_containerElement = null;
+		_contributorKey = null;
+		_data = null;
+		_defaultEventHandler = null;
+		_elementClasses = null;
 		_id = null;
 	}
 
@@ -136,7 +224,12 @@ public class BaseContainerTag extends IncludeTag {
 	private static final boolean _CLEAN_UP_SET_ATTRIBUTES = true;
 
 	private String _className;
+	private String _componentId;
 	private String _containerElement;
+	private String _contributorKey;
+	private Map<String, String> _data;
+	private String _defaultEventHandler;
+	private String _elementClasses;
 	private String _id;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
@@ -34,8 +34,13 @@ import javax.servlet.jsp.PageContext;
  */
 public class BaseContainerTag extends IncludeTag {
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getCssClass()}
+	 */
+	@Deprecated
 	public String getClassName() {
-		return _className;
+		return getCssClass();
 	}
 
 	/**
@@ -58,6 +63,10 @@ public class BaseContainerTag extends IncludeTag {
 		return _contributorKey;
 	}
 
+	public String getCssClass() {
+		return _cssClass;
+	}
+
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
@@ -76,19 +85,24 @@ public class BaseContainerTag extends IncludeTag {
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #getClassName()}
+	 *             #getCssClass()}
 	 */
 	@Deprecated
 	public String getElementClasses() {
-		return getClassName();
+		return getCssClass();
 	}
 
 	public String getId() {
 		return _id;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setCssClass(String)}
+	 */
+	@Deprecated
 	public void setClassName(String className) {
-		_className = className;
+		setCssClass(className);
 	}
 
 	/**
@@ -111,6 +125,10 @@ public class BaseContainerTag extends IncludeTag {
 		_contributorKey = contributorKey;
 	}
 
+	public void setCssClass(String cssClass) {
+		_cssClass = cssClass;
+	}
+
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
@@ -129,11 +147,11 @@ public class BaseContainerTag extends IncludeTag {
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setClassName(String)}
+	 *             #setCssClass(String)}
 	 */
 	@Deprecated
 	public void setElementClasses(String elementClasses) {
-		setClassName(elementClasses);
+		setCssClass(elementClasses);
 	}
 
 	public void setId(String id) {
@@ -151,10 +169,10 @@ public class BaseContainerTag extends IncludeTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
-		_className = null;
 		_componentId = null;
 		_containerElement = null;
 		_contributorKey = null;
+		_cssClass = null;
 		_data = null;
 		_defaultEventHandler = null;
 		_elementClasses = null;
@@ -166,12 +184,21 @@ public class BaseContainerTag extends IncludeTag {
 		return _CLEAN_UP_SET_ATTRIBUTES;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	protected String processClassName(Set<String> className) {
-		if (Validator.isNotNull(_className)) {
-			className.addAll(StringUtil.split(_className, CharPool.SPACE));
+		return processCssClass(className);
+	}
+
+	protected String processCssClass(Set<String> cssClass) {
+		if (Validator.isNotNull(_cssClass)) {
+			cssClass.addAll(StringUtil.split(_cssClass, CharPool.SPACE));
 		}
 
-		return StringUtil.merge(className, StringPool.SPACE);
+		return StringUtil.merge(cssClass, StringPool.SPACE);
 	}
 
 	@Override
@@ -196,7 +223,7 @@ public class BaseContainerTag extends IncludeTag {
 		jspWriter.write("<");
 		jspWriter.write(_containerElement);
 		jspWriter.write(" class=\"");
-		jspWriter.write(processClassName(new LinkedHashSet<>()));
+		jspWriter.write(processCssClass(new LinkedHashSet<>()));
 		jspWriter.write("\"");
 
 		if (Validator.isNotNull(_id)) {
@@ -223,10 +250,10 @@ public class BaseContainerTag extends IncludeTag {
 
 	private static final boolean _CLEAN_UP_SET_ATTRIBUTES = true;
 
-	private String _className;
 	private String _componentId;
 	private String _containerElement;
 	private String _contributorKey;
+	private String _cssClass;
 	private Map<String, String> _data;
 	private String _defaultEventHandler;
 	private String _elementClasses;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
@@ -69,7 +69,7 @@ public class BaseContainerTag extends IncludeTag {
 		super.cleanUp();
 
 		_className = null;
-		_containerElement = "div";
+		_containerElement = null;
 		_id = null;
 	}
 
@@ -100,6 +100,10 @@ public class BaseContainerTag extends IncludeTag {
 	@Override
 	protected int processStartTag() throws Exception {
 		JspWriter jspWriter = pageContext.getOut();
+
+		if (_containerElement == null) {
+			setContainerElement("div");
+		}
 
 		jspWriter.write("<");
 		jspWriter.write(_containerElement);
@@ -132,7 +136,7 @@ public class BaseContainerTag extends IncludeTag {
 	private static final boolean _CLEAN_UP_SET_ATTRIBUTES = true;
 
 	private String _className;
-	private String _containerElement = "div";
+	private String _containerElement;
 	private String _id;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/BadgeTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/BadgeTag.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Chema Balsas
+ */
+public class BadgeTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		if (getContainerElement() == null) {
+			setContainerElement("span");
+		}
+
+		return super.doStartTag();
+	}
+
+	public String getDisplayType() {
+		return _displayType;
+	}
+
+	public String getLabel(String label) {
+		return _label;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getDisplayType()}
+	 */
+	@Deprecated
+	public String getStyle() {
+		return getDisplayType();
+	}
+
+	public void setDisplayType(String displayType) {
+		_displayType = displayType;
+	}
+
+	public void setLabel(String label) {
+		_label = label;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setDisplayType(String)}
+	 */
+	@Deprecated
+	public void setStyle(String style) {
+		setDisplayType(style);
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_displayType = "primary";
+		_label = null;
+		_style = null;
+	}
+
+	@Override
+	protected String getEndPage() {
+		return _END_PAGE;
+	}
+
+	@Override
+	protected String getStartPage() {
+		return _START_PAGE;
+	}
+
+	@Override
+	protected String processClassName(Set<String> className) {
+		className.add("badge");
+		className.add("badge-" + _displayType);
+
+		return super.processClassName(className);
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write("<span");
+		jspWriter.write(" class=\"badge-item badge-item-expand");
+		jspWriter.write("\">");
+		jspWriter.write(_label);
+		jspWriter.write("</span>");
+
+		return SKIP_BODY;
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:badge:";
+
+	private static final String _END_PAGE = "/badge/end.jsp";
+
+	private static final String _START_PAGE = "/badge/start.jsp";
+
+	private String _displayType = "primary";
+	private String _label;
+	private String _style;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/BadgeTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/BadgeTag.java
@@ -90,12 +90,22 @@ public class BadgeTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("badge");
-		className.add("badge-" + _displayType);
+		return processCssClass(className);
+	}
 
-		return super.processClassName(className);
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("badge");
+		cssClass.add("badge-" + _displayType);
+
+		return super.processCssClass(cssClass);
 	}
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ColTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ColTag.java
@@ -94,33 +94,43 @@ public class ColTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
+		return processCssClass(className);
+	}
+
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
 		if (Validator.isNotNull(_size)) {
-			className.add("col-" + _size);
+			cssClass.add("col-" + _size);
 		}
 
 		if (Validator.isNotNull(_lg)) {
-			className.add("col-lg-" + _lg);
+			cssClass.add("col-lg-" + _lg);
 		}
 
 		if (Validator.isNotNull(_md)) {
-			className.add("col-md-" + _md);
+			cssClass.add("col-md-" + _md);
 		}
 
 		if (Validator.isNotNull(_sm)) {
-			className.add("col-sm-" + _sm);
+			cssClass.add("col-sm-" + _sm);
 		}
 
 		if (Validator.isNotNull(_xl)) {
-			className.add("col-xl-" + _xl);
+			cssClass.add("col-xl-" + _xl);
 		}
 
-		if (className.isEmpty()) {
-			className.add("col");
+		if (cssClass.isEmpty()) {
+			cssClass.add("col");
 		}
 
-		return super.processClassName(className);
+		return super.processCssClass(cssClass);
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:col:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContainerTag.java
@@ -67,20 +67,30 @@ public class ContainerTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
+		return processCssClass(className);
+	}
+
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
 		if (!_fluid) {
-			className.add("container");
+			cssClass.add("container");
 		}
 		else {
-			className.add("container-fluid");
+			cssClass.add("container-fluid");
 
 			if (Validator.isNotNull(_size)) {
-				className.add("container-fluid-max-" + _size);
+				cssClass.add("container-fluid-max-" + _size);
 			}
 		}
 
-		return super.processClassName(className);
+		return super.processCssClass(cssClass);
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:container:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentColTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentColTag.java
@@ -66,19 +66,29 @@ public class ContentColTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("autofit-col");
+		return processCssClass(className);
+	}
+
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("autofit-col");
 
 		if (_expand) {
-			className.add("autofit-col-expand");
+			cssClass.add("autofit-col-expand");
 		}
 
 		if (_gutters) {
-			className.add("autofit-col-gutters");
+			cssClass.add("autofit-col-gutters");
 		}
 
-		return super.processClassName(className);
+		return super.processCssClass(cssClass);
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:content-col:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentRowTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentRowTag.java
@@ -86,37 +86,47 @@ public class ContentRowTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("autofit-row");
+		return processCssClass(className);
+	}
+
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("autofit-row");
 
 		if (_floatElements != null) {
 			if (_floatElements.equals(StringPool.BLANK)) {
-				className.add("autofit-float");
+				cssClass.add("autofit-float");
 			}
 			else {
-				className.add("autofit-float-" + _floatElements);
+				cssClass.add("autofit-float-" + _floatElements);
 			}
 		}
 
 		if (_padded) {
-			className.add("autofit-padded");
+			cssClass.add("autofit-padded");
 		}
 
 		if (_noGutters != null) {
 			if (_noGutters.equals("x") || _noGutters.equals("y")) {
-				className.add("autofit-padded-no-gutters-" + _noGutters);
+				cssClass.add("autofit-padded-no-gutters-" + _noGutters);
 			}
 			else {
-				className.add("autofit-padded-no-gutters");
+				cssClass.add("autofit-padded-no-gutters");
 			}
 		}
 
 		if (Validator.isNotNull(_verticalAlign)) {
-			className.add("autofit-row-" + _verticalAlign);
+			cssClass.add("autofit-row-" + _verticalAlign);
 		}
 
-		return super.processClassName(className);
+		return super.processCssClass(cssClass);
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:content-row:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentSectionTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentSectionTag.java
@@ -42,11 +42,21 @@ public class ContentSectionTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("autofit-section");
+		return processCssClass(className);
+	}
 
-		return super.processClassName(className);
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("autofit-section");
+
+		return super.processCssClass(cssClass);
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:content-section:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/IconTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/IconTag.java
@@ -107,12 +107,22 @@ public class IconTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("lexicon-icon");
-		className.add("lexicon-icon-" + _symbol);
+		return processCssClass(className);
+	}
 
-		return super.processClassName(className);
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("lexicon-icon");
+		cssClass.add("lexicon-icon-" + _symbol);
+
+		return super.processCssClass(cssClass);
 	}
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/IconTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/IconTag.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Chema Balsas
+ */
+public class IconTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		setContainerElement("svg");
+
+		setDynamicAttribute(StringPool.BLANK, "role", "presentation");
+		setDynamicAttribute(StringPool.BLANK, "viewBox", "0 0 512 512");
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		String pathThemeImages = themeDisplay.getPathThemeImages();
+
+		_spritemap = pathThemeImages.concat("/clay/icons.svg");
+
+		return super.doStartTag();
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public boolean getMonospaced() {
+		return _monospaced;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getSpritemap() {
+		return _spritemap;
+	}
+
+	public String getSymbol() {
+		return _symbol;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setMonospaced(boolean monospaced) {
+		_monospaced = monospaced;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setSpritemap(String spritemap) {
+		_spritemap = spritemap;
+	}
+
+	public void setSymbol(String symbol) {
+		_symbol = symbol;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_monospaced = false;
+		_spritemap = null;
+		_symbol = null;
+	}
+
+	@Override
+	protected String getEndPage() {
+		return _END_PAGE;
+	}
+
+	@Override
+	protected String getStartPage() {
+		return _START_PAGE;
+	}
+
+	@Override
+	protected String processClassName(Set<String> className) {
+		className.add("lexicon-icon");
+		className.add("lexicon-icon-" + _symbol);
+
+		return super.processClassName(className);
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write("<use xlink:href=\"");
+		jspWriter.write(_spritemap);
+		jspWriter.write("#");
+		jspWriter.write(_symbol);
+		jspWriter.write("\" />");
+
+		return SKIP_BODY;
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:icon:";
+
+	private static final String _END_PAGE = "/icon/end.jsp";
+
+	private static final String _START_PAGE = "/icon/start.jsp";
+
+	private boolean _monospaced;
+	private String _spritemap;
+	private String _symbol;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemAfterTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemAfterTag.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+
+/**
+ * @author Chema Balsas
+ */
+public class LabelItemAfterTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		if (getContainerElement() == null) {
+			setContainerElement("span");
+		}
+
+		return super.doStartTag();
+	}
+
+	@Override
+	protected String getEndPage() {
+		return _END_PAGE;
+	}
+
+	@Override
+	protected String getStartPage() {
+		return _START_PAGE;
+	}
+
+	@Override
+	protected String processClassName(Set<String> className) {
+		className.add("label-item");
+		className.add("label-item-after");
+
+		return super.processClassName(className);
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:label-item-after:";
+
+	private static final String _END_PAGE = "/label_item_after/end.jsp";
+
+	private static final String _START_PAGE = "/label_item_after/start.jsp";
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemAfterTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemAfterTag.java
@@ -46,12 +46,22 @@ public class LabelItemAfterTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("label-item");
-		className.add("label-item-after");
+		return processCssClass(className);
+	}
 
-		return super.processClassName(className);
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("label-item");
+		cssClass.add("label-item-after");
+
+		return super.processCssClass(cssClass);
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:label-item-after:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemBeforeTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemBeforeTag.java
@@ -46,12 +46,22 @@ public class LabelItemBeforeTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("label-item");
-		className.add("label-item-before");
+		return processCssClass(className);
+	}
 
-		return super.processClassName(className);
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("label-item");
+		cssClass.add("label-item-before");
+
+		return super.processCssClass(cssClass);
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE =

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemBeforeTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemBeforeTag.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+
+/**
+ * @author Chema Balsas
+ */
+public class LabelItemBeforeTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		if (getContainerElement() == null) {
+			setContainerElement("span");
+		}
+
+		return super.doStartTag();
+	}
+
+	@Override
+	protected String getEndPage() {
+		return _END_PAGE;
+	}
+
+	@Override
+	protected String getStartPage() {
+		return _START_PAGE;
+	}
+
+	@Override
+	protected String processClassName(Set<String> className) {
+		className.add("label-item");
+		className.add("label-item-before");
+
+		return super.processClassName(className);
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE =
+		"clay:label-item-before:";
+
+	private static final String _END_PAGE = "/label_item_before/end.jsp";
+
+	private static final String _START_PAGE = "/label_item_before/start.jsp";
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemExpandTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemExpandTag.java
@@ -46,12 +46,22 @@ public class LabelItemExpandTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("label-item");
-		className.add("label-item-expand");
+		return processCssClass(className);
+	}
 
-		return super.processClassName(className);
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("label-item");
+		cssClass.add("label-item-expand");
+
+		return super.processCssClass(cssClass);
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE =

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemExpandTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemExpandTag.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+
+/**
+ * @author Chema Balsas
+ */
+public class LabelItemExpandTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		if (getContainerElement() == null) {
+			setContainerElement("span");
+		}
+
+		return super.doStartTag();
+	}
+
+	@Override
+	protected String getEndPage() {
+		return _END_PAGE;
+	}
+
+	@Override
+	protected String getStartPage() {
+		return _START_PAGE;
+	}
+
+	@Override
+	protected String processClassName(Set<String> className) {
+		className.add("label-item");
+		className.add("label-item-expand");
+
+		return super.processClassName(className);
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE =
+		"clay:label-item-expand:";
+
+	private static final String _END_PAGE = "/label_item_expand/end.jsp";
+
+	private static final String _START_PAGE = "/label_item_expand/start.jsp";
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.taglib.util.TagResourceBundleUtil;
 
-import java.util.ResourceBundle;
 import java.util.Set;
 
 import javax.servlet.jsp.JspException;
@@ -129,10 +128,6 @@ public class LabelTag extends BaseContainerTag {
 		_displayType = displayType;
 	}
 
-	public void setElementClasses(String elementClasses) {
-		setClassName(elementClasses);
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
@@ -231,10 +226,11 @@ public class LabelTag extends BaseContainerTag {
 
 			jspWriter.write("<span class=\"label-item label-item-expand\">");
 
-			ResourceBundle resourceBundle =
-				TagResourceBundleUtil.getResourceBundle(pageContext);
+			jspWriter.write(
+				LanguageUtil.get(
+					TagResourceBundleUtil.getResourceBundle(pageContext),
+					_label));
 
-			jspWriter.write(LanguageUtil.get(resourceBundle, _label));
 			jspWriter.write("</span>");
 
 			if (_dismissible) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.ResourceBundle;
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Chema Balsas
+ */
+public class LabelTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		if (getContainerElement() == null) {
+			setContainerElement("span");
+		}
+
+		return super.doStartTag();
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getDismissible()}
+	 */
+	@Deprecated
+	public boolean getCloseable() {
+		return getDismissible();
+	}
+
+	public boolean getDismissible() {
+		return _dismissible;
+	}
+
+	public String getDisplayType() {
+		return _displayType;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getHref() {
+		return _href;
+	}
+
+	public String getLabel() {
+		return _label;
+	}
+
+	public boolean getLarge() {
+		return _large;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getMessage() {
+		return _message;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getLarge()}
+	 */
+	@Deprecated
+	public String getSize() {
+		if (_large) {
+			return "lg";
+		}
+
+		return null;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getSpritemap() {
+		return _spritemap;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getDisplayType()}
+	 */
+	@Deprecated
+	public String getStyle() {
+		return getDisplayType();
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setDismissible(boolean)}
+	 */
+	@Deprecated
+	public void setCloseable(boolean closeable) {
+		setDismissible(closeable);
+	}
+
+	public void setDismissible(boolean dismissible) {
+		_dismissible = dismissible;
+	}
+
+	public void setDisplayType(String displayType) {
+		_displayType = displayType;
+	}
+
+	public void setElementClasses(String elementClasses) {
+		setClassName(elementClasses);
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setHref(String href) {
+		_href = href;
+	}
+
+	public void setLabel(String label) {
+		_label = label;
+	}
+
+	public void setLarge(boolean large) {
+		_large = large;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setMessage(String message) {
+		_message = message;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setLarge(boolean)}
+	 */
+	@Deprecated
+	public void setSize(String size) {
+		setLarge(size.equals("lg"));
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setSpritemap(String spritemap) {
+		_spritemap = spritemap;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setDisplayType(String)}
+	 */
+	@Deprecated
+	public void setStyle(String style) {
+		setDisplayType(style);
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_dismissible = false;
+		_displayType = "secondary";
+		_href = null;
+		_label = null;
+		_large = false;
+		_message = null;
+		_spritemap = null;
+	}
+
+	@Override
+	protected String getEndPage() {
+		return _END_PAGE;
+	}
+
+	@Override
+	protected String getStartPage() {
+		return _START_PAGE;
+	}
+
+	@Override
+	protected String processClassName(Set<String> className) {
+		className.add("label");
+		className.add("label-" + _displayType);
+
+		if (_dismissible) {
+			className.add("label-dismissible");
+		}
+
+		if (_large) {
+			className.add("label-lg");
+		}
+
+		return super.processClassName(className);
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		if (Validator.isNotNull(_label)) {
+			JspWriter jspWriter = pageContext.getOut();
+
+			jspWriter.write("<span class=\"label-item label-item-expand\">");
+
+			ResourceBundle resourceBundle =
+				TagResourceBundleUtil.getResourceBundle(pageContext);
+
+			jspWriter.write(LanguageUtil.get(resourceBundle, _label));
+			jspWriter.write("</span>");
+
+			if (_dismissible) {
+				jspWriter.write("<span class=\"label-item label-item-after\">");
+
+				jspWriter.write("<button class=\"close\" type=\"button\">");
+
+				IconTag iconTag = new IconTag();
+
+				iconTag.setSymbol("times");
+
+				iconTag.doTag(pageContext);
+
+				jspWriter.write("</button>");
+				jspWriter.write("</span>");
+			}
+
+			return SKIP_BODY;
+		}
+
+		return EVAL_BODY_INCLUDE;
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:label:";
+
+	private static final String _END_PAGE = "/label/end.jsp";
+
+	private static final String _START_PAGE = "/label/start.jsp";
+
+	private boolean _dismissible;
+	private String _displayType = "secondary";
+	private String _href;
+	private String _label;
+	private boolean _large;
+	private String _message;
+	private String _spritemap;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
@@ -201,20 +201,30 @@ public class LabelTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("label");
-		className.add("label-" + _displayType);
+		return processCssClass(className);
+	}
+
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("label");
+		cssClass.add("label-" + _displayType);
 
 		if (_dismissible) {
-			className.add("label-dismissible");
+			cssClass.add("label-dismissible");
 		}
 
 		if (_large) {
-			className.add("label-lg");
+			cssClass.add("label-lg");
 		}
 
-		return super.processClassName(className);
+		return super.processCssClass(cssClass);
 	}
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/RowTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/RowTag.java
@@ -42,11 +42,21 @@ public class RowTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("row");
+		return processCssClass(className);
+	}
 
-		return super.processClassName(className);
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("row");
+
+		return super.processCssClass(cssClass);
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:row:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetFooterTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetFooterTag.java
@@ -42,11 +42,21 @@ public class SheetFooterTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("sheet-footer");
+		return processCssClass(className);
+	}
 
-		return super.processClassName(className);
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("sheet-footer");
+
+		return super.processCssClass(cssClass);
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:sheet-footer:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetHeaderTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetHeaderTag.java
@@ -42,11 +42,21 @@ public class SheetHeaderTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("sheet-header");
+		return processCssClass(className);
+	}
 
-		return super.processClassName(className);
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("sheet-header");
+
+		return super.processCssClass(cssClass);
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:sheet-header:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetSectionTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetSectionTag.java
@@ -42,11 +42,21 @@ public class SheetSectionTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("sheet-section");
+		return processCssClass(className);
+	}
 
-		return super.processClassName(className);
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("sheet-section");
+
+		return super.processCssClass(cssClass);
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:sheet-section:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetTag.java
@@ -58,15 +58,25 @@ public class SheetTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("sheet");
+		return processCssClass(className);
+	}
+
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("sheet");
 
 		if (Validator.isNotNull(_size)) {
-			className.add("sheet-" + _size);
+			cssClass.add("sheet-" + _size);
 		}
 
-		return super.processClassName(className);
+		return super.processCssClass(cssClass);
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:sheet:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StickerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StickerTag.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Chema Balsas
+ */
+public class StickerTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		if (getContainerElement() == null) {
+			setContainerElement("span");
+		}
+
+		return super.doStartTag();
+	}
+
+	public String getDisplayType() {
+		return _displayType;
+	}
+
+	public String getIcon() {
+		return _icon;
+	}
+
+	public boolean getInline() {
+		return _inline;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getLabel() {
+		return _label;
+	}
+
+	public boolean getOutside() {
+		return _outside;
+	}
+
+	public String getPosition() {
+		return _position;
+	}
+
+	public String getShape() {
+		return _shape;
+	}
+
+	public String getSize() {
+		return _size;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getSpritemap() {
+		return _spritemap;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getDisplayType()}
+	 */
+	@Deprecated
+	public String getStyle() {
+		return getDisplayType();
+	}
+
+	public void setDisplayType(String displayType) {
+		_displayType = displayType;
+	}
+
+	public void setIcon(String icon) {
+		_icon = icon;
+	}
+
+	public void setInline(boolean inline) {
+		_inline = inline;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setLabel(String label) {
+		_label = label;
+	}
+
+	public void setOutside(boolean outside) {
+		_outside = outside;
+	}
+
+	public void setPosition(String position) {
+		_position = position;
+	}
+
+	public void setShape(String shape) {
+		_shape = shape;
+	}
+
+	public void setSize(String size) {
+		_size = size;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setSpritemap(String spritemap) {
+		_spritemap = spritemap;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setDisplayType(String)}
+	 */
+	@Deprecated
+	public void setStyle(String style) {
+		setDisplayType(style);
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_displayType = null;
+		_icon = null;
+		_inline = false;
+		_label = null;
+		_outside = false;
+		_position = null;
+		_shape = "rounded";
+		_size = null;
+		_spritemap = null;
+	}
+
+	@Override
+	protected String getEndPage() {
+		return _END_PAGE;
+	}
+
+	@Override
+	protected String getStartPage() {
+		return _START_PAGE;
+	}
+
+	@Override
+	protected String processClassName(Set<String> className) {
+		className.add("sticker");
+
+		if (Validator.isNotNull(_displayType)) {
+			className.add("sticker-" + _displayType);
+		}
+
+		if (Validator.isNotNull(_position)) {
+			className.add("sticker-" + _position);
+
+			if (_outside) {
+				className.add("sticker-outside");
+			}
+		}
+
+		if (Validator.isNotNull(_shape)) {
+			className.add("sticker-" + _shape);
+		}
+
+		if (Validator.isNotNull(_size)) {
+			className.add("sticker-" + _size);
+		}
+
+		return super.processClassName(className);
+	}
+
+	@Override
+	protected int processEndTag() throws Exception {
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write("</span>");
+
+		return super.processEndTag();
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write("<span class=\"sticker-overlay");
+
+		if (_inline) {
+			jspWriter.write(" inline-item");
+		}
+
+		jspWriter.write("\">");
+
+		if (Validator.isNotNull(_icon)) {
+			IconTag iconTag = new IconTag();
+
+			iconTag.setSymbol(_icon);
+
+			iconTag.doTag(pageContext);
+
+			return SKIP_BODY;
+		}
+
+		return EVAL_BODY_INCLUDE;
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:sticker:";
+
+	private static final String _END_PAGE = "/sticker/end.jsp";
+
+	private static final String _START_PAGE = "/sticker/start.jsp";
+
+	private String _displayType;
+	private String _icon;
+	private boolean _inline;
+	private String _label;
+	private boolean _outside;
+	private String _position;
+	private String _shape = "rounded";
+	private String _size;
+	private String _spritemap;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StickerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StickerTag.java
@@ -169,31 +169,41 @@ public class StickerTag extends BaseContainerTag {
 		return _START_PAGE;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #processCssClass(String)}
+	 */
+	@Deprecated
 	@Override
 	protected String processClassName(Set<String> className) {
-		className.add("sticker");
+		return processCssClass(className);
+	}
+
+	@Override
+	protected String processCssClass(Set<String> cssClass) {
+		cssClass.add("sticker");
 
 		if (Validator.isNotNull(_displayType)) {
-			className.add("sticker-" + _displayType);
+			cssClass.add("sticker-" + _displayType);
 		}
 
 		if (Validator.isNotNull(_position)) {
-			className.add("sticker-" + _position);
+			cssClass.add("sticker-" + _position);
 
 			if (_outside) {
-				className.add("sticker-outside");
+				cssClass.add("sticker-outside");
 			}
 		}
 
 		if (Validator.isNotNull(_shape)) {
-			className.add("sticker-" + _shape);
+			cssClass.add("sticker-" + _shape);
 		}
 
 		if (Validator.isNotNull(_size)) {
-			className.add("sticker-" + _size);
+			cssClass.add("sticker-" + _size);
 		}
 
-		return super.processClassName(className);
+		return super.processCssClass(cssClass);
 	}
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/BadgeTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/BadgeTag.java
@@ -18,7 +18,10 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.soy.base.BaseClayTag;
 
 /**
  * @author Carlos Lancha
+ * @deprecated As of Athanasius (7.3.x), replaced by {@link
+ *             com.liferay.frontend.taglib.clay.servlet.taglib.BadgeTag}
  */
+@Deprecated
 public class BadgeTag extends BaseClayTag {
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/IconTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/IconTag.java
@@ -18,7 +18,10 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.soy.base.BaseClayTag;
 
 /**
  * @author Chema Balsas
+ * @deprecated As of Athanasius (7.3.x), replaced by {@link
+ *             com.liferay.frontend.taglib.clay.servlet.taglib.IconTag}
  */
+@Deprecated
 public class IconTag extends BaseClayTag {
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/LabelTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/LabelTag.java
@@ -18,7 +18,10 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.soy.base.BaseClayTag;
 
 /**
  * @author Chema Balsas
+ * @deprecated As of Athanasius (7.3.x), replaced by {@link
+ *             com.liferay.frontend.taglib.clay.servlet.taglib.LabelTag}
  */
+@Deprecated
 public class LabelTag extends BaseClayTag {
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/StickerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/StickerTag.java
@@ -18,7 +18,10 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.soy.base.BaseClayTag;
 
 /**
  * @author Carlos Lancha
+ * @deprecated As of Athanasius (7.3.x), replaced by {@link
+ *             com.liferay.frontend.taglib.clay.servlet.taglib.StickerTag}
  */
+@Deprecated
 public class StickerTag extends BaseClayTag {
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -105,12 +105,6 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.BadgeTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
-			<description></description>
-			<name>className</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
@@ -125,6 +119,12 @@
 		<attribute>
 			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -147,7 +147,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>className</code>]]>.</description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -394,13 +394,13 @@
 		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
-			<name>className</name>
+			<name>containerElement</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
-			<name>containerElement</name>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -443,13 +443,13 @@
 		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
-			<name>className</name>
+			<name>containerElement</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
-			<name>containerElement</name>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -474,13 +474,13 @@
 		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
-			<name>className</name>
+			<name>containerElement</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
-			<name>containerElement</name>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -499,13 +499,13 @@
 		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
-			<name>className</name>
+			<name>containerElement</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
-			<name>containerElement</name>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -530,13 +530,13 @@
 		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
-			<name>className</name>
+			<name>containerElement</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
-			<name>containerElement</name>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -573,13 +573,13 @@
 		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
-			<name>className</name>
+			<name>containerElement</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
-			<name>containerElement</name>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -1113,11 +1113,6 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.IconTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
-			<name>className</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
@@ -1126,6 +1121,11 @@
 		<attribute>
 			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -1142,7 +1142,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>className</code>]]>.</description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1371,12 +1371,6 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.LabelTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
-			<description></description>
-			<name>className</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>dismissible</code>]]>.</description>
 			<name>closeable</name>
 			<required>false</required>
@@ -1391,6 +1385,12 @@
 		<attribute>
 			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -1413,7 +1413,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>className</code>]]>.</description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1474,7 +1474,7 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.LabelItemAfterTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
-			<name>className</name>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -1492,7 +1492,7 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.LabelItemBeforeTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
-			<name>className</name>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -1510,7 +1510,7 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.LabelItemExpandTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
-			<name>className</name>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -2213,13 +2213,13 @@
 		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
-			<name>className</name>
+			<name>containerElement</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
-			<name>containerElement</name>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -2310,13 +2310,13 @@
 		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
-			<name>className</name>
+			<name>containerElement</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
-			<name>containerElement</name>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -2329,13 +2329,13 @@
 		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
-			<name>className</name>
+			<name>containerElement</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
-			<name>containerElement</name>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -2348,13 +2348,13 @@
 		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
-			<name>className</name>
+			<name>containerElement</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
-			<name>containerElement</name>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -2367,13 +2367,13 @@
 		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
-			<name>className</name>
+			<name>containerElement</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
-			<name>containerElement</name>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -2385,12 +2385,6 @@
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.StickerTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
-			<description></description>
-			<name>className</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
@@ -2399,6 +2393,12 @@
 		<attribute>
 			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -2421,7 +2421,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>className</code>]]>.</description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1368,46 +1368,58 @@
 	<tag>
 		<description></description>
 		<name>label</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.LabelTag</tag-class>
-		<body-content>empty</body-content>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.LabelTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
+			<name>className</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>dismissible</code>]]>.</description>
 			<name>closeable</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>displayType</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>className</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>href</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1421,33 +1433,94 @@
 		<attribute>
 			<description></description>
 			<name>label</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>large</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>message</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>large</code>]]>.</description>
 			<name>size</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>spritemap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
 			<name>style</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
+	</tag>
+	<tag>
+		<description></description>
+		<name>label-item-after</name>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.LabelItemAfterTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<name>className</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>id</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
+	</tag>
+	<tag>
+		<description></description>
+		<name>label-item-before</name>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.LabelItemBeforeTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<name>className</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>id</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
+	</tag>
+	<tag>
+		<description></description>
+		<name>label-item-expand</name>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.LabelItemExpandTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<name>className</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>id</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -2382,34 +2382,46 @@
 	<tag>
 		<description></description>
 		<name>sticker</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.StickerTag</tag-class>
-		<body-content>empty</body-content>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.StickerTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
+			<name>className</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>displayType</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>className</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -2428,6 +2440,12 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>inline</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>label</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -2457,17 +2475,18 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>spritemap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
 			<name>style</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -102,34 +102,52 @@
 	<tag>
 		<description></description>
 		<name>badge</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.BadgeTag</tag-class>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.BadgeTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
 			<description></description>
+			<name>className</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>containerElement</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>displayType</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>className</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -141,17 +159,17 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
 			<name>label</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
 			<name>style</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1092,34 +1092,39 @@
 	<tag>
 		<description></description>
 		<name>icon</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.IconTag</tag-class>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.IconTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
-			<description></description>
+			<name>className</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>className</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1131,13 +1136,13 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>monospaced</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>spritemap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1148,6 +1153,7 @@
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/badge/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/badge/end.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/badge/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/badge/start.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/icon/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/icon/end.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/icon/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/icon/start.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label/end.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label/start.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_after/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_after/end.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_after/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_after/start.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_before/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_before/end.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_before/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_before/start.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_expand/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_expand/end.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_expand/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_expand/start.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sticker/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sticker/end.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sticker/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sticker/start.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/horizontal_card_icon/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/horizontal_card_icon/page.jsp
@@ -31,8 +31,9 @@ if (bodyContent != null) {
 		<%= bodyContentString %>
 	</c:when>
 	<c:otherwise>
-		<div class="sticker sticker-secondary">
-			<aui:icon image="<%= icon %>" markupView="lexicon" />
-		</div>
+		<clay:sticker
+			displayType="secondary"
+			icon="<%= icon %>"
+		/>
 	</c:otherwise>
 </c:choose>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/vertical_card_small_image/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/vertical_card_small_image/page.jsp
@@ -16,6 +16,9 @@
 
 <%@ include file="/card/vertical_card_small_image/init.jsp" %>
 
-<div class="sticker sticker-bottom-left <%= cssClass %>">
+<clay:sticker
+	className="<%= cssClass %>"
+	position="bottom-left"
+>
 	<img alt="thumbnail" class="img-responsive" src="<%= src %>" />
-</div>
+</clay:sticker>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/vertical_card_small_image/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/vertical_card_small_image/page.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/card/vertical_card_small_image/init.jsp" %>
 
 <clay:sticker
-	className="<%= cssClass %>"
+	cssClass="<%= cssClass %>"
 	position="bottom-left"
 >
 	<img alt="thumbnail" class="img-responsive" src="<%= src %>" />

--- a/modules/apps/invitation/invitation-invite-members-web/src/main/resources/META-INF/resources/invite_members/view_invite.jsp
+++ b/modules/apps/invitation/invitation-invite-members-web/src/main/resources/META-INF/resources/invite_members/view_invite.jsp
@@ -37,7 +37,7 @@ Group group = GroupLocalServiceUtil.getGroup(scopeGroupId);
 
 		<div class="dialog-body">
 			<clay:container-fluid
-				className="main-content-body"
+				cssClass="main-content-body"
 			>
 				<aui:fieldset-group markupView="lexicon">
 					<aui:fieldset>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
@@ -62,11 +62,9 @@ Set<String> groupTypes = groupSelectorDisplayContext.getGroupTypes();
 					<liferay-frontend:horizontal-card-col>
 						<c:choose>
 							<c:when test="<%= Validator.isNotNull(curGroup.getLogoURL(themeDisplay, false)) %>">
-								<span class="sticker sticker-rounded">
-									<span class="sticker-overlay">
-										<img alt="" class="sticker-img" src="<%= curGroup.getLogoURL(themeDisplay, false) %>" />
-									</span>
-								</span>
+								<clay:sticker>
+									<img alt="" class="sticker-img" src="<%= curGroup.getLogoURL(themeDisplay, false) %>" />
+								</clay:sticker>
 							</c:when>
 							<c:otherwise>
 								<liferay-frontend:horizontal-card-icon

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
@@ -41,7 +41,7 @@ Set<String> groupTypes = groupSelectorDisplayContext.getGroupTypes();
 </c:if>
 
 <clay:container-fluid
-	className="lfr-item-viewer"
+	cssClass="lfr-item-viewer"
 >
 	<liferay-ui:search-container
 		searchContainer="<%= groupSelectorDisplayContext.getSearchContainer() %>"

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -71,7 +71,7 @@ ItemSelectorRepositoryEntryManagementToolbarDisplayContext itemSelectorRepositor
 />
 
 <clay:container-fluid
-	className="item-selector lfr-item-viewer"
+	cssClass="item-selector lfr-item-viewer"
 	id='<%= randomNamespace + "ItemSelectorContainer" %>'
 >
 	<c:if test="<%= showSearchInfo %>">

--- a/modules/apps/item-selector/item-selector-upload-web/src/main/resources/META-INF/resources/upload.jsp
+++ b/modules/apps/item-selector/item-selector-upload-web/src/main/resources/META-INF/resources/upload.jsp
@@ -49,7 +49,7 @@ Map<String, Object> context = HashMapBuilder.<String, Object>put(
 %>
 
 <clay:container-fluid
-	className="lfr-item-viewer"
+	cssClass="lfr-item-viewer"
 	id="itemSelectorUploadContainer"
 >
 	<div class="drop-enabled drop-zone item-selector upload-view">

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -31,7 +31,7 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptor.getSearchCo
 </c:if>
 
 <clay:container-fluid
-	className="item-selector lfr-item-viewer"
+	cssClass="item-selector lfr-item-viewer"
 	id='<%= renderResponse.getNamespace() + "entriesContainer" %>'
 >
 	<c:if test="<%= itemSelectorViewDescriptor.isShowBreadcrumb() %>">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
@@ -45,7 +45,7 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 		<b><liferay-ui:message key="version" /></b>: <%= article.getVersion() %>
 
 		<clay:label
-			className="ml-2"
+			className="ml-2 text-uppercase"
 			displayType="<%= WorkflowConstants.getStatusStyle(article.getStatus()) %>"
 			label="<%= WorkflowConstants.getStatusLabel(article.getStatus()) %>"
 		/>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
@@ -44,9 +44,11 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 	<p class="article-version-status">
 		<b><liferay-ui:message key="version" /></b>: <%= article.getVersion() %>
 
-		<span class="label label-<%= WorkflowConstants.getStatusStyle(article.getStatus()) %> ml-2 text-uppercase">
-			<liferay-ui:message key="<%= WorkflowConstants.getStatusLabel(article.getStatus()) %>" />
-		</span>
+		<clay:label
+			className="ml-2"
+			displayType="<%= WorkflowConstants.getStatusStyle(article.getStatus()) %>"
+			label="<%= WorkflowConstants.getStatusLabel(article.getStatus()) %>"
+		/>
 	</p>
 </c:if>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
@@ -45,7 +45,7 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 		<b><liferay-ui:message key="version" /></b>: <%= article.getVersion() %>
 
 		<clay:label
-			className="ml-2 text-uppercase"
+			cssClass="ml-2 text-uppercase"
 			displayType="<%= WorkflowConstants.getStatusStyle(article.getStatus()) %>"
 			label="<%= WorkflowConstants.getStatusLabel(article.getStatus()) %>"
 		/>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -139,7 +139,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 
 	<div class="contextual-sidebar-content">
 		<clay:container-fluid
-			className="container-view"
+			cssClass="container-view"
 		>
 			<div class="sheet sheet-lg">
 				<aui:model-context bean="<%= article %>" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" model="<%= JournalArticle.class %>" />

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_data_layout_builder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_data_layout_builder.jsp
@@ -77,7 +77,7 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 	</nav>
 
 	<clay:container-fluid
-		className="container-view"
+		cssClass="container-view"
 	>
 		<c:if test="<%= (ddmStructure != null) && (DDMStorageLinkLocalServiceUtil.getStructureStorageLinksCount(journalEditDDMStructuresDisplayContext.getDDMStructureId()) > 0) %>">
 			<div class="alert alert-warning">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_form_builder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_form_builder.jsp
@@ -101,7 +101,7 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 
 	<div class="contextual-sidebar-content">
 		<clay:container-fluid
-			className="container-view"
+			cssClass="container-view"
 		>
 			<liferay-ui:error exception="<%= DDMFormLayoutValidationException.class %>" message="please-enter-a-valid-form-layout" />
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
@@ -98,7 +98,7 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 
 	<div class="contextual-sidebar-content">
 		<clay:container-fluid
-			className="container-view"
+			cssClass="container-view"
 		>
 			<div class="sheet">
 				<liferay-ui:error exception="<%= TemplateNameException.class %>" message="please-enter-a-valid-name" />

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template_display.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template_display.jsp
@@ -26,11 +26,11 @@ JournalDDMTemplateHelper journalDDMTemplateHelper = (JournalDDMTemplateHelper)re
 
 <div id="templateScriptContainer">
 	<clay:row
-		className="form-group lfr-template-editor-container"
+		cssClass="form-group lfr-template-editor-container"
 	>
 		<c:if test="<%= journalEditDDMTemplateDisplayContext.isAutocompleteEnabled() %>">
 			<clay:col
-				className="lfr-template-palette-container"
+				cssClass="lfr-template-palette-container"
 				id='<%= renderResponse.getNamespace() + "templatePaletteContainer" %>'
 				md="3"
 			>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
@@ -25,7 +25,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 />
 
 <clay:container-fluid
-	className="item-selector lfr-item-viewer"
+	cssClass="item-selector lfr-item-viewer"
 	id='<%= renderResponse.getNamespace() + "articlesContainer" %>'
 >
 	<liferay-site-navigation:breadcrumb

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content.jsp
@@ -21,7 +21,7 @@ JournalArticleDisplay articleDisplay = journalDisplayContext.getArticleDisplay()
 %>
 
 <clay:container-fluid
-	className="mt-2"
+	cssClass="mt-2"
 >
 	<%= articleDisplay.getContent() %>
 </clay:container-fluid>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
@@ -61,7 +61,7 @@ if (Validator.isNotNull(title)) {
 />
 
 <clay:container-fluid
-	className="closed sidenav-container sidenav-right"
+	cssClass="closed sidenav-container sidenav-right"
 	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 >
 	<c:if test="<%= journalDisplayContext.isShowInfoButton() %>">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -120,14 +120,16 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 
 							<span class="text-default">
 								<c:if test="<%= !curArticle.isApproved() && curArticle.hasApprovedVersion() %>">
-									<span class="label label-success text-uppercase">
-										<liferay-ui:message key="approved" />
-									</span>
+									<clay:label
+										displayType="success"
+										label="approved"
+									/>
 								</c:if>
 
-								<span class="label label-<%= WorkflowConstants.getStatusStyle(curArticle.getStatus()) %> text-uppercase">
-									<liferay-ui:message key="<%= WorkflowConstants.getStatusLabel(curArticle.getStatus()) %>" />
-								</span>
+								<clay:label
+									displayType="<%= WorkflowConstants.getStatusStyle(curArticle.getStatus()) %>"
+									label="<%= WorkflowConstants.getStatusLabel(curArticle.getStatus()) %>"
+								/>
 							</span>
 						</liferay-ui:search-container-column-text>
 
@@ -190,14 +192,16 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 							name="status"
 						>
 							<c:if test="<%= !curArticle.isApproved() && curArticle.hasApprovedVersion() %>">
-								<span class="label label-success text-uppercase">
-									<liferay-ui:message key="approved" />
-								</span>
+								<clay:label
+									displayType="success"
+									label="approved"
+								/>
 							</c:if>
 
-							<span class="label label-<%= WorkflowConstants.getStatusStyle(curArticle.getStatus()) %> text-uppercase">
-								<liferay-ui:message key="<%= WorkflowConstants.getStatusLabel(curArticle.getStatus()) %>" />
-							</span>
+								<clay:label
+									displayType="<%= WorkflowConstants.getStatusStyle(curArticle.getStatus()) %>"
+									label="<%= WorkflowConstants.getStatusLabel(curArticle.getStatus()) %>"
+								/>
 						</liferay-ui:search-container-column-text>
 
 						<liferay-ui:search-container-column-date

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -198,10 +198,10 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 								/>
 							</c:if>
 
-								<clay:label
-									displayType="<%= WorkflowConstants.getStatusStyle(curArticle.getStatus()) %>"
-									label="<%= WorkflowConstants.getStatusLabel(curArticle.getStatus()) %>"
-								/>
+							<clay:label
+								displayType="<%= WorkflowConstants.getStatusStyle(curArticle.getStatus()) %>"
+								label="<%= WorkflowConstants.getStatusLabel(curArticle.getStatus()) %>"
+							/>
 						</liferay-ui:search-container-column-text>
 
 						<liferay-ui:search-container-column-date

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/article_tools.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/article_tools.jsp
@@ -26,7 +26,7 @@ int status = (Integer)request.getAttribute(KBWebKeys.KNOWLEDGE_BASE_STATUS);
 	<c:if test="<%= kbGroupServiceConfiguration.sourceURLEnabled() && Validator.isUrl(kbArticle.getSourceURL()) %>">
 		<a href="<%= HtmlUtil.escapeAttribute(kbArticle.getSourceURL()) %>" target="_blank">
 			<clay:label
-				className="kb-article-source-url"
+				cssClass="kb-article-source-url"
 				displayType="success"
 				label="<%= HtmlUtil.escape(kbGroupServiceConfiguration.sourceURLEditMessageKey()) %>"
 			/>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/article_tools.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/article_tools.jsp
@@ -25,9 +25,11 @@ int status = (Integer)request.getAttribute(KBWebKeys.KNOWLEDGE_BASE_STATUS);
 <div class="kb-article-tools">
 	<c:if test="<%= kbGroupServiceConfiguration.sourceURLEnabled() && Validator.isUrl(kbArticle.getSourceURL()) %>">
 		<a href="<%= HtmlUtil.escapeAttribute(kbArticle.getSourceURL()) %>" target="_blank">
-			<span class="kb-article-source-url label label-success">
-				<liferay-ui:message key="<%= HtmlUtil.escape(kbGroupServiceConfiguration.sourceURLEditMessageKey()) %>" />
-			</span>
+			<clay:label
+				className="kb-article-source-url"
+				displayType="success"
+				label="<%= HtmlUtil.escape(kbGroupServiceConfiguration.sourceURLEditMessageKey()) %>"
+			/>
 		</a>
 	</c:if>
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -68,7 +68,7 @@ if (parentResourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 />
 
 <clay:container-fluid
-	className="closed sidenav-container sidenav-right"
+	cssClass="closed sidenav-container sidenav-right"
 	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 >
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="infoPanel" var="sidebarPanelURL">

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_suggestion.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/admin/init.jsp" %>
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
 </clay:container-fluid>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/view_suggestion.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/admin/init.jsp" %>
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
 </clay:container-fluid>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/view_suggestion.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/admin/init.jsp" %>
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
 </clay:container-fluid>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/search/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/search/view_suggestion.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/admin/init.jsp" %>
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
 </clay:container-fluid>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/section/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/section/view_suggestion.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/admin/init.jsp" %>
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<liferay-util:include page="/admin/common/view_suggestion.jsp" servletContext="<%= application %>" />
 </clay:container-fluid>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
@@ -23,7 +23,7 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 %>
 
 <clay:container-fluid
-	className="pt-2"
+	cssClass="pt-2"
 >
 	<liferay-frontend:edit-form
 		action="<%= (sourcePlid <= 0) ? layoutsAdminDisplayContext.getAddLayoutURL() : layoutsAdminDisplayContext.getCopyLayoutURL(sourcePlid) %>"
@@ -41,7 +41,7 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 					<liferay-ui:message key="add-this-page-to-the-following-menus" />
 
 					<clay:container-fluid
-						className="auto-site-navigation-menus mt-3"
+						cssClass="auto-site-navigation-menus mt-3"
 					>
 						<clay:row>
 
@@ -69,7 +69,7 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 					%>
 
 					<clay:container-fluid
-						className="auto-site-navigation-menus mt-3"
+						cssClass="auto-site-navigation-menus mt-3"
 					>
 						<clay:row>
 							<aui:input id='<%= "menu_" + autoSiteNavigationMenu.getSiteNavigationMenuId() %>' label='<%= LanguageUtil.format(request, "add-this-page-to-x", HtmlUtil.escape(autoSiteNavigationMenu.getName())) %>' name="TypeSettingsProperties--siteNavigationMenuId--" type="checkbox" value="<%= autoSiteNavigationMenu.getSiteNavigationMenuId() %>" />

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
@@ -34,7 +34,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 %>
 
 <clay:container-fluid
-	className="container-view"
+	cssClass="container-view"
 	id='<%= renderResponse.getNamespace() + "layoutPageTemplateEntries" %>'
 >
 	<clay:row>

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_display_page_master_layout.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_display_page_master_layout.jsp
@@ -28,7 +28,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 %>
 
 <clay:container-fluid
-	className="mt-4"
+	cssClass="mt-4"
 >
 	<div class="lfr-search-container-wrapper">
 		<ul class="card-page card-page-equal-height">

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry_master_layout.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry_master_layout.jsp
@@ -37,7 +37,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 %>
 
 <clay:container-fluid
-	className="mt-4"
+	cssClass="mt-4"
 >
 	<div class="lfr-search-container-wrapper">
 		<ul class="card-page card-page-equal-height">

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
@@ -30,7 +30,7 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 <liferay-ui:success key="layoutPageTemplatePublished" message="the-page-template-was-published-succesfully" />
 
 <clay:container-fluid
-	className="container-view"
+	cssClass="container-view"
 >
 	<clay:row>
 		<clay:col

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_admin/page.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_admin/page.jsp
@@ -24,7 +24,7 @@ LayoutClassedModelUsagesDisplayContext layoutClassedModelUsagesDisplayContext = 
 %>
 
 <clay:container-fluid
-	className="container-form-lg"
+	cssClass="container-form-lg"
 >
 	<clay:row>
 		<clay:col

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_fragment_layout/render_layout_structure.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_fragment_layout/render_layout_structure.jsp
@@ -101,7 +101,7 @@ for (String childrenItemId : childrenItemIds) {
 			%>
 
 			<clay:col
-				className="<%= ResponsiveLayoutStructureUtil.getColumnCssClass(rowLayoutStructureItem, columnLayoutStructureItem) %>"
+				cssClass="<%= ResponsiveLayoutStructureUtil.getColumnCssClass(rowLayoutStructureItem, columnLayoutStructureItem) %>"
 			>
 
 				<%
@@ -238,10 +238,10 @@ for (String childrenItemId : childrenItemIds) {
 			<c:choose>
 				<c:when test="<%= includeContainer %>">
 					<clay:container-fluid
-						className="p-0"
+						cssClass="p-0"
 					>
 						<clay:row
-							className="<%= ResponsiveLayoutStructureUtil.getRowCssClass(rowLayoutStructureItem) %>"
+							cssClass="<%= ResponsiveLayoutStructureUtil.getRowCssClass(rowLayoutStructureItem) %>"
 						>
 
 							<%
@@ -254,7 +254,7 @@ for (String childrenItemId : childrenItemIds) {
 				</c:when>
 				<c:otherwise>
 					<clay:row
-						className="<%= ResponsiveLayoutStructureUtil.getRowCssClass(rowLayoutStructureItem) %>"
+						cssClass="<%= ResponsiveLayoutStructureUtil.getRowCssClass(rowLayoutStructureItem) %>"
 					>
 
 						<%

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/layout/view/display_page.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/layout/view/display_page.jsp
@@ -65,7 +65,7 @@ String ppid = ParamUtil.getString(request, "p_p_id");
 			<c:when test="<%= (assetRendererFactory != null) && !assetRendererFactory.hasPermission(permissionChecker, infoDisplayObjectProvider.getClassPK(), ActionKeys.VIEW) %>">
 				<div class="layout-content" id="main-content" role="main">
 					<clay:container-fluid
-						className="pt-3"
+						cssClass="pt-3"
 					>
 						<div class="alert alert-danger">
 							<liferay-ui:message key="you-do-not-have-permission-to-view-this-page" />

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-panel/src/main/resources/META-INF/resources/layout/view/panel.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-panel/src/main/resources/META-INF/resources/layout/view/panel.jsp
@@ -19,7 +19,7 @@
 <c:choose>
 	<c:when test="<%= !themeDisplay.isStatePopUp() %>">
 		<clay:container-fluid
-			className="lfr-panel-page"
+			cssClass="lfr-panel-page"
 			id="main-content"
 		>
 			<clay:row>
@@ -36,7 +36,7 @@
 				%>
 
 				<clay:col
-					className="panel-page-menu"
+					cssClass="panel-page-menu"
 					md="3"
 				>
 
@@ -68,7 +68,7 @@
 				</clay:col>
 
 				<clay:col
-					className="<%= panelBodyCssClass %>"
+					cssClass="<%= panelBodyCssClass %>"
 					md="9"
 				>
 					<%@ include file="/layout/view/panel_description.jspf" %>

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-portlet/src/main/resources/META-INF/resources/layout/view/render_layout_structure.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-portlet/src/main/resources/META-INF/resources/layout/view/render_layout_structure.jsp
@@ -90,7 +90,7 @@ for (String childrenItemId : childrenItemIds) {
 			%>
 
 			<clay:col
-				className="<%= ResponsiveLayoutStructureUtil.getColumnCssClass(rowLayoutStructureItem, columnLayoutStructureItem) %>"
+				cssClass="<%= ResponsiveLayoutStructureUtil.getColumnCssClass(rowLayoutStructureItem, columnLayoutStructureItem) %>"
 			>
 
 				<%
@@ -226,7 +226,7 @@ for (String childrenItemId : childrenItemIds) {
 				<c:when test="<%= parentLayoutStructureItem instanceof RootLayoutStructureItem %>">
 					<div className="container-fluid p-0">
 						<clay:row
-							className="<%= ResponsiveLayoutStructureUtil.getRowCssClass(rowLayoutStructureItem) %>"
+							cssClass="<%= ResponsiveLayoutStructureUtil.getRowCssClass(rowLayoutStructureItem) %>"
 						>
 
 							<%
@@ -239,7 +239,7 @@ for (String childrenItemId : childrenItemIds) {
 				</c:when>
 				<c:otherwise>
 					<clay:row
-						className="<%= ResponsiveLayoutStructureUtil.getRowCssClass(rowLayoutStructureItem) %>"
+						cssClass="<%= ResponsiveLayoutStructureUtil.getRowCssClass(rowLayoutStructureItem) %>"
 					>
 
 						<%

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/icon.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/icon.jsp
@@ -20,7 +20,10 @@
 String iconURL = ParamUtil.getString(request, "iconURL");
 %>
 
-<div class="search-container-icon sticker sticker-secondary">
+<clay:sticker
+	className="search-container"
+	displaytype="secondary"
+>
 	<c:choose>
 		<c:when test='<%= iconURL.contains(".svg#") %>'>
 			<svg class="lexicon-icon">
@@ -31,4 +34,4 @@ String iconURL = ParamUtil.getString(request, "iconURL");
 			<img alt="thumbnail" class="img-fluid" src="<%= iconURL %>" />
 		</c:when>
 	</c:choose>
-</div>
+</clay:sticker>

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/icon.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/icon.jsp
@@ -21,7 +21,7 @@ String iconURL = ParamUtil.getString(request, "iconURL");
 %>
 
 <clay:sticker
-	className="search-container"
+	cssClass="search-container"
 	displaytype="secondary"
 >
 	<c:choose>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_statistics.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_statistics.jsp
@@ -45,7 +45,7 @@ portletURL.setParameter("mbCategoryId", String.valueOf(categoryId));
 			>
 				<div class="overview-container statistics-panel">
 					<clay:sticker
-						className="sticker-categories sticker-user-icon"
+						cssClass="sticker-categories sticker-user-icon"
 						icon="categories"
 					/>
 
@@ -60,7 +60,7 @@ portletURL.setParameter("mbCategoryId", String.valueOf(categoryId));
 			>
 				<div class="overview-container statistics-panel">
 					<clay:sticker
-						className="sticker-posts sticker-user-icon"
+						cssClass="sticker-posts sticker-user-icon"
 						icon="message-boards"
 					/>
 
@@ -75,7 +75,7 @@ portletURL.setParameter("mbCategoryId", String.valueOf(categoryId));
 			>
 				<div class="overview-container statistics-panel">
 					<clay:sticker
-						className="sticker-participants sticker-user-icon"
+						cssClass="sticker-participants sticker-user-icon"
 						icon="users"
 					/>
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_statistics.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_statistics.jsp
@@ -44,11 +44,10 @@ portletURL.setParameter("mbCategoryId", String.valueOf(categoryId));
 				md="4"
 			>
 				<div class="overview-container statistics-panel">
-					<div class="sticker sticker-categories sticker-user-icon">
-						<clay:icon
-							symbol="categories"
-						/>
-					</div>
+					<clay:sticker
+						className="sticker-categories sticker-user-icon"
+						icon="categories"
+					/>
 
 					<small class="text-uppercase"><liferay-ui:message key="categories" /></small>
 
@@ -60,11 +59,10 @@ portletURL.setParameter("mbCategoryId", String.valueOf(categoryId));
 				md="4"
 			>
 				<div class="overview-container statistics-panel">
-					<div class="sticker sticker-posts sticker-user-icon">
-						<clay:icon
-							symbol="message-boards"
-						/>
-					</div>
+					<clay:sticker
+						className="sticker-posts sticker-user-icon"
+						icon="message-boards"
+					/>
 
 					<small class="text-uppercase"><liferay-ui:message key="posts" /></small>
 
@@ -76,11 +74,10 @@ portletURL.setParameter("mbCategoryId", String.valueOf(categoryId));
 				md="4"
 			>
 				<div class="overview-container statistics-panel">
-					<div class="sticker sticker-participants sticker-user-icon">
-						<clay:icon
-							symbol="users"
-						/>
-					</div>
+					<clay:sticker
+						className="sticker-participants sticker-user-icon"
+						icon="users"
+					/>
 
 					<small class="text-uppercase"><liferay-ui:message key="participants" /></small>
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_statistics.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_statistics.jsp
@@ -41,11 +41,10 @@ MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, category
 				md="4"
 			>
 				<div class="overview-container statistics-panel">
-					<div class="sticker sticker-categories sticker-user-icon">
-						<clay:icon
-							symbol="categories"
-						/>
-					</div>
+					<clay:sticker
+						className="sticker-categories sticker-user-icon"
+						icon="categories"
+					/>
 
 					<small class="text-uppercase"><liferay-ui:message key="categories" /></small>
 
@@ -57,11 +56,10 @@ MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, category
 				md="4"
 			>
 				<div class="overview-container statistics-panel">
-					<div class="sticker sticker-posts sticker-user-icon">
-						<clay:icon
-							symbol="message-boards"
-						/>
-					</div>
+					<clay:sticker
+						className="sticker-posts sticker-user-icon"
+						icon="message-boards"
+					/>
 
 					<small class="text-uppercase"><liferay-ui:message key="posts" /></small>
 
@@ -73,11 +71,10 @@ MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, category
 				md="4"
 			>
 				<div class="overview-container statistics-panel">
-					<div class="sticker sticker-participants sticker-user-icon">
-						<clay:icon
-							symbol="users"
-						/>
-					</div>
+					<clay:sticker
+						className="sticker-participants sticker-user-icon"
+						icon="users"
+					/>
 
 					<small class="text-uppercase"><liferay-ui:message key="participants" /></small>
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_statistics.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_statistics.jsp
@@ -42,7 +42,7 @@ MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, category
 			>
 				<div class="overview-container statistics-panel">
 					<clay:sticker
-						className="sticker-categories sticker-user-icon"
+						cssClass="sticker-categories sticker-user-icon"
 						icon="categories"
 					/>
 
@@ -57,7 +57,7 @@ MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, category
 			>
 				<div class="overview-container statistics-panel">
 					<clay:sticker
-						className="sticker-posts sticker-user-icon"
+						cssClass="sticker-posts sticker-user-icon"
 						icon="message-boards"
 					/>
 
@@ -72,7 +72,7 @@ MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, category
 			>
 				<div class="overview-container statistics-panel">
 					<clay:sticker
-						className="sticker-participants sticker-user-icon"
+						cssClass="sticker-participants sticker-user-icon"
 						icon="users"
 					/>
 

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
@@ -86,7 +86,7 @@ navigationURL.setParameter(SearchContainer.DEFAULT_CUR_PARAM, "0");
 />
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<aui:form action="<%= currentURL %>" method="get" name="fm">
 		<div class="user-notifications">

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes.jsp
@@ -25,7 +25,7 @@ AssignScopesDisplayContext assignScopesDisplayContext = (AssignScopesDisplayCont
 %>
 
 <clay:container-fluid
-	className="container-view"
+	cssClass="container-view"
 >
 	<liferay-ui:error exception="<%= OAuth2ApplicationClientCredentialUserIdException.class %>">
 

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tree.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tree.jsp
@@ -33,7 +33,7 @@ pageContext.setAttribute("scopeAliasesDescriptionsMap", scopeAliasesDescriptions
 %>
 
 <clay:container-fluid
-	className="container-view"
+	cssClass="container-view"
 >
 	<div class="sheet">
 		<div class="sheet-header">

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
@@ -33,7 +33,7 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 
 <aui:form action="<%= updateOAuth2ApplicationURL %>" id="oauth2-application-fm" method="post" name="oauth2-application-fm">
 	<clay:container-fluid
-		className="container-view"
+		cssClass="container-view"
 	>
 		<div class="sheet">
 			<clay:row>

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -41,7 +41,7 @@ String displayStyle = oAuth2ApplicationsManagementToolbarDisplayContext.getDispl
 />
 
 <clay:container-fluid
-	className="closed"
+	cssClass="closed"
 >
 	<aui:form action="<%= currentURLObj %>" method="get" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
@@ -31,7 +31,7 @@ if (Validator.isNotNull(replyTo) && !replyTo.startsWith(PortalUtil.getPortalURL(
 %>
 
 <clay:container-fluid
-	className="closed consent"
+	cssClass="closed consent"
 >
 	<aui:form action="<%= replyTo %>" data-senna-off="true" method="post" name="fm">
 		<aui:fieldset-group markupView="lexicon">

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view_application.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view_application.jsp
@@ -31,7 +31,7 @@ renderResponse.setTitle(oAuth2Application.getName());
 %>
 
 <clay:container-fluid
-	className="view-application"
+	cssClass="view-application"
 >
 	<portlet:actionURL name="/connected_applications/revoke_oauth2_authorizations" var="revokeOAuth2AuthorizationURL" />
 

--- a/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/view.jsp
+++ b/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/view.jsp
@@ -21,7 +21,7 @@
 <liferay-util:include page="/polls/management_bar.jsp" servletContext="<%= application %>" />
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<aui:form method="post" name="fm">
 		<aui:input name="deleteQuestionIds" type="hidden" />

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/connections.jsp
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/connections.jsp
@@ -36,7 +36,7 @@ SearchEngineDisplayContext
 %>
 
 <clay:container-fluid
-	className="container-form-lg search-engine-page-container"
+	cssClass="container-form-lg search-engine-page-container"
 >
 	<c:choose>
 		<c:when test="<%= searchEngineDisplayContext.isMissingSearchEngine() %>">

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/connections.jsp
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/connections.jsp
@@ -75,11 +75,10 @@ SearchEngineDisplayContext
 					<h3 class="search-engine-page-title">
 						<liferay-ui:message key="active-connections" />
 
-						<span class="badge badge-secondary">
-							<span class="badge-item badge-item-expand">
-								<%= (connectionInformationList == null) ? 0 : connectionInformationList.size() %>
-							</span>
-						</span>
+						<clay:badge
+							displayType="secondary"
+							label="<%= String.valueOf((connectionInformationList == null) ? 0 : connectionInformationList.size()) %>"
+						/>
 					</h3>
 
 					<c:choose>

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/connections.jsp
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/connections.jsp
@@ -98,11 +98,9 @@ SearchEngineDisplayContext
 												for (String label : connectionInformation.getLabels()) {
 												%>
 
-													<span class="label label-secondary">
-														<span class="label-item label-item-expand">
-															<liferay-ui:message key="<%= label %>" />
-														</span>
-													</span>
+													<clay:label
+														label="<%= label %>"
+													/>
 
 												<%
 												}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
@@ -43,7 +43,7 @@ Hits hits = searchDisplayContext.getHits();
 	</c:if>
 
 	<clay:col
-		className="result"
+		cssClass="result"
 		md="9"
 	>
 		<%@ include file="/main_search_suggest.jspf" %>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
@@ -19,7 +19,7 @@ Hits hits = searchDisplayContext.getHits();
 %>
 
 <clay:row
-	className='<%= "search-layout" + (searchDisplayContext.isShowMenu() ? " menu-column" : StringPool.BLANK) %>'
+	cssClass='<%= "search-layout" + (searchDisplayContext.isShowMenu() ? " menu-column" : StringPool.BLANK) %>'
 >
 	<c:if test="<%= searchDisplayContext.isShowMenu() %>">
 		<clay:col

--- a/modules/apps/portal-security-wedeploy-auth/portal-security-wedeploy-auth-web/src/main/resources/META-INF/resources/wedeploy_auth_admin/view.jsp
+++ b/modules/apps/portal-security-wedeploy-auth/portal-security-wedeploy-auth-web/src/main/resources/META-INF/resources/wedeploy_auth_admin/view.jsp
@@ -37,7 +37,7 @@ weDeployAuthAppsSearchContainer.setResults(weDeployAuthApps);
 />
 
 <clay:container-fluid
-	className="container-view"
+	cssClass="container-view"
 >
 	<liferay-ui:search-container
 		id="weDeployAuthApps"

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/edit_workflow_task.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/edit_workflow_task.jsp
@@ -67,7 +67,7 @@ renderResponse.setTitle(headerTitle);
 
 <clay:container-fluid>
 	<clay:col
-		className="lfr-asset-column lfr-asset-column-details"
+		cssClass="lfr-asset-column lfr-asset-column-details"
 	>
 		<liferay-ui:success key='<%= workflowTaskDisplayContext.getPortletResource() + "requestProcessed" %>' message="your-request-completed-successfully" />
 

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view.jsp
@@ -27,7 +27,7 @@ portletDisplay.setShowBackIcon(false);
 <liferay-util:include page="/toolbar.jsp" servletContext="<%= application %>" />
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<%@ include file="/workflow_tasks.jspf" %>
 </clay:container-fluid>

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -44,10 +44,10 @@ renderResponse.setTitle(title);
 %>
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<clay:col
-		className="lfr-asset-column lfr-asset-column-details"
+		cssClass="lfr-asset-column lfr-asset-column-details"
 		md="12"
 	>
 		<div class="card-horizontal main-content-card">

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
@@ -60,14 +60,17 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 			<div class="info-bar-item">
 				<c:choose>
 					<c:when test="<%= active %>">
-						<span class="label label-info label-lg">
-							<liferay-ui:message key="published" />
-						</span>
+						<clay:label
+							displayType="info"
+							label="published"
+							large="true"
+						/>
 					</c:when>
 					<c:otherwise>
-						<span class="label label-lg label-secondary">
-							<liferay-ui:message key="not-published" />
-						</span>
+						<clay:label
+							label="not-published"
+							large="true"
+						/>
 					</c:otherwise>
 				</c:choose>
 			</div>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
@@ -246,7 +246,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 							</clay:col>
 
 							<clay:col
-								className="workflow-definition-upload"
+								cssClass="workflow-definition-upload"
 								size="12"
 							>
 								<liferay-util:buffer
@@ -263,7 +263,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 							</clay:col>
 
 							<clay:col
-								className="workflow-definition-content-source-wrapper"
+								cssClass="workflow-definition-content-source-wrapper"
 								id='<%= renderResponse.getNamespace() + "contentSourceWrapper" %>'
 								size="12"
 							>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view.jsp
@@ -50,7 +50,7 @@ WorkflowDefinitionSearch workflowDefinitionSearch = new WorkflowDefinitionSearch
 />
 
 <clay:container-fluid
-	className="workflow-definition-container"
+	cssClass="workflow-definition-container"
 >
 	<liferay-ui:error exception="<%= RequiredWorkflowDefinitionException.class %>">
 		<liferay-ui:message arguments="<%= workflowDefinitionDisplayContext.getMessageArguments((RequiredWorkflowDefinitionException)errorException) %>" key="<%= workflowDefinitionDisplayContext.getMessageKey((RequiredWorkflowDefinitionException)errorException) %>" translateArguments="<%= false %>" />

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view_workflow_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view_workflow_definition.jsp
@@ -46,14 +46,17 @@ boolean previewBeforeRestore = WorkflowWebKeys.WORKFLOW_PREVIEW_BEFORE_RESTORE_S
 			<div class="info-bar-item">
 				<c:choose>
 					<c:when test="<%= workflowDefinition.isActive() %>">
-						<span class="label label-info label-lg">
-							<liferay-ui:message key="published" />
-						</span>
+						<clay:label
+							displayType="info"
+							label="published"
+							large="true"
+						/>
 					</c:when>
 					<c:otherwise>
-						<span class="label label-lg label-secondary">
-							<liferay-ui:message key="not-published" />
-						</span>
+						<clay:label
+							label="not-published"
+							large="true"
+						/>
 					</c:otherwise>
 				</c:choose>
 			</div>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view_workflow_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view_workflow_definition.jsp
@@ -102,7 +102,7 @@ boolean previewBeforeRestore = WorkflowWebKeys.WORKFLOW_PREVIEW_BEFORE_RESTORE_S
 					</clay:col>
 
 					<clay:col
-						className="workflow-definition-content-source-wrapper"
+						cssClass="workflow-definition-content-source-wrapper"
 						id='<%= renderResponse.getNamespace() + "contentSourceWrapper" %>'
 					>
 						<div class="workflow-definition-content-source" id="<portlet:namespace />contentEditor"></div>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition_link/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition_link/view.jsp
@@ -25,7 +25,7 @@ boolean showStripeMessage = workflowDefinitionLinkDisplayContext.showStripeMessa
 <liferay-util:include page="/definition_link/management_bar.jsp" servletContext="<%= application %>" />
 
 <clay:container-fluid
-	className="workflow-definition-link-container"
+	cssClass="workflow-definition-link-container"
 	id='<%= renderResponse.getNamespace() + "Container" %>'
 >
 	<c:if test="<%= showStripeMessage %>">

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/edit_workflow_instance.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/edit_workflow_instance.jsp
@@ -36,7 +36,7 @@ renderResponse.setTitle(workflowInstanceEditDisplayContext.getHeaderTitle());
 
 <clay:container-fluid>
 	<clay:col
-		className="lfr-asset-column lfr-asset-column-details"
+		cssClass="lfr-asset-column lfr-asset-column-details"
 	>
 		<aui:fieldset-group markupView="lexicon">
 			<aui:fieldset>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/view.jsp
@@ -29,7 +29,7 @@ PortletURL portletURL = workflowInstanceViewDisplayContext.getViewPortletURL();
 </aui:form>
 
 <clay:container-fluid
-	className="main-content-body workflow-instance-container"
+	cssClass="main-content-body workflow-instance-container"
 >
 	<%@ include file="/instance/workflow_instance.jspf" %>
 </clay:container-fluid>

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/border_styles.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/border_styles.jsp
@@ -18,7 +18,7 @@
 
 <clay:row>
 	<clay:col
-		className="lfr-border-width use-for-all-column"
+		cssClass="lfr-border-width use-for-all-column"
 		md="4"
 	>
 		<aui:fieldset label="border-width">
@@ -64,7 +64,7 @@
 	</clay:col>
 
 	<clay:col
-		className="lfr-border-style"
+		cssClass="lfr-border-style"
 		md="4"
 	>
 		<aui:fieldset label="border-style">
@@ -121,7 +121,7 @@
 	</clay:col>
 
 	<clay:col
-		className="lfr-border-color"
+		cssClass="lfr-border-color"
 		md="4"
 	>
 		<aui:fieldset label="border-color">

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/margin_and_padding.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/margin_and_padding.jsp
@@ -18,7 +18,7 @@
 
 <clay:row>
 	<clay:col
-		className="lfr-padding use-for-all-column"
+		cssClass="lfr-padding use-for-all-column"
 		md="6"
 	>
 		<aui:fieldset label="padding">
@@ -64,7 +64,7 @@
 	</clay:col>
 
 	<clay:col
-		className="lfr-margin use-for-all-column"
+		cssClass="lfr-margin use-for-all-column"
 		md="6"
 	>
 		<aui:fieldset label="margin">

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/view_resources.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/view_resources.jsp
@@ -117,7 +117,7 @@ if (Validator.isNotNull(keywords)) {
 </h4>
 
 <clay:row
-	className="m-1"
+	cssClass="m-1"
 >
 
 	<%

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/build.gradle
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":apps:product-navigation:product-navigation-control-menu-api")
 	compileOnly project(":apps:product-navigation:product-navigation-personal-menu-api")

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/resources/META-INF/resources/control_menu/personal_menu_icon.jsp
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/resources/META-INF/resources/control_menu/personal_menu_icon.jsp
@@ -56,9 +56,11 @@
 			%>
 
 			<aui:a href="<%= (notificationsURL != null) ? notificationsURL : null %>">
-				<span class="badge badge-danger panel-notifications-count">
-					<span class="badge-item badge-item-expand"><%= notificationsCount %></span>
-				</span>
+				<clay:badge
+					className="panel-notifications-count"
+					displayType="danger"
+					label="<%= String.valueOf(notificationsCount) %>"
+				/>
 			</aui:a>
 		</c:if>
 	</span>

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/resources/META-INF/resources/control_menu/personal_menu_icon.jsp
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/resources/META-INF/resources/control_menu/personal_menu_icon.jsp
@@ -57,7 +57,7 @@
 
 			<aui:a href="<%= (notificationsURL != null) ? notificationsURL : null %>">
 				<clay:badge
-					className="panel-notifications-count"
+					cssClass="panel-notifications-count"
 					displayType="danger"
 					label="<%= String.valueOf(notificationsCount) %>"
 				/>

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/product-navigation" prefix="liferay-product-navigation" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/build.gradle
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:application-list:application-list-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:layout:layout-admin-api")
 	compileOnly project(":apps:layout:layout-taglib")

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/init.jsp
@@ -20,6 +20,7 @@
 
 <%@ taglib uri="http://liferay.com/tld/application-list" prefix="liferay-application-list" %><%@
 taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/layout" prefix="liferay-layout" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/product_menu.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/product_menu.jsp
@@ -43,7 +43,7 @@
 
 								<c:if test="<%= notificationsCount > 0 %>">
 									<clay:sticker
-										className="panel-notifications-count"
+										cssClass="panel-notifications-count"
 										displayType="warning"
 										position="top-right"
 										size="sm"

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/product_menu.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/product_menu.jsp
@@ -42,7 +42,14 @@
 								%>
 
 								<c:if test="<%= notificationsCount > 0 %>">
-									<span class="panel-notifications-count sticker sticker-rounded sticker-sm sticker-top-right sticker-warning"><%= notificationsCount %></span>
+									<clay:sticker
+										className="panel-notifications-count"
+										displayType="warning"
+										position="top-right"
+										size="sm"
+									>
+										<%= notificationsCount %>
+									</clay:sticker>
 								</c:if>
 
 								<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
@@ -19,10 +19,10 @@
 <div id="<portlet:namespace />simulationDeviceContainer">
 	<div class="list-group-panel">
 		<clay:container-fluid
-			className="devices"
+			cssClass="devices"
 		>
 			<clay:row
-				className="default-devices"
+				cssClass="default-devices"
 			>
 				<button class="btn btn-unstyled col-4 d-lg-block d-none lfr-device-item selected text-center" data-device="desktop" type="button">
 					<aui:icon cssClass="icon icon-monospaced" image="desktop" markupView="lexicon" />
@@ -60,7 +60,7 @@
 			</clay:row>
 
 			<clay:row
-				className="custom-devices d-lg-flex d-none hide"
+				cssClass="custom-devices d-lg-flex d-none hide"
 				id='<%= renderResponse.getNamespace() + "customDeviceContainer" %>'
 			>
 				<aui:input cssClass="input-sm" inlineField="<%= true %>" label='<%= LanguageUtil.get(request, "height") + " (px):" %>' name="height" size="4" value="600" wrapperCssClass="col-6" />

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
@@ -145,9 +145,10 @@ portletURL.setWindowState(LiferayWindowState.EXCLUSIVE);
 							<div class="aspect-ratio-bg-cover sticker" style="background-image: url(<%= siteAdministrationPanelCategoryDisplayContext.getLogoURL() %>);"></div>
 						</c:when>
 						<c:otherwise>
-							<div class="sticker sticker-secondary">
-								<aui:icon image="<%= group.getIconCssClass() %>" markupView="lexicon" />
-							</div>
+							<clay:sticker
+								displayType="secondary"
+								icon="<%= group.getIconCssClass() %>"
+							/>
 						</c:otherwise>
 					</c:choose>
 				</div>
@@ -168,7 +169,14 @@ portletURL.setWindowState(LiferayWindowState.EXCLUSIVE);
 			</div>
 
 			<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.getNotificationsCount() > 0 %>">
-				<span class="panel-notifications-count sticker sticker-rounded sticker-sm sticker-top-right sticker-warning"><%= siteAdministrationPanelCategoryDisplayContext.getNotificationsCount() %></span>
+				<clay:sticker
+					className="panel-notifications-count"
+					displayType="warning"
+					position="top-right"
+					size="sm"
+				>
+					<%= siteAdministrationPanelCategoryDisplayContext.getNotificationsCount() %>
+				</clay:sticker>
 			</c:if>
 
 			<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
@@ -170,7 +170,7 @@ portletURL.setWindowState(LiferayWindowState.EXCLUSIVE);
 
 			<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.getNotificationsCount() > 0 %>">
 				<clay:sticker
-					className="panel-notifications-count"
+					cssClass="panel-notifications-count"
 					displayType="warning"
 					position="top-right"
 					size="sm"

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/build.gradle
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:application-list:application-list-api")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:product-navigation:product-navigation-personal-menu-api")
 	compileOnly project(":apps:product-navigation:product-navigation-taglib")
 	compileOnly project(":apps:site:site-api")

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/product-navigation" prefix="liferay-product-navigation" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -37,9 +37,11 @@
 				%>
 
 				<aui:a href="<%= (notificationsURL != null) ? notificationsURL : null %>">
-					<span class="badge badge-danger panel-notifications-count">
-						<span class="badge-item badge-item-expand"><%= notificationsCount %></span>
-					</span>
+					<clay:badge
+						className="panel-notifications-count"
+						displayType="danger"
+						label="<%= String.valueOf(notificationsCount) %>"
+					/>
 				</aui:a>
 			</c:if>
 		</span>

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -38,7 +38,7 @@
 
 				<aui:a href="<%= (notificationsURL != null) ? notificationsURL : null %>">
 					<clay:badge
-						className="panel-notifications-count"
+						cssClass="panel-notifications-count"
 						displayType="danger"
 						label="<%= String.valueOf(notificationsCount) %>"
 					/>

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
@@ -29,7 +29,7 @@ RedirectManagementToolbarDisplayContext redirectManagementToolbarDisplayContext 
 />
 
 <clay:container-fluid
-	className="closed redirect-entries sidenav-container sidenav-right"
+	cssClass="closed redirect-entries sidenav-container sidenav-right"
 	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 >
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/redirect/info_panel" var="sidebarPanelURL" />

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions.jsp
@@ -66,7 +66,7 @@ if (!portletName.equals(PortletKeys.SERVER_ADMIN)) {
 </c:if>
 
 <clay:container-fluid
-	className="container-form-lg"
+	cssClass="container-form-lg"
 	id='<%= renderResponse.getNamespace() + "permissionContainer" %>'
 >
 	<clay:row>
@@ -79,7 +79,7 @@ if (!portletName.equals(PortletKeys.SERVER_ADMIN)) {
 		</c:if>
 
 		<clay:col
-			className="lfr-permission-content-container"
+			cssClass="lfr-permission-content-container"
 			id='<%= renderResponse.getNamespace() + "permissionContentContainer" %>'
 			md="<%= portletName.equals(PortletKeys.SERVER_ADMIN) ? String.valueOf(12) : String.valueOf(9) %>"
 		>

--- a/modules/apps/roles/roles-item-selector-web/src/main/resources/META-INF/resources/role_item_selector.jsp
+++ b/modules/apps/roles/roles-item-selector-web/src/main/resources/META-INF/resources/role_item_selector.jsp
@@ -25,7 +25,7 @@ RoleItemSelectorViewDisplayContext roleItemSelectorViewDisplayContext = (RoleIte
 />
 
 <clay:container-fluid
-	className="container-form-lg container-view"
+	cssClass="container-form-lg container-view"
 	id='<%= renderResponse.getNamespace() + "roleSelectorWrapper" %>'
 >
 	<liferay-ui:search-container

--- a/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
@@ -21,7 +21,7 @@ SegmentsSimulationDisplayContext segmentsSimulationDisplayContext = new Segments
 %>
 
 <clay:container-fluid
-	className="segments-simulation"
+	cssClass="segments-simulation"
 	id='<%= renderResponse.getNamespace() + "segmentsSimulationContainer" %>'
 >
 	<c:choose>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/preview_segments_entry_users.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/preview_segments_entry_users.jsp
@@ -21,7 +21,7 @@ PreviewSegmentsEntryUsersDisplayContext previewSegmentsEntryUsersDisplayContext 
 %>
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<liferay-ui:search-container
 		searchContainer="<%= previewSegmentsEntryUsersDisplayContext.getSearchContainer() %>"

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/shared_assets/view.jsp
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/shared_assets/view.jsp
@@ -45,7 +45,7 @@ sharedAssetsViewDisplayContext.populateResults(sharingEntriesSearchContainer);
 %>
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<liferay-ui:search-container
 		id="sharingEntries"

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/shared_assets/view.jsp
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/shared_assets/view.jsp
@@ -83,11 +83,10 @@ sharedAssetsViewDisplayContext.populateResults(sharingEntriesSearchContainer);
 				orderable="<%= false %>"
 			>
 				<c:if test="<%= !sharedAssetsViewDisplayContext.isVisible(sharingEntry) %>">
-					<span class="label label-info">
-						<span class="label-item label-item-expand">
-							<liferay-ui:message key="not-visible" />
-						</span>
-					</span>
+					<clay:label
+						displayType="info"
+						label="not-visible"
+					/>
 				</c:if>
 			</liferay-ui:search-container-column-text>
 

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/edit_site_navigation_menu.jsp
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/edit_site_navigation_menu.jsp
@@ -70,7 +70,7 @@ renderResponse.setTitle(siteNavigationAdminDisplayContext.getSiteNavigationMenuN
 </c:if>
 
 <clay:container-fluid
-	className="contextual-sidebar-content site-navigation-content"
+	cssClass="contextual-sidebar-content site-navigation-content"
 >
 	<div class="lfr-search-container-wrapper site-navigation-menu-container">
 		<liferay-ui:error embed="<%= false %>" key="<%= InvalidSiteNavigationMenuItemOrderException.class.getName() %>" message="the-order-of-site-navigation-menu-items-is-invalid" />

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -170,7 +170,7 @@ else {
 											<div class="card-body ">
 												<div class="card-col-field">
 													<clay:sticker
-														className="sticker-static"
+														cssClass="sticker-static"
 														displayType="secondary"
 														icon="blogs"
 													/>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -169,9 +169,11 @@ else {
 										<div class="card card-horizontal taglib-horizontal-card">
 											<div class="card-body ">
 												<div class="card-col-field">
-													<div class="sticker sticker-secondary sticker-static">
-														<aui:icon image="blogs" markupView="lexicon" />
-													</div>
+													<clay:sticker
+														className="sticker-static"
+														displayType="secondary"
+														icon="blogs"
+													/>
 												</div>
 
 												<div class="card-col-content card-col-gutters">

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/site_url.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/site_url.jsp
@@ -154,7 +154,7 @@ if (privateVirtualHostnames.isEmpty()) {
 		%>
 
 			<clay:container-fluid
-				className="lfr-form-row"
+				cssClass="lfr-form-row"
 			>
 				<clay:row>
 					<aui:input inlineField="<%= true %>" label="public-pages" maxlength="200" name="publicVirtualHostname[]" placeholder="virtual-host" type="text" value="<%= virtualHostname %>" wrapperCssClass="col-sm-6" />
@@ -193,7 +193,7 @@ if (privateVirtualHostnames.isEmpty()) {
 		%>
 
 			<clay:container-fluid
-				className="lfr-form-row"
+				cssClass="lfr-form-row"
 			>
 				<clay:row>
 					<aui:input inlineField="<%= true %>" label="private-pages" maxlength="200" name="privateVirtualHostname[]" placeholder="virtual-host" type="text" value="<%= virtualHostname %>" wrapperCssClass="col-sm-6" />
@@ -246,7 +246,7 @@ if (privateVirtualHostnames.isEmpty()) {
 			%>
 
 				<clay:container-fluid
-					className="lfr-form-row"
+					cssClass="lfr-form-row"
 				>
 					<clay:row>
 						<aui:input inlineField="<%= true %>" label="staging-public-pages" maxlength="200" name="stagingPublicVirtualHostname[]" placeholder="virtual-host" type="text" value="<%= virtualHostname %>" wrapperCssClass="col-sm-6" />
@@ -297,7 +297,7 @@ if (privateVirtualHostnames.isEmpty()) {
 			%>
 
 				<clay:container-fluid
-					className="lfr-form-row"
+					cssClass="lfr-form-row"
 				>
 					<clay:row>
 						<aui:input inlineField="<%= true %>" label="staging-private-pages" maxlength="200" name="stagingPrivateVirtualHostname[]" placeholder="virtual-host" type="text" value="<%= virtualHostname %>" wrapperCssClass="col-sm-6" />

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -38,7 +38,7 @@ if (group != null) {
 />
 
 <clay:container-fluid
-	className="closed sidenav-container sidenav-right"
+	cssClass="closed sidenav-container sidenav-right"
 	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 >
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/site/info_panel" var="sidebarPanelURL" />

--- a/modules/apps/site/site-item-selector-web/src/main/resources/META-INF/resources/view_sites.jsp
+++ b/modules/apps/site/site-item-selector-web/src/main/resources/META-INF/resources/view_sites.jsp
@@ -145,7 +145,9 @@ GroupSearch groupSearch = siteItemSelectorViewDisplayContext.getGroupSearch();
 							<div class="card-body">
 								<div class="card-row">
 									<div class="autofit-col">
-										<span class="sticker sticker-secondary">
+										<clay:sticker
+											displayType="secondary"
+										>
 											<c:choose>
 												<c:when test="<%= Validator.isNotNull(siteVerticalCard.getImageSrc()) %>">
 													<span class="sticker-overlay">
@@ -153,13 +155,12 @@ GroupSearch groupSearch = siteItemSelectorViewDisplayContext.getGroupSearch();
 													</span>
 												</c:when>
 												<c:otherwise>
-													<liferay-ui:icon
-														icon="<%= group.getIconCssClass() %>"
-														markupView="lexicon"
+													<clay:icon
+														symbol="<%= group.getIconCssClass() %>"
 													/>
 												</c:otherwise>
 											</c:choose>
-										</span>
+										</clay:sticker>
 									</div>
 
 									<div class="autofit-col autofit-col-expand autofit-col-gutters">

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organizations.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organizations.jsp
@@ -32,7 +32,7 @@ OrganizationsManagementToolbarDisplayContext organizationsManagementToolbarDispl
 />
 
 <clay:container-fluid
-	className="closed sidenav-container sidenav-right"
+	cssClass="closed sidenav-container sidenav-right"
 	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 >
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/organization/info_panel" var="sidebarPanelURL">

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users.jsp
@@ -36,7 +36,7 @@ Role role = usersDisplayContext.getRole();
 <liferay-ui:error embed="<%= false %>" exception="<%= RequiredUserException.class %>" message="one-or-more-users-were-not-removed-since-they-belong-to-a-user-group" />
 
 <clay:container-fluid
-	className="closed sidenav-container sidenav-right"
+	cssClass="closed sidenav-container sidenav-right"
 	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 >
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/user/info_panel" var="sidebarPanelURL">

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/edit_layout_set_branch.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/edit_layout_set_branch.jsp
@@ -64,7 +64,7 @@ if (layoutSetBranch != null) {
 </liferay-util:include>
 
 <clay:container-fluid
-	className="container-view"
+	cssClass="container-view"
 	id='<%= renderResponse.getNamespace() + ((layoutSetBranch != null) ? "updateBranch" : "addBranch") %>'
 >
 	<aui:model-context bean="<%= layoutSetBranch %>" model="<%= LayoutSetBranch.class %>" />

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -163,7 +163,7 @@ if (liveLayout != null) {
 											</clay:col>
 
 											<clay:col
-												className="staging-alert-container"
+												cssClass="staging-alert-container"
 												id='<%= renderResponse.getNamespace() + "layoutRevisionStatus" %>'
 											>
 												<aui:model-context bean="<%= layoutRevision %>" model="<%= LayoutRevision.class %>" />
@@ -172,7 +172,7 @@ if (liveLayout != null) {
 											</clay:col>
 
 											<clay:col
-												className="col-auto staging-alert-container"
+												cssClass="col-auto staging-alert-container"
 												id='<%= renderResponse.getNamespace() + "layoutRevisionDetails" %>'
 											>
 												<aui:model-context bean="<%= layoutRevision %>" model="<%= LayoutRevision.class %>" />
@@ -182,7 +182,7 @@ if (liveLayout != null) {
 										</c:when>
 										<c:otherwise>
 											<clay:col
-												className="staging-alert-container"
+												cssClass="staging-alert-container"
 											>
 												<c:choose>
 													<c:when test="<%= liveLayout == null %>">
@@ -197,7 +197,7 @@ if (liveLayout != null) {
 											</clay:col>
 
 											<clay:col
-												className="staging-button-container"
+												cssClass="staging-button-container"
 												md="2"
 												sm="3"
 											>
@@ -212,7 +212,7 @@ if (liveLayout != null) {
 							</c:when>
 							<c:otherwise>
 								<clay:col
-									className="staging-alert-container"
+									cssClass="staging-alert-container"
 								>
 									<div class="alert alert-warning hide warning-content" id="<portlet:namespace />warningMessage">
 										<liferay-ui:message key="an-inital-staging-publication-is-in-progress" />

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/publish_templates/view.jsp
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/publish_templates/view.jsp
@@ -66,7 +66,7 @@ StagingProcessesWebPublishTemplatesToolbarDisplayContext stagingProcessesWebPubl
 />
 
 <clay:container-fluid
-	className="closed sidenav-container sidenav-right"
+	cssClass="closed sidenav-container sidenav-right"
 	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 >
 	<aui:form action="<%= portletURL %>">

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/input_scheduler/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/input_scheduler/page.jsp
@@ -228,7 +228,7 @@
 						%>
 
 						<clay:row
-							className="weekdays"
+							cssClass="weekdays"
 						>
 
 							<%

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_info/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_info/page.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/process_info/init.jsp" %>
 
 <clay:container-fluid
-	className="text-secondary"
+	cssClass="text-secondary"
 >
 	<clay:row>
 		<clay:col

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_status/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_status/page.jsp
@@ -16,6 +16,9 @@
 
 <%@ include file="/process_status/init.jsp" %>
 
-<span class="label label-<%= clayClassPostfix %> process-status" data-qa-id="processResult">
-	<liferay-ui:message key="<%= backgroundTaskStatusLabel %>" />
-</span>
+<clay:label
+	className="process-status"
+	data-qa-id="processResult"
+	displayType="<%= clayClassPostfix %>"
+	label="<%= backgroundTaskStatusLabel %>"
+/>

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_status/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_status/page.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/process_status/init.jsp" %>
 
 <clay:label
-	className="process-status"
+	cssClass="process-status"
 	data-qa-id="processResult"
 	displayType="<%= clayClassPostfix %>"
 	label="<%= backgroundTaskStatusLabel %>"

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/status/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/status/page.jsp
@@ -24,9 +24,10 @@
 			</span>
 		</c:when>
 		<c:otherwise>
-			<span class="label label-warning">
-				<liferay-ui:message key="not-staged" />
-			</span>
+			<clay:label
+				displayType="warning"
+				label="not-staged"
+			/>
 		</c:otherwise>
 	</c:choose>
 </c:if>

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view.jsp
@@ -27,7 +27,7 @@ TrashManagementToolbarDisplayContext trashManagementToolbarDisplayContext = new 
 <liferay-util:include page="/restore_path.jsp" servletContext="<%= application %>" />
 
 <clay:container-fluid
-	className="closed sidenav-container sidenav-right"
+	cssClass="closed sidenav-container sidenav-right"
 	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 >
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/trash/info_panel" var="sidebarPanelURL" />

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -29,7 +29,7 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 		/>
 
 		<clay:container-fluid
-			className="closed sidenav-container sidenav-right"
+			cssClass="closed sidenav-container sidenav-right"
 			id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 		>
 			<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/trash/info_panel" var="sidebarPanelURL" />

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
@@ -33,7 +33,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 </portlet:renderURL>
 
 <clay:container-fluid
-	className="container-form-lg"
+	cssClass="container-form-lg"
 >
 	<aui:form method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "exportApplicationData();" %>'>
 		<aui:input name="p_u_i_d" type="hidden" value="<%= String.valueOf(selectedUser.getUserId()) %>" />

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/anonymize_nonreviewable_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/anonymize_nonreviewable_uad_data.jsp
@@ -105,7 +105,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 								>
 									<clay:label
 										displayType='<%= uadApplicationSummaryDisplay.hasItems() ? "warning" : "success" %>'
-										label='<%= uadApplicationSummaryDisplay.hasItems() ? StringUtil.toUpperCase(LanguageUtil.get(request, "pending"), locale) : StringUtil.toUpperCase(LanguageUtil.get(request, "done"), locale) %>'
+										label='<%= uadApplicationSummaryDisplay.hasItems() ? "pending" : "done" %>'
 									/>
 								</liferay-ui:search-container-column-text>
 							</liferay-ui:search-container-row>

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/anonymize_nonreviewable_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/anonymize_nonreviewable_uad_data.jsp
@@ -104,8 +104,8 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 									name="status"
 								>
 									<clay:label
+										displayType='<%= uadApplicationSummaryDisplay.hasItems() ? "warning" : "success" %>'
 										label='<%= uadApplicationSummaryDisplay.hasItems() ? StringUtil.toUpperCase(LanguageUtil.get(request, "pending"), locale) : StringUtil.toUpperCase(LanguageUtil.get(request, "done"), locale) %>'
-										style='<%= uadApplicationSummaryDisplay.hasItems() ? "warning" : "success" %>'
 									/>
 								</liferay-ui:search-container-column-text>
 							</liferay-ui:search-container-row>

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/anonymize_nonreviewable_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/anonymize_nonreviewable_uad_data.jsp
@@ -32,7 +32,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 <liferay-util:include page="/uad_data_navigation_bar.jsp" servletContext="<%= application %>" />
 
 <clay:container-fluid
-	className="container-form-lg"
+	cssClass="container-form-lg"
 >
 	<aui:form method="post" name="nonreviewableUADDataForm">
 		<aui:input name="p_u_i_d" type="hidden" value="<%= String.valueOf(selectedUser.getUserId()) %>" />

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/completed_data_erasure.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/completed_data_erasure.jsp
@@ -27,7 +27,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 %>
 
 <clay:container-fluid
-	className="container-form-lg"
+	cssClass="container-form-lg"
 >
 	<liferay-ui:empty-result-message
 		message="you-have-successfully-anonymized-all-remaining-data"

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/export_processes.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/export_processes.jsp
@@ -37,8 +37,8 @@ UADExportProcessDisplayContext uadExportProcessDisplayContext = new UADExportPro
 				</h5>
 
 				<clay:label
+					displayType="<%= UADExportProcessUtil.getStatusStyle(backgroundTask.getStatus()) %>"
 					label="<%= StringUtil.toUpperCase(LanguageUtil.get(request, backgroundTask.getStatusLabel()), locale) %>"
-					style="<%= UADExportProcessUtil.getStatusStyle(backgroundTask.getStatus()) %>"
 				/>
 			</div>
 		</liferay-ui:search-container-column-text>

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/export_processes.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/export_processes.jsp
@@ -38,7 +38,7 @@ UADExportProcessDisplayContext uadExportProcessDisplayContext = new UADExportPro
 
 				<clay:label
 					displayType="<%= UADExportProcessUtil.getStatusStyle(backgroundTask.getStatus()) %>"
-					label="<%= StringUtil.toUpperCase(LanguageUtil.get(request, backgroundTask.getStatusLabel()), locale) %>"
+					label="<%= backgroundTask.getStatusLabel() %>"
 				/>
 			</div>
 		</liferay-ui:search-container-column-text>

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
@@ -38,7 +38,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 <liferay-util:include page="/uad_data_navigation_bar.jsp" servletContext="<%= application %>" />
 
 <clay:container-fluid
-	className="container-form-lg"
+	cssClass="container-form-lg"
 >
 	<clay:row>
 		<clay:col

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_entities.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_entities.jsp
@@ -150,9 +150,9 @@ long[] groupIds = viewUADEntitiesDisplay.getGroupIds();
 
 							<c:if test='<%= columnEntryKey.equals("name") || columnEntryKey.equals("title") %>'>
 								<c:if test="<%= uadEntity.isInTrash() %>">
-									<span class="label label-secondary">
-										<span class="label-item label-item-expand"><%= StringUtil.toUpperCase(LanguageUtil.get(request, "in-trash"), locale) %></span>
-									</span>
+									<clay:label
+										label="in-trash"
+									/>
 								</c:if>
 
 								<c:if test="<%= showUserIcon %>">

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_entities.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_entities.jsp
@@ -71,7 +71,7 @@ long[] groupIds = viewUADEntitiesDisplay.getGroupIds();
 	</c:choose>
 
 	<clay:container-fluid
-		className="closed sidenav-container sidenav-right"
+		cssClass="closed sidenav-container sidenav-right"
 		id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 	>
 		<div id="breadcrumb">

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/additional_email_addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/additional_email_addresses.jsp
@@ -100,9 +100,10 @@ List<EmailAddress> emailAddresses = EmailAddressServiceUtil.getEmailAddresses(cl
 			cssClass="table-cell-expand-smaller"
 		>
 			<c:if test="<%= emailAddress.isPrimary() %>">
-				<span class="label label-primary">
-					<span class="label-item label-item-expand"><%= StringUtil.toUpperCase(LanguageUtil.get(request, "primary"), locale) %></span>
-				</span>
+				<clay:label
+					displayType="primary"
+					label="primary"
+				/>
 			</c:if>
 		</liferay-ui:search-container-column-text>
 

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/additional_email_addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/additional_email_addresses.jsp
@@ -26,8 +26,8 @@ List<EmailAddress> emailAddresses = EmailAddressServiceUtil.getEmailAddresses(cl
 %>
 
 <clay:content-row
-	cssClass="sheet-subtitle"
 	containerElement="h3"
+	cssClass="sheet-subtitle"
 >
 	<clay:content-col
 		expand="true"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/additional_email_addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/additional_email_addresses.jsp
@@ -26,7 +26,7 @@ List<EmailAddress> emailAddresses = EmailAddressServiceUtil.getEmailAddresses(cl
 %>
 
 <clay:content-row
-	className="sheet-subtitle"
+	cssClass="sheet-subtitle"
 	containerElement="h3"
 >
 	<clay:content-col

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
@@ -87,9 +87,11 @@ List<Address> addresses = AddressServiceUtil.getAddresses(className, classPK);
 
 				<tr>
 					<td>
-						<div class="sticker sticker-secondary sticker-static">
-							<aui:icon image="picture" markupView="lexicon" />
-						</div>
+						<clay:sticker
+							className="sticker-static"
+							displayType="secondary"
+							icon="picture"
+						/>
 					</td>
 					<td class="table-cell-expand">
 						<h4>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
@@ -27,8 +27,8 @@ List<Address> addresses = AddressServiceUtil.getAddresses(className, classPK);
 
 <clay:sheet-header>
 	<clay:content-row
-		cssClass="sheet-title"
 		containerElement="h2"
+		cssClass="sheet-title"
 	>
 		<clay:content-col
 			expand="true"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
@@ -109,9 +109,10 @@ List<Address> addresses = AddressServiceUtil.getAddresses(className, classPK);
 
 						<c:if test="<%= address.isPrimary() %>">
 							<div class="address-primary-label-wrapper">
-								<span class="label label-primary">
-									<span class="label-item label-item-expand"><%= StringUtil.toUpperCase(LanguageUtil.get(request, "primary"), locale) %></span>
-								</span>
+								<clay:label
+									displayType="primary"
+									label="primary"
+								/>
 							</div>
 						</c:if>
 					</td>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
@@ -27,7 +27,7 @@ List<Address> addresses = AddressServiceUtil.getAddresses(className, classPK);
 
 <clay:sheet-header>
 	<clay:content-row
-		className="sheet-title"
+		cssClass="sheet-title"
 		containerElement="h2"
 	>
 		<clay:content-col
@@ -88,7 +88,7 @@ List<Address> addresses = AddressServiceUtil.getAddresses(className, classPK);
 				<tr>
 					<td>
 						<clay:sticker
-							className="sticker-static"
+							cssClass="sticker-static"
 							displayType="secondary"
 							icon="picture"
 						/>
@@ -120,7 +120,7 @@ List<Address> addresses = AddressServiceUtil.getAddresses(className, classPK);
 					</td>
 					<td>
 						<clay:content-col
-							className="lfr-search-container-wrapper"
+							cssClass="lfr-search-container-wrapper"
 						>
 							<liferay-util:include page="/common/address_action.jsp" servletContext="<%= application %>">
 								<liferay-util:param name="addressId" value="<%= String.valueOf(address.getAddressId()) %>" />

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/phone_numbers.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/phone_numbers.jsp
@@ -106,9 +106,10 @@ List<Phone> phones = PhoneServiceUtil.getPhones(className, classPK);
 			cssClass="table-cell-expand-smaller"
 		>
 			<c:if test="<%= phone.isPrimary() %>">
-				<span class="label label-primary">
-					<span class="label-item label-item-expand"><%= StringUtil.toUpperCase(LanguageUtil.get(request, "primary"), locale) %></span>
-				</span>
+				<clay:label
+					displayType="primary"
+					label="primary"
+				/>
 			</c:if>
 		</liferay-ui:search-container-column-text>
 

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/phone_numbers.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/phone_numbers.jsp
@@ -26,8 +26,8 @@ List<Phone> phones = PhoneServiceUtil.getPhones(className, classPK);
 %>
 
 <clay:content-row
-	cssClass="sheet-subtitle"
 	containerElement="h3"
+	cssClass="sheet-subtitle"
 >
 	<clay:content-col
 		expand="true"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/phone_numbers.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/phone_numbers.jsp
@@ -26,7 +26,7 @@ List<Phone> phones = PhoneServiceUtil.getPhones(className, classPK);
 %>
 
 <clay:content-row
-	className="sheet-subtitle"
+	cssClass="sheet-subtitle"
 	containerElement="h3"
 >
 	<clay:content-col

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/websites.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/websites.jsp
@@ -26,8 +26,8 @@ List<Website> websites = WebsiteServiceUtil.getWebsites(className, classPK);
 %>
 
 <clay:content-row
-	cssClass="sheet-subtitle"
 	containerElement="h3"
+	cssClass="sheet-subtitle"
 >
 	<clay:content-col
 		expand="true"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/websites.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/websites.jsp
@@ -26,7 +26,7 @@ List<Website> websites = WebsiteServiceUtil.getWebsites(className, classPK);
 %>
 
 <clay:content-row
-	className="sheet-subtitle"
+	cssClass="sheet-subtitle"
 	containerElement="h3"
 >
 	<clay:content-col

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/websites.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/websites.jsp
@@ -100,9 +100,10 @@ List<Website> websites = WebsiteServiceUtil.getWebsites(className, classPK);
 			cssClass="table-cell-expand-smaller"
 		>
 			<c:if test="<%= website.isPrimary() %>">
-				<span class="label label-primary">
-					<span class="label-item label-item-expand"><%= StringUtil.toUpperCase(LanguageUtil.get(request, "primary"), locale) %></span>
-				</span>
+				<clay:label
+					displayType="primary"
+					label="primary"
+				/>
 			</c:if>
 		</liferay-ui:search-container-column-text>
 

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/opening_hours.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/opening_hours.jsp
@@ -26,7 +26,7 @@ List<OrgLabor> orgLabors = OrgLaborServiceUtil.getOrgLabors(organizationId);
 
 <clay:sheet-header>
 	<clay:content-row
-		className="sheet-title"
+		cssClass="sheet-title"
 		containerElement="h3"
 	>
 		<clay:content-col
@@ -83,14 +83,14 @@ List<OrgLabor> orgLabors = OrgLaborServiceUtil.getOrgLabors(organizationId);
 
 		<div class="opening-hours-entry">
 			<clay:content-row
-				className="opening-hours-header"
+				cssClass="opening-hours-header"
 			>
 				<clay:content-col>
 					<h5><%= orgLaborDisplay.getTitle() %></h5>
 				</clay:content-col>
 
 				<clay:content-col
-					className="lfr-search-container-wrapper"
+					cssClass="lfr-search-container-wrapper"
 				>
 					<liferay-util:include page="/organization/opening_hours_action.jsp" servletContext="<%= application %>">
 						<liferay-util:param name="orgLaborId" value="<%= String.valueOf(orgLabor.getOrgLaborId()) %>" />

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/opening_hours.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/opening_hours.jsp
@@ -26,8 +26,8 @@ List<OrgLabor> orgLabors = OrgLaborServiceUtil.getOrgLabors(organizationId);
 
 <clay:sheet-header>
 	<clay:content-row
-		cssClass="sheet-title"
 		containerElement="h3"
+		cssClass="sheet-title"
 	>
 		<clay:content-col
 			expand="true"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/parent_organization.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/parent_organization.jsp
@@ -67,8 +67,8 @@ if (parentOrganization != null) {
 %>
 
 <clay:content-row
-	cssClass="sheet-subtitle"
 	containerElement="h3"
+	cssClass="sheet-subtitle"
 >
 	<clay:content-col
 		expand="true"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/parent_organization.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/parent_organization.jsp
@@ -67,7 +67,7 @@ if (parentOrganization != null) {
 %>
 
 <clay:content-row
-	className="sheet-subtitle"
+	cssClass="sheet-subtitle"
 	containerElement="h3"
 >
 	<clay:content-col

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/organizations.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/organizations.jsp
@@ -34,8 +34,8 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "organi
 <liferay-ui:membership-policy-error />
 
 <clay:content-row
-	cssClass="sheet-subtitle"
 	containerElement="h3"
+	cssClass="sheet-subtitle"
 >
 	<clay:content-col
 		expand="true"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/organizations.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/organizations.jsp
@@ -34,7 +34,7 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "organi
 <liferay-ui:membership-policy-error />
 
 <clay:content-row
-	className="sheet-subtitle"
+	cssClass="sheet-subtitle"
 	containerElement="h3"
 >
 	<clay:content-col

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -68,7 +68,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 
 <clay:sheet-section>
 	<clay:content-row
-		className="sheet-subtitle"
+		cssClass="sheet-subtitle"
 		containerElement="h3"
 	>
 		<clay:content-col
@@ -252,7 +252,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 
 <clay:sheet-section>
 	<clay:content-row
-		className="sheet-subtitle"
+		cssClass="sheet-subtitle"
 		containerElement="h3"
 	>
 		<clay:content-col
@@ -487,7 +487,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 
 <clay:sheet-section>
 	<clay:content-row
-		className="sheet-subtitle"
+		cssClass="sheet-subtitle"
 		containerElement="h3"
 	>
 		<clay:content-col

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -68,8 +68,8 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 
 <clay:sheet-section>
 	<clay:content-row
-		cssClass="sheet-subtitle"
 		containerElement="h3"
+		cssClass="sheet-subtitle"
 	>
 		<clay:content-col
 			expand="true"
@@ -252,8 +252,8 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 
 <clay:sheet-section>
 	<clay:content-row
-		cssClass="sheet-subtitle"
 		containerElement="h3"
+		cssClass="sheet-subtitle"
 	>
 		<clay:content-col
 			expand="true"
@@ -487,8 +487,8 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 
 <clay:sheet-section>
 	<clay:content-row
-		cssClass="sheet-subtitle"
 		containerElement="h3"
+		cssClass="sheet-subtitle"
 	>
 		<clay:content-col
 			expand="true"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/sites.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/sites.jsp
@@ -32,7 +32,7 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "sites"
 <liferay-ui:membership-policy-error />
 
 <clay:content-row
-	className="sheet-subtitle"
+	cssClass="sheet-subtitle"
 	containerElement="h3"
 >
 	<clay:content-col

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/sites.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/sites.jsp
@@ -32,8 +32,8 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "sites"
 <liferay-ui:membership-policy-error />
 
 <clay:content-row
-	cssClass="sheet-subtitle"
 	containerElement="h3"
+	cssClass="sheet-subtitle"
 >
 	<clay:content-col
 		expand="true"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/user_groups.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/user_groups.jsp
@@ -31,7 +31,7 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "userGr
 <liferay-ui:membership-policy-error />
 
 <clay:content-row
-	className="sheet-subtitle"
+	cssClass="sheet-subtitle"
 	containerElement="h3"
 >
 	<clay:content-col

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/user_groups.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/user_groups.jsp
@@ -31,8 +31,8 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "userGr
 <liferay-ui:membership-policy-error />
 
 <clay:content-row
-	cssClass="sheet-subtitle"
 	containerElement="h3"
+	cssClass="sheet-subtitle"
 >
 	<clay:content-col
 		expand="true"

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/wiki_pages.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/wiki_pages.jsp
@@ -81,7 +81,7 @@ String searchURL = HttpUtil.removeParameter(searchBaseURL.toString(), liferayPor
 />
 
 <clay:container-fluid
-	className="lfr-item-viewer"
+	cssClass="lfr-item-viewer"
 	id='<%= renderResponse.getNamespace() + "wikiPagesSelectorContainer" %>'
 >
 	<liferay-ui:search-container

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view.jsp
@@ -93,7 +93,7 @@ WikiNodesManagementToolbarDisplayContext wikiNodesManagementToolbarDisplayContex
 />
 
 <clay:container-fluid
-	className="closed sidenav-container sidenav-right"
+	cssClass="closed sidenav-container sidenav-right"
 	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 >
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/wiki/node_info_panel" var="sidebarPanelURL" />

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_pages.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_pages.jsp
@@ -103,7 +103,7 @@ WikiPagesManagementToolbarDisplayContext wikiPagesManagementToolbarDisplayContex
 />
 
 <clay:container-fluid
-	className="closed sidenav-container sidenav-right"
+	cssClass="closed sidenav-container sidenav-right"
 	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
 >
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/wiki/page_info_panel" var="sidebarPanelURL">

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/report/requested_report_detail.jsp
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/report/requested_report_detail.jsp
@@ -53,7 +53,7 @@ renderResponse.setTitle(definition.getName(locale));
 	<aui:fieldset-group markupView="lexicon">
 		<aui:fieldset>
 			<clay:row
-				className="lfr-asset-column lfr-asset-column-details"
+				cssClass="lfr-asset-column lfr-asset-column-details"
 			>
 				<clay:col
 					md="6"

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -19,7 +19,7 @@
 <liferay-util:include page="/admin/toolbar.jsp" servletContext="<%= application %>" />
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<c:choose>
 		<c:when test="<%= hasAddSourcePermission && reportsEngineDisplayContext.isSourcesTabSelected() %>">

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -53,7 +53,7 @@ RankingResultContentDisplayContext rankingResultContentDisplayContext = rankingR
 %>
 
 <clay:container-fluid
-	className="container-no-gutters-sm-down container-view"
+	cssClass="container-no-gutters-sm-down container-view"
 >
 	<c:choose>
 		<c:when test="<%= rankingResultContentDisplayContext.isVisible() %>">

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view.jsp
@@ -19,7 +19,7 @@
 <liferay-portlet:renderURL varImpl="searchURL" />
 
 <clay:container-fluid
-	className="container-view"
+	cssClass="container-view"
 >
 	<aui:form action="<%= searchURL %>" method="get" name="fm">
 		<liferay-portlet:renderURLParams varImpl="searchURL" />

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -88,14 +88,17 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 						<div class="info-bar-item">
 							<c:choose>
 								<c:when test="<%= (kaleoDefinition != null) && kaleoDefinition.isActive() %>">
-									<span class="label label-info label-lg">
-										<liferay-ui:message key="published" />
-									</span>
+									<clay:label
+										displayType="info"
+										label="published"
+										large="true"
+									/>
 								</c:when>
 								<c:otherwise>
-									<span class="label label-lg label-secondary">
-										<liferay-ui:message key="not-published" />
-									</span>
+									<clay:label
+										label="not-published"
+										large="true"
+									/>
 								</c:otherwise>
 							</c:choose>
 						</div>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/view_workflow_definitions.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/view_workflow_definitions.jsp
@@ -25,7 +25,7 @@ KaleoDefinitionVersionSearch kaleoDefinitionVersionSearch = kaleoDesignerDisplay
 <liferay-util:include page="/designer/management_bar.jsp" servletContext="<%= application %>" />
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<liferay-ui:error exception="<%= RequiredWorkflowDefinitionException.class %>">
 		<liferay-ui:message arguments="<%= kaleoDesignerDisplayContext.getMessageArguments((RequiredWorkflowDefinitionException)errorException) %>" key="<%= kaleoDesignerDisplayContext.getMessageKey((RequiredWorkflowDefinitionException)errorException) %>" translateArguments="<%= false %>" />

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_kaleo_process.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_kaleo_process.jsp
@@ -65,7 +65,7 @@ renderResponse.setTitle(title);
 
 <c:if test="<%= kaleoProcessStarted %>">
 	<clay:container-fluid
-		className="alert alert-info"
+		cssClass="alert alert-info"
 	>
 		<liferay-ui:message key="updating-the-field-set-or-workflow-will-cause-loss-of-data" />
 	</clay:container-fluid>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_record.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_record.jsp
@@ -57,7 +57,7 @@ renderResponse.setTitle((ddlRecord != null) ? LanguageUtil.format(request, "edit
 </portlet:actionURL>
 
 <clay:container-fluid
-	className="sidenav-container sidenav-right"
+	cssClass="sidenav-container sidenav-right"
 >
 	<div class="lfr-form-content">
 		<aui:form action="<%= updateDDLRecordURL %>" cssClass="lfr-dynamic-form" enctype="multipart/form-data" onSubmit='<%= "event.preventDefault(); submitForm(event.target);" %>'>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_request.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_request.jsp
@@ -34,7 +34,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "new-x", kaleoProcess.getNa
 %>
 
 <clay:container-fluid
-	className="sidenav-container sidenav-right"
+	cssClass="sidenav-container sidenav-right"
 >
 	<portlet:actionURL name="startWorkflowInstance" var="startWorkflowInstanceURL" />
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/asset/full_content.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/asset/full_content.jsp
@@ -27,7 +27,7 @@ KaleoProcessLink kaleoProcessLink = (KaleoProcessLink)request.getAttribute(Kaleo
 %>
 
 <clay:container-fluid
-	className="main-content-body"
+	cssClass="main-content-body"
 >
 	<aui:fieldset>
 


### PR DESCRIPTION
Resend of https://github.com/brianchandotcom/liferay-portal/pull/89310 which was a resend of https://github.com/jbalsas/liferay-portal/pull/2173

From the last review, this fixes `setCssClass(String className)` for `setCssClass(String cssClass)`. 

**Note: The `cssClass` attribute is the pattern we use everywhere which is modelled after `div class="${cssClass}"`. I assume we just couldn't pick `class` because it's a Java reserved keyword.**

Resend of https://github.com/brianchandotcom/liferay-portal/pull/89227 with the following changes:
- Replaced `className` attribute by `cssClass` to follow old pattern
- Replace usages of `className` in JSPs inside `clay:` tags

On top of that, this PR contains:

### `clay:icon`
- Tag migration
- Legacy tag attribute deprecation 
- Legacy tag implementation deprecation

### `clay:badge`
- Tag migration
- Legacy tag attribute deprecation 
- Legacy tag implementation deprecation
- Replacement of raw html usages. This should be fine performance-wise now... 🤞 

### `clay:label`
- Tag migration
- Legacy tag attribute deprecation 
- Legacy tag implementation deprecation
- Replacement of raw html usages. This should be fine performance-wise now... 🤞 

### `clay:sticker`
- Tag migration
- Legacy tag attribute deprecation 
- Legacy tag implementation deprecation
- Replacement of raw html usages. This should be fine performance-wise now... 🤞 