### PR TITLE
[LPS-116504, LPS-112471, LPS-112472] Updates clay:progressbar and clay:radio and adds props attribute to react:component

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/view.jsp
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/view.jsp
@@ -148,7 +148,7 @@ PortletURL portletURL = renderResponse.createRenderURL();
 							</portlet:resourceURL>
 
 							<%
-							Map<String, Object> data = HashMapBuilder.<String, Object>put(
+							Map<String, Object> props = HashMapBuilder.<String, Object>put(
 								"adaptedImages", Math.min(adaptedImages, totalImages)
 							).put(
 								"adaptiveMediaProgressComponentId", liferayPortletResponse.getNamespace() + "AdaptRemaining" + uuid
@@ -168,8 +168,8 @@ PortletURL portletURL = renderResponse.createRenderURL();
 							%>
 
 							<react:component
-								data="<%= data %>"
 								module="adaptive_media/js/AdaptiveMediaProgress.es"
+								props="<%= props %>"
 							/>
 						</div>
 					</liferay-ui:search-container-column-text>

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/edit_entry.jsp
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/edit_entry.jsp
@@ -69,7 +69,7 @@ List<Long> dataLayoutIds = appBuilderAppPortletTabContext.getDataLayoutIds();
 							<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" var="baseResourceURL" />
 
 							<%
-							Map<String, Object> data = HashMapBuilder.<String, Object>put(
+							Map<String, Object> props = HashMapBuilder.<String, Object>put(
 								"appDeploymentType", request.getAttribute(AppBuilderWebKeys.APP_DEPLOYMENT_TYPE)
 							).put(
 								"appId", appBuilderApp.getAppBuilderAppId()
@@ -103,8 +103,8 @@ List<Long> dataLayoutIds = appBuilderAppPortletTabContext.getDataLayoutIds();
 							%>
 
 							<react:component
-								data="<%= data %>"
 								module="js/pages/entry/EditEntryApp.es"
+								props="<%= props %>"
 							/>
 						</div>
 					</div>

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/edit_form_view.jsp
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/edit_form_view.jsp
@@ -37,7 +37,7 @@ boolean newCustomObject = ParamUtil.getBoolean(request, "newCustomObject");
 		<div class="app-builder-form-view-app" id="<%= editFormViewRootElementId %>">
 
 			<%
-			Map<String, Object> data = HashMapBuilder.<String, Object>put(
+			Map<String, Object> props = HashMapBuilder.<String, Object>put(
 				"basePortletURL", basePortletURL.toString()
 			).put(
 				"customObjectSidebarElementId", customObjectSidebarElementId
@@ -57,8 +57,8 @@ boolean newCustomObject = ParamUtil.getBoolean(request, "newCustomObject");
 			%>
 
 			<react:component
-				data="<%= data %>"
 				module="js/pages/form-view/EditFormViewApp.es"
+				props="<%= props %>"
 			/>
 		</div>
 

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/view.jsp
@@ -22,7 +22,8 @@
 
 <div id="<portlet:namespace />-app-builder-root">
 	<react:component
-		data='<%=
+		module="js/index.es"
+		props='<%=
 			HashMapBuilder.<String, Object>put(
 				"basePortletURL", String.valueOf(renderResponse.createRenderURL())
 			).put(
@@ -35,6 +36,5 @@
 				"showNativeObjectsTab", request.getAttribute(AppBuilderWebKeys.SHOW_NATIVE_OBJECTS_TAB)
 			).build()
 		%>'
-		module="js/index.es"
 	/>
 </div>

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/view_apps.jsp
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/view_apps.jsp
@@ -24,7 +24,8 @@
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" var="baseResourceURL" />
 
 	<react:component
-		data='<%=
+		module="js/pages/apps/index.es"
+		props='<%=
 			HashMapBuilder.<String, Object>put(
 				"appsTabs", request.getAttribute(AppBuilderWebKeys.APPS_TABS)
 			).put(
@@ -41,6 +42,5 @@
 				"userId", themeDisplay.getUserId()
 			).build()
 		%>'
-		module="js/pages/apps/index.es"
 	/>
 </div>

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -21,7 +21,7 @@
 	<%
 	AppBuilderApp appBuilderApp = (AppBuilderApp)request.getAttribute(AppBuilderWebKeys.APP);
 
-	Map<String, Object> data = HashMapBuilder.<String, Object>put(
+	Map<String, Object> props = HashMapBuilder.<String, Object>put(
 		"appDeploymentType", request.getAttribute(AppBuilderWebKeys.APP_DEPLOYMENT_TYPE)
 	).put(
 		"appId", appBuilderApp.getAppBuilderAppId()
@@ -47,7 +47,7 @@
 	%>
 
 	<react:component
-		data="<%= data %>"
 		module="js/pages/entry/ViewEntriesApp.es"
+		props="<%= props %>"
 	/>
 </div>

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp
@@ -128,7 +128,7 @@ renderResponse.setTitle(title);
 										).build());
 								}
 
-								Map<String, Object> data = HashMapBuilder.<String, Object>put(
+								Map<String, Object> props = HashMapBuilder.<String, Object>put(
 									"categoryIds", Collections.singletonList(parentCategoryId)
 								).put(
 									"groupIds", Collections.singletonList(scopeGroupId)
@@ -144,8 +144,8 @@ renderResponse.setTitle(title);
 								%>
 
 								<react:component
-									data="<%= data %>"
 									module="js/AssetCategoriesSelectorTag.es"
+									props="<%= props %>"
 								/>
 							</div>
 						</aui:field-wrapper>

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -19,6 +19,6 @@
 <liferay-ui:success key="categoryAdded" message='<%= GetterUtil.getString(MultiSessionMessages.get(renderRequest, "categoryAdded")) %>' />
 
 <react:component
-	data="<%= assetCategoriesSelectorDisplayContext.getData() %>"
 	module="js/SelectCategory.es"
+	props="<%= assetCategoriesSelectorDisplayContext.getData() %>"
 />

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/filter.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/filter.jsp
@@ -51,7 +51,7 @@
 		<div>
 
 			<%
-			Map<String, Object> data = HashMapBuilder.<String, Object>put(
+			Map<String, Object> props = HashMapBuilder.<String, Object>put(
 				"categorySelectorURL", editAssetListDisplayContext.getCategorySelectorURL()
 			).put(
 				"groupIds", ListUtil.toList(editAssetListDisplayContext.getReferencedModelsGroupIds())
@@ -67,8 +67,8 @@
 			%>
 
 			<react:component
-				data="<%= data %>"
 				module="auto_field/index"
+				props="<%= props %>"
 			/>
 		</div>
 	</liferay-frontend:fieldset>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/filter.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/filter.jsp
@@ -53,7 +53,7 @@
 <div>
 
 	<%
-	Map<String, Object> data = HashMapBuilder.<String, Object>put(
+	Map<String, Object> props = HashMapBuilder.<String, Object>put(
 		"categorySelectorURL", assetPublisherDisplayContext.getCategorySelectorURL()
 	).put(
 		"groupIds", ListUtil.toList(assetPublisherDisplayContext.getReferencedModelsGroupIds())
@@ -73,7 +73,7 @@
 	%>
 
 	<react:component
-		data="<%= data %>"
 		module="auto_field/index"
+		props="<%= props %>"
 	/>
 </div>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/page.jsp
@@ -37,8 +37,8 @@ AssetCategoriesNavigationDisplayContext assetCategoriesNavigationDisplayContext 
 	<c:otherwise>
 		<div class="categories-tree container-fluid-1280" id="<%= assetCategoriesNavigationDisplayContext.getNamespace() %>categoriesContainer">
 			<react:component
-				data="<%= assetCategoriesNavigationDisplayContext.getData() %>"
 				module="asset_categories_navigation/js/AssetCategoriesNavigationTreeView"
+				props="<%= assetCategoriesNavigationDisplayContext.getData() %>"
 			/>
 		</div>
 	</c:otherwise>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/page.jsp
@@ -103,7 +103,7 @@ List<Map<String, Object>> vocabularies = (List<Map<String, Object>>)data.get("vo
 	</div>
 
 	<react:component
-		data="<%= data %>"
 		module="asset_categories_selector/AssetCategoriesSelectorTag.es"
+		props="<%= data %>"
 	/>
 </div>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/page.jsp
@@ -70,7 +70,7 @@ List<Map<String, String>> selectedItems = (List<Map<String, String>>)data.get("s
 	</div>
 
 	<react:component
-		data="<%= data %>"
 		module="asset_tags_selector/AssetTagsSelectorTag.es"
+		props="<%= data %>"
 	/>
 </div>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_changes.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_changes.jsp
@@ -144,8 +144,8 @@ portletDisplay.setShowBackIcon(true);
 	<c:choose>
 		<c:when test="<%= viewChangesDisplayContext.hasChanges() %>">
 			<react:component
-				data="<%= viewChangesDisplayContext.getReactData() %>"
 				module="change_lists/js/ChangeTrackingChangesView"
+				props="<%= viewChangesDisplayContext.getReactData() %>"
 			/>
 		</c:when>
 		<c:otherwise>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
@@ -38,8 +38,8 @@ ContentDashboardAdminManagementToolbarDisplayContext contentDashboardAdminManage
 					</div>
 
 					<react:component
-						data="<%= contentDashboardAdminDisplayContext.getData() %>"
 						module="js/AuditGraphApp"
+						props="<%= contentDashboardAdminDisplayContext.getData() %>"
 					/>
 				</div>
 			</div>

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/end.jsp
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/end.jsp
@@ -19,7 +19,7 @@
 <portlet:renderURL var="basePortletURL" />
 
 <%
-Map<String, Object> data = HashMapBuilder.<String, Object>put(
+Map<String, Object> props = HashMapBuilder.<String, Object>put(
 	"availableLanguageIds", availableLanguageIds
 ).put(
 	"config", configJSONObject
@@ -100,7 +100,7 @@ Map<String, Object> data = HashMapBuilder.<String, Object>put(
 
 <div id="<%= componentId + "container" %>">
 	<react:component
-		data="<%= data %>"
 		module="data_layout_builder/js/App.es"
+		props="<%= props %>"
 	/>
 </div>

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/languages.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/languages.jsp
@@ -57,7 +57,7 @@ boolean inheritLocales = GetterUtil.getBoolean(typeSettingsProperties.getPropert
 <div class="site-languages">
 
 	<%
-	HashMap<String, Object> data = HashMapBuilder.<String, Object>put(
+	HashMap<String, Object> props = HashMapBuilder.<String, Object>put(
 		"availableLocales", DepotLanguageUtil.getAvailableLocalesJSONArray(locale)
 	).put(
 		"defaultLocaleId", LocaleUtil.toLanguageId(company.getDefaultUser().getLocale())
@@ -73,7 +73,7 @@ boolean inheritLocales = GetterUtil.getBoolean(typeSettingsProperties.getPropert
 	%>
 
 	<react:component
-		data="<%= data %>"
 		module="js/Languages.es"
+		props="<%= props %>"
 	/>
 </div>

--- a/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/view.jsp
+++ b/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/view.jsp
@@ -37,7 +37,7 @@ previewFileURLs[0] = DLURLHelperUtil.getPreviewURL(fileVersion.getFileEntry(), f
 
 String previewFileURL = previewFileURLs[0];
 
-Map<String, Object> data = HashMapBuilder.<String, Object>put(
+Map<String, Object> props = HashMapBuilder.<String, Object>put(
 	"baseImageURL", previewFileURL
 ).put(
 	"initialPage", 1
@@ -54,7 +54,7 @@ Map<String, Object> data = HashMapBuilder.<String, Object>put(
 
 <div id="<portlet:namespace /><%= randomNamespace %>previewDocument">
 	<react:component
-		data="<%= data %>"
 		module="preview/js/DocumentPreviewer.es"
+		props="<%= props %>"
 	/>
 </div>

--- a/modules/apps/document-library/document-library-preview-image/src/main/resources/META-INF/resources/preview/view.jsp
+++ b/modules/apps/document-library/document-library-preview-image/src/main/resources/META-INF/resources/preview/view.jsp
@@ -49,15 +49,15 @@ String previewURL = DLURLHelperUtil.getPreviewURL(fileVersion.getFileEntry(), fi
 	<c:otherwise>
 
 		<%
-		Map<String, Object> data = HashMapBuilder.<String, Object>put(
+		Map<String, Object> props = HashMapBuilder.<String, Object>put(
 			"imageURL", previewURL
 		).build();
 		%>
 
 		<div id="<portlet:namespace /><%= randomNamespace %>previewImage">
 			<react:component
-				data="<%= data %>"
 				module="preview/js/ImagePreviewer.es"
+				props="<%= props %>"
 			/>
 		</div>
 	</c:otherwise>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/version_details.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/version_details.jsp
@@ -19,7 +19,7 @@
 <div>
 
 	<%
-	Map<String, Object> data =
+	Map<String, Object> props =
 		HashMapBuilder.<String, Object>put(
 			"dlVersionNumberIncreaseValues",
 			HashMapBuilder.<String, Object>put(
@@ -35,7 +35,7 @@
 	%>
 
 	<react:component
-		data="<%= data %>"
 		module="document_library/js/checkin/Checkin.es"
+		props="<%= props %>"
 	/>
 </div>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -84,8 +84,8 @@ String navigation = ParamUtil.getString(request, "navigation");
 
 		<div>
 			<react:component
-				data="<%= context %>"
 				module="document_library/js/bulk/BulkStatus.es"
+				props="<%= context %>"
 			/>
 		</div>
 
@@ -333,8 +333,8 @@ String navigation = ParamUtil.getString(request, "navigation");
 
 		<div>
 			<react:component
-				data="<%= editTagsData %>"
 				module="document_library/js/categorization/tags/EditTags.es"
+				props="<%= editTagsData %>"
 			/>
 		</div>
 
@@ -358,8 +358,8 @@ String navigation = ParamUtil.getString(request, "navigation");
 
 		<div>
 			<react:component
-				data="<%= editCategoriesData %>"
 				module="document_library/js/categorization/categories/EditCategories.es"
+				props="<%= editCategoriesData %>"
 			/>
 		</div>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view_summary.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view_summary.jsp
@@ -28,7 +28,8 @@ if (ddmFormInstanceReport != null) {
 
 <div id="<portlet:namespace />report">
 	<react:component
-		data='<%=
+		module="js/index.es"
+		props='<%=
 			HashMapBuilder.<String, Object>put(
 				"data", ddmFormInstanceReportData
 			).put(
@@ -39,6 +40,5 @@ if (ddmFormInstanceReport != null) {
 				"portletNamespace", PortalUtil.getPortletNamespace(DDMPortletKeys.DYNAMIC_DATA_MAPPING_FORM_REPORT)
 			).build()
 		%>'
-		module="js/index.es"
 	/>
 </div>

--- a/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/page.jsp
+++ b/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/page.jsp
@@ -50,7 +50,7 @@ boolean onlyIcon = GetterUtil.getBoolean(request.getAttribute("liferay-flags:fla
 	</c:choose>
 
 	<react:component
-		data="<%= data %>"
 		module="flags/js/index.es"
+		props="<%= data %>"
 	/>
 </div>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_entry.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_entry.jsp
@@ -22,7 +22,7 @@ EditFragmentEntryDisplayContext editFragmentEntryDisplayContext = new EditFragme
 
 <div>
 	<react:component
-		data="<%= editFragmentEntryDisplayContext.getFragmentEditorData() %>"
 		module="js/fragment-editor/FragmentEditor"
+		props="<%= editFragmentEntryDisplayContext.getFragmentEditorData() %>"
 	/>
 </div>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
@@ -34,7 +34,7 @@ if (editorData != null) {
 	editorConfigJSONObject = (JSONObject)editorData.get("editorConfig");
 }
 
-Map<String, Object> data = HashMapBuilder.<String, Object>put(
+Map<String, Object> props = HashMapBuilder.<String, Object>put(
 	"contents", contents
 ).put(
 	"editorConfig", editorConfigJSONObject
@@ -51,7 +51,7 @@ Map<String, Object> data = HashMapBuilder.<String, Object>put(
 
 <div>
 	<react:component
-		data="<%= data %>"
 		module="editor/ClassicEditor"
+		props="<%= props %>"
 	/>
 </div>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ProgressBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ProgressBarTag.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Chema Balsas
+ */
+public class ProgressBarTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		if (_value == _maxValue) {
+			setStatus("success");
+		}
+
+		if (_status.equals("complete")) {
+			setStatus("success");
+			setValue(_maxValue);
+		}
+
+		return super.doStartTag();
+	}
+
+	public int getMaxValue() {
+		return _maxValue;
+	}
+
+	public int getMinValue() {
+		return _minValue;
+	}
+
+	public String getStatus() {
+		return _status;
+	}
+
+	public int getValue() {
+		return _value;
+	}
+
+	public void setMaxValue(int maxValue) {
+		_maxValue = maxValue;
+	}
+
+	public void setMinValue(int minValue) {
+		_minValue = minValue;
+	}
+
+	public void setStatus(String status) {
+		_status = status;
+	}
+
+	public void setValue(int value) {
+		_value = value;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_maxValue = 100;
+		_minValue = 0;
+		_status = "info";
+		_value = 0;
+	}
+
+	@Override
+	protected String processCssClasses(Set<String> cssClasses) {
+		cssClasses.add("progress-group");
+		cssClasses.add("progress-" + _status);
+
+		return super.processCssClasses(cssClasses);
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write("<div class=\"progress\"><div aria-valuemax=\"");
+		jspWriter.write(String.valueOf(_maxValue));
+		jspWriter.write("\" aria-valuemin=\"");
+		jspWriter.write(String.valueOf(_minValue));
+		jspWriter.write("\" aria-valuenow=\"");
+		jspWriter.write(String.valueOf(_value));
+		jspWriter.write("\" class=\"progress-bar\" role=\"progressbar\" ");
+		jspWriter.write("style=\"width: ");
+		jspWriter.write(String.valueOf(_value));
+		jspWriter.write("%\"></div>");
+
+		jspWriter.write("<div class=\"progress-group-addon\">");
+
+		if (_status.equals("success")) {
+			jspWriter.write("<div class=\"progress-group-feedback\">");
+
+			IconTag iconTag = new IconTag();
+
+			iconTag.setSymbol("check-circle");
+
+			iconTag.doTag(pageContext);
+
+			jspWriter.write("</div");
+		}
+		else {
+			jspWriter.write(String.valueOf(_value));
+			jspWriter.write("%");
+		}
+
+		jspWriter.write("</div></div>");
+
+		return SKIP_BODY;
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:progressbar:";
+
+	private int _maxValue = 100;
+	private int _minValue;
+	private String _status = "info";
+	private int _value;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ProgressBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ProgressBarTag.java
@@ -107,7 +107,7 @@ public class ProgressBarTag extends BaseContainerTag {
 		jspWriter.write("\" class=\"progress-bar\" role=\"progressbar\" ");
 		jspWriter.write("style=\"width: ");
 		jspWriter.write(String.valueOf(_value));
-		jspWriter.write("%\"></div>");
+		jspWriter.write("%\"></div></div>");
 
 		jspWriter.write("<div class=\"progress-group-addon\">");
 
@@ -127,7 +127,7 @@ public class ProgressBarTag extends BaseContainerTag {
 			jspWriter.write("%");
 		}
 
-		jspWriter.write("</div></div>");
+		jspWriter.write("</div>");
 
 		return SKIP_BODY;
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/RadioTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/RadioTag.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Chema Balsas
+ */
+public class RadioTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		return super.doStartTag();
+	}
+
+	public boolean getChecked() {
+		return _checked;
+	}
+
+	public boolean getDisabled() {
+		return _disabled;
+	}
+
+	public boolean getInline() {
+		return _inline;
+	}
+
+	public String getLabel() {
+		return _label;
+	}
+
+	public String getName() {
+		return _name;
+	}
+
+	public boolean getShowLabel() {
+		return _showLabel;
+	}
+
+	public String getValue() {
+		return _value;
+	}
+
+	public void setChecked(boolean checked) {
+		_checked = checked;
+	}
+
+	public void setDisabled(boolean disabled) {
+		_disabled = disabled;
+	}
+
+	public void setInline(boolean inline) {
+		_inline = inline;
+	}
+
+	public void setLabel(String label) {
+		_label = label;
+	}
+
+	public void setName(String name) {
+		_name = name;
+	}
+
+	public void setShowLabel(boolean showLabel) {
+		_showLabel = showLabel;
+	}
+
+	public void setValue(String value) {
+		_value = value;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_checked = false;
+		_disabled = false;
+		_inline = false;
+		_label = null;
+		_name = null;
+		_showLabel = true;
+		_value = null;
+	}
+
+	@Override
+	protected String processCssClasses(Set<String> cssClasses) {
+		cssClasses.add("custom-control");
+		cssClasses.add("custom-radio");
+
+		if (_inline) {
+			cssClasses.add("custom-control-inline");
+		}
+
+		return super.processCssClasses(cssClasses);
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write("<label><input");
+
+		if (_checked) {
+			jspWriter.write(" checked");
+		}
+
+		jspWriter.write(" class=\"custom-control-input\"");
+
+		if (_disabled) {
+			jspWriter.write(" disabled");
+		}
+
+		if (Validator.isNotNull(_name)) {
+			jspWriter.write(" name=\"");
+			jspWriter.write(_name);
+			jspWriter.write("\"");
+		}
+
+		jspWriter.write(" role=\"radio\" type=\"radio\"");
+
+		if (Validator.isNotNull(_value)) {
+			jspWriter.write(" value=\"");
+			jspWriter.write(_value);
+			jspWriter.write("\"");
+		}
+
+		jspWriter.write("/><span class=\"custom-control-label\"><span");
+		jspWriter.write(" class=\"custom-control-label-text");
+
+		if (!_showLabel) {
+			jspWriter.write(" sr-only");
+		}
+
+		jspWriter.write("\">");
+		jspWriter.write(_label);
+		jspWriter.write("</span></span></label>");
+
+		return SKIP_BODY;
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:radio:";
+
+	private boolean _checked;
+	private boolean _disabled;
+	private boolean _inline;
+	private String _label;
+	private String _name;
+	private boolean _showLabel = true;
+	private String _value;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -2383,7 +2383,7 @@
 	<tag>
 		<description></description>
 		<name>radio</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.RadioTag</tag-class>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.RadioTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
 			<description></description>
@@ -2392,25 +2392,32 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -2422,7 +2429,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -2463,6 +2470,7 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -2298,34 +2298,46 @@
 	<tag>
 		<description></description>
 		<name>progressbar</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.ProgressBarTag</tag-class>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.ProgressBarTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>containerElement</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -2349,7 +2361,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>spritemap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -2366,6 +2378,7 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
 		<description></description>

--- a/modules/apps/frontend-taglib/frontend-taglib-react/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-react/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib React
 Bundle-SymbolicName: com.liferay.frontend.taglib.react
-Bundle-Version: 4.0.8
+Bundle-Version: 4.1.0
 Export-Package: com.liferay.frontend.taglib.react.servlet.taglib
 Provide-Capability:\
 	osgi.extender;\

--- a/modules/apps/frontend-taglib/frontend-taglib-react/src/main/java/com/liferay/frontend/taglib/react/servlet/taglib/ComponentTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-react/src/main/java/com/liferay/frontend/taglib/react/servlet/taglib/ComponentTag.java
@@ -108,7 +108,7 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #setProps(Map<String, Object>)}
+	 *             #setProps(Map)}
 	 */
 	@Deprecated
 	public void setData(Map<String, Object> data) {
@@ -141,6 +141,7 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #getProps()}
 	 */
+	@Deprecated
 	protected Map<String, Object> getData() {
 		return getProps();
 	}
@@ -182,8 +183,9 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #prepareData(Map<String, Object>)}
+	 *             #prepareData(Map)}
 	 */
+	@Deprecated
 	protected void prepareData(Map<String, Object> data) {
 		prepareProps(data);
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-react/src/main/java/com/liferay/frontend/taglib/react/servlet/taglib/ComponentTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-react/src/main/java/com/liferay/frontend/taglib/react/servlet/taglib/ComponentTag.java
@@ -41,10 +41,10 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 	public int doEndTag() throws JspException {
 		JspWriter jspWriter = pageContext.getOut();
 
-		Map<String, Object> data = getData();
+		Map<String, Object> props = getProps();
 
 		try {
-			prepareData(data);
+			prepareProps(props);
 
 			ComponentDescriptor componentDescriptor = new ComponentDescriptor(
 				getModule(), getComponentId(), null, isPositionInLine());
@@ -53,7 +53,7 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 				ReactRendererProvider.getReactRenderer();
 
 			reactRenderer.renderReact(
-				componentDescriptor, data, request, jspWriter);
+				componentDescriptor, props, request, jspWriter);
 		}
 		catch (Exception exception) {
 			throw new JspException(exception);
@@ -106,12 +106,21 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 		_componentId = componentId;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setProps(Map<String, Object>)}
+	 */
+	@Deprecated
 	public void setData(Map<String, Object> data) {
-		_data = data;
+		setProps(data);
 	}
 
 	public void setModule(String module) {
 		_module = module;
+	}
+
+	public void setProps(Map<String, Object> props) {
+		_props = props;
 	}
 
 	@Override
@@ -123,13 +132,21 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 
 	protected void cleanUp() {
 		_componentId = null;
-		_data = Collections.emptyMap();
 		_module = null;
+		_props = Collections.emptyMap();
 		_setServletContext = false;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getProps()}
+	 */
 	protected Map<String, Object> getData() {
-		return _data;
+		return getProps();
+	}
+
+	protected Map<String, Object> getProps() {
+		return _props;
 	}
 
 	protected boolean isPositionInLine() {
@@ -163,12 +180,20 @@ public class ComponentTag extends ParamAndPropertyAncestorTagImpl {
 		return false;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #prepareData(Map<String, Object>)}
+	 */
 	protected void prepareData(Map<String, Object> data) {
+		prepareProps(data);
+	}
+
+	protected void prepareProps(Map<String, Object> props) {
 	}
 
 	private String _componentId;
-	private Map<String, Object> _data = Collections.emptyMap();
 	private String _module;
+	private Map<String, Object> _props = Collections.emptyMap();
 	private boolean _setServletContext;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-react/src/main/resources/META-INF/resources/react.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-react/src/main/resources/META-INF/resources/react.tld
@@ -20,7 +20,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>The chosen template's context map.</description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>props</code>]]>.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -29,6 +29,12 @@
 			<description>The AMD module that contains the component's JavaScript.</description>
 			<name>module</name>
 			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The chosen template's props.</description>
+			<name>props</name>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>

--- a/modules/apps/frontend-taglib/frontend-taglib-react/src/main/resources/com/liferay/frontend/taglib/react/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-react/src/main/resources/com/liferay/frontend/taglib/react/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff_version_comparator/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/diff_version_comparator/page.jsp
@@ -22,7 +22,7 @@ Map<String, Object> data = (Map<String, Object>)request.getAttribute("liferay-fr
 
 <div>
 	<react:component
-		data="<%= data %>"
 		module="diff_version_comparator/index"
+		props="<%= data %>"
 	/>
 </div>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/page.jsp
@@ -22,7 +22,7 @@ Map<String, Object> data = (Map<String, Object>)request.getAttribute("liferay-fr
 
 <div>
 	<react:component
-		data="<%= data %>"
 		module="translation_manager/index"
+		props="<%= data %>"
 	/>
 </div>

--- a/modules/apps/item-selector/item-selector-url-web/src/main/resources/META-INF/resources/url.jsp
+++ b/modules/apps/item-selector/item-selector-url-web/src/main/resources/META-INF/resources/url.jsp
@@ -19,7 +19,7 @@
 <%
 ItemSelectorURLViewDisplayContext itemSelectorURLViewDisplayContext = (ItemSelectorURLViewDisplayContext)request.getAttribute(ItemSelectorURLView.ITEM_SELECTOR_URL_VIEW_DISPLAY_CONTEXT);
 
-Map<String, Object> data = HashMapBuilder.<String, Object>put(
+Map<String, Object> props = HashMapBuilder.<String, Object>put(
 	"eventName", itemSelectorURLViewDisplayContext.getItemSelectedEventName()
 ).build();
 %>
@@ -28,8 +28,8 @@ Map<String, Object> data = HashMapBuilder.<String, Object>put(
 	<clay:sheet>
 		<div class="panel-group panel-group-flush">
 			<react:component
-				data="<%= data %>"
 				module="js/ItemSelectorUrl.es"
+				props="<%= props %>"
 			/>
 		</div>
 	</clay:sheet>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
@@ -29,8 +29,8 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 <c:if test="<%= journalWebConfiguration.changeableDefaultLanguage() %>">
 	<div id="<%= liferayPortletResponse.getNamespace() + "-change-default-language" %>">
 		<react:component
-			data="<%= journalEditArticleDisplayContext.getChangeDefaultLanguageData() %>"
 			module="js/ChangeDefaultLanguage.es"
+			props="<%= journalEditArticleDisplayContext.getChangeDefaultLanguageData() %>"
 			servletContext="<%= application %>"
 		/>
 	</div>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/import_translation.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/import_translation.jsp
@@ -82,7 +82,7 @@ renderResponse.setTitle(LanguageUtil.get(resourceBundle, "import-translation"));
 		>
 
 			<%
-			Map<String, Object> data = HashMapBuilder.<String, Object>put(
+			Map<String, Object> props = HashMapBuilder.<String, Object>put(
 				"articleResourcePrimKey", articleResourcePrimKey
 			).put(
 				"saveDraftBtnId", liferayPortletResponse.getNamespace() + "saveDraftBtn"
@@ -94,8 +94,8 @@ renderResponse.setTitle(LanguageUtil.get(resourceBundle, "import-translation"));
 			%>
 
 			<react:component
-				data="<%= data %>"
 				module="js/ImportTranslation.es"
+				props="<%= props %>"
 			/>
 		</clay:sheet>
 	</clay:container-fluid>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_folder.jsp
@@ -19,7 +19,7 @@
 <%
 String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "selectFolder");
 
-Map<String, Object> data = HashMapBuilder.<String, Object>put(
+Map<String, Object> props = HashMapBuilder.<String, Object>put(
 	"itemSelectorSaveEvent", eventName
 ).put(
 	"namespace", liferayPortletResponse.getNamespace()
@@ -31,6 +31,6 @@ Map<String, Object> data = HashMapBuilder.<String, Object>put(
 %>
 
 <react:component
-	data="<%= data %>"
 	module="js/SelectFolder.es"
+	props="<%= props %>"
 />

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/translate.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/translate.jsp
@@ -38,8 +38,8 @@ renderResponse.setTitle(journalTranslateDisplayContext.getTitle());
 				<li class="tbar-item tbar-item-expand">
 					<div class="tbar-section text-left">
 						<react:component
-							data="<%= journalTranslateDisplayContext.getTranslateLanguagesSelectorData() %>"
 							module="js/translate/TranslateLanguagesSelector"
+							props="<%= journalTranslateDisplayContext.getTranslateLanguagesSelectorData() %>"
 						/>
 					</div>
 				</li>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
@@ -149,8 +149,8 @@ if (Validator.isNotNull(title)) {
 
 	<div>
 		<react:component
-			data="<%= journalDisplayContext.getExportTranslationData() %>"
 			module="js/export_translation/ExportTranslation.es"
+			props="<%= journalDisplayContext.getExportTranslationData() %>"
 		/>
 	</div>
 </clay:container-fluid>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/details.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/details.jsp
@@ -103,7 +103,8 @@ String friendlyURLBase = StringPool.BLANK;
 
 				<div class="btn-url-history-wrapper">
 					<react:component
-						data='<%=
+						module="js/friendly_url_history/FriendlyURLHistory"
+						props='<%=
 							HashMapBuilder.<String, Object>put(
 								"defaultLanguageId",
 								LocaleUtil.toLanguageId(company.getDefaultUser().getLocale())
@@ -118,7 +119,6 @@ String friendlyURLBase = StringPool.BLANK;
 								restoreFriendlyURLEntryLocalizationURL
 							).build()
 						%>'
-						module="js/friendly_url_history/FriendlyURLHistory"
 					/>
 				</div>
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -60,8 +60,8 @@ LayoutsAdminManagementToolbarDisplayContext layoutsManagementToolbarDisplayConte
 
 					<div>
 						<react:component
-							data="<%= millerColumnsDisplayContext.getLayoutData() %>"
 							module="js/layout/Layout"
+							props="<%= millerColumnsDisplayContext.getLayoutData() %>"
 						/>
 					</div>
 				</c:otherwise>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/view.jsp
@@ -34,7 +34,7 @@ ContentPageEditorDisplayContext contentPageEditorDisplayContext = (ContentPageEd
 	</div>
 
 	<react:component
-		data="<%= contentPageEditorDisplayContext.getEditorContext(npmResolvedPackageName) %>"
 		module="page_editor/app/index"
+		props="<%= contentPageEditorDisplayContext.getEditorContext(npmResolvedPackageName) %>"
 	/>
 </div>

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/open_graph.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/open_graph.jsp
@@ -88,8 +88,8 @@ Layout selLayout = layoutsSEODisplayContext.getSelLayout();
 						</div>
 
 						<react:component
-							data="<%= layoutsSEODisplayContext.getOpenGraphMappingData() %>"
 							module="js/seo/display_page_templates/OpenGraphMapping"
+							props="<%= layoutsSEODisplayContext.getOpenGraphMappingData() %>"
 							servletContext="<%= application %>"
 						/>
 					</div>
@@ -134,7 +134,7 @@ Layout selLayout = layoutsSEODisplayContext.getSelLayout();
 						<div>
 
 							<%
-							Map<String, Object> data = HashMapBuilder.<String, Object>put(
+							Map<String, Object> props = HashMapBuilder.<String, Object>put(
 								"displayType", "og"
 							).put(
 								"targets",
@@ -171,8 +171,8 @@ Layout selLayout = layoutsSEODisplayContext.getSelLayout();
 							%>
 
 							<react:component
-								data="<%= data %>"
 								module="js/seo/PreviewSeo.es"
+								props="<%= props %>"
 								servletContext="<%= application %>"
 							/>
 						</div>

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
@@ -82,8 +82,8 @@ UnicodeProperties layoutTypeSettings = selLayout.getTypeSettingsProperties();
 						</div>
 
 						<react:component
-							data="<%= layoutsSEODisplayContext.getSEOMappingData() %>"
 							module="js/seo/display_page_templates/SeoMapping"
+							props="<%= layoutsSEODisplayContext.getSEOMappingData() %>"
 							servletContext="<%= application %>"
 						/>
 					</div>
@@ -145,7 +145,7 @@ UnicodeProperties layoutTypeSettings = selLayout.getTypeSettingsProperties();
 						<div>
 
 							<%
-							Map<String, Object> data = HashMapBuilder.<String, Object>put(
+							Map<String, Object> props = HashMapBuilder.<String, Object>put(
 								"targets",
 								HashMapBuilder.<String, Object>put(
 									"description",
@@ -175,8 +175,8 @@ UnicodeProperties layoutTypeSettings = selLayout.getTypeSettingsProperties();
 							%>
 
 							<react:component
-								data="<%= data %>"
 								module="js/seo/PreviewSeo.es"
+								props="<%= props %>"
 								servletContext="<%= application %>"
 							/>
 						</div>

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/page.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/page.jsp
@@ -22,7 +22,7 @@ Map<String, Object> data = (Map<String, Object>)request.getAttribute("liferay-la
 
 <div>
 	<react:component
-		data="<%= data %>"
 		module="select_layout/js/SelectLayout.es"
+		props="<%= data %>"
 	/>
 </div>

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/field_mappings.jsp
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/field_mappings.jsp
@@ -28,7 +28,7 @@ FieldMappingsDisplayContext fieldMappingsDisplayContext = (FieldMappingsDisplayC
 
 <div>
 	<react:component
-		data="<%= fieldMappingsDisplayContext.getData() %>"
 		module="js/FieldMappings.es"
+		props="<%= fieldMappingsDisplayContext.getData() %>"
 	/>
 </div>

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/color_picker_input.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/color_picker_input.jsp
@@ -46,7 +46,7 @@ String name = ParamUtil.getString(request, "name");
 	</div>
 
 	<%
-	Map<String, Object> data = HashMapBuilder.<String, Object>put(
+	Map<String, Object> props = HashMapBuilder.<String, Object>put(
 		"color", color
 	).put(
 		"label", label
@@ -56,8 +56,8 @@ String name = ParamUtil.getString(request, "name");
 	%>
 
 	<react:component
-		data="<%= data %>"
 		module="js/ColorPickerInput.es"
+		props="<%= props %>"
 		servletContext="<%= application %>"
 	/>
 </div>

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/applications_menu/applications_menu.jsp
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/applications_menu/applications_menu.jsp
@@ -30,7 +30,7 @@ ApplicationsMenuDisplayContext applicationsMenuDisplayContext = new Applications
 	/>
 
 	<react:component
-		data="<%= applicationsMenuDisplayContext.getApplicationsMenuComponentData() %>"
 		module="js/ApplicationsMenu"
+		props="<%= applicationsMenuDisplayContext.getApplicationsMenuComponentData() %>"
 	/>
 </li>

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/add_panel.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/add_panel.jsp
@@ -30,8 +30,8 @@
 			<c:if test="<%= addContentPanelDisplayContext.showAddPanel() %>">
 				<div class="add-content-menu" data-qa-id="addPanelBody" id="<portlet:namespace />addPanelContainer">
 					<react:component
-						data="<%= addContentPanelDisplayContext.getAddContentPanelData() %>"
 						module="js/AddPanel"
+						props="<%= addContentPanelDisplayContext.getAddContentPanelData() %>"
 					/>
 				</div>
 			</c:if>

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
@@ -22,8 +22,8 @@ LayoutsTreeDisplayContext layoutsTreeDisplayContext = new LayoutsTreeDisplayCont
 
 <div id="<%= liferayPortletResponse.getNamespace() + "-layout-finder" %>">
 	<react:component
-		data="<%= layoutsTreeDisplayContext.getLayoutFinderData() %>"
 		module="js/LayoutFinder.es"
+		props="<%= layoutsTreeDisplayContext.getLayoutFinderData() %>"
 		servletContext="<%= application %>"
 	/>
 </div>
@@ -31,8 +31,8 @@ LayoutsTreeDisplayContext layoutsTreeDisplayContext = new LayoutsTreeDisplayCont
 <div id="<%= liferayPortletResponse.getNamespace() + "layoutsTree" %>">
 	<div id="<%= liferayPortletResponse.getNamespace() + "-page-type" %>">
 		<react:component
-			data="<%= layoutsTreeDisplayContext.getPageTypeSelectorData() %>"
 			module="js/PageTypeSelector.es"
+			props="<%= layoutsTreeDisplayContext.getPageTypeSelectorData() %>"
 			servletContext="<%= application %>"
 		/>
 	</div>

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp
@@ -88,7 +88,7 @@ if (size != null) {
 	resourceURL.setParameter("portletId", themeDisplay.getPpid());
 	resourceURL.setResourceID("/get_personal_menu_items");
 
-	Map<String, Object> data = HashMapBuilder.<String, Object>put(
+	Map<String, Object> props = HashMapBuilder.<String, Object>put(
 		"color", color
 	).put(
 		"isImpersonated", themeDisplay.isImpersonated()
@@ -101,12 +101,12 @@ if (size != null) {
 	).build();
 
 	if (user2.getPortraitId() > 0) {
-		data.put("userPortraitURL", user2.getPortraitURL(themeDisplay));
+		props.put("userPortraitURL", user2.getPortraitURL(themeDisplay));
 	}
 	%>
 
 	<react:component
-		data="<%= data %>"
 		module="personal_menu/js/PersonalMenu.es"
+		props="<%= props %>"
 	/>
 </div>

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/view.jsp
@@ -27,7 +27,7 @@ String questionsRootElementId = liferayPortletResponse.getNamespace() + "-questi
 	<%
 	QuestionsConfiguration questionsConfiguration = (QuestionsConfiguration)request.getAttribute(QuestionsConfiguration.class.getName());
 
-	Map<String, Object> data = HashMapBuilder.<String, Object>put(
+	Map<String, Object> props = HashMapBuilder.<String, Object>put(
 		"defaultRank", renderRequest.getAttribute(QuestionsWebKeys.DEFAULT_RANK)
 	).put(
 		"imageBrowseURL", renderRequest.getAttribute(QuestionsWebKeys.IMAGE_BROWSE_URL)
@@ -47,7 +47,7 @@ String questionsRootElementId = liferayPortletResponse.getNamespace() + "-questi
 	%>
 
 	<react:component
-		data="<%= data %>"
 		module="js/index.es"
+		props="<%= props %>"
 	/>
 </div>

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/page.jsp
@@ -165,7 +165,7 @@ String type = GetterUtil.getString((String)request.getAttribute("liferay-ratings
 	</c:choose>
 
 	<react:component
-		data="<%= data %>"
 		module="js/Ratings"
+		props="<%= data %>"
 	/>
 </div>

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/edit_redirect_entry.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/edit_redirect_entry.jsp
@@ -115,7 +115,7 @@ else {
 		<%
 		boolean autoFocusDestination = Validator.isNotNull(sourceURL) && Validator.isNull(destinationURL);
 
-		Map<String, Object> data = HashMapBuilder.<String, Object>put(
+		Map<String, Object> props = HashMapBuilder.<String, Object>put(
 			"autofocus", autoFocusDestination
 		).put(
 			"initialDestinationUrl", (redirectEntry != null) ? redirectEntry.getDestinationURL() : ParamUtil.getString(request, "destinationURL")
@@ -128,8 +128,8 @@ else {
 			<aui:input name="destinationURL" value="<%= destinationURL %>" />
 
 			<react:component
-				data="<%= data %>"
 				module="js/DestinationUrlInput"
+				props="<%= props %>"
 			/>
 		</div>
 
@@ -163,12 +163,12 @@ else {
 
 <div>
 	<react:component
-		data='<%=
+		module="js/ChainedRedirections"
+		props='<%=
 			HashMapBuilder.<String, Object>put(
 				"saveButtonLabel", LanguageUtil.get(request, (redirectEntry == null) ? "create" : "save")
 			).build()
 		%>'
-		module="js/ChainedRedirections"
 	/>
 </div>
 

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions_resource_scope.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions_resource_scope.jsp
@@ -51,7 +51,7 @@ String portletId = (String)objArray[9];
 
 			PortletURL itemSelectorURL = itemSelector.getItemSelectorURL(RequestBackedPortletURLFactoryUtil.create(liferayPortletRequest), liferayPortletResponse.getNamespace() + "selectGroup", groupItemSelectorCriterion);
 
-			Map<String, Object> data = HashMapBuilder.<String, Object>put(
+			Map<String, Object> props = HashMapBuilder.<String, Object>put(
 				"itemSelectorURL",
 				itemSelectorURL.toString()
 			).put(
@@ -60,8 +60,8 @@ String portletId = (String)objArray[9];
 		%>
 
 			<react:component
-				data="<%= data %>"
 				module="js/GroupLabels.es"
+				props="<%= props %>"
 			/>
 
 		<%

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/edit_segments_entry.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/edit_segments_entry.jsp
@@ -49,8 +49,8 @@ renderResponse.setTitle(editSegmentsEntryDisplayContext.getTitle(locale));
 		</div>
 
 		<react:component
-			data="<%= editSegmentsEntryDisplayContext.getData() %>"
 			module="js/SegmentsApp.es"
+			props="<%= editSegmentsEntryDisplayContext.getData() %>"
 		/>
 	</div>
 </aui:form>

--- a/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/collaborators/page.jsp
+++ b/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/collaborators/page.jsp
@@ -24,7 +24,7 @@
 
 <div class="collaborators" id="<portlet:namespace/>collaborators-root">
 	<react:component
-		data='<%= (Map<String, Object>)request.getAttribute("liferay-sharing:collaborators:data") %>'
 		module="collaborators/js/index.es"
+		props='<%= (Map<String, Object>)request.getAttribute("liferay-sharing:collaborators:data") %>'
 	/>
 </div>

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/manage_collaborators/view.jsp
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/manage_collaborators/view.jsp
@@ -17,6 +17,6 @@
 <%@ include file="/manage_collaborators/init.jsp" %>
 
 <react:component
-	data="<%= (Map<String, Object>)request.getAttribute(SharingWebKeys.SHARING_REACT_DATA) %>"
 	module="manage_collaborators/js/ManageCollaborators.es"
+	props="<%= (Map<String, Object>)request.getAttribute(SharingWebKeys.SHARING_REACT_DATA) %>"
 />

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/sharing/view.jsp
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/sharing/view.jsp
@@ -17,6 +17,6 @@
 <%@ include file="/sharing/init.jsp" %>
 
 <react:component
-	data="<%= (Map<String, Object>)request.getAttribute(SharingWebKeys.SHARING_REACT_DATA) %>"
 	module="sharing/js/Sharing.es"
+	props="<%= (Map<String, Object>)request.getAttribute(SharingWebKeys.SHARING_REACT_DATA) %>"
 />

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/edit_site_navigation_menu.jsp
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/edit_site_navigation_menu.jsp
@@ -52,15 +52,13 @@ renderResponse.setTitle(siteNavigationAdminDisplayContext.getSiteNavigationMenuN
 							/>
 						</button>
 
-						<%
-						Map<String, Object> data = HashMapBuilder.<String, Object>put(
-							"dropdownItems", siteNavigationAdminDisplayContext.getAddSiteNavigationMenuItemDropdownItems()
-						).build();
-						%>
-
 						<react:component
-							data="<%= data %>"
 							module="js/add_menu/index"
+							props='<%=
+								HashMapBuilder.<String, Object>put(
+									"dropdownItems", siteNavigationAdminDisplayContext.getAddSiteNavigationMenuItemDropdownItems()
+								).build()
+							%>'
 						/>
 					</div>
 				</li>
@@ -128,7 +126,7 @@ renderResponse.setTitle(siteNavigationAdminDisplayContext.getSiteNavigationMenuN
 		</portlet:renderURL>
 
 		<%
-		Map<String, Object> data = HashMapBuilder.<String, Object>put(
+		Map<String, Object> props = HashMapBuilder.<String, Object>put(
 			"editSiteNavigationMenuItemParentURL", editSiteNavigationMenuItemParentURL.toString()
 		).put(
 			"editSiteNavigationMenuItemURL", editSiteNavigationMenuItemURL.toString()
@@ -147,8 +145,8 @@ renderResponse.setTitle(siteNavigationAdminDisplayContext.getSiteNavigationMenuN
 
 		<react:component
 			componentId="contextualSidebar"
-			data="<%= data %>"
 			module="js/ContextualSidebar"
+			props="<%= props %>"
 		/>
 	</div>
 </c:if>

--- a/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/view_site_navigation_menu_items.jsp
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/view_site_navigation_menu_items.jsp
@@ -24,7 +24,7 @@ SiteNavigationMenuItemItemSelectorViewDisplayContext siteNavigationMenuItemItemS
 	<c:when test="<%= siteNavigationMenuItemItemSelectorViewDisplayContext.isShowSelectSiteNavigationMenuItem() %>">
 
 		<%
-		Map<String, Object> data = HashMapBuilder.<String, Object>put(
+		Map<String, Object> props = HashMapBuilder.<String, Object>put(
 			"itemSelectorSaveEvent", siteNavigationMenuItemItemSelectorViewDisplayContext.getItemSelectedEventName()
 		).put(
 			"namespace", liferayPortletResponse.getNamespace()
@@ -37,8 +37,8 @@ SiteNavigationMenuItemItemSelectorViewDisplayContext siteNavigationMenuItemItemS
 
 		<div class="select-site-navigation-menu-item">
 			<react:component
-				data="<%= data %>"
 				module="js/SelectSiteNavigationMenuItem.es"
+				props="<%= props %>"
 			/>
 		</div>
 	</c:when>

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/edit_style_book_entry.jsp
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/edit_style_book_entry.jsp
@@ -22,7 +22,7 @@ EditStyleBookEntryDisplayContext editStyleBookEntryDisplayContext = new EditStyl
 
 <div>
 	<react:component
-		data="<%= editStyleBookEntryDisplayContext.getStyleBookEditorData() %>"
 		module="js/style-book-editor/StyleBookEditor"
+		props="<%= editStyleBookEntryDisplayContext.getStyleBookEditorData() %>"
 	/>
 </div>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/analytics_reports_panel.jsp
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/analytics_reports_panel.jsp
@@ -28,8 +28,8 @@ AnalyticsReportsDisplayContext analyticsReportsDisplayContext = (AnalyticsReport
 			</div>
 
 			<react:component
-				data="<%= analyticsReportsDisplayContext.getData() %>"
 				module="js/AnalyticsReportsApp"
+				props="<%= analyticsReportsDisplayContext.getData() %>"
 			/>
 		</div>
 	</c:when>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/edit_results_rankings.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/edit_results_rankings.jsp
@@ -56,8 +56,8 @@ renderResponse.setTitle(LanguageUtil.get(request, "customize-results"));
 		</div>
 
 		<react:component
-			data="<%= editRankingDisplayContext.getData() %>"
 			module="js/ResultRankingsApp.es"
+			props="<%= editRankingDisplayContext.getData() %>"
 		/>
 	</div>
 </aui:form>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/edit_synonym_sets.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/resources/META-INF/resources/edit_synonym_sets.jsp
@@ -51,8 +51,8 @@ portletDisplay.setURLBack(editSynonymSetsDisplayContext.getBackURL());
 		<span aria-hidden="true" class="loading-animation"></span>
 
 		<react:component
-			data="<%= editSynonymSetsDisplayContext.getData() %>"
 			module="js/SynonymSetsApp.es"
+			props="<%= editSynonymSetsDisplayContext.getData() %>"
 		/>
 	</liferay-frontend:edit-form-body>
 </liferay-frontend:edit-form>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/view.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-Map<String, Object> data = HashMapBuilder.<String, Object>put(
+Map<String, Object> props = HashMapBuilder.<String, Object>put(
 	"defaultDelta", PropsValues.SEARCH_CONTAINER_PAGE_DEFAULT_DELTA
 ).put(
 	"deltaValues", PropsValues.SEARCH_CONTAINER_PAGE_DELTA_VALUES
@@ -36,7 +36,7 @@ Map<String, Object> data = HashMapBuilder.<String, Object>put(
 	<span aria-hidden="true" class="loading-animation"></span>
 
 	<react:component
-		data="<%= data %>"
 		module="js/index.es"
+		props="<%= props %>"
 	/>
 </div>

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/segments_experiment_panel.jsp
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/segments_experiment_panel.jsp
@@ -28,8 +28,8 @@ SegmentsExperimentDisplayContext segmentsExperimentDisplayContext = (SegmentsExp
 			</div>
 
 			<react:component
-				data="<%= segmentsExperimentDisplayContext.getData() %>"
 				module="js/SegmentsExperimentApp.es"
+				props="<%= segmentsExperimentDisplayContext.getData() %>"
 			/>
 		</div>
 	</c:when>


### PR DESCRIPTION
Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/137

From @john-co:

> Reviewed. Test failures are unrelated. ✔️
>
> Due to sheer number of jobs/tests being run, I recommend no retest is needed and can be manually forwarded if no other code changes are needed.

--- 

I know this has better chances at making it through separated and it would probably be the way to go, but I'm going to give this a go since most of the changes seem trivial...

**In this PR we:**
- Update `clay:progressbar` to use a java-based version instead of the old soy-based one. Checked 1 existing usage
- Update `clay:radio` to use a java-based version instead of the old soy-based one. Checked 1 existing usage
- Adds `props` attribute to `react:component` to better match expectations instead of calling it `data`
- Updates usages of `data` to `props`

**How to test it:**
- The update of `props` in `react:component` should be pretty obvious throughout CI... hoping to see issues there :fingers-crossed:
- Tested `clay:progressbar` in the User Associated Data widget. Check the [Exporting User Data](https://help.liferay.com/hc/en-us/articles/360029132051-Exporting-User-Data) tutorial (won't work with default user Test test, need to create another admin user for it).

<img width="1422" alt="Screen Shot 2020-07-20 at 16 18 06" src="https://user-images.githubusercontent.com/905006/87950072-1d692280-caa7-11ea-829e-fb32f87fffab.png">

- Tested `clay:radio` in the User Associated Data widget. Check the [Sanitizing User Data](https://help.liferay.com/hc/en-us/articles/360028819072-Sanitizing-User-Data#the-personal-data-erasure-screen) tutorial (won't work with default user Test test, need to create another admin user for it).
<img width="1237" alt="Screen Shot 2020-07-20 at 16 16 40" src="https://user-images.githubusercontent.com/905006/87950106-278b2100-caa7-11ea-9dc8-f5b05e2bf317.png">

**Not done:**
- Progressbars in the uad example are slightly misaligned... not sure if this was there before or is the result of this PR. Would need a followup
- Many  apis passing `props` to `react:component` are named `*DisplayContext.getSomethingData()`. I haven't renamed them here, but we might wanna for consistency... 🤔 