### PR TITLE
LRQA-62752 Explicitly set appserver types where this test can run on instead of being arbitrary

### DIFF
--- a/build-dist.xml
+++ b/build-dist.xml
@@ -2118,7 +2118,7 @@ and put it in ${app.server.parent.dir}. Then rerun this task.
 			file="${app.server.websphere.instance.dir}/config/cells/liferay-cell/nodes/liferay-node/servers/server1/server.xml"
 		>
 			<replacetoken><![CDATA[genericJvmArguments="-Xquickstart"]]></replacetoken>
-			<replacevalue><![CDATA[genericJvmArguments="-Xquickstart ${app.server.websphere.jvm.args}"]]></replacevalue>
+			<replacevalue expandProperties="true"><![CDATA[genericJvmArguments="-Xquickstart ${app.server.websphere.jvm.args}"]]></replacevalue>
 		</replace>
 
 		<echo>Installing fix pack. This may take a few minutes.</echo>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringConfigs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringConfigs.testcase
@@ -30,6 +30,7 @@ definition {
 
 	@priority = "5"
 	test StartupJDBCPING {
+		property app.server.types = "tomcat";
 		property cluster.jdbc.ping = "true";
 		property portal.acceptance = "true";
 		property test.name.skip.portal.instance = "ClusteringConfigs#StartupJDBCPING";


### PR DESCRIPTION
This can go back to 7.2.x