### PR TITLE
LPS-121217 Add remote app `navigate()` API 

### DIFF
--- a/modules/apps/remote-app/remote-app-client-js/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/remote-app/remote-app-client-js/src/main/resources/META-INF/resources/js/index.ts
@@ -858,6 +858,13 @@ const SDK = Object.freeze({
 				log(...messages);
 			},
 
+			navigate(url: string) {
+				postMessage({
+					command: 'navigate',
+					url,
+				});
+			},
+
 			on(
 				event: string,
 				subscriber: (event: SDKEvent) => void

--- a/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {fetch, openToast} from 'frontend-js-web';
+
 const APPS_TO_IDS = new Map();
 
 const APP_IDS = new Set();
@@ -121,7 +123,7 @@ function receiveMessage(event) {
 					const resource = data.resource;
 					const init = data.init;
 
-					Liferay.Util.fetch(resource, init)
+					fetch(resource, init)
 						.then((response) => {
 							RESPONSES[requestID] = response;
 
@@ -300,7 +302,7 @@ function receiveMessage(event) {
 
 						// example of dealing with untrusted input
 
-						Liferay.Util.openToast({
+						openToast({
 							message: escape(message),
 							type: escape(type),
 						});

--- a/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/remote-app/remote-app-support-web/src/main/resources/META-INF/resources/index.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {fetch, openToast} from 'frontend-js-web';
+import {fetch, navigate, openToast} from 'frontend-js-web';
 
 const APPS_TO_IDS = new Map();
 
@@ -291,7 +291,15 @@ function receiveMessage(event) {
 				}
 				break;
 
-			// just a demo of a higher-level command
+			case 'navigate':
+				{
+					const url = getString(data, 'url');
+
+					if (url) {
+						navigate(url);
+					}
+				}
+				break;
 
 			case 'openToast':
 				{


### PR DESCRIPTION
Manual forward as per [this comment](https://github.com/liferay-frontend/liferay-portal/pull/397#issuecomment-696706000), due to [unrelated failure](https://liferay.slack.com/archives/C19PWQ74J/p1600777257021200).

Original PR: https://github.com/liferay-frontend/liferay-portal/pull/397

---

This allows the application in the iframe to trigger a navigation in an SPA-aware manner.