### PR TITLE
LPS-114024 Remove tomcat legacy directory cleanup to prevent unintentional data loss

### DIFF
--- a/app.server.properties
+++ b/app.server.properties
@@ -84,8 +84,6 @@
 ##
 
     app.server.tomcat.version=9.0.37
-    app.server.tomcat.legacy.cleanup.enabled=true
-    app.server.tomcat.legacy.versions=9.0.6,9.0.10,9.0.17,9.0.33
     app.server.tomcat.dir=${app.server.parent.dir}/tomcat-${app.server.tomcat.version}
     app.server.tomcat.bin.dir=${app.server.tomcat.dir}/bin
     app.server.tomcat.classes.global.dir=${app.server.tomcat.dir}/lib

--- a/build-dist.xml
+++ b/build-dist.xml
@@ -1109,24 +1109,6 @@ wrapper.java.additional.11="-Dfile.encoding=UTF-8"]]></replacevalue>
 	</target>
 
 	<target name="unzip-tomcat">
-		<if>
-			<equals arg1="${app.server.tomcat.legacy.cleanup.enabled}" arg2="true" />
-			<then>
-				<for list="${app.server.tomcat.legacy.versions}" param="app.server.tomcat.legacy.version">
-					<sequential>
-						<var name="app.server.tomcat.legacy.dir" value="${app.server.parent.dir}/tomcat-@{app.server.tomcat.legacy.version}" />
-
-						<if>
-							<available file="${app.server.tomcat.legacy.dir}" type="dir" />
-							<then>
-								<delete dir="${app.server.tomcat.legacy.dir}" />
-							</then>
-						</if>
-					</sequential>
-				</for>
-			</then>
-		</if>
-
 		<delete dir="${app.server.tomcat.dir}" />
 
 		<if>


### PR DESCRIPTION
We added this cleanup feature because internal users complained that they were getting confused whenever we updated a Tomcat version, they would accidentally start the old version of tomcat after `ant all` and get errors.

However, this has caused issues for other internal users who store custom configs in their existing tomcat directory. Since the directory will be automatically deleted by this code, they are at risk of losing data.

I think we should value preventing data loss over some temporary confusion when we upgrade.