### PR TITLE
[TS] LPS-118240 Not possible to set a _score sort in asc

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/sort/ElasticsearchSortTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/sort/ElasticsearchSortTest.java
@@ -28,4 +28,8 @@ public class ElasticsearchSortTest extends BaseSortTestCase {
 		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
 	}
 
+	protected String getScoreParameter() {
+		return "_score";
+	}
+
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sort/DefaultSortTranslator.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sort/DefaultSortTranslator.java
@@ -67,65 +67,87 @@ public class DefaultSortTranslator implements SortTranslator {
 
 			sortFieldNames.add(sortFieldName);
 
-			SortOrder sortOrder = SortOrder.ASC;
-
-			if (sort.isReverse() || sortFieldName.equals("_score")) {
-				sortOrder = SortOrder.DESC;
-			}
-
-			SortBuilder<?> sortBuilder = null;
-
-			if (sortFieldName.equals("_score")) {
-				sortBuilder = SortBuilders.scoreSort();
-			}
-			else if (sort.getType() == Sort.GEO_DISTANCE_TYPE) {
-				GeoDistanceSort geoDistanceSort = (GeoDistanceSort)sort;
-
-				List<GeoPoint> geoPoints = new ArrayList<>();
-
-				for (GeoLocationPoint geoLocationPoint :
-						geoDistanceSort.getGeoLocationPoints()) {
-
-					geoPoints.add(
-						new GeoPoint(
-							geoLocationPoint.getLatitude(),
-							geoLocationPoint.getLongitude()));
-				}
-
-				GeoDistanceSortBuilder geoDistanceSortBuilder =
-					SortBuilders.geoDistanceSort(
-						sortFieldName, geoPoints.toArray(new GeoPoint[0]));
-
-				geoDistanceSortBuilder.geoDistance(GeoDistance.ARC);
-
-				Collection<String> geoHashes = geoDistanceSort.getGeoHashes();
-
-				if (!geoHashes.isEmpty()) {
-					geoDistanceSort.addGeoHash(
-						geoHashes.toArray(new String[0]));
-				}
-
-				sortBuilder = geoDistanceSortBuilder;
-			}
-			else {
-				FieldSortBuilder fieldSortBuilder = SortBuilders.fieldSort(
-					sortFieldName);
-
-				fieldSortBuilder.unmappedType("keyword");
-
-				sortBuilder = fieldSortBuilder;
-			}
-
-			sortBuilder.order(sortOrder);
-
-			searchSourceBuilder.sort(sortBuilder);
+			searchSourceBuilder.sort(getSortBuilder(sort, sortFieldName));
 		}
+	}
+
+	protected SortBuilder<?> getFieldSortBuilder(Sort sort, String fieldName) {
+		FieldSortBuilder fieldSortBuilder = SortBuilders.fieldSort(fieldName);
+
+		fieldSortBuilder.unmappedType("keyword");
+
+		if (sort.isReverse()) {
+			fieldSortBuilder.order(SortOrder.DESC);
+		}
+
+		return fieldSortBuilder;
+	}
+
+	protected SortBuilder<?> getGeoDistanceSortBuilder(
+		Sort sort, String fieldName) {
+
+		GeoDistanceSort geoDistanceSort = (GeoDistanceSort)sort;
+
+		List<GeoPoint> geoPoints = new ArrayList<>();
+
+		for (GeoLocationPoint geoLocationPoint :
+				geoDistanceSort.getGeoLocationPoints()) {
+
+			geoPoints.add(
+				new GeoPoint(
+					geoLocationPoint.getLatitude(),
+					geoLocationPoint.getLongitude()));
+		}
+
+		GeoDistanceSortBuilder geoDistanceSortBuilder =
+			SortBuilders.geoDistanceSort(
+				fieldName, geoPoints.toArray(new GeoPoint[0]));
+
+		geoDistanceSortBuilder.geoDistance(GeoDistance.ARC);
+
+		Collection<String> geoHashes = geoDistanceSort.getGeoHashes();
+
+		if (!geoHashes.isEmpty()) {
+			geoDistanceSort.addGeoHash(geoHashes.toArray(new String[0]));
+		}
+
+		if (sort.isReverse()) {
+			geoDistanceSortBuilder.order(SortOrder.DESC);
+		}
+
+		return geoDistanceSortBuilder;
+	}
+
+	protected SortBuilder<?> getScoreSortBuilder(Sort sort) {
+		SortBuilder<?> sortBuilder = SortBuilders.scoreSort();
+
+		if (sort.isReverse()) {
+			sortBuilder.order(SortOrder.ASC);
+		}
+
+		return sortBuilder;
+	}
+
+	protected SortBuilder<?> getSortBuilder(Sort sort, String fieldName) {
+		if (fieldName.equals("_score")) {
+			return getScoreSortBuilder(sort);
+		}
+
+		if (sort.getType() == Sort.GEO_DISTANCE_TYPE) {
+			return getGeoDistanceSortBuilder(sort, fieldName);
+		}
+
+		return getFieldSortBuilder(sort, fieldName);
 	}
 
 	protected String getSortFieldName(Sort sort, String scoreFieldName) {
 		String sortFieldName = sort.getFieldName();
 
 		if (Objects.equals(sortFieldName, Field.PRIORITY)) {
+			return sortFieldName;
+		}
+
+		if (Objects.equals(sortFieldName, "_score")) {
 			return sortFieldName;
 		}
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchSortTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchSortTest.java
@@ -28,4 +28,8 @@ public class ElasticsearchSortTest extends BaseSortTestCase {
 		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
 	}
 
+	protected String getScoreParameter() {
+		return "_score";
+	}
+
 }

--- a/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/main/java/com/liferay/portal/search/solr7/internal/search/engine/adapter/search/SearchSolrQueryAssemblerImpl.java
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/main/java/com/liferay/portal/search/solr7/internal/search/engine/adapter/search/SearchSolrQueryAssemblerImpl.java
@@ -77,12 +77,46 @@ public class SearchSolrQueryAssemblerImpl implements SearchSolrQueryAssembler {
 		solrQuery.addHighlightField(localizedFieldName);
 	}
 
+	protected SolrQuery.SortClause getFieldSortClause(
+		com.liferay.portal.kernel.search.Sort sort, String fieldName) {
+
+		if (sort.isReverse()) {
+			return SolrQuery.SortClause.desc(fieldName);
+		}
+
+		return SolrQuery.SortClause.asc(fieldName);
+	}
+
+	protected SolrQuery.SortClause getScoreSortClause(
+		com.liferay.portal.kernel.search.Sort sort) {
+
+		if (sort.isReverse()) {
+			return SolrQuery.SortClause.asc("score");
+		}
+
+		return SolrQuery.SortClause.desc("score");
+	}
+
+	protected SolrQuery.SortClause getSortClause(
+		com.liferay.portal.kernel.search.Sort sort, String fieldName) {
+
+		if (fieldName.equals("score")) {
+			return getScoreSortClause(sort);
+		}
+
+		return getFieldSortClause(sort, fieldName);
+	}
+
 	protected String getSortFieldName(
 		com.liferay.portal.kernel.search.Sort sort, String scoreFieldName) {
 
 		String sortFieldName = sort.getFieldName();
 
 		if (Objects.equals(sortFieldName, Field.PRIORITY)) {
+			return sortFieldName;
+		}
+
+		if (Objects.equals(sortFieldName, "score")) {
 			return sortFieldName;
 		}
 
@@ -251,13 +285,7 @@ public class SearchSolrQueryAssemblerImpl implements SearchSolrQueryAssembler {
 
 			sortFieldNames.add(sortFieldName);
 
-			SolrQuery.ORDER order = SolrQuery.ORDER.asc;
-
-			if (sort.isReverse() || sortFieldName.equals("score")) {
-				order = SolrQuery.ORDER.desc;
-			}
-
-			solrQuery.addSort(new SolrQuery.SortClause(sortFieldName, order));
+			solrQuery.addSort(getSortClause(sort, sortFieldName));
 		}
 	}
 

--- a/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/test/java/com/liferay/portal/search/solr7/internal/sort/SolrSortTest.java
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/test/java/com/liferay/portal/search/solr7/internal/sort/SolrSortTest.java
@@ -28,4 +28,8 @@ public class SolrSortTest extends BaseSortTestCase {
 		return new SolrIndexingFixture();
 	}
 
+	protected String getScoreParameter() {
+		return "score";
+	}
+
 }


### PR DESCRIPTION
Author: @joshuacords
Reviewer: @arboliveira

LPS-118240 Not possible to set a "_score" sort in asc
https://issues.liferay.com/browse/LPS-118240

Manually forwarding this PR since the only `ci:forward` failure was a fluke which [we discussed with CI Infrastructure](https://liferay.slack.com/archives/CL3TWSMHQ/p1597165114191500).

**Test Results from https://github.com/liferay-search/liferay-portal/pull/17**
- 

|Test Suite  | Analysis |
| ------------- | ------------- |
| ✔️ ci:test:sf - 1 out of 1 jobs passed  |   |
| ✔️ ci:test:stable - 22 out of 22 jobs passed  |   |
| ❌ ci:test:relevant - 39 out of 41 jobs passed  | Only failure was the `unit-jdk8_stable` fluke mentioned above  |
| ❌ ci:test:search - 69 out of 71 jobs passed  | All test failures accounted for  |
| ❌ ci:test:search-solr - 52 out of 54 jobs passed  | All test failures accounted for  |