### PR TITLE
LPS-118138 Deprecate because it's not longer useful 

### DIFF
--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/configuration/VerifyProcessTrackerConfiguration.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/configuration/VerifyProcessTrackerConfiguration.java
@@ -32,6 +32,10 @@ public interface VerifyProcessTrackerConfiguration {
 	@Meta.AD(deflt = "true", name = "auto-verify", required = false)
 	public boolean autoVerify();
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
 	@Meta.AD(deflt = "true", name = "index-read-only", required = false)
 	public boolean indexReadOnly();
 

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -248,11 +248,6 @@ public class VerifyProcessTrackerOSGiCommands {
 		List<VerifyProcess> verifyProcesses = getVerifyProcesses(
 			verifyProcessTrackerMap, verifyProcessName);
 
-		boolean indexReadOnly = indexStatusManager.isIndexReadOnly();
-
-		indexStatusManager.setIndexReadOnly(
-			_verifyProcessTrackerConfiguration.indexReadOnly());
-
 		NotificationThreadLocal.setEnabled(false);
 		StagingAdvicesThreadLocal.setEnabled(false);
 		WorkflowThreadLocal.setEnabled(false);
@@ -313,7 +308,6 @@ public class VerifyProcessTrackerOSGiCommands {
 			}
 		}
 		finally {
-			indexStatusManager.setIndexReadOnly(indexReadOnly);
 			NotificationThreadLocal.setEnabled(true);
 			StagingAdvicesThreadLocal.setEnabled(true);
 			WorkflowThreadLocal.setEnabled(true);

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/UpgradeProcessUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/UpgradeProcessUtil.java
@@ -17,13 +17,9 @@ package com.liferay.portal.kernel.upgrade.util;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.search.IndexWriterHelperUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.PropsKeys;
-import com.liferay.portal.kernel.util.PropsUtil;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -117,37 +113,31 @@ public class UpgradeProcessUtil {
 			int buildNumber, List<UpgradeProcess> upgradeProcesses)
 		throws UpgradeException {
 
-		return upgradeProcess(buildNumber, upgradeProcesses, _INDEX_ON_UPGRADE);
+		boolean ranUpgradeProcess = false;
+
+		for (UpgradeProcess upgradeProcess : upgradeProcesses) {
+			boolean tempRanUpgradeProcess = _upgradeProcess(
+				buildNumber, upgradeProcess);
+
+			if (tempRanUpgradeProcess) {
+				ranUpgradeProcess = true;
+			}
+		}
+
+		return ranUpgradeProcess;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *			 #upgradeProcess(int, List)} ()}
+	 */
+	@Deprecated
 	public static boolean upgradeProcess(
 			int buildNumber, List<UpgradeProcess> upgradeProcesses,
 			boolean indexOnUpgrade)
 		throws UpgradeException {
 
-		boolean ranUpgradeProcess = false;
-
-		boolean tempIndexReadOnly = IndexWriterHelperUtil.isIndexReadOnly();
-
-		if (indexOnUpgrade) {
-			IndexWriterHelperUtil.setIndexReadOnly(true);
-		}
-
-		try {
-			for (UpgradeProcess upgradeProcess : upgradeProcesses) {
-				boolean tempRanUpgradeProcess = _upgradeProcess(
-					buildNumber, upgradeProcess);
-
-				if (tempRanUpgradeProcess) {
-					ranUpgradeProcess = true;
-				}
-			}
-		}
-		finally {
-			IndexWriterHelperUtil.setIndexReadOnly(tempIndexReadOnly);
-		}
-
-		return ranUpgradeProcess;
+		return upgradeProcess(buildNumber, upgradeProcesses);
 	}
 
 	private static boolean _upgradeProcess(
@@ -182,9 +172,6 @@ public class UpgradeProcessUtil {
 
 		return false;
 	}
-
-	private static final boolean _INDEX_ON_UPGRADE = GetterUtil.getBoolean(
-		PropsUtil.get(PropsKeys.INDEX_ON_UPGRADE));
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		UpgradeProcessUtil.class);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-118138

- Manually forwarding this PR since there were no unique failures in https://github.com/xbrianlee/liferay-portal/pull/495. The only failures were caused by [LPS-118301](https://issues.liferay.com/browse/LPS-118301) (App Builder regression).
- This PR was also manually tested and it resolves the auto-upgrade bug.

cc/ @achaparro