### PR TITLE
LPS-113561 Avoids adding event handlers when the modal is not visible

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
@@ -215,11 +215,12 @@ renderResponse.setTitle(headerTitle);
 							<liferay-ui:icon
 								cssClass="modify-link select-file-entry-type"
 								icon="search"
+								id="selectDocumentTypeButton"
 								label="<%= true %>"
 								linkCssClass="btn btn-secondary"
 								markupView="lexicon"
 								message="select-document-type"
-								url='<%= "javascript:" + liferayPortletResponse.getNamespace() + "openFileEntryTypeSelector();" %>'
+								url="javascript:;"
 							/>
 
 							<aui:select cssClass='<%= !fileEntryTypes.isEmpty() ? "default-document-type" : "default-document-type hide" %>' helpMessage="default-document-type-help" label="default-document-type" name="defaultFileEntryTypeId">
@@ -330,38 +331,8 @@ renderResponse.setTitle(headerTitle);
 	</c:if>
 </liferay-util:buffer>
 
-<aui:script use="liferay-search-container">
-	var <portlet:namespace />documentTypesChanged = false;
-
-	window['<portlet:namespace />openFileEntryTypeSelector'] = function () {
-		var searchContainer = Liferay.SearchContainer.get(
-			'<portlet:namespace />dlFileEntryTypesSearchContainer'
-		);
-
-		var searchContainerData = searchContainer.getData();
-
-		if (!searchContainerData.length) {
-			searchContainerData = [];
-		}
-		else {
-			searchContainerData = searchContainerData.split(',');
-		}
-
-		Liferay.Util.openModal({
-			id: '<portlet:namespace />fileEntryTypeSelector',
-			onSelect: function (selectedItem) {
-				<portlet:namespace />selectFileEntryType(
-					selectedItem.entityid,
-					selectedItem.entityname
-				);
-			},
-			selectEventName: '<portlet:namespace />selectFileEntryType',
-			selectedData: searchContainerData,
-			title: '<%= UnicodeLanguageUtil.get(request, "document-types") %>',
-			url:
-				'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/document_library/select_restricted_file_entry_type.jsp" /><portlet:param name="includeBasicFileEntryType" value="<%= Boolean.TRUE.toString() %>" /></portlet:renderURL>',
-		});
-	};
+<aui:script sandbox="<%= true %>">
+	window['<portlet:namespace />documentTypesChanged'] = false;
 
 	window['<portlet:namespace />savePage'] = function () {
 		var message =
@@ -380,10 +351,28 @@ renderResponse.setTitle(headerTitle);
 		}
 	};
 
-	window['<portlet:namespace />selectFileEntryType'] = function (
-		fileEntryTypeId,
-		fileEntryTypeName
-	) {
+	Liferay.Util.toggleRadio('<portlet:namespace />restrictionTypeInherit', '', [
+		'<portlet:namespace />restrictionTypeDefinedDiv',
+		'<portlet:namespace />restrictionTypeWorkflowDiv',
+	]);
+
+	Liferay.Util.toggleRadio(
+		'<portlet:namespace />restrictionTypeDefined',
+		'<portlet:namespace />restrictionTypeDefinedDiv',
+		'<portlet:namespace />restrictionTypeWorkflowDiv'
+	);
+
+	<c:if test="<%= !rootFolder %>">
+		Liferay.Util.toggleRadio(
+			'<portlet:namespace />restrictionTypeWorkflow',
+			'<portlet:namespace />restrictionTypeWorkflowDiv',
+			'<portlet:namespace />restrictionTypeDefinedDiv'
+		);
+	</c:if>
+</aui:script>
+
+<aui:script use="liferay-search-container">
+	var selectFileEntryType = function (fileEntryTypeId, fileEntryTypeName) {
 		var searchContainer = Liferay.SearchContainer.get(
 			'<portlet:namespace />dlFileEntryTypesSearchContainer'
 		);
@@ -455,23 +444,41 @@ renderResponse.setTitle(headerTitle);
 		select.appendChild(option);
 	};
 
-	Liferay.Util.toggleRadio('<portlet:namespace />restrictionTypeInherit', '', [
-		'<portlet:namespace />restrictionTypeDefinedDiv',
-		'<portlet:namespace />restrictionTypeWorkflowDiv',
-	]);
-	Liferay.Util.toggleRadio(
-		'<portlet:namespace />restrictionTypeDefined',
-		'<portlet:namespace />restrictionTypeDefinedDiv',
-		'<portlet:namespace />restrictionTypeWorkflowDiv'
+	var selectDocumentTypeButton = document.getElementById(
+		'<portlet:namespace />selectDocumentTypeButton'
 	);
 
-	<c:if test="<%= !rootFolder %>">
-		Liferay.Util.toggleRadio(
-			'<portlet:namespace />restrictionTypeWorkflow',
-			'<portlet:namespace />restrictionTypeWorkflowDiv',
-			'<portlet:namespace />restrictionTypeDefinedDiv'
-		);
-	</c:if>
+	if (selectDocumentTypeButton) {
+		selectDocumentTypeButton.addEventListener('click', function () {
+			var searchContainer = Liferay.SearchContainer.get(
+				'<portlet:namespace />dlFileEntryTypesSearchContainer'
+			);
+
+			var searchContainerData = searchContainer.getData();
+
+			if (!searchContainerData.length) {
+				searchContainerData = [];
+			}
+			else {
+				searchContainerData = searchContainerData.split(',');
+			}
+
+			Liferay.Util.openModal({
+				id: '<portlet:namespace />fileEntryTypeSelector',
+				onSelect: function (selectedItem) {
+					selectFileEntryType(
+						selectedItem.entityid,
+						selectedItem.entityname
+					);
+				},
+				selectEventName: '<portlet:namespace />selectFileEntryType',
+				selectedData: searchContainerData,
+				title: '<%= UnicodeLanguageUtil.get(request, "document-types") %>',
+				url:
+					'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/document_library/select_restricted_file_entry_type.jsp" /><portlet:param name="includeBasicFileEntryType" value="<%= Boolean.TRUE.toString() %>" /></portlet:renderURL>',
+			});
+		});
+	}
 
 	var searchContainer = Liferay.SearchContainer.get(
 		'<portlet:namespace />dlFileEntryTypesSearchContainer'

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries.jsp
@@ -121,164 +121,159 @@ if (portletTitleBasedNavigation) {
 									});
 								});
 
-								Liferay.provide(
-									window,
-									'<portlet:namespace />updateMultipleFiles',
-									function () {
-										var Lang = A.Lang;
+								window['<portlet:namespace />updateMultipleFiles'] = function () {
+									var Lang = A.Lang;
 
-										var commonFileMetadataContainer = A.one(
-											'#<portlet:namespace />commonFileMetadataContainer'
+									var commonFileMetadataContainer = A.one(
+										'#<portlet:namespace />commonFileMetadataContainer'
+									);
+									var selectedFileNameContainer = A.one(
+										'#<portlet:namespace />selectedFileNameContainer'
+									);
+									var ddmFormFieldNamespaces = A.all(
+										'#<portlet:namespace />ddmFormFieldNamespace'
+									).val();
+
+									var inputTpl =
+										'<input id="<portlet:namespace />selectedFileName{0}" name="<portlet:namespace />selectedFileName" type="hidden" value="{1}" />';
+
+									var values = A.all(
+										'input[name=<portlet:namespace />selectUploadedFile]:checked'
+									).val();
+
+									var buffer = [];
+									var dataBuffer = [];
+									var length = values.length;
+
+									for (var i = 0; i < length; i++) {
+										dataBuffer[0] = i;
+										dataBuffer[1] = values[i];
+
+										buffer[i] = Lang.sub(inputTpl, dataBuffer);
+									}
+
+									selectedFileNameContainer.html(buffer.join(''));
+
+									commonFileMetadataContainer.plug(A.LoadingMask);
+
+									commonFileMetadataContainer.loadingmask.show();
+
+									for (var i = 0; i < ddmFormFieldNamespaces.length; i++) {
+										var ddmFormFieldNamespace = ddmFormFieldNamespaces[i];
+
+										var ddmForm = Liferay.component(
+											'<portlet:namespace />' + ddmFormFieldNamespace + 'ddmForm'
 										);
-										var selectedFileNameContainer = A.one(
-											'#<portlet:namespace />selectedFileNameContainer'
-										);
-										var ddmFormFieldNamespaces = A.all(
-											'#<portlet:namespace />ddmFormFieldNamespace'
-										).val();
 
-										var inputTpl =
-											'<input id="<portlet:namespace />selectedFileName{0}" name="<portlet:namespace />selectedFileName" type="hidden" value="{1}" />';
+										ddmForm.updateDDMFormInputValue();
+									}
 
-										var values = A.all(
-											'input[name=<portlet:namespace />selectUploadedFile]:checked'
-										).val();
-
-										var buffer = [];
-										var dataBuffer = [];
-										var length = values.length;
-
-										for (var i = 0; i < length; i++) {
-											dataBuffer[0] = i;
-											dataBuffer[1] = values[i];
-
-											buffer[i] = Lang.sub(inputTpl, dataBuffer);
-										}
-
-										selectedFileNameContainer.html(buffer.join(''));
-
-										commonFileMetadataContainer.plug(A.LoadingMask);
-
-										commonFileMetadataContainer.loadingmask.show();
-
-										for (var i = 0; i < ddmFormFieldNamespaces.length; i++) {
-											var ddmFormFieldNamespace = ddmFormFieldNamespaces[i];
-
-											var ddmForm = Liferay.component(
-												'<portlet:namespace />' + ddmFormFieldNamespace + 'ddmForm'
-											);
-
-											ddmForm.updateDDMFormInputValue();
-										}
-
-										Liferay.Util.fetch(document.<portlet:namespace />fm2.action, {
-											body: new FormData(document.<portlet:namespace />fm2),
-											method: 'POST',
+									Liferay.Util.fetch(document.<portlet:namespace />fm2.action, {
+										body: new FormData(document.<portlet:namespace />fm2),
+										method: 'POST',
+									})
+										.then(function (response) {
+											return response.json();
 										})
-											.then(function (response) {
-												return response.json();
-											})
-											.then(function (response) {
-												var itemFailed = false;
+										.then(function (response) {
+											var itemFailed = false;
 
-												for (var i = 0; i < response.length; i++) {
-													var item = response[i];
+											for (var i = 0; i < response.length; i++) {
+												var item = response[i];
 
-													var checkBox = A.one(
-														'input[data-fileName="' + item.originalFileName + '"]'
+												var checkBox = A.one(
+													'input[data-fileName="' + item.originalFileName + '"]'
+												);
+
+												var li = checkBox.ancestor();
+
+												checkBox.remove(true);
+
+												li.removeClass('selectable').removeClass('selected');
+
+												var cssClass = null;
+												var childHTML = null;
+
+												if (item.added) {
+													cssClass = 'file-saved';
+
+													var originalFileName = item.originalFileName;
+
+													var pos = originalFileName.indexOf(
+														'<%= TempFileEntryUtil.TEMP_RANDOM_SUFFIX %>'
 													);
 
-													var li = checkBox.ancestor();
+													if (pos != -1) {
+														originalFileName = originalFileName.substr(0, pos);
+													}
 
-													checkBox.remove(true);
-
-													li.removeClass('selectable').removeClass('selected');
-
-													var cssClass = null;
-													var childHTML = null;
-
-													if (item.added) {
-														cssClass = 'file-saved';
-
-														var originalFileName = item.originalFileName;
-
-														var pos = originalFileName.indexOf(
-															'<%= TempFileEntryUtil.TEMP_RANDOM_SUFFIX %>'
-														);
-
-														if (pos != -1) {
-															originalFileName = originalFileName.substr(0, pos);
-														}
-
-														if (originalFileName === item.fileName) {
-															childHTML =
-																'<span class="card-bottom success-message"><%= UnicodeLanguageUtil.get(request, "successfully-saved") %></span>';
-														}
-														else {
-															childHTML =
-																'<span class="card-bottom success-message"><%= UnicodeLanguageUtil.get(request, "successfully-saved") %> (' +
-																item.fileName +
-																')</span>';
-														}
+													if (originalFileName === item.fileName) {
+														childHTML =
+															'<span class="card-bottom success-message"><%= UnicodeLanguageUtil.get(request, "successfully-saved") %></span>';
 													}
 													else {
-														cssClass = 'upload-error';
-
 														childHTML =
-															'<span class="card-bottom error-message">' +
-															item.errorMessage +
-															'</span>';
-
-														itemFailed = true;
+															'<span class="card-bottom success-message"><%= UnicodeLanguageUtil.get(request, "successfully-saved") %> (' +
+															item.fileName +
+															')</span>';
 													}
-
-													li.addClass(cssClass);
-													li.append(childHTML);
-												}
-
-												<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/document_library/upload_multiple_file_entries" var="uploadMultipleFileEntries">
-													<portlet:param name="repositoryId" value="<%= String.valueOf(repositoryId) %>" />
-													<portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" />
-												</liferay-portlet:resourceURL>
-
-												if (commonFileMetadataContainer.io) {
-													commonFileMetadataContainer.io.start();
 												}
 												else {
-													commonFileMetadataContainer.load(
-														'<%= uploadMultipleFileEntries %>'
-													);
+													cssClass = 'upload-error';
+
+													childHTML =
+														'<span class="card-bottom error-message">' +
+														item.errorMessage +
+														'</span>';
+
+													itemFailed = true;
 												}
 
-												Liferay.fire('filesSaved');
+												li.addClass(cssClass);
+												li.append(childHTML);
+											}
 
-												commonFileMetadataContainer.unplug(A.LoadingMask);
+											<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/document_library/upload_multiple_file_entries" var="uploadMultipleFileEntries">
+												<portlet:param name="repositoryId" value="<%= String.valueOf(repositoryId) %>" />
+												<portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" />
+											</liferay-portlet:resourceURL>
 
-												if (!itemFailed) {
-													location.href = '<%= HtmlUtil.escapeJS(redirect) %>';
-												}
-											})
-											.catch(function (error) {
-												var selectedItems = A.all(
-													'#<portlet:namespace />fileUpload li.selected'
+											if (commonFileMetadataContainer.io) {
+												commonFileMetadataContainer.io.start();
+											}
+											else {
+												commonFileMetadataContainer.load(
+													'<%= uploadMultipleFileEntries %>'
 												);
+											}
 
-												selectedItems
-													.removeClass('selectable')
-													.removeClass('selected')
-													.addClass('upload-error');
+											Liferay.fire('filesSaved');
 
-												selectedItems.append(
-													'<span class="card-bottom error-message"><%= UnicodeLanguageUtil.get(request, "an-unexpected-error-occurred-while-deleting-the-file") %></span>'
-												);
+											commonFileMetadataContainer.unplug(A.LoadingMask);
 
-												selectedItems.all('input').remove(true);
+											if (!itemFailed) {
+												location.href = '<%= HtmlUtil.escapeJS(redirect) %>';
+											}
+										})
+										.catch(function (error) {
+											var selectedItems = A.all(
+												'#<portlet:namespace />fileUpload li.selected'
+											);
 
-												commonFileMetadataContainer.loadingmask.hide();
-											});
-									},
-									['aui-base']
-								);
+											selectedItems
+												.removeClass('selectable')
+												.removeClass('selected')
+												.addClass('upload-error');
+
+											selectedItems.append(
+												'<span class="card-bottom error-message"><%= UnicodeLanguageUtil.get(request, "an-unexpected-error-occurred-while-deleting-the-file") %></span>'
+											);
+
+											selectedItems.all('input').remove(true);
+
+											commonFileMetadataContainer.loadingmask.hide();
+										});
+								};
 							</aui:script>
 						</clay:col>
 					</clay:row>

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -226,42 +226,47 @@ const Modal = ({
 	useEffect(() => {
 		const eventHandlers = eventHandlersRef.current;
 
-		if (onSelect && selectEventName) {
-			const selectEventHandler = Liferay.on(
-				selectEventName,
-				(selectedItem) => {
-					processClose();
+		if (visible) {
+			if (onSelect && selectEventName) {
+				const selectEventHandler = Liferay.once(
+					selectEventName,
+					(selectedItem) => {
+						processClose();
 
-					onSelect(selectedItem);
+						onSelect(selectedItem);
+					}
+				);
+
+				eventHandlers.push(selectEventHandler);
+			}
+
+			customEvents.forEach((customEvent) => {
+				if (customEvent.name && customEvent.onEvent) {
+					const eventHandler = Liferay.on(
+						customEvent.name,
+						(event) => {
+							customEvent.onEvent(event);
+						}
+					);
+
+					eventHandlers.push(eventHandler);
 				}
-			);
+			});
 
-			eventHandlers.push(selectEventHandler);
+			const closeEventHandler = Liferay.on('closeModal', (event) => {
+				if (event.id && id && event.id !== id) {
+					return;
+				}
+
+				processClose();
+
+				if (event.redirect) {
+					navigate(event.redirect);
+				}
+			});
+
+			eventHandlers.push(closeEventHandler);
 		}
-
-		customEvents.forEach((customEvent) => {
-			if (customEvent.name && customEvent.onEvent) {
-				const eventHandler = Liferay.on(customEvent.name, (event) => {
-					customEvent.onEvent(event);
-				});
-
-				eventHandlers.push(eventHandler);
-			}
-		});
-
-		const closeEventHandler = Liferay.on('closeModal', (event) => {
-			if (event.id && id && event.id !== id) {
-				return;
-			}
-
-			processClose();
-
-			if (event.redirect) {
-				navigate(event.redirect);
-			}
-		});
-
-		eventHandlers.push(closeEventHandler);
 
 		return () => {
 			eventHandlers.forEach((eventHandler) => {
@@ -279,6 +284,7 @@ const Modal = ({
 		onSelect,
 		processClose,
 		selectEventName,
+		visible,
 	]);
 
 	return (


### PR DESCRIPTION
Rebase and resend of https://github.com/brianchandotcom/liferay-portal/pull/90582#issuecomment-648928598

--- 

Followup from https://github.com/liferay-frontend/liferay-portal/pull/11

I've added:
- Squashed all history into one initial commit [`LPS-113561 Avoid Liferay.provide in document-library-web`](https://github.com/liferay-frontend/liferay-portal/pull/50/commits/5df6fefb813b0597b8abb14880e2d0eb78386ca0)
- [Refactored `edit_folder.jsp` to avoid race conditions](https://github.com/liferay-frontend/liferay-portal/pull/50/commits/5df6fefb813b0597b8abb14880e2d0eb78386ca0). I opted to basically just move the event to a listener.
- Fixed a small issue with [`openModal` and events not being properly detached](https://github.com/liferay-frontend/liferay-portal/pull/50/commits/89cb9a4aba9fe0a0bcd576b6c8200ecfa68a517c) (actually, events being too eagerly registered). We should followup on this one because Modal components stack and never get unmounted. I think we already knew this, but let's see if we can clean it up, @markocikos, @wincent!

I also thought about simply reverting `upload_multiple_file_entries.jsp`, because we technically could have a race condition there but to get to it one needs to:
- Submitting a form which isn't visible initially 
- That can only be rendered after `<aui:script use="liferay-upload">` has initialized
- And some user actions (picking a file, or selecting one from the previous uploads list) has been taken

One would have to cheat in order to submit the form earlier (making it visible somehow and triggering the submission). In a normal flow, `liferay-upload` will also satisfy `aui-base,aui-loading-mask-deprecated,node-load` which are the dependencies where we declare the global `window['<portlet:namespace />updateMultipleFiles']`, so I'd say this is rare enough to leave as is until we can actually come back here and clean this up a bit more. Or nicely ask @liferay-lima to look into it 😉 

--- 

As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561) we
eventually want to deprecate the `Liferay.provide` function

To test the change for the `<portlet:namspace />selectFileEntryType`
function:

- Navigate to "Content and Data > Documents and Media"
- Click on the "+" button and choose "Folder"
- Type a name for the folder you want to create
- Click on the "Save" button
- Click on the kebab menu to the right of the folder you created and
  choose "Edit"
- Select the radio button with the label
  "Define Specific Document Type Restrictions and Workflow for This
   Folder (A folder)"
- Click on "Select Document Type"
- In the modal window choose one of the document types and click on
  "Choose"
- Click on the "Save button"

As a result, a notification should be displayed letting you know your
request has completed successfully and no JS errors should appear in the
browser's console.

To test the change for the `<portlet:namspace />updateMultipleFiles`
function:

- Navigate to "Content and Data > Documents and Media"
- Click on the "+" button and choose "Multiple Files Upload"
- Click on the "Select Files" button
- Upload at least 2 files (images or text documents are OK)
- Click on the "Publish" button

As a result, the files you uploaded should be visible in the "Documents"
list and no JS errors should appear in the console.