### PR TITLE
LPS-112475 Updates clay:alert and clay:stripe tag implementation and usages

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/add_domains.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/add_domains.jsp
@@ -22,11 +22,10 @@ String eventName = ParamUtil.getString(request, "eventName", liferayPortletRespo
 
 <div class="modal-body">
 	<clay:alert
-		elementClasses="hide"
+		cssClass="hide"
+		displayType="danger"
 		id='<%= renderResponse.getNamespace() + "domainAlert" %>'
-		message='<%= LanguageUtil.get(request, "please-enter-valid-mail-domains-separated-by-commas") %>'
-		style="danger"
-		title='<%= LanguageUtil.get(request, "error") %>'
+		message="please-enter-valid-mail-domains-separated-by-commas"
 	/>
 
 	<aui:field-wrapper cssClass="form-group">

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/select_account_users.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/select_account_users.jsp
@@ -31,8 +31,7 @@ SelectAccountUsersManagementToolbarDisplayContext selectAccountUsersManagementTo
 <clay:container-fluid>
 	<c:if test='<%= !Objects.equals(selectAccountUsersManagementToolbarDisplayContext.getNavigation(), "all-users") %>'>
 		<clay:alert
-			message='<%= LanguageUtil.get(request, "showing-users-with-valid-domains-only") %>'
-			title='<%= LanguageUtil.get(request, "info") %>'
+			message="showing-users-with-valid-domains-only"
 		/>
 	</c:if>
 

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/view.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/view.jsp
@@ -22,9 +22,8 @@ boolean blogsPortletFound = ParamUtil.getBoolean(request, "blogsPortletFound", t
 
 <c:if test="<%= !blogsPortletFound %>">
 	<clay:stripe
-		message='<%= LanguageUtil.get(resourceBundle, "no-suitable-application-found-to-display-the-blogs-entry") %>'
-		style="danger"
-		title='<%= LanguageUtil.get(resourceBundle, "error") + ":" %>'
+		displayType="danger"
+		message="no-suitable-application-found-to-display-the-blogs-entry"
 	/>
 </c:if>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_preview_error.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_preview_error.jsp
@@ -40,8 +40,7 @@ FileVersion fileVersion = (FileVersion)request.getAttribute(WebKeys.DOCUMENT_LIB
 	</c:when>
 	<c:when test="<%= exception instanceof DLPreviewGenerationInProcessException %>">
 		<clay:alert
-			message='<%= LanguageUtil.get(resourceBundle, "generating-preview-will-take-a-few-minutes") %>'
-			title='<%= LanguageUtil.get(request, "info") + ":" %>'
+			message="generating-preview-will-take-a-few-minutes"
 		/>
 	</c:when>
 	<c:otherwise>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
@@ -28,16 +28,14 @@ boolean showCSVWarning = StringUtil.equals("enabled-with-warning", csvExport);
 <div class="hide" id="<portlet:namespace />exportList">
 	<div id="<portlet:namespace />csvWarning">
 		<clay:alert
-			message='<%= LanguageUtil.get(resourceBundle, "csv-warning-message") %>'
-			style="warning"
-			title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
+			displayType="warning"
+			message="csv-warning-message"
 		/>
 	</div>
 
 	<clay:alert
-		message='<%= LanguageUtil.get(resourceBundle, "timezone-warning-message") %>'
-		style="warning"
-		title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
+		displayType="warning"
+		message="timezone-warning-message"
 	/>
 
 	<aui:select label="file-extension" name="fileExtension">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_renderer/init-ext.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_renderer/init-ext.jspf
@@ -26,7 +26,6 @@ page import="com.liferay.dynamic.data.mapping.exception.NoSuchStructureLayoutExc
 page import="com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderingException" %><%@
 page import="com.liferay.dynamic.data.mapping.model.DDMFormInstance" %><%@
 page import="com.liferay.dynamic.data.mapping.validator.DDMFormValuesValidationException" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.LocaleUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
@@ -34,8 +33,7 @@ page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.workflow.WorkflowConstants" %>
 
-<%@ page import="java.util.Locale" %><%@
-page import="java.util.ResourceBundle" %>
+<%@ page import="java.util.Locale" %>
 
 <%
 String ddmFormHTML = (String)request.getAttribute("liferay-form:ddm-form-renderer:ddmFormHTML");
@@ -45,5 +43,4 @@ boolean hasViewFormInstancePermission = GetterUtil.getBoolean(request.getAttribu
 boolean isFormAvailable = GetterUtil.getBoolean(request.getAttribute("liferay-form:ddm-form-renderer:isFormAvailable"));
 String languageId = (String)request.getAttribute("liferay-form:ddm-form-renderer:languageId");
 String redirectURL = (String)request.getAttribute("liferay-form:ddm-form-renderer:redirectURL");
-ResourceBundle resourceBundle = (ResourceBundle)request.getAttribute("liferay-form:ddm-form-renderer:resourceBundle");
 %>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_renderer/page.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_renderer/page.jsp
@@ -25,9 +25,7 @@ if (ddmFormInstance != null) {
 <c:choose>
 	<c:when test="<%= ddmFormInstanceId == 0 %>">
 		<clay:alert
-			message='<%= LanguageUtil.get(resourceBundle, "select-an-existing-form-or-add-a-form-to-be-displayed-in-this-application") %>'
-			style="info"
-			title='<%= LanguageUtil.get(resourceBundle, "info") %>'
+			message="select-an-existing-form-or-add-a-form-to-be-displayed-in-this-application"
 		/>
 	</c:when>
 	<c:otherwise>
@@ -77,9 +75,8 @@ if (ddmFormInstance != null) {
 
 					<c:if test="<%= !hasAddFormInstanceRecordPermission %>">
 						<clay:alert
-							message='<%= LanguageUtil.get(resourceBundle, "you-do-not-have-the-permission-to-submit-this-form") %>'
-							style="warning"
-							title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
+							displayType="warning"
+							message="you-do-not-have-the-permission-to-submit-this-form"
 						/>
 					</c:if>
 
@@ -110,16 +107,14 @@ if (ddmFormInstance != null) {
 			</c:when>
 			<c:when test="<%= !hasViewFormInstancePermission %>">
 				<clay:alert
-					message='<%= LanguageUtil.get(resourceBundle, "you-do-not-have-the-permission-to-view-this-form") %>'
-					style="warning"
-					title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
+					displayType="warning"
+					message="you-do-not-have-the-permission-to-view-this-form"
 				/>
 			</c:when>
 			<c:otherwise>
 				<clay:alert
-					message='<%= LanguageUtil.get(resourceBundle, "this-form-not-available-or-it-was-not-published") %>'
-					style="warning"
-					title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
+					displayType="warning"
+					message="this-form-not-available-or-it-was-not-published"
 				/>
 			</c:otherwise>
 		</c:choose>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/export_form_instance.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/export_form_instance.jspf
@@ -28,22 +28,17 @@ boolean showCSVWarning = StringUtil.equals("enabled-with-warning", csvExport);
 <div class="hide" id="<portlet:namespace />exportFormInstance">
 	<div class="hide" id="<portlet:namespace />csvWarning">
 		<clay:alert
-			message='<%= LanguageUtil.get(resourceBundle, "csv-warning-message") %>'
-			style="warning"
-			title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
+			displayType="warning"
+			message="csv-warning-message"
 		/>
 	</div>
 
 	<clay:alert
-		message='<%= LanguageUtil.get(resourceBundle, "timezone-warning-message") %>'
-		style="info"
-		title='<%= LanguageUtil.get(resourceBundle, "info") %>'
+		message="timezone-warning-message"
 	/>
 
 	<clay:alert
-		message='<%= LanguageUtil.get(resourceBundle, "the-export-includes-data-from-all-fields-and-form-versions") %>'
-		style="info"
-		title='<%= LanguageUtil.get(resourceBundle, "info") %>'
+		message="the-export-includes-data-from-all-fields-and-form-versions"
 	/>
 
 	<aui:select label="file-extension" name="fileExtension">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
@@ -32,9 +32,8 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 		<div class="ddm-form-basic-info">
 			<clay:container-fluid>
 				<clay:alert
-					message='<%= LanguageUtil.get(resourceBundle, "you-do-not-have-the-permission-to-view-this-form") %>'
-					style="warning"
-					title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
+					displayType="warning"
+					message="you-do-not-have-the-permission-to-view-this-form"
 				/>
 			</clay:container-fluid>
 		</div>
@@ -43,9 +42,8 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 		<div class="ddm-form-basic-info">
 			<clay:container-fluid>
 				<clay:alert
-					message='<%= LanguageUtil.get(resourceBundle, "you-need-to-be-signed-in-to-view-this-form") %>'
-					style="warning"
-					title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
+					displayType="warning"
+					message="you-need-to-be-signed-in-to-view-this-form"
 				/>
 			</clay:container-fluid>
 		</div>
@@ -148,9 +146,8 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 							<div class="ddm-form-basic-info">
 								<clay:container-fluid>
 									<clay:alert
-										message='<%= LanguageUtil.get(resourceBundle, "you-do-not-have-the-permission-to-submit-this-form") %>'
-										style="warning"
-										title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
+										displayType="warning"
+										message="you-do-not-have-the-permission-to-submit-this-form"
 									/>
 								</clay:container-fluid>
 							</div>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_import.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_import.jsp
@@ -41,10 +41,8 @@ ImportDisplayContext importDisplayContext = new ImportDisplayContext(request, re
 
 		<c:if test="<%= ListUtil.isNotEmpty(draftFragmentsImporterResultEntries) %>">
 			<clay:alert
-				closeable="<%= true %>"
-				destroyOnHide="<%= true %>"
+				dismissible="true"
 				message='<%= LanguageUtil.format(request, "the-following-fragments-have-validation-issues.-they-have-been-left-in-draft-status-x", "<strong>" + StringUtil.merge(draftFragmentsImporterResultEntries, StringPool.COMMA_AND_SPACE) + "</strong>", false) %>'
-				title='<%= LanguageUtil.get(request, "info") %>'
 			/>
 		</c:if>
 
@@ -54,11 +52,9 @@ ImportDisplayContext importDisplayContext = new ImportDisplayContext(request, re
 
 		<c:if test="<%= ListUtil.isNotEmpty(invalidFragmentsImporterResultEntries) %>">
 			<clay:alert
-				closeable="<%= true %>"
-				destroyOnHide="<%= true %>"
+				dismissible="<%= true %>"
+				displayType="warning"
 				message='<%= LanguageUtil.format(request, "the-following-fragments-could-not-be-imported-x", "<strong>" + StringUtil.merge(invalidFragmentsImporterResultEntries, StringPool.COMMA_AND_SPACE) + "</strong>", false) %>'
-				style="warning"
-				title='<%= LanguageUtil.get(request, "warning") %>'
 			/>
 		</c:if>
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_import.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_import.jsp
@@ -41,7 +41,7 @@ ImportDisplayContext importDisplayContext = new ImportDisplayContext(request, re
 
 		<c:if test="<%= ListUtil.isNotEmpty(draftFragmentsImporterResultEntries) %>">
 			<clay:alert
-				dismissible="true"
+				dismissible="<%= true %>"
 				message='<%= LanguageUtil.format(request, "the-following-fragments-have-validation-issues.-they-have-been-left-in-draft-status-x", "<strong>" + StringUtil.merge(draftFragmentsImporterResultEntries, StringPool.COMMA_AND_SPACE) + "</strong>", false) %>'
 			/>
 		</c:if>

--- a/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/java/com/liferay/frontend/compatibility/ie/internal/servlet/taglib/IETopHeadDynamicInclude.java
+++ b/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/java/com/liferay/frontend/compatibility/ie/internal/servlet/taglib/IETopHeadDynamicInclude.java
@@ -95,7 +95,7 @@ public class IETopHeadDynamicInclude extends BaseDynamicInclude {
 
 	private static final String[] _JS_FILE_NAMES = {
 		"closest.js", "control.menu.js", "/core-js-bundle.min.js", "/fetch.js",
-		"/svg.contains.js", "/uint16array.slice.js"
+		"remove.js", "/svg.contains.js", "/uint16array.slice.js"
 	};
 
 	@Reference

--- a/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/java/com/liferay/frontend/compatibility/ie/internal/servlet/taglib/IETopHeadDynamicInclude.java
+++ b/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/java/com/liferay/frontend/compatibility/ie/internal/servlet/taglib/IETopHeadDynamicInclude.java
@@ -91,11 +91,11 @@ public class IETopHeadDynamicInclude extends BaseDynamicInclude {
 		_bundleContext = bundleContext;
 	}
 
-	private static final String[] _CSS_FILE_NAMES = {"/css/main.css"};
+	private static final String[] _CSS_FILE_NAMES = {"css/main.css"};
 
 	private static final String[] _JS_FILE_NAMES = {
-		"closest.js", "control.menu.js", "/core-js-bundle.min.js", "/fetch.js",
-		"remove.js", "/svg.contains.js", "/uint16array.slice.js"
+		"closest.js", "control.menu.js", "core-js-bundle.min.js", "fetch.js",
+		"remove.js", "svg.contains.js", "uint16array.slice.js"
 	};
 
 	@Reference

--- a/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/resources/META-INF/resources/remove.js
+++ b/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/resources/META-INF/resources/remove.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+if (!Element.prototype.remove) {
+	Element.prototype.remove = function () {
+		if (this.parentNode === null) {
+			return;
+		}
+
+		this.parentNode.removeChild(this);
+	};
+}

--- a/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/resources/META-INF/resources/remove.js
+++ b/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/resources/META-INF/resources/remove.js
@@ -12,12 +12,14 @@
  * details.
  */
 
-if (!Element.prototype.remove) {
-	Element.prototype.remove = function () {
-		if (this.parentNode === null) {
-			return;
-		}
+[Element, CharacterData, DocumentType].forEach(function (item) {
+	if (!item.prototype.remove) {
+		item.prototype.remove = function () {
+			if (this.parentNode === null) {
+				return;
+			}
 
-		this.parentNode.removeChild(this);
-	};
-}
+			this.parentNode.removeChild(this);
+		};
+	}
+});

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/alerts.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/alerts.jsp
@@ -23,14 +23,14 @@
 </blockquote>
 
 <clay:alert
+	displayType="danger"
 	message="This is an error message."
-	style="danger"
 	title="Error"
 />
 
 <clay:alert
+	displayType="success"
 	message="This is a success message."
-	style="success"
 	title="Success"
 />
 
@@ -40,8 +40,8 @@
 />
 
 <clay:alert
+	displayType="warning"
 	message="This is a warning message."
-	style="warning"
 	title="Warning"
 />
 
@@ -52,14 +52,14 @@
 </blockquote>
 
 <clay:stripe
+	displayType="danger"
 	message="This is an error message."
-	style="danger"
 	title="Error"
 />
 
 <clay:stripe
+	displayType="success"
 	message="This is a success message."
-	style="success"
 	title="Success"
 />
 
@@ -69,7 +69,7 @@
 />
 
 <clay:stripe
+	displayType="warning"
 	message="This is a warning message."
-	style="warning"
 	title="Warning"
 />

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Chema Balsas
+ */
+public class AlertTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		setDynamicAttribute(StringPool.BLANK, "role", "alert");
+
+		return super.doStartTag();
+	}
+
+	public boolean getAutoClose() {
+		return _autoClose;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getDismissible()}
+	 */
+	@Deprecated
+	public boolean getCloseable() {
+		return _dismissible;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public boolean getDestroyOnHide() {
+		return _destroyOnHide;
+	}
+
+	public boolean getDismissible() {
+		return _dismissible;
+	}
+
+	public String getDisplayType() {
+		return _displayType;
+	}
+
+	public String getMessage() {
+		return _message;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getDisplayType()}
+	 */
+	@Deprecated
+	public String getStyle() {
+		return getDisplayType();
+	}
+
+	public String getTitle() {
+		return _title;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getType() {
+		return _type;
+	}
+
+	public String getVariant() {
+		return _variant;
+	}
+
+	public void setAutoClose(boolean autoClose) {
+		_autoClose = autoClose;
+	}
+
+	public void setCloseable(boolean closeable) {
+		setDismissible(closeable);
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setDestroyOnHide(boolean destroyOnHide) {
+		_destroyOnHide = destroyOnHide;
+	}
+
+	public void setDismissible(boolean dismissible) {
+		_dismissible = dismissible;
+	}
+
+	public void setDisplayType(String displayType) {
+		_displayType = displayType;
+	}
+
+	public void setMessage(String message) {
+		_message = message;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setDisplayType(String)}
+	 */
+	@Deprecated
+	public void setStyle(String style) {
+		setDisplayType(style);
+	}
+
+	public void setTitle(String title) {
+		_title = title;
+	}
+
+	public void setType(String type) {
+		_type = type;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setVariant(String variant) {
+		_variant = variant;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_autoClose = false;
+		_destroyOnHide = false;
+		_dismissible = false;
+		_displayType = "info";
+		_message = null;
+		_title = null;
+		_type = null;
+		_variant = null;
+	}
+
+	@Override
+	protected String processCssClasses(Set<String> cssClasses) {
+		cssClasses.add("alert");
+
+		if (_dismissible) {
+			cssClasses.add("alert-dismissible");
+		}
+
+		if (Validator.isNotNull(_variant) && _variant.equals("stripe")) {
+			cssClasses.add("alert-fluid");
+		}
+
+		if (Validator.isNotNull(_displayType)) {
+			cssClasses.add("alert-" + _displayType);
+		}
+
+		return super.processCssClasses(cssClasses);
+	}
+
+	@Override
+	protected int processEndTag() throws Exception {
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write("</div></div>");
+
+		if (_dismissible) {
+			jspWriter.write("<button class=\"close\" onclick=\"");
+			jspWriter.write("event.target.closest('[role=alert]').remove()\"");
+			jspWriter.write(" type=\"button\">");
+
+			IconTag iconTag = new IconTag();
+
+			iconTag.setSymbol("times");
+
+			iconTag.doTag(pageContext);
+
+			jspWriter.write("</button>");
+		}
+
+		if (Validator.isNotNull(_variant) && _variant.equals("stripe")) {
+			jspWriter.write("</div>");
+		}
+
+		jspWriter.write("</div>");
+
+		return super.processEndTag();
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		JspWriter jspWriter = pageContext.getOut();
+
+		if (Validator.isNotNull(_variant) && _variant.equals("stripe")) {
+			jspWriter.write("<div class=\"container-fluid ");
+			jspWriter.write("container-fluid-max-xl\">");
+		}
+
+		jspWriter.write("<div class=\"alert-autofit-row autofit-row\"><div ");
+		jspWriter.write("class=\"autofit-col\"><div ");
+		jspWriter.write("class=\"autofit-section\"><span ");
+		jspWriter.write("class=\"alert-indicator\">");
+
+		IconTag iconTag = new IconTag();
+
+		iconTag.setSymbol(_getIcon(_displayType));
+
+		iconTag.doTag(pageContext);
+
+		jspWriter.write("</span></div></div><div class=\"autofit-col ");
+		jspWriter.write("autofit-col-expand\"><div class=\"autofit-section\">");
+		jspWriter.write("<strong class=\"lead\">");
+		jspWriter.write(_getTitle(_title, _displayType));
+		jspWriter.write(":</strong>");
+
+		if (Validator.isNotNull(_message)) {
+			jspWriter.write(
+				LanguageUtil.get(
+					TagResourceBundleUtil.getResourceBundle(pageContext),
+					_message));
+
+			return SKIP_BODY;
+		}
+
+		return EVAL_BODY_INCLUDE;
+	}
+
+	private String _getIcon(String displayType) {
+		if (displayType.equals("danger")) {
+			return "exclamation-full";
+		}
+		else if (displayType.equals("success")) {
+			return "check-circle-full";
+		}
+		else if (displayType.equals("warning")) {
+			return "warning-full";
+		}
+		else {
+			return "info-circle";
+		}
+	}
+
+	private String _getTitle(String title, String displayType) {
+		if (Validator.isNull(title)) {
+			title = displayType;
+		}
+
+		if (title.equals("danger")) {
+			title = "error";
+		}
+
+		return LanguageUtil.get(
+			TagResourceBundleUtil.getResourceBundle(pageContext), title);
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:alert:";
+
+	private boolean _autoClose;
+	private boolean _destroyOnHide;
+	private boolean _dismissible;
+	private String _displayType = "info";
+	private String _message;
+	private String _title;
+	private String _type;
+	private String _variant;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StripeTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StripeTag.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import javax.servlet.jsp.JspException;
+
+/**
+ * @author Chema Balsas
+ */
+public class StripeTag extends AlertTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		setVariant("stripe");
+
+		return super.doStartTag();
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:stripe:";
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -12,8 +12,8 @@
 	<tag>
 		<description></description>
 		<name>alert</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.AlertTag</tag-class>
-		<body-content>empty</body-content>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.AlertTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
 			<name>autoClose</name>
@@ -21,43 +21,55 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>dismissible</code>]]>.</description>
 			<name>closeable</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>destroyOnHide</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>dismissible</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>displayType</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -71,17 +83,17 @@
 		<attribute>
 			<description></description>
 			<name>message</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>spritemap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
 			<name>style</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -89,15 +101,16 @@
 		<attribute>
 			<description></description>
 			<name>title</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>type</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -2529,8 +2529,8 @@
 	<tag>
 		<description></description>
 		<name>stripe</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.StripeTag</tag-class>
-		<body-content>empty</body-content>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.StripeTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
 			<description></description>
 			<name>autoClose</name>
@@ -2538,37 +2538,55 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>dismissible</code>]]>.</description>
+			<name>closeable</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>destroyOnHide</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>dismissible</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>displayType</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -2582,17 +2600,17 @@
 		<attribute>
 			<description></description>
 			<name>message</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>spritemap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>displayType</code>]]>.</description>
 			<name>style</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -2600,9 +2618,16 @@
 		<attribute>
 			<description></description>
 			<name>title</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
+			<name>type</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description>Deprecated as of Athanasius (7.3.x), with no direct replacement.</description>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template_display.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template_display.jsp
@@ -102,23 +102,19 @@ JournalDDMTemplateHelper journalDDMTemplateHelper = (JournalDDMTemplateHelper)re
 			%>
 
 			<clay:alert
-				closeable="<%= true %>"
-				componentId="languageMessageContainer"
-				destroyOnHide="<%= true %>"
-				elementClasses='<%= ((ddmTemplate == null) && (templateLanguageTypes.length > 1)) || ((ddmTemplate != null) && !Objects.equals(ddmTemplate.getLanguage(), journalEditDDMTemplateDisplayContext.getLanguage())) ? "mb-3" : "hide mb-3" %>'
-				message='<%= LanguageUtil.get(request, "changing-the-language-does-not-automatically-translate-the-existing-template-script") %>'
-				style="warning"
-				title='<%= LanguageUtil.get(request, "warning") %>'
+				cssClass='<%= ((ddmTemplate == null) && (templateLanguageTypes.length > 1)) || ((ddmTemplate != null) && !Objects.equals(ddmTemplate.getLanguage(), journalEditDDMTemplateDisplayContext.getLanguage())) ? "mb-3" : "hide mb-3" %>'
+				dismissible="<%= true %>"
+				displayType="warning"
+				id="languageMessageContainer"
+				message="changing-the-language-does-not-automatically-translate-the-existing-template-script"
 			/>
 
 			<clay:alert
-				closeable="<%= true %>"
-				componentId="cacheableMessageContainer"
-				destroyOnHide="<%= true %>"
-				elementClasses='<%= journalEditDDMTemplateDisplayContext.isCacheable() ? "mb-3" : "hide mb-3" %>'
-				message='<%= LanguageUtil.get(request, "this-template-is-marked-as-cacheable.-avoid-using-code-that-uses-request-handling,-the-cms-query-api,-taglibs,-or-other-dynamic-features.-uncheck-the-cacheable-property-if-dynamic-behavior-is-needed") %>'
-				style="warning"
-				title='<%= LanguageUtil.get(request, "warning") %>'
+				cssClass='<%= journalEditDDMTemplateDisplayContext.isCacheable() ? "mb-3" : "hide mb-3" %>'
+				dismissible="<%= true %>"
+				displayType="warning"
+				id="cacheableMessageContainer"
+				message="this-template-is-marked-as-cacheable.-avoid-using-code-that-uses-request-handling,-the-cms-query-api,-taglibs,-or-other-dynamic-features.-uncheck-the-cacheable-property-if-dynamic-behavior-is-needed"
 			/>
 
 			<div class="lfr-rich-editor" id="<portlet:namespace />richEditor"></div>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
@@ -22,9 +22,7 @@ JournalViewMoreMenuItemsDisplayContext journalViewMoreMenuItemsDisplayContext = 
 
 <c:if test="<%= journalDisplayContext.getAddMenuFavItemsLength() == 0 %>">
 	<clay:stripe
-		destroyOnHide="<%= true %>"
 		message='<%= LanguageUtil.format(resourceBundle, "you-can-add-as-many-as-x-favorites-in-your-quick-menu", journalWebConfiguration.maxAddMenuItems()) %>'
-		title='<%= LanguageUtil.get(resourceBundle, "info") + ":" %>'
 	/>
 </c:if>
 
@@ -32,9 +30,8 @@ JournalViewMoreMenuItemsDisplayContext journalViewMoreMenuItemsDisplayContext = 
 
 <c:if test="<%= journalDisplayContext.getAddMenuFavItemsLength() >= journalWebConfiguration.maxAddMenuItems() %>">
 	<clay:stripe
-		message='<%= LanguageUtil.get(resourceBundle, "right-now-your-quick-menu-is-full-of-favorites-if-you-want-to-add-another-one-please-remove-at-least-one-of-them") %>'
-		style="warning"
-		title='<%= LanguageUtil.get(resourceBundle, "warning") + ":" %>'
+		displayType="warning"
+		message="right-now-your-quick-menu-is-full-of-favorites-if-you-want-to-add-another-one-please-remove-at-least-one-of-them"
 	/>
 </c:if>
 

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/init.jsp
@@ -38,7 +38,6 @@ page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.exception.SitemapChangeFrequencyException" %><%@
 page import="com.liferay.portal.kernel.exception.SitemapIncludeException" %><%@
 page import="com.liferay.portal.kernel.exception.SitemapPagePriorityException" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Layout" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
@@ -90,8 +90,7 @@ UnicodeProperties layoutTypeSettings = selLayout.getTypeSettingsProperties();
 						var="infoCanonicalURL"
 					>
 						<clay:alert
-							message='<%= LanguageUtil.get(resourceBundle, "use-custom-canonical-url-alert-info") %>'
-							title='<%= LanguageUtil.get(request, "info") + ":" %>'
+							message="use-custom-canonical-url-alert-info"
 						/>
 					</liferay-util:buffer>
 

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/connections.jsp
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/connections.jsp
@@ -180,9 +180,8 @@ SearchEngineDisplayContext
 
 									<c:if test="<%= Validator.isNotNull(errorMessage) %>">
 										<clay:alert
+											displayType="danger"
 											message="<%= errorMessage %>"
-											style="danger"
-											title='<%= LanguageUtil.get(request, "error") %>'
 										/>
 									</c:if>
 								</clay:sheet>
@@ -194,9 +193,7 @@ SearchEngineDisplayContext
 						</c:when>
 						<c:otherwise>
 							<clay:alert
-								message='<%= LanguageUtil.get(request, "no-active-connections") %>'
-								style="info"
-								title='<%= LanguageUtil.get(request, "info") %>'
+								message="no-active-connections"
 							/>
 						</c:otherwise>
 					</c:choose>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition_link/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition_link/view.jsp
@@ -30,10 +30,8 @@ boolean showStripeMessage = workflowDefinitionLinkDisplayContext.showStripeMessa
 >
 	<c:if test="<%= showStripeMessage %>">
 		<clay:alert
-			closeable="<%= true %>"
-			destroyOnHide="<%= true %>"
-			message='<%= LanguageUtil.get(resourceBundle, "the-assets-from-documents-and-media-and-forms-are-assigned-within-their-respective-applications") %>'
-			title="Info"
+			dismissible="<%= true %>"
+			message="the-assets-from-documents-and-media-and-forms-are-assigned-within-their-respective-applications"
 		/>
 	</c:if>
 

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/edit_redirect_entry.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/edit_redirect_entry.jsp
@@ -147,10 +147,9 @@ else {
 
 		<c:if test="<%= redirectEntry != null %>">
 			<clay:alert
-				elementClasses="hide"
+				cssClass="hide"
 				id='<%= renderResponse.getNamespace() + "typeInfoAlert" %>'
-				message='<%= LanguageUtil.get(resourceBundle, "changes-to-this-redirect-might-not-be-immediately-seen-for-users-whose-browsers-have-cached-the-old-redirect-configuration") %>'
-				title='<%= LanguageUtil.get(request, "info") + ":" %>'
+				message="changes-to-this-redirect-might-not-be-immediately-seen-for-users-whose-browsers-have-cached-the-old-redirect-configuration"
 			/>
 		</c:if>
 	</liferay-frontend:edit-form-body>

--- a/modules/apps/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -129,9 +129,7 @@ else {
 %>
 
 <clay:stripe
-	destroyOnHide="<%= true %>"
 	message="<%= stripeMessage %>"
-	title='<%= LanguageUtil.get(request, "info") %>'
 />
 
 <clay:management-toolbar

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_phone_number.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_phone_number.jsp
@@ -60,9 +60,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 
 			<clay:sheet-section>
 				<clay:alert
-					message='<%= LanguageUtil.get(request, "extension-must-be-numeric") %>'
-					style="info"
-					title='<%= LanguageUtil.get(request, "info") + ":" %>'
+					message="extension-must-be-numeric"
 				/>
 
 				<aui:model-context bean="<%= phone %>" model="<%= Phone.class %>" />

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_website.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_website.jsp
@@ -61,8 +61,6 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 			<clay:sheet-section>
 				<clay:alert
 					message='<%= LanguageUtil.format(request, "url-must-start-with-x-or-x", new String[] {"http://", "https://"}, false) %>'
-					style="info"
-					title='<%= LanguageUtil.get(request, "info") + ":" %>'
 				/>
 
 				<aui:model-context bean="<%= website %>" model="<%= Website.class %>" />

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/organization_site.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/organization_site.jsp
@@ -122,9 +122,8 @@ if (organization != null) {
 				<c:choose>
 					<c:when test="<%= ((organization == null) || ((publicLayoutSetPrototype == null) && (organization.getPublicLayoutsPageCount() == 0))) && !layoutSetPrototypes.isEmpty() %>">
 						<clay:alert
-							message='<%= LanguageUtil.get(request, "this-action-cannot-be-undone") %>'
-							style="warning"
-							title='<%= LanguageUtil.get(request, "warning") + ":" %>'
+							displayType="warning"
+							message="this-action-cannot-be-undone"
 						/>
 
 						<aui:select label="" name="publicLayoutSetPrototypeId">
@@ -198,9 +197,8 @@ if (organization != null) {
 				<c:choose>
 					<c:when test="<%= ((organization == null) || ((privateLayoutSetPrototype == null) && (organization.getPrivateLayoutsPageCount() == 0))) && !layoutSetPrototypes.isEmpty() %>">
 						<clay:alert
-							message='<%= LanguageUtil.get(request, "this-action-cannot-be-undone") %>'
-							style="warning"
-							title='<%= LanguageUtil.get(request, "warning") + ":" %>'
+							displayType="warning"
+							message="this-action-cannot-be-undone"
 						/>
 
 						<aui:select label="" name="privateLayoutSetPrototypeId">

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/instant_messenger.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/instant_messenger.jsp
@@ -38,9 +38,7 @@ Contact selContact = (Contact)request.getAttribute("user.selContact");
 	</c:when>
 	<c:otherwise>
 		<clay:alert
-			message='<%= LanguageUtil.get(request, "this-section-will-be-editable-after-creating-the-user") %>'
-			style="info"
-			title='<%= LanguageUtil.get(request, "info") + ":" %>'
+			message="this-section-will-be-editable-after-creating-the-user"
 		/>
 	</c:otherwise>
 </c:choose>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_information.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_information.jsp
@@ -92,9 +92,8 @@ String organizationIdsString = ParamUtil.getString(request, "organizationsSearch
 		<c:if test="<%= lockedOut %>">
 			<aui:button-row>
 				<clay:alert
-					message='<%= LanguageUtil.get(request, "this-user-account-has-been-locked-due-to-excessive-failed-login-attempts") %>'
-					style="warning"
-					title='<%= LanguageUtil.get(request, "warning") + ":" %>'
+					displayType="warning"
+					message="this-user-account-has-been-locked-due-to-excessive-failed-login-attempts"
 				/>
 
 				<%

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/sms.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/sms.jsp
@@ -35,9 +35,7 @@ Contact selContact = (Contact)request.getAttribute("user.selContact");
 	</c:when>
 	<c:otherwise>
 		<clay:alert
-			message='<%= LanguageUtil.get(request, "this-section-will-be-editable-after-creating-the-user") %>'
-			style="info"
-			title='<%= LanguageUtil.get(request, "info") + ":" %>'
+			message="this-section-will-be-editable-after-creating-the-user"
 		/>
 	</c:otherwise>
 </c:choose>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/social_network.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/social_network.jsp
@@ -38,9 +38,7 @@ Contact selContact = (Contact)request.getAttribute("user.selContact");
 	</c:when>
 	<c:otherwise>
 		<clay:alert
-			message='<%= LanguageUtil.get(request, "this-section-will-be-editable-after-creating-the-user") %>'
-			style="info"
-			title='<%= LanguageUtil.get(request, "info") + ":" %>'
+			message="this-section-will-be-editable-after-creating-the-user"
 		/>
 	</c:otherwise>
 </c:choose>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_organizations.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_organizations.jsp
@@ -138,9 +138,7 @@ if (filterManageableOrganizations) {
 	</c:when>
 	<c:otherwise>
 		<clay:alert
-			message='<%= LanguageUtil.get(request, "you-do-not-belong-to-an-organization-and-are-not-allowed-to-view-other-organizations") %>'
-			style="info"
-			title='<%= LanguageUtil.get(request, "info") + ":" %>'
+			message="you-do-not-belong-to-an-organization-and-are-not-allowed-to-view-other-organizations"
 		/>
 	</c:otherwise>
 </c:choose>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_tree.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_tree.jsp
@@ -170,9 +170,7 @@ if (organization != null) {
 	</c:when>
 	<c:otherwise>
 		<clay:alert
-			message='<%= LanguageUtil.get(request, "you-do-not-belong-to-an-organization-and-are-not-allowed-to-view-other-organizations") %>'
-			style="info"
-			title='<%= LanguageUtil.get(request, "info") + ":" %>'
+			message="you-do-not-belong-to-an-organization-and-are-not-allowed-to-view-other-organizations"
 		/>
 	</c:otherwise>
 </c:choose>


### PR DESCRIPTION
Manual forward from https://github.com/wincent/liferay-portal/pull/349 after
- ci:test:relevant - 148 out of 157 jobs passed in 2 hours 22 minutes
- ci:test:relevant - 152 out of 155 jobs passed in 1 hour 28 minutes
- ci:test:relevant - 159 out of 163 jobs passed in 1 hour 56 minutes
- ci:test:relevant - 160 out of 163 jobs passed in 1 hour 48 minutes

All with no unique or unrelated failures.

--- 

This PR updates the implementation of both `AlertTag` and `StripeTag` inside `frontend-taglib-clay` so they're rendered directly from Java (no Soy dependency).

It includes:

### `clay:alert`
- Tag migration
- Legacy tag attribute deprecation 
- Legacy tag implementation deprecation

### `clay:stripe`
- Tag migration
- Legacy tag attribute deprecation 
- Legacy tag implementation deprecation

Visually, output is the same, but added a couple of modifications over the previous implementation:
- The `title` value is inferred from `displayType` if no specific `title` is passed (this removes a lot of boilerplate)
- The `message` and `title` attributes are translated inside the tag (no longer needed to pass them already translated if one doesn't want to). This is more in line with the rest of tags.
- Inlined `onclick` method in the close button in the case of `dismissible` alerts to avoid having to rehydrate the markup with our React component (trying to push this to the last moment...)