### PR TITLE
LPS-114017 - Apply the use of clay content taglib in connected-app-web

### DIFF
--- a/modules/apps/connected-app/connected-app-web/src/main/resources/META-INF/resources/connected_apps.jsp
+++ b/modules/apps/connected-app/connected-app-web/src/main/resources/META-INF/resources/connected_apps.jsp
@@ -46,16 +46,22 @@
 			for (ConnectedApp connectedApp : connectedApps) {
 			%>
 
-				<div class="autofit-padded-no-gutters-x autofit-row autofit-row-center mb-3">
-					<div class="autofit-col">
+				<clay:content-row
+					cssClass="mb-3"
+					noGutters="x"
+					verticalAlign="center"
+				>
+					<clay:content-col>
 						<img class="icon-monospaced" src="<%= HtmlUtil.escapeAttribute(connectedApp.getImageURL()) %>" />
-					</div>
+					</clay:content-col>
 
-					<div class="autofit-col autofit-col-expand">
+					<clay:content-col
+						expand="true"
+					>
 						<%= HtmlUtil.escape(connectedApp.getName(locale)) %>
-					</div>
+					</clay:content-col>
 
-					<div class="autofit-col">
+					<clay:content-col>
 						<clay:button
 							data-key="<%= connectedApp.getKey() %>"
 							displayType="secondary"
@@ -63,8 +69,8 @@
 							small="<%= true %>"
 							type="submit"
 						/>
-					</div>
-				</div>
+					</clay:content-col>
+				</clay:content-row>
 
 			<%
 			}


### PR DESCRIPTION
Rebased and resent from https://github.com/brianchandotcom/liferay-portal/pull/89861#event-3426232364

--- 

> Forwarded from: [jbalsas#2212](https://github.com/jbalsas/liferay-portal/pull/2212) (Took 1 `ci:forward` attempt in 1 minute)
> 
> @marcoscv-work
> @jbalsas
> 
> Original pull request comment:
> As part of our effort to Improve HTML Layout Generation Strategies in DXP, here a PR about changing autofit-* and sheet-* for clay:sheet* and clay:content*
> 
> This "PR" updates markup with new taglibs. What we expect is to see the same visual design, so no visual changes are required on `connected-app-web` module.
> The way to validate the changes is to see the same visual result. if is there any previously agreed difference it would be correctly pointed in comments
> 
> LPS-114017 - Apply the use of clay content taglib in connected-app-web
> 
> ### ✔️ ci:test:stable - 20 out of 20 jobs passed
> ### ✔️ ci:test:relevant - 43 out of 43 jobs passed in 1 hour 24 minutes
> Click here for more details.
> ### ✔️ ci:test:sf - 1 out of 1 jobs passed in 4 minutes
> Click here for more details.