### PR TITLE
[7.4.x only] LRQA-62922 | master

### DIFF
--- a/modules/apps/wiki/wiki-web/src/main/resources/com/liferay/wiki/web/portlet/template/dependencies/portlet_display_template_social.ftl
+++ b/modules/apps/wiki/wiki-web/src/main/resources/com/liferay/wiki/web/portlet/template/dependencies/portlet_display_template_social.ftl
@@ -241,7 +241,7 @@
 >
 	<#if wikiPortletInstanceConfiguration.enablePageRatings()>
 		<div class="${cssClass}">
-			<@liferay_ui["ratings"]
+			<@liferay_ratings["ratings"]
 				className=wikiPageClassName
 				classPK=entry.getResourcePrimKey()
 			/>

--- a/modules/apps/wiki/wiki-web/src/main/resources/com/liferay/wiki/web/portlet/template/dependencies/portlet_display_template_social.ftl
+++ b/modules/apps/wiki/wiki-web/src/main/resources/com/liferay/wiki/web/portlet/template/dependencies/portlet_display_template_social.ftl
@@ -63,7 +63,7 @@
 		${viewCategorizedPagesURL.setParameter("mvcRenderCommandName", "/wiki/view_categorized_pages")}
 		${viewCategorizedPagesURL.setParameter("nodeId", entry.getNodeId()?string)}
 
-		<@liferay_ui["asset-categories-summary"]
+		<@liferay_asset["asset-categories-summary"]
 			className=wikiPageClassName
 			classPK=entry.getResourcePrimKey()
 			portletURL=viewCategorizedPagesURL
@@ -76,7 +76,7 @@
 		${viewTaggedPagesURL.setParameter("mvcRenderCommandName", "/wiki/view_tagged_pages")}
 		${viewTaggedPagesURL.setParameter("nodeId", entry.getNodeId()?string)}
 
-		<@liferay_ui["asset-tags-summary"]
+		<@liferay_asset["asset-tags-summary"]
 			className=wikiPageClassName
 			classPK=entry.getResourcePrimKey()
 			portletURL=viewTaggedPagesURL

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/adt_blogs_basic.ftl
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/adt_blogs_basic.ftl
@@ -45,14 +45,14 @@
 			</#if>
 
 			<span class="entry-categories">
-				<@liferay_ui["asset-categories-summary"]
+				<@liferay_asset["asset-categories-summary"]
 					className=blogsEntryClassName
 					classPK=entry.getEntryId()
 					portletURL=renderResponse.createRenderURL()
 				/>
 			</span>
 			<span class="entry-tags">
-				<@liferay_ui["asset-tags-summary"]
+				<@liferay_asset["asset-tags-summary"]
 					className=blogsEntryClassName
 					classPK=entry.getEntryId()
 					portletURL=renderResponse.createRenderURL()

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/adt_wiki_social.ftl
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/adt_wiki_social.ftl
@@ -54,7 +54,7 @@
 		${viewCategorizedPagesURL.setParameter("struts_action", "/wiki/view_categorized_pages")}
 		${viewCategorizedPagesURL.setParameter("nodeId", entry.getNodeId()?string)}
 
-		<@liferay_ui["asset-categories-summary"]
+		<@liferay_asset["asset-categories-summary"]
 			className=wikiPageClassName
 			classPK=entry.getResourcePrimKey()
 			portletURL=viewCategorizedPagesURL
@@ -67,7 +67,7 @@
 		${viewTaggedPagesURL.setParameter("struts_action", "/wiki/view_tagged_pages")}
 		${viewTaggedPagesURL.setParameter("nodeId", entry.getNodeId()?string)}
 
-		<@liferay_ui["asset-tags-summary"]
+		<@liferay_asset["asset-tags-summary"]
 			className=wikiPageClassName
 			classPK=entry.getResourcePrimKey()
 			portletURL=viewTaggedPagesURL

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/carousel-display-template.txt
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/carousel-display-template.txt
@@ -20,7 +20,7 @@
 						<#assign article = cur_contents.getData()?eval />
 
 						<#-- Here is our taglib call -->
-						<@liferay_ui["asset-display"]
+						<@liferay_asset["asset-display"]
 							className=article.className
 							classPK=getterUtil.getLong(article.classPK, 0)
 							template="full_content"

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/thumbnail-display-template.txt
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/thumbnail-display-template.txt
@@ -5,7 +5,7 @@
 	<#list contents.getSiblings() as cur_contents>
 		<#assign article = cur_contents.getData()?eval />
         <li class="col-lg-4 col-md-4 col-xs-6">
-		<@liferay_ui["asset-display"]
+		<@liferay_asset["asset-display"]
 			className=article.className
 			classPK=getterUtil.getLong(article.classPK, 0)
 			template="full_content"


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-62922

@brianchandotcom
Could you have a look at the revert commit?
Step to reproduce

1. Add a widget page
2. Add a Blogs widget to page
3. Add a new Blogs entry via Blogs
4. Navigate to Widget Templates admin
5. Add a widget template based on Blogs Template
6. Upload the adt_blogs_basic.ftl from portalweb\dependencies then Save
7. Navigate to page
8. Click the ellipsis button of Blogs then Click Configuration
9. Choose new widget template in Display Template then Save
10. The freemarker error is shown in Blogs
```
The following has evaluated to null or missing:
 ==> liferay_ui["asset-categories-summary"] 
```

Additionally, I checked liferay-asset:asset-display, liferay-asset:asset-tags-summary are used in codes.

@ambrinchaudhary
Could you confirm again?