### PR TITLE
Revert "LRQA-53768 Temporarily disable js fast load for slow app servers"

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -8994,11 +8994,7 @@ portal.security.manager.strategy=liferay</echo>
 		</if>
 
 		<if>
-			<or>
-				<equals arg1="${app.server.type}" arg2="weblogic" />
-				<equals arg1="${app.server.type}" arg2="websphere" />
-				<equals arg1="${javascript.fast.load}" arg2="false" />
-			</or>
+			<equals arg1="${javascript.fast.load}" arg2="false" />
 			<then>
 				<echo append="true" file="portal-impl/src/portal-ext.properties">
 


### PR DESCRIPTION
Can go back to 7.1.x but 7.3.x ONLY needed an additional commit. Sent https://github.com/brianchandotcom/liferay-portal-ee/pull/33119