### PR TITLE
LPS-121673 Remove unused submit event handler from dialog modal

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
@@ -132,10 +132,6 @@
 		display: none;
 	}
 
-	.button-holder.dialog-footer {
-		position: relative;
-	}
-
 	.calendar-create-event-btn-row {
 		margin: 0 0 1em;
 		text-align: center;

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -15,8 +15,6 @@
 (function (A, Liferay) {
 	A.use('aui-base-lang');
 
-	var AArray = A.Array;
-
 	var Lang = A.Lang;
 
 	var EVENT_CLICK = 'click';
@@ -1127,31 +1125,23 @@
 				};
 			}
 
-			var eventHandles = [
-				iframeBody.delegate('submit', detachEventHandles, 'form'),
+			var cancelEventHandler = iframeBody.delegate(
+				EVENT_CLICK,
+				(event) => {
+					dialog.set(
+						'visible',
+						false,
+						event.currentTarget.hasClass('lfr-hide-dialog')
+							? SRC_HIDE_LINK
+							: null
+					);
 
-				iframeBody.delegate(
-					EVENT_CLICK,
-					(event) => {
-						dialog.set(
-							'visible',
-							false,
-							event.currentTarget.hasClass('lfr-hide-dialog')
-								? SRC_HIDE_LINK
-								: null
-						);
+					cancelEventHandler.detach();
 
-						detachEventHandles();
-					},
-					'.btn-cancel,.lfr-hide-dialog'
-				),
-			];
-
-			function detachEventHandles() {
-				AArray.invoke(eventHandles, 'detach');
-
-				iframeDocument.purge(true);
-			}
+					iframeDocument.purge(true);
+				},
+				'.btn-cancel,.lfr-hide-dialog'
+			);
 
 			Liferay.fire('modalIframeLoaded', {
 				src: event.dialog.iframe.node.getAttribute('src'),


### PR DESCRIPTION
Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/611 after the same Commerce error in common with other PRs

--- 

**[BUG](https://issues.liferay.com/browse/LPS-121673):** Using any dialog modal created by the `Liferay.Util.openWindow`, after click on the save/submit button the cancel button doesn't work as proposed and the dialog doesn't close.

**FIX:** This PR removes the events detachment when submit the form inside the dialog modal, and keep only the cancel event detachment allowing the user submit many times and close the modal when the cancel button is clicked.

**TEST STEPS:**
1. Go to Site Menu > Site Builder > Pages > Create a Widget page and set it as "1 Column"
2. Go to the page created and add a Calendar widget
3. Click on the "arrow" icon next to one of the calendars > Calendar Settings
4. Click on "Save"
5. Click on "Cancel"