### PR TITLE
LPS-113561 Avoid unnecessary call to `Liferay.provide` in asset-list-web

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/scope.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/scope.jsp
@@ -86,7 +86,7 @@ PortletURL portletURL = editAssetListDisplayContext.getPortletURL();
 			continue;
 		}
 
-		String onClick = "addRow('" + group.getGroupId() + "', '" + HtmlUtil.escapeJS(HtmlUtil.escape(group.getDescriptiveName(themeDisplay.getLocale()))) + "', '" + LanguageUtil.get(request, group.getScopeLabel(themeDisplay)) + "');";
+		String onClick = renderResponse.getNamespace() + "addRow('" + group.getGroupId() + "', '" + HtmlUtil.escapeJS(HtmlUtil.escape(group.getDescriptiveName(themeDisplay.getLocale()))) + "', '" + LanguageUtil.get(request, group.getScopeLabel(themeDisplay)) + "');";
 	%>
 
 		<liferay-ui:icon
@@ -156,7 +156,7 @@ PortletURL portletURL = editAssetListDisplayContext.getPortletURL();
 					var searchContainerData = searchContainer.getData();
 
 					if (searchContainerData.indexOf(entityId) == -1) {
-						addRow(
+						<portlet:namespace />addRow(
 							entityId,
 							event.groupdescriptivename,
 							event.groupscopelabel
@@ -167,7 +167,12 @@ PortletURL portletURL = editAssetListDisplayContext.getPortletURL();
 		});
 	}
 
-	Liferay.provide(window, 'addRow', function (groupId, name, scopeLabel) {
+	window['<portlet:namespace />addRow'] = function (groupId, name, scopeLabel) {
+		var data = searchContainer.getData(true);
+		if (data.includes(groupId)) {
+			return;
+		}
+
 		var rowColumns = [];
 
 		rowColumns.push('<span class="text-truncate">' + name + '</span>');
@@ -183,9 +188,9 @@ PortletURL portletURL = editAssetListDisplayContext.getPortletURL();
 		searchContainer.updateDataStore();
 
 		updateGroupIds();
-	});
+	};
 
-	Liferay.provide(window, 'updateGroupIds', function () {
+	function updateGroupIds() {
 		var groupIds = document.getElementById('<portlet:namespace />groupIds');
 
 		if (groupIds) {
@@ -193,5 +198,5 @@ PortletURL portletURL = editAssetListDisplayContext.getPortletURL();
 
 			groupIds.setAttribute('value', searchContainerData.split(','));
 		}
-	});
+	}
 </aui:script>


### PR DESCRIPTION
Manual forward from https://github.com/wincent/liferay-portal/pull/335 which previously [passed tests](https://github.com/wincent/liferay-portal/pull/335#issuecomment-641938010):

<html><h3>:heavy_check_mark: ci:test:stable - 20 out of 20 jobs passed</h3><h3>:heavy_check_mark: ci:test:relevant - 61 out of 61 jobs passed in 2 hours 36 minutes</h3></html>

(Forwarding because I just edited the commit message and want to conserve resources.)

cc @julien

Original message follows.

---

As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561), we eventually want to deprecated the `Liferay.provide` function.

The code here was using it twice to expose functions on the `window` object: one of those was internal only, so didn't need to be exposed, and the other doesn't have any dependencies (which is the main reason you would use `Liferay.provide` in the first place), so can just be defined manually.

Additionally, we avoid the same group being added twice in the "scope" section.

Tested as follows:

- Navigate to "Content and Data" > "Collections"
- From the "New" drop down menu, select "Dynamic Selection"
- Give it the name you want and click on the "Save" button
- Scroll down to the "Scope" section
- Click on the "Select" button
- Choose "Global"
- Click on the "Select" button again and choose "Global" again

As a result the "Global" item should be present only once in the "scope" section.

With the devtools open, locate the input element who's `id` attribute is `_com_liferay_asset_list_web_portlet_AssetListPortlet_groupIds` and confirm that it's `value` attribute contains several numbers (ids), none of which are duplicated.

PR 1 of the 6 described here: [#320 (comment)](https://github.com/wincent/liferay-portal/pull/320#issuecomment-641223200)