### PR TITLE
LRQA-62593 | master

### DIFF
--- a/build-test-elasticsearch7.xml
+++ b/build-test-elasticsearch7.xml
@@ -130,7 +130,7 @@ xpack.ml.enabled: false</echo>
 kibanaURL="https://localhost:5601"
 proxyServletLogEnable="true"</echo>
 
-			<echo append="true" file="${liferay.home}/osgi/configs/com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConnectionConfiguration-remote.config">${line.separator}active="true"
+			<echo append="true" file="${liferay.home}/osgi/configs/com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConnectionConfiguration-remote.config">active="true"
 authenticationEnabled="true"
 connectionId="xpack"
 httpSSLEnabled="true"


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-62593

The only unique failure in the ci:test:relevant run was an unrelated semantic versioning error: https://github.com/joshchong/liferay-portal/pull/375#issuecomment-719087716

7.3.x PR: https://github.com/brianchandotcom/liferay-portal-ee/pull/32081

cc @brookedalton 