### PR TITLE
LPS-114387 DBPartition: use schema name prefix property with a default value to make it optional 

### DIFF
--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -174,7 +174,7 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 		ReflectionTestUtil.setFieldValue(
 			DBPartitionUtil.class, "_DATABASE_PARTITION_ENABLED", false);
 		ReflectionTestUtil.setFieldValue(
-			DBPartitionUtil.class, "_DATABASE_PARTITION_INSTANCE_ID",
+			DBPartitionUtil.class, "_DATABASE_PARTITION_SCHEMA_NAME_PREFIX",
 			StringPool.BLANK);
 
 		_lazyConnectionDataSourceProxy.setTargetDataSource(_currentDataSource);
@@ -193,8 +193,8 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 			DBPartitionUtil.class, "_DATABASE_PARTITION_ENABLED", true);
 
 		ReflectionTestUtil.setFieldValue(
-			DBPartitionUtil.class, "_DATABASE_PARTITION_INSTANCE_ID",
-			_DB_PARTITION_INSTANCE_ID);
+			DBPartitionUtil.class, "_DATABASE_PARTITION_SCHEMA_NAME_PREFIX",
+			_DB_PARTITION_SCHEMA_NAME_PREFIX);
 
 		DBPartitionUtil.setDefaultCompanyId(PortalUtil.getDefaultCompanyId());
 
@@ -214,16 +214,17 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 
 	private static String _getSchemaName(long companyId) {
 		if (_dbPartitionEnabled) {
-			return PropsUtil.get("database.partition.instance.id") +
-				StringPool.UNDERLINE + companyId;
+			return PropsUtil.get("database.partition.schema.name.prefix") +
+				companyId;
 		}
 
-		return _DB_PARTITION_INSTANCE_ID + StringPool.UNDERLINE + companyId;
+		return _DB_PARTITION_SCHEMA_NAME_PREFIX + companyId;
 	}
 
 	private static final long _COMPANY_ID = 1L;
 
-	private static final String _DB_PARTITION_INSTANCE_ID = "dbPartitionTest";
+	private static final String _DB_PARTITION_SCHEMA_NAME_PREFIX =
+		"lpartitiontest_";
 
 	private static Connection _connection;
 	private static final DataSource _currentDataSource =

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.spring.hibernate.DialectDetector;
 
 import java.sql.Connection;
@@ -130,12 +129,6 @@ public class DBPartitionUtil {
 			throw new Error("Database partition requires MySQL");
 		}
 
-		if (Validator.isNull(_DATABASE_PARTITION_INSTANCE_ID)) {
-			throw new Error(
-				"Database partition requires setting the property " +
-					"\"database.partition.instance.id\"");
-		}
-
 		try (Connection connection = dataSource.getConnection()) {
 			_defaultSchemaName = connection.getCatalog();
 		}
@@ -166,8 +159,7 @@ public class DBPartitionUtil {
 	}
 
 	private static String _getSchemaName(long companyId) {
-		return _DATABASE_PARTITION_INSTANCE_ID + StringPool.UNDERLINE +
-			companyId;
+		return _DATABASE_PARTITION_SCHEMA_NAME_PREFIX + companyId;
 	}
 
 	private static boolean _isControlTable(
@@ -206,8 +198,10 @@ public class DBPartitionUtil {
 	private static final boolean _DATABASE_PARTITION_ENABLED =
 		GetterUtil.getBoolean(PropsUtil.get("database.partition.enabled"));
 
-	private static final String _DATABASE_PARTITION_INSTANCE_ID = PropsUtil.get(
-		"database.partition.instance.id");
+	private static final String _DATABASE_PARTITION_SCHEMA_NAME_PREFIX =
+		GetterUtil.get(
+			PropsUtil.get("database.partition.schema.name.prefix"),
+			"lpartition_");
 
 	private static final Set<String> _controlTableNames = new HashSet<>(
 		Arrays.asList("Company", "Portlet", "VirtualHost"));


### PR DESCRIPTION
@vicnate5 @kyle-miho

Please take into account this, we have changed the previous property and now is called database.partition.schema.name.prefix and it is not required

I will update the documents once Brian approves it.