### PR TITLE
LPS-125579 Adapt modules for new sass build process from npm-scripts (master only)

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/build.gradle
+++ b/modules/apps/adaptive-media/adaptive-media-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/blogs/blogs-web/build.gradle
+++ b/modules/apps/blogs/blogs-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/calendar/calendar-web/build.gradle
+++ b/modules/apps/calendar/calendar-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/change-tracking/change-tracking-web/build.gradle
+++ b/modules/apps/change-tracking/change-tracking-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "clay-css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/contacts/contacts-web/build.gradle
+++ b/modules/apps/contacts/contacts-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/content-dashboard/content-dashboard-web/build.gradle
+++ b/modules/apps/content-dashboard/content-dashboard-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/data-engine/data-engine-taglib/build.gradle
+++ b/modules/apps/data-engine/data-engine-taglib/build.gradle
@@ -1,11 +1,5 @@
 apply plugin: "com.liferay.alloy.taglib"
 
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 buildTaglibs {
 	componentsXmlFiles "liferay-data-engine.xml"
 	javaPackage = "com.liferay.data.engine.taglib.servlet"

--- a/modules/apps/depot/depot-web/build.gradle
+++ b/modules/apps/depot/depot-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/document-library/document-library-video/build.gradle
+++ b/modules/apps/document-library/document-library-video/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/document-library/document-library-web/build.gradle
+++ b/modules/apps/document-library/document-library-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/fragment/fragment-web/build.gradle
+++ b/modules/apps/fragment/fragment-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/build.gradle
+++ b/modules/apps/frontend-theme/frontend-theme-classic-style-guide-sample-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"

--- a/modules/apps/invitation/invitation-invite-members-web/build.gradle
+++ b/modules/apps/invitation/invitation-invite-members-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/journal/journal-web/build.gradle
+++ b/modules/apps/journal/journal-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/layout/layout-admin-web/build.gradle
+++ b/modules/apps/layout/layout-admin-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/layout/layout-content-page-editor-web/build.gradle
+++ b/modules/apps/layout/layout-content-page-editor-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileInclude group: "com.liferay", name: "org.jsoup", version: "1.10.2.LIFERAY-PATCHED-3"
 

--- a/modules/apps/layout/layout-seo-web/build.gradle
+++ b/modules/apps/layout/layout-seo-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/message-boards/message-boards-web/build.gradle
+++ b/modules/apps/message-boards/message-boards-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/portal-workflow/portal-workflow-task-web/build.gradle
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/build.gradle
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/build.gradle
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/build.gradle
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/questions/questions-web/build.gradle
+++ b/modules/apps/questions/questions-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/ratings/ratings-taglib/build.gradle
+++ b/modules/apps/ratings/ratings-taglib/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/redirect/redirect-web/build.gradle
+++ b/modules/apps/redirect/redirect-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "clay-css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/roles/roles-admin-web/build.gradle
+++ b/modules/apps/roles/roles-admin-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/site-navigation/site-navigation-admin-web/build.gradle
+++ b/modules/apps/site-navigation/site-navigation-admin-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/site-navigation/site-navigation-menu-web/build.gradle
+++ b/modules/apps/site-navigation/site-navigation-menu-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/staging/staging-bar-web/build.gradle
+++ b/modules/apps/staging/staging-bar-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/style-book/style-book-web/build.gradle
+++ b/modules/apps/style-book/style-book-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/translation/translation-web/build.gradle
+++ b/modules/apps/translation/translation-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/users-admin/users-admin-web/build.gradle
+++ b/modules/apps/users-admin/users-admin-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/wiki/wiki-web/build.gradle
+++ b/modules/apps/wiki/wiki-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -422,6 +422,20 @@ gradle.beforeProject {
 			buildCSS {
 				rtlExcludedPathRegexps = [".+"]
 			}
+
+			if (FileUtil.exists(project, "package.json")) {
+				File packageJSONFile = project.file("package.json")
+
+				if (packageJSONFile.text.contains("liferay-npm-scripts build")) {
+					buildCSS {
+						enabled = false
+					}
+
+					copyCSS {
+						enabled = false
+					}
+				}
+			}
 		}
 
 		pluginManager.withPlugin("com.liferay.osgi.plugin") {

--- a/modules/dxp/apps/analytics/analytics-reports-web/build.gradle
+++ b/modules/dxp/apps/analytics/analytics-reports-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileInclude group: "org.apache.httpcomponents", name: "httpclient", version: "4.5.3"
 	compileInclude group: "org.apache.httpcomponents", name: "httpcore", version: "4.4.6"

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/build.gradle
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/dxp/apps/segments/segments-experiment-web/build.gradle
+++ b/modules/dxp/apps/segments/segments-experiment-web/build.gradle
@@ -1,9 +1,3 @@
-buildCSS {
-	imports = [
-		new File(npmInstall.nodeModulesDir, "@clayui/css/src/scss")
-	]
-}
-
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormRules.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormRules.testcase
@@ -1297,8 +1297,8 @@ definition {
 	@description = "This is a use case for LPS-73332."
 	@priority = "2"
 	test ViewPreviousFormRuleIsCopiedToNewDuplicatedForm {
-		property portal.acceptance = "true";
-		property portal.upstream = "true";
+		property portal.acceptance = "quarantine";
+		property portal.upstream = "quarantine";
 		property test.name.skip.portal.instance = "FormRules#ViewPreviousFormRuleIsCopiedToNewDuplicatedForm";
 
 		Navigator.openURL();
@@ -1405,8 +1405,8 @@ definition {
 	@description = "This is a use case for LPS-75495."
 	@priority = "3"
 	test ViewShowRuleActivationAfterInputtingUnrelatedField {
-		property portal.acceptance = "true";
-		property portal.upstream = "true";
+		property portal.acceptance = "quarantine";
+		property portal.upstream = "quarantine";
 		property test.name.skip.portal.instance = "FormRules#ViewShowRuleActivationAfterInputtingUnrelatedField";
 
 		Navigator.openURL();


### PR DESCRIPTION
Manual forward from https://github.com/liferay-frontend/liferay-portal/pull/680

Passing tests at https://github.com/liferay-frontend/liferay-portal/pull/680#issuecomment-757020293

This removes un-used gradle tasks and only runs buildCSS and copyCSS if the module is not using npm-scripts to build the frontend assets.

------------------------------------------

This is a follow up from https://github.com/liferay-frontend/liferay-portal/pull/617

- Updates npm-scripts to [36.8.0](https://github.com/liferay/liferay-frontend-projects/releases/tag/npm-scripts%2Fv36.8.0)
- Updates gradle plugins to only run the buildCSS and copyCSS tasks if the `build` npm script doesn't exist
- Removes any specified buildCSS and copyCSS tasks from modules that rely on npm-scripts