### PR TITLE
LPS-124464 Apply Liferay-Theme-Contributor-Weight to RTLServlet

### DIFF
--- a/modules/apps/frontend-css/frontend-css-rtl-servlet/src/main/java/com/liferay/frontend/css/rtl/servlet/internal/RTLServletTracker.java
+++ b/modules/apps/frontend-css/frontend-css-rtl-servlet/src/main/java/com/liferay/frontend/css/rtl/servlet/internal/RTLServletTracker.java
@@ -16,11 +16,15 @@ package com.liferay.frontend.css.rtl.servlet.internal;
 
 import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.GetterUtil;
 
+import java.util.Dictionary;
 import java.util.Hashtable;
 
 import javax.servlet.Servlet;
 
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
@@ -108,6 +112,16 @@ public class RTLServletTracker {
 			RTLServlet.class.getName());
 		properties.put(
 			HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN, "*.css");
+
+		Bundle bundle = serviceReference.getBundle();
+
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
+
+		int themeContributorWeight = GetterUtil.getInteger(
+			headers.get("Liferay-Theme-Contributor-Weight"));
+
+		properties.put("service.ranking", themeContributorWeight);
 
 		return properties;
 	}


### PR DESCRIPTION
Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/589 to avoid retesting because of the baseline error

--- 

https://issues.liferay.com/browse/LPS-124464

## Steps to reproduce

1. Start up Liferay
2. Deploy org.foo.product.menu.contributor.one-1.0.jar (see linked LPS ticket)
3. Navigate to each of the following URLs and observe that they both have the content `body { color: #000; }`
* http://localhost:8080/o/product-navigation-product-menu-dxp-theme-contributor/css/product-navigation-product-menu.css
* http://localhost:8080/combo?browserId=other&minifierType=css&/o/product-navigation-product-menu-dxp-theme-contributor/css/product-navigation-product-menu.css
4. Deploy org.foo.product.menu.contributor.two-1.0.jar (see linked LPS ticket)
5. Navigate to the above URLs again

### Expected behavior
Both URLs have the content `body { color: #111; }`

### Actual behavior
Only the non combo URL has the content `body { color: #111; }`
The combo URL still has the content `body { color: #000; }`

## Solution overview

Apply Liferay-Theme-Contributor-Weight to the component registration of the RTLServlet instance.