### PR TITLE
Revert "LRQA-59226 Quarantine failing search test"

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -2057,7 +2057,6 @@ definition {
 	@description = "This is a use case for LPS-84035."
 	@priority = "5"
 	test ViewCreatedSearchPagePermissions {
-		property portal.acceptance = "quarantine";
 		property custom.properties = "jsonws.web.service.paths.excludes=";
 
 		JSONUser.addUser(


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-59226

This test was mistakenly quarantined.