### PR TITLE
Revert "LPS-115019 Use tag-extension in TLDs in order to specify the view state for JSP tags"

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -3,9 +3,8 @@
 <taglib
 	version="2.1"
 	xmlns="http://java.sun.com/xml/ns/javaee"
-	xmlns:jspvs="urn:liferay.com:liferay-jsp-view-state_1.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd urn:liferay.com:liferay-jsp-view-state_1.0.0 http://www.liferay.com/dtd/liferay-jsp-view-state_1_0_0.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
 >
 	<tlib-version>1.0</tlib-version>
 	<short-name>liferay-clay</short-name>
@@ -2281,60 +2280,6 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-		<tag-extension namespace="urn:liferay.com:liferay-jsp-view-state_1.0.0">
-			<extension-element id="actionDropdownItems" xsi:type="jspvs:String"/>
-			<extension-element id="addEntryMessage" xsi:type="jspvs:String"/>
-			<extension-element id="addEntryURL" xsi:type="jspvs:RenderURL"/>
-			<extension-element id="clearResultsURL" xsi:type="jspvs:RenderURL"/>
-			<extension-element id="componentId" xsi:type="jspvs:String" />
-			<extension-element id="contentRenderer" xsi:type="jspvs:String" />
-			<extension-element id="creationMenu" xsi:type="jspvs:fqcn">
-				<jspvs:fqcn>com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu</jspvs:fqcn>
-			</extension-element>
-			<extension-element id="data" xsi:type="jspvs:fqcn">
-				<jspvs:fqcn>java.util.Map&lt;java.lang.String,java.lang.String&gt;</jspvs:fqcn>
-			</extension-element>
-			<extension-element id="defaultEventHandler" xsi:type="jspvs:String" />
-			<extension-element id="disabled" xsi:type="jspvs:boolean" />
-			<extension-element id="displayStyle" xsi:type="jspvs:String" />
-			<extension-element id="displayStyleURL" xsi:type="jspvs:RenderURL"/>
-			<extension-element id="elementClasses" xsi:type="jspvs:String" />
-			<extension-element id="filterDropdownItems" xsi:type="jspvs:fqcn">
-				<jspvs:fqcn>java.util.List&lt;com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem&gt;</jspvs:fqcn>
-			</extension-element>
-			<extension-element id="filterLabelItems" xsi:type="jspvs:fqcn">
-				<jspvs:fqcn>java.util.List&lt;com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem&gt;</jspvs:fqcn>
-			</extension-element>
-			<extension-element id="id" xsi:type="jspvs:String" />
-			<extension-element id="infoPanelId" xsi:type="jspvs:String" />
-			<extension-element id="itemsTotal" xsi:type="jspvs:int" />
-			<extension-element id="namespace" xsi:type="jspvs:String" />
-			<extension-element id="searchActionURL" xsi:type="jspvs:RenderURL"/>
-			<extension-element id="searchContainerId" xsi:type="jspvs:String" />
-			<extension-element id="searchFormMethod" xsi:type="jspvs:String" />
-			<extension-element id="searchFormName" xsi:type="jspvs:String" />
-			<extension-element id="searchInputName" xsi:type="jspvs:String" />
-			<extension-element id="searchURL" xsi:type="jspvs:RenderURL"/>
-			<extension-element id="searchValue" xsi:type="jspvs:String" />
-			<extension-element id="selectable" xsi:type="jspvs:boolean" />
-			<extension-element id="selectedItems" xsi:type="jspvs:int" />
-			<extension-element id="sortingOrder" xsi:type="jspvs:String" />
-			<extension-element id="sortingURLCurrent" xsi:type="jspvs:RenderURL"/>
-			<extension-element id="sortingURLReverse" xsi:type="jspvs:RenderURL"/>
-			<extension-element id="showAdvancedSearch" xsi:type="jspvs:boolean"/>
-			<extension-element id="showCreationMenu" xsi:type="jspvs:boolean"/>
-			<extension-element id="showDisplayStyleCard" xsi:type="jspvs:boolean"/>
-			<extension-element id="showDisplayStyleList" xsi:type="jspvs:boolean"/>
-			<extension-element id="showDisplayStyleTable" xsi:type="jspvs:boolean"/>
-			<extension-element id="showFiltersDoneButton" xsi:type="jspvs:boolean"/>
-			<extension-element id="showInfoButton" xsi:type="jspvs:boolean"/>
-			<extension-element id="showSearch" xsi:type="jspvs:boolean"/>
-			<extension-element id="supportsBulkActions" xsi:type="jspvs:boolean"/>
-			<extension-element id="spritemap" xsi:type="jspvs:String"/>
-			<extension-element id="viewTypeItems" xsi:type="jspvs:fqcn">
-				<jspvs:fqcn>java.util.List&lt;com.liferay.frontend.taglib.clay.servlet.taglib.util.ViewTypeItem&gt;</jspvs:fqcn>
-			</extension-element>
-		</tag-extension>
 	</tag>
 	<tag>
 		<description></description>

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -3,9 +3,8 @@
 <taglib
 	version="2.1"
 	xmlns="http://java.sun.com/xml/ns/javaee"
-	xmlns:jspvs="urn:liferay.com:liferay-jsp-view-state_1.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd urn:liferay.com:liferay-jsp-view-state_1.0.0 http://www.liferay.com/dtd/liferay-jsp-view-state_1_0_0.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
 >
 	<description>Provides the Liferay UI component tags, prefixed with <![CDATA[<code>liferay-ui:</code>]]>.</description>
 	<tlib-version>1.0</tlib-version>
@@ -3050,17 +3049,6 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-		<tag-extension namespace="urn:liferay.com:liferay-jsp-view-state_1.0.0">
-			<extension-element id="cur" xsi:type="jspvs:default" />
-			<extension-element id="delta" xsi:type="jspvs:default" />
-			<extension-element id="displayStyle" xsi:type="jspvs:String" />
-			<extension-element id="end" xsi:type="jspvs:int"/>
-			<extension-element id="keywords" xsi:type="jspvs:String"/>
-			<extension-element id="orderByCol" xsi:type="jspvs:default"/>
-			<extension-element id="orderByType" xsi:type="jspvs:default"/>
-			<extension-element id="resetCur" xsi:type="jspvs:boolean"/>
-			<extension-element id="start" xsi:type="jspvs:int"/>
-		</tag-extension>
 	</tag>
 	<tag>
 		<description>Creates a date column in a search container.</description>


### PR DESCRIPTION
Tested and confirmed that this revert resolves blocker https://issues.liferay.com/browse/LPS-119991. @ngriffin7a