### PR TITLE
LPS-120062 Use the same value is applied in the CSS

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json
@@ -948,7 +948,7 @@
 							"type": "String"
 						},
 						{
-							"defaultValue": "#6C757D",
+							"defaultValue": "#A7A9BC",
 							"editorType": "ColorPicker",
 							"label": "text-muted",
 							"mappings": [


### PR DESCRIPTION
Manual forward from https://github.com/liferay-frontend/liferay-portal/pull/342

[Test run](https://github.com/liferay-frontend/liferay-portal/pull/342#issuecomment-684795781)
✔️ ci:test:stable - 21 out of 21 jobs passed
❌ ci:test:relevant - 43 out of 46 jobs passed in 1 hour 40 minutes

--- 

This is related to the pr I sent yesterday https://github.com/liferay-frontend/liferay-portal/pull/333

> Some default values in the token definition of the classic theme were not the same as the one used in the CSS
> 
> Blockquote small color is defined here
> 
> Body bg is defined here
> 
> In the case of body bg color maybe we want another color? I've used what the theme is defining right now, but maybe there is a mistake there also, can you review it?

I missed text-muted color that was not synchronized with the css value applied