### PR TITLE
LPS-125114 - Remove uses of metal core

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/package.json
+++ b/modules/apps/adaptive-media/adaptive-media-web/package.json
@@ -8,7 +8,6 @@
 		"formik": "2.1.4",
 		"frontend-js-react-web": "*",
 		"frontend-js-web": "*",
-		"metal": "2.16.8",
 		"prop-types": "15.7.2",
 		"react": "16.12.0"
 	},

--- a/modules/apps/commerce/commerce-cart-taglib/package.json
+++ b/modules/apps/commerce/commerce-cart-taglib/package.json
@@ -1,7 +1,6 @@
 {
 	"dependencies": {
 		"clay-icon": "2.22.0",
-		"metal": "2.16.8",
 		"metal-component": "2.16.8",
 		"metal-soy": "2.16.9",
 		"metal-state": "2.16.8"

--- a/modules/apps/commerce/commerce-frontend-taglib/package.json
+++ b/modules/apps/commerce/commerce-frontend-taglib/package.json
@@ -5,7 +5,6 @@
 		"clay-pagination-bar": "2.22.0",
 		"clay-table": "2.22.0",
 		"frontend-js-web": "*",
-		"metal": "2.16.8",
 		"metal-component": "2.16.8",
 		"metal-soy": "2.16.9",
 		"metal-state": "2.16.8"

--- a/modules/apps/commerce/commerce-product-content-web/package.json
+++ b/modules/apps/commerce/commerce-product-content-web/package.json
@@ -1,6 +1,5 @@
 {
 	"dependencies": {
-		"metal": "2.16.8",
 		"metal-component": "2.16.8",
 		"metal-soy": "2.16.9",
 		"metal-state": "2.16.8"

--- a/modules/apps/commerce/commerce-product-options-web/package.json
+++ b/modules/apps/commerce/commerce-product-options-web/package.json
@@ -1,6 +1,5 @@
 {
 	"dependencies": {
-		"metal": "2.16.8",
 		"metal-component": "2.16.8",
 		"metal-soy": "2.16.9",
 		"metal-state": "2.16.8"

--- a/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium-impl/package.json
+++ b/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium-impl/package.json
@@ -5,7 +5,6 @@
 		"clay-modal": "2.22.0",
 		"clay-pagination-bar": "2.22.0",
 		"clay-table": "2.22.0",
-		"metal": "2.16.8",
 		"metal-component": "2.16.8",
 		"metal-soy": "2.16.9",
 		"metal-state": "2.16.8"

--- a/modules/apps/data-engine/data-engine-taglib/package.json
+++ b/modules/apps/data-engine/data-engine-taglib/package.json
@@ -21,7 +21,6 @@
 		"frontend-js-react-web": "*",
 		"frontend-js-web": "*",
 		"lodash.omit": "^4.5.0",
-		"metal": "2.16.8",
 		"metal-jsx": "2.16.8",
 		"moment": "^2.24.0",
 		"prop-types": "15.7.2",

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/data-layout-builder/DataLayoutBuilder.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/data-layout-builder/DataLayoutBuilder.es.js
@@ -18,7 +18,6 @@ import FormBuilderWithLayoutProvider, {
 	FieldSupport,
 } from 'dynamic-data-mapping-form-builder';
 import {PagesVisitor} from 'dynamic-data-mapping-form-renderer';
-import core from 'metal';
 import React from 'react';
 
 import {
@@ -772,14 +771,14 @@ class DataLayoutBuilder extends React.Component {
 				description = description === null ? '' : description;
 				title = title === null ? '' : title;
 
-				if (!core.isString(description)) {
+				if (typeof description !== 'string') {
 					description = description[defaultLanguageId];
 					localizedDescription = {
 						[defaultLanguageId]: description,
 					};
 				}
 
-				if (!core.isString(title)) {
+				if (typeof title !== 'string') {
 					title = title[defaultLanguageId];
 					localizedTitle = {
 						[defaultLanguageId]: title,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/index.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/index.js
@@ -13,7 +13,7 @@
  */
 
 import ClayIcon from '@clayui/icon';
-import core from 'metal';
+import {isObject} from 'frontend-js-web';
 import React from 'react';
 
 import {PageProvider} from '../../hooks/usePage.es';
@@ -85,13 +85,13 @@ const isEmptyPage = ({rows}) => {
 };
 
 const normalizePage = (page, editingLanguageId) => {
-	if (core.isObject(page.description)) {
+	if (isObject(page.description)) {
 		page = {
 			...page,
 			description: page.description[editingLanguageId],
 		};
 	}
-	if (core.isObject(page.title)) {
+	if (isObject(page.title)) {
 		page = {
 			...page,
 			title: page.title[editingLanguageId],

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
@@ -29,7 +29,6 @@ import {
 import {sub} from 'dynamic-data-mapping-form-builder/js/util/strings.es';
 import {PagesVisitor, compose} from 'dynamic-data-mapping-form-renderer';
 import {delegate} from 'frontend-js-web';
-import core from 'metal';
 import {EventHandler} from 'metal-events';
 import Component from 'metal-jsx';
 import {Config} from 'metal-state';
@@ -970,12 +969,18 @@ class Form extends Component {
 			successPageSettings.enabled = true;
 		}
 
-		if (successPageSettings && core.isString(successPageSettings.title)) {
+		if (
+			successPageSettings &&
+			typeof successPageSettings.title === 'string'
+		) {
 			successPageSettings.title = {};
 			successPageSettings.title[defaultLanguageId] = '';
 		}
 
-		if (successPageSettings && core.isString(successPageSettings.body)) {
+		if (
+			successPageSettings &&
+			typeof successPageSettings.body === 'string'
+		) {
 			successPageSettings.body = {};
 			successPageSettings.body[defaultLanguageId] = '';
 		}
@@ -1020,14 +1025,14 @@ class Form extends Component {
 					title,
 				} = page;
 
-				if (description && !core.isString(description)) {
+				if (description && typeof description !== 'string') {
 					description = description[themeDisplay.getLanguageId()];
 					localizedDescription = {
 						[themeDisplay.getLanguageId()]: description,
 					};
 				}
 
-				if (title && !core.isString(title)) {
+				if (title && typeof title !== 'string') {
 					title = title[themeDisplay.getLanguageId()];
 					localizedTitle = {
 						[themeDisplay.getLanguageId()]: title,

--- a/modules/apps/fragment/fragment-web/package.json
+++ b/modules/apps/fragment/fragment-web/package.json
@@ -4,7 +4,6 @@
 		"@clayui/tabs": "3.3.2",
 		"codemirror": "^5.52.0",
 		"frontend-js-web": "*",
-		"metal": "2.16.8",
 		"metal-component": "2.16.8",
 		"metal-state": "2.16.8"
 	},

--- a/modules/apps/frontend-js/frontend-js-metal-web/bnd.bnd
+++ b/modules/apps/frontend-js/frontend-js-metal-web/bnd.bnd
@@ -33,6 +33,5 @@ Liferay-JS-Submodules-Bridge:\
 	metal-useragent
 Provide-Capability:\
 	soy;\
-		type="metal";\
 		version:Version="1.0.0"
 Web-ContextPath: /frontend-js-metal-web

--- a/modules/apps/frontend-js/frontend-js-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-web/package.json
@@ -11,7 +11,6 @@
 		"lodash.isequal": "4.5.0",
 		"lodash.memoize": "4.1.2",
 		"lodash.unescape": "4.0.1",
-		"metal": "2.16.8",
 		"metal-component": "2.16.8",
 		"metal-events": "2.16.8",
 		"react": "16.12.0",

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -80,6 +80,7 @@ export {default as fetch} from './liferay/util/fetch.es';
 export {default as focusFormField} from './liferay/util/focus_form_field';
 export {default as getPortletId} from './liferay/util/get_portlet_id';
 export {default as inBrowserView} from './liferay/util/in_browser_view';
+export {default as isObject} from './liferay/util/is_object';
 export {default as isPhone} from './liferay/util/is_phone';
 export {default as isTablet} from './liferay/util/is_tablet';
 export {default as navigate} from './liferay/util/navigate.es';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/CompatibilityEventProxy.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/CompatibilityEventProxy.es.js
@@ -12,8 +12,9 @@
  * details.
  */
 
-import {core} from 'metal';
 import State from 'metal-state';
+
+import isObject from './util/is_object';
 
 /**
  * Adds compatibility for YUI events, re-emitting events according to YUI naming
@@ -75,7 +76,7 @@ class CompatibilityEventProxy extends State {
 					: eventName;
 				const yuiEvent = target._yuievt.events[prefixedEventName];
 
-				if (core.isObject(event)) {
+				if (isObject(event)) {
 					try {
 						event.target = this.host;
 					}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
@@ -12,10 +12,16 @@
  * details.
  */
 
-import core from 'metal';
-
 import PortletBase from './PortletBase.es';
 import delegate from './delegate/delegate.es';
+
+function isBoolean(val) {
+	return typeof val === 'boolean';
+}
+
+function isString(val) {
+	return typeof val === 'string';
+}
 
 /**
  * Appends list item elements to dropdown menus with inline-scrollers on scroll
@@ -201,7 +207,7 @@ DynamicInlineScroll.STATE = {
 	 */
 	cur: {
 		setter: 'getNumber_',
-		validator: core.isString,
+		validator: isString,
 	},
 
 	/**
@@ -212,7 +218,7 @@ DynamicInlineScroll.STATE = {
 	 * @type {string}
 	 */
 	curParam: {
-		validator: core.isString,
+		validator: isString,
 	},
 
 	/**
@@ -223,7 +229,7 @@ DynamicInlineScroll.STATE = {
 	 * @type {boolean}
 	 */
 	forcePost: {
-		validator: core.isBoolean,
+		validator: isBoolean,
 	},
 
 	/**
@@ -234,7 +240,7 @@ DynamicInlineScroll.STATE = {
 	 * @type {string}
 	 */
 	formName: {
-		validator: core.isString,
+		validator: isString,
 	},
 
 	/**
@@ -247,7 +253,7 @@ DynamicInlineScroll.STATE = {
 	 */
 	initialPages: {
 		setter: 'getNumber_',
-		validator: core.isString,
+		validator: isString,
 	},
 
 	/**
@@ -258,7 +264,7 @@ DynamicInlineScroll.STATE = {
 	 * @type {string}
 	 */
 	jsCall: {
-		validator: core.isString,
+		validator: isString,
 	},
 
 	/**
@@ -269,7 +275,7 @@ DynamicInlineScroll.STATE = {
 	 * @type {string}
 	 */
 	namespace: {
-		validator: core.isString,
+		validator: isString,
 	},
 
 	/**
@@ -281,7 +287,7 @@ DynamicInlineScroll.STATE = {
 	 */
 	pages: {
 		setter: 'getNumber_',
-		validator: core.isString,
+		validator: isString,
 	},
 
 	/**
@@ -292,7 +298,7 @@ DynamicInlineScroll.STATE = {
 	 * @type {string}
 	 */
 	randomNamespace: {
-		validator: core.isString,
+		validator: isString,
 	},
 
 	/**
@@ -303,7 +309,7 @@ DynamicInlineScroll.STATE = {
 	 * @type {string}
 	 */
 	url: {
-		validator: core.isString,
+		validator: isString,
 	},
 
 	/**
@@ -314,7 +320,7 @@ DynamicInlineScroll.STATE = {
 	 * @type {string}
 	 */
 	urlAnchor: {
-		validator: core.isString,
+		validator: isString,
 	},
 };
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/PortletBase.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/PortletBase.es.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import core from 'metal';
 import Component from 'metal-component';
 
 import objectToFormData from './util/form/object_to_form_data.es';
@@ -23,6 +22,10 @@ function toElementHelper(elementOrSelector) {
 	}
 
 	return elementOrSelector;
+}
+
+function isString(val) {
+	return typeof val === 'string';
 }
 
 /**
@@ -182,7 +185,7 @@ PortletBase.STATE = {
 	 * @type {string}
 	 */
 	namespace: {
-		validator: core.isString,
+		validator: isString,
 	},
 
 	/**
@@ -193,7 +196,7 @@ PortletBase.STATE = {
 	 * @type {string}
 	 */
 	portletNamespace: {
-		validator: core.isString,
+		validator: isString,
 	},
 
 	/**

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/component.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/component.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-import {isFunction} from 'metal';
-
 const componentConfigs = {};
 let componentPromiseWrappers = {};
 const components = {};
@@ -136,9 +134,10 @@ const _onStartNavigate = function (event) {
 				}
 			);
 
-			const cacheableComponent = isFunction(component.isCacheable)
-				? component.isCacheable(uri)
-				: false;
+			const cacheableComponent =
+				typeof component.isCacheable === 'function'
+					? component.isCacheable(uri)
+					: false;
 
 			return (
 				cacheableComponent &&
@@ -207,7 +206,7 @@ const component = function (id, value, componentConfig) {
 	if (arguments.length === 1) {
 		let component = components[id];
 
-		if (component && isFunction(component)) {
+		if (component && typeof component === 'function') {
 			componentsFn[id] = component;
 
 			component = component();

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/PortletInit.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/PortletInit.es.js
@@ -12,10 +12,10 @@
  * details.
  */
 
-import {isDefAndNotNull, isFunction, isObject, isString} from 'metal';
 import uuidv1 from 'uuid/v1';
 
 import fetch from './../util/fetch.es';
+import isObject from './../util/is_object';
 import RenderState from './RenderState.es';
 import PortletConstants from './portlet_constants.es';
 import {
@@ -202,7 +202,7 @@ class PortletInit {
 	 */
 
 	_setPageState(portletId, updateString) {
-		if (!isString(updateString)) {
+		if (typeof updateString !== 'string') {
 			throw new TypeError(`Invalid update string: ${updateString}`);
 		}
 
@@ -636,7 +636,7 @@ class PortletInit {
 			);
 		}
 
-		if (!isString(type) || !isFunction(handler)) {
+		if (typeof type !== 'string' || typeof handler !== 'function') {
 			throw new TypeError('Invalid arguments passed to addEventListener');
 		}
 
@@ -706,7 +706,7 @@ class PortletInit {
 		let cacheability = null;
 
 		if (cache) {
-			if (isString(cache)) {
+			if (typeof cache === 'string') {
 				if (
 					cache === 'cacheLevelPage' ||
 					cache === 'cacheLevelPortlet' ||
@@ -731,7 +731,7 @@ class PortletInit {
 			cacheability = 'cacheLevelPage';
 		}
 
-		if (resourceId && !isString(resourceId)) {
+		if (resourceId && typeof resourceId !== 'string') {
 			throw new TypeError(
 				'Invalid argument type. Resource ID argument must be a string.'
 			);
@@ -838,7 +838,7 @@ class PortletInit {
 			);
 		}
 
-		if (!isDefAndNotNull(handle)) {
+		if (handle === undefined || handle === null) {
 			throw new TypeError(
 				`The event handle provided is ${typeof handle}`
 			);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/RenderState.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/RenderState.es.js
@@ -12,8 +12,7 @@
  * details.
  */
 
-import {isObject, isString} from 'metal';
-
+import isObject from './../util/is_object';
 import PortletConstants from './portlet_constants.es';
 
 class RenderState {
@@ -82,7 +81,7 @@ class RenderState {
 	 */
 
 	getValue(name, defaultValue) {
-		if (!isString(name)) {
+		if (typeof name !== 'string') {
 			throw new TypeError('Parameter name must be a string');
 		}
 
@@ -111,7 +110,7 @@ class RenderState {
 	 */
 
 	getValues(name, defaultValue) {
-		if (!isString(name)) {
+		if (typeof name !== 'string') {
 			throw new TypeError('Parameter name must be a string');
 		}
 
@@ -139,7 +138,7 @@ class RenderState {
 	 */
 
 	remove(name) {
-		if (!isString(name)) {
+		if (typeof name !== 'string') {
 			throw new TypeError('Parameter name must be a string');
 		}
 
@@ -157,7 +156,7 @@ class RenderState {
 	 */
 
 	setPortletMode(portletMode) {
-		if (!isString(portletMode)) {
+		if (typeof portletMode !== 'string') {
 			throw new TypeError('Portlet Mode must be a string');
 		}
 
@@ -180,11 +179,15 @@ class RenderState {
 	 */
 
 	setValue(name, value) {
-		if (!isString(name)) {
+		if (typeof name !== 'string') {
 			throw new TypeError('Parameter name must be a string');
 		}
 
-		if (!isString(value) && value !== null && !Array.isArray(value)) {
+		if (
+			typeof value !== 'string' &&
+			value !== null &&
+			!Array.isArray(value)
+		) {
 			throw new TypeError(
 				'Parameter value must be a string, an array or null'
 			);
@@ -220,7 +223,7 @@ class RenderState {
 	 */
 
 	setWindowState(windowState) {
-		if (!isString(windowState)) {
+		if (typeof windowState !== 'string') {
 			throw new TypeError('Window State must be a string');
 		}
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/portlet_util.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/portlet_util.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-import {isDefAndNotNull, isString} from 'metal';
-
 // Constants for URL generation
 
 const AJAX_ACTION_VALUE = '0';
@@ -834,7 +832,7 @@ const validateForm = function (form) {
  */
 
 const validateParameters = function (parameters) {
-	if (!isDefAndNotNull(parameters)) {
+	if (!(parameters !== undefined && parameters !== null)) {
 		throw new TypeError(`The parameter object is: ${typeof parameters}`);
 	}
 
@@ -882,7 +880,7 @@ const validateState = function (state = {}, portletData = {}) {
 
 	const portletMode = state.portletMode;
 
-	if (!isString(portletMode)) {
+	if (typeof portletMode !== 'string') {
 		throw new TypeError(
 			`Invalid parameters. portletMode is ${typeof portletMode}`
 		);
@@ -899,7 +897,7 @@ const validateState = function (state = {}, portletData = {}) {
 
 	const windowState = state.windowState;
 
-	if (!isString(windowState)) {
+	if (typeof windowState !== 'string') {
 		throw new TypeError(
 			`Invalid parameters. windowState is ${typeof windowState}`
 		);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/form/object_to_form_data.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/form/object_to_form_data.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {isObject} from 'metal';
+import isObject from './../is_object';
 
 /**
  * Returns a FormData containing serialized object.

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/form/post_form.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/form/post_form.es.js
@@ -12,8 +12,7 @@
  * details.
  */
 
-import {isDef, isObject, isString} from 'metal';
-
+import isObject from './../is_object';
 import setFormValues from './set_form_values.es';
 
 /**
@@ -44,10 +43,10 @@ export default function postForm(form, options) {
 				return;
 			}
 
-			if (!isDef(url)) {
+			if (url === undefined) {
 				submitForm(form);
 			}
-			else if (isString(url)) {
+			else if (typeof url === 'string') {
 				submitForm(form, url);
 			}
 		}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/form/set_form_values.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/form/set_form_values.es.js
@@ -12,8 +12,7 @@
  * details.
  */
 
-import {isDef, isObject} from 'metal';
-
+import isObject from './../is_object';
 import getFormElement from './get_form_element.es';
 
 /**
@@ -25,7 +24,7 @@ import getFormElement from './get_form_element.es';
  */
 
 export default function setFormValues(form, data) {
-	if (!isDef(form) || form.nodeName !== 'FORM' || !isObject(data)) {
+	if (form === undefined || form.nodeName !== 'FORM' || !isObject(data)) {
 		return;
 	}
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/format_storage.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/format_storage.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-import {isNumber} from 'metal';
-
 const DEFAULT_OPTIONS = {
 	addSpaceBeforeSuffix: false,
 	decimalSeparator: '.',
@@ -44,7 +42,7 @@ export default function formatStorage(size, options = {}) {
 		...options,
 	};
 
-	if (!isNumber(size)) {
+	if (typeof size !== 'number') {
 		throw new TypeError('Parameter size must be a number');
 	}
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/format_xml.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/format_xml.es.js
@@ -12,8 +12,6 @@
  * details.
  */
 
-import {isString} from 'metal';
-
 const NEW_LINE = '\r\n';
 
 const REGEX_CDATA = /<!\[CDATA\[.*?\]\]>/gs;
@@ -75,7 +73,7 @@ export default function formatXML(content, options = {}) {
 		...options,
 	};
 
-	if (!isString(content)) {
+	if (typeof content !== 'string') {
 		throw new TypeError('Parameter content must be a string');
 	}
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_crop_region.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_crop_region.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {isObject} from 'metal';
+import isObject from './is_object';
 
 /**
  * Returns dimensions and coordinates representing a cropped region

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/is_object.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/is_object.js
@@ -13,26 +13,13 @@
  */
 
 /**
- * Returns a DOM element or elements in a form.
- * @param {!Element} form The form DOM element
- * @param {!string} elementName The name of the DOM element
- * @return {Element|NodeList|null} The DOM element or elements in the form, with
- * the given name
- * @review
+ * Returns true if the specified value is an object. This includes arrays
+ * and functions.
+ * @param {?} val Variable to test.
+ * @return {boolean} Whether variable is an object.
  */
+export default function isObject(val) {
+	const type = typeof val;
 
-export default function getFormElement(form, elementName) {
-	let formElement = null;
-
-	if (
-		form !== undefined &&
-		form.nodeName === 'FORM' &&
-		typeof elementName === 'string'
-	) {
-		const ns = form.dataset.fmNamespace || '';
-
-		formElement = form.elements[ns + elementName] || null;
-	}
-
-	return formElement;
+	return (type === 'object' && val !== null) || type === 'function';
 }

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/object_to_url_search_params.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/object_to_url_search_params.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {isObject} from 'metal';
+import isObject from './is_object';
 
 /**
  * Returns a FormData containing serialized object.

--- a/modules/apps/layout/layout-admin-web/package.json
+++ b/modules/apps/layout/layout-admin-web/package.json
@@ -13,7 +13,6 @@
 		"@clayui/popover": "3.5.2",
 		"classnames": "2.2.6",
 		"frontend-js-web": "*",
-		"metal": "2.16.8",
 		"metal-component": "2.16.8",
 		"metal-drag-drop": "3.3.1",
 		"metal-events": "2.16.8",

--- a/modules/apps/layout/layout-seo-web/package.json
+++ b/modules/apps/layout/layout-seo-web/package.json
@@ -2,7 +2,6 @@
 	"dependencies": {
 		"frontend-js-react-web": "*",
 		"frontend-js-web": "*",
-		"metal": "2.16.8",
 		"prop-types": "15.7.2",
 		"react": "16.12.0"
 	},

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/PreviewSeo.es.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/PreviewSeo.es.js
@@ -13,7 +13,7 @@
  */
 
 import {useIsMounted} from 'frontend-js-react-web';
-import {isObject} from 'metal';
+import {isObject} from 'frontend-js-web';
 import {PropTypes} from 'prop-types';
 import React, {useCallback, useEffect, useState} from 'react';
 

--- a/modules/apps/map/map-common/package.json
+++ b/modules/apps/map/map-common/package.json
@@ -1,7 +1,6 @@
 {
 	"dependencies": {
 		"frontend-js-web": "*",
-		"metal": "2.16.8",
 		"metal-state": "2.16.8"
 	},
 	"name": "map-common",

--- a/modules/apps/map/map-openstreetmap/package.json
+++ b/modules/apps/map/map-openstreetmap/package.json
@@ -1,6 +1,5 @@
 {
 	"dependencies": {
-		"metal": "2.16.8",
 		"metal-state": "2.16.8"
 	},
 	"name": "map-openstreetmap",

--- a/modules/apps/message-boards/message-boards-web/package.json
+++ b/modules/apps/message-boards/message-boards-web/package.json
@@ -1,7 +1,6 @@
 {
 	"dependencies": {
 		"frontend-js-web": "*",
-		"metal": "2.16.8",
 		"metal-events": "2.16.8"
 	},
 	"name": "message-boards-web",

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/package.json
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/package.json
@@ -5,7 +5,6 @@
 		"@clayui/icon": "3.1.0",
 		"@clayui/loading-indicator": "3.2.0",
 		"frontend-js-web": "*",
-		"metal": "2.16.8",
 		"metal-events": "2.16.8",
 		"metal-state": "2.16.8",
 		"react": "16.12.0",

--- a/modules/apps/segments/segments-web/package.json
+++ b/modules/apps/segments/segments-web/package.json
@@ -12,7 +12,6 @@
 		"date-fns": "^1.30.1",
 		"formik": "2.1.4",
 		"frontend-js-web": "*",
-		"metal": "2.16.8",
 		"odata-v4-parser": "^0.1.29",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/utils/utils.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/utils/utils.es.js
@@ -13,7 +13,6 @@
  */
 
 import dateFns from 'date-fns';
-import {getUid} from 'metal';
 
 import {CONJUNCTIONS} from './constants.es';
 
@@ -32,12 +31,14 @@ export const createNewGroup = (items) => ({
 	items,
 });
 
+let uniqueIdCounter_ = 1;
+
 /**
  * Generates a unique group id.
  * @return {string} The unique id.
  */
 export function generateGroupId() {
-	return `${GROUP_ID_NAMESPACE}${getUid()}`;
+	return `${GROUP_ID_NAMESPACE}${uniqueIdCounter_++}`;
 }
 
 /**

--- a/modules/apps/wiki/wiki-web/package.json
+++ b/modules/apps/wiki/wiki-web/package.json
@@ -1,7 +1,6 @@
 {
 	"dependencies": {
 		"frontend-js-web": "*",
-		"metal": "2.16.8",
 		"metal-events": "2.16.8"
 	},
 	"name": "wiki-web",


### PR DESCRIPTION
Manual forward from https://github.com/liferay-frontend/liferay-portal/pull/681

QA approval at https://github.com/liferay-frontend/liferay-portal/pull/681#issuecomment-759122113

------------------------

Removes all uses of metal core utilities. Most replacements are now inline checks, except for isObject which I moved to util since it required more than one or two typeof checks.