### PR TITLE
LPS-112458 Updates clay:button to Clay3 version

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_view_usages/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_view_usages/init.jsp
@@ -28,10 +28,7 @@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Layout" %><%@
 page import="com.liferay.portal.kernel.service.LayoutLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %>
-
-<%@ page import="java.util.Map" %>
 
 <liferay-theme:defineObjects />
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_view_usages/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_view_usages/page.jsp
@@ -54,19 +54,11 @@ AssetEntryUsagesDisplayContext assetEntryUsagesDisplayContext = new AssetEntryUs
 					%>
 
 					<c:if test="<%= curLayout != null %>">
-
-						<%
-						Map<String, String> data = HashMapBuilder.put(
-							"href", assetEntryUsagesDisplayContext.getPreviewURL(assetEntryUsage)
-						).build();
-						%>
-
 						<clay:button
-							data="<%= data %>"
-							elementClasses="preview-asset-entry-usage table-action-link"
+							cssClass="preview-asset-entry-usage table-action-link"
+							data-href="<%= assetEntryUsagesDisplayContext.getPreviewURL(assetEntryUsage) %>"
+							displayType="secondary"
 							icon="view"
-							monospaced="<%= true %>"
-							style="secondary"
 						/>
 					</c:if>
 				</c:if>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
@@ -39,10 +39,9 @@
 	<c:if test="<%= selectAssetDisplayPageDisplayContext.isAssetDisplayPageTypeDefault() && selectAssetDisplayPageDisplayContext.isShowViewInContextLink() && selectAssetDisplayPageDisplayContext.isURLViewInContext() %>">
 		<div class="input-group-item input-group-item-shrink">
 			<clay:button
+				displayType="secondary"
 				icon="view"
 				id='<%= liferayPortletResponse.getNamespace() + "previewDefaultDisplayPageButton" %>'
-				monospaced="<%= true %>"
-				style="secondary"
 			/>
 		</div>
 	</c:if>
@@ -62,10 +61,9 @@
 		<c:if test="<%= selectAssetDisplayPageDisplayContext.isAssetDisplayPageTypeSpecific() && selectAssetDisplayPageDisplayContext.isShowViewInContextLink() && selectAssetDisplayPageDisplayContext.isURLViewInContext() %>">
 			<div class="input-group-item input-group-item-shrink">
 				<clay:button
-					elementClasses="btn-secondary"
+					displayType="secondary"
 					icon="view"
 					id='<%= liferayPortletResponse.getNamespace() + "previewSpecificDisplayPageButton" %>'
-					monospaced="<%= true %>"
 				/>
 			</div>
 		</c:if>

--- a/modules/apps/connected-app/connected-app-web/src/main/resources/META-INF/resources/connected_apps.jsp
+++ b/modules/apps/connected-app/connected-app-web/src/main/resources/META-INF/resources/connected_apps.jsp
@@ -56,18 +56,11 @@
 					</div>
 
 					<div class="autofit-col">
-
-						<%
-						Map<String, String> data = HashMapBuilder.put(
-							"key", connectedApp.getKey()
-						).build();
-						%>
-
 						<clay:button
-							data="<%= data %>"
-							elementClasses="btn-secondary"
-							label='<%= LanguageUtil.get(resourceBundle, "revoke") %>'
-							size="sm"
+							data-key="<%= connectedApp.getKey() %>"
+							displayType="secondary"
+							label="revoke"
+							small="<%= true %>"
 							type="submit"
 						/>
 					</div>

--- a/modules/apps/connected-app/connected-app-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/connected-app/connected-app-web/src/main/resources/META-INF/resources/init.jsp
@@ -28,14 +28,11 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 <%@ page import="com.liferay.connected.app.ConnectedApp" %><%@
 page import="com.liferay.connected.app.ConnectedAppManager" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.User" %><%@
-page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %>
 
-<%@ page import="java.util.List" %><%@
-page import="java.util.Map" %>
+<%@ page import="java.util.List" %>
 
 <liferay-frontend:defineObjects />
 

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/sites.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/sites.jsp
@@ -36,12 +36,11 @@ List<DepotEntryGroupRel> depotEntryGroupRels = depotAdminSitesDisplayContext.get
 		<clay:content-col>
 			<span class="heading-end">
 				<clay:button
-					elementClasses="btn-secondary"
+					displayType="secondary"
 					id='<%= renderResponse.getNamespace() + "addConnectedSiteButton" %>'
-					label='<%= LanguageUtil.get(request, "add") %>'
-					size="sm"
-					style="secondary"
-					title='<%= LanguageUtil.get(request, "connect-to-a-site") %>'
+					label="add"
+					small="<%= true %>"
+					title="connect-to-a-site"
 				/>
 			</span>
 		</clay:content-col>

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/resources/META-INF/resources/open_google_docs.jsp
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/resources/META-INF/resources/open_google_docs.jsp
@@ -56,7 +56,7 @@ String googleDocsRedirect = ParamUtil.getString(request, "googleDocsRedirect");
 							icon="angle-left"
 							id="closeAndCheckinBtn"
 							label='<%= LanguageUtil.format(resourceBundle, "save-and-return-to-x", themeDisplay.getSiteGroupName()) %>'
-							size="sm"
+							small="<%= true %>"
 							type="submit"
 						/>
 					</form>
@@ -73,8 +73,8 @@ String googleDocsRedirect = ParamUtil.getString(request, "googleDocsRedirect");
 				<form action="<%= cancelCheckoutURL %>" method="post">
 					<clay:button
 						id="discardChangesBtn"
-						label='<%= LanguageUtil.get(resourceBundle, "discard-changes") %>'
-						size="sm"
+						label="discard-changes"
+						small="<%= true %>"
 						type="submit"
 					/>
 				</form>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_upper_tbar.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_upper_tbar.jsp
@@ -48,12 +48,11 @@ FileVersion fileVersion = (FileVersion)request.getAttribute("file_entry_upper_tb
 				</li>
 				<li class="tbar-item">
 					<clay:button
-						elementClasses="btn-outline-borderless btn-outline-secondary"
+						borderless="<%= true %>"
+						displayType="secondary"
 						icon="info-circle-open"
 						id='<%= liferayPortletResponse.getNamespace() + "OpenContextualSidebar" %>'
-						monospaced="true"
-						size="sm"
-						style="<%= false %>"
+						small="<%= true %>"
 						title='<%= LanguageUtil.get(resourceBundle, "info") %>'
 					/>
 				</li>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -239,10 +239,6 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 						}
 
 						String urlInputId = liferayPortletResponse.getNamespace() + "urlInput";
-
-						Map<String, String> urlButtonData = HashMapBuilder.put(
-							"clipboard-target", "#" + urlInputId
-						).build();
 						%>
 
 						<div class="form-group">
@@ -255,11 +251,11 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 
 								<span class="input-group-append input-group-item input-group-item-shrink">
 									<clay:button
-										data="<%= urlButtonData %>"
-										elementClasses="btn-secondary dm-infopanel-copy-clipboard lfr-portal-tooltip"
+										cssClass="dm-infopanel-copy-clipboard lfr-portal-tooltip"
+										data-clipboard-target='<%= "#" + urlInputId %>'
+										displayType="secondary"
 										icon="paste"
-										style="secondary"
-										title='<%= LanguageUtil.get(resourceBundle, "copy-link") %>'
+										title="copy-link"
 									/>
 								</span>
 							</div>
@@ -278,10 +274,6 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 							}
 
 							String webDavURLInputId = liferayPortletResponse.getNamespace() + "webDavURLInput";
-
-							Map<String, String> webDavButtonData = HashMapBuilder.put(
-								"clipboard-target", "#" + webDavURLInputId
-							).build();
 							%>
 
 							<div class="form-group">
@@ -298,11 +290,11 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 
 									<span class="input-group-append input-group-item input-group-item-shrink">
 										<clay:button
-											data="<%= webDavButtonData %>"
-											elementClasses="btn-secondary dm-infopanel-copy-clipboard lfr-portal-tooltip"
+											cssClass="dm-infopanel-copy-clipboard lfr-portal-tooltip"
+											data-clipboard-target='<%= "#" + webDavURLInputId %>'
+											displayType="secondary"
 											icon="paste"
-											style="secondary"
-											title='<%= LanguageUtil.get(resourceBundle, "copy-link") %>'
+											title="copy-link"
 										/>
 									</span>
 								</div>

--- a/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/page.jsp
+++ b/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/page.jsp
@@ -28,23 +28,23 @@ boolean onlyIcon = GetterUtil.getBoolean(request.getAttribute("liferay-flags:fla
 	<c:choose>
 		<c:when test="<%= onlyIcon %>">
 			<clay:button
+				borderless="<%= true %>"
+				cssClass="lfr-portal-tooltip"
 				disabled="<%= true %>"
-				elementClasses="btn-outline-borderless btn-outline-secondary lfr-portal-tooltip"
+				displayType="secondary"
 				icon="flag-empty"
-				monospaced="<%= true %>"
-				size="sm"
-				style="secondary"
+				small="<%= true %>"
 				title="<%= message %>"
 			/>
 		</c:when>
 		<c:otherwise>
 			<clay:button
+				borderless="<%= true %>"
 				disabled="<%= true %>"
-				elementClasses="btn-outline-borderless btn-outline-secondary"
+				displayType="secondary"
 				icon="flag-empty"
-				label="<%= message %>"
-				size="sm"
-				style="secondary"
+				label="message"
+				small="<%= true %>"
 			/>
 		</c:otherwise>
 	</c:choose>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
@@ -46,6 +46,14 @@ public class ButtonTag extends BaseContainerTag {
 			setDynamicAttribute(StringPool.BLANK, "disabled", _disabled);
 		}
 
+		if (Validator.isNotNull(_title)) {
+			setDynamicAttribute(
+				StringPool.BLANK, "title",
+				LanguageUtil.get(
+					TagResourceBundleUtil.getResourceBundle(pageContext),
+					_title));
+		}
+
 		setDynamicAttribute(StringPool.BLANK, "type", _type);
 
 		return super.doStartTag();
@@ -99,6 +107,19 @@ public class ButtonTag extends BaseContainerTag {
 		return _outline;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getLarge()}
+	 */
+	@Deprecated
+	public String getSize() {
+		if (_small) {
+			return "sm";
+		}
+
+		return null;
+	}
+
 	public boolean getSmall() {
 		return _small;
 	}
@@ -110,6 +131,14 @@ public class ButtonTag extends BaseContainerTag {
 	@Deprecated
 	public String getStyle() {
 		return getDisplayType();
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getTitle() {
+		return _title;
 	}
 
 	/**
@@ -168,6 +197,15 @@ public class ButtonTag extends BaseContainerTag {
 		_outline = outline;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setLarge(boolean)}
+	 */
+	@Deprecated
+	public void setSize(String size) {
+		setSmall(size.equals("sm"));
+	}
+
 	public void setSmall(boolean small) {
 		_small = small;
 	}
@@ -179,6 +217,14 @@ public class ButtonTag extends BaseContainerTag {
 	@Deprecated
 	public void setStyle(String style) {
 		setDisplayType(style);
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setTitle(String title) {
+		_title = title;
 	}
 
 	/**
@@ -204,6 +250,7 @@ public class ButtonTag extends BaseContainerTag {
 		_monospaced = false;
 		_outline = false;
 		_small = false;
+		_title = null;
 		_type = "button";
 	}
 
@@ -251,7 +298,7 @@ public class ButtonTag extends BaseContainerTag {
 			JspWriter jspWriter = pageContext.getOut();
 
 			if (Validator.isNotNull(_icon)) {
-				jspWriter.write("<svg class=\"lexicon-icon lexicon-icon");
+				jspWriter.write("<svg class=\"lexicon-icon lexicon-icon-");
 				jspWriter.write(_icon);
 				jspWriter.write("\" role=\"presentation\" viewBox=\"0 0 512 ");
 				jspWriter.write("512\"><use xlink:href=\"");
@@ -296,6 +343,7 @@ public class ButtonTag extends BaseContainerTag {
 	private boolean _monospaced;
 	private boolean _outline;
 	private boolean _small;
+	private String _title;
 	private String _type = "button";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -174,10 +174,10 @@
 	<tag>
 		<description></description>
 		<name>button</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.ButtonTag</tag-class>
-		<body-content>empty</body-content>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.ButtonTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>ariaLabel</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -190,36 +190,48 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>borderless</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>disabled</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>displayType</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -231,7 +243,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>iconAlignment</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -255,47 +267,54 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>name</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>small</code>]]>.</description>
 			<name>size</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>small</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>spritemap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
 			<name>style</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>title</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>type</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>value</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/page.jsp
@@ -71,8 +71,8 @@
 								componentId="<%= componentId %>"
 								data='<%= (HashMap)actionDropdownItem.get("data") %>'
 								defaultEventHandler="<%= defaultEventHandler %>"
+								displayType="<%= buttonCssClass %>"
 								label='<%= String.valueOf(actionDropdownItem.get("label")) %>'
-								style="<%= buttonCssClass %>"
 							/>
 						</c:otherwise>
 					</c:choose>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/page.jsp
@@ -115,19 +115,18 @@ if (fileEntryId != 0) {
 
 	<div class='change-image-controls <%= (fileEntryId != 0) ? StringPool.BLANK : "hide" %>'>
 		<clay:button
-			elementClasses="browse-image"
+			cssClass="browse-image"
+			displaytype="secondary"
 			icon="picture"
-			monospaced="<%= true %>"
-			style="secondary"
-			title='<%= LanguageUtil.get(resourceBundle, "change-image") %>'
+			title="change-image"
 		/>
 
 		<clay:button
-			elementClasses="btn-monospaced"
+			displayType="secondary"
 			icon="trash"
 			id='<%= randomNamespace + "removeImage" %>'
-			style="secondary"
-			title='<%= LanguageUtil.get(resourceBundle, "remove-image") %>'
+			monospaced="<%= true %>"
+			title="remove-image"
 		/>
 	</div>
 </div>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/action_button_preview.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/action_button_preview.jsp
@@ -17,8 +17,9 @@
 <%@ include file="/repository_entry_browser/init.jsp" %>
 
 <clay:button
-	elementClasses="btn-outline-borderless btn-outline-secondary component-action icon-view"
+	borderless="<%= true %>"
+	displayType="secondary"
+	elementClasses="component-action icon-view"
 	icon="view"
 	monospaced="<%= true %>"
-	style="outline-secondary"
 />

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -204,10 +204,10 @@ ItemSelectorRepositoryEntryManagementToolbarDisplayContext itemSelectorRepositor
 
 							<liferay-ui:search-container-column-text>
 								<clay:button
-									elementClasses="btn-outline-borderless btn-outline-secondary component-action icon-view"
+									borderless="<%= true %>"
+									cssClass="component-action icon-view"
+									displayType="secondary"
 									icon="view"
-									monospaced="<%= true %>"
-									style="outline-secondary"
 								/>
 							</liferay-ui:search-container-column-text>
 
@@ -478,10 +478,10 @@ ItemSelectorRepositoryEntryManagementToolbarDisplayContext itemSelectorRepositor
 
 									<liferay-ui:search-container-column-text>
 										<clay:button
-											elementClasses="btn-outline-borderless btn-outline-secondary component-action icon-view"
+											borderless="<%= true %>"
+											cssClass="component-action icon-view"
+											displayType="secondary"
 											icon="view"
-											monospaced="<%= true %>"
-											style="outline-secondary"
 										/>
 									</liferay-ui:search-container-column-text>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
@@ -39,10 +39,9 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 			<c:if test="<%= (article != null) && !article.isNew() && (journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT) %>">
 				<div class="input-group-item input-group-item-shrink">
 					<clay:button
-						elementClasses="btn-secondary"
+						displayType="secondary"
 						icon="view"
 						id='<%= liferayPortletResponse.getNamespace() + "previewWithTemplate" %>'
-						monospaced="<%= true %>"
 					/>
 				</div>
 			</c:if>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -88,11 +88,10 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 						</c:if>
 
 						<clay:button
+							borderless="<%= true %>"
 							icon="cog"
 							id='<%= renderResponse.getNamespace() + "contextualSidebarButton" %>'
-							monospaced="<%= true %>"
-							size="sm"
-							style="borderless"
+							small="<%= true %>"
 						/>
 					</div>
 				</li>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_form_builder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_form_builder.jsp
@@ -70,11 +70,10 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 						<aui:button cssClass="btn-sm mr-3" type="submit" value="<%= journalEditDDMStructuresDisplayContext.getSaveButtonLabel() %>" />
 
 						<clay:button
+							borderless="<%= true %>"
 							icon="cog"
 							id='<%= renderResponse.getNamespace() + "contextualSidebarButton" %>'
-							monospaced="<%= true %>"
-							size="sm"
-							style="borderless"
+							small="<%= true %>"
 						/>
 					</div>
 				</li>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
@@ -67,11 +67,10 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 						<aui:button cssClass="btn-sm mr-3" onClick="<%= taglibOnClickSaveTemplate %>" type="submit" value="save" />
 
 						<clay:button
+							borderless="<%= true %>"
 							icon="cog"
 							id='<%= renderResponse.getNamespace() + "contextualSidebarButton" %>'
-							monospaced="<%= true %>"
-							size="sm"
-							style="borderless"
+							small="<%= true %>"
 						/>
 					</div>
 				</li>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
@@ -102,13 +102,14 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 
 		<liferay-frontend:edit-form-footer>
 			<clay:button
-				label='<%= LanguageUtil.get(resourceBundle, "add") %>'
+				label="add"
 				type="submit"
 			/>
 
 			<clay:button
-				elementClasses="btn-cancel btn-secondary"
-				label='<%= LanguageUtil.get(resourceBundle, "cancel") %>'
+				displayType="secondary"
+				elementClasses="btn-cancel"
+				label="cancel"
 			/>
 		</liferay-frontend:edit-form-footer>
 	</liferay-frontend:edit-form>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
@@ -74,19 +74,18 @@ if ((layoutPageTemplateEntry == null) || !Objects.equals(layoutPageTemplateEntry
 
 		<div class="button-holder">
 			<clay:button
-				elementClasses='<%= (masterLayoutPageTemplateEntry == null) ? "btn-secondary hide" : "btn-secondary" %>'
+				cssClass='<%= (masterLayoutPageTemplateEntry == null) ? "hide" : StringPool.BLANK %>'
+				displayType="secondary"
 				id='<%= renderResponse.getNamespace() + "editMasterLayoutButton" %>'
-				label='<%= LanguageUtil.get(request, "edit-master") %>'
-				size="sm"
-				style="<%= false %>"
+				label="edit-master"
+				small="<%= true %>"
 			/>
 
 			<clay:button
-				elementClasses="btn-secondary"
+				displaytype="secondary"
 				id='<%= renderResponse.getNamespace() + "changeMasterLayoutButton" %>'
-				label='<%= LanguageUtil.get(request, "change-master") %>'
-				size="sm"
-				style="<%= false %>"
+				label="change-master"
+				small="<%= true %>"
 			/>
 		</div>
 	</clay:sheet-section>

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_view/init.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_view/init.jsp
@@ -28,10 +28,7 @@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Layout" %><%@
 page import="com.liferay.portal.kernel.service.LayoutLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %>
-
-<%@ page import="java.util.Map" %>
 
 <liferay-theme:defineObjects />
 

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_view/page.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_view/page.jsp
@@ -54,19 +54,11 @@ LayoutClassedModelUsagesDisplayContext layoutClassedModelUsagesDisplayContext = 
 					%>
 
 					<c:if test="<%= curLayout != null %>">
-
-						<%
-						Map<String, String> data = HashMapBuilder.put(
-							"href", layoutClassedModelUsagesDisplayContext.getPreviewURL(layoutClassedModelUsage)
-						).build();
-						%>
-
 						<clay:button
-							data="<%= data %>"
-							elementClasses="preview-layout-classed-model-usage table-action-link"
+							cssClass="preview-layout-classed-model-usage table-action-link"
+							data-href="<%= layoutClassedModelUsagesDisplayContext.getPreviewURL(layoutClassedModelUsage) %>"
+							displayType="secondary"
 							icon="view"
-							monospaced="<%= true %>"
-							style="secondary"
 						/>
 					</c:if>
 				</c:if>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/filter/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/filter/view.jsp
@@ -75,12 +75,12 @@ Map<String, Object> contextObjects = HashMapBuilder.<String, Object>put(
 					<aui:input cssClass="custom-filter-value-input" data-qa-id="customFilterValueInput" disabled="<%= customFilterDisplayContext.isImmutable() %>" id="<%= renderResponse.getNamespace() + StringUtil.randomId() %>" label="" name="<%= HtmlUtil.escapeAttribute(customFilterDisplayContext.getParameterName()) %>" useNamespace="<%= false %>" value="<%= HtmlUtil.escapeAttribute(customFilterDisplayContext.getFilterValue()) %>" />
 
 					<clay:button
-						ariaLabel='<%= LanguageUtil.get(request, "apply") %>'
+						aria-label='<%= LanguageUtil.get(request, "apply") %>'
+						cssClass="custom-filter-apply-button"
 						disabled="<%= customFilterDisplayContext.isImmutable() %>"
-						elementClasses="custom-filter-apply-button"
-						label='<%= LanguageUtil.get(request, "apply") %>'
-						size="sm"
-						style="secondary"
+						displayType="secondary"
+						label="apply"
+						small="<%= true %>"
 						type="submit"
 					/>
 				</liferay-ui:panel>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/bar/view.jsp
@@ -96,9 +96,9 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 
 								<div class="input-group-append input-group-item input-group-item-shrink">
 									<clay:button
-										ariaLabel='<%= LanguageUtil.get(request, "submit") %>'
+										aria-label='<%= LanguageUtil.get(request, "submit") %>'
+										displayType="secondary"
 										icon="search"
-										style="secondary"
 										type="submit"
 									/>
 								</div>
@@ -111,10 +111,9 @@ SearchBarPortletDisplayContext searchBarPortletDisplayContext = (SearchBarPortle
 
 									<div class="input-group-inset-item input-group-inset-item-after">
 										<clay:button
-											ariaLabel='<%= LanguageUtil.get(request, "submit") %>'
-											elementClasses="btn-unstyled"
+											aria-label='<%= LanguageUtil.get(request, "submit") %>'
+											displayType="unstyled"
 											icon="search"
-											style="<%= false %>"
 											type="submit"
 										/>
 									</div>

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/global_menu/global_menu.jsp
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/global_menu/global_menu.jsp
@@ -22,12 +22,11 @@ GlobalMenuDisplayContext globalMenuDisplayContext = new GlobalMenuDisplayContext
 
 <li class="control-menu-nav-item control-menu-nav-item-separator">
 	<clay:button
-		elementClasses="lfr-portal-tooltip"
+		cssClass="lfr-portal-tooltip"
+		displayType="unstyled"
 		icon="grid"
-		monospaced="<%= true %>"
-		size="sm"
-		style="unstyled"
-		title='<%= LanguageUtil.get(request, "global-menu") %>'
+		small="<%= true %>"
+		title="global-menu"
 	/>
 
 	<react:component

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/global_menu/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/global_menu/init.jsp
@@ -17,5 +17,4 @@
 <%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %>
 
-<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
-page import="com.liferay.product.navigation.global.menu.web.internal.display.context.GlobalMenuDisplayContext" %>
+<%@ page import="com.liferay.product.navigation.global.menu.web.internal.display.context.GlobalMenuDisplayContext" %>

--- a/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/button/init.jsp
+++ b/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/button/init.jsp
@@ -19,7 +19,6 @@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.petra.string.StringPool" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %>
 
 <liferay-theme:defineObjects />

--- a/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/button/page.jsp
+++ b/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/button/page.jsp
@@ -23,11 +23,10 @@ String buttonComponentId = randomNamespace + "shareButton";
 %>
 
 <clay:button
-	elementClasses="btn-secondary"
+	displayType="secondary"
 	id="<%= buttonComponentId %>"
-	label='<%= LanguageUtil.get(request, "share") %>'
-	size="sm"
-	style="secondary"
+	label="share"
+	small="<%= true %>"
 />
 
 <aui:script>

--- a/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/settings.jsp
+++ b/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/settings.jsp
@@ -126,8 +126,8 @@ if (deployed && oAuthEnabled) {
 			<div class="btn-group">
 				<div class="btn-group-item">
 					<clay:button
-						label='<%= LanguageUtil.get(request, "save") %>'
-						style="primary"
+						displayType="primary"
+						label="save"
 						type="submit"
 					/>
 				</div>


### PR DESCRIPTION
Manual forward of https://github.com/jbalsas/liferay-portal/pull/2213

https://github.com/jbalsas/liferay-portal/pull/2213
✔️ ci:test:stable - 20 out of 20 jobs passed
❌ ci:test:relevant - 104 out of 105 jobs passed in 2 hours 52 minutes

--- 

This PR follows https://github.com/brianchandotcom/liferay-portal/compare/805dec8098...86307c3d7b and applies the new `clay:button` as default after having [discarded performance issues](https://github.com/slnn/liferay-portal/pull/483#issuecomment-640440074).

We still have plenty of raw usages and `aui:button` usages that will be cleaned up in the future.