### PR TITLE
ISOPS-151 Add translations to Journal Properties Transformer Listener

### DIFF
--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_ar.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_ar.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=يعد تطبيق Journal Properties Transformer Listener مثالاً على تطبيق مستمع محول دفتر اليومية.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_bg.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_bg.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Приложението Слушател на трансформатор на свойства на журнала е пример за приложение за слушане на трансформатор на журнали.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_ca.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_ca.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=L’aplicació Listener del transformador de propietats del diari és un exemple d’una aplicació d’oient del transformador de diari.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_cs.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_cs.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Aplikace Listener Transformer Listener je příkladem aplikace Listener transformátoru deníku.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_da.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_da.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Journal Properties Transformer Listener-appen er et eksempel på en journal-transformer-lytter-app.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_de.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_de.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Die Journal Properties Transformer Listener-App ist ein Beispiel für eine Journal Transformer Listener-App.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_el.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_el.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Η εφαρμογή Journal Properties Transformer Listener είναι ένα παράδειγμα μιας εφαρμογής Listener Transformer Listener.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_en_AU.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_en_AU.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_en_GB.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_en_GB.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_es.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_es.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=La aplicación Journal Properties Transformer Listener es un ejemplo de una aplicación de escucha de transformación de diario.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_et.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_et.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Rakendus Teataja atribuutide trafo kuulaja on näide päevikutrafode kuulaja rakendusest.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_eu.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_eu.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Journal Properties Transformer Listener aplikazioa Journal Transformers Listener aplikazioaren adibidea da.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_fa.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_fa.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=برنامه Journal Properties Transformer Listener مثالی از برنامه شنونده ترانسفورماتور ژورنال است.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_fi.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_fi.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Päiväkirjaominaisuuksien muuntajan kuuntelusovellus on esimerkki päiväkirjamuuntajan kuuntelusovelluksesta.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_fr.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_fr.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=L'application Journal Properties Transformer Listener est un exemple d'application d'écoute de journal Transformer.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_fr_CA.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_fr_CA.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=L'application Journal Properties Transformer Listener est un exemple d'application d'écoute de journal Transformer.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_gl.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_gl.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=A aplicación de escoita de transformadores de xornal é un exemplo de aplicación de escoita de transformadores de xornal.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_hi_IN.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_hi_IN.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=जर्नल प्रॉपर्टीज ट्रांसफॉर्मर लिसनर ऐप एक जर्नल ट्रांसफॉर्मर श्रोता ऐप का एक उदाहरण है।

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_hr.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_hr.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Aplikacija Slušatelj transformatora svojstava časopisa primjer je aplikacije slušatelja transformatora dnevnika.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_hu.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_hu.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=A Napló tulajdonságai Transformer Listener alkalmazás egy példa egy napló transzformátor figyelő alkalmazásra.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_in.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_in.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Aplikasi Journal Properties Transformer Listener adalah contoh aplikasi pendengar transformator jurnal.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_it.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_it.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=L'app Listener del trasformatore del journal è un esempio di un'app del listener del trasformatore del journal.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_iw.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_iw.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description= אפליקציית המאזין שנאי היומן מאפיינים היא דוגמה לאפליקציה המאזין לשנאי יומן.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_ja.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_ja.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Journal Properties Transformer Listenerアプリは、ジャーナルトランスフォーマーリスナーアプリの例です。

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_kk.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_kk.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Journal Properties Transformer Listener қосымшасы - журнал трансформаторы тыңдаушылар бағдарламасының мысалы.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_ko.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_ko.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description= 저널 속성 변환기 리스너 앱은 저널 변환기 리스너 앱의 예입니다.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_lo.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_lo.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=ວາລະສານ Properties Transformer Listener ແມ່ນຕົວຢ່າງຂອງແອັບຟັງການປ່ຽນແປງແບບຂ່າວ.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_lt.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_lt.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=„Journal Properties Transformer Listener“ programa yra žurnalų transformatorių klausytojų programos pavyzdys.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_nb.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_nb.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Journal Properties Transformer Listener-appen er et eksempel på en journal-transformator-lytter-app.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_nl.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_nl.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=De app Journal Properties Transformer Listener is een voorbeeld van een listener-app voor journaaltransformatoren.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_nl_BE.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_nl_BE.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=De app Journal Properties Transformer Listener is een voorbeeld van een listener-app voor journaaltransformatoren.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_pl.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_pl.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Aplikacja Journal Properties Transformer Listener jest przykładem aplikacji nasłuchującej transformator dziennika.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_pt_BR.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_pt_BR.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=O aplicativo Journal Properties Transformer Listener é um exemplo de um aplicativo Journal Transformer Listener.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_pt_PT.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_pt_PT.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=O aplicativo Journal Properties Transformer Listener é um exemplo de um aplicativo Journal Transformer Listener.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_ro.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_ro.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Aplicația de ascultare a transformatorului de jurnale este un exemplu de aplicație de ascultare a transformatorului de jurnal.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_ru.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_ru.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Приложение Journal Properties Transformer Listener является примером приложения прослушивателя преобразования журнала.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_sk.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_sk.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Aplikácia poslucháča denníka Transformers Listener je príkladom aplikácie poslucháča denníka transformátora.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_sl.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_sl.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Aplikacija Journal Transformer Listener je primer aplikacije poslušalca transformatorja dnevnika.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_sr_RS.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_sr_RS.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Апликација Прислушкивач трансформатора својстава дневника пример је апликације слушача трансформатора дневника.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_sr_RS_latin.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_sr_RS_latin.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Aplikacija Prisluškivač transformatora svojstava dnevnika primer je aplikacije slušača transformatora dnevnika.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_sv.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_sv.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Appen Journal Egenskaper Transformer Listener är ett exempel på en lyssnar-app för journaltransformator.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_ta_IN.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_ta_IN.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=ஜர்னல் பண்புகள் மின்மாற்றி கேட்போர் பயன்பாடு ஒரு பத்திரிகை மின்மாற்றி கேட்போர் பயன்பாட்டின் எடுத்துக்காட்டு.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_th.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_th.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=แอป Journal Properties Transformer Listener เป็นตัวอย่างของแอปตัวฟังหม้อแปลงวารสาร

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_tr.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_tr.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Journal Properties Transformer Listener uygulaması, dergi dönüştürücü dinleyici uygulamasına bir örnektir.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_uk.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_uk.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Програма "Властивості журналу" Transformer Listener "є прикладом програми прослуховування трансформатора журналу.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_vi.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_vi.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Ứng dụng Journal Properties Transformer Listener là một ví dụ về ứng dụng trình nghe biến áp tạp chí.

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_zh_CN.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_zh_CN.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Journal Properties Transformer Listener应用程序是日记变换器侦听器应用程序的示例。

--- a/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_zh_TW.properties
+++ b/modules/apps/journal-properties-transformer-listener/app.bnd-localization/bundle_zh_TW.properties
@@ -1,1 +1,1 @@
-liferay-releng-app-description=The Journal Properties Transformer Listener app is an example of a journal transformer listener app. (Automatic Copy)
+liferay-releng-app-description=Journal Properties Transformer Listener應用程序是日記變換器偵聽器應用程序的示例。


### PR DESCRIPTION
I am sending this pull as a result of https://issues.liferay.com/browse/ISOPS-13 (ISOPS-151 is a code commit subtask). Our current system for syncing localization files to crowdin is having issues handling bundles.properties files because currently none of them the portal over are translated. Rather than doing a major refactor, we decided to translate one of the modules manually to provide the system a basis to work off of. 

I have two more branches that also need to be updated, 7.2.x and 7.3.x