### PR TITLE
Revert "LPS-121461 remove dependency all together"

### DIFF
--- a/modules/apps/petra/petra-url-pattern-mapper/build.gradle
+++ b/modules/apps/petra/petra-url-pattern-mapper/build.gradle
@@ -1,3 +1,7 @@
+dependencies {
+	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
+}
+
 liferay {
 	deployDir = appServerLibGlobalDir
 }

--- a/modules/apps/petra/petra-url-pattern-mapper/src/main/java/com/liferay/petra/url/pattern/mapper/URLPatternMapper.java
+++ b/modules/apps/petra/petra-url-pattern-mapper/src/main/java/com/liferay/petra/url/pattern/mapper/URLPatternMapper.java
@@ -18,14 +18,15 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import org.osgi.annotation.versioning.ProviderType;
+
 /**
  * @author Carlos Sierra Andrés
  */
+@ProviderType
 public interface URLPatternMapper<T> {
 
-	public default void consumeValues(Consumer<T> consumer, String urlPath) {
-		consumer.accept(getValue(urlPath));
-	}
+	public void consumeValues(Consumer<T> consumer, String urlPath);
 
 	public T getValue(String urlPath);
 


### PR DESCRIPTION
Hey Brian, @Preston-Crary

Alas consumeValues can't be implemented in terms of getValue. Actually it is the method getValues which can be implemented in terms of consumeValues.

getValue has different semantics from consumeValues or getValues.

Bests.

Carlos.