### PR TITLE
LPS-125364 Fix modal fullscreen style

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss
@@ -29,7 +29,7 @@
 }
 
 .modal-dialog {
-	&:not(.dialog-iframe-modal) {
+	&:not(.dialog-iframe-modal):not(.modal-full-screen) {
 		position: relative;
 	}
 


### PR DESCRIPTION
Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/668

[Apparent unrelated flaky Commerce JS test:](https://github.com/liferay-frontend/liferay-portal/pull/668#issuecomment-752583103)
❌ ci:test:stable - 8 out of 9 jobs passed
❌ ci:test:relevant - 21 out of 23 jobs passed in 2 hours 32 minutes

---

In this PR we are fixing the position of the `modal-dialog` caused by a conflict with the legacy library `aui`.

With this change we are reproducing the standard behavior it has in Clay:
- default `position: relative`
- in `.modal-full-screen`  >  `position: absolute`

And we are still supporting the `.modal.modal-dialog` special scenario defined in DXP
- `.dialog-iframe-modal` > `position: absolute`

![modal](https://user-images.githubusercontent.com/46778114/103346640-e145df00-4a94-11eb-9bb9-e6030cbe5748.jpg)
