### PR TITLE
LPS-117600 Fixes error when dropping a Field / FieldSet over another FieldSet

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/Field/Field.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/Field/Field.es.js
@@ -18,7 +18,14 @@ import ClayButton from '@clayui/button';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {sub} from 'dynamic-data-mapping-form-field-type/util/strings.es';
 import MetalComponent from 'metal-component';
-import React, {Suspense, lazy, useCallback, useRef, useState} from 'react';
+import React, {
+	Suspense,
+	lazy,
+	useCallback,
+	useContext,
+	useRef,
+	useState,
+} from 'react';
 
 import {usePage} from '../../hooks/usePage.es';
 import {useStorage} from '../../hooks/useStorage.es';
@@ -152,7 +159,22 @@ const FieldLazy = ({
 	);
 };
 
+const getRootParentField = (field, {root}) => {
+	if (root) {
+		return {
+			...field,
+			root,
+		};
+	}
+
+	return {
+		...field,
+		root: field,
+	};
+};
+
 export const Field = ({field, ...otherProps}) => {
+	const parentField = useContext(ParentFieldContext);
 	const {fieldTypes} = usePage();
 	const [hasError, setHasError] = useState();
 
@@ -188,7 +210,9 @@ export const Field = ({field, ...otherProps}) => {
 	return (
 		<ErrorBoundary onError={setHasError}>
 			<Suspense fallback={<ClayLoadingIndicator />}>
-				<ParentFieldContext.Provider value={field}>
+				<ParentFieldContext.Provider
+					value={getRootParentField(field, parentField)}
+				>
 					<AutoFocus>
 						<div
 							className="ddm-field"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/DefaultVariant.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/DefaultVariant.es.js
@@ -82,6 +82,7 @@ export const Column = ({
 	};
 
 	const firstField = column.fields[0];
+	const rootParentField = parentField.root ?? firstField;
 
 	return (
 		<ClayLayout.Col
@@ -96,12 +97,15 @@ export const Column = ({
 						'ddm-field-container ddm-target h-100',
 						{
 							'active-drop-child':
-								firstField.type === 'fieldset' && overTarget,
+								firstField.type === 'fieldset' &&
+								overTarget &&
+								!rootParentField.ddmStructureId,
 							'ddm-fieldset':
 								firstField.type === 'fieldset' &&
 								firstField.ddmStructureId,
 							selected: firstField.selected,
-							'target-over targetOver': overTarget,
+							'target-over targetOver':
+								!rootParentField.ddmStructureId && overTarget,
 						}
 					)}
 					data-field-name={firstField.fieldName}
@@ -118,7 +122,11 @@ export const Column = ({
 
 					<div
 						className="ddm-drag"
-						ref={allowNestedFields ? drop : undefined}
+						ref={
+							allowNestedFields && !rootParentField.ddmStructureId
+								? drop
+								: undefined
+						}
 					>
 						{fields}
 					</div>
@@ -228,9 +236,10 @@ export const Placeholder = ({
 		>
 			<div
 				className={classnames('ddm-target', {
-					'target-over targetOver': overTarget,
+					'target-over targetOver':
+						overTarget && !parentField.root?.ddmStructureId,
 				})}
-				ref={drop}
+				ref={!parentField.root?.ddmStructureId ? drop : undefined}
 			/>
 		</ClayLayout.Col>
 	);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/util/FormSupport.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/util/FormSupport.es.js
@@ -166,11 +166,6 @@ export const getParentField = (pages, fieldName) => {
 
 export const isEmptyColumn = (pages, pageIndex, rowIndex, columnIndex) => {
 	return (
-		!pages[pageIndex] ||
-		!pages[pageIndex].rows ||
-		!pages[pageIndex].rows[rowIndex] ||
-		!pages[pageIndex].rows[rowIndex].columns ||
-		!pages[pageIndex].rows[rowIndex].columns[columnIndex] ||
 		pages[pageIndex].rows[rowIndex].columns[columnIndex].fields.length === 0
 	);
 };


### PR DESCRIPTION
Manual forward of https://github.com/oliveiraaraujo/liferay-portal/pull/62

Based on the QA comment https://github.com/oliveiraaraujo/liferay-portal/pull/62#issuecomment-666596578

---

Fixed the error when dragging a Sidebar Field or FieldSet over a FieldSet. I also reverted a change added to FormSupport that was preventing the creating field groups.