### PR TITLE
LPS-124465 Avoid unwanted minification of `Liferay` global

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/deprecated.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/deprecated.js
@@ -14,7 +14,7 @@
 
 // For details about this file see: LPS-2155
 
-(function (A, Liferay) {
+(function (A) {
 	var Util = Liferay.Util;
 
 	var Lang = A.Lang;
@@ -502,4 +502,4 @@
 		},
 		['aui-io']
 	);
-})(AUI(), Liferay);
+})(AUI());

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-(function (A, Liferay) {
+(function (A) {
 	A.use('aui-base-lang');
 
 	var AArray = A.Array;
@@ -1721,4 +1721,4 @@
 		TOOLTIP: 10000,
 		WINDOW: 1200,
 	};
-})(AUI(), Liferay);
+})(AUI());

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/dom_task_runner.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/dom_task_runner.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-(function (Liferay) {
+(function () {
 	var DOMTaskRunner = {
 		_scheduledTasks: [],
 
@@ -63,4 +63,4 @@
 	};
 
 	Liferay.DOMTaskRunner = DOMTaskRunner;
-})(Liferay);
+})();

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-(function (A, Liferay) {
+(function (A) {
 	var CLICK_EVENTS = {};
 	var Util = Liferay.Util;
 
@@ -204,4 +204,4 @@
 			dialog.hide();
 		}
 	});
-})(AUI(), Liferay);
+})(AUI());

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/lazy_load.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/lazy_load.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-(function (Liferay) {
+(function () {
 	Liferay.lazyLoad = function () {
 		var failureCallback;
 
@@ -66,4 +66,4 @@
 			);
 		};
 	};
-})(Liferay);
+})();

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js
@@ -14,7 +14,7 @@
 
 Liferay = window.Liferay || {};
 
-(function (Liferay) {
+(function () {
 	var isFunction = function (val) {
 		return typeof val === 'function';
 	};
@@ -225,4 +225,4 @@ Liferay = window.Liferay || {};
 		PORTLET:
 			'<div class="portlet"><div class="portlet-topper"><div class="portlet-title"></div></div><div class="portlet-content"></div><div class="forbidden-action"></div></div>',
 	};
-})(Liferay);
+})();

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-(function (A, Liferay) {
+(function (A) {
 	var Lang = A.Lang;
 
 	var Util = Liferay.Util;
@@ -676,4 +676,4 @@
 	};
 
 	Liferay.Portlet = Portlet;
-})(AUI(), Liferay);
+})(AUI());


### PR DESCRIPTION
Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/636 after a failure seen in various PRs today.

---

As explained in https://issues.liferay.com/browse/LPS-124465 our
minification takes some care to avoid mangling property access:

https://github.com/liferay/liferay-frontend-projects/blob/a33874a2630a07e24cd46421fb346235467ea6c5/projects/npm-tools/packages/npm-scripts/src/config/terser.config.js#L10-L12

Combined with the fact that `Liferay` is usually accessed as a global
and therefore not minified, that means that we can rely on the minifier
leaving strings like `Liferay.Language.get` untouched in the source. The
LanguageFilter can then find those strings and substitute them on the
fly.

In LPS-124465 we see a pattern that breaks this. `Liferay` is passed
into a function, where, as a local binding, the minifier is free to
rewrite it (eg. to `t`), so our source text now reads `t.Language.get`
and the LanguageFilters does not substitute it.

Fix taken here is to avoid that pattern in `portlet.js` and everywhere
else we seem to be doing it (not many places, all found with a crude
regex for `\((\s*\w+\s*,)*\bLiferay\b(\s*,\s*\w+\s*)*\)`; that won't
cover everything, like things split across multiple lines, but it will
catch most things... probably everything).

Instead of:

```js
(function (Liferay) {
    // blah...
})(Liferay);
```

we just do:

```js
(function () {
    // blah...
})();
```

There was one place where we had:

```js
Liferay = window.Liferay || {};
```

Note that the minifier is "smart" enough to know that `Liferay` there is
not a global, and it preserves the name. But prior to this PR, if you
inspect the build output it does the unwanted `t` mangling; ie. before:

    Liferay=window.Liferay||{},function(t){ /* a bunch of stuff */ }(Liferay);

after:

    Liferay=window.Liferay||{},function(){ /* a bunch of stuff */ }();