### PR TITLE
LPS-122094 [7.4-only] Update to @liferay/npm-scripts v37.0.0

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
@@ -112,7 +112,7 @@ List<String> domains = accountEntryDisplay.getDomains();
 
 	searchContainerContentBox.delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var link = event.currentTarget;
 
 			var rowId = link.attr('data-rowId');
@@ -131,7 +131,7 @@ List<String> domains = accountEntryDisplay.getDomains();
 	var addDomainsIcon = document.getElementById('<portlet:namespace />addDomains');
 
 	if (addDomainsIcon) {
-		addDomainsIcon.addEventListener('click', function (event) {
+		addDomainsIcon.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			Liferay.Util.openModal({
@@ -142,7 +142,7 @@ List<String> domains = accountEntryDisplay.getDomains();
 						onEvent: function (event) {
 							var newDomains = event.data.split(',');
 
-							newDomains.forEach(function (domain) {
+							newDomains.forEach((domain) => {
 								domain = domain.trim();
 
 								if (!domains.includes(domain)) {

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/select_account_organizations.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/select_account_organizations.jsp
@@ -59,7 +59,7 @@ SearchContainer<Organization> organizationSearchContainer = AssignableAccountOrg
 		'<portlet:namespace />organizations'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var selectedItems = event.elements.allSelectedElements;
 
 		var result = {};

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/select_account_users.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/select_account_users.jsp
@@ -107,7 +107,7 @@ String eventName = ParamUtil.getString(request, "eventName", liferayPortletRespo
 		'<portlet:namespace />accountUsers'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var selectedItems = event.elements.allSelectedElements;
 
 		var result = {};

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/account_user/account_entries.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/account_user/account_entries.jsp
@@ -151,7 +151,7 @@ portletDisplay.setURLBack(backURL);
 
 	searchContainerContentBox.delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var link = event.currentTarget;
 
 			var rowId = link.attr('data-rowId');
@@ -189,7 +189,7 @@ portletDisplay.setURLBack(backURL);
 	var selectAccountLink = A.one('#<portlet:namespace />selectAccountLink');
 
 	if (selectAccountLink) {
-		selectAccountLink.on('click', function (event) {
+		selectAccountLink.on('click', (event) => {
 			var searchContainerData = searchContainer.getData();
 
 			if (!searchContainerData.length) {

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entries.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entries.jsp
@@ -61,7 +61,7 @@ SearchContainer<AccountEntryDisplay> accountEntryDisplaySearchContainer = Accoun
 		'<portlet:namespace />accountEntries'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var selectedItems = event.elements.allSelectedElements;
 
 		var result = {};

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entry.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entry.jsp
@@ -114,7 +114,7 @@ if (selectAccountEntryManagementToolbarDisplayContext.isSingleSelect()) {
 				'<portlet:namespace />accountEntries'
 			);
 
-			searchContainer.on('rowToggled', function (event) {
+			searchContainer.on('rowToggled', (event) => {
 				var selectedItems = event.elements.allSelectedElements;
 
 				var result = {};

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/add_channel.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/add_channel.jsp
@@ -166,17 +166,17 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 		}
 	}
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		return <portlet:namespace />handleSubmitButton(
 			event.elements.allSelectedElements
 		);
 	});
 
-	Liferay.componentReady('<portlet:namespace />selectGroups').then(function (
-		searchContainer
-	) {
-		return <portlet:namespace />handleSubmitButton(
-			searchContainer.select.getAllSelectedElements()
-		);
-	});
+	Liferay.componentReady('<portlet:namespace />selectGroups').then(
+		(searchContainer) => {
+			return <portlet:namespace />handleSubmitButton(
+				searchContainer.select.getAllSelectedElements()
+			);
+		}
+	);
 </aui:script>

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts_fields.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts_fields.jsp
@@ -204,7 +204,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 	Liferay.provide(
 		window,
 		'<portlet:namespace />showConfirmationModal',
-		function (event) {
+		(event) => {
 			var dialog = Liferay.Util.Window.getWindow({
 				dialog: {
 					bodyContent:

--- a/modules/apps/analytics/analytics-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
+++ b/modules/apps/analytics/analytics-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
@@ -43,7 +43,7 @@ String analyticsClientGroupIds = (String)request.getAttribute(AnalyticsWebKeys.A
 		a.src = u;
 		a.onload = c;
 		m.parentNode.insertBefore(a, m);
-	})('https://analytics-js-cdn.liferay.com', function () {
+	})('https://analytics-js-cdn.liferay.com', () => {
 		var config = <%= analyticsClientConfig %>;
 
 		var dxpMiddleware = function (request) {
@@ -68,7 +68,7 @@ String analyticsClientGroupIds = (String)request.getAttribute(AnalyticsWebKeys.A
 		Analytics.send('pageViewed', 'Page');
 
 		<c:if test="<%= GetterUtil.getBoolean(PropsUtil.get(PropsKeys.JAVASCRIPT_SINGLE_PAGE_APPLICATION_ENABLED)) %>">
-			Liferay.on('endNavigate', function (event) {
+			Liferay.on('endNavigate', (event) => {
 				Analytics.dispose();
 
 				var groupId = themeDisplay.getScopeGroupIdOrLiveGroupId();

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
@@ -290,7 +290,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 		if (customizeAnnouncementsDisplayedCheckbox) {
 			customizeAnnouncementsDisplayedCheckbox.addEventListener(
 				'change',
-				function () {
+				() => {
 					<portlet:namespace />modified(
 						document.getElementById(
 							'<portlet:namespace />announcementsDisplayedPanel'
@@ -324,7 +324,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 			selectedHTML = selectedHTML.concat(selected[i].innerHTML);
 		}
 
-		Liferay.on('inputmoveboxes:moveItem', function (event) {
+		Liferay.on('inputmoveboxes:moveItem', (event) => {
 			var currSelectedHTML = '';
 
 			for (var i = selected.length - 1; i >= 0; --i) {
@@ -347,7 +347,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 		);
 
 		if (pageDeltaInput) {
-			pageDeltaInput.addEventListener('change', function (event) {
+			pageDeltaInput.addEventListener('change', (event) => {
 				var displaySettingsPanel = document.getElementById(
 					'<portlet:namespace />displaySettingsPanel'
 				);

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/view_entries.jspf
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/view_entries.jspf
@@ -80,7 +80,7 @@ if ((entriesCount == 0) && portletName.equals(AnnouncementsPortletKeys.ALERTS) &
 				entryId: entryId,
 				value: <%= AnnouncementsFlagConstants.HIDDEN %>,
 			},
-			function (response) {
+			(response) => {
 				Liferay.Service(
 					'/announcementsflag/delete-flag',
 					{

--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel_category/end.jsp
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel_category/end.jsp
@@ -29,7 +29,7 @@
 
 	<c:if test="<%= persistState %>">
 		<aui:script position="auto">
-			Liferay.on('liferay.collapse.hidden', function (event) {
+			Liferay.on('liferay.collapse.hidden', (event) => {
 				var panelId = event.panel.getAttribute('id');
 
 				if (panelId === '<%= id %>') {
@@ -40,7 +40,7 @@
 				}
 			});
 
-			Liferay.on('liferay.collapse.shown', function (event) {
+			Liferay.on('liferay.collapse.shown', (event) => {
 				var panelId = event.panel.getAttribute('id');
 
 				if (panelId === '<%= id %>') {

--- a/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -230,7 +230,7 @@
 				'<portlet:namespace />selectAssetEntries'
 			);
 
-			searchContainer.on('rowToggled', function (event) {
+			searchContainer.on('rowToggled', (event) => {
 				var selectedItems = event.elements.allSelectedElements;
 
 				var arr = [];
@@ -274,7 +274,7 @@
 				document.querySelector('#<portlet:namespace />selectAssetFm'),
 				'click',
 				'.selector-button',
-				function (event) {
+				(event) => {
 					event.preventDefault();
 
 					Liferay.Util.getOpener().Liferay.fire(

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp
@@ -212,7 +212,7 @@ renderResponse.setTitle(title);
 					);
 					cancelButton.setAttribute('type', 'button');
 					cancelButton.innerText = '<liferay-ui:message key="cancel" />';
-					cancelButton.addEventListener('click', function () {
+					cancelButton.addEventListener('click', () => {
 						footer.get('boundingBox').all('.add-category-toolbar-button').hide();
 						Liferay.Util.navigate('<%= HtmlUtil.escapeJS(redirect) %>');
 					});
@@ -227,7 +227,7 @@ renderResponse.setTitle(title);
 					saveAndAddNewButton.setAttribute('type', 'submit');
 					saveAndAddNewButton.innerText =
 						'<liferay-ui:message key="save-and-add-a-new-one" />';
-					saveAndAddNewButton.addEventListener('click', function () {
+					saveAndAddNewButton.addEventListener('click', () => {
 						<portlet:namespace />saveAndAddNew();
 					});
 
@@ -240,7 +240,7 @@ renderResponse.setTitle(title);
 					);
 					submitButton.setAttribute('type', 'submit');
 					submitButton.innerText = '<liferay-ui:message key="save" />';
-					submitButton.addEventListener('click', function () {
+					submitButton.addEventListener('click', () => {
 						submitForm(document.querySelector('#<portlet:namespace />fm'));
 					});
 

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category_action.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category_action.jsp
@@ -100,7 +100,7 @@ AssetCategory category = (AssetCategory)row.getObject();
 		);
 
 		if (moveCategoryIcon) {
-			moveCategoryIcon.addEventListener('click', function (event) {
+			moveCategoryIcon.addEventListener('click', (event) => {
 				var itemSelectorDialog = new ItemSelectorDialog.default({
 					eventName: '<portlet:namespace />selectCategory',
 					title:
@@ -111,7 +111,7 @@ AssetCategory category = (AssetCategory)row.getObject();
 
 				itemSelectorDialog.open();
 
-				itemSelectorDialog.on('selectedItemChange', function (event) {
+				itemSelectorDialog.on('selectedItemChange', (event) => {
 					var selectedItem = event.selectedItem;
 
 					if (selectedItem) {

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/edit_vocabulary_settings.jspf
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/edit_vocabulary_settings.jspf
@@ -152,7 +152,7 @@ if (vocabulary != null) {
 
 	form.delegate(
 		'change',
-		function (event) {
+		(event) => {
 			var target = event.currentTarget;
 
 			var row = target.ancestor('.lfr-form-row');

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view_vocabularies.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view_vocabularies.jsp
@@ -107,7 +107,7 @@
 		'<portlet:namespace />assetVocabularies'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(assetCategoriesDisplayContext.getEventName()) %>',
 			{

--- a/modules/apps/asset/asset-display-page-item-selector-web/src/main/resources/META-INF/resources/display_pages.jsp
+++ b/modules/apps/asset/asset-display-page-item-selector-web/src/main/resources/META-INF/resources/display_pages.jsp
@@ -57,11 +57,11 @@ AssetDisplayPagesItemSelectorViewDisplayContext assetDisplayPagesItemSelectorVie
 		document.querySelector('#<portlet:namespace />fm'),
 		'click',
 		'.layout-page-template-entry',
-		function (event) {
+		(event) => {
 			var activeCards = document.querySelectorAll('.form-check-card.active');
 
 			if (activeCards.length) {
-				activeCards.forEach(function (card) {
+				activeCards.forEach((card) => {
 					card.classList.remove('active');
 				});
 			}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/scope.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/scope.jsp
@@ -117,7 +117,7 @@ List<Group> selectedGroups = editAssetListDisplayContext.getSelectedGroups();
 
 	searchContainer.get('contentBox').delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var link = event.currentTarget;
 
 			var tr = link.ancestor('tr');
@@ -136,7 +136,7 @@ List<Group> selectedGroups = editAssetListDisplayContext.getSelectedGroups();
 	);
 
 	if (selectManageableGroupIcon) {
-		selectManageableGroupIcon.addEventListener('click', function (event) {
+		selectManageableGroupIcon.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			Liferay.Util.openSelectionModal({

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
@@ -224,7 +224,7 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 		document.body,
 		'click',
 		'.asset-selector a',
-		function (event) {
+		(event) => {
 			event.preventDefault();
 
 			var delegateTarget = event.delegateTarget;
@@ -236,11 +236,12 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 					if (selectedItems) {
 						var assetEntryIds = [];
 
-						Array.prototype.forEach.call(selectedItems, function (
-							assetEntry
-						) {
-							assetEntryIds.push(assetEntry.entityid);
-						});
+						Array.prototype.forEach.call(
+							selectedItems,
+							(assetEntry) => {
+								assetEntryIds.push(assetEntry.entityid);
+							}
+						);
 
 						Liferay.Util.postForm(document.<portlet:namespace />fm, {
 							data: {

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
@@ -230,7 +230,7 @@ for (long groupId : groupIds) {
 		var assetClassName = '';
 		var assetEntryIds = [];
 
-		Array.prototype.forEach.call(assetEntryList, function (assetEntry) {
+		Array.prototype.forEach.call(assetEntryList, (assetEntry) => {
 			assetEntryIds.push(assetEntry.entityid);
 
 			assetClassName = assetEntry.assetclassname;
@@ -252,7 +252,7 @@ for (long groupId : groupIds) {
 		document.body,
 		'click',
 		'.asset-selector a',
-		function (event) {
+		(event) => {
 			event.preventDefault();
 
 			var delegateTarget = event.delegateTarget;

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_list.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_list.jsp
@@ -52,7 +52,7 @@ AssetListEntry assetListEntry = assetPublisherDisplayContext.fetchAssetListEntry
 	);
 
 	if (selectAssetListButton) {
-		selectAssetListButton.addEventListener('click', function () {
+		selectAssetListButton.addEventListener('click', () => {
 			Liferay.Util.openSelectionModal({
 				onSelect: function (selectedItem) {
 					if (selectedItem) {
@@ -77,7 +77,7 @@ AssetListEntry assetListEntry = assetPublisherDisplayContext.fetchAssetListEntry
 	);
 
 	if (clearAssetListButton) {
-		clearAssetListButton.addEventListener('click', function (event) {
+		clearAssetListButton.addEventListener('click', (event) => {
 			assetListTitle.innerHTML = '<liferay-ui:message key="none" />';
 
 			assetListEntryId.value = '';

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/display_settings.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/display_settings.jsp
@@ -83,7 +83,7 @@ PortletURL configurationRenderURL = (PortletURL)request.getAttribute("configurat
 
 		var hiddenFields = document.querySelectorAll('.hidden-field');
 
-		Array.prototype.forEach.call(hiddenFields, function (field) {
+		Array.prototype.forEach.call(hiddenFields, (field) => {
 			var fieldContainer = field.closest('.form-group');
 
 			if (fieldContainer) {

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/scope.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/scope.jsp
@@ -148,7 +148,7 @@ itemSelectorURL.setParameter("portletResource", assetPublisherDisplayContext.get
 	);
 
 	if (scopeSelect) {
-		scopeSelect.addEventListener('click', function (event) {
+		scopeSelect.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			var searchContainer = Liferay.SearchContainer.get(

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -276,7 +276,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 			if (removeOrderBySubtype) {
 				Array.prototype.forEach.call(
 					orderingPanel.querySelectorAll('.order-by-subtype'),
-					function (option) {
+					(option) => {
 						option.remove();
 					}
 				);
@@ -378,55 +378,56 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 					'#<portlet:namespace /><%= className %>subtypeFieldsWrapper, #<portlet:namespace /><%= className %>subtypeFieldsFilterEnableWrapper'
 				);
 
-				Array.prototype.forEach.call(subtypeFieldsWrappers, function (
-					subtypeFieldsWrapper
-				) {
-					if (selectedSubtype != 'false' && selectedSubtype != 'true') {
-						Array.prototype.forEach.call(
-							orderingPanel.querySelectorAll('.order-by-subtype'),
-							function (option) {
-								option.remove();
+				Array.prototype.forEach.call(
+					subtypeFieldsWrappers,
+					(subtypeFieldsWrapper) => {
+						if (selectedSubtype != 'false' && selectedSubtype != 'true') {
+							Array.prototype.forEach.call(
+								orderingPanel.querySelectorAll('.order-by-subtype'),
+								(option) => {
+									option.remove();
+								}
+							);
+
+							var optTextOrderByColumn1 =
+								MAP_DDM_STRUCTURES[
+									'<%= className %>_' +
+										selectedSubtype +
+										'_optTextOrderByColumn1'
+								];
+
+							if (optTextOrderByColumn1) {
+								orderByColumn1.append(buildFragment(optTextOrderByColumn1));
 							}
-						);
 
-						var optTextOrderByColumn1 =
-							MAP_DDM_STRUCTURES[
-								'<%= className %>_' +
-									selectedSubtype +
-									'_optTextOrderByColumn1'
-							];
+							var optTextOrderByColumn2 =
+								MAP_DDM_STRUCTURES[
+									'<%= className %>_' +
+										selectedSubtype +
+										'_optTextOrderByColumn2'
+								];
 
-						if (optTextOrderByColumn1) {
-							orderByColumn1.append(buildFragment(optTextOrderByColumn1));
-						}
+							if (optTextOrderByColumn2) {
+								orderByColumn2.append(buildFragment(optTextOrderByColumn2));
+							}
 
-						var optTextOrderByColumn2 =
-							MAP_DDM_STRUCTURES[
-								'<%= className %>_' +
-									selectedSubtype +
-									'_optTextOrderByColumn2'
-							];
-
-						if (optTextOrderByColumn2) {
-							orderByColumn2.append(buildFragment(optTextOrderByColumn2));
-						}
-
-						if (structureOptions) {
-							subtypeFieldsWrapper.classList.remove('hide');
+							if (structureOptions) {
+								subtypeFieldsWrapper.classList.remove('hide');
+							}
+							else if (hideSubtypeFilterEnableWrapper) {
+								subtypeFieldsWrapper.classList.add('hide');
+							}
 						}
 						else if (hideSubtypeFilterEnableWrapper) {
 							subtypeFieldsWrapper.classList.add('hide');
 						}
 					}
-					else if (hideSubtypeFilterEnableWrapper) {
-						subtypeFieldsWrapper.classList.add('hide');
-					}
-				});
+				);
 			}
 
 			<%= className %>toggleSubclassesFields(false);
 
-			<%= className %>SubtypeSelector.addEventListener('change', function (event) {
+			<%= className %>SubtypeSelector.addEventListener('change', (event) => {
 				setDDMFields('<%= className %>', '', '', '', '');
 
 				var subtypeFieldsFilterEnabledCheckbox = document.getElementById(
@@ -441,9 +442,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 					'.asset-subtypefields'
 				);
 
-				Array.prototype.forEach.call(assetSubtypeFields, function (
-					assetSubtypeField
-				) {
+				Array.prototype.forEach.call(assetSubtypeFields, (assetSubtypeField) => {
 					assetSubtypeField.classList.add('hide');
 				});
 
@@ -479,7 +478,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 		'<portlet:namespace />ddmStructureFieldValue'
 	);
 
-	assetSelector.addEventListener('change', function (event) {
+	assetSelector.addEventListener('change', (event) => {
 		if (ddmStructureFieldNameInput) {
 			ddmStructureFieldNameInput.value = '';
 		}
@@ -497,7 +496,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 		sourcePanel,
 		'click',
 		'.asset-subtypefields-wrapper-enable label',
-		function (event) {
+		(event) => {
 			var subtypeFieldsFilterEnabledInput = event.delegateTarget.querySelector(
 				'input'
 			);
@@ -509,7 +508,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 			if (subtypeFieldsFilterEnabledInput) {
 				Array.prototype.forEach.call(
 					assetSubtypefieldsPopupButtons,
-					function (assetSubtypefieldsPopupButton) {
+					(assetSubtypefieldsPopupButton) => {
 						Util.toggleDisabled(
 							assetSubtypefieldsPopupButton,
 							!subtypeFieldsFilterEnabledInput.checked
@@ -520,7 +519,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 		}
 	);
 
-	Liferay.after('inputmoveboxes:moveItem', function (event) {
+	Liferay.after('inputmoveboxes:moveItem', (event) => {
 		if (
 			event.fromBox.attr('id') ==
 				'<portlet:namespace />currentClassNameIds' ||
@@ -534,7 +533,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 		'<portlet:namespace />ddmStructureDisplayFieldValue'
 	);
 
-	delegate(sourcePanel, 'click', '.asset-subtypefields-popup', function (event) {
+	delegate(sourcePanel, 'click', '.asset-subtypefields-popup', (event) => {
 		var delegateTarget = event.delegateTarget;
 
 		var btn = delegateTarget.querySelector('.btn');

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -59,7 +59,7 @@ if (Validator.isNotNull(assetPublisherViewContentDisplayContext.getReturnToFullP
 </c:choose>
 
 <aui:script>
-	Liferay.once('allPortletsReady', function () {
+	Liferay.once('allPortletsReady', () => {
 		document
 			.getElementById('p_p_id_<%= portletDisplay.getId() %>_')
 			.scrollIntoView();

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_view_usages/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_view_usages/page.jsp
@@ -81,7 +81,7 @@ AssetEntryUsagesDisplayContext assetEntryUsagesDisplayContext = new AssetEntryUs
 			document.querySelector('#<portlet:namespace />assetEntryUsagesList'),
 			'click',
 			'.preview-asset-entry-usage',
-			function (event) {
+			(event) => {
 				var delegateTarget = event.delegateTarget;
 
 				Liferay.Util.openModal({

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/page.jsp
@@ -114,7 +114,7 @@
 <aui:script use="aui-base,liferay-search-container">
 	var assetSelectorHandle = A.getBody().delegate(
 		'click',
-		function (event) {
+		(event) => {
 			event.preventDefault();
 
 			var searchContainerName =
@@ -136,36 +136,41 @@
 				multiple: true,
 				onSelect: function (assetEntryIds) {
 					if (assetEntryIds) {
-						Array.prototype.forEach.call(assetEntryIds, function (
-							assetEntry
-						) {
-							var entityId = assetEntry.entityid;
+						Array.prototype.forEach.call(
+							assetEntryIds,
+							(assetEntry) => {
+								var entityId = assetEntry.entityid;
 
-							if (searchContainerData.indexOf(entityId) == -1) {
-								var entryLink =
-									'<div class="text-right"><a class="modify-link" data-rowId="' +
-									entityId +
-									'" href="javascript:;"><%= UnicodeFormatter.toString(removeLinkIcon) %></a></div>';
+								if (searchContainerData.indexOf(entityId) == -1) {
+									var entryLink =
+										'<div class="text-right"><a class="modify-link" data-rowId="' +
+										entityId +
+										'" href="javascript:;"><%= UnicodeFormatter.toString(removeLinkIcon) %></a></div>';
 
-								var entryHtml =
-									'<h4 class="list-group-title">' +
-									Liferay.Util.escapeHTML(assetEntry.assettitle) +
-									'</h4><p class="list-group-subtitle">' +
-									Liferay.Util.escapeHTML(assetEntry.assettype) +
-									'</p><p class="list-group-subtitle">' +
-									Liferay.Util.escapeHTML(
-										assetEntry.groupdescriptivename
-									) +
-									'</p>';
+									var entryHtml =
+										'<h4 class="list-group-title">' +
+										Liferay.Util.escapeHTML(
+											assetEntry.assettitle
+										) +
+										'</h4><p class="list-group-subtitle">' +
+										Liferay.Util.escapeHTML(
+											assetEntry.assettype
+										) +
+										'</p><p class="list-group-subtitle">' +
+										Liferay.Util.escapeHTML(
+											assetEntry.groupdescriptivename
+										) +
+										'</p>';
 
-								searchContainer.addRow(
-									[entryHtml, entryLink],
-									entityId
-								);
+									searchContainer.addRow(
+										[entryHtml, entryLink],
+										entityId
+									);
 
-								searchContainer.updateDataStore();
+									searchContainer.updateDataStore();
+								}
 							}
-						});
+						);
 					}
 				},
 				selectEventName:
@@ -195,7 +200,7 @@
 
 	searchContainer.get('contentBox').delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var link = event.currentTarget;
 
 			var tr = link.ancestor('tr');

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
@@ -91,7 +91,7 @@
 		'<portlet:namespace />specificDisplayPageNameInput'
 	);
 
-	chooseSpecificDisplayPage.addEventListener('click', function (event) {
+	chooseSpecificDisplayPage.addEventListener('click', (event) => {
 		Liferay.Util.openSelectionModal({
 			onSelect: function (selectedItem) {
 				assetDisplayPageIdInput.value = '';
@@ -126,7 +126,7 @@
 	);
 
 	if (previewDefaultDisplayPageButton) {
-		previewDefaultDisplayPageButton.addEventListener('click', function (event) {
+		previewDefaultDisplayPageButton.addEventListener('click', (event) => {
 			Liferay.Util.openModal({
 				title: '<liferay-ui:message key="preview" />',
 				url:
@@ -136,9 +136,7 @@
 	}
 
 	if (previewSpecificDisplayPageButton) {
-		previewSpecificDisplayPageButton.addEventListener('click', function (
-			event
-		) {
+		previewSpecificDisplayPageButton.addEventListener('click', (event) => {
 			Liferay.Util.openModal({
 				title: '<liferay-ui:message key="preview" />',
 				url:

--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/merge_tag.jsp
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/merge_tag.jsp
@@ -123,12 +123,12 @@ renderResponse.setTitle(LanguageUtil.get(request, "merge-tags"));
 	);
 
 	if (form && mergeTagNamesInputs && targetTagNameSelect) {
-		form.addEventListener('submit', function (event) {
-			var mergeTagNames = Array.from(mergeTagNamesInputs).map(function (
-				mergeTagNamesInput
-			) {
-				return mergeTagNamesInput.value;
-			});
+		form.addEventListener('submit', (event) => {
+			var mergeTagNames = Array.from(mergeTagNamesInputs).map(
+				(mergeTagNamesInput) => {
+					return mergeTagNamesInput.value;
+				}
+			);
 
 			if (mergeTagNames.length < 2) {
 				alert(

--- a/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -52,11 +52,11 @@
 
 	var selectedTagNames = <%= JSONFactoryUtil.serialize(assetTagsSelectorDisplayContext.getSelectedTagNames()) %>;
 
-	selectedTagNames = selectedTagNames.filter(function (tag) {
+	selectedTagNames = selectedTagNames.filter((tag) => {
 		return searchContainerData.indexOf(tag) === -1;
 	});
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var items = '';
 
 		var selectedItems = event.elements.allSelectedElements;

--- a/modules/apps/blogs/blogs-recent-bloggers-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/blogs/blogs-recent-bloggers-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -67,7 +67,7 @@ if (organizationId > 0) {
 
 				<portlet:namespace />selectOrganizationButton.addEventListener(
 					'click',
-					function (event) {
+					(event) => {
 						Liferay.Util.openSelectionModal({
 							onSelect: function (event) {
 								var form = document.getElementById('<portlet:namespace />fm');

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/configuration.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_aggregator/configuration.jsp
@@ -68,7 +68,7 @@ if (organizationId > 0) {
 
 					<portlet:namespace />selectOrganizationButton.addEventListener(
 						'click',
-						function (event) {
+						(event) => {
 							Liferay.Util.openSelectionModal({
 								onSelect: function (event) {
 									var form = document.getElementById('<portlet:namespace />fm');
@@ -129,7 +129,7 @@ if (organizationId > 0) {
 					);
 
 					if (selectionMethodElement) {
-						selectionMethodElement.addEventListener('change', function (event) {
+						selectionMethodElement.addEventListener('change', (event) => {
 							var usersSelectionOptions = document.getElementById(
 								'<portlet:namespace />usersSelectionOptions'
 							);

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_entry.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_entry.jsp
@@ -106,26 +106,31 @@ renderResponse.setTitle(headerTitle);
 								);
 
 								if (<portlet:namespace />selectFolderButton) {
-									<portlet:namespace />selectFolderButton.addEventListener('click', function (
-										event
-									) {
-										Liferay.Util.openSelectionModal({
-											onSelect: function (event) {
-												var folderData = {
-													idString: 'folderId',
-													idValue: event.entityid,
-													nameString: 'folderName',
-													nameValue: event.entityname,
-												};
+									<portlet:namespace />selectFolderButton.addEventListener(
+										'click',
+										(event) => {
+											Liferay.Util.openSelectionModal({
+												onSelect: function (event) {
+													var folderData = {
+														idString: 'folderId',
+														idValue: event.entityid,
+														nameString: 'folderName',
+														nameValue: event.entityname,
+													};
 
-												Liferay.Util.selectFolder(folderData, '<portlet:namespace />');
-											},
-											selectEventName: '<portlet:namespace />selectFolder',
-											title: '<liferay-ui:message arguments="folder" key="select-x" />',
-											url:
-												'<liferay-portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" /></liferay-portlet:renderURL>',
-										});
-									});
+													Liferay.Util.selectFolder(
+														folderData,
+														'<portlet:namespace />'
+													);
+												},
+												selectEventName: '<portlet:namespace />selectFolder',
+												title:
+													'<liferay-ui:message arguments="folder" key="select-x" />',
+												url:
+													'<liferay-portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" /></liferay-portlet:renderURL>',
+											});
+										}
+									);
 								}
 							</aui:script>
 

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_folder.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_folder.jsp
@@ -114,26 +114,31 @@ renderResponse.setTitle(headerTitle);
 							);
 
 							if (<portlet:namespace />selectFolderButton) {
-								<portlet:namespace />selectFolderButton.addEventListener('click', function (
-									event
-								) {
-									Liferay.Util.openSelectionModal({
-										onSelect: function (event) {
-											var folderData = {
-												idString: 'parentFolderId',
-												idValue: event.entityid,
-												nameString: 'parentFolderName',
-												nameValue: event.entityname,
-											};
+								<portlet:namespace />selectFolderButton.addEventListener(
+									'click',
+									(event) => {
+										Liferay.Util.openSelectionModal({
+											onSelect: function (event) {
+												var folderData = {
+													idString: 'parentFolderId',
+													idValue: event.entityid,
+													nameString: 'parentFolderName',
+													nameValue: event.entityname,
+												};
 
-											Liferay.Util.selectFolder(folderData, '<portlet:namespace />');
-										},
-										selectEventName: '<portlet:namespace />selectFolder',
-										title: '<liferay-ui:message arguments="folder" key="select-x" />',
-										url:
-											'<liferay-portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" /></liferay-portlet:renderURL>',
-									});
-								});
+												Liferay.Util.selectFolder(
+													folderData,
+													'<portlet:namespace />'
+												);
+											},
+											selectEventName: '<portlet:namespace />selectFolder',
+											title:
+												'<liferay-ui:message arguments="folder" key="select-x" />',
+											url:
+												'<liferay-portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" /></liferay-portlet:renderURL>',
+										});
+									}
+								);
 							}
 						</aui:script>
 

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/move_entries.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/move_entries.jsp
@@ -284,42 +284,43 @@ if (portletTitleBasedNavigation) {
 	);
 
 	if (<portlet:namespace />selectFolderButton) {
-		<portlet:namespace />selectFolderButton.addEventListener('click', function (
-			event
-		) {
-			var folderName = document.getElementById(
-				'<portlet:namespace />folderName'
-			);
+		<portlet:namespace />selectFolderButton.addEventListener(
+			'click',
+			(event) => {
+				var folderName = document.getElementById(
+					'<portlet:namespace />folderName'
+				);
 
-			if (folderName) {
-				Liferay.Util.openSelectionModal({
-					onSelect: function (event) {
-						var folderData = {
-							idString: 'newFolderId',
-							idValue: event.entityid,
-							nameString: 'folderName',
-							nameValue: event.entityname,
-						};
+				if (folderName) {
+					Liferay.Util.openSelectionModal({
+						onSelect: function (event) {
+							var folderData = {
+								idString: 'newFolderId',
+								idValue: event.entityid,
+								nameString: 'folderName',
+								nameValue: event.entityname,
+							};
 
-						Liferay.Util.selectFolder(
-							folderData,
-							'<portlet:namespace />'
-						);
-					},
-					selectedData: [folderName.value],
-					selectEventName: '<portlet:namespace />selectFolder',
-					title:
-						'<liferay-ui:message arguments="folder" key="select-x" />',
+							Liferay.Util.selectFolder(
+								folderData,
+								'<portlet:namespace />'
+							);
+						},
+						selectedData: [folderName.value],
+						selectEventName: '<portlet:namespace />selectFolder',
+						title:
+							'<liferay-ui:message arguments="folder" key="select-x" />',
 
-					<portlet:renderURL var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-						<portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" />
-						<portlet:param name="folderId" value="<%= String.valueOf(newFolderId) %>" />
-					</portlet:renderURL>
+						<portlet:renderURL var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+							<portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" />
+							<portlet:param name="folderId" value="<%= String.valueOf(newFolderId) %>" />
+						</portlet:renderURL>
 
-					url: '<%= selectFolderURL.toString() %>',
-				});
+						url: '<%= selectFolderURL.toString() %>',
+					});
+				}
 			}
-		});
+		);
 	}
 </aui:script>
 

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks_admin/configuration.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks_admin/configuration.jsp
@@ -184,27 +184,32 @@ catch (NoSuchFolderException nsfe) {
 					);
 
 					if (<portlet:namespace />selectFolderButton) {
-						<portlet:namespace />selectFolderButton.addEventListener('click', function (
-							event
-						) {
-							Liferay.Util.openSelectionModal({
-								onSelect: function (event) {
-									var folderData = {
-										idString: 'rootFolderId',
-										idValue: event.entityid,
-										nameString: 'rootFolderName',
-										nameValue: event.entityname,
-									};
+						<portlet:namespace />selectFolderButton.addEventListener(
+							'click',
+							(event) => {
+								Liferay.Util.openSelectionModal({
+									onSelect: function (event) {
+										var folderData = {
+											idString: 'rootFolderId',
+											idValue: event.entityid,
+											nameString: 'rootFolderName',
+											nameValue: event.entityname,
+										};
 
-									Liferay.Util.selectFolder(folderData, '<portlet:namespace />');
-								},
-								selectEventName:
-									'<%= HtmlUtil.escapeJS(PortalUtil.getPortletNamespace(portletResource)) %>selectFolder',
-								title: '<liferay-ui:message arguments="folder" key="select-x" />',
-								url:
-									'<liferay-portlet:renderURL portletName="<%= portletResource %>" windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" /></liferay-portlet:renderURL>',
-							});
-						});
+										Liferay.Util.selectFolder(
+											folderData,
+											'<portlet:namespace />'
+										);
+									},
+									selectEventName:
+										'<%= HtmlUtil.escapeJS(PortalUtil.getPortletNamespace(portletResource)) %>selectFolder',
+									title:
+										'<liferay-ui:message arguments="folder" key="select-x" />',
+									url:
+										'<liferay-portlet:renderURL portletName="<%= portletResource %>" windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcRenderCommandName" value="/bookmarks/select_folder" /></liferay-portlet:renderURL>',
+								});
+							}
+						);
 					}
 				</aui:script>
 			</liferay-ui:section>

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/calendar_booking_recurrence_container.jspf
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/calendar_booking_recurrence_container.jspf
@@ -294,7 +294,7 @@ if (recurrence != null) {
 
 		editEventFormNode.once(
 			'key',
-			function (event) {
+			(event) => {
 				if (window.<portlet:namespace />recurrenceDialog.get('visible')) {
 					event.stopPropagation();
 				}
@@ -367,7 +367,7 @@ if (recurrence != null) {
 		Liferay.on('destroyPortlet', destroyRecurrenceDialog);
 	};
 
-	repeatCheckboxNode.on('change', function (event) {
+	repeatCheckboxNode.on('change', (event) => {
 		var checked = event.currentTarget.get('checked');
 
 		if (!checked) {
@@ -380,13 +380,13 @@ if (recurrence != null) {
 		<portlet:namespace />openRecurrenceDialog(checked);
 	});
 
-	summaryNode.on('click', function (event) {
+	summaryNode.on('click', (event) => {
 		<portlet:namespace />openRecurrenceDialog(true);
 
 		event.halt();
 	});
 
-	recurrenceDialogController.on('recurrenceChange', function (event) {
+	recurrenceDialogController.on('recurrenceChange', (event) => {
 		window.<portlet:namespace />updateSummaries();
 	});
 

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/configuration/user_settings.jspf
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/configuration/user_settings.jspf
@@ -52,7 +52,7 @@
 	);
 
 	if (usePortalTimeZoneCheckbox) {
-		usePortalTimeZoneCheckbox.on('change', function (event) {
+		usePortalTimeZoneCheckbox.on('change', (event) => {
 			document.<portlet:namespace />fm.<portlet:namespace />timeZoneId.disabled = usePortalTimeZoneCheckbox.attr(
 				'checked'
 			);

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
@@ -194,7 +194,7 @@ while (manageableCalendarsIterator.hasNext()) {
 %>
 
 <aui:script use="liferay-calendar-container,liferay-calendar-remote-services,liferay-component">
-	Liferay.component('<portlet:namespace />calendarContainer', function () {
+	Liferay.component('<portlet:namespace />calendarContainer', () => {
 		var calendarContainer = new Liferay.CalendarContainer({
 			groupCalendarResourceId: <%= groupCalendarResource.getCalendarResourceId() %>,
 
@@ -219,7 +219,7 @@ while (manageableCalendarsIterator.hasNext()) {
 		return calendarContainer;
 	});
 
-	Liferay.component('<portlet:namespace />remoteServices', function () {
+	Liferay.component('<portlet:namespace />remoteServices', () => {
 		var remoteServices = new Liferay.CalendarRemoteServices({
 			baseActionURL:
 				'<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), PortletRequest.ACTION_PHASE) %>',
@@ -563,7 +563,7 @@ while (manageableCalendarsIterator.hasNext()) {
 	Liferay.provide(
 		window,
 		'<portlet:namespace />updateCalendarBooking',
-		function () {
+		() => {
 			var A = AUI();
 
 			<c:if test="<%= invitable %>">
@@ -627,13 +627,13 @@ while (manageableCalendarsIterator.hasNext()) {
 
 	var scheduler = window.<portlet:namespace />scheduler;
 
-	A.one('#<portlet:namespace />saveButton').on('click', function () {
+	A.one('#<portlet:namespace />saveButton').on('click', () => {
 		A.one('#<portlet:namespace />workflowAction').val(
 			'<%= WorkflowConstants.ACTION_SAVE_DRAFT %>'
 		);
 	});
 
-	A.one('#<portlet:namespace />publishButton').on('click', function () {
+	A.one('#<portlet:namespace />publishButton').on('click', () => {
 		A.one('#<portlet:namespace />workflowAction').val(
 			'<%= WorkflowConstants.ACTION_PUBLISH %>'
 		);
@@ -651,7 +651,7 @@ while (manageableCalendarsIterator.hasNext()) {
 			window.<portlet:namespace />calendarListPending,
 		]);
 
-		A.each(calendarContainer.get('availableCalendars'), function (item, index) {
+		A.each(calendarContainer.get('availableCalendars'), (item, index) => {
 			item.set('disabled', true);
 		});
 	};
@@ -836,7 +836,7 @@ while (manageableCalendarsIterator.hasNext()) {
 		schedulerEvent: placeholderSchedulerEvent,
 	});
 
-	scheduler.after('*:load', function (event) {
+	scheduler.after('*:load', (event) => {
 		scheduler.addEvents(placeholderSchedulerEvent);
 
 		scheduler.syncEventsUI();
@@ -846,12 +846,12 @@ while (manageableCalendarsIterator.hasNext()) {
 		var manageableCalendars = {};
 
 		<%= CalendarUtil.toCalendarsJSONArray(themeDisplay, manageableCalendars) %>.forEach(
-			function (item, index) {
+			(item, index) => {
 				manageableCalendars[item.calendarId] = item;
 			}
 		);
 
-		A.one('#<portlet:namespace />calendarId').on('valueChange', function (event) {
+		A.one('#<portlet:namespace />calendarId').on('valueChange', (event) => {
 			var calendarId = parseInt(event.target.val(), 10);
 
 			var calendar = manageableCalendars[calendarId];
@@ -865,7 +865,7 @@ while (manageableCalendarsIterator.hasNext()) {
 				</c:if>
 
 				<portlet:namespace />calendarListPending,
-			].forEach(function (calendarList) {
+			].forEach((calendarList) => {
 				calendarList.remove(calendarList.getCalendar(calendarId));
 				calendarList.remove(calendarList.getCalendar(defaultCalendarId));
 			});
@@ -901,7 +901,7 @@ while (manageableCalendarsIterator.hasNext()) {
 		calendarContainer.createCalendarsAutoComplete(
 			'<%= calendarResourcesURL %>',
 			inviteResourcesInput,
-			function (event) {
+			(event) => {
 				var calendar = event.result.raw;
 
 				calendar.disabled = true;
@@ -925,7 +925,7 @@ while (manageableCalendarsIterator.hasNext()) {
 					calendar.calendarId,
 					placeholderSchedulerEvent.get('startDate'),
 					placeholderSchedulerEvent.get('endDate'),
-					function (result) {
+					(result) => {
 						if (result) {
 							<portlet:namespace />calendarListDeclined.add(calendar);
 						}
@@ -969,7 +969,7 @@ while (manageableCalendarsIterator.hasNext()) {
 	A.one('#<portlet:namespace />endTime').set('maxLength', maxLength);
 	A.one('#<portlet:namespace />startTime').set('maxLength', maxLength);
 
-	allDayCheckbox.after('click', function () {
+	allDayCheckbox.after('click', () => {
 		var endDateContainer = A.one('#<portlet:namespace />endDateContainer');
 		var startDateContainer = A.one('#<portlet:namespace />startDateContainer');
 

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar.jsp
@@ -28,7 +28,7 @@ boolean columnOptionsVisible = GetterUtil.getBoolean(SessionClicks.get(request, 
 %>
 
 <aui:script use="liferay-calendar-container,liferay-calendar-remote-services,liferay-component">
-	Liferay.component('<portlet:namespace />calendarContainer', function () {
+	Liferay.component('<portlet:namespace />calendarContainer', () => {
 		var calendarContainer = new Liferay.CalendarContainer({
 			groupCalendarResourceId: <%= groupCalendarResource.getCalendarResourceId() %>,
 
@@ -54,7 +54,7 @@ boolean columnOptionsVisible = GetterUtil.getBoolean(SessionClicks.get(request, 
 		return calendarContainer;
 	});
 
-	Liferay.component('<portlet:namespace />remoteServices', function () {
+	Liferay.component('<portlet:namespace />remoteServices', () => {
 		var remoteServices = new Liferay.CalendarRemoteServices({
 			baseActionURL:
 				'<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), PortletRequest.ACTION_PHASE) %>',
@@ -345,7 +345,7 @@ boolean columnOptionsVisible = GetterUtil.getBoolean(SessionClicks.get(request, 
 
 	syncCalendarsMap();
 
-	A.each(calendarContainer.get('availableCalendars'), function (item, index) {
+	A.each(calendarContainer.get('availableCalendars'), (item, index) => {
 		item.on({
 			visibleChange: function (event) {
 				var instance = this;
@@ -375,9 +375,7 @@ boolean columnOptionsVisible = GetterUtil.getBoolean(SessionClicks.get(request, 
 			);
 	};
 
-	<portlet:namespace />scheduler.after(['scheduler-events:load'], function (
-		event
-	) {
+	<portlet:namespace />scheduler.after(['scheduler-events:load'], (event) => {
 		event.currentTarget.eachEvent(
 			<portlet:namespace />refreshSchedulerEventTooltipTitle
 		);

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_booking.jsp
@@ -282,21 +282,21 @@ AssetEntry layoutAssetEntry = AssetEntryLocalServiceUtil.getEntry(CalendarBookin
 			if (<%= calendarBooking.isRecurring() %>) {
 				Liferay.RecurrenceUtil.openConfirmationPanel(
 					'invokeTransition',
-					function () {
+					() => {
 						document.<portlet:namespace />fm.<portlet:namespace />updateInstance.value =
 							'true';
 						document.<portlet:namespace />fm.<portlet:namespace />allFollowing.value =
 							'false';
 						submitForm(document.<portlet:namespace />fm);
 					},
-					function () {
+					() => {
 						document.<portlet:namespace />fm.<portlet:namespace />updateInstance.value =
 							'true';
 						document.<portlet:namespace />fm.<portlet:namespace />allFollowing.value =
 							'true';
 						submitForm(document.<portlet:namespace />fm);
 					},
-					function () {
+					() => {
 						submitForm(document.<portlet:namespace />fm);
 					}
 				);

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_menus.jspf
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_menus.jspf
@@ -41,7 +41,7 @@
 									destroy: function (event) {
 										remoteServices.getResourceCalendars(
 											calendarResourceId,
-											function (calendars) {
+											(calendars) => {
 												var calendarList =
 													window
 														.<portlet:namespace />calendarLists[
@@ -228,14 +228,14 @@
 								destroy: function (event) {
 									remoteServices.getCalendar(
 										activeCalendar.get('calendarId'),
-										function (calendar) {
+										(calendar) => {
 											var activeCalendarId = activeCalendar.get(
 												'calendarId'
 											);
 
 											var calendars = calendarList
 												.get('calendars')
-												.map(function (item) {
+												.map((item) => {
 													if (
 														activeCalendarId ===
 														item.get('calendarId')
@@ -350,10 +350,10 @@
 
 						remoteServices.deleteCalendar(
 							activeCalendar.get('calendarId'),
-							function () {
+							() => {
 								remoteServices.getResourceCalendars(
 									activeCalendar.get('calendarResourceId'),
-									function (calendars) {
+									(calendars) => {
 										calendarList.set('calendars', calendars);
 
 										<portlet:namespace />syncCalendarsMap();
@@ -496,7 +496,7 @@
 
 	A.one('#<portlet:namespace />calendarListContainer').delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var currentTarget = event.currentTarget;
 
 			window.<portlet:namespace />calendarListsMenu.calendarResourceId = currentTarget.getAttribute(
@@ -529,7 +529,7 @@
 		calendarContainer.createCalendarsAutoComplete(
 			'<%= calendarResourcesURL %>',
 			addOtherCalendarInput,
-			function (event) {
+			(event) => {
 				window.<portlet:namespace />otherCalendarList.add(event.result.raw);
 
 				<portlet:namespace />refreshVisibleCalendarRenderingRules();
@@ -539,7 +539,7 @@
 		);
 	</c:if>
 
-	A.one('#<portlet:namespace />columnToggler').on('click', function (event) {
+	A.one('#<portlet:namespace />columnToggler').on('click', (event) => {
 		var columnTogglerIconId = '<portlet:namespace />columnTogglerIcon';
 		var columnGrid = A.one('#<portlet:namespace />columnGrid');
 		var columnOptions = A.one('#<portlet:namespace />columnOptions');
@@ -630,7 +630,7 @@
 			Liferay.CalendarUtil.toUTC(miniCalendarStartDate),
 			Liferay.CalendarUtil.toUTC(miniCalendarEndDate),
 			'busy',
-			function (rulesDefinition) {
+			(rulesDefinition) => {
 				var selectedDates = <portlet:namespace />miniCalendar._getSelectedDatesList();
 
 				window.<portlet:namespace />miniCalendar.set('customRenderer', {

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendars.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendars.jsp
@@ -127,7 +127,7 @@ portletURL.setParameter("calendarResourceId", String.valueOf(calendarResource.ge
 	Liferay.provide(
 		window,
 		'<portlet:namespace />importCalendar',
-		function (url) {
+		(url) => {
 			var A = AUI();
 
 			if (!<portlet:namespace />importDialog) {
@@ -148,10 +148,10 @@ portletURL.setParameter("calendarResourceId", String.valueOf(calendarResource.ge
 									body: new FormData(form),
 									method: 'POST',
 								})
-									.then(function (response) {
+									.then((response) => {
 										return response.text();
 									})
-									.then(function (data) {
+									.then((data) => {
 										var responseData = {};
 
 										try {

--- a/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
+++ b/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
@@ -50,7 +50,7 @@ String url = (String)request.getAttribute("liferay-captcha:captcha:url");
 
 			if (refreshCaptcha && !hasEventAttached) {
 				hasEventAttached = true;
-				refreshCaptcha.addEventListener('click', function () {
+				refreshCaptcha.addEventListener('click', () => {
 					var url = Liferay.Util.addParams(
 						't=' + Date.now(),
 						'<%= HtmlUtil.escapeJS(url) %>'

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -366,7 +366,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 					body: formData,
 					method: 'POST',
 				})
-					.then(function (response) {
+					.then((response) => {
 						var promise;
 
 						var contentType = response.headers.get('content-type');
@@ -380,13 +380,13 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 
 						return promise;
 					})
-					.then(function (response) {
+					.then((response) => {
 						var exception = response.exception;
 
 						if (!exception) {
 							Liferay.onceAfter(
 								'<%= portletDisplay.getId() %>:messagePosted',
-								function (event) {
+								(event) => {
 									<%= randomNamespace %>onMessagePosted(
 										response,
 										refreshPage
@@ -433,7 +433,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 
 						Util.toggleDisabled(commentButtons, false);
 					})
-					.catch(function () {
+					.catch(() => {
 						<%= randomNamespace %>showStatusMessage({
 							id: '<%= randomNamespace %>',
 							message:
@@ -470,10 +470,10 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 						body: Util.objectToFormData(Util.ns('<%= namespace %>', options)),
 						method: 'POST',
 					})
-						.then(function (response) {
+						.then((response) => {
 							return response.text();
 						})
-						.then(function (response) {
+						.then((response) => {
 							var editorWrapper = document.querySelector(
 								'#' + formId + ' .editor-wrapper'
 							);
@@ -491,7 +491,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 
 							<%= randomNamespace %>showEl(formId);
 						})
-						.catch(function () {
+						.catch(() => {
 							<%= randomNamespace %>showStatusMessage({
 								id: '<%= randomNamespace %>',
 								message:
@@ -524,7 +524,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 
 			window.<%= randomNamespace %>showStatusMessage = Liferay.lazyLoad(
 				'frontend-js-web/liferay/toast/commands/OpenToast.es',
-				function (toastCommands, data) {
+				(toastCommands, data) => {
 					toastCommands.openToast(data);
 				}
 			);
@@ -608,7 +608,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 			var rootIndexPageElement = Util.getFormElement(form, 'rootIndexPage');
 
 			if (moreCommentsTrigger && indexElement && rootIndexPageElement) {
-				moreCommentsTrigger.addEventListener('click', function (event) {
+				moreCommentsTrigger.addEventListener('click', (event) => {
 					var data = Util.ns('<%= namespace %>', {
 						className: '<%= discussionTaglibHelper.getClassName() %>',
 						classPK: '<%= discussionTaglibHelper.getClassPK() %>',
@@ -630,10 +630,10 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 						body: Util.objectToFormData(data),
 						method: 'POST',
 					})
-						.then(function (response) {
+						.then((response) => {
 							return response.text();
 						})
-						.then(function (response) {
+						.then((response) => {
 							var moreCommentsContainer = document.getElementById(
 								'<%= namespace %>moreCommentsContainer'
 							);
@@ -651,7 +651,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 								runScriptsInElement.default(newCommentsContainer);
 							}
 						})
-						.catch(function () {
+						.catch(() => {
 							<%= randomNamespace %>showStatusMessage({
 								id: '<%= randomNamespace %>',
 								message:
@@ -670,37 +670,37 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 			) {
 				Liferay.onceAfter(
 					'<%= portletDisplay.getId() %>:portletRefreshed',
-					function (event) {
+					(event) => {
 						var randomNamespaceNodes = document.querySelectorAll(
 							'input[id^="<%= namespace %>"][id$="randomNamespace"]'
 						);
 
-						Array.prototype.forEach.call(randomNamespaceNodes, function (
-							node,
-							index
-						) {
-							var randomId = node.value;
+						Array.prototype.forEach.call(
+							randomNamespaceNodes,
+							(node, index) => {
+								var randomId = node.value;
 
-							if (index === 0) {
-								<%= randomNamespace %>showStatusMessage({
-									id: randomId,
-									message:
-										'<%= UnicodeLanguageUtil.get(resourceBundle, "your-request-completed-successfully") %>',
-									type: 'success',
-								});
+								if (index === 0) {
+									<%= randomNamespace %>showStatusMessage({
+										id: randomId,
+										message:
+											'<%= UnicodeLanguageUtil.get(resourceBundle, "your-request-completed-successfully") %>',
+										type: 'success',
+									});
+								}
+
+								var currentMessageSelector =
+									randomId + 'message_' + response.commentId;
+
+								var targetNode = document.getElementById(
+									currentMessageSelector
+								);
+
+								if (targetNode) {
+									location.hash = '#' + currentMessageSelector;
+								}
 							}
-
-							var currentMessageSelector =
-								randomId + 'message_' + response.commentId;
-
-							var targetNode = document.getElementById(
-								currentMessageSelector
-							);
-
-							if (targetNode) {
-								location.hash = '#' + currentMessageSelector;
-							}
-						});
+						);
 					}
 				);
 
@@ -758,7 +758,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 
 			discussionContainer.delegate(
 				'click',
-				function (event) {
+				(event) => {
 					event.preventDefault();
 					event.stopPropagation();
 

--- a/modules/apps/commerce/commerce-account-admin-web/src/main/resources/META-INF/resources/account/organizations.jsp
+++ b/modules/apps/commerce/commerce-account-admin-web/src/main/resources/META-INF/resources/account/organizations.jsp
@@ -152,7 +152,7 @@ PortletURL portletURL = commerceAccountOrganizationRelAdminDisplayContext.getPor
 	<aui:script use="liferay-item-selector-dialog">
 		window.document
 			.querySelector('#<portlet:namespace />addCommerceAccountOrganizationRel')
-			.addEventListener('click', function (event) {
+			.addEventListener('click', (event) => {
 				event.preventDefault();
 
 				var itemSelectorDialog = new A.LiferayItemSelectorDialog({
@@ -164,15 +164,14 @@ PortletURL portletURL = commerceAccountOrganizationRelAdminDisplayContext.getPor
 							var selectedItems = event.newVal;
 
 							if (selectedItems) {
-								A.Array.each(selectedItems, function (
-									item,
-									index,
-									selectedItems
-								) {
-									<portlet:namespace />addOrganizationIds.push(
-										item.id
-									);
-								});
+								A.Array.each(
+									selectedItems,
+									(item, index, selectedItems) => {
+										<portlet:namespace />addOrganizationIds.push(
+											item.id
+										);
+									}
+								);
 
 								window.document.querySelector(
 									'#<portlet:namespace />organizationIds'

--- a/modules/apps/commerce/commerce-account-admin-web/src/main/resources/META-INF/resources/account/users.jsp
+++ b/modules/apps/commerce/commerce-account-admin-web/src/main/resources/META-INF/resources/account/users.jsp
@@ -162,7 +162,7 @@ PortletURL portletURL = commerceAccountUserRelAdminDisplayContext.getPortletURL(
 	<aui:script use="liferay-item-selector-dialog">
 		window.document
 			.querySelector('#<portlet:namespace />addCommerceAccountUserRel')
-			.addEventListener('click', function (event) {
+			.addEventListener('click', (event) => {
 				event.preventDefault();
 
 				var itemSelectorDialog = new A.LiferayItemSelectorDialog({
@@ -174,13 +174,12 @@ PortletURL portletURL = commerceAccountUserRelAdminDisplayContext.getPortletURL(
 							var selectedItems = event.newVal;
 
 							if (selectedItems) {
-								A.Array.each(selectedItems, function (
-									item,
-									index,
-									selectedItems
-								) {
-									<portlet:namespace />addUserIds.push(item.id);
-								});
+								A.Array.each(
+									selectedItems,
+									(item, index, selectedItems) => {
+										<portlet:namespace />addUserIds.push(item.id);
+									}
+								);
 
 								window.document.querySelector(
 									'#<portlet:namespace />userIds'

--- a/modules/apps/commerce/commerce-account-group-admin-web/src/main/resources/META-INF/resources/account_group/accounts.jsp
+++ b/modules/apps/commerce/commerce-account-group-admin-web/src/main/resources/META-INF/resources/account_group/accounts.jsp
@@ -152,7 +152,7 @@ PortletURL portletURL = commerceAccountGroupAdminDisplayContext.getPortletURL();
 			.querySelector(
 				'#<portlet:namespace />addCommerceAccountGroupCommerceAccountRel'
 			)
-			.addEventListener('click', function (event) {
+			.addEventListener('click', (event) => {
 				event.preventDefault();
 
 				var itemSelectorDialog = new A.LiferayItemSelectorDialog({
@@ -164,15 +164,14 @@ PortletURL portletURL = commerceAccountGroupAdminDisplayContext.getPortletURL();
 							var selectedItems = event.newVal;
 
 							if (selectedItems) {
-								A.Array.each(selectedItems, function (
-									item,
-									index,
-									selectedItems
-								) {
-									<portlet:namespace />addCommerceAccountIds.push(
-										item.commerceAccountId
-									);
-								});
+								A.Array.each(
+									selectedItems,
+									(item, index, selectedItems) => {
+										<portlet:namespace />addCommerceAccountIds.push(
+											item.commerceAccountId
+										);
+									}
+								);
 
 								window.document.querySelector(
 									'#<portlet:namespace />commerceAccountIds'

--- a/modules/apps/commerce/commerce-account-item-selector-web/src/main/resources/META-INF/resources/account_group_account_item_selector.jsp
+++ b/modules/apps/commerce/commerce-account-item-selector-web/src/main/resources/META-INF/resources/account_group_account_item_selector.jsp
@@ -100,7 +100,7 @@ PortletURL portletURL = commerceAccountGroupAccountItemSelectorViewDisplayContex
 		'<portlet:namespace />commerceAccounts'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var allSelectedElements = event.elements.allSelectedElements;
 		var arr = [];
 

--- a/modules/apps/commerce/commerce-account-item-selector-web/src/main/resources/META-INF/resources/account_group_item_selector.jsp
+++ b/modules/apps/commerce/commerce-account-item-selector-web/src/main/resources/META-INF/resources/account_group_item_selector.jsp
@@ -103,7 +103,7 @@ PortletURL portletURL = commerceAccountGroupItemSelectorViewDisplayContext.getPo
 		'<portlet:namespace />commerceAccountGroups'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var allSelectedElements = event.elements.allSelectedElements;
 		var arr = [];
 

--- a/modules/apps/commerce/commerce-account-item-selector-web/src/main/resources/META-INF/resources/account_item_selector.jsp
+++ b/modules/apps/commerce/commerce-account-item-selector-web/src/main/resources/META-INF/resources/account_item_selector.jsp
@@ -100,7 +100,7 @@ PortletURL portletURL = commerceAccountItemSelectorViewDisplayContext.getPortlet
 		'<portlet:namespace />commerceAccounts'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var allSelectedElements = event.elements.allSelectedElements;
 		var arr = [];
 

--- a/modules/apps/commerce/commerce-account-web/src/main/resources/META-INF/resources/view_account_addresses.jsp
+++ b/modules/apps/commerce/commerce-account-web/src/main/resources/META-INF/resources/view_account_addresses.jsp
@@ -71,21 +71,19 @@ portletURL.setParameter(PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE + "backUR
 	</aui:form>
 
 	<aui:script>
-		Liferay.provide(window, '<portlet:namespace />openAddressModal', function (
-			evt
-		) {
+		Liferay.provide(window, '<portlet:namespace />openAddressModal', (evt) => {
 			var addressModal = Liferay.component('addressModal');
 			addressModal.resetForm();
 			addressModal.open();
 		});
 
-		Liferay.provide(window, 'editCommerceAddress', function (id) {
+		Liferay.provide(window, 'editCommerceAddress', (id) => {
 			var addressModal = Liferay.component('addressModal');
 			addressModal.fetchExistingAddress(id);
 			addressModal.open();
 		});
 
-		Liferay.provide(window, 'deleteCommerceAddress', function (id) {
+		Liferay.provide(window, 'deleteCommerceAddress', (id) => {
 			document.querySelector('#<portlet:namespace /><%= Constants.CMD %>').value =
 				'<%= Constants.DELETE %>';
 			document.querySelector(
@@ -95,8 +93,8 @@ portletURL.setParameter(PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE + "backUR
 			submitForm(document.<portlet:namespace />addressFm);
 		});
 
-		Liferay.componentReady('addressModal').then(function (addressModal) {
-			addressModal.on('addressModalSave', function (formData) {
+		Liferay.componentReady('addressModal').then((addressModal) => {
+			addressModal.on('addressModalSave', (formData) => {
 				document.querySelector('#<portlet:namespace />name').value =
 					formData.referent;
 				document.querySelector('#<portlet:namespace />street1').value =

--- a/modules/apps/commerce/commerce-account-web/src/main/resources/META-INF/resources/view_account_info.jsp
+++ b/modules/apps/commerce/commerce-account-web/src/main/resources/META-INF/resources/view_account_info.jsp
@@ -56,14 +56,14 @@ CommerceAccount commerceAccount = commerceAccountDisplayContext.getCurrentCommer
 		Liferay.provide(
 			window,
 			'<portlet:namespace />openAddOrganizationsModal',
-			function (evt) {
+			(evt) => {
 				var addOrganizationsModal = Liferay.component('addOrganizationsModal');
 
 				addOrganizationsModal.open();
 			}
 		);
 
-		Liferay.provide(window, 'deleteCommerceAccountOrganization', function (id) {
+		Liferay.provide(window, 'deleteCommerceAccountOrganization', (id) => {
 			document.querySelector('#<portlet:namespace /><%= Constants.CMD %>').value =
 				'<%= Constants.REMOVE %>';
 			document.querySelector('#<portlet:namespace />organizationId').value = id;
@@ -71,26 +71,26 @@ CommerceAccount commerceAccount = commerceAccountDisplayContext.getCurrentCommer
 			submitForm(document.<portlet:namespace />commerceAccountOrganizationRelFm);
 		});
 
-		Liferay.componentReady('addOrganizationsModal').then(function (
-			addOrganizationsModal
-		) {
-			addOrganizationsModal.on('addOrganization', function (event) {
-				var orgIds = event
-					.map(function (org) {
-						return org.id;
-					})
-					.join(',');
+		Liferay.componentReady('addOrganizationsModal').then(
+			(addOrganizationsModal) => {
+				addOrganizationsModal.on('addOrganization', (event) => {
+					var orgIds = event
+						.map((org) => {
+							return org.id;
+						})
+						.join(',');
 
-				document.querySelector(
-					'#<portlet:namespace />addOrganizationIds'
-				).value = orgIds;
+					document.querySelector(
+						'#<portlet:namespace />addOrganizationIds'
+					).value = orgIds;
 
-				addOrganizationsModal.close();
+					addOrganizationsModal.close();
 
-				submitForm(
-					document.<portlet:namespace />commerceAccountOrganizationRelFm
-				);
-			});
-		});
+					submitForm(
+						document.<portlet:namespace />commerceAccountOrganizationRelFm
+					);
+				});
+			}
+		);
 	</aui:script>
 </c:if>

--- a/modules/apps/commerce/commerce-account-web/src/main/resources/META-INF/resources/view_account_list.jsp
+++ b/modules/apps/commerce/commerce-account-web/src/main/resources/META-INF/resources/view_account_list.jsp
@@ -57,15 +57,13 @@ request.setAttribute("view.jsp-filterPerAccount", false);
 	/>
 
 	<aui:script>
-		Liferay.provide(window, '<portlet:namespace />openAddAccountModal', function (
-			evt
-		) {
+		Liferay.provide(window, '<portlet:namespace />openAddAccountModal', (evt) => {
 			var addAccountModal = Liferay.component('addAccountModal');
 
 			addAccountModal.open();
 		});
 
-		Liferay.provide(window, 'setCurrentAccount', function (id) {
+		Liferay.provide(window, 'setCurrentAccount', (id) => {
 			document.querySelector('#<portlet:namespace /><%= Constants.CMD %>').value =
 				'setCurrentAccount';
 			document.querySelector(
@@ -75,7 +73,7 @@ request.setAttribute("view.jsp-filterPerAccount", false);
 			submitForm(document.<portlet:namespace />commerceAccountFm);
 		});
 
-		Liferay.provide(window, 'toggleActiveCommerceAccount', function (id) {
+		Liferay.provide(window, 'toggleActiveCommerceAccount', (id) => {
 			document.querySelector('#<portlet:namespace /><%= Constants.CMD %>').value =
 				'setActive';
 			document.querySelector(
@@ -85,22 +83,22 @@ request.setAttribute("view.jsp-filterPerAccount", false);
 			submitForm(document.<portlet:namespace />commerceAccountFm);
 		});
 
-		Liferay.componentReady('addAccountModal').then(function (addAccountModal) {
-			addAccountModal.on('AddAccountModalSave', function (event) {
+		Liferay.componentReady('addAccountModal').then((addAccountModal) => {
+			addAccountModal.on('AddAccountModalSave', (event) => {
 				var existingUserIds = event.administratorsEmail
-					.filter(function (el) {
+					.filter((el) => {
 						return el.userId;
 					})
-					.map(function (usr) {
+					.map((usr) => {
 						return usr.userId;
 					})
 					.join(',');
 
 				var newUserEmails = event.administratorsEmail
-					.filter(function (el) {
+					.filter((el) => {
 						return !el.userId;
 					})
-					.map(function (usr) {
+					.map((usr) => {
 						return usr.email;
 					})
 					.join(',');

--- a/modules/apps/commerce/commerce-account-web/src/main/resources/META-INF/resources/view_account_members.jsp
+++ b/modules/apps/commerce/commerce-account-web/src/main/resources/META-INF/resources/view_account_members.jsp
@@ -65,13 +65,13 @@ portletURL.setParameter(PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE + "backUR
 		Liferay.provide(
 			window,
 			'<portlet:namespace />openUserInvitationModal',
-			function (evt) {
+			(evt) => {
 				var userInvitationModal = Liferay.component('userInvitationModal');
 				userInvitationModal.open();
 			}
 		);
 
-		Liferay.provide(window, 'removeCommerceAccountUser', function (id) {
+		Liferay.provide(window, 'removeCommerceAccountUser', (id) => {
 			document.querySelector('#<portlet:namespace /><%= Constants.CMD %>').value =
 				'<%= Constants.REMOVE %>';
 			document.querySelector('#<portlet:namespace />userId').value = id;
@@ -79,24 +79,22 @@ portletURL.setParameter(PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE + "backUR
 			submitForm(document.<portlet:namespace />inviteUserFm);
 		});
 
-		Liferay.componentReady('userInvitationModal').then(function (
-			userInvitationModal
-		) {
-			userInvitationModal.on('inviteUserToAccount', function (users) {
+		Liferay.componentReady('userInvitationModal').then((userInvitationModal) => {
+			userInvitationModal.on('inviteUserToAccount', (users) => {
 				var existingUsersIds = users
-					.filter(function (el) {
+					.filter((el) => {
 						return el.userId;
 					})
-					.map(function (usr) {
+					.map((usr) => {
 						return usr.userId;
 					})
 					.join(',');
 
 				var newUsersEmails = users
-					.filter(function (el) {
+					.filter((el) => {
 						return !el.userId;
 					})
-					.map(function (usr) {
+					.map((usr) => {
 						return usr.email;
 					})
 					.join(',');

--- a/modules/apps/commerce/commerce-account-web/src/main/resources/META-INF/resources/view_commerce_account_user.jsp
+++ b/modules/apps/commerce/commerce-account-web/src/main/resources/META-INF/resources/view_commerce_account_user.jsp
@@ -107,17 +107,15 @@ portletURL.setParameter("userId", String.valueOf(selectedUser.getUserId()));
 		/>
 
 		<aui:script>
-			Liferay.provide(window, '<portlet:namespace />openUserRolesModal', function (
-				evt
-			) {
+			Liferay.provide(window, '<portlet:namespace />openUserRolesModal', (evt) => {
 				var userRolesModal = Liferay.component('userRolesModal');
 				userRolesModal.open();
 			});
 
-			Liferay.componentReady('userRolesModal').then(function (userRolesModal) {
-				userRolesModal.on('updateRoles', function (selectedRoles) {
+			Liferay.componentReady('userRolesModal').then((userRolesModal) => {
+				userRolesModal.on('updateRoles', (selectedRoles) => {
 					var selectedRoleIds = selectedRoles
-						.map(function (role) {
+						.map((role) => {
 							return role.id;
 						})
 						.join(',');

--- a/modules/apps/commerce/commerce-cart-content-web/src/main/resources/META-INF/resources/cart/view.jsp
+++ b/modules/apps/commerce/commerce-cart-content-web/src/main/resources/META-INF/resources/cart/view.jsp
@@ -217,7 +217,7 @@ Map<Long, List<CommerceOrderValidatorResult>> commerceOrderValidatorResultMap = 
 	</div>
 
 	<aui:script>
-		Liferay.after('current-order-updated', function (event) {
+		Liferay.after('current-order-updated', (event) => {
 			Liferay.Portlet.refresh('#p_p_id<portlet:namespace />');
 		});
 	</aui:script>

--- a/modules/apps/commerce/commerce-cart-content-web/src/main/resources/META-INF/resources/cart_mini/transition.jspf
+++ b/modules/apps/commerce/commerce-cart-content-web/src/main/resources/META-INF/resources/cart_mini/transition.jspf
@@ -33,7 +33,7 @@
 	Liferay.provide(
 		window,
 		'<portlet:namespace />transition',
-		function (event) {
+		(event) => {
 			var A = AUI();
 
 			var link = event.currentTarget;

--- a/modules/apps/commerce/commerce-cart-content-web/src/main/resources/META-INF/resources/cart_mini/view.jsp
+++ b/modules/apps/commerce/commerce-cart-content-web/src/main/resources/META-INF/resources/cart_mini/view.jsp
@@ -277,7 +277,7 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 		if (orderTransition) {
 			orderTransition.delegate(
 				'click',
-				function (event) {
+				(event) => {
 					<portlet:namespace />transition(event);
 				},
 				'.transition-link'
@@ -286,7 +286,7 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 	</aui:script>
 
 	<aui:script>
-		Liferay.after('current-order-updated', function (event) {
+		Liferay.after('current-order-updated', (event) => {
 			Liferay.Portlet.refresh('#p_p_id<portlet:namespace />');
 		});
 	</aui:script>

--- a/modules/apps/commerce/commerce-cart-content-web/src/main/resources/META-INF/resources/cart_total/view.jsp
+++ b/modules/apps/commerce/commerce-cart-content-web/src/main/resources/META-INF/resources/cart_total/view.jsp
@@ -150,7 +150,7 @@ SearchContainer<CommerceOrderItem> commerceOrderItemSearchContainer = commerceCa
 	</aui:button-row>
 
 	<aui:script>
-		Liferay.after('current-order-updated', function (event) {
+		Liferay.after('current-order-updated', (event) => {
 			Liferay.Portlet.refresh('#p_p_id<portlet:namespace />');
 		});
 	</aui:script>

--- a/modules/apps/commerce/commerce-cart-taglib/src/main/resources/META-INF/resources/quantity_control/page.jsp
+++ b/modules/apps/commerce/commerce-cart-taglib/src/main/resources/META-INF/resources/quantity_control/page.jsp
@@ -65,7 +65,7 @@ String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_commerce_
 	Liferay.provide(
 		window,
 		'<%= portletNamespace + randomNamespace %>updateQuantity',
-		function () {
+		() => {
 			var A = AUI();
 
 			var form = A.one('#<%= portletNamespace + randomNamespace %>Fm');
@@ -88,7 +88,7 @@ String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_commerce_
 
 		form.delegate(
 			'change',
-			function () {
+			() => {
 				<%= portletNamespace + randomNamespace %>updateQuantity();
 			},
 			'select'

--- a/modules/apps/commerce/commerce-catalog-web/src/main/resources/META-INF/resources/add_commerce_catalog.jsp
+++ b/modules/apps/commerce/commerce-catalog-web/src/main/resources/META-INF/resources/add_commerce_catalog.jsp
@@ -75,7 +75,7 @@ List<CommerceCurrency> commerceCurrencies = commerceCatalogDisplayContext.getCom
 			Liferay.provide(
 				window,
 				'<portlet:namespace />apiSubmit',
-				function (form) {
+				(form) => {
 					var API_URL = '/o/headless-commerce-admin-catalog/v1.0/catalogs';
 
 					window.parent.Liferay.fire(events.IS_LOADING_MODAL, {
@@ -83,7 +83,7 @@ List<CommerceCurrency> commerceCurrencies = commerceCatalogDisplayContext.getCom
 					});
 
 					FormUtils.apiSubmit(form, API_URL)
-						.then(function (payload) {
+						.then((payload) => {
 							var redirectURL = new Liferay.PortletURL.createURL(
 								'<%= editCatalogPortletURL.toString() %>'
 							);
@@ -100,7 +100,7 @@ List<CommerceCurrency> commerceCurrencies = commerceCatalogDisplayContext.getCom
 								},
 							});
 						})
-						.catch(function () {
+						.catch(() => {
 							window.parent.Liferay.fire(events.IS_LOADING_MODAL, {
 								isLoading: false,
 							});

--- a/modules/apps/commerce/commerce-channel-web/src/main/resources/META-INF/resources/add_commerce_channel.jsp
+++ b/modules/apps/commerce/commerce-channel-web/src/main/resources/META-INF/resources/add_commerce_channel.jsp
@@ -84,7 +84,7 @@ PortletURL editCommerceChannelRenderURL = commerceChannelDisplayContext.getEditC
 		Liferay.provide(
 			window,
 			'<portlet:namespace />apiSubmit',
-			function (form) {
+			(form) => {
 				var API_URL = '/o/headless-commerce-admin-channel/v1.0/channels';
 
 				window.parent.Liferay.fire(events.IS_LOADING_MODAL, {
@@ -92,7 +92,7 @@ PortletURL editCommerceChannelRenderURL = commerceChannelDisplayContext.getEditC
 				});
 
 				FormUtils.apiSubmit(form, API_URL)
-					.then(function (payload) {
+					.then((payload) => {
 						var redirectURL = new Liferay.PortletURL.createURL(
 							'<%= editCommerceChannelRenderURL.toString() %>'
 						);
@@ -109,7 +109,7 @@ PortletURL editCommerceChannelRenderURL = commerceChannelDisplayContext.getEditC
 							},
 						});
 					})
-					.catch(function () {
+					.catch(() => {
 						window.parent.Liferay.fire(events.IS_LOADING_MODAL, {
 							isLoading: false,
 						});

--- a/modules/apps/commerce/commerce-channel-web/src/main/resources/META-INF/resources/channel/site.jsp
+++ b/modules/apps/commerce/commerce-channel-web/src/main/resources/META-INF/resources/channel/site.jsp
@@ -116,7 +116,7 @@ if (commerceChannel != null) {
 	);
 
 	if (selectSiteButton) {
-		selectSiteButton.addEventListener('click', function (event) {
+		selectSiteButton.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			Liferay.Util.selectEntity({
@@ -142,7 +142,7 @@ if (commerceChannel != null) {
 
 	searchContainerContentBox.delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var link = event.currentTarget;
 
 			var rowId = link.attr('data-rowId');
@@ -156,7 +156,7 @@ if (commerceChannel != null) {
 		'.modify-link'
 	);
 
-	var sitesSelectItemHandle = Liferay.on('sitesSelectItem', function (event) {
+	var sitesSelectItemHandle = Liferay.on('sitesSelectItem', (event) => {
 		var item = event.data;
 
 		if (item) {
@@ -191,7 +191,7 @@ if (commerceChannel != null) {
 		}
 	});
 
-	Liferay.on('beforeNavigate', function (event) {
+	Liferay.on('beforeNavigate', (event) => {
 		sitesSelectItemHandle.detach();
 	});
 </aui:script>

--- a/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/checkout_step/address.jsp
+++ b/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/checkout_step/address.jsp
@@ -383,7 +383,7 @@ long commerceRegionId = BeanParamUtil.getLong(currentCommerceAddress, request, "
 							},
 						];
 
-						list.forEach(function (listElement) {
+						list.forEach((listElement) => {
 							callbackList.push(listElement);
 						});
 
@@ -420,7 +420,7 @@ long commerceRegionId = BeanParamUtil.getLong(currentCommerceAddress, request, "
 							},
 						];
 
-						list.forEach(function (listElement) {
+						list.forEach((listElement) => {
 							callbackList.push(listElement);
 						});
 

--- a/modules/apps/commerce/commerce-discount-content-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/commerce/commerce-discount-content-web/src/main/resources/META-INF/resources/view.jsp
@@ -70,9 +70,7 @@ if (commerceOrder != null) {
 			</div>
 
 			<aui:script use="aui-base">
-				A.one('#<portlet:namespace />couponCodeIconRemove').on('click', function (
-					event
-				) {
+				A.one('#<portlet:namespace />couponCodeIconRemove').on('click', (event) => {
 					event.preventDefault();
 
 					submitForm(document.<portlet:namespace />fm);

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/coupon_code/page.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/coupon_code/page.jsp
@@ -53,17 +53,17 @@ if (commerceOrder != null) {
 
 			couponCodeIconRemove.addEventListener(
 				'click',
-				function (event) {
+				(event) => {
 					var actionURL =
 						'<%= PortalUtil.getPortalURL(request) + "/o/commerce-ui/order/" + commerceOrder.getCommerceOrderId() + "/coupon-code" %>';
 
 					Liferay.Util.fetch(actionURL, {
 						method: 'post',
 					})
-						.then(function (res) {
+						.then((res) => {
 							return res.json();
 						})
-						.then(function (payload) {
+						.then((payload) => {
 							if (payload.success) {
 								window.location.reload();
 							}
@@ -102,7 +102,7 @@ if (commerceOrder != null) {
 
 			applyCouponCodeButton.addEventListener(
 				'click',
-				function (event) {
+				(event) => {
 					var actionURL =
 						'<%= PortalUtil.getPortalURL(request) + "/o/commerce-ui/order/" + commerceOrder.getCommerceOrderId() + "/coupon-code/" %>';
 
@@ -114,10 +114,10 @@ if (commerceOrder != null) {
 					Liferay.Util.fetch(actionURL, {
 						method: 'post',
 					})
-						.then(function (res) {
+						.then((res) => {
 							return res.json();
 						})
-						.then(function (payload) {
+						.then((payload) => {
 							if (payload.success) {
 								window.location.reload();
 							}

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/header/page.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/header/page.jsp
@@ -106,7 +106,7 @@ String myWorkflowTasksPortletNamespace = PortalUtil.getPortletNamespace(PortletK
 								<aui:script require="commerce-frontend-js/utilities/eventsDefinitions as events">
 									document
 										.querySelector('#erc-edit-modal-opener')
-										.addEventListener('click', function (e) {
+										.addEventListener('click', (e) => {
 											e.preventDefault();
 											Liferay.fire(events.OPEN_MODAL, {id: 'erc-edit-modal'});
 										});
@@ -176,7 +176,7 @@ String myWorkflowTasksPortletNamespace = PortalUtil.getPortletNamespace(PortletK
 								<aui:script>
 									document
 										.querySelector('#<portlet:namespace />assign-to-me-modal-opener')
-										.addEventListener('click', function (e) {
+										.addEventListener('click', (e) => {
 											Liferay.Util.openWindow({
 												dialog: {
 													destroyOnHide: true,
@@ -212,7 +212,7 @@ String myWorkflowTasksPortletNamespace = PortalUtil.getPortletNamespace(PortletK
 							<aui:script>
 								document
 									.querySelector('#<portlet:namespace />assign-to-modal-opener')
-									.addEventListener('click', function (e) {
+									.addEventListener('click', (e) => {
 										Liferay.Util.openWindow({
 											dialog: {
 												destroyOnHide: true,
@@ -233,7 +233,7 @@ String myWorkflowTasksPortletNamespace = PortalUtil.getPortletNamespace(PortletK
 									window.location.reload();
 								}
 
-								Liferay.provide(window, '<portlet:namespace />toggleDropdown', function () {
+								Liferay.provide(window, '<portlet:namespace />toggleDropdown', () => {
 									var dropdownElement = window.document.querySelector(
 										'#<portlet:namespace />commerce-dropdown-assigned-to'
 									);
@@ -280,18 +280,16 @@ String myWorkflowTasksPortletNamespace = PortalUtil.getPortletNamespace(PortletK
 
 							<c:if test="<%= submitCheck && Validator.isNotNull(action.getFormId()) %>">
 								<aui:script>
-									document
-										.getElementById('<%= actionId %>')
-										.addEventListener('click', function (e) {
-											e.preventDefault();
-											var form = document.getElementById('<%= action.getFormId() %>');
-											if (!form) {
-												throw new Error(
-													'Form with id: ' + <%= action.getFormId() %> + ' not found!'
-												);
-											}
-											submitForm(form);
-										});
+									document.getElementById('<%= actionId %>').addEventListener('click', (e) => {
+										e.preventDefault();
+										var form = document.getElementById('<%= action.getFormId() %>');
+										if (!form) {
+											throw new Error(
+												'Form with id: ' + <%= action.getFormId() %> + ' not found!'
+											);
+										}
+										submitForm(form);
+									});
 								</aui:script>
 							</c:if>
 
@@ -353,7 +351,7 @@ String myWorkflowTasksPortletNamespace = PortalUtil.getPortletNamespace(PortletK
 		updateMenuDistanceFromTop();
 		window.addEventListener('resize', debouncedUpdateMenuDistanceFromTop);
 
-		Liferay.once('beforeNavigate', function () {
+		Liferay.once('beforeNavigate', () => {
 			window.removeEventListener(
 				'resize',
 				debouncedUpdateMenuDistanceFromTop

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/info_box/start.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/info_box/start.jsp
@@ -32,7 +32,7 @@ String linkId = PortalUtil.generateRandomKey(request, "info-box") + StringPool.U
 					var link = document.getElementById('<%= linkId %>');
 
 					if (link) {
-						link.addEventListener('click', function (e) {
+						link.addEventListener('click', (e) => {
 							e.preventDefault();
 							Liferay.fire(eventsDefinitions.OPEN_MODAL, {
 								id: '<%= actionTargetId %>',

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/modal_content/end.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/modal_content/end.jsp
@@ -48,7 +48,7 @@
 		window.top.Liferay.fire(events.CLOSE_MODAL, eventDetail);
 	}
 
-	window.addEventListener('keyup', function (event) {
+	window.addEventListener('keyup', (event) => {
 		event.preventDefault();
 
 		if (event.key === 'Escape') {
@@ -62,8 +62,8 @@
 
 	window.top.Liferay.fire(events.IS_LOADING_MODAL, {isLoading: false});
 
-	document.querySelectorAll('.modal-closer').forEach(function (trigger) {
-		trigger.addEventListener('click', function (e) {
+	document.querySelectorAll('.modal-closer').forEach((trigger) => {
+		trigger.addEventListener('click', (e) => {
 			e.preventDefault();
 			window.top.Liferay.fire(events.CLOSE_MODAL);
 		});
@@ -76,7 +76,7 @@
 	if (iframeForm) {
 		iframeForm.appendChild(iframeFooter);
 
-		iframeForm.addEventListener('submit', function (e) {
+		iframeForm.addEventListener('submit', (e) => {
 			window.top.Liferay.fire(events.IS_LOADING_MODAL, {isLoading: true});
 
 			var form = Liferay.Form.get(iframeForm.id);

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/panel/start.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/panel/start.jsp
@@ -30,7 +30,7 @@ String collapseSwitchId = Validator.isNotNull(collapseSwitchName) ? collapseSwit
 					var link = document.getElementById('<%= linkId %>');
 
 					if (link) {
-						link.addEventListener('click', function (e) {
+						link.addEventListener('click', (e) => {
 							e.preventDefault();
 							Liferay.fire(eventsDefinitions.OPEN_MODAL, {
 								id: '<%= actionTargetId %>',
@@ -71,8 +71,8 @@ String collapseSwitchId = Validator.isNotNull(collapseSwitchName) ? collapseSwit
 								'<%= randomNamespace %>collapse'
 							);
 
-							[toggleSwitch, toggleLabel].forEach(function (el) {
-								el.addEventListener('click', function (e) {
+							[toggleSwitch, toggleLabel].forEach((el) => {
+								el.addEventListener('click', (e) => {
 									e.preventDefault();
 
 									if (collapseClickable) {
@@ -85,7 +85,7 @@ String collapseSwitchId = Validator.isNotNull(collapseSwitchName) ? collapseSwit
 
 									collapseClickable = false;
 
-									setTimeout(function () {
+									setTimeout(() => {
 										collapseClickable = true;
 									}, 400);
 								});

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/side_panel_content/end.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/side_panel_content/end.jsp
@@ -37,8 +37,8 @@
 
 	document
 		.querySelectorAll('.side-panel-iframe-close, .btn-cancel')
-		.forEach(function (trigger) {
-			trigger.addEventListener('click', function (e) {
+		.forEach((trigger) => {
+			trigger.addEventListener('click', (e) => {
 				e.preventDefault();
 				window.parent.Liferay.fire(events.CLOSE_SIDE_PANEL);
 			});

--- a/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/country_item_selector.jsp
+++ b/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/country_item_selector.jsp
@@ -113,7 +113,7 @@ PortletURL portletURL = commerceCountryItemSelectorViewDisplayContext.getPortlet
 		'<portlet:namespace />commerceCountries'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 			{

--- a/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/price_list_item_selector.jsp
+++ b/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/price_list_item_selector.jsp
@@ -120,7 +120,7 @@ PortletURL portletURL = commercePriceListItemSelectorViewDisplayContext.getPortl
 		'<portlet:namespace />commercePriceLists'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 			{

--- a/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/pricing_class_item_selector.jsp
+++ b/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/pricing_class_item_selector.jsp
@@ -112,7 +112,7 @@ PortletURL portletURL = commercePricingClassItemSelectorViewDisplayContext.getPo
 		'<portlet:namespace />commercePricingClasses'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 			{

--- a/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/product_instance_item_selector.jsp
+++ b/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/product_instance_item_selector.jsp
@@ -108,7 +108,7 @@ PortletURL portletURL = commerceProductInstanceItemSelectorViewDisplayContext.ge
 		'<portlet:namespace />cpInstances'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(commerceProductInstanceItemSelectorViewDisplayContext.getItemSelectedEventName()) %>',
 			{

--- a/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/warehouse_item_selector.jsp
+++ b/modules/apps/commerce/commerce-item-selector-web/src/main/resources/META-INF/resources/warehouse_item_selector.jsp
@@ -98,7 +98,7 @@ for (ManagementBarFilterItem managementBarFilterItem : managementBarFilterItems)
 		'<portlet:namespace />commerceInventoryWarehouses'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 			{

--- a/modules/apps/commerce/commerce-notification-web/src/main/resources/META-INF/resources/edit_notification_template.jsp
+++ b/modules/apps/commerce/commerce-notification-web/src/main/resources/META-INF/resources/edit_notification_template.jsp
@@ -215,7 +215,7 @@ if (commerceNotificationTemplate != null) {
 	Liferay.provide(
 		window,
 		'<portlet:namespace />selectType',
-		function () {
+		() => {
 			var A = AUI();
 
 			var name = A.one('#<portlet:namespace />name').val();

--- a/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/pending_orders/edit_order.jsp
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/pending_orders/edit_order.jsp
@@ -396,7 +396,7 @@ List<CommerceAddress> billingAddresses = commerceOrderContentDisplayContext.getB
 	if (orderTransition) {
 		orderTransition.delegate(
 			'click',
-			function (event) {
+			(event) => {
 				<portlet:namespace />transition(event);
 			},
 			'.transition-link'

--- a/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/pending_orders/transition.jspf
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/pending_orders/transition.jspf
@@ -31,7 +31,7 @@
 	Liferay.provide(
 		window,
 		'<portlet:namespace />transition',
-		function (event) {
+		(event) => {
 			var A = AUI();
 
 			var link = event.currentTarget;

--- a/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/order/edit_billing_address.jsp
+++ b/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/order/edit_billing_address.jsp
@@ -75,7 +75,7 @@ long commerceRegionId = BeanParamUtil.getLong(billingAddress, request, "commerce
 						},
 					];
 
-					list.forEach(function (listElement) {
+					list.forEach((listElement) => {
 						callbackList.push(listElement);
 					});
 
@@ -111,7 +111,7 @@ long commerceRegionId = BeanParamUtil.getLong(billingAddress, request, "commerce
 						},
 					];
 
-					list.forEach(function (listElement) {
+					list.forEach((listElement) => {
 						callbackList.push(listElement);
 					});
 

--- a/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/order/edit_shipping_address.jsp
+++ b/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/order/edit_shipping_address.jsp
@@ -75,7 +75,7 @@ long commerceRegionId = BeanParamUtil.getLong(shippingAddress, request, "commerc
 						},
 					];
 
-					list.forEach(function (listElement) {
+					list.forEach((listElement) => {
 						callbackList.push(listElement);
 					});
 
@@ -111,7 +111,7 @@ long commerceRegionId = BeanParamUtil.getLong(shippingAddress, request, "commerc
 						},
 					];
 
-					list.forEach(function (listElement) {
+					list.forEach((listElement) => {
 						callbackList.push(listElement);
 					});
 

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/definition_pricing_class/definition_pricing_classes.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/definition_pricing_class/definition_pricing_classes.jsp
@@ -49,9 +49,9 @@ CProduct cProduct = cpDefinition.getCProduct();
 						headers: headers,
 						method: 'POST',
 					}
-				).then(function (response) {
+				).then((response) => {
 					if (!response.ok) {
-						return response.json().then(function (data) {
+						return response.json().then((data) => {
 							return Promise.reject(data.errorDescription);
 						});
 					}
@@ -82,12 +82,12 @@ CProduct cProduct = cpDefinition.getCProduct();
 						method: 'POST',
 					}
 				)
-					.then(function (response) {
+					.then((response) => {
 						if (response.ok) {
 							return response.json();
 						}
 
-						return response.json().then(function (data) {
+						return response.json().then((data) => {
 							return Promise.reject(data.message);
 						});
 					})

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/add_commerce_discount.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/add_commerce_discount.jsp
@@ -66,7 +66,7 @@ PortletURL editDiscountPortletURL = commerceDiscountDisplayContext.getEditCommer
 			Liferay.provide(
 				window,
 				'<portlet:namespace />apiSubmit',
-				function (form) {
+				(form) => {
 					var commerceDiscountTarget = form.querySelector(
 						'#commerceDiscountTarget'
 					).value;
@@ -86,7 +86,7 @@ PortletURL editDiscountPortletURL = commerceDiscountDisplayContext.getEditCommer
 					};
 
 					return CommerceDiscountResource.addDiscount(discountData)
-						.then(function (payload) {
+						.then((payload) => {
 							var redirectURL = new Liferay.PortletURL.createURL(
 								'<%= editDiscountPortletURL.toString() %>'
 							);
@@ -107,7 +107,7 @@ PortletURL editDiscountPortletURL = commerceDiscountDisplayContext.getEditCommer
 								},
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				},

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/details.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/details.jsp
@@ -200,7 +200,7 @@ boolean hasPermission = commerceDiscountDisplayContext.hasPermission(ActionKeys.
 	Liferay.provide(
 		window,
 		'<portlet:namespace />selectType',
-		function () {
+		() => {
 			var A = AUI();
 
 			var type = A.one('#<portlet:namespace />usePercentage').val();
@@ -219,7 +219,7 @@ boolean hasPermission = commerceDiscountDisplayContext.hasPermission(ActionKeys.
 	Liferay.provide(
 		window,
 		'<portlet:namespace />selectTarget',
-		function () {
+		() => {
 			var A = AUI();
 
 			var type = A.one('#<portlet:namespace />target').val();

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/edit_commerce_discount.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/edit_commerce_discount.jsp
@@ -57,7 +57,7 @@ else {
 <aui:script>
 	document
 		.getElementById('<portlet:namespace />publishButton')
-		.addEventListener('click', function (e) {
+		.addEventListener('click', (e) => {
 			e.preventDefault();
 
 			var form = document.getElementById('<portlet:namespace />fm');

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/qualifier/account_groups.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/qualifier/account_groups.jspf
@@ -40,13 +40,13 @@
 						id,
 						accountGroupData
 					)
-						.then(function () {
+						.then(() => {
 							Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 								id:
 									'<%= CommercePricingDataSetConstants.COMMERCE_DATA_SET_KEY_DISCOUNT_QUALIFIER_ACCOUNT_GROUPS %>',
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/qualifier/accounts.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/qualifier/accounts.jspf
@@ -37,13 +37,13 @@
 					};
 
 					return CommerceDiscountAccountsResource.addDiscountAccount(id, accountData)
-						.then(function () {
+						.then(() => {
 							Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 								id:
 									'<%= CommercePricingDataSetConstants.COMMERCE_DATA_SET_KEY_DISCOUNT_QUALIFIER_ACCOUNTS %>',
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/qualifier/channels.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/qualifier/channels.jspf
@@ -37,13 +37,13 @@
 					};
 
 					return CommerceDiscountChannelsResource.addDiscountChannel(id, channelData)
-						.then(function () {
+						.then(() => {
 							Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 								id:
 									'<%= CommercePricingDataSetConstants.COMMERCE_DATA_SET_KEY_DISCOUNT_QUALIFIER_CHANNELS %>',
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/qualifiers.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/qualifiers.jsp
@@ -97,7 +97,7 @@ boolean hasPermission = commerceDiscountQualifiersDisplayContext.hasPermission(A
 	Liferay.provide(
 		window,
 		'<portlet:namespace />chooseAccountQualifiers',
-		function (value) {
+		(value) => {
 			var portletURL = new Liferay.PortletURL.createURL(
 				'<%= currentURLObj %>'
 			);
@@ -112,7 +112,7 @@ boolean hasPermission = commerceDiscountQualifiersDisplayContext.hasPermission(A
 	Liferay.provide(
 		window,
 		'<portlet:namespace />chooseChannelQualifiers',
-		function (value) {
+		(value) => {
 			var portletURL = new Liferay.PortletURL.createURL(
 				'<%= currentURLObj %>'
 			);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/rule/add_commerce_discount_rule.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/rule/add_commerce_discount_rule.jsp
@@ -53,7 +53,7 @@ List<CommerceDiscountRuleType> commerceDiscountRuleTypes = commerceDiscountDispl
 			Liferay.provide(
 				window,
 				'<portlet:namespace />apiSubmit',
-				function (form) {
+				(form) => {
 					var name = form.querySelector('#name').value;
 
 					var commerceDiscountRuleType = form.querySelector('#type').value;
@@ -67,7 +67,7 @@ List<CommerceDiscountRuleType> commerceDiscountRuleTypes = commerceDiscountDispl
 						'<%= commerceDiscountId %>',
 						discountRuleData
 					)
-						.then(function (payload) {
+						.then((payload) => {
 							window.parent.Liferay.fire(events.CLOSE_MODAL, {
 								successNotification: {
 									message:
@@ -76,7 +76,7 @@ List<CommerceDiscountRuleType> commerceDiscountRuleTypes = commerceDiscountDispl
 								},
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				},

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/rule/edit_commerce_discount_rule.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/rule/edit_commerce_discount_rule.jsp
@@ -94,7 +94,7 @@ String type = BeanParamUtil.getString(commerceDiscountRule, request, "type");
 	Liferay.provide(
 		window,
 		'<portlet:namespace />apiSubmit',
-		function () {
+		() => {
 			var form = document.getElementById('<portlet:namespace />fm');
 			var name = form.querySelector('#<portlet:namespace />name').value;
 
@@ -112,7 +112,7 @@ String type = BeanParamUtil.getString(commerceDiscountRule, request, "type");
 				'<%= commerceDiscountRule.getCommerceDiscountRuleId() %>',
 				discountRuleData
 			)
-				.then(function () {
+				.then(() => {
 					NotificationUtils.showNotification(
 						'<liferay-ui:message key="your-request-completed-successfully" />'
 					);
@@ -124,7 +124,7 @@ String type = BeanParamUtil.getString(commerceDiscountRule, request, "type");
 
 					return;
 				})
-				.catch(function () {
+				.catch(() => {
 					alert(
 						'<liferay-ui:message key="your-request-failed-to-complete" />'
 					);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/rule/type/added_all/v1_0/view.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/rule/type/added_all/v1_0/view.jsp
@@ -69,7 +69,7 @@ List<CPDefinition> cpDefinitions = addedAllCommerceDiscountRuleDisplayContext.ge
 <aui:script use="liferay-item-selector-dialog">
 	window.document
 		.querySelector('#<portlet:namespace />selectCommerceDiscountCPDefinition')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			var itemSelectorDialog = new A.LiferayItemSelectorDialog({
@@ -138,7 +138,7 @@ List<CPDefinition> cpDefinitions = addedAllCommerceDiscountRuleDisplayContext.ge
 
 	searchContainerContentBox.delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var link = event.currentTarget;
 
 			var rowId = link.attr('data-rowId');

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/rule/type/added_any/v1_0/view.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/rule/type/added_any/v1_0/view.jsp
@@ -69,7 +69,7 @@ List<CPDefinition> cpDefinitions = addedAnyCommerceDiscountRuleDisplayContext.ge
 <aui:script use="liferay-item-selector-dialog">
 	window.document
 		.querySelector('#<portlet:namespace />selectCommerceDiscountCPDefinition')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			var itemSelectorDialog = new A.LiferayItemSelectorDialog({
@@ -138,7 +138,7 @@ List<CPDefinition> cpDefinitions = addedAnyCommerceDiscountRuleDisplayContext.ge
 
 	searchContainerContentBox.delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var link = event.currentTarget;
 
 			var rowId = link.attr('data-rowId');

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/rule/type/products.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/rule/type/products.jspf
@@ -57,7 +57,7 @@ String typeSettings = unicodeProperties.getProperty(commerceDiscountRule.getType
 				'<%= commerceDiscountRule.getCommerceDiscountRuleId() %>',
 				ruleData
 			)
-				.then(function (payload) {
+				.then((payload) => {
 					Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 						id:
 							'<%= CommercePricingDataSetConstants.COMMERCE_DATA_SET_KEY_DISCOUNT_RULE_PRODUCT_DEFINITIONS %>',
@@ -71,7 +71,7 @@ String typeSettings = unicodeProperties.getProperty(commerceDiscountRule.getType
 						'<portlet:namespace />typeSettings'
 					).value = typeSettings;
 				})
-				.catch(function (error) {
+				.catch((error) => {
 					return Promise.reject(error);
 				});
 		}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/target/categories.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/target/categories.jspf
@@ -40,13 +40,13 @@
 						id,
 						categoryData
 					)
-						.then(function () {
+						.then(() => {
 							Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 								id:
 									'<%= CommercePricingDataSetConstants.COMMERCE_DATA_SET_KEY_DISCOUNT_CATEGORIES %>',
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/target/pricing_classes.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/target/pricing_classes.jspf
@@ -40,13 +40,13 @@
 						id,
 						productGroupData
 					)
-						.then(function () {
+						.then(() => {
 							Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 								id:
 									'<%= CommercePricingDataSetConstants.COMMERCE_DATA_SET_KEY_DISCOUNT_PRICING_CLASSES %>',
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/target/products.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/discount/target/products.jspf
@@ -37,13 +37,13 @@
 					};
 
 					return CommerceDiscountProductsResource.addDiscountProduct(id, productData)
-						.then(function () {
+						.then(() => {
 							Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 								id:
 									'<%= CommercePricingDataSetConstants.COMMERCE_DATA_SET_KEY_DISCOUNT_PRODUCT_DEFINITIONS %>',
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/edit_commerce_price_list.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/edit_commerce_price_list.jsp
@@ -64,7 +64,7 @@ else {
 <aui:script>
 	document
 		.getElementById('<portlet:namespace />publishButton')
-		.addEventListener('click', function (e) {
+		.addEventListener('click', (e) => {
 			e.preventDefault();
 
 			var form = document.getElementById('<portlet:namespace />fm');

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_entries.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_entries.jsp
@@ -53,14 +53,14 @@ if (CommercePriceListConstants.TYPE_PROMOTION.equals(commercePriceEntryDisplayCo
 					};
 
 					return CommercePriceEntriesResource.addPriceEntry(id, priceEntryData)
-						.then(function () {
-							setTimeout(function () {
+						.then(() => {
+							setTimeout(() => {
 								Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 									id: '<%= datasetId %>',
 								});
 							}, 500);
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_modifier/categories.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_modifier/categories.jsp
@@ -49,13 +49,13 @@ long commercePriceModifierId = commercePriceListDisplayContext.getCommercePriceM
 						id,
 						categoryData
 					)
-						.then(function () {
+						.then(() => {
 							Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 								id:
 									'<%= CommercePricingDataSetConstants.COMMERCE_DATA_SET_KEY_PRICE_MODIFIER_CATEGORIES %>',
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_modifier/info.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_modifier/info.jsp
@@ -129,7 +129,7 @@ if (modifierType.equals(CommercePriceModifierConstants.MODIFIER_TYPE_PERCENTAGE)
 	Liferay.provide(
 		window,
 		'<portlet:namespace />selectType',
-		function () {
+		() => {
 			var A = AUI();
 
 			var type = A.one('#<portlet:namespace />modifierType').val();

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_modifier/pricing_classes.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_modifier/pricing_classes.jsp
@@ -49,13 +49,13 @@ long commercePriceModifierId = commercePriceListDisplayContext.getCommercePriceM
 						id,
 						productGroupData
 					)
-						.then(function () {
+						.then(() => {
 							Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 								id:
 									'<%= CommercePricingDataSetConstants.COMMERCE_DATA_SET_KEY_PRICE_MODIFIER_PRICING_CLASSES %>',
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_modifier/products.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/price_modifier/products.jsp
@@ -49,13 +49,13 @@ long commercePriceModifierId = commercePriceListDisplayContext.getCommercePriceM
 						id,
 						productData
 					)
-						.then(function () {
+						.then(() => {
 							Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 								id:
 									'<%= CommercePricingDataSetConstants.COMMERCE_DATA_SET_KEY_PRICE_MODIFIER_PRODUCT_DEFINITIONS %>',
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/qualifier/account_groups.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/qualifier/account_groups.jspf
@@ -40,13 +40,13 @@
 						id,
 						accountGroupData
 					)
-						.then(function () {
+						.then(() => {
 							Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 								id:
 									'<%= CommercePricingDataSetConstants.COMMERCE_DATA_SET_KEY_PRICE_LIST_QUALIFIER_ACCOUNT_GROUPS %>',
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/qualifier/accounts.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/qualifier/accounts.jspf
@@ -40,13 +40,13 @@
 						id,
 						accountData
 					)
-						.then(function () {
+						.then(() => {
 							Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 								id:
 									'<%= CommercePricingDataSetConstants.COMMERCE_DATA_SET_KEY_PRICE_LIST_QUALIFIER_ACCOUNTS %>',
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/qualifier/channels.jspf
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/qualifier/channels.jspf
@@ -40,13 +40,13 @@
 						id,
 						channelData
 					)
-						.then(function () {
+						.then(() => {
 							Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 								id:
 									'<%= CommercePricingDataSetConstants.COMMERCE_DATA_SET_KEY_PRICE_LIST_QUALIFIER_CHANNELS %>',
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/qualifiers.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/price_lists/qualifiers.jsp
@@ -95,7 +95,7 @@ boolean hasPermission = commercePriceListQualifiersDisplayContext.hasPermission(
 	Liferay.provide(
 		window,
 		'<portlet:namespace />chooseAccountQualifiers',
-		function (value) {
+		(value) => {
 			var portletURL = new Liferay.PortletURL.createURL(
 				'<%= currentURLObj %>'
 			);
@@ -110,7 +110,7 @@ boolean hasPermission = commercePriceListQualifiersDisplayContext.hasPermission(
 	Liferay.provide(
 		window,
 		'<portlet:namespace />chooseChannelQualifiers',
-		function (value) {
+		(value) => {
 			var portletURL = new Liferay.PortletURL.createURL(
 				'<%= currentURLObj %>'
 			);

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/pricing_class/add_commerce_pricing_class.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/pricing_class/add_commerce_pricing_class.jsp
@@ -46,7 +46,7 @@ String defaultLanguageId = LocaleUtil.toLanguageId(defaultLocale);
 			Liferay.provide(
 				window,
 				'<portlet:namespace />apiSubmit',
-				function (form) {
+				(form) => {
 					var description = form.querySelector('#description').value;
 					var title = form.querySelector('#title').value;
 
@@ -56,7 +56,7 @@ String defaultLanguageId = LocaleUtil.toLanguageId(defaultLocale);
 					};
 
 					return CommerceProductGroupsResource.addProductGroup(productGroupData)
-						.then(function (payload) {
+						.then((payload) => {
 							var redirectURL = new Liferay.PortletURL.createURL(
 								'<%= editPricingClassPortletURL.toString() %>'
 							);
@@ -73,7 +73,7 @@ String defaultLanguageId = LocaleUtil.toLanguageId(defaultLocale);
 								},
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				},

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/pricing_class/products.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/pricing_class/products.jsp
@@ -52,13 +52,13 @@ boolean hasPermission = commercePricingClassCPDefinitionDisplayContext.hasPermis
 						id,
 						productData
 					)
-						.then(function () {
+						.then(() => {
 							Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 								id:
 									'<%= CommercePricingDataSetConstants.COMMERCE_DATA_SET_KEY_PRICING_CLASSES_PRODUCT_DEFINITIONS %>',
 							});
 						})
-						.catch(function (error) {
+						.catch((error) => {
 							return Promise.reject(error);
 						});
 				}

--- a/modules/apps/commerce/commerce-product-asset-categories-navigation-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/commerce/commerce-product-asset-categories-navigation-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -115,7 +115,7 @@ if (assetVocabulary != null) {
 </aui:form>
 
 <aui:script use="aui-base,event-input">
-	A.one('#<portlet:namespace />submitButton').on('click', function () {
+	A.one('#<portlet:namespace />submitButton').on('click', () => {
 		if (
 			A.one('#<portlet:namespace />preferencesUseRootCategory').attr(
 				'checked'

--- a/modules/apps/commerce/commerce-product-asset-categories-navigation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/commerce/commerce-product-asset-categories-navigation-web/src/main/resources/META-INF/resources/view.jsp
@@ -60,7 +60,7 @@ if (assetVocabulary != null) {
 			'#<portlet:namespace />taglibAssetCategoriesNavigationPanel .lfr-asset-category-list-container'
 		);
 
-		treeViews.each(function (item, index, collection) {
+		treeViews.each((item, index, collection) => {
 			var assetCategoryList = item.one('.lfr-asset-category-list');
 
 			var treeView = new A.TreeView({
@@ -76,7 +76,7 @@ if (assetVocabulary != null) {
 
 				selectedChild.expand();
 
-				selectedChild.eachParent(function (node) {
+				selectedChild.eachParent((node) => {
 					if (node instanceof A.TreeNode) {
 						node.expand();
 					}

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/resources/META-INF/resources/display_layout/edit_cp_display_layout.jsp
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/resources/META-INF/resources/display_layout/edit_cp_display_layout.jsp
@@ -115,7 +115,7 @@ if (cpDisplayLayout != null) {
 
 	window.document
 		.querySelector('#<portlet:namespace />chooseDisplayPage')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			var itemSelectorDialog = new A.LiferayItemSelectorDialog({
 				eventName: 'selectDisplayPage',
 				on: {
@@ -140,7 +140,7 @@ if (cpDisplayLayout != null) {
 			itemSelectorDialog.open();
 		});
 
-	displayPageItemRemove.addEventListener('click', function () {
+	displayPageItemRemove.addEventListener('click', () => {
 		displayPageNameInput.innerHTML = '<liferay-ui:message key="none" />';
 
 		pagesContainerInput.value = '';
@@ -225,7 +225,7 @@ if (cpDisplayLayout != null) {
 
 	window.document
 		.querySelector('#<portlet:namespace />selectCategories')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			var itemSelectorDialog = new ItemSelectorDialog.default({
 				eventName: '<portlet:namespace />selectCategory',
 				'strings.add': '<liferay-ui:message key="done" />',
@@ -236,11 +236,11 @@ if (cpDisplayLayout != null) {
 
 			itemSelectorDialog.open();
 
-			itemSelectorDialog.on('selectedItemChange', function (event) {
+			itemSelectorDialog.on('selectedItemChange', (event) => {
 				if (event.selectedItem) {
 					var selectedItem = event.selectedItem;
 
-					Object.keys(selectedItem).forEach(function (key) {
+					Object.keys(selectedItem).forEach((key) => {
 						var item = selectedItem[key];
 
 						if (!item.unchecked) {

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/resources/META-INF/resources/edit_asset_category_cp_attachment_file_entry.jsp
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/resources/META-INF/resources/edit_asset_category_cp_attachment_file_entry.jsp
@@ -78,7 +78,7 @@ renderResponse.setTitle((cpAttachmentFileEntry == null) ? LanguageUtil.get(reque
 </aui:form>
 
 <aui:script use="aui-base,event-input">
-	A.one('#<portlet:namespace />publishButton').on('click', function () {
+	A.one('#<portlet:namespace />publishButton').on('click', () => {
 		var workflowActionInput = A.one('#<portlet:namespace />workflowAction');
 
 		if (workflowActionInput) {

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/META-INF/resources/price_range_facets/view.jsp
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/META-INF/resources/price_range_facets/view.jsp
@@ -135,7 +135,7 @@ CPPriceRangeFacetsDisplayContext cpPriceRangeFacetsDisplayContext = (CPPriceRang
 					</div>
 
 					<aui:script>
-						Liferay.provide(window, '<portlet:namespace />submitPriceRange', function () {
+						Liferay.provide(window, '<portlet:namespace />submitPriceRange', () => {
 							var max = document.getElementById('<portlet:namespace />maximum').value;
 
 							if (max == '') {

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/META-INF/resources/sort/view.jsp
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/META-INF/resources/sort/view.jsp
@@ -59,7 +59,7 @@ SearchContainer<CPCatalogEntry> cpCatalogEntrySearchContainer = cpSearchResultsD
 				<aui:script>
 					document
 						.querySelector('#<%= liferayPortletResponse.getNamespace() + sortOption %>')
-						.addEventListener('click', function (e) {
+						.addEventListener('click', (e) => {
 							e.preventDefault();
 							<%= liferayPortletResponse.getNamespace() + "changeOrderBy('" + sortOption + "');" %>;
 						});
@@ -77,7 +77,7 @@ SearchContainer<CPCatalogEntry> cpCatalogEntrySearchContainer = cpSearchResultsD
 	Liferay.provide(
 		window,
 		'<portlet:namespace />changeOrderBy',
-		function (orderBy) {
+		(orderBy) => {
 			var portletURL = new Liferay.PortletURL.createURL(
 				'<%= themeDisplay.getURLCurrent() %>'
 			);
@@ -90,7 +90,7 @@ SearchContainer<CPCatalogEntry> cpCatalogEntrySearchContainer = cpSearchResultsD
 		['liferay-portlet-url']
 	);
 
-	Liferay.provide(window, '<portlet:namespace />toggleDropdown', function () {
+	Liferay.provide(window, '<portlet:namespace />toggleDropdown', () => {
 		var dropdownElement = window.document.querySelector(
 			'#<portlet:namespace />commerce-dropdown-order-by'
 		);

--- a/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/product_detail/render/form_handlers/metal_js.jspf
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/product_detail/render/form_handlers/metal_js.jspf
@@ -41,11 +41,11 @@
 				method: 'post',
 			}
 		)
-			.then(function (response) {
+			.then((response) => {
 				return response.json();
 			})
-			.then(function (response) {
-				var images = response.map(function (image) {
+			.then((response) => {
+				var images = response.map((image) => {
 					return {
 						thumbnailUrl: image.url,
 						url: image.url,
@@ -199,22 +199,22 @@
 		updateProductFields(cpInstance);
 	}
 
-	Liferay.componentReady('ProductOptions' + cpDefinitionId).then(function (
-		DDMFormInstance
-	) {
-		if (DDMFormInstance) {
-			var FormHandler = DDMFormHandler.default;
+	Liferay.componentReady('ProductOptions' + cpDefinitionId).then(
+		(DDMFormInstance) => {
+			if (DDMFormInstance) {
+				var FormHandler = DDMFormHandler.default;
 
-			var FormHandlerConfiguration = {
-				actionURL: '<%= checkCPInstanceURL %>',
-				cpDefinitionId: '<%= cpDefinitionId %>',
-				DDMFormInstance: DDMFormInstance,
-				portletId: CP_CONTENT_WEB_PORTLET_KEY,
-			};
+				var FormHandlerConfiguration = {
+					actionURL: '<%= checkCPInstanceURL %>',
+					cpDefinitionId: '<%= cpDefinitionId %>',
+					DDMFormInstance: DDMFormInstance,
+					portletId: CP_CONTENT_WEB_PORTLET_KEY,
+				};
 
-			new FormHandler(FormHandlerConfiguration);
+				new FormHandler(FormHandlerConfiguration);
 
-			Liferay.on(eventsDefinitions.CP_INSTANCE_CHANGED, updateView);
+				Liferay.on(eventsDefinitions.CP_INSTANCE_CHANGED, updateView);
+			}
 		}
-	});
+	);
 </aui:script>

--- a/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/product_publisher/configuration/ordering.jsp
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/product_publisher/configuration/ordering.jsp
@@ -98,7 +98,7 @@ CPPublisherConfigurationDisplayContext cpPublisherConfigurationDisplayContext = 
 <aui:script use="aui-base">
 	A.one('#<portlet:namespace />ordering').delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var currentTarget = event.currentTarget;
 
 			var orderByTypeContainer = currentTarget.ancestor(

--- a/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/product_publisher/configuration/product_entries.jsp
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/product_publisher/configuration/product_entries.jsp
@@ -143,7 +143,7 @@ List<CPCatalogEntry> catalogEntries = cpPublisherConfigurationDisplayContext.get
 <aui:script use="liferay-item-selector-dialog">
 	window.document
 		.querySelector('#<portlet:namespace />addCommerceProductDefinition')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			var itemSelectorDialog = new A.LiferayItemSelectorDialog({

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/attachment_file_entry/image_selector.jspf
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/attachment_file_entry/image_selector.jspf
@@ -63,7 +63,7 @@ long fileEntryId = BeanParamUtil.getLong(cpAttachmentFileEntry, request, "fileEn
 	);
 
 	if (selectFileButton) {
-		selectFileButton.addEventListener('click', function (event) {
+		selectFileButton.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			var itemSelectorDialog = new A.LiferayItemSelectorDialog({
@@ -111,7 +111,7 @@ long fileEntryId = BeanParamUtil.getLong(cpAttachmentFileEntry, request, "fileEn
 	);
 
 	if (deleteFileButton) {
-		deleteFileButton.addEventListener('click', function (event) {
+		deleteFileButton.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			window.document.querySelector(

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/add_cp_definition.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/add_cp_definition.jsp
@@ -43,7 +43,7 @@
 		Liferay.provide(
 			window,
 			'<portlet:namespace />apiSubmit',
-			function () {
+			() => {
 				ModalUtils.isSubmitting();
 
 				var formattedData = Object.assign(
@@ -60,7 +60,7 @@
 				] = document.getElementById('<portlet:namespace />name').value;
 
 				AdminCatalogResource.createProduct(formattedData)
-					.then(function (cpDefinition) {
+					.then((cpDefinition) => {
 						var redirectURL = new Liferay.PortletURL.createURL(
 							'<%= editProductDefinitionURL %>'
 						);

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/details.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/details.jsp
@@ -226,7 +226,7 @@ if ((cpDefinition != null) && (cpDefinition.getExpirationDate() != null)) {
 								headers: headers,
 								method: 'POST',
 							}
-						).then(function () {
+						).then(() => {
 							Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 								id:
 									'<%= CommerceProductDataSetConstants.COMMERCE_DATA_SET_KEY_PRODUCT_DEFINITION_SPECIFICATIONS %>',
@@ -255,12 +255,12 @@ if ((cpDefinition != null) && (cpDefinition.getExpirationDate() != null)) {
 								method: 'POST',
 							}
 						)
-							.then(function (response) {
+							.then((response) => {
 								if (response.ok) {
 									return response.json();
 								}
 
-								return response.json().then(function (data) {
+								return response.json().then((data) => {
 									return Promise.reject(data.errorDescription);
 								});
 							})
@@ -355,7 +355,7 @@ if ((cpDefinition != null) && (cpDefinition.getExpirationDate() != null)) {
 	<aui:script>
 		document
 			.getElementById('<portlet:namespace />commerceCatalogGroupId')
-			.addEventListener('change', function (event) {
+			.addEventListener('change', (event) => {
 				var languageId = event.target.querySelector(
 					'[value="' + event.target.value + '"]'
 				).dataset.languageid;

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/duplicate_cp_definition.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/duplicate_cp_definition.jsp
@@ -49,13 +49,13 @@ CPDefinition cpDefinition = cpDefinitionsDisplayContext.getCPDefinition();
 		Liferay.provide(
 			window,
 			'<portlet:namespace />apiSubmit',
-			function (form) {
+			(form) => {
 				var API_URL =
 					'/o/headless-commerce-admin-catalog/v1.0/products/<%= cpDefinition.getCProductId() %>/clone?catalogId=' +
 					<portlet:namespace />product.catalogId;
 
 				FormUtils.apiSubmit(form, API_URL)
-					.then(function (payload) {
+					.then((payload) => {
 						var headers = new Headers({
 							Accept: 'application/json',
 							'Content-Type': 'application/json',
@@ -80,7 +80,7 @@ CPDefinition cpDefinition = cpDefinitionsDisplayContext.getCPDefinition();
 								headers: headers,
 								method: 'patch',
 							}
-						).then(function () {
+						).then(() => {
 							var redirectURL = new Liferay.PortletURL.createURL(
 								'<%= editProductDefinitionURL %>'
 							);
@@ -101,7 +101,7 @@ CPDefinition cpDefinition = cpDefinitionsDisplayContext.getCPDefinition();
 							});
 						});
 					})
-					.catch(function () {
+					.catch(() => {
 						window.parent.Liferay.fire(events.IS_LOADING_MODAL, {
 							isLoading: false,
 						});

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition_links.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition_links.jsp
@@ -67,7 +67,7 @@ PortletURL portletURL = cpDefinitionLinkDisplayContext.getPortletURL();
 
 			Liferay.on(
 				'<portlet:namespace />addCommerceProductDefinitionLink<%= type %>',
-				function () {
+				() => {
 					var itemSelectorDialog = new A.LiferayItemSelectorDialog({
 						eventName: 'productDefinitionsSelectItem',
 						on: {

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition_option_rels.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition_option_rels.jsp
@@ -52,16 +52,16 @@ CPDefinition cpDefinition = cpDefinitionOptionRelDisplayContext.getCPDefinition(
 						method: 'POST',
 					}
 				)
-					.then(function (response) {
+					.then((response) => {
 						if (response.ok) {
 							return response.json();
 						}
 
-						return response.json().then(function (data) {
+						return response.json().then((data) => {
 							return Promise.reject(data.errorDescription);
 						});
 					})
-					.then(function (e) {
+					.then((e) => {
 						Liferay.fire(events.UPDATE_DATASET_DISPLAY, {
 							id:
 								'<%= CommerceProductDataSetConstants.COMMERCE_DATA_SET_KEY_PRODUCT_OPTIONS %>',
@@ -91,12 +91,12 @@ CPDefinition cpDefinition = cpDefinitionOptionRelDisplayContext.getCPDefinition(
 						method: 'POST',
 					}
 				)
-					.then(function (response) {
+					.then((response) => {
 						if (response.ok) {
 							return response.json();
 						}
 
-						return response.json().then(function (data) {
+						return response.json().then((data) => {
 							return Promise.reject(data.errorDescription);
 						});
 					})

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/display_layout/edit_cp_display_layout.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/display_layout/edit_cp_display_layout.jsp
@@ -138,7 +138,7 @@ if (cpDisplayLayout != null) {
 <aui:script use="aui-base,liferay-item-selector-dialog">
 	window.document
 		.querySelector('#<portlet:namespace />selectProduct')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			Liferay.Util.selectEntity({
@@ -163,7 +163,7 @@ if (cpDisplayLayout != null) {
 
 	searchContainerContentBox.delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var link = event.currentTarget;
 
 			var rowId = link.attr('data-rowId');
@@ -177,7 +177,7 @@ if (cpDisplayLayout != null) {
 		'.modify-link'
 	);
 
-	Liferay.on('productDefinitionsSelectItem', function (event) {
+	Liferay.on('productDefinitionsSelectItem', (event) => {
 		var item = event.data;
 
 		if (item) {
@@ -229,7 +229,7 @@ if (cpDisplayLayout != null) {
 
 	window.document
 		.querySelector('#<portlet:namespace />chooseDisplayPage')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			var itemSelectorDialog = new A.LiferayItemSelectorDialog({
 				eventName: 'selectDisplayPage',
 				on: {
@@ -254,7 +254,7 @@ if (cpDisplayLayout != null) {
 			itemSelectorDialog.open();
 		});
 
-	displayPageItemRemove.addEventListener('click', function (event) {
+	displayPageItemRemove.addEventListener('click', (event) => {
 		displayPageNameInput.innerHTML = '<liferay-ui:message key="none" />';
 
 		pagesContainerInput.value = '';

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_cp_attachment_file_entry.jspf
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_cp_attachment_file_entry.jspf
@@ -112,50 +112,46 @@ if (cpAttachmentFileEntry != null) {
 	}
 	catch (_ignore) {}
 
-	Liferay.componentReady('ProductOptions<%= cpDefinitionId %>').then(function (
-		ddmForm
-	) {
-		if (!ddmForm.on) {
-			return;
-		}
+	Liferay.componentReady('ProductOptions<%= cpDefinitionId %>').then(
+		(ddmForm) => {
+			if (!ddmForm.on) {
+				return;
+			}
 
-		if (!fieldValues.length) {
-			fieldValues = FormsHelper.getDefaultFieldsShape(ddmForm);
-		}
+			if (!fieldValues.length) {
+				fieldValues = FormsHelper.getDefaultFieldsShape(ddmForm);
+			}
 
-		ddmForm.on('fieldEdited', function (field) {
-			fieldValues = FormsHelper.updateFields(fieldValues, field);
+			ddmForm.on('fieldEdited', (field) => {
+				fieldValues = FormsHelper.updateFields(fieldValues, field);
 
-			var form = document['<portlet:namespace />fm'];
-			form['<portlet:namespace />ddmFormValues'].value = JSON.stringify(
-				fieldValues
-			);
-		});
-	});
-
-	Liferay.provide(
-		window,
-		'<portlet:namespace />saveAttachmentFileEntry',
-		function () {
-			var form = window.document['<portlet:namespace />fm'];
-
-			var ddmForm = Liferay.component('ProductOptions<%= cpDefinitionId %>');
-
-			if (ddmForm) {
+				var form = document['<portlet:namespace />fm'];
 				form['<portlet:namespace />ddmFormValues'].value = JSON.stringify(
 					fieldValues
 				);
-			}
-
-			submitForm(form);
+			});
 		}
 	);
+
+	Liferay.provide(window, '<portlet:namespace />saveAttachmentFileEntry', () => {
+		var form = window.document['<portlet:namespace />fm'];
+
+		var ddmForm = Liferay.component('ProductOptions<%= cpDefinitionId %>');
+
+		if (ddmForm) {
+			form['<portlet:namespace />ddmFormValues'].value = JSON.stringify(
+				fieldValues
+			);
+		}
+
+		submitForm(form);
+	});
 </aui:script>
 
 <aui:script use="aui-base,event-input">
 	var publishButton = A.one('#<portlet:namespace />publishButton');
 
-	publishButton.on('click', function () {
+	publishButton.on('click', () => {
 		var workflowActionInput = A.one('#<portlet:namespace />workflowAction');
 
 		if (workflowActionInput) {

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_cp_definition.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_cp_definition.jsp
@@ -74,7 +74,7 @@ else {
 <aui:script>
 	document
 		.getElementById('<portlet:namespace />publishButton')
-		.addEventListener('click', function (e) {
+		.addEventListener('click', (e) => {
 			e.preventDefault();
 
 			var form = document.getElementById('<portlet:namespace />fm');

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_cp_definition_option_value_rel.jspf
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_cp_definition_option_value_rel.jspf
@@ -128,7 +128,7 @@ long cpDefinitionOptionValueRelId = cpDefinitionOptionValueRelDisplayContext.get
 				},
 			});
 
-			Liferay.provide(window, '<portlet:namespace />removeSku', function () {
+			Liferay.provide(window, '<portlet:namespace />removeSku', () => {
 				var url = new URL(
 					'<%= cpDefinitionOptionValueRelDisplayContext.getRemoveSkuUrl(currentURL) %>'
 				);

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_definition_visibility.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_definition_visibility.jsp
@@ -79,7 +79,7 @@ Map<String, String> contextParams = HashMapBuilder.<String, String>put(
 </aui:form>
 
 <aui:script use="liferay-item-selector-dialog">
-	Liferay.on('<portlet:namespace />selectCommerceAccountGroup', function () {
+	Liferay.on('<portlet:namespace />selectCommerceAccountGroup', () => {
 		var itemSelectorDialog = new A.LiferayItemSelectorDialog({
 			eventName: 'accountGroupSelectItem',
 			on: {
@@ -91,15 +91,14 @@ Map<String, String> contextParams = HashMapBuilder.<String, String>put(
 					if (selectedItems) {
 						var A = AUI();
 
-						A.Array.each(selectedItems, function (
-							item,
-							index,
-							selectedItems
-						) {
-							<portlet:namespace />addCommerceAccountGroupIds.push(
-								item.commerceAccountGroupId
-							);
-						});
+						A.Array.each(
+							selectedItems,
+							(item, index, selectedItems) => {
+								<portlet:namespace />addCommerceAccountGroupIds.push(
+									item.commerceAccountGroupId
+								);
+							}
+						);
 
 						window.document.querySelector(
 							'#<portlet:namespace />commerceAccountGroupIds'
@@ -121,7 +120,7 @@ Map<String, String> contextParams = HashMapBuilder.<String, String>put(
 		itemSelectorDialog.open();
 	});
 
-	Liferay.on('<portlet:namespace />selectCommerceChannel', function () {
+	Liferay.on('<portlet:namespace />selectCommerceChannel', () => {
 		var itemSelectorDialog = new A.LiferayItemSelectorDialog({
 			eventName: 'channelSelectItem',
 			on: {
@@ -133,15 +132,14 @@ Map<String, String> contextParams = HashMapBuilder.<String, String>put(
 					if (selectedItems) {
 						var A = AUI();
 
-						A.Array.each(selectedItems, function (
-							item,
-							index,
-							selectedItems
-						) {
-							<portlet:namespace />addCommerceChannelIds.push(
-								item.commerceChannelId
-							);
-						});
+						A.Array.each(
+							selectedItems,
+							(item, index, selectedItems) => {
+								<portlet:namespace />addCommerceChannelIds.push(
+									item.commerceChannelId
+								);
+							}
+						);
 
 						window.document.querySelector(
 							'#<portlet:namespace />commerceChannelIds'

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/instance/details.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/instance/details.jsp
@@ -219,23 +219,23 @@ if ((cpInstance != null) && (cpInstance.getExpirationDate() != null)) {
 
 	Liferay.componentReady(
 		'ProductOptions<%= cpDefinition.getCPDefinitionId() %>'
-	).then(function (ddmForm) {
+	).then((ddmForm) => {
 		if (!ddmForm.on) {
 			return;
 		}
-		ddmForm.on('fieldEdited', function (e) {
+		ddmForm.on('fieldEdited', (e) => {
 			var key = e.fieldInstance.fieldName;
 			var updatedItem = {
 				key: e.fieldInstance.fieldName,
 				value: e.value,
 			};
 
-			var itemFound = fieldValues.find(function (item) {
+			var itemFound = fieldValues.find((item) => {
 				return item.key === key;
 			});
 
 			if (itemFound) {
-				fieldValues = fieldValues.reduce(function (acc, item) {
+				fieldValues = fieldValues.reduce((acc, item) => {
 					return acc.concat(item.key === key ? updatedItem : item);
 				}, []);
 			}
@@ -262,7 +262,7 @@ if ((cpInstance != null) && (cpInstance.getExpirationDate() != null)) {
 
 			var fieldValues = [];
 
-			fields.forEach(function (field) {
+			fields.forEach((field) => {
 				var fieldValue = {};
 
 				fieldValue.key = field.get('fieldName');
@@ -297,7 +297,7 @@ if ((cpInstance != null) && (cpInstance.getExpirationDate() != null)) {
 
 	var publishButton = form.one('#<portlet:namespace />publishButton');
 
-	publishButton.on('click', function () {
+	publishButton.on('click', () => {
 		var workflowActionInput = form.one('#<portlet:namespace />workflowAction');
 
 		if (workflowActionInput) {

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/channel_item_selector.jsp
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/channel_item_selector.jsp
@@ -103,7 +103,7 @@ PortletURL portletURL = commerceChannelItemSelectorViewDisplayContext.getPortlet
 		'<portlet:namespace />commerceChannels'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var allSelectedElements = event.elements.allSelectedElements;
 		var arr = [];
 

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/definition_item_selector.jsp
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/definition_item_selector.jsp
@@ -190,7 +190,7 @@ PortletURL portletURL = cpDefinitionItemSelectorViewDisplayContext.getPortletURL
 				'<portlet:namespace />cpDefinitions'
 			);
 
-			searchContainer.on('rowToggled', function (event) {
+			searchContainer.on('rowToggled', (event) => {
 				Liferay.Util.getOpener().Liferay.fire(
 					'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 					{

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/instance_item_selector.jsp
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/instance_item_selector.jsp
@@ -116,7 +116,7 @@ PortletURL portletURL = cpInstanceItemSelectorViewDisplayContext.getPortletURL()
 		'<portlet:namespace />cpInstances'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 			{

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/option_item_selector.jsp
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/option_item_selector.jsp
@@ -100,7 +100,7 @@ PortletURL portletURL = cpOptionItemSelectorViewDisplayContext.getPortletURL();
 		'<portlet:namespace />cpOptions'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 			{

--- a/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/specification_option_item_selector.jsp
+++ b/modules/apps/commerce/commerce-product-item-selector-web/src/main/resources/META-INF/resources/specification_option_item_selector.jsp
@@ -100,7 +100,7 @@ PortletURL portletURL = cpSpecificationOptionItemSelectorViewDisplayContext.getP
 		'<portlet:namespace />cpSpecificationOptions'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(itemSelectedEventName) %>',
 			{

--- a/modules/apps/commerce/commerce-product-type-grouped-web/src/main/resources/META-INF/resources/render/view.jsp
+++ b/modules/apps/commerce/commerce-product-type-grouped-web/src/main/resources/META-INF/resources/render/view.jsp
@@ -284,11 +284,11 @@ String productContentAuthToken = AuthTokenUtil.getToken(request, plid, CPPortlet
 </div>
 
 <aui:script>
-	window.document.addEventListener('DOMContentLoaded', function () {
+	window.document.addEventListener('DOMContentLoaded', () => {
 		var thumbElements = window.document.querySelectorAll('.thumb');
 
-		Array.from(thumbElements).forEach(function (thumbElement) {
-			thumbElement.addEventListener('click', function (event) {
+		Array.from(thumbElements).forEach((thumbElement) => {
+			thumbElement.addEventListener('click', (event) => {
 				window.document
 					.querySelector('#<portlet:namespace />full-image')
 					.setAttribute(

--- a/modules/apps/commerce/commerce-product-type-grouped-web/src/main/resources/META-INF/resources/view_cp_definition_grouped_entries.jsp
+++ b/modules/apps/commerce/commerce-product-type-grouped-web/src/main/resources/META-INF/resources/view_cp_definition_grouped_entries.jsp
@@ -209,7 +209,7 @@ renderResponse.setTitle(cpDefinition.getName(themeDisplay.getLanguageId()));
 <aui:script use="liferay-item-selector-dialog">
 	window.document
 		.querySelector('#<portlet:namespace />addDefinitionGroupedEntry')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			var itemSelectorDialog = new A.LiferayItemSelectorDialog({

--- a/modules/apps/commerce/commerce-product-type-simple/src/main/resources/META-INF/resources/render/view.jsp
+++ b/modules/apps/commerce/commerce-product-type-simple/src/main/resources/META-INF/resources/render/view.jsp
@@ -250,11 +250,11 @@ String productContentAuthToken = AuthTokenUtil.getToken(request, plid, CPPortlet
 </div>
 
 <aui:script>
-	window.document.addEventListener('DOMContentLoaded', function () {
+	window.document.addEventListener('DOMContentLoaded', () => {
 		var thumbElements = window.document.querySelectorAll('.thumb');
 
-		Array.from(thumbElements).forEach(function (thumbElement) {
-			thumbElement.addEventListener('click', function (event) {
+		Array.from(thumbElements).forEach((thumbElement) => {
+			thumbElement.addEventListener('click', (event) => {
 				window.document
 					.querySelector('#<portlet:namespace />full-image')
 					.setAttribute(

--- a/modules/apps/commerce/commerce-product-type-virtual-order-content-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/commerce/commerce-product-type-virtual-order-content-web/src/main/resources/META-INF/resources/view.jsp
@@ -132,7 +132,7 @@ CommerceVirtualOrderItemContentDisplayContext commerceVirtualOrderItemContentDis
 				Liferay.provide(
 					window,
 					'<portlet:namespace />closePopup',
-					function (dialogId) {
+					(dialogId) => {
 						var dialog = Liferay.Util.Window.getById(dialogId);
 
 						dialog.destroy();
@@ -143,7 +143,7 @@ CommerceVirtualOrderItemContentDisplayContext commerceVirtualOrderItemContentDis
 				Liferay.provide(
 					window,
 					'<portlet:namespace />downloadCommerceVirtualOrderItem',
-					function (dialogId, commerceVirtualOrderItemId) {
+					(dialogId, commerceVirtualOrderItemId) => {
 						<portlet:namespace />closePopup(dialogId);
 
 						var formName =

--- a/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/details.jspf
+++ b/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/details.jspf
@@ -69,7 +69,7 @@
 
 	window.document
 		.querySelector('#<portlet:namespace />selectFile')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			var itemSelectorDialog = new A.LiferayItemSelectorDialog({
@@ -112,7 +112,7 @@
 
 	window.document
 		.querySelector('#<portlet:namespace />fileEntryRemove')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			window.document.querySelector(

--- a/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/order_item/virtual_settings.jsp
+++ b/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/order_item/virtual_settings.jsp
@@ -138,7 +138,7 @@ if ((commerceVirtualOrderItem != null) && (commerceVirtualOrderItem.getDuration(
 
 	window.document
 		.querySelector('#<portlet:namespace />selectFile')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			var itemSelectorDialog = new A.LiferayItemSelectorDialog({
@@ -181,7 +181,7 @@ if ((commerceVirtualOrderItem != null) && (commerceVirtualOrderItem.getDuration(
 
 	window.document
 		.querySelector('#<portlet:namespace />fileEntryRemove')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			window.document.querySelector(

--- a/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/render/view.jsp
+++ b/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/render/view.jsp
@@ -274,11 +274,11 @@ String sampleURL = virtualCPTypeHelper.getSampleURL(cpDefinitionId, cpInstanceId
 </div>
 
 <aui:script>
-	window.document.addEventListener('DOMContentLoaded', function () {
+	window.document.addEventListener('DOMContentLoaded', () => {
 		var thumbElements = window.document.querySelectorAll('.thumb');
 
-		Array.from(thumbElements).forEach(function (thumbElement) {
-			thumbElement.addEventListener('click', function (event) {
+		Array.from(thumbElements).forEach((thumbElement) => {
+			thumbElement.addEventListener('click', (event) => {
 				window.document
 					.querySelector('#<portlet:namespace />full-image')
 					.setAttribute(

--- a/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/sample.jspf
+++ b/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/sample.jspf
@@ -71,7 +71,7 @@
 
 	window.document
 		.querySelector('#<portlet:namespace />selectSampleFile')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			var itemSelectorDialog = new A.LiferayItemSelectorDialog({
@@ -114,7 +114,7 @@
 
 	window.document
 		.querySelector('#<portlet:namespace />sampleFileEntryRemove')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			var useSampleCheckbox = A.one('#<portlet:namespace />useSample');
@@ -141,10 +141,10 @@
 </aui:script>
 
 <aui:script>
-	AUI().ready('node', 'event', function (A) {
+	AUI().ready('node', 'event', (A) => {
 		selectSampleFileType(A);
 
-		A.one('#<portlet:namespace />useSample').on('click', function (b) {
+		A.one('#<portlet:namespace />useSample').on('click', (b) => {
 			selectSampleFileType(A);
 		});
 	});

--- a/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/terms_of_use.jspf
+++ b/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/terms_of_use.jspf
@@ -86,7 +86,7 @@
 
 	window.document
 		.querySelector('#<portlet:namespace />selectArticle')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			Liferay.Util.selectEntity(
@@ -102,7 +102,7 @@
 					uri:
 						'<%= cpDefinitionVirtualSettingDisplayContext.getTermsOfUseJournalArticleBrowserURL() %>',
 				},
-				function (event) {
+				(event) => {
 					window.document.querySelector(
 						'#<portlet:namespace />termsOfUseJournalArticleResourcePrimKey'
 					).value = event.assetclasspk;
@@ -116,7 +116,7 @@
 
 	window.document
 		.querySelector('#<portlet:namespace />journalArticleRemove')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			window.document.querySelector(

--- a/modules/apps/commerce/commerce-shipment-web/src/main/resources/META-INF/resources/add_commerce_shipment.jsp
+++ b/modules/apps/commerce/commerce-shipment-web/src/main/resources/META-INF/resources/add_commerce_shipment.jsp
@@ -81,13 +81,13 @@ CommerceShipmentDisplayContext commerceShipmentDisplayContext = (CommerceShipmen
 					method: 'GET',
 				}
 			)
-				.then(function (response) {
+				.then((response) => {
 					return response.json();
 				})
-				.then(function (response) {
+				.then((response) => {
 					var select = A.one('#<portlet:namespace />commerceAddressId');
 
-					response.items.forEach(function (item) {
+					response.items.forEach((item) => {
 						var option = A.Node.create(
 							'<option id="<portlet:namespace />commerceAddressId-' +
 								item.id +
@@ -113,7 +113,7 @@ CommerceShipmentDisplayContext commerceShipmentDisplayContext = (CommerceShipmen
 	);
 
 	if (commerceAccount) {
-		commerceAccount.addEventListener('change', function () {
+		commerceAccount.addEventListener('change', () => {
 			if (commerceAccount.value) {
 				<portlet:namespace />updateAddressField(commerceAccount.value);
 			}

--- a/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/definition/edit_definition_subscription_info.jsp
+++ b/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/definition/edit_definition_subscription_info.jsp
@@ -212,7 +212,7 @@ if (deliveryMaxSubscriptionCycles > 0) {
 	Liferay.provide(
 		window,
 		'<portlet:namespace />selectSubscriptionType',
-		function () {
+		() => {
 			var A = AUI();
 
 			var deliverySubscriptionEnabled = A.one(
@@ -252,7 +252,7 @@ if (deliveryMaxSubscriptionCycles > 0) {
 	Liferay.provide(
 		window,
 		'<portlet:namespace />selectDeliverySubscriptionType',
-		function () {
+		() => {
 			var A = AUI();
 
 			var subscriptionEnabled = A.one(
@@ -300,14 +300,14 @@ if (deliveryMaxSubscriptionCycles > 0) {
 </aui:script>
 
 <aui:script use="liferay-form">
-	A.one('#<portlet:namespace />neverEnds').on('change', function (event) {
+	A.one('#<portlet:namespace />neverEnds').on('change', (event) => {
 		var formValidator = Liferay.Form.get('<portlet:namespace />fm')
 			.formValidator;
 
 		formValidator.validateField('<portlet:namespace />maxSubscriptionCycles');
 	});
 
-	A.one('#<portlet:namespace />deliveryNeverEnds').on('change', function (event) {
+	A.one('#<portlet:namespace />deliveryNeverEnds').on('change', (event) => {
 		var formValidator = Liferay.Form.get('<portlet:namespace />fm')
 			.formValidator;
 

--- a/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/definition/edit_instance_subscription_info.jsp
+++ b/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/definition/edit_instance_subscription_info.jsp
@@ -239,7 +239,7 @@ if (deliveryMaxSubscriptionCycles > 0) {
 	Liferay.provide(
 		window,
 		'<portlet:namespace />selectSubscriptionType',
-		function () {
+		() => {
 			var A = AUI();
 
 			var overrideSubscriptionInfo = A.one(
@@ -286,7 +286,7 @@ if (deliveryMaxSubscriptionCycles > 0) {
 	Liferay.provide(
 		window,
 		'<portlet:namespace />selectDeliverySubscriptionType',
-		function () {
+		() => {
 			var A = AUI();
 
 			var overrideSubscriptionInfo = A.one(
@@ -341,14 +341,14 @@ if (deliveryMaxSubscriptionCycles > 0) {
 </aui:script>
 
 <aui:script use="liferay-form">
-	A.one('#<portlet:namespace />neverEnds').on('change', function (event) {
+	A.one('#<portlet:namespace />neverEnds').on('change', (event) => {
 		var formValidator = Liferay.Form.get('<portlet:namespace />fm')
 			.formValidator;
 
 		formValidator.validateField('<portlet:namespace />maxSubscriptionCycles');
 	});
 
-	A.one('#<portlet:namespace />deliveryNeverEnds').on('change', function (event) {
+	A.one('#<portlet:namespace />deliveryNeverEnds').on('change', (event) => {
 		var formValidator = Liferay.Form.get('<portlet:namespace />fm')
 			.formValidator;
 

--- a/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/subscription_entry/general.jsp
+++ b/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/subscription_entry/general.jsp
@@ -398,7 +398,7 @@ if (deliveryMaxSubscriptionCycles > 0) {
 	Liferay.provide(
 		window,
 		'<portlet:namespace />selectSubscriptionType',
-		function () {
+		() => {
 			var A = AUI();
 
 			var subscriptionLength = A.one(
@@ -427,7 +427,7 @@ if (deliveryMaxSubscriptionCycles > 0) {
 	Liferay.provide(
 		window,
 		'<portlet:namespace />selectDeliverySubscriptionType',
-		function () {
+		() => {
 			var A = AUI();
 
 			var deliverySubscriptionLength = A.one(
@@ -464,14 +464,14 @@ if (deliveryMaxSubscriptionCycles > 0) {
 </aui:script>
 
 <aui:script use="liferay-form">
-	A.one('#<portlet:namespace />neverEnds').on('change', function (event) {
+	A.one('#<portlet:namespace />neverEnds').on('change', (event) => {
 		var formValidator = Liferay.Form.get('<portlet:namespace />fm')
 			.formValidator;
 
 		formValidator.validateField('<portlet:namespace />maxSubscriptionCycles');
 	});
 
-	A.one('#<portlet:namespace />deliveryNeverEnds').on('change', function (event) {
+	A.one('#<portlet:namespace />deliveryNeverEnds').on('change', (event) => {
 		var formValidator = Liferay.Form.get('<portlet:namespace />fm')
 			.formValidator;
 

--- a/modules/apps/commerce/commerce-taglib/src/main/resources/META-INF/resources/tier_price/page.jsp
+++ b/modules/apps/commerce/commerce-taglib/src/main/resources/META-INF/resources/tier_price/page.jsp
@@ -79,7 +79,7 @@ String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 	</div>
 
 	<aui:script use="aui-base">
-		Liferay.provide(window, '<%= randomNamespace %>setQuantity', function (qt) {
+		Liferay.provide(window, '<%= randomNamespace %>setQuantity', (qt) => {
 			var quantityNode = document.querySelector('#<%= taglibQuantityInputId %>');
 
 			if (quantityNode) {

--- a/modules/apps/commerce/commerce-warehouse-web/src/main/resources/META-INF/resources/view_warehouse_items.jsp
+++ b/modules/apps/commerce/commerce-warehouse-web/src/main/resources/META-INF/resources/view_warehouse_items.jsp
@@ -149,8 +149,8 @@ if (Validator.isNotNull(backURL)) {
 			'input[id^=' + quantityPrefix + ']'
 		);
 
-		Array.from(quantityInputElements).forEach(function (quantityInputElement) {
-			quantityInputElement.addEventListener('keypress', function (event) {
+		Array.from(quantityInputElements).forEach((quantityInputElement) => {
+			quantityInputElement.addEventListener('keypress', (event) => {
 				if (event.keyCode == enterKeyCode) {
 					event.preventDefault();
 

--- a/modules/apps/connected-app/connected-app-web/src/main/resources/META-INF/resources/connected_apps.jsp
+++ b/modules/apps/connected-app/connected-app-web/src/main/resources/META-INF/resources/connected_apps.jsp
@@ -96,7 +96,7 @@
 		document.getElementById('<portlet:namespace />connectedApp'),
 		'click',
 		'[data-key]',
-		function (event) {
+		(event) => {
 			connectedAppKeyInput.setAttribute('value', event.target.dataset.key);
 		}
 	);

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/contacts_center/contacts_center_toolbar.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/contacts_center/contacts_center_toolbar.jsp
@@ -220,7 +220,7 @@ if (user2 != null) {
 
 	buttonColumn.delegate(
 		'click',
-		function (event) {
+		(event) => {
 			editToolbar.toggleClass('hide-more-buttons', false);
 
 			viewMoreButton.hide();
@@ -273,16 +273,16 @@ if (user2 != null) {
 			body: data,
 			method: 'POST',
 		})
-			.then(function (response) {
+			.then((response) => {
 				return response.json();
 			})
-			.then(function (data) {
+			.then((data) => {
 				Liferay.component('contactsCenter').renderSelectedContacts(
 					data,
 					lastNameAnchor
 				);
 			})
-			.catch(function () {
+			.catch(() => {
 				Liferay.component('contactsCenter').showMessage(false);
 			});
 	}

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/contacts_center/edit_entry.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/contacts_center/edit_entry.jsp
@@ -68,7 +68,7 @@ if (entryId > 0) {
 		}
 	};
 
-	form.on('submit', function (event) {
+	form.on('submit', (event) => {
 		var end = <%= ContactsConstants.MAX_RESULT_COUNT %>;
 
 		var lastNameAnchor = '';
@@ -103,10 +103,10 @@ if (entryId > 0) {
 			body: new FormData(form.getDOM()),
 			method: 'POST',
 		})
-			.then(function (response) {
+			.then((response) => {
 				return response.json();
 			})
-			.then(function (data) {
+			.then((data) => {
 				if (!data.success) {
 					var message = A.one('#<portlet:namespace />errorMessage');
 
@@ -122,7 +122,7 @@ if (entryId > 0) {
 					Liferay.component('contactsCenter').closePopup();
 				}
 			})
-			.catch(function () {
+			.catch(() => {
 				failureCallback();
 			});
 	});

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/contacts_center/view_resources.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/contacts_center/view_resources.jsp
@@ -86,13 +86,13 @@ boolean portalUser = ParamUtil.getBoolean(request, "portalUser");
 											body: data,
 											method: 'POST',
 										})
-											.then(function (response) {
+											.then((response) => {
 												return response.text();
 											})
-											.then(function (data) {
+											.then((data) => {
 												location.href = '<%= HtmlUtil.escape(redirect) %>';
 											})
-											.catch(function () {
+											.catch(() => {
 												Liferay.component('contactsCenter').showMessage(false);
 											});
 									}

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/user/user_toolbar.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/user/user_toolbar.jsp
@@ -161,14 +161,14 @@ else if (SocialRelationLocalServiceUtil.hasRelation(themeDisplay.getUserId(), us
 	if (contactAction) {
 		contactAction.delegate(
 			'click',
-			function (event) {
+			(event) => {
 				event.preventDefault();
 
 				Liferay.Util.fetch(event.currentTarget.getAttribute('href'))
-					.then(function (response) {
+					.then((response) => {
 						return response.text();
 					})
-					.then(function (data) {
+					.then((data) => {
 						var contactProfile = A.one(
 							'.contacts-portlet .contacts-container'
 						);

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/view.jsp
@@ -423,7 +423,7 @@ portletURL.setWindowState(WindowState.NORMAL);
 		<aui:script use="aui-loading-mask-deprecated,datatype-number,liferay-contacts-center">
 			var searchInput = A.one('.contacts-portlet #<portlet:namespace />name');
 
-			Liferay.component('contactsCenter', function () {
+			Liferay.component('contactsCenter', () => {
 				return new Liferay.ContactsCenter({
 					baseActionURL:
 						'<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), PortletRequest.ACTION_PHASE) %>',
@@ -447,14 +447,14 @@ portletURL.setWindowState(WindowState.NORMAL);
 
 			var contactsCenter = Liferay.component('contactsCenter');
 
-			Liferay.once('beforeNavigate', function () {
+			Liferay.once('beforeNavigate', () => {
 				Liferay.destroyComponent('contactsCenter');
 			});
 
 			<c:if test="<%= !userPublicPage %>">
 				var contactFilterSelect = A.one('#<portlet:namespace />filterBy');
 
-				contactFilterSelect.on('change', function (event) {
+				contactFilterSelect.on('change', (event) => {
 					searchInput.set('value', '');
 
 					contactsCenter.updateContacts(
@@ -469,7 +469,7 @@ portletURL.setWindowState(WindowState.NORMAL);
 			var toggleUser = A.one('.contacts-portlet .toggle-user');
 
 			if (toggleUser) {
-				toggleUser.on('click', function (event) {
+				toggleUser.on('click', (event) => {
 					contactsCenterNode.toggleClass('show-user', false);
 				});
 			}
@@ -478,7 +478,7 @@ portletURL.setWindowState(WindowState.NORMAL);
 
 			contactsResult.delegate(
 				'click',
-				function (event) {
+				(event) => {
 					contactsCenterNode.toggleClass('show-user', true);
 
 					var contactsContainer = A.one('.contacts-portlet .contacts-container');
@@ -490,15 +490,15 @@ portletURL.setWindowState(WindowState.NORMAL);
 					var node = event.currentTarget;
 
 					Liferay.Util.fetch(node.getAttribute('data-viewSummaryURL'))
-						.then(function (response) {
+						.then((response) => {
 							return response.text();
 						})
-						.then(function (data) {
+						.then((data) => {
 							contactsCenter.renderContent(data, true);
 
 							contactsContainer.loadingmask.hide();
 						})
-						.catch(function () {
+						.catch(() => {
 							contactsContainer.loadingmask.hide();
 
 							contactsCenter.showMessage(false);
@@ -509,7 +509,7 @@ portletURL.setWindowState(WindowState.NORMAL);
 
 			contactsResult.delegate(
 				'click',
-				function (event) {
+				(event) => {
 					var node = event.currentTarget;
 
 					var start = A.DataType.Number.parse(node.getAttribute('data-end'));
@@ -533,10 +533,10 @@ portletURL.setWindowState(WindowState.NORMAL);
 							method: 'POST',
 						}
 					)
-						.then(function (response) {
+						.then((response) => {
 							return response.json();
 						})
-						.then(function (data) {
+						.then((data) => {
 							contactsCenter.showMoreResult(data, lastNameAnchor);
 						});
 				},
@@ -545,7 +545,7 @@ portletURL.setWindowState(WindowState.NORMAL);
 
 			contactsResult.delegate(
 				'click',
-				function (event) {
+				(event) => {
 					var checkBox = event.target;
 
 					var userId = checkBox.val();
@@ -562,10 +562,10 @@ portletURL.setWindowState(WindowState.NORMAL);
 								method: 'POST',
 							}
 						)
-							.then(function (response) {
+							.then((response) => {
 								return response.json();
 							})
-							.then(function (data) {
+							.then((data) => {
 								if (data.success) {
 									contactsCenter.addContactResult(data);
 								}
@@ -594,13 +594,13 @@ portletURL.setWindowState(WindowState.NORMAL);
 					Liferay.Util.fetch(node.getAttribute('data-viewSummaryURL'), {
 						body: data,
 					})
-						.then(function (response) {
+						.then((response) => {
 							return response.text();
 						})
-						.then(function (data) {
+						.then((data) => {
 							contactsCenter.renderContent(data);
 						})
-						.catch(function () {
+						.catch(() => {
 							contactsCenter.showMessage(false);
 						});
 				},
@@ -614,7 +614,7 @@ portletURL.setWindowState(WindowState.NORMAL);
 					var addContact = A.one('#<portlet:namespace />addContact');
 
 					if (addContact) {
-						addContact.on('click', function (event) {
+						addContact.on('click', (event) => {
 							contactsCenter.showPopup(
 								'<%= LanguageUtil.get(request, "add-contact") %>',
 								'<portlet:renderURL windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>"><portlet:param name="mvcPath" value="/contacts_center/edit_entry.jsp" /><portlet:param name="redirect" value="<%= currentURL %>" /></portlet:renderURL>'
@@ -627,7 +627,7 @@ portletURL.setWindowState(WindowState.NORMAL);
 					if (contacts) {
 						contacts.on(
 							'click',
-							function (event) {
+							(event) => {
 								contactFilterSelect.set(
 									'value',
 									'<%= ContactsConstants.FILTER_BY_TYPE_MY_CONTACTS %>'
@@ -648,7 +648,7 @@ portletURL.setWindowState(WindowState.NORMAL);
 				if (connections) {
 					connections.on(
 						'click',
-						function (event) {
+						(event) => {
 							contactFilterSelect.set(
 								'value',
 								'<%= ContactsConstants.FILTER_BY_TYPE_BI_CONNECTION %>'
@@ -668,7 +668,7 @@ portletURL.setWindowState(WindowState.NORMAL);
 				if (following) {
 					following.on(
 						'click',
-						function (event) {
+						(event) => {
 							contactFilterSelect.set(
 								'value',
 								'<%= ContactsConstants.FILTER_BY_TYPE_UNI_FOLLOWER %>'
@@ -688,7 +688,7 @@ portletURL.setWindowState(WindowState.NORMAL);
 				if (followers) {
 					followers.on(
 						'click',
-						function (event) {
+						(event) => {
 							contactFilterSelect.set(
 								'value',
 								'<%= ContactsConstants.FILTER_BY_FOLLOWERS %>'
@@ -708,7 +708,7 @@ portletURL.setWindowState(WindowState.NORMAL);
 				if (all) {
 					all.on(
 						'click',
-						function (event) {
+						(event) => {
 							contactFilterSelect.set(
 								'value',
 								'<%= ContactsConstants.FILTER_BY_DEFAULT %>'

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view_content_dashboard_item_types.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view_content_dashboard_item_types.jsp
@@ -66,7 +66,7 @@ ContentDashboardItemTypeItemSelectorViewDisplayContext contentDashboardItemTypeI
 		'<portlet:namespace />contentDashboardItemTypes'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var allSelectedElements = event.elements.allSelectedElements;
 		var arr = [];
 

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/memberships/depot_groups.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/memberships/depot_groups.jsp
@@ -132,7 +132,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 			'<portlet:namespace />selectDepotGroupLink'
 		);
 
-		selectDepotGroupLink.addEventListener('click', function (event) {
+		selectDepotGroupLink.addEventListener('click', (event) => {
 			Liferay.Util.openSelectionModal({
 				onSelect: function (selectedItem) {
 					if (selectedItem) {
@@ -180,7 +180,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 		var handleOnModifyLink = searchContainerContentBox.delegate(
 			'click',
-			function (event) {
+			(event) => {
 				var link = event.currentTarget;
 
 				var rowId = link.attr('data-rowId');

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/roles/depot_roles.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/roles/depot_roles.jsp
@@ -130,14 +130,14 @@ DepotAdminRolesDisplayContext depotAdminRolesDisplayContext = (DepotAdminRolesDi
 			searchContainerContentBox
 				.all('.modify-link')
 				.getData()
-				.map(function (data) {
+				.map((data) => {
 					return data.groupid + '-' + data.rowid;
 				})
 		);
 
 		searchContainerContentBox.delegate(
 			'click',
-			function (event) {
+			(event) => {
 				var link = event.currentTarget;
 				var tr = link.ancestor('tr');
 
@@ -209,9 +209,7 @@ DepotAdminRolesDisplayContext depotAdminRolesDisplayContext = (DepotAdminRolesDi
 			);
 		}
 
-		A.one('#<portlet:namespace />selectDepotRoleLink').on('click', function (
-			event
-		) {
+		A.one('#<portlet:namespace />selectDepotRoleLink').on('click', (event) => {
 			Util.openSelectionModal({
 				onSelect: function (event) {
 					var A = AUI();

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/recycle_bin.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/recycle_bin.jsp
@@ -49,7 +49,7 @@ int trashEntriesMaxAge = PropertiesParamUtil.getInteger(typeSettingsProperties, 
 		if (trashEnabledCheckbox) {
 			var trashEnabledDefault = trashEnabledCheckbox.checked;
 
-			trashEnabledCheckbox.addEventListener('change', function (event) {
+			trashEnabledCheckbox.addEventListener('change', (event) => {
 				var trashEnabled = trashEnabledCheckbox.checked;
 
 				if (!trashEnabled && trashEnabledDefault) {

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
@@ -73,7 +73,7 @@ DepotAdminSelectRoleDisplayContext depotAdminSelectRoleDisplayContext = (DepotAd
 
 				var delegate = delegateModule.default;
 
-				delegate(form, 'click', '.group-selector-button', function (event) {
+				delegate(form, 'click', '.group-selector-button', (event) => {
 					Liferay.Util.postForm(form, {
 						data: {
 							groupId: event.delegateTarget.dataset.groupid,

--- a/modules/apps/dispatch/dispatch-talend-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dispatch/dispatch-talend-web/src/main/resources/META-INF/resources/view.jsp
@@ -60,10 +60,8 @@ String fileEntryName = (String)request.getAttribute(DispatchWebKeys.FILE_ENTRY_N
 </div>
 
 <aui:script>
-	AUI().ready(function (A) {
-		A.one('#<portlet:namespace />fileEntryRemove').on('click', function (
-			event
-		) {
+	AUI().ready((A) => {
+		A.one('#<portlet:namespace />fileEntryRemove').on('click', (event) => {
 			event.preventDefault();
 
 			A.one('#<portlet:namespace />fileEntry').removeClass('hide');

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/details.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/details.jsp
@@ -80,7 +80,7 @@ if (dispatchTrigger != null) {
 	Liferay.provide(
 		window,
 		'<portlet:namespace />selectType',
-		function () {
+		() => {
 			var A = AUI();
 
 			var processType = A.one(<portlet:namespace />type).val();
@@ -122,7 +122,7 @@ if (dispatchTrigger != null) {
 
 	contentEditor.set(STR_VALUE, content);
 
-	Liferay.on('<portlet:namespace />saveTrigger', function (event) {
+	Liferay.on('<portlet:namespace />saveTrigger', (event) => {
 		var form = window.document['<portlet:namespace />fm'];
 
 		form['<portlet:namespace />dispatchTaskSettings'].value = contentEditor.get(

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/dispatch_trigger.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/trigger/dispatch_trigger.jsp
@@ -166,12 +166,12 @@ if ((dispatchTrigger != null) && (dispatchTrigger.getEndDate() != null)) {
 	Liferay.provide(
 		window,
 		'<portlet:namespace />updateEndDateTimeInputsDisabled',
-		function (checked) {
+		(checked) => {
 			document
 				.querySelectorAll(
 					'.end-date-input-selector input, .end-time-input-selector input'
 				)
-				.forEach(function (input) {
+				.forEach((input) => {
 					input.disabled = checked;
 				});
 		}

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/resources/META-INF/resources/dynamic_include/view.jsp
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/resources/META-INF/resources/dynamic_include/view.jsp
@@ -42,7 +42,7 @@ DLOpenerGoogleDriveFileReference dlOpenerGoogleDriveFileReference = (DLOpenerGoo
 
 			showStatusMessage = Liferay.lazyLoad(
 				'frontend-js-web/liferay/toast/commands/OpenToast.es',
-				function (toastCommands, data) {
+				(toastCommands, data) => {
 					toastCommands.openToast(data);
 				}
 			);
@@ -57,14 +57,14 @@ DLOpenerGoogleDriveFileReference dlOpenerGoogleDriveFileReference = (DLOpenerGoo
 				Liferay.Util.fetch('<%= googleDriveBackgroundTaskStatusURL %>', {
 					method: 'POST',
 				})
-					.then(function (response) {
+					.then((response) => {
 						if (!response.ok) {
 							throw defaultError;
 						}
 
 						return response.json();
 					})
-					.then(function (response) {
+					.then((response) => {
 						if (response.complete) {
 							url = response.googleDocsEditURL;
 
@@ -77,7 +77,7 @@ DLOpenerGoogleDriveFileReference dlOpenerGoogleDriveFileReference = (DLOpenerGoo
 							setTimeout(polling, TIME_POLLING);
 						}
 					})
-					.catch(function (error) {
+					.catch((error) => {
 						showError(error);
 
 						Liferay.Util.getWindow(dialogId).hide();
@@ -115,10 +115,10 @@ DLOpenerGoogleDriveFileReference dlOpenerGoogleDriveFileReference = (DLOpenerGoo
 						width: 320,
 					},
 				},
-				function () {
+				() => {
 					setTimeout(polling, TIME_POLLING);
 
-					setTimeout(function () {
+					setTimeout(() => {
 						isTimeConsumed = true;
 
 						navigate();

--- a/modules/apps/document-library/document-library-analytics/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
+++ b/modules/apps/document-library/document-library-analytics/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
@@ -42,7 +42,7 @@
 					anchor.search
 						.substr(1)
 						.split('&')
-						.forEach(function (item) {
+						.forEach((item) => {
 							var tmp = item.split('=');
 
 							if (tmp[0] === parameterName) {
@@ -64,11 +64,11 @@
 		}
 	}
 
-	Liferay.once('destroyPortlet', function () {
+	Liferay.once('destroyPortlet', () => {
 		document.body.removeEventListener('click', handleDownloadClick);
 	});
 
-	Liferay.once('portletReady', function () {
+	Liferay.once('portletReady', () => {
 		document.body.addEventListener('click', handleDownloadClick);
 	});
 </aui:script>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp
@@ -55,7 +55,7 @@ DLAccessFromDesktopDisplayContext dlAccessFromDesktopDisplayContext = new DLAcce
 		);
 
 		if (webdavActionLink) {
-			webdavActionLink.addEventListener('click', function (event) {
+			webdavActionLink.addEventListener('click', (event) => {
 				event.preventDefault();
 
 				if (webdavContentContainer) {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -137,7 +137,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 				);
 
 				if (selectFolderButton) {
-					selectFolderButton.addEventListener('click', function (event) {
+					selectFolderButton.addEventListener('click', (event) => {
 						Liferay.Util.getOpener().Liferay.Util.openSelectionModal({
 							id:
 								'_<%= HtmlUtil.escapeJS(dlRequestHelper.getPortletResource()) %>_selectFolder',
@@ -172,7 +172,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 				);
 
 				if (showActionsInput) {
-					showActionsInput.addEventListener('change', function (event) {
+					showActionsInput.addEventListener('change', (event) => {
 						var currentColumnsElement = document.getElementById(
 							'<portlet:namespace />currentEntryColumns'
 						);
@@ -192,7 +192,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 									'#<portlet:namespace />currentEntryColumns option[value="action"], #<portlet:namespace />availableEntryColumns option[value="action"]'
 								);
 
-								Array.prototype.forEach.call(options, function (option) {
+								Array.prototype.forEach.call(options, (option) => {
 									option.remove();
 								});
 							}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/additional_metadata_fields.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/additional_metadata_fields.jsp
@@ -110,7 +110,7 @@ DLFileEntryAdditionalMetadataSetsDisplayContext dlFileEntryAdditionalMetadataSet
 
 	searchContainer.get('contentBox').delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var link = event.currentTarget;
 
 			var tr = link.ancestor('tr');

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure.jsp
@@ -122,7 +122,7 @@ renderResponse.setTitle(title);
 				.get('translatedLanguages')
 				.values();
 
-			translatedLanguages.forEach(function (languageId) {
+			translatedLanguages.forEach((languageId) => {
 				localizedValues[languageId] = inputLocalized.getValue(languageId);
 			});
 		}
@@ -132,7 +132,7 @@ renderResponse.setTitle(title);
 
 	function <portlet:namespace />saveDDMStructure() {
 		Liferay.componentReady('<portlet:namespace />dataLayoutBuilder').then(
-			function (dataLayoutBuilder) {
+			(dataLayoutBuilder) => {
 				var name = <portlet:namespace />getInputLocalizedValues('name');
 
 				var description = <portlet:namespace />getInputLocalizedValues(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -289,7 +289,7 @@ renderResponse.setTitle(headerTitle);
 								);
 
 								if (selectFolderButton) {
-									selectFolderButton.addEventListener('click', function (event) {
+									selectFolderButton.addEventListener('click', (event) => {
 										Liferay.Util.openSelectionModal({
 											id: '<portlet:namespace />selectFolder',
 											onSelect: function (selectedItem) {
@@ -658,8 +658,8 @@ renderResponse.setTitle(headerTitle);
 	function <portlet:namespace />showVersionDetailsDialog() {
 		Liferay.componentReady(
 			'<portlet:namespace />DocumentLibraryCheckinModal'
-		).then(function (documentLibraryCheckinModal) {
-			documentLibraryCheckinModal.open(function (versionIncrease, changeLog) {
+		).then((documentLibraryCheckinModal) => {
+			documentLibraryCheckinModal.open((versionIncrease, changeLog) => {
 				Liferay.Util.postForm(form, {
 					data: {
 						changeLog: changeLog,
@@ -706,7 +706,7 @@ renderResponse.setTitle(headerTitle);
 		);
 
 		if (updateVersionDetailsElement && versionDetailsElement) {
-			updateVersionDetailsElement.addEventListener('click', function (event) {
+			updateVersionDetailsElement.addEventListener('click', (event) => {
 				versionDetailsElement.classList.toggle('hide');
 			});
 		}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_picker.jspf
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_picker.jspf
@@ -96,7 +96,7 @@ DLFilePicker dlFilePicker = dlEditFileEntryDisplayContext.getDLFilePicker(lifera
 					'#<portlet:namespace />fm .lfr-ddm-form-container .ddm-field'
 				);
 
-				Array.prototype.forEach.call(ddmFieldWrappers, function (ddmFieldWrapper) {
+				Array.prototype.forEach.call(ddmFieldWrappers, (ddmFieldWrapper) => {
 					var fieldName = ddmFieldWrapper.dataset.fieldName;
 
 					var input = ddmFieldWrapper.querySelector('input');
@@ -112,11 +112,9 @@ DLFilePicker dlFilePicker = dlEditFileEntryDisplayContext.getDLFilePicker(lifera
 			var customizedFileButton = document.getElementById('<portlet:namespace />file');
 
 			if (customizedFileButton) {
-				var filePicker = new <%= dlFilePicker.getJavaScriptModuleName() %>(
-					function () {
-						Liferay.Util.toggleDisabled(customizedFileButton, false);
-					}
-				);
+				var filePicker = new <%= dlFilePicker.getJavaScriptModuleName() %>(() => {
+					Liferay.Util.toggleDisabled(customizedFileButton, false);
+				});
 
 				customizedFileButton.addEventListener(
 					'click',

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_type.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_type.jsp
@@ -125,7 +125,7 @@ renderResponse.setTitle((fileEntryType == null) ? LanguageUtil.get(request, "new
 				.get('translatedLanguages')
 				.values();
 
-			translatedLanguages.forEach(function (languageId) {
+			translatedLanguages.forEach((languageId) => {
 				localizedValues[languageId] = inputLocalized.getValue(languageId);
 			});
 		}
@@ -135,7 +135,7 @@ renderResponse.setTitle((fileEntryType == null) ? LanguageUtil.get(request, "new
 
 	function <portlet:namespace />saveStructure() {
 		Liferay.componentReady('<portlet:namespace />dataLayoutBuilder').then(
-			function (dataLayoutBuilder) {
+			(dataLayoutBuilder) => {
 				var name = <portlet:namespace />getInputLocalizedValues('name');
 
 				var description = <portlet:namespace />getInputLocalizedValues(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
@@ -72,7 +72,7 @@ renderResponse.setTitle(dlEditFileShortcutDisplayContext.getTitle());
 		'<portlet:namespace />selectToFileEntryButton'
 	);
 
-	selectToFileEntryButton.addEventListener('click', function (event) {
+	selectToFileEntryButton.addEventListener('click', (event) => {
 		Liferay.Util.openSelectionModal({
 			onSelect: function (selectedItem) {
 				if (selectedItem) {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
@@ -377,7 +377,7 @@ renderResponse.setTitle(dlEditFolderDisplayContext.getHeaderTitle());
 	);
 
 	if (selectDocumentTypeButton) {
-		selectDocumentTypeButton.addEventListener('click', function () {
+		selectDocumentTypeButton.addEventListener('click', () => {
 			var searchContainer = Liferay.SearchContainer.get(
 				'<portlet:namespace />dlFileEntryTypesSearchContainer'
 			);
@@ -414,7 +414,7 @@ renderResponse.setTitle(dlEditFolderDisplayContext.getHeaderTitle());
 
 	searchContainer.get('contentBox').delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var A = AUI();
 
 			var link = event.currentTarget;

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_repository.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_repository.jsp
@@ -211,7 +211,7 @@ renderResponse.setTitle(headerTitle);
 	);
 
 	if (repositoryTypesSelect) {
-		repositoryTypesSelect.addEventListener('change', function (event) {
+		repositoryTypesSelect.addEventListener('change', (event) => {
 			showConfiguration(repositoryTypesSelect);
 		});
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/folder_action.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/folder_action.jsp
@@ -152,7 +152,7 @@ FolderActionDisplayContext folderActionDisplayContext = new FolderActionDisplayC
 		);
 
 		if (slideShow) {
-			slideShow.on('click', function (event) {
+			slideShow.on('click', (event) => {
 				var slideShowWindow = window.open(
 					'<%= folderActionDisplayContext.getViewSlideShowURL() %>',
 					'slideShow',

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/search_info.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/search_info.jsp
@@ -150,7 +150,7 @@ List<Folder> mountFolders = DLAppServiceUtil.getMountFolders(scopeGroupId, DLFol
 <c:if test="<%= windowState.equals(WindowState.MAXIMIZED) %>">
 	<aui:script>
 		Liferay.componentReady('<portlet:namespace />entriesManagementToolbar').then(
-			function () {
+			() => {
 				Liferay.Util.focusFormField(
 					document.getElementsByName('<portlet:namespace />keywords')[0]
 				);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_entry_type.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_entry_type.jsp
@@ -94,7 +94,7 @@ portletURL.setParameter("eventName", eventName);
 
 	form.delegate(
 		'click',
-		function (event) {
+		(event) => {
 			event.preventDefault();
 
 			var currentTarget = event.currentTarget;

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries.jsp
@@ -112,7 +112,7 @@ if (portletTitleBasedNavigation) {
 						%>
 
 						<aui:script use="aui-base,aui-loading-mask-deprecated,node-load">
-							Liferay.on('tempFileRemoved', function () {
+							Liferay.on('tempFileRemoved', () => {
 								Liferay.Util.openToast({
 									message:
 										'<%= LanguageUtil.get(request, "your-request-completed-successfully") %>',
@@ -157,10 +157,10 @@ if (portletTitleBasedNavigation) {
 									body: new FormData(document.<portlet:namespace />fm2),
 									method: 'POST',
 								})
-									.then(function (response) {
+									.then((response) => {
 										return response.json();
 									})
-									.then(function (response) {
+									.then((response) => {
 										var itemFailed = false;
 
 										for (var i = 0; i < response.length; i++) {
@@ -240,7 +240,7 @@ if (portletTitleBasedNavigation) {
 											location.href = '<%= HtmlUtil.escapeJS(redirect) %>';
 										}
 									})
-									.catch(function (error) {
+									.catch((error) => {
 										var selectedItems = A.all(
 											'#<portlet:namespace />fileUpload li.selected'
 										);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries_resources.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries_resources.jsp
@@ -217,14 +217,14 @@ else {
 						if (documentTypeMenuList) {
 							var delegate = delegateModule.default;
 
-							delegate(documentTypeMenuList, 'click', 'li a', function (event) {
+							delegate(documentTypeMenuList, 'click', 'li a', (event) => {
 								event.preventDefault();
 
 								Liferay.Util.fetch(event.delegateTarget.getAttribute('href'))
-									.then(function (response) {
+									.then((response) => {
 										return response.text();
 									})
-									.then(function (response) {
+									.then((response) => {
 										var commonFileMetadataContainer = document.getElementById(
 											'<portlet:namespace />commonFileMetadataContainer'
 										);
@@ -241,7 +241,7 @@ else {
 
 										var selectedFileNodes = Array.prototype.filter.call(
 											fileNodes,
-											function (fileNode) {
+											(fileNode) => {
 												return fileNode.checked;
 											}
 										);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -207,7 +207,7 @@ if (portletTitleBasedNavigation) {
 		);
 
 		if (openContextualSidebarButton) {
-			openContextualSidebarButton.addEventListener('click', function (event) {
+			openContextualSidebarButton.addEventListener('click', (event) => {
 				event.currentTarget.classList.toggle('active');
 
 				document

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_more_menu_items.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_more_menu_items.jsp
@@ -89,7 +89,7 @@ DLViewMoreMenuItemsDisplayContext dlViewMoreMenuItemsDisplayContext = new DLView
 
 	A.one('#<portlet:namespace />addMenuItemFm').delegate(
 		'click',
-		function (event) {
+		(event) => {
 			Util.getOpener().Liferay.fire(
 				'<%= HtmlUtil.escapeJS(dlViewMoreMenuItemsDisplayContext.getEventName()) %>',
 				{

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
@@ -104,7 +104,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 	);
 
 	if (openFolderSelectorButton) {
-		openFolderSelectorButton.addEventListener('click', function (event) {
+		openFolderSelectorButton.addEventListener('click', (event) => {
 			Liferay.Util.getOpener().Liferay.Util.openSelectionModal({
 				id:
 					'_<%= HtmlUtil.escapeJS(igRequestHelper.getPortletResource()) %>_selectFolder',

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/player.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/player.jsp
@@ -73,11 +73,11 @@ for (String previewFileURL : previewFileURLs) {
 			if (audio._audio) {
 				var audioNode = audio._audio.getDOMNode();
 
-				audioNode.addEventListener('pause', function () {
+				audioNode.addEventListener('pause', () => {
 					playing = false;
 				});
 
-				audioNode.addEventListener('play', function () {
+				audioNode.addEventListener('play', () => {
 					window.parent.Liferay.fire(
 						'<portlet:namespace /><%= randomNamespace %>Audio:play'
 					);
@@ -88,7 +88,7 @@ for (String previewFileURL : previewFileURLs) {
 
 			window.parent.Liferay.on(
 				'<portlet:namespace /><%= randomNamespace %>ImageViewer:currentIndexChange',
-				function () {
+				() => {
 					if (playing) {
 						audio.pause();
 					}
@@ -97,7 +97,7 @@ for (String previewFileURL : previewFileURLs) {
 
 			window.parent.Liferay.on(
 				'<portlet:namespace /><%= randomNamespace %>ImageViewer:close',
-				function () {
+				() => {
 					audio.load();
 				}
 			);
@@ -142,7 +142,7 @@ for (String previewFileURL : previewFileURLs) {
 
 			window.parent.Liferay.on(
 				'<portlet:namespace /><%= randomNamespace %>ImageViewer:currentIndexChange',
-				function () {
+				() => {
 					if (playing) {
 						video.pause();
 					}
@@ -151,7 +151,7 @@ for (String previewFileURL : previewFileURLs) {
 
 			window.parent.Liferay.on(
 				'<portlet:namespace /><%= randomNamespace %>ImageViewer:close',
-				function () {
+				() => {
 					video.load();
 				}
 			);

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -246,7 +246,7 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 	var submitButton = A.one('#<portlet:namespace />fm_submit');
 
 	if (submitButton) {
-		submitButton.on('click', function (event) {
+		submitButton.on('click', (event) => {
 			if (form) {
 				form.submit();
 			}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/custom_spreadsheet_editors.jspf
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/custom_spreadsheet_editors.jspf
@@ -25,7 +25,7 @@
 		var activeColumn = spreadSheet.getColumn(activeCell);
 		var activeRecord = spreadSheet.getRecord(activeCell);
 
-		return !window.<portlet:namespace />structure.some(function (item, index) {
+		return !window.<portlet:namespace />structure.some((item, index) => {
 			var fieldName = item.name;
 			var fieldValue = activeRecord.get(fieldName);
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record_set.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record_set.jsp
@@ -192,7 +192,7 @@ if (ddlDisplayContext.isAdminPortlet()) {
 				title:
 					'<%= UnicodeLanguageUtil.get(request, "data-definitions") %>',
 			},
-			function (event) {
+			(event) => {
 				Liferay.Util.setFormValues(form, {
 					ddmStructureId: event.ddmstructureid,
 					ddmStructureNameDisplay: Liferay.Util.unescape(event.name),

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/export_record_set.jspf
@@ -105,7 +105,7 @@ boolean showCSVWarning = StringUtil.equals("enabled-with-warning", csvExport);
 						);
 
 						Liferay.Util.fetch(url, {body: formData, method: 'POST'})
-							.then(function (response) {
+							.then((response) => {
 								var filenamePattern = /filename=\"(.*)\"/;
 								var match = filenamePattern.exec(
 									response.headers.get('content-disposition')
@@ -115,7 +115,7 @@ boolean showCSVWarning = StringUtil.equals("enabled-with-warning", csvExport);
 								}
 								return response.blob();
 							})
-							.then(function (blob) {
+							.then((blob) => {
 								var link = document.createElement('a');
 								link.setAttribute(
 									'href',
@@ -128,7 +128,7 @@ boolean showCSVWarning = StringUtil.equals("enabled-with-warning", csvExport);
 
 								Liferay.fire('closeModal');
 							})
-							.catch(function (error) {
+							.catch((error) => {
 								Liferay.Util.openToast({
 									message: Liferay.Language.get(
 										'an-unexpected-system-error-occurred'

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/management_bar.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/management_bar.jsp
@@ -81,10 +81,8 @@ PortletURL portletURL = renderResponse.createRenderURL();
 		deleteRecordSets: deleteRecordSets,
 	};
 
-	Liferay.componentReady('ddlManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
+	Liferay.componentReady('ddlManagementToolbar').then((managementToolbar) => {
+		managementToolbar.on('actionItemClicked', (event) => {
 			var itemData = event.data.item.data;
 
 			if (itemData && itemData.action && ACTIONS[itemData.action]) {

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_records.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_records.jsp
@@ -203,8 +203,8 @@ if (!ddlDisplayContext.isAdminPortlet()) {
 
 	Liferay.componentReady(
 		'<%= randomNamespace + "ddlViewRecordsManagementToolbar" %>'
-	).then(function (managementToolbar) {
-		managementToolbar.on('actionItemClicked', function (event) {
+	).then((managementToolbar) => {
+		managementToolbar.on('actionItemClicked', (event) => {
 			var itemData = event.data.item.data;
 
 			if (itemData && itemData.action && ACTIONS[itemData.action]) {

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_spreadsheet_records.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_spreadsheet_records.jsp
@@ -68,11 +68,7 @@ DDMStructure ddmStructure = recordSet.getDDMStructure();
 		var a = recA.get(field);
 		var b = recB.get(field);
 
-		return A.ArraySort.compareIgnoreWhiteSpace(a, b, desc, function (
-			a,
-			b,
-			desc
-		) {
+		return A.ArraySort.compareIgnoreWhiteSpace(a, b, desc, (a, b, desc) => {
 			var num1 = parseFloat(a);
 			var num2 = parseFloat(b);
 
@@ -102,7 +98,7 @@ DDMStructure ddmStructure = recordSet.getDDMStructure();
 		number: 1,
 	};
 
-	var keys = columns.map(function (item, index) {
+	var keys = columns.map((item, index) => {
 		var key = item.key;
 
 		if (!item.sortFn) {
@@ -129,7 +125,7 @@ DDMStructure ddmStructure = recordSet.getDDMStructure();
 
 	var records = <%= ddlDisplayContext.getRecordsJSONArray(records, !editable, locale) %>;
 
-	records.sort(function (a, b) {
+	records.sort((a, b) => {
 		return a.displayIndex - b.displayIndex;
 	});
 
@@ -138,7 +134,7 @@ DDMStructure ddmStructure = recordSet.getDDMStructure();
 		keys
 	);
 
-	records.forEach(function (item, index) {
+	records.forEach((item, index) => {
 		data.splice(item.displayIndex, 0, item);
 	});
 
@@ -178,7 +174,7 @@ DDMStructure ddmStructure = recordSet.getDDMStructure();
 	<c:if test="<%= editable %>">
 		var numberOfRecordsNode = A.one('#<portlet:namespace />numberOfRecords');
 
-		A.one('#<portlet:namespace />addRecords').on('click', function (event) {
+		A.one('#<portlet:namespace />addRecords').on('click', (event) => {
 			var numberOfRecords = parseInt(numberOfRecordsNode.val(), 10) || 0;
 
 			spreadSheet.addEmptyRows(numberOfRecords);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/management_bar.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/management_bar.jsp
@@ -75,15 +75,15 @@ PortletURL portletURL = ddmDataProviderDisplayContext.getPortletURL();
 		deleteDataProviderInstances: deleteDataProviderInstances,
 	};
 
-	Liferay.componentReady('ddmDataProviderManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on(['actionItemClicked'], function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('ddmDataProviderManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on(['actionItemClicked'], (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action]();
+				}
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
@@ -84,7 +84,7 @@ int totalItems = ddmFormReportDisplayContext.getTotalItems();
 		document.querySelector('.portlet-ddm-form-report-tabs'),
 		'click',
 		'li',
-		function (event) {
+		(event) => {
 			var navItem = event.delegateTarget.closest('.nav-item');
 			var navItemIndex = Number(navItem.dataset.navItemIndex);
 			var navLink = navItem.querySelector('.nav-link');

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_builder/start.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_builder/start.jsp
@@ -40,7 +40,7 @@
 
 		Liferay.component(
 			'<%= HtmlUtil.escapeJS(refererPortletNamespace) %>formBuilder',
-			function () {
+			() => {
 				return new Liferay.DDM.FormBuilder({
 					context: JSON.parse(
 						'<%= HtmlUtil.escapeJS(formBuilderContext) %>'
@@ -56,7 +56,7 @@
 
 		Liferay.component(
 			'<%= HtmlUtil.escapeJS(refererPortletNamespace) %>ruleBuilder',
-			function () {
+			() => {
 				return new Liferay.DDM.FormBuilderRuleBuilder({
 					formBuilder: Liferay.component(
 						'<%= HtmlUtil.escapeJS(refererPortletNamespace) %>formBuilder'

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
@@ -141,7 +141,7 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 		start: function (initialPages) {
 			Liferay.Loader.require(
 				'<%= mainRequire %>',
-				function (packageName) {
+				(packageName) => {
 					var context = <%= serializedFormBuilderContext %>;
 
 					if (context.pages.length === 0 && initialPages) {
@@ -173,7 +173,7 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 						'#<portlet:namespace />-container'
 					);
 				},
-				function (error) {
+				(error) => {
 					throw error;
 				}
 			);
@@ -188,7 +188,7 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 				'<portlet:namespace />translationManager'
 			);
 
-			Liferay.destroyComponents(function (component) {
+			Liferay.destroyComponents((component) => {
 				var destroy = false;
 
 				if (component === translationManager) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -211,7 +211,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 		start: function (initialPages) {
 			Liferay.Loader.require(
 				'<%= mainRequire %>',
-				function (packageName) {
+				(packageName) => {
 					var context = <%= serializedFormBuilderContext %>;
 
 					if (context.pages.length === 0 && initialPages) {
@@ -254,7 +254,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 						'#<portlet:namespace />-container'
 					);
 				},
-				function (error) {
+				(error) => {
 					throw error;
 				}
 			);
@@ -269,7 +269,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 				'<portlet:namespace />translationManager'
 			);
 
-			Liferay.destroyComponents(function (component) {
+			Liferay.destroyComponents((component) => {
 				var destroy = false;
 
 				if (component === translationManager) {
@@ -334,7 +334,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 				stack: false,
 				title: '<liferay-ui:message key="settings" />',
 			},
-			function (dialogWindow) {
+			(dialogWindow) => {
 				var bodyNode = dialogWindow.bodyNode;
 
 				var settingsNode = A.one('#<portlet:namespace />settings');

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/export_form_instance.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/export_form_instance.jspf
@@ -65,7 +65,7 @@ boolean showCSVWarning = StringUtil.equals("enabled-with-warning", csvExport);
 	Liferay.provide(
 		window,
 		'<portlet:namespace />exportFormInstance',
-		function (url) {
+		(url) => {
 			var A = AUI();
 
 			var form = A.Node.create('<form />');

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/form_instance_records_search_container.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/form_instance_records_search_container.jsp
@@ -183,8 +183,8 @@ PortletURL portletURL = ddmFormViewFormInstanceRecordsDisplayContext.getPortletU
 	};
 
 	Liferay.componentReady('ddmFormInstanceRecordsManagementToolbar').then(
-		function (managementToolbar) {
-			managementToolbar.on(['actionItemClicked'], function (event) {
+		(managementToolbar) => {
+			managementToolbar.on(['actionItemClicked'], (event) => {
 				var itemData = event.data.item.data;
 
 				if (itemData && itemData.action && ACTIONS[itemData.action]) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/management_bar.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/management_bar.jsp
@@ -106,10 +106,8 @@
 		deleteStructures: deleteStructures,
 	};
 
-	Liferay.componentReady('ddmFormManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on(['actionItemClicked'], function (event) {
+	Liferay.componentReady('ddmFormManagementToolbar').then((managementToolbar) => {
+		managementToolbar.on(['actionItemClicked'], (event) => {
 			var itemData = event.data.item.data;
 
 			if (itemData && itemData.action && ACTIONS[itemData.action]) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/configuration.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/configuration.jsp
@@ -145,7 +145,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 	Liferay.provide(
 		window,
 		'<portlet:namespace />selectFormInstance',
-		function (formInstanceId, formInstanceName) {
+		(formInstanceId, formInstanceName) => {
 			var A = AUI();
 
 			document.<portlet:namespace />fm.<portlet:namespace />formInstanceId.value = formInstanceId;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
@@ -229,7 +229,7 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 								<portlet:param name="preview" value="<%= String.valueOf(ddmFormDisplayContext.isPreview()) %>" />
 							</liferay-portlet:resourceURL>
 
-							Liferay.on('sessionExpired', function (event) {
+							Liferay.on('sessionExpired', (event) => {
 								<portlet:namespace />clearInterval(<portlet:namespace />intervalId);
 							});
 
@@ -304,7 +304,7 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 						var rememberMe = true;
 					</c:if>
 
-					<portlet:namespace />sessionIntervalId = setInterval(function () {
+					<portlet:namespace />sessionIntervalId = setInterval(() => {
 						if (Liferay.Session || rememberMe) {
 							clearInterval(<portlet:namespace />sessionIntervalId);
 
@@ -318,7 +318,7 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 							else {
 								Liferay.componentReady(
 									'<%= ddmFormDisplayContext.getContainerId() %>'
-								).then(function (component) {
+								).then((component) => {
 									<portlet:namespace />form = component;
 
 									if (component) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html_field/start.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html_field/start.jsp
@@ -46,7 +46,7 @@
 		<aui:script use="liferay-ddm-form">
 			Liferay.component(
 				'<portlet:namespace /><%= HtmlUtil.escapeJS(fieldsNamespace) %>ddmForm',
-				function () {
+				() => {
 					return new Liferay.DDM.Form({
 						container: '#<%= randomNamespace %>',
 						ddmFormValuesInput:

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
@@ -104,7 +104,7 @@ Group ddmTemplateGroup = GroupLocalServiceUtil.getGroup(ddmTemplateGroupId);
 	);
 
 	if (selectDDMTemplateLink) {
-		selectDDMTemplateLink.addEventListener('click', function (event) {
+		selectDDMTemplateLink.addEventListener('click', (event) => {
 			Liferay.Util.openDDMPortlet(
 				{
 					basePortletURL: '<%= basePortletURL %>',
@@ -121,7 +121,7 @@ Group ddmTemplateGroup = GroupLocalServiceUtil.getGroup(ddmTemplateGroupId);
 					title:
 						'<%= UnicodeLanguageUtil.get(request, "widget-templates") %>',
 				},
-				function (event) {
+				(event) => {
 					if (!event.newVal) {
 						submitForm(
 							document.<portlet:namespace />fm,
@@ -139,7 +139,7 @@ Group ddmTemplateGroup = GroupLocalServiceUtil.getGroup(ddmTemplateGroupId);
 	);
 
 	if (displayStyle && displayStyleGroupIdInput) {
-		displayStyle.addEventListener('change', function (event) {
+		displayStyle.addEventListener('change', (event) => {
 			var selectedDisplayStyle = displayStyle.querySelector('option:checked');
 
 			if (selectedDisplayStyle) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_structure.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_structure.jsp
@@ -361,7 +361,7 @@ if (Validator.isNotNull(requestUpdateStructureURL)) {
 				showManageTemplates: false,
 				title: '<%= HtmlUtil.escapeJS(scopeTitle) %>',
 			},
-			function (event) {
+			(event) => {
 				var form = document.<portlet:namespace />fm;
 
 				Liferay.Util.setFormValues(form, {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_template.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_template.jsp
@@ -366,7 +366,7 @@ DDMNavigationHelper ddmNavigationHelper = ddmDisplay.getDDMNavigationHelper();
 
 			container.delegate(
 				'change',
-				function (event) {
+				(event) => {
 					var index = types.indexOf(event.currentTarget);
 
 					selectSmallImageType(index);
@@ -390,7 +390,7 @@ DDMNavigationHelper ddmNavigationHelper = ddmDisplay.getDDMNavigationHelper();
 						A.one('#<portlet:namespace />smallImage').attr('checked', expanded);
 
 						if (expanded) {
-							types.each(function (item, index) {
+							types.each((item, index) => {
 								if (item.get('checked')) {
 									values.item(index).attr('disabled', false);
 								}
@@ -425,7 +425,7 @@ DDMNavigationHelper ddmNavigationHelper = ddmDisplay.getDDMNavigationHelper();
 						showAncestorScopes: true,
 						title: '<%= UnicodeLanguageUtil.get(request, "structures") %>',
 					},
-					function (event) {
+					(event) => {
 						if (
 							document.<portlet:namespace />fm.<portlet:namespace />classPK
 								.value != event.ddmstructureid
@@ -443,7 +443,7 @@ DDMNavigationHelper ddmNavigationHelper = ddmDisplay.getDDMNavigationHelper();
 
 	<aui:button-row>
 		<aui:script>
-			Liferay.after('<portlet:namespace />saveTemplate', function () {
+			Liferay.after('<portlet:namespace />saveTemplate', () => {
 				submitForm(document.<portlet:namespace />fm);
 			});
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_template_display.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_template_display.jspf
@@ -188,7 +188,7 @@ if (Validator.isNotNull(scriptContent)) {
 			var getItems = function () {
 				var results = [];
 
-				paletteItems.each(function (item, index) {
+				paletteItems.each((item, index) => {
 					results.push({
 						data: item.text().trim(),
 						node: item.ancestor(),
@@ -222,18 +222,18 @@ if (Validator.isNotNull(scriptContent)) {
 				source: getItems(),
 			});
 
-			paletteSearch.on('results', function (event) {
-				paletteItems.each(function (item, index) {
+			paletteSearch.on('results', (event) => {
+				paletteItems.each((item, index) => {
 					item.ancestor().addClass('hide');
 				});
 
-				event.results.forEach(function (item, index) {
+				event.results.forEach((item, index) => {
 					item.raw.node.removeClass('hide');
 				});
 
 				var foundVisibleSection;
 
-				paletteSectionsNode.each(function (item, index) {
+				paletteSectionsNode.each((item, index) => {
 					var visibleItem = item.one('.palette-item-container:not(.hide)');
 
 					if (visibleItem) {
@@ -270,7 +270,7 @@ if (Validator.isNotNull(scriptContent)) {
 			var cursorPos;
 			var processed;
 
-			AObject.each(fragments, function (item, index) {
+			AObject.each(fragments, (item, index) => {
 				if (processed) {
 					cursorPos = editor.getCursorPosition();
 				}
@@ -363,7 +363,7 @@ if (Validator.isNotNull(scriptContent)) {
 
 	A.on(
 		'domready',
-		function (event) {
+		(event) => {
 			richEditor = new A.AceEditor({
 				boundingBox: editorNode,
 				height: 400,
@@ -383,11 +383,11 @@ if (Validator.isNotNull(scriptContent)) {
 				setEditorContent(editorContentElement.val());
 			}
 
-			Liferay.on('<portlet:namespace />saveTemplate', function (event) {
+			Liferay.on('<portlet:namespace />saveTemplate', (event) => {
 				editorContentElement.val(getEditorContent());
 			});
 
-			selectLanguageNode.on('change', function (event) {
+			selectLanguageNode.on('change', (event) => {
 				Liferay.fire('<portlet:namespace />refreshEditor');
 			});
 
@@ -426,7 +426,7 @@ if (Validator.isNotNull(scriptContent)) {
 		'#<portlet:namespace />richEditor'
 	);
 
-	Liferay.on('<portlet:namespace />refreshEditor', function (event) {
+	Liferay.on('<portlet:namespace />refreshEditor', (event) => {
 		var form = A.one('#<portlet:namespace />fm');
 
 		<portlet:renderURL var="refreshTemplateURL">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_template_form.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_template_form.jspf
@@ -36,13 +36,13 @@ String fieldsJSONArrayString = String.valueOf(_getFormTemplateFieldsJSONArray(st
 		var modeInput = document.getElementById('<portlet:namespace />mode');
 
 		if (modeInput) {
-			modeInput.addEventListener('change', function (event) {
+			modeInput.addEventListener('change', (event) => {
 				<portlet:namespace />toggleMode(formBuilder, event.target.value);
 			});
 		}
 	}
 
-	Liferay.on('<portlet:namespace />formBuilderLoaded', function (event) {
+	Liferay.on('<portlet:namespace />formBuilderLoaded', (event) => {
 		var formBuilder = event.formBuilder;
 
 		<portlet:namespace />attachValueChange(formBuilder);
@@ -65,8 +65,8 @@ String fieldsJSONArrayString = String.valueOf(_getFormTemplateFieldsJSONArray(st
 		var without = function (array) {
 			var elems = Array.from(arguments).slice(1);
 
-			elems.forEach(function (value) {
-				array = array.filter(function (elem) {
+			elems.forEach((value) => {
+				array = array.filter((elem) => {
 					return elem != value;
 				});
 			});
@@ -115,7 +115,7 @@ String fieldsJSONArrayString = String.valueOf(_getFormTemplateFieldsJSONArray(st
 
 		var availableFields = <%= structureJSONArray.toString() %>;
 
-		availableFields.forEach(function (item, index) {
+		availableFields.forEach((item, index) => {
 			item.iconClass = FormBuilder.DEFAULT_ICON_CLASS;
 		});
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/form_builder.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/form_builder.jspf
@@ -296,7 +296,7 @@ for (Locale availableLocale : LanguageUtil.getAvailableLocales(themeDisplay.getS
 			var propertyList = formBuilder.propertyList;
 
 			if (propertyList) {
-				propertyList.get('data').each(function (model) {
+				propertyList.get('data').each((model) => {
 					var editor = model.get('editor');
 
 					if (editor) {
@@ -319,7 +319,7 @@ for (Locale availableLocale : LanguageUtil.getAvailableLocales(themeDisplay.getS
 		'<%= HtmlUtil.escapeJS(portletResourceNamespace) %>getContentValue'
 	] = getContentValue;
 
-	Liferay.on('<portlet:namespace />saveTemplate', function (event) {
+	Liferay.on('<portlet:namespace />saveTemplate', (event) => {
 		A.one('#<portlet:namespace />scriptContent').val(getContentValue());
 	});
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/management_bar.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/management_bar.jsp
@@ -66,15 +66,15 @@
 		deleteStructures: deleteStructures,
 	};
 
-	Liferay.componentReady('ddmStructureManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('ddmStructureManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('actionItemClicked', (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action]();
+				}
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_structure.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_structure.jsp
@@ -107,13 +107,14 @@ SearchContainer<DDMStructure> structureSearch = ddmDisplayContext.getStructureSe
 </aui:form>
 
 <aui:script>
-	Liferay.componentReady('ddmStructureManagementToolbar').then(function (
-		managementToolbar
-	) {
-		Liferay.Util.focusFormField(
-			document.<portlet:namespace />searchForm.<portlet:namespace />keywords
-		);
-	});
+	Liferay.componentReady('ddmStructureManagementToolbar').then(
+		(managementToolbar) => {
+			Liferay.Util.focusFormField(
+				document.<portlet:namespace />searchForm
+					.<portlet:namespace />keywords
+			);
+		}
+	);
 
 	Liferay.Util.selectEntityHandler(
 		'#<portlet:namespace />selectStructureFm',

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_template.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/select_template.jsp
@@ -116,7 +116,7 @@ if ((classPK > 0) && (structureClassNameId == classNameId)) {
 </aui:form>
 
 <aui:script>
-	Liferay.componentReady('ddmTemplateManagementToolbar').then(function () {
+	Liferay.componentReady('ddmTemplateManagementToolbar').then(() => {
 		Liferay.Util.focusFormField(
 			document.<portlet:namespace />searchForm.<portlet:namespace />keywords
 		);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/template_management_bar.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/template_management_bar.jsp
@@ -70,15 +70,15 @@ boolean includeCheckBox = ParamUtil.getBoolean(request, "includeCheckBox", true)
 		deleteTemplates: deleteTemplates,
 	};
 
-	Liferay.componentReady('ddmTemplateManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('ddmTemplateManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('actionItemClicked', (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action]();
+				}
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
+++ b/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
@@ -321,7 +321,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 									init: function () {
 										Liferay.MapBase.get(
 											'<%= portletDisplay.getNamespace()+"ExpandoAttribute--" + mapDisplayName + "--" %>',
-											function (map) {
+											(map) => {
 												map.on(
 													'positionChange',
 													geolocationField.onPositionChange,
@@ -833,8 +833,8 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 						<aui:script require="map-common/js/MapBase.es as MapBase">
 							Liferay.MapBase.get(
 								'<%= portletDisplay.getNamespace()+"ExpandoAttribute--" + mapDisplayName + "--" %>',
-								function (map) {
-									map.once('positionChange', function (event) {
+								(map) => {
+									map.once('positionChange', (event) => {
 										var inputName =
 											'<%= portletDisplay.getNamespace()+"ExpandoAttribute--" + HtmlUtil.escapeJS(name) + "--" %>';
 

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/advanced_properties.jspf
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/advanced_properties.jspf
@@ -146,7 +146,7 @@
 	function populatePrecisionType(precisionTypeElement, numberSize) {
 		var numberSizeOptions = '';
 
-		numberSize.forEach(function (bit) {
+		numberSize.forEach((bit) => {
 			numberSizeOptions += '<option value="' + bit + '">' + bit + '</option>';
 		});
 

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/default_value_input.jspf
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/default_value_input.jspf
@@ -132,7 +132,7 @@
 		<aui:script require="map-common/js/MapBase.es as MapBase">
 			var geolocationField = {
 				init: function () {
-					Liferay.MapBase.get('<portlet:namespace /><%= name %>', function (map) {
+					Liferay.MapBase.get('<portlet:namespace /><%= name %>', (map) => {
 						map.on(
 							'positionChange',
 							geolocationField.onPositionChange,
@@ -323,7 +323,7 @@
 	}
 
 	function updateElement(formElementIds, action) {
-		formElementIds.forEach(function (formElementId) {
+		formElementIds.forEach((formElementId) => {
 			var formElement = document.getElementById(
 				'<portlet:namespace />' + formElementId
 			);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/export_templates/edit_export_configuration.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/export_templates/edit_export_configuration.jsp
@@ -178,7 +178,7 @@ renderResponse.setTitle((exportImportConfiguration == null) ? LanguageUtil.get(r
 
 	var form = A.one('#<portlet:namespace />fm1');
 
-	form.on('submit', function (event) {
+	form.on('submit', (event) => {
 		event.halt();
 
 		var exportImport = Liferay.component(

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/new_export/export_layouts.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/new_export/export_layouts.jsp
@@ -215,7 +215,7 @@ renderResponse.setTitle(!configuredExport ? LanguageUtil.get(request, "new-custo
 
 	var form = liferayForm.formNode;
 
-	form.on('submit', function (event) {
+	form.on('submit', (event) => {
 		event.halt();
 
 		var exportImport = Liferay.component(

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet.jsp
@@ -472,7 +472,7 @@ portletURL.setParameter("portletResource", portletResource);
 
 			var form = liferayForm.formNode;
 
-			form.on('submit', function (event) {
+			form.on('submit', (event) => {
 				event.halt();
 
 				var exportImport = Liferay.component(
@@ -565,7 +565,7 @@ portletURL.setParameter("portletResource", portletResource);
 
 	Liferay.component('<portlet:namespace />ExportImportComponent', exportImport);
 
-	Liferay.once('destroyPortlet', function () {
+	Liferay.once('destroyPortlet', () => {
 		exportImport.destroy();
 	});
 </aui:script>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_validation.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_validation.jsp
@@ -90,11 +90,11 @@ boolean privateLayout = ParamUtil.getBoolean(request, "privateLayout");
 
 		var continueButton = A.one('#<portlet:namespace />continueButton');
 
-		liferayUpload._uploader.on('alluploadscomplete', function (event) {
+		liferayUpload._uploader.on('alluploadscomplete', (event) => {
 			toggleContinueButton();
 		});
 
-		Liferay.on('tempFileRemoved', function (event) {
+		Liferay.on('tempFileRemoved', (event) => {
 			toggleContinueButton();
 		});
 
@@ -116,7 +116,7 @@ boolean privateLayout = ParamUtil.getBoolean(request, "privateLayout");
 <aui:script use="aui-base,aui-io-plugin-deprecated,aui-loading-mask-deprecated,io">
 	var form = A.one('#<portlet:namespace />fm1');
 
-	form.on('submit', function (event) {
+	form.on('submit', (event) => {
 		event.halt();
 
 		var exportImportOptions = A.one(

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_validation.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_validation.jsp
@@ -97,11 +97,11 @@ String redirect = ParamUtil.getString(request, "redirect");
 				'<liferay-portlet:actionURL doAsUserId="<%= user.getUserId() %>" name="/export_import/export_import"><portlet:param name="mvcRenderCommandName" value="/export_import/export_import" /><portlet:param name="<%= Constants.CMD %>" value="<%= Constants.ADD_TEMP %>" /><portlet:param name="redirect" value="<%= redirect %>" /><portlet:param name="plid" value="<%= String.valueOf(plid) %>" /> <portlet:param name="groupId" value="<%= String.valueOf(themeDisplay.getScopeGroupId()) %>" /><portlet:param name="portletResource" value="<%= portletResource %>" /></liferay-portlet:actionURL>&ticketKey=<%= ticket.getKey() %><liferay-ui:input-permissions-params modelName="<%= Group.class.getName() %>" />',
 		});
 
-		liferayUpload._uploader.on('alluploadscomplete', function (event) {
+		liferayUpload._uploader.on('alluploadscomplete', (event) => {
 			toggleContinueButton();
 		});
 
-		Liferay.on('tempFileRemoved', function (event) {
+		Liferay.on('tempFileRemoved', (event) => {
 			toggleContinueButton();
 		});
 
@@ -134,14 +134,14 @@ String redirect = ParamUtil.getString(request, "redirect");
 	if (continueButton && exportImportOptions) {
 		var form = document.<portlet:namespace />fm1;
 
-		continueButton.addEventListener('click', function (event) {
+		continueButton.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			Liferay.Util.fetch(form.action)
-				.then(function (response) {
+				.then((response) => {
 					return response.text();
 				})
-				.then(function (response) {
+				.then((response) => {
 					exportImportOptions.innerHTML = response;
 
 					runScriptsInElement.default(exportImportOptions);

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_collections.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_collections.jsp
@@ -70,7 +70,7 @@ FragmentCollectionsDisplayContext fragmentCollectionsDisplayContext = new Fragme
 		'<portlet:namespace />fragmentCollections'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(fragmentCollectionsDisplayContext.getEventName()) %>',
 			{

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -195,7 +195,7 @@ name = HtmlUtil.escapeJS(name);
 		if (editorConfig.extraPlugins) {
 			editorConfig.extraPlugins = A.Array.filter(
 				editorConfig.extraPlugins.split(','),
-				function (item) {
+				(item) => {
 					return item !== 'ae_embed';
 				}
 			).join(',');
@@ -281,7 +281,7 @@ name = HtmlUtil.escapeJS(name);
 
 	var ignoreClass = ['ddm-options-target'];
 
-	var preventImageDragoverHandler = windowNode.on('dragover', function (event) {
+	var preventImageDragoverHandler = windowNode.on('dragover', (event) => {
 		var validDropTarget = event.target.getDOMNode().isContentEditable;
 
 		if (!validDropTarget) {
@@ -289,9 +289,9 @@ name = HtmlUtil.escapeJS(name);
 		}
 	});
 
-	var preventImageDropHandler = windowNode.on('drop', function (event) {
+	var preventImageDropHandler = windowNode.on('drop', (event) => {
 		var node = event.target.getDOMNode();
-		var ignoreNode = node.className.split(' ').filter(function (value) {
+		var ignoreNode = node.className.split(' ').filter((value) => {
 			return ignoreClass.includes(value);
 		});
 		var validDropTarget = ignoreNode.length > 0 ? true : node.isContentEditable;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -166,7 +166,7 @@ name = HtmlUtil.escapeJS(name);
 		nativeEditor.config.contentsLangDirection = contentsLanguageDir;
 	};
 
-	var preventImageDragoverHandler = windowNode.on('dragover', function (event) {
+	var preventImageDragoverHandler = windowNode.on('dragover', (event) => {
 		var validDropTarget = event.target.getDOMNode().isContentEditable;
 
 		if (!validDropTarget) {
@@ -174,7 +174,7 @@ name = HtmlUtil.escapeJS(name);
 		}
 	});
 
-	var preventImageDropHandler = windowNode.on('drop', function (event) {
+	var preventImageDropHandler = windowNode.on('drop', (event) => {
 		var validDropTarget = event.target.getDOMNode().isContentEditable;
 
 		if (!validDropTarget) {
@@ -349,7 +349,7 @@ name = HtmlUtil.escapeJS(name);
 			if (!ckePanelDelegate) {
 				ckePanelDelegate = ckEditor.delegate(
 					'click',
-					function (event) {
+					(event) => {
 						var panelFrame = A.one('.cke_combopanel .cke_panel_frame');
 
 						addAUIClass(panelFrame);
@@ -374,7 +374,7 @@ name = HtmlUtil.escapeJS(name);
 	<c:if test="<%= inlineEdit && Validator.isNotNull(inlineEditSaveURL) %>">
 		var inlineEditor;
 
-		Liferay.on('toggleControls', function (event) {
+		Liferay.on('toggleControls', (event) => {
 			if (event.src === 'ui') {
 				var ckEditor = CKEDITOR.instances['<%= name %>'];
 
@@ -447,7 +447,7 @@ name = HtmlUtil.escapeJS(name);
 				ckEditorContent = getInitialContent();
 			}
 
-			ckEditor.setData(ckEditorContent, function () {
+			ckEditor.setData(ckEditorContent, () => {
 				ckEditor.resetDirty();
 
 				ckEditorContent = '';
@@ -481,7 +481,7 @@ name = HtmlUtil.escapeJS(name);
 
 		CKEDITOR.<%= inlineEdit ? "inline" : "replace" %>('<%= name %>', config);
 
-		Liferay.on('<%= name %>selectItem', function (event) {
+		Liferay.on('<%= name %>selectItem', (event) => {
 			CKEDITOR.tools.callFunction(event.ckeditorfuncnum, event.value);
 		});
 
@@ -507,7 +507,7 @@ name = HtmlUtil.escapeJS(name);
 		%>
 
 		<c:if test="<%= useCustomDataProcessor %>">
-			ckEditor.on('customDataProcessorLoaded', function () {
+			ckEditor.on('customDataProcessorLoaded', () => {
 				customDataProcessorLoaded = true;
 
 				if (instanceReady) {
@@ -527,7 +527,7 @@ name = HtmlUtil.escapeJS(name);
 							editorPath +
 							'"]'
 					)
-					.forEach(function (tag) {
+					.forEach((tag) => {
 						tag.setAttribute('data-senna-track', 'temporary');
 					});
 			});
@@ -535,7 +535,7 @@ name = HtmlUtil.escapeJS(name);
 
 		var instanceReady = false;
 
-		ckEditor.on('instanceReady', function () {
+		ckEditor.on('instanceReady', () => {
 			<c:choose>
 				<c:when test="<%= useCustomDataProcessor %>">
 					instanceReady = true;
@@ -559,7 +559,7 @@ name = HtmlUtil.escapeJS(name);
 			</c:if>
 
 			<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
-				var contentChangeHandle = setInterval(function () {
+				var contentChangeHandle = setInterval(() => {
 					try {
 						window['<%= name %>'].onChangeCallback();
 					}
@@ -590,7 +590,7 @@ name = HtmlUtil.escapeJS(name);
 				eventHandles.push(
 					A.getWin().on(
 						'resize',
-						A.debounce(function () {
+						A.debounce(() => {
 							if (currentToolbarSet != getToolbarSet(initialToolbarSet)) {
 								var ckeditorInstance =
 									CKEDITOR.instances['<%= name %>'];
@@ -624,7 +624,7 @@ name = HtmlUtil.escapeJS(name);
 			</c:if>
 		});
 
-		ckEditor.on('dataReady', function (event) {
+		ckEditor.on('dataReady', (event) => {
 			if (instancePendingData) {
 				var pendingData = instancePendingData;
 
@@ -657,7 +657,7 @@ name = HtmlUtil.escapeJS(name);
 			}
 		});
 
-		ckEditor.on('setData', function (event) {
+		ckEditor.on('setData', (event) => {
 			instanceDataReady = false;
 		});
 
@@ -687,7 +687,7 @@ name = HtmlUtil.escapeJS(name);
 			var onBlur = function (activeElement) {
 				resetActiveElementValidation(activeElement);
 
-				setTimeout(function () {
+				setTimeout(() => {
 					if (activeElement) {
 						ckEditor.focusManager.blur(true);
 						activeElement.focus();
@@ -695,7 +695,7 @@ name = HtmlUtil.escapeJS(name);
 				}, 0);
 			};
 
-			ckEditor.on('instanceReady', function () {
+			ckEditor.on('instanceReady', () => {
 				var editorWrapper = A.one('#cke_<%= name %>');
 
 				if (editorWrapper) {

--- a/modules/apps/frontend-taglib/frontend-taglib-chart-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-chart-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -175,7 +175,7 @@
 </clay:container-fluid>
 
 <aui:script>
-	Liferay.componentReady('polling-interval-line-chart').then(function (chart) {
+	Liferay.componentReady('polling-interval-line-chart').then((chart) => {
 		chart.data = function () {
 			return Promise.resolve([
 				{
@@ -198,10 +198,10 @@
 		};
 	});
 
-	Liferay.componentReady('predictive-chart').then(function (chart) {
+	Liferay.componentReady('predictive-chart').then((chart) => {
 		var oldData = chart.data.slice();
 
-		setTimeout(function () {
+		setTimeout(() => {
 			var newData = {
 				data: [
 					[230, 230, 230],
@@ -220,7 +220,7 @@
 				id: 'data3',
 			};
 
-			chart.data = new Promise(function (resolve, reject) {
+			chart.data = new Promise((resolve, reject) => {
 				oldData.push(newData);
 				resolve(oldData);
 			});

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/add_menu/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/add_menu/page.jsp
@@ -136,7 +136,7 @@ String viewMoreURL = (String)request.getAttribute("liferay-frontend:add-menu:vie
 						<aui:script use="liferay-util-window">
 							var viewMoreAddMenuElements = A.one('#<%= namespace %>viewMoreButton');
 
-							viewMoreAddMenuElements.on('click', function (event) {
+							viewMoreAddMenuElements.on('click', (event) => {
 								Liferay.Util.Session.set(
 									'com.liferay.addmenu_customizeAddMenuAdviceMessage',
 									true

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/end.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/end.jsp
@@ -24,7 +24,7 @@
 	<aui:script sandbox="<%= true %>" use="aui-base,liferay-store">
 		var storeTask = A.debounce(Liferay.Store, 100);
 
-		Liferay.on('liferay.collapse.show', function (event) {
+		Liferay.on('liferay.collapse.show', (event) => {
 			if (event.panel.getAttribute('id') === '<%= id %>Content') {
 				var task = {};
 
@@ -34,7 +34,7 @@
 			}
 		});
 
-		Liferay.on('liferay.collapse.hide', function (event) {
+		Liferay.on('liferay.collapse.hide', (event) => {
 			if (event.panel.getAttribute('id') === '<%= id %>Content') {
 				var task = {};
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/form_navigator/sections.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/form_navigator/sections.jsp
@@ -100,10 +100,10 @@ List<FormNavigatorEntry<Object>> formNavigatorEntries = (List<FormNavigatorEntry
 				</c:otherwise>
 			</c:choose>
 
-			Liferay.once('<portlet:namespace />formReady', function (event) {
+			Liferay.once('<portlet:namespace />formReady', (event) => {
 				if (!sectionContent.classList.contains('show')) {
 					if (focusField) {
-						Liferay.on('liferay.collapse.shown', function (event) {
+						Liferay.on('liferay.collapse.shown', (event) => {
 							var panelId = event.panel.getAttribute('id');
 
 							if (panelId === sectionContent.getAttribute('id')) {

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/form_navigator_steps/steps.jspf
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/form_navigator_steps/steps.jspf
@@ -171,7 +171,7 @@
 
 	Liferay.component(
 		'<portlet:namespace /><%= formNavigatorStepsDisplayContext.getFormName() %>Tabview',
-		function () {
+		() => {
 			return new A.TabView({
 				boundingBox: '#<portlet:namespace />tabsBoundingBox',
 				srcNode: '#<portlet:namespace />tabs',
@@ -269,12 +269,12 @@
 
 	var history = new A.HistoryHash();
 
-	tabview.after('selectionChange', function (event) {
+	tabview.after('selectionChange', (event) => {
 		var tab = event.newVal;
 
 		var tabIndex = tabview.indexOf(tab);
 
-		tabview.each(function (item, index) {
+		tabview.each((item, index) => {
 			var node = tabview.item(index).get('boundingBox');
 
 			if (tabview.indexOf(item) < tabIndex) {
@@ -302,7 +302,7 @@
 		history.addValue('<portlet:namespace />tab', sectionId);
 	});
 
-	A.on('history:change', function (event) {
+	A.on('history:change', (event) => {
 		var state = event.newVal;
 
 		var changed = event.changed.<portlet:namespace />tab;
@@ -398,7 +398,7 @@
 			if (form.formNode.compareTo(formNode)) {
 				var validator = form.formValidator;
 
-				validator.on('submitError', function () {
+				validator.on('submitError', () => {
 					var errorClass = validator.get('errorClass');
 
 					var errorField = formNode.one('.' + errorClass);

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/info_bar/end.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/info_bar/end.jsp
@@ -53,7 +53,7 @@
 
 		document.addEventListener('scroll', checkPosition);
 
-		Liferay.once('destroyPortlet', function () {
+		Liferay.once('destroyPortlet', () => {
 			document.removeEventListener('scroll', checkPosition);
 		});
 	</aui:script>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/management_bar_sidenav_toggler_button/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/management_bar_sidenav_toggler_button/page.jsp
@@ -39,14 +39,14 @@
 			width: '<%= width %>',
 		});
 
-		sidenavInstance.on('closed.lexicon.sidenav', function (event) {
+		sidenavInstance.on('closed.lexicon.sidenav', (event) => {
 			Liferay.Util.Session.set(
 				'com.liferay.info.panel_<%= sidenavId %>',
 				'closed'
 			);
 		});
 
-		sidenavInstance.on('open.lexicon.sidenav', function (event) {
+		sidenavInstance.on('open.lexicon.sidenav', (event) => {
 			Liferay.Util.Session.set(
 				'com.liferay.info.panel_<%= sidenavId %>',
 				'open'

--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
@@ -152,7 +152,7 @@
 			monitorHeight: <%= iFramePortletInstanceConfiguration.resizeAutomatically() %>,
 		});
 
-		iframe.on('load', function () {
+		iframe.on('load', () => {
 			var height = A.Plugin.AutosizeIframe.getContentHeight(iframe);
 
 			if (height == null) {

--- a/modules/apps/image-uploader/image-uploader-web/src/main/resources/META-INF/resources/upload_image.jsp
+++ b/modules/apps/image-uploader/image-uploader-web/src/main/resources/META-INF/resources/upload_image.jsp
@@ -131,7 +131,7 @@ String randomNamespace = ParamUtil.getString(request, "randomNamespace");
 				);
 
 				if (uploadImageButton) {
-					uploadImageButton.addEventListener('keydown', function (event) {
+					uploadImageButton.addEventListener('keydown', (event) => {
 						event.preventDefault();
 
 						if (event.key == 'Enter' || event.key == ' ') {

--- a/modules/apps/invitation/invitation-invite-members-web/src/main/resources/META-INF/resources/invite_members/view.jsp
+++ b/modules/apps/invitation/invitation-invite-members-web/src/main/resources/META-INF/resources/invite_members/view.jsp
@@ -36,9 +36,7 @@ Group group = GroupLocalServiceUtil.getGroup(scopeGroupId);
 				'<portlet:namespace />inviteMembersButton'
 			);
 
-			<portlet:namespace />inviteMembersButton.addEventListener('click', function (
-				event
-			) {
+			<portlet:namespace />inviteMembersButton.addEventListener('click', (event) => {
 				Liferay.Util.openWindow({
 					dialog: {
 						cssClass: 'so-portlet-invite-members',

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -617,7 +617,7 @@ SearchContainer<?> searchContainer = new SearchContainer(renderRequest, itemSele
 		</c:if>
 	});
 
-	itemSelector.on('selectedItem', function (event) {
+	itemSelector.on('selectedItem', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= itemSelectedEventName %>',
 			event

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -192,7 +192,7 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 				'<portlet:namespace />entries'
 			);
 
-			searchContainer.on('rowToggled', function (event) {
+			searchContainer.on('rowToggled', (event) => {
 				var searchContainerItems = event.elements.allSelectedElements;
 
 				var arr = [];
@@ -232,11 +232,11 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 				document.querySelector('#<portlet:namespace />entriesContainer'),
 				'click',
 				'.entry',
-				function (event) {
+				(event) => {
 					var activeCards = document.querySelectorAll('.form-check-card.active');
 
 					if (activeCards.length) {
-						activeCards.forEach(function (card) {
+						activeCards.forEach((card) => {
 							card.classList.remove('active');
 						});
 					}

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -60,7 +60,7 @@
 
 	var delegate = delegateModule.default;
 
-	delegate(articlePreview, 'click', '.web-content-selector', function (event) {
+	delegate(articlePreview, 'click', '.web-content-selector', (event) => {
 		event.preventDefault();
 
 		Liferay.Util.openSelectionModal({
@@ -75,7 +75,7 @@
 		});
 	});
 
-	delegate(articlePreview, 'click', '.selector-button', function (event) {
+	delegate(articlePreview, 'click', '.selector-button', (event) => {
 		event.preventDefault();
 		retrieveWebContent(-1);
 	});

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/journal_template.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/journal_template.jsp
@@ -125,15 +125,15 @@ AssetRenderer<JournalArticle> assetRenderer = assetRendererFactory.getAssetRende
 							method: 'POST',
 						}
 					)
-						.then(function (response) {
+						.then((response) => {
 							return response.text();
 						})
-						.then(function (response) {
+						.then((response) => {
 							templatePreview.plug(A.Plugin.ParseContent);
 
 							templatePreview.setContent(response);
 						})
-						.catch(function () {
+						.catch(() => {
 							templatePreview.html(
 								'<div class="alert alert-danger hidden"><liferay-ui:message key="an-unexpected-error-occurred" /></div>'
 							);
@@ -156,14 +156,14 @@ AssetRenderer<JournalArticle> assetRenderer = assetRendererFactory.getAssetRende
 
 	A.one('#<%= refererPortletName + "ddmTemplateTypeDefault" %>').on(
 		'click',
-		function (event) {
+		(event) => {
 			templateKeyInput.setAttribute('value', '');
 		}
 	);
 
 	A.one('#<%= refererPortletName + "clearddmTemplateButton" %>').on(
 		'click',
-		function (event) {
+		(event) => {
 			templateKeyInput.setAttribute('value', '');
 
 			templatePreview.html(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
@@ -78,7 +78,7 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 		);
 
 		if (previewWithTemplate) {
-			previewWithTemplate.addEventListener('click', function (event) {
+			previewWithTemplate.addEventListener('click', (event) => {
 				var url = '<%= previewArticleContentTemplateURL %>';
 
 				<%
@@ -184,7 +184,7 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 	);
 
 	if (clearDDMTemplateButton) {
-		clearDDMTemplateButton.addEventListener('click', function (event) {
+		clearDDMTemplateButton.addEventListener('click', (event) => {
 			changeDDMTemplate();
 		});
 	}
@@ -194,7 +194,7 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 	);
 
 	if (selectDDMTemplateButton) {
-		selectDDMTemplateButton.addEventListener('click', function (event) {
+		selectDDMTemplateButton.addEventListener('click', (event) => {
 			Liferay.Util.openSelectionModal({
 				onSelect: function (selectedItem) {
 					changeDDMTemplate(selectedItem);
@@ -212,7 +212,7 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 	);
 
 	if (editDDMTemplateLink) {
-		editDDMTemplateLink.addEventListener('click', function (event) {
+		editDDMTemplateLink.addEventListener('click', (event) => {
 			if (
 				confirm(
 					'<%= UnicodeLanguageUtil.get(request, "editing-the-current-template-deletes-all-unsaved-content") %>'

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/configuration/icon/view_source_icon.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/configuration/icon/view_source_icon.jsp
@@ -32,7 +32,7 @@ JournalArticle article = (JournalArticle)request.getAttribute(WebKeys.JOURNAL_AR
 	);
 
 	if (viewResourcesButton) {
-		viewResourcesButton.addEventListener('click', function (event) {
+		viewResourcesButton.addEventListener('click', (event) => {
 			Liferay.Util.openModal({
 				title:
 					'<%= HtmlUtil.escapeJS(HtmlUtil.escape(article.getTitle(themeDisplay.getLocale()))) %>',

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/ddm_template/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/ddm_template/basic_info.jsp
@@ -90,7 +90,7 @@ DDMStructure ddmStructure = journalEditDDMTemplateDisplayContext.getDDMStructure
 		);
 
 		if (selectDDMStructure) {
-			selectDDMStructure.addEventListener('click', function (event) {
+			selectDDMStructure.addEventListener('click', (event) => {
 				Liferay.Util.openSelectionModal({
 					onSelect: function (selectedItem) {
 						if (

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
@@ -116,13 +116,13 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 </aui:form>
 
 <aui:script>
-	Liferay.after('<portlet:namespace />saveAndContinue', function () {
+	Liferay.after('<portlet:namespace />saveAndContinue', () => {
 		document.<portlet:namespace />fm.<portlet:namespace />saveAndContinue.value = true;
 
 		Liferay.fire('<portlet:namespace />saveTemplate');
 	});
 
-	Liferay.after('<portlet:namespace />saveTemplate', function () {
+	Liferay.after('<portlet:namespace />saveTemplate', () => {
 		submitForm(document.<portlet:namespace />fm);
 	});
 
@@ -141,7 +141,7 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 	}
 
 	if (contextualSidebarButton) {
-		contextualSidebarButton.addEventListener('click', function (event) {
+		contextualSidebarButton.addEventListener('click', (event) => {
 			if (
 				contextualSidebarContainer.classList.contains(
 					'contextual-sidebar-visible'

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
@@ -424,7 +424,7 @@ renderResponse.setTitle((feed == null) ? LanguageUtil.get(request, "new-feed") :
 	);
 
 	if (contentFieldSelector) {
-		contentFieldSelector.addEventListener('change', function () {
+		contentFieldSelector.addEventListener('change', () => {
 			var contentFieldValue = '';
 			var ddmRendererTemplateKeyValue = '';
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -154,7 +154,7 @@ renderResponse.setTitle(title);
 								'<portlet:namespace />selectFolderButton'
 							);
 
-							selectFolderButton.addEventListener('click', function (event) {
+							selectFolderButton.addEventListener('click', (event) => {
 								Liferay.Util.openSelectionModal({
 									onSelect: function (selectedItem) {
 										if (selectedItem) {
@@ -382,7 +382,7 @@ renderResponse.setTitle(title);
 	);
 
 	if (selectDDMStructureButton) {
-		selectDDMStructureButton.addEventListener('click', function (event) {
+		selectDDMStructureButton.addEventListener('click', (event) => {
 			Liferay.Util.openSelectionModal({
 				onSelect: function (selectedItem) {
 					var ddmStructureLink =
@@ -425,7 +425,7 @@ renderResponse.setTitle(title);
 
 	searchContainer.get('contentBox').delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var link = event.currentTarget;
 
 			var tr = link.ancestor('tr');

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/import_translation.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/import_translation.jsp
@@ -107,7 +107,7 @@ renderResponse.setTitle(LanguageUtil.get(resourceBundle, "import-translation"));
 <script>
 	var saveDraftBtn = document.getElementById('<portlet:namespace />saveDraftBtn');
 
-	saveDraftBtn.addEventListener('click', function () {
+	saveDraftBtn.addEventListener('click', () => {
 		var workflowActionInput = document.getElementById(
 			'<portlet:namespace />workflowAction'
 		);

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
@@ -374,7 +374,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 		document.querySelector('#<portlet:namespace />articlesContainer'),
 		'click',
 		'.articles',
-		function (event) {
+		(event) => {
 			<c:choose>
 				<c:when test='<%= Objects.equals(journalArticleItemSelectorViewDisplayContext.getDisplayStyle(), "icon") %>'>
 					var activeFormCheckCards = document.querySelectorAll(
@@ -384,7 +384,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 					var formCheckCard = event.delegateTarget.closest('.form-check-card');
 
 					if (activeFormCheckCards.length) {
-						activeFormCheckCards.forEach(function (card) {
+						activeFormCheckCards.forEach((card) => {
 							card.classList.remove('active');
 						});
 					}
@@ -398,7 +398,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 					var articles = event.delegateTarget.closest('.articles');
 
 					if (activeArticles.length) {
-						activeArticles.forEach(function (article) {
+						activeArticles.forEach((article) => {
 							article.classList.remove('active');
 						});
 					}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_article_translations.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_article_translations.jsp
@@ -66,7 +66,7 @@
 		'<portlet:namespace />articleTranslations'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(journalDisplayContext.getDeleteTranslationsEventName()) %>',
 			{

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_ddm_structure.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_ddm_structure.jsp
@@ -89,7 +89,7 @@ SearchContainer<DDMStructure> ddmStructureSearch = journalSelectDDMStructureDisp
 </aui:form>
 
 <aui:script>
-	document.addEventListener('DOMContentLoaded', function () {
+	document.addEventListener('DOMContentLoaded', () => {
 		Liferay.Util.selectEntityHandler(
 			'#<portlet:namespace />selectDDMStructureFm',
 			'<%= HtmlUtil.escapeJS(journalSelectDDMStructureDisplayContext.getEventName()) %>'

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_ddm_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_ddm_template.jsp
@@ -96,7 +96,7 @@ JournalSelectDDMTemplateDisplayContext journalSelectDDMTemplateDisplayContext = 
 </aui:form>
 
 <aui:script>
-	document.addEventListener('DOMContentLoaded', function () {
+	document.addEventListener('DOMContentLoaded', () => {
 		Liferay.Util.selectEntityHandler(
 			'#<portlet:namespace />selectDDMTemplateFm',
 			'<%= HtmlUtil.escapeJS(journalSelectDDMTemplateDisplayContext.getEventName()) %>'

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
@@ -106,7 +106,7 @@ JournalViewMoreMenuItemsDisplayContext journalViewMoreMenuItemsDisplayContext = 
 
 	var delegate = delegateModule.default;
 
-	delegate(addMenuItemFm, 'click', '.selector-button', function (event) {
+	delegate(addMenuItemFm, 'click', '.selector-button', (event) => {
 		Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(journalViewMoreMenuItemsDisplayContext.getEventName()) %>',
 			{

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_article.jsp
@@ -293,7 +293,7 @@ if (portletTitleBasedNavigation) {
 		var titleInput = document.getElementById('<portlet:namespace />title');
 		var urlTitleInput = document.getElementById('<portlet:namespace />urlTitle');
 
-		titleInput.addEventListener('input', function (event) {
+		titleInput.addEventListener('input', (event) => {
 			var customUrl = urlTitleInput.dataset.customUrl;
 
 			if (customUrl === 'false') {
@@ -303,14 +303,14 @@ if (portletTitleBasedNavigation) {
 			}
 		});
 
-		urlTitleInput.addEventListener('input', function (event) {
+		urlTitleInput.addEventListener('input', (event) => {
 			event.currentTarget.dataset.customUrl = urlTitleInput.value !== '';
 		});
 	</c:if>
 
 	document
 		.getElementById('<portlet:namespace />publishButton')
-		.addEventListener('click', function () {
+		.addEventListener('click', () => {
 			var workflowActionInput = document.getElementById(
 				'<portlet:namespace />workflowAction'
 			);
@@ -353,7 +353,7 @@ if (portletTitleBasedNavigation) {
 		selectedFileNameContainer.innerHTML = buffer.join('');
 	};
 
-	form.addEventListener('submit', function () {
+	form.addEventListener('submit', () => {
 		document.getElementById(
 			'<portlet:namespace />content'
 		).value = window.<portlet:namespace />contentEditor.getHTML();

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/history.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/history.jsp
@@ -189,7 +189,7 @@ if (portletTitleBasedNavigation) {
 	);
 
 	if (compareVersionsButton) {
-		compareVersionsButton.addEventListener('click', function (event) {
+		compareVersionsButton.addEventListener('click', (event) => {
 			var rowIds = document.querySelectorAll(
 				'input[name="<portlet:namespace />rowIds"]:checked'
 			);
@@ -222,7 +222,7 @@ if (portletTitleBasedNavigation) {
 	function <portlet:namespace />initRowsChecked() {
 		Array.from(
 			document.querySelectorAll('input[name=<portlet:namespace />rowIds]')
-		).forEach(function (item, index, collection) {
+		).forEach((item, index, collection) => {
 			if (index >= 2) {
 				item.checked = false;
 			}
@@ -255,7 +255,7 @@ if (portletTitleBasedNavigation) {
 		document.body,
 		'click',
 		'input[name=<portlet:namespace />rowIds]',
-		function (event) {
+		(event) => {
 			<portlet:namespace />updateRowsChecked(event.delegateTarget);
 		}
 	);

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/move_object.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/move_object.jsp
@@ -115,7 +115,7 @@ if (portletTitleBasedNavigation) {
 	);
 
 	if (selectKBObjectButton) {
-		selectKBObjectButton.addEventListener('click', function (event) {
+		selectKBObjectButton.addEventListener('click', (event) => {
 			Liferay.Util.openSelectionModal({
 				onSelect: function (event) {
 					Liferay.Util.setFormValues(document.<portlet:namespace />fm, {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_suggestion.jsp
@@ -128,7 +128,7 @@ int nextStatus = KBUtil.getNextStatus(kbComment.getStatus());
 	);
 
 	if (deleteButtonElement) {
-		deleteButtonElement.addEventListener('click', function (event) {
+		deleteButtonElement.addEventListener('click', (event) => {
 			if (
 				!confirm(
 					'<liferay-ui:message key="are-you-sure-you-want-to-delete-this" />'

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -339,10 +339,8 @@ if (parentResourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 		deleteEntries: deleteEntries,
 	};
 
-	Liferay.componentReady('kbAdminManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
+	Liferay.componentReady('kbAdminManagementToolbar').then((managementToolbar) => {
+		managementToolbar.on('actionItemClicked', (event) => {
 			var itemData = event.data.item.data;
 
 			if (itemData && itemData.action && ACTIONS[itemData.action]) {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_suggestions.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_suggestions.jsp
@@ -109,15 +109,15 @@ request.setAttribute("view_suggestions.jsp-searchContainer", kbCommentsSearchCon
 		deleteKBComments: deleteKBComments,
 	};
 
-	Liferay.componentReady('kbSuggestionListManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('kbSuggestionListManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('actionItemClicked', (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action]();
+				}
+			});
+		}
+	);
 </script>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_templates.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_templates.jsp
@@ -142,15 +142,15 @@ KBTemplatesManagementToolbarDisplayContext kbTemplatesManagementToolbarDisplayCo
 		deleteKBTemplates: deleteKBTemplates,
 	};
 
-	Liferay.componentReady('kbTemplatesManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('kbTemplatesManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('actionItemClicked', (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action]();
+				}
+			});
+		}
+	);
 </script>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/configuration.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/configuration.jsp
@@ -110,7 +110,7 @@ kbArticlePortletInstanceConfiguration = ParameterMapUtil.setParameterMap(KBArtic
 	if (<portlet:namespace />form) {
 		document
 			.getElementById('<portlet:namespace />selectKBArticleButton')
-			.addEventListener('click', function (event) {
+			.addEventListener('click', (event) => {
 				Liferay.Util.openSelectionModal({
 					onSelect: function (event) {
 						var kbArticleData = {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/configuration.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/configuration.jsp
@@ -136,7 +136,7 @@ kbDisplayPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(KBDispl
 	if (<portlet:namespace />form) {
 		document
 			.getElementById('<portlet:namespace />selectKBObjectButton')
-			.addEventListener('click', function (event) {
+			.addEventListener('click', (event) => {
 				Liferay.Util.openSelectionModal({
 					onSelect: function (event) {
 						document.getElementById(

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/content_root_selector.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/display/content_root_selector.jsp
@@ -80,7 +80,7 @@ List<KBFolder> kbFolders = KBUtil.getAlternateRootKBFolders(scopeGroupId, kbDisp
 		if (<portlet:namespace />form) {
 			document
 				.getElementById('<portlet:namespace />rootKBFolderId')
-				.addEventListener('change', function () {
+				.addEventListener('change', () => {
 					<portlet:namespace />form.submit();
 				});
 		}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
@@ -120,7 +120,7 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 
 	var form = document.<portlet:namespace />fm;
 
-	form.addEventListener('submit', function (event) {
+	form.addEventListener('submit', (event) => {
 		event.preventDefault();
 		event.stopPropagation();
 
@@ -142,7 +142,7 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 
 		Array.prototype.slice
 			.call(form.querySelectorAll('input'))
-			.forEach(function (input) {
+			.forEach((input) => {
 				if (input.type == 'checkbox' && !input.checked) {
 					return;
 				}
@@ -156,10 +156,10 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 			body: formData,
 			method: 'POST',
 		})
-			.then(function (response) {
+			.then((response) => {
 				return response.json();
 			})
-			.then(function (response) {
+			.then((response) => {
 				if (response.redirectURL) {
 					var redirectURL = new URL(
 						response.redirectURL,

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/customization_settings.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/customization_settings.jsp
@@ -84,7 +84,7 @@ boolean hasUpdateLayoutPermission = GetterUtil.getBoolean(request.getAttribute(C
 							namespace: '<%= portletNamespace %>',
 						});
 
-						Liferay.once('screenLoad', function () {
+						Liferay.once('screenLoad', () => {
 							layoutCustomizationSettings.destroy();
 						});
 					</aui:script>
@@ -165,7 +165,7 @@ boolean hasUpdateLayoutPermission = GetterUtil.getBoolean(request.getAttribute(C
 					);
 
 					if (closeCustomizationOptions && controlMenu) {
-						closeCustomizationOptions.addEventListener('click', function (event) {
+						closeCustomizationOptions.addEventListener('click', (event) => {
 							controlMenu.classList.toggle('open');
 						});
 					}
@@ -175,7 +175,7 @@ boolean hasUpdateLayoutPermission = GetterUtil.getBoolean(request.getAttribute(C
 					);
 
 					if (customizationButton && controlMenu) {
-						customizationButton.addEventListener('click', function (event) {
+						customizationButton.addEventListener('click', (event) => {
 							controlMenu.classList.toggle('open');
 						});
 					}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/details.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/details.jsp
@@ -217,7 +217,7 @@ String friendlyURLBase = StringPool.BLANK;
 	);
 
 	if (layoutPrototypeLinkEnabled) {
-		layoutPrototypeLinkEnabled.addEventListener('change', function (event) {
+		layoutPrototypeLinkEnabled.addEventListener('change', (event) => {
 			var layoutPrototypeLinkChecked = event.currentTarget.checked;
 
 			var layoutPrototypeInfoMessage = document.querySelector(
@@ -245,10 +245,7 @@ String friendlyURLBase = StringPool.BLANK;
 				'#<portlet:namespace />editLayoutFm .propagatable-field'
 			);
 
-			Array.prototype.forEach.call(propagatableFields, function (
-				field,
-				index
-			) {
+			Array.prototype.forEach.call(propagatableFields, (field, index) => {
 				Liferay.Util.toggleDisabled(field, layoutPrototypeLinkChecked);
 			});
 		});

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
@@ -239,13 +239,13 @@ else {
 			'<portlet:namespace />styleBookWarning'
 		);
 
-		regularInheritLookAndFeel.addEventListener('change', function (event) {
+		regularInheritLookAndFeel.addEventListener('change', (event) => {
 			if (event.target.checked) {
 				styleBookWarning.classList.add('hide');
 			}
 		});
 
-		regularUniqueLookAndFeelCheckbox.addEventListener('change', function (event) {
+		regularUniqueLookAndFeelCheckbox.addEventListener('change', (event) => {
 			if (event.target.checked) {
 				styleBookWarning.classList.remove('hide');
 			}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/general.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/general.jsp
@@ -81,7 +81,7 @@ renderResponse.setTitle(selLayout.getName(locale));
 					);
 
 					if (enableLayoutButton) {
-						enableLayoutButton.addEventListener('click', function (event) {
+						enableLayoutButton.addEventListener('click', (event) => {
 							<portlet:actionURL name="/layout_admin/enable_layout" var="enableLayoutURL">
 								<portlet:param name="redirect" value="<%= currentURL %>" />
 								<portlet:param name="incompleteLayoutRevisionId" value="<%= String.valueOf(layoutRevision.getLayoutRevisionId()) %>" />
@@ -96,7 +96,7 @@ renderResponse.setTitle(selLayout.getName(locale));
 					);
 
 					if (deleteLayoutButton) {
-						deleteLayoutButton.addEventListener('click', function (event) {
+						deleteLayoutButton.addEventListener('click', (event) => {
 							<portlet:actionURL name="/layout_admin/delete_layout" var="deleteLayoutURL">
 								<portlet:param name="redirect" value="<%= currentURL %>" />
 								<portlet:param name="selPlid" value="<%= String.valueOf(layoutsAdminDisplayContext.getSelPlid()) %>" />
@@ -254,7 +254,7 @@ renderResponse.setTitle(selLayout.getName(locale));
 <aui:script>
 	var form = document.getElementById('<portlet:namespace />editLayoutFm');
 
-	form.addEventListener('submit', function (event) {
+	form.addEventListener('submit', (event) => {
 		var applyLayoutPrototype = document.getElementById(
 			'<portlet:namespace />applyLayoutPrototype'
 		);

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp
@@ -122,7 +122,7 @@ Layout curLayout = (Layout)row.getObject();
 		document.body,
 		'click',
 		'.<portlet:namespace />copy-layout-action-option',
-		function (event) {
+		(event) => {
 			Liferay.Util.openModal({
 				id: '<portlet:namespace />addLayoutDialog',
 				title: '<liferay-ui:message key="copy-page" />',
@@ -136,7 +136,7 @@ Layout curLayout = (Layout)row.getObject();
 		document.body,
 		'click',
 		'.<portlet:namespace />view-collection-items-action-option',
-		function (event) {
+		(event) => {
 			Liferay.Util.openModal({
 				id: '<portlet:namespace />viewCollectionItemsDialog',
 				title: '<liferay-ui:message key="collection-items" />',

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_merge_alert.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_merge_alert.jsp
@@ -45,7 +45,7 @@ int mergeFailCount = SitesUtil.getMergeFailCount(layoutPrototype);
 			);
 
 			if (resetButton) {
-				resetButton.addEventListener('click', function (event) {
+				resetButton.addEventListener('click', (event) => {
 					<portlet:actionURL name="/layout_admin/reset_merge_fail_count_and_merge" var="resetMergeFailCountURL">
 						<portlet:param name="redirect" value="<%= redirect %>" />
 						<portlet:param name="layoutPrototypeId" value="<%= String.valueOf(layoutPrototype.getLayoutPrototypeId()) %>" />

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_collections.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_collections.jsp
@@ -53,7 +53,7 @@ SelectLayoutCollectionDisplayContext selectLayoutCollectionDisplayContext = (Sel
 		collections,
 		'click',
 		'.select-collection-action-option',
-		function (event) {}
+		(event) => {}
 	);
 
 	function handleDestroyPortlet() {

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_collections.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_collections.jsp
@@ -68,7 +68,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-collection"));
 		collections,
 		'click',
 		'.select-collection-action-option',
-		function (event) {
+		(event) => {
 			Liferay.Util.navigate(
 				event.delegateTarget.dataset.selectLayoutMasterLayoutUrl
 			);

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_master_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_master_layout.jsp
@@ -73,7 +73,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 		layoutPageTemplateEntries,
 		'click',
 		'.add-layout-action-option',
-		function (event) {
+		(event) => {
 			Liferay.Util.openModal({
 				height: '60vh',
 				id: '<portlet:namespace />addLayoutDialog',

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
@@ -173,7 +173,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 		layoutPageTemplateEntries,
 		'click',
 		'.add-layout-action-option',
-		function (event) {
+		(event) => {
 			Liferay.Util.openModal({
 				height: '60vh',
 				id: '<portlet:namespace />addLayoutDialog',
@@ -188,7 +188,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 		layoutPageTemplateEntries,
 		'keydown',
 		'.add-layout-action-option',
-		function (event) {
+		(event) => {
 			if (event.code === 'Space' || event.code === 'Enter') {
 				event.preventDefault();
 				event.delegateTarget.click();

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_master_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_master_layout.jsp
@@ -53,11 +53,11 @@ List<LayoutPageTemplateEntry> masterLayoutPageTemplateEntries = selectLayoutPage
 		document.body,
 		'click',
 		'.select-master-layout-option',
-		function (event) {
+		(event) => {
 			var activeCards = document.querySelectorAll('.form-check-card.active');
 
 			if (activeCards.length) {
-				activeCards.forEach(function (card) {
+				activeCards.forEach((card) => {
 					card.classList.remove('active');
 				});
 			}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_style_book.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_style_book.jsp
@@ -69,11 +69,11 @@ List<StyleBookEntry> styleBookEntries = selectLayoutPageTemplateEntryDisplayCont
 		document.body,
 		'click',
 		'.select-master-layout-option',
-		function (event) {
+		(event) => {
 			var activeCards = document.querySelectorAll('.form-check-card.active');
 
 			if (activeCards.length) {
-				activeCards.forEach(function (card) {
+				activeCards.forEach((card) => {
 					card.classList.remove('active');
 				});
 			}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/merge_alert.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/merge_alert.jsp
@@ -44,7 +44,7 @@ int mergeFailCount = SitesUtil.getMergeFailCount(layoutPrototype);
 			);
 
 			if (resetButton) {
-				resetButton.addEventListener('click', function (event) {
+				resetButton.addEventListener('click', (event) => {
 					<portlet:actionURL name="/layout_page_template_admin/reset_merge_fail_count_and_merge" var="resetMergeFailCountURL">
 						<portlet:param name="redirect" value="<%= redirect %>" />
 						<portlet:param name="layoutPrototypeId" value="<%= String.valueOf(layoutPrototype.getLayoutPrototypeId()) %>" />

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_collections.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_collections.jsp
@@ -58,7 +58,7 @@ LayoutPageTemplateCollectionsDisplayContext layoutPageTemplateCollectionsDisplay
 		'<portlet:namespace />layoutPageTemplateCollections'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(layoutPageTemplateCollectionsDisplayContext.getEventName()) %>',
 			{

--- a/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/merge_alert.jsp
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/merge_alert.jsp
@@ -44,7 +44,7 @@ int mergeFailCount = SitesUtil.getMergeFailCount(layoutSetPrototype);
 			);
 
 			if (resetButton) {
-				resetButton.addEventListener('click', function (event) {
+				resetButton.addEventListener('click', (event) => {
 					<portlet:actionURL name="resetMergeFailCount" var="resetMergeFailCountURL">
 						<portlet:param name="layoutSetPrototypeId" value="<%= String.valueOf(layoutSetPrototype.getLayoutSetPrototypeId()) %>" />
 						<portlet:param name="redirect" value="<%= redirect %>" />

--- a/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/view.jsp
@@ -203,15 +203,15 @@
 		deleteLayoutSetPrototypes: deleteLayoutSetPrototypes,
 	};
 
-	Liferay.componentReady('layoutSetPrototypeWebManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('layoutSetPrototypeWebManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('actionItemClicked', (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action]();
+				}
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_view/page.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layout_classed_model_usages_view/page.jsp
@@ -85,7 +85,7 @@ LayoutClassedModelUsagesDisplayContext layoutClassedModelUsagesDisplayContext = 
 			),
 			'click',
 			'.preview-layout-classed-model-usage',
-			function (event) {
+			(event) => {
 				Liferay.Util.openModal({
 					iframeBodyCssClass: 'article-preview',
 					title: '<liferay-ui:message key="preview" />',

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layouts_tree/page.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layouts_tree/page.jsp
@@ -116,7 +116,7 @@ String treeId = (String)request.getAttribute("liferay-layout:layouts-tree:treeId
 
 	Liferay.component('<%= namespace + treeId %>', treeview);
 
-	Liferay.once('screenLoad', function () {
+	Liferay.once('screenLoad', () => {
 		treeview.destroy();
 	});
 </aui:script>

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-collection/src/main/resources/META-INF/resources/entries/collection_items_detail.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-collection/src/main/resources/META-INF/resources/entries/collection_items_detail.jsp
@@ -31,7 +31,7 @@ CollectionItemsDetailDisplayContext collectionItemsDetailDisplayContext = (Colle
 		'<%= collectionItemsDetailDisplayContext.getNamespace() %>viewCollectionItems'
 	);
 
-	viewCollectionItems.addEventListener('click', function (event) {
+	viewCollectionItems.addEventListener('click', (event) => {
 		Liferay.Util.openModal({
 			id:
 				'<%= collectionItemsDetailDisplayContext.getNamespace() %>viewCollectionItemsDialog',

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded_js.jspf
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded_js.jspf
@@ -20,7 +20,7 @@
 	if (iframe) {
 		iframe.plug(A.Plugin.AutosizeIframe);
 
-		iframe.on('load', function () {
+		iframe.on('load', () => {
 			var height = A.Plugin.AutosizeIframe.getContentHeight(iframe);
 
 			if (height == null) {

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/resources/META-INF/resources/layout/edit/link_to_layout.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/resources/META-INF/resources/layout/edit/link_to_layout.jsp
@@ -30,7 +30,7 @@
 			'<portlet:namespace />selectLayoutButton'
 		);
 
-		selectLayoutButton.addEventListener('click', function (event) {
+		selectLayoutButton.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			Liferay.Util.openSelectionModal({

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-panel/src/main/resources/META-INF/resources/layout/edit/panel.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-panel/src/main/resources/META-INF/resources/layout/edit/panel.jsp
@@ -55,7 +55,7 @@ if (selLayout != null) {
 		formatJSONResults: function (json) {
 			var output = [];
 
-			A.each(json.children.list, function (item, index) {
+			A.each(json.children.list, (item, index) => {
 				var childPortlets = [];
 				var total = 0;
 
@@ -159,7 +159,7 @@ if (selLayout != null) {
 		initPanelSelectPortlets();
 	</c:if>
 
-	Liferay.on('<portlet:namespace />toggleLayoutTypeFields', function (event) {
+	Liferay.on('<portlet:namespace />toggleLayoutTypeFields', (event) => {
 		if (event.type == 'panel') {
 			initPanelSelectPortlets();
 		}

--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/login.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/login.jsp
@@ -194,7 +194,7 @@
 			var form = document.getElementById('<portlet:namespace /><%= formName %>');
 
 			if (form) {
-				form.addEventListener('submit', function (event) {
+				form.addEventListener('submit', (event) => {
 					<c:if test="<%= Validator.isNotNull(redirect) %>">
 						var redirect = form.querySelector('#<portlet:namespace />redirect');
 
@@ -211,7 +211,7 @@
 				var password = form.querySelector('#<portlet:namespace />password');
 
 				if (password) {
-					password.addEventListener('keypress', function (event) {
+					password.addEventListener('keypress', (event) => {
 						Liferay.Util.showCapsLock(
 							event,
 							'<portlet:namespace />passwordCapsLockSpan'

--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/login_redirect.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/login_redirect.jsp
@@ -85,13 +85,13 @@ boolean anonymousAccount = ParamUtil.getBoolean(request, "anonymousUser");
 				}),
 				method: 'POST',
 			})
-				.then(function (response) {
+				.then((response) => {
 					return response.ok ? response.json() : Promise.reject();
 				})
-				.then(function (data) {
+				.then((data) => {
 					return !data.exception ? data.userStatus : Promise.reject();
 				})
-				.then(function (userStatus) {
+				.then((userStatus) => {
 					var message = '';
 
 					if (userStatus == 'user_added') {

--- a/modules/apps/marketplace/marketplace-store-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/marketplace/marketplace-store-web/src/main/resources/META-INF/resources/view.jsp
@@ -57,7 +57,7 @@ viewURL.setWindowState(LiferayWindowState.EXCLUSIVE);
 	});
 
 	Liferay.MarketplaceMessenger.receiveMessage(
-		function (event) {
+		(event) => {
 			var response = event.responseData;
 
 			if (response.cmd) {
@@ -100,7 +100,7 @@ viewURL.setWindowState(LiferayWindowState.EXCLUSIVE);
 				}
 			}
 		},
-		function () {
+		() => {
 			return true;
 		}
 	);

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_category.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_category.jsp
@@ -102,7 +102,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "move"),
 	);
 
 	if (selectCategoryButton) {
-		selectCategoryButton.addEventListener('click', function (event) {
+		selectCategoryButton.addEventListener('click', (event) => {
 			Liferay.Util.openSelectionModal({
 				onSelect: function (event) {
 					var form = document.<portlet:namespace />fm;

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_thread.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_thread.jsp
@@ -145,7 +145,7 @@ if (portletTitleBasedNavigation) {
 	);
 
 	if (selectCategoryButton) {
-		selectCategoryButton.addEventListener('click', function (event) {
+		selectCategoryButton.addEventListener('click', (event) => {
 			Liferay.Util.openSelectionModal({
 				onSelect: function (event) {
 					Liferay.Util.setFormValues(form, {

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
@@ -95,10 +95,10 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 			addQuickReplyLoadingMask.classList.remove('hide');
 
 			Liferay.Util.fetch(editMessageQuickURL)
-				.then(function (response) {
+				.then((response) => {
 					return response.text();
 				})
-				.then(function (response) {
+				.then((response) => {
 					addQuickReplyContainer.innerHTML = response;
 
 					runScriptsInElement.default(addQuickReplyContainer);
@@ -117,7 +117,7 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 					var editorName =
 						'<portlet:namespace />replyMessageBody' + messageId;
 
-					Liferay.componentReady(editorName).then(function (editor) {
+					Liferay.componentReady(editorName).then((editor) => {
 						editor.focus();
 					});
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message_content.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message_content.jsp
@@ -305,7 +305,7 @@ if (portletTitleBasedNavigation) {
 	);
 
 	if (moreMessagesButton) {
-		moreMessagesButton.addEventListener('click', function (event) {
+		moreMessagesButton.addEventListener('click', (event) => {
 			var form = document.<portlet:namespace />fm;
 
 			var index = Liferay.Util.getFormElement(form, 'index');
@@ -329,10 +329,10 @@ if (portletTitleBasedNavigation) {
 				body: formData,
 				method: 'POST',
 			})
-				.then(function (response) {
+				.then((response) => {
 					return response.text();
 				})
-				.then(function (response) {
+				.then((response) => {
 					var messageContainer = document.getElementById(
 						'<portlet:namespace />messageContainer'
 					);

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view.jsp
@@ -141,15 +141,15 @@ if (category != null) {
 		unlockEntries: unlockEntries,
 	};
 
-	Liferay.componentReady('mbEntriesManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('mbEntriesManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('actionItemClicked', (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action]();
+				}
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_banned_users.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_banned_users.jsp
@@ -151,15 +151,15 @@ PortalUtil.setPageSubtitle(LanguageUtil.get(request, "banned-users"), request);
 		unbanUser: unbanUser,
 	};
 
-	Liferay.componentReady('mbBannedUsersManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('mbBannedUsersManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('actionItemClicked', (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action]();
+				}
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/edit_action.jsp
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/edit_action.jsp
@@ -117,10 +117,10 @@ MDRRuleGroupInstance ruleGroupInstance = (MDRRuleGroupInstance)renderRequest.get
 				method: 'POST',
 			}
 		)
-			.then(function (response) {
+			.then((response) => {
 				return response.text();
 			})
-			.then(function (response) {
+			.then((response) => {
 				var layouts = document.getElementById(
 					'<portlet:namespace />layouts'
 				);
@@ -152,10 +152,10 @@ MDRRuleGroupInstance ruleGroupInstance = (MDRRuleGroupInstance)renderRequest.get
 			body: formData,
 			method: 'POST',
 		})
-			.then(function (response) {
+			.then((response) => {
 				return response.text();
 			})
-			.then(function (response) {
+			.then((response) => {
 				var typeSettings = document.getElementById(
 					'<portlet:namespace />typeSettings'
 				);

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/edit_rule.jsp
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/edit_rule.jsp
@@ -134,10 +134,10 @@ renderResponse.setTitle(title);
 					'&<portlet:namespace />type=' +
 					<%= ruleId %>
 			)
-				.then(function (response) {
+				.then((response) => {
 					return response.text();
 				})
-				.then(function (response) {
+				.then((response) => {
 					typeSettingsContainer.innerHTML = response;
 				});
 		};

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/edit_rule_group_instance_priorities.jsp
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/edit_rule_group_instance_priorities.jsp
@@ -91,15 +91,14 @@ List<MDRRuleGroupInstance> ruleGroupInstances = MDRRuleGroupInstanceServiceUtil.
 				ruleGroupInstanceNodes
 			);
 
-			var ruleGroupInstances = ruleGroupInstanceNodesArray.map(function (
-				item,
-				index
-			) {
-				return {
-					priority: index,
-					ruleGroupInstanceId: item.dataset.ruleGroupInstanceId,
-				};
-			});
+			var ruleGroupInstances = ruleGroupInstanceNodesArray.map(
+				(item, index) => {
+					return {
+						priority: index,
+						ruleGroupInstanceId: item.dataset.ruleGroupInstanceId,
+					};
+				}
+			);
 
 			ruleGroupsInstancesJSONElement.value = JSON.stringify(
 				ruleGroupInstances
@@ -151,7 +150,7 @@ List<MDRRuleGroupInstance> ruleGroupInstances = MDRRuleGroupInstanceServiceUtil.
 
 				var nodes = container.all('.list-group-item');
 
-				nodes.each(function (item, index, collection) {
+				nodes.each((item, index, collection) => {
 					var priorityNode = item.one(
 						'.rule-group-instance-priority-value'
 					);

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/layout/mobile_device_rules_rule_group_instance_action.jsp
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/layout/mobile_device_rules_rule_group_instance_action.jsp
@@ -73,7 +73,7 @@ MDRRuleGroup mdrRuleGroup = MDRRuleGroupLocalServiceUtil.getMDRRuleGroup(mdrRule
 
 		A.one('#<portlet:namespace /><%= row.getRowId() %>manageActions').on(
 			'click',
-			function (event) {
+			(event) => {
 				var currentTarget = event.currentTarget;
 
 				Liferay.Util.openWindow({

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/layout/mobile_device_rules_toolbar.jspf
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/layout/mobile_device_rules_toolbar.jspf
@@ -43,10 +43,10 @@
 
 			'<%= HtmlUtil.escapeJS(viewRuleGroupInstancesURL.toString()) %>'
 		)
-			.then(function (response) {
+			.then((response) => {
 				return response.text();
 			})
-			.then(function (response) {
+			.then((response) => {
 				var uniqueRuleGroupInstancesContainer = document.getElementById(
 					'<portlet:namespace />uniqueRuleGroupInstancesContainer'
 				);
@@ -67,7 +67,7 @@
 					userId: themeDisplay.getUserId(),
 				}),
 			},
-			function (response, xhr) {
+			(response, xhr) => {
 				<portlet:namespace />updateRuleGroupInstances();
 			}
 		);
@@ -89,7 +89,7 @@
 					userId: themeDisplay.getUserId(),
 				}),
 			},
-			function (response, xhr) {
+			(response, xhr) => {
 				<portlet:namespace />updateRuleGroupInstances();
 			}
 		);
@@ -102,7 +102,7 @@
 	);
 
 	if (saveInstanceButton) {
-		saveInstanceButton.addEventListener('click', function (event) {
+		saveInstanceButton.addEventListener('click', (event) => {
 			Liferay.Util.openSelectionModal({
 				onSelect: function (event) {
 					<portlet:namespace />saveRuleGroupInstance(
@@ -132,7 +132,7 @@
 	);
 
 	if (managePrioritiesButton) {
-		managePrioritiesButton.addEventListener('click', function (event) {
+		managePrioritiesButton.addEventListener('click', (event) => {
 			Liferay.Util.openWindow({
 				dialogIframe: {
 					bodyCssClass: 'dialog-with-footer',

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/view.jsp
@@ -230,18 +230,15 @@ ruleGroupSearch.setResults(mdrRuleGroups);
 		);
 
 		if (deleteSelectedDeviceFamiliesButton) {
-			deleteSelectedDeviceFamiliesButton.addEventListener(
-				'click',
-				function () {
-					if (
-						confirm(
-							'<%= UnicodeLanguageUtil.get(resourceBundle, "are-you-sure-you-want-to-delete-this") %>'
-						)
-					) {
-						submitForm(document.<portlet:namespace />fm);
-					}
+			deleteSelectedDeviceFamiliesButton.addEventListener('click', () => {
+				if (
+					confirm(
+						'<%= UnicodeLanguageUtil.get(resourceBundle, "are-you-sure-you-want-to-delete-this") %>'
+					)
+				) {
+					submitForm(document.<portlet:namespace />fm);
 				}
-			);
+			});
 		}
 	})();
 </script>

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/view_actions.jsp
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/view_actions.jsp
@@ -173,7 +173,7 @@ PortletURL portletURL = mdrActionDisplayContext.getPortletURL();
 		);
 
 		if (deleteActionsButton) {
-			deleteActionsButton.addEventListener('click', function () {
+			deleteActionsButton.addEventListener('click', () => {
 				if (
 					confirm(
 						'<%= UnicodeLanguageUtil.get(resourceBundle, "are-you-sure-you-want-to-delete-this") %>'

--- a/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/my-subscriptions/my-subscriptions-web/src/main/resources/META-INF/resources/view.jsp
@@ -153,15 +153,15 @@ int subscriptionsCount = mySubscriptionsManagementToolbarDisplayContext.getTotal
 		unsubscribe: unsubscribe,
 	};
 
-	Liferay.componentReady('mySubscriptionsManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('mySubscriptionsManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('actionItemClicked', (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action]();
+				}
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
@@ -160,17 +160,17 @@ navigationURL.setParameter(SearchContainer.DEFAULT_CUR_PARAM, "0");
 		markNotificationsAsUnread: markNotificationsAsUnread,
 	};
 
-	Liferay.componentReady('notificationsManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('notificationsManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('actionItemClicked', (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action]();
+				}
+			});
+		}
+	);
 </aui:script>
 
 <aui:script use="aui-base">
@@ -178,7 +178,7 @@ navigationURL.setParameter(SearchContainer.DEFAULT_CUR_PARAM, "0");
 
 	form.delegate(
 		'click',
-		function (event) {
+		(event) => {
 			event.preventDefault();
 
 			var currentTarget = event.currentTarget;
@@ -186,10 +186,10 @@ navigationURL.setParameter(SearchContainer.DEFAULT_CUR_PARAM, "0");
 			Liferay.Util.fetch(currentTarget.attr('href'), {
 				method: 'POST',
 			})
-				.then(function (response) {
+				.then((response) => {
 					return response.json();
 				})
-				.then(function (response) {
+				.then((response) => {
 					if (response.success) {
 						var notificationContainer = currentTarget.ancestor(
 							'li.list-group-item'

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes.jsp
@@ -93,7 +93,7 @@ AssignScopesDisplayContext assignScopesDisplayContext = (AssignScopesDisplayCont
 </clay:container-fluid>
 
 <aui:script sandbox="<%= true %>">
-	AUI().use('node', 'aui-modal', function (A) {
+	AUI().use('node', 'aui-modal', (A) => {
 		if (A.all('#<portlet:namespace />navGlobalScopes .panel').size() > 0) {
 			A.one('#<portlet:namespace />navScopeTypes').toggleClass(
 				'hidden',
@@ -112,7 +112,7 @@ AssignScopesDisplayContext assignScopesDisplayContext = (AssignScopesDisplayCont
 
 		appsAccordion.delegate(
 			'click',
-			function (event) {
+			(event) => {
 				event.stopPropagation();
 
 				if (handle) {
@@ -138,7 +138,7 @@ AssignScopesDisplayContext assignScopesDisplayContext = (AssignScopesDisplayCont
 						'<%= UnicodeLanguageUtil.get(request, "choose-one-of-the-following-global-scopes-that-include-this-resource-scope") %>',
 				}).render();
 
-				modal.on('visibleChange', function (event) {
+				modal.on('visibleChange', (event) => {
 					if (event.newVal) {
 						return;
 					}
@@ -147,7 +147,7 @@ AssignScopesDisplayContext assignScopesDisplayContext = (AssignScopesDisplayCont
 						.querySelectorAll(
 							'#<portlet:namespace />globalAccordion .panel'
 						)
-						.forEach(function (globalAccordionPanel) {
+						.forEach((globalAccordionPanel) => {
 							globalAccordionPanel.classList.remove('hide');
 						});
 
@@ -181,7 +181,7 @@ AssignScopesDisplayContext assignScopesDisplayContext = (AssignScopesDisplayCont
 					.querySelectorAll(
 						'#<portlet:namespace />globalAccordion .panel'
 					)
-					.forEach(function (globalAccordionPanel) {
+					.forEach((globalAccordionPanel) => {
 						globalAccordionPanel.classList.add('hide');
 					});
 
@@ -190,7 +190,7 @@ AssignScopesDisplayContext assignScopesDisplayContext = (AssignScopesDisplayCont
 						.querySelectorAll(
 							'#<portlet:namespace />globalAccordion .panel[data-master]'
 						)
-						.forEach(function (globalAccordionPanel) {
+						.forEach((globalAccordionPanel) => {
 							var masterScopeAliases = globalAccordionPanel.getAttribute(
 								'data-master'
 							);
@@ -340,7 +340,7 @@ AssignScopesDisplayContext assignScopesDisplayContext = (AssignScopesDisplayCont
 
 		<portlet:namespace />recalculateAll();
 
-		A.one('#<portlet:namespace />save').on('click', function (event) {
+		A.one('#<portlet:namespace />save').on('click', (event) => {
 			event.preventDefault();
 
 			var scopeAliases = [];

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tree.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tree.jsp
@@ -151,7 +151,7 @@ pageContext.setAttribute("scopeAliasesDescriptionsMap", assignScopesTreeDisplayC
 </clay:container-fluid>
 
 <aui:script sandbox="<%= true %>">
-	AUI().use('node', 'aui-modal', function (A) {
+	AUI().use('node', 'aui-modal', (A) => {
 		A.all('input[name="<portlet:namespace />scopeAliases"]').each(function () {
 			this.on('click', function () {
 				<portlet:namespace />recalculateScopeChildrens(this);

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
@@ -245,10 +245,10 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 				method: 'POST',
 			}
 		)
-			.then(function (response) {
+			.then((response) => {
 				return response.text();
 			})
-			.then(function (response) {
+			.then((response) => {
 				var newClientSecretField = A.one(
 					'#<portlet:namespace />newClientSecret'
 				);
@@ -393,7 +393,7 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 			plugins: [Liferay.WidgetZIndex],
 		}).render();
 
-		modal.on('render', function (event) {
+		modal.on('render', (event) => {
 			<portlet:namespace />updateComponent(applyField, populateField.val());
 		});
 
@@ -507,7 +507,7 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 
 	clientProfile.delegate(
 		'change',
-		function (event) {
+		(event) => {
 			var newClientProfileValue = event.currentTarget.val();
 			<portlet:namespace />updateAllowedGrantTypes(newClientProfileValue);
 		},

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_left_column.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_left_column.jsp
@@ -131,9 +131,7 @@ OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2
 								);
 
 								if (allowedAuthorizationTypeCheckbox) {
-									allowedAuthorizationTypeCheckbox.addEventListener('click', function (
-										event
-									) {
+									allowedAuthorizationTypeCheckbox.addEventListener('click', (event) => {
 										<portlet:namespace />requiredRedirectURIs();
 									});
 								}
@@ -182,7 +180,7 @@ OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2
 					);
 
 					if (useSignedInUserButton) {
-						useSignedInUserButton.addEventListener('click', function (event) {
+						useSignedInUserButton.addEventListener('click', (event) => {
 							A.one('#<portlet:namespace />clientCredentialUserId').val(
 								'<%= user.getUserId() %>'
 							);
@@ -197,7 +195,7 @@ OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2
 					);
 
 					if (selectUserButton) {
-						selectUserButton.addEventListener('click', function (event) {
+						selectUserButton.addEventListener('click', (event) => {
 							Liferay.Util.openSelectionModal({
 								onSelect: function (event) {
 									A.one('#<portlet:namespace />clientCredentialUserId').val(

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
@@ -140,7 +140,7 @@ if (Validator.isNotNull(replyTo) && !replyTo.startsWith(PortalUtil.getPortalURL(
 								var allowButton = document.getElementById('<portlet:namespace />allow');
 
 								if (allowButton) {
-									allowButton.addEventListener('click', function () {
+									allowButton.addEventListener('click', () => {
 										document.getElementById('oauthDecision').value = 'allow';
 										Liferay.Util.postForm(document.<portlet:namespace />fm);
 									});
@@ -149,7 +149,7 @@ if (Validator.isNotNull(replyTo) && !replyTo.startsWith(PortalUtil.getPortalURL(
 								var cancelButton = document.getElementById('<portlet:namespace />cancel');
 
 								if (cancelButton) {
-									cancelButton.addEventListener('click', function () {
+									cancelButton.addEventListener('click', () => {
 										document.getElementById('oauthDecision').value = 'deny';
 										Liferay.Util.postForm(document.<portlet:namespace />fm);
 									});

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view_application.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view_application.jsp
@@ -153,7 +153,7 @@ renderResponse.setTitle(oAuth2Application.getName());
 	);
 
 	if (removeAccessButton) {
-		removeAccessButton.addEventListener('click', function () {
+		removeAccessButton.addEventListener('click', () => {
 			if (
 				confirm(
 					'<%= UnicodeLanguageUtil.format(request, "x-will-no-longer-have-access-to-your-account-removed-access-cannot-be-recovered", new String[] {oAuth2Application.getName()}) %>'

--- a/modules/apps/organizations/organizations-item-selector-web/src/main/resources/META-INF/resources/organization_item_selector.jsp
+++ b/modules/apps/organizations/organizations-item-selector-web/src/main/resources/META-INF/resources/organization_item_selector.jsp
@@ -108,7 +108,7 @@ PortletURL portletURL = organizationItemSelectorViewDisplayContext.getPortletURL
 		'<portlet:namespace />organizations'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var allSelectedElements = event.elements.allSelectedElements;
 
 		var arr = [];

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/select_members.jsp
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/select_members.jsp
@@ -87,7 +87,7 @@ SearchContainer<?> searchContainer = editPasswordPolicyAssignmentsManagementTool
 		'<portlet:namespace />' + 'passwordPolicyMembers'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var selectedItems = event.elements.allSelectedElements;
 
 		var result = {};

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
@@ -125,7 +125,7 @@ CustomFacetPortletInstanceConfiguration customFacetPortletInstanceConfiguration 
 		'#<portlet:namespace />fm .facet-term'
 	);
 
-	facetTerms.forEach(function (term) {
+	facetTerms.forEach((term) => {
 		Liferay.Util.toggleDisabled(term, false);
 	});
 </aui:script>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
@@ -69,7 +69,7 @@ for (AssetRendererFactory<?> assetRendererFactory : assetEntriesSearchFacet.getA
 	var currentAssetTypes = Liferay.Util.getFormElement(form, 'currentAssetTypes');
 
 	if (currentAssetTypes) {
-		form.addEventListener('submit', function (event) {
+		form.addEventListener('submit', (event) => {
 			event.preventDefault();
 
 			var data = {};

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/modified.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/modified.jsp
@@ -393,9 +393,7 @@ int index = 0;
 	customRangeFrom.on('selectionChange', onRangeSelectionChange);
 	customRangeTo.on('selectionChange', onRangeSelectionChange);
 
-	A.one('.<%= randomNamespace %>custom-range-toggle').on('click', function (
-		event
-	) {
+	A.one('.<%= randomNamespace %>custom-range-toggle').on('click', (event) => {
 		event.halt();
 
 		A.one('#<%= randomNamespace + "customRange" %>').toggle();

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
@@ -113,7 +113,7 @@ Hits hits = searchDisplayContext.getHits();
 	var delegate = delegateModule.default;
 
 	if (facetNavigation) {
-		delegate(facetNavigation, 'click', '.facet-value a', function (event) {
+		delegate(facetNavigation, 'click', '.facet-value a', (event) => {
 			event.preventDefault();
 
 			var target = event.delegateTarget;
@@ -125,12 +125,12 @@ Hits hits = searchDisplayContext.getHits();
 
 				var facetValueSiblings = Array.prototype.filter.call(
 					target.parentNode.children,
-					function (child) {
+					(child) => {
 						return child !== target;
 					}
 				);
 
-				facetValueSiblings.forEach(function (facet) {
+				facetValueSiblings.forEach((facet) => {
 					facet.classList.remove('active');
 				});
 
@@ -168,14 +168,12 @@ Hits hits = searchDisplayContext.getHits();
 	);
 
 	if (searchResultsContainer) {
-		delegate(searchResultsContainer, 'click', '.expand-details', function (
-			event
-		) {
+		delegate(searchResultsContainer, 'click', '.expand-details', (event) => {
 			var target = event.delegateTarget;
 
 			var targetSiblings = Array.prototype.filter.call(
 				target.parentNode.children,
-				function (child) {
+				(child) => {
 					return (
 						child !== target &&
 						child.classList.contains('table-details')
@@ -183,7 +181,7 @@ Hits hits = searchDisplayContext.getHits();
 				}
 			);
 
-			targetSiblings.forEach(function (sibling) {
+			targetSiblings.forEach((sibling) => {
 				if (sibling.classList.contains('hide')) {
 					sibling.classList.remove('hide');
 				}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search.jsp
@@ -84,7 +84,7 @@ PortalUtil.setPageKeywords(pageKeywords, request);
 	var keywordsInput = document.getElementById('<portlet:namespace />keywords');
 
 	if (keywordsInput) {
-		keywordsInput.addEventListener('keydown', function (event) {
+		keywordsInput.addEventListener('keydown', (event) => {
 			if (event.keyCode === 13) {
 				<portlet:namespace />search();
 			}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/sort/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/sort/view.jsp
@@ -88,8 +88,8 @@ SortPortletInstanceConfiguration sortPortletInstanceConfiguration = sortDisplayC
 </c:choose>
 
 <aui:script use="liferay-search-sort-util">
-	AUI().ready('aui-base', 'node', 'event', function (A) {
-		A.one('#<portlet:namespace />sortSelection').on('change', function () {
+	AUI().ready('aui-base', 'node', 'event', (A) => {
+		A.one('#<portlet:namespace />sortSelection').on('change', () => {
 			var selections = [];
 
 			var sortSelect = A.one('#<portlet:namespace />sortSelection').get(

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/configuration.jsp
@@ -111,7 +111,7 @@ TypeFacetPortletPreferences typeFacetPortletPreferences = new com.liferay.portal
 	var currentAssetTypes = Liferay.Util.getFormElement(form, 'currentAssetTypes');
 
 	if (currentAssetTypes) {
-		form.addEventListener('submit', function (event) {
+		form.addEventListener('submit', (event) => {
 			event.preventDefault();
 
 			var data = {};

--- a/modules/apps/portal-security/portal-security-service-access-policy-web/src/main/resources/META-INF/resources/edit_entry.jsp
+++ b/modules/apps/portal-security/portal-security-service-access-policy-web/src/main/resources/META-INF/resources/edit_entry.jsp
@@ -150,8 +150,8 @@ renderResponse.setTitle((sapEntry == null) ? LanguageUtil.get(request, "new-serv
 		document.<portlet:namespace />fm,
 		'click',
 		'#<portlet:namespace />advancedMode, #<portlet:namespace />friendlyMode',
-		function (event) {
-			Array.prototype.forEach.call(alternatingElements, function (element) {
+		(event) => {
+			Array.prototype.forEach.call(alternatingElements, (element) => {
 				element.classList.toggle('hide');
 			});
 		}
@@ -196,10 +196,10 @@ renderResponse.setTitle((sapEntry == null) ? LanguageUtil.get(request, "new-serv
 				);
 
 				Liferay.Util.fetch(getActionMethodNamesURL.toString())
-					.then(function (response) {
+					.then((response) => {
 						return response.json();
 					})
-					.then(function (data) {
+					.then((data) => {
 						methodObj.actionMethodNames = data;
 						callback(actionMethodNames);
 					});
@@ -213,7 +213,7 @@ renderResponse.setTitle((sapEntry == null) ? LanguageUtil.get(request, "new-serv
 	var getContextName = function (serviceClassName) {
 		var serviceClassNameToContextName = A.Array.find(
 			serviceClassNamesToContextNames,
-			function (item, index) {
+			(item, index) => {
 				return item.serviceClassName === serviceClassName;
 			}
 		);
@@ -278,7 +278,7 @@ renderResponse.setTitle((sapEntry == null) ? LanguageUtil.get(request, "new-serv
 
 		A.all(
 			'#<portlet:namespace />allowedServiceSignaturesFriendlyContentBox .lfr-form-row:not(.hide)'
-		).each(function (item, index) {
+		).each((item, index) => {
 			var actionMethodName = item.one('.action-method-name').val();
 			var serviceClassName = item.one('.service-class-name').val();
 
@@ -309,7 +309,7 @@ renderResponse.setTitle((sapEntry == null) ? LanguageUtil.get(request, "new-serv
 
 		entries = A.Array.dedupe(entries);
 
-		entries.forEach(function (item, index) {
+		entries.forEach((item, index) => {
 			var row = rowTemplate.clone();
 
 			var actionMethodNameInput = row.one('.action-method-name');

--- a/modules/apps/portal-settings/portal-settings-authentication-cas-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/cas.jsp
+++ b/modules/apps/portal-settings/portal-settings-authentication-cas-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/cas.jsp
@@ -85,22 +85,22 @@ String noSuchUserRedirectURL = casConfiguration.noSuchUserRedirectURL();
 
 		var searchParams = Liferay.Util.objectToURLSearchParams(data);
 
-		searchParams.forEach(function (value, key) {
+		searchParams.forEach((value, key) => {
 			url.searchParams.append(key, value);
 		});
 
 		Liferay.Util.fetch(url)
-			.then(function (response) {
+			.then((response) => {
 				return response.text();
 			})
-			.then(function (text) {
+			.then((text) => {
 				Liferay.Util.openModal({
 					bodyHTML: text,
 					size: 'full-screen',
 					title: '<%= UnicodeLanguageUtil.get(request, "cas") %>',
 				});
 			})
-			.catch(function (error) {
+			.catch((error) => {
 				Liferay.Util.openToast({
 					message: Liferay.Language.get(
 						'an-unexpected-system-error-occurred'

--- a/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/edit_ldap_server.jsp
+++ b/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/edit_ldap_server.jsp
@@ -290,7 +290,7 @@ renderResponse.setTitle((ldapServerId == 0) ? LanguageUtil.get(resourceBundle, "
 	function <portlet:namespace />mapValues(fields, fieldValues) {
 		var form = document.<portlet:namespace />fm;
 
-		return fields.reduce(function (prev, item, index) {
+		return fields.reduce((prev, item, index) => {
 			var mappingElement = Liferay.Util.getFormElement(
 				form,
 				fieldValues[index]
@@ -621,22 +621,22 @@ renderResponse.setTitle((ldapServerId == 0) ? LanguageUtil.get(resourceBundle, "
 
 			var searchParams = Liferay.Util.objectToURLSearchParams(data);
 
-			searchParams.forEach(function (value, key) {
+			searchParams.forEach((value, key) => {
 				url.searchParams.append(key, value);
 			});
 
 			Liferay.Util.fetch(url)
-				.then(function (response) {
+				.then((response) => {
 					return response.text();
 				})
-				.then(function (text) {
+				.then((text) => {
 					Liferay.Util.openModal({
 						bodyHTML: text,
 						size: 'full-screen',
 						title: '<%= UnicodeLanguageUtil.get(request, "ldap") %>',
 					});
 				})
-				.catch(function (error) {
+				.catch((error) => {
 					Liferay.Util.openToast({
 						message: Liferay.Language.get(
 							'an-unexpected-system-error-occurred'

--- a/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/ldap/servers.jsp
+++ b/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/ldap/servers.jsp
@@ -182,11 +182,12 @@ boolean ldapAuthEnabled = ldapAuthConfiguration.enabled();
 			'.ldap-servers .table-data tr'
 		);
 
-		var ldapServerIds = Array.prototype.map.call(ldapServerIdsNodes, function (
-			ldapServerIdsNode
-		) {
-			return ldapServerIdsNode.dataset.ldapserverid;
-		});
+		var ldapServerIds = Array.prototype.map.call(
+			ldapServerIdsNodes,
+			(ldapServerIdsNode) => {
+				return ldapServerIdsNode.dataset.ldapserverid;
+			}
+		);
 
 		Liferay.Util.setFormValues(document.<portlet:namespace />fm, {
 			'ldap--<%= LDAPConstants.AUTH_SERVER_PRIORITY %>--': ldapServerIds.join(

--- a/modules/apps/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/opensso.jsp
+++ b/modules/apps/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/opensso.jsp
@@ -94,22 +94,22 @@ String version = openSSOConfiguration.version();
 		var url = new URL(baseUrl);
 
 		var searchParams = Liferay.Util.objectToFormData(data);
-		searchParams.forEach(function (value, key) {
+		searchParams.forEach((value, key) => {
 			url.searchParams.append(key, value);
 		});
 
 		Liferay.Util.fetch(url)
-			.then(function (response) {
+			.then((response) => {
 				return response.text();
 			})
-			.then(function (text) {
+			.then((text) => {
 				Liferay.Util.openModal({
 					bodyHTML: text,
 					size: 'full-screen',
 					title: '<%= UnicodeLanguageUtil.get(request, "opensso") %>',
 				});
 			})
-			.catch(function (error) {
+			.catch((error) => {
 				Liferay.Util.openToast({
 					message: Liferay.Language.get(
 						'an-unexpected-system-error-occurred'

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/language.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/language.jsp
@@ -112,7 +112,7 @@
 	var languageSelectInput = A.one('#<portlet:namespace />languageId');
 
 	if (languageSelectInput) {
-		languageSelectInput.on('change', function () {
+		languageSelectInput.on('change', () => {
 			new A.Alert({
 				bodyContent:
 					'<liferay-ui:message key="this-change-will-only-affect-the-newly-created-localized-content" />',

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/ratings.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/ratings.jsp
@@ -79,7 +79,7 @@ CompanyPortletRatingsDefinitionDisplayContext companyPortletRatingsDefinitionDis
 
 	ratingsSettingsContainer.delegate(
 		'change',
-		function (event) {
+		(event) => {
 			ratingsTypeChanged = true;
 		},
 		'select'
@@ -87,7 +87,7 @@ CompanyPortletRatingsDefinitionDisplayContext companyPortletRatingsDefinitionDis
 
 	var form = A.one('#<portlet:namespace />fm');
 
-	form.on('submit', function (event) {
+	form.on('submit', (event) => {
 		if (
 			ratingsTypeChanged &&
 			!confirm(

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/recycle_bin.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/recycle_bin.jsp
@@ -31,7 +31,7 @@
 		if (trashEnabledCheckbox) {
 			var trashEnabledDefault = trashEnabledCheckbox.checked;
 
-			trashEnabledCheckbox.addEventListener('change', function (event) {
+			trashEnabledCheckbox.addEventListener('change', (event) => {
 				if (!trashEnabledCheckbox.checked && trashEnabledDefault) {
 					if (
 						!confirm(

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/workflow_task_assign.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/workflow_task_assign.jsp
@@ -77,7 +77,7 @@ boolean hasAssignableUsers = workflowTaskDisplayContext.hasAssignableUsers(workf
 	var done = A.one('#<portlet:namespace />done');
 
 	if (done) {
-		done.on('click', function (event) {
+		done.on('click', (event) => {
 			var data = new FormData(
 				document.querySelector('#<portlet:namespace />assignFm')
 			);
@@ -85,7 +85,7 @@ boolean hasAssignableUsers = workflowTaskDisplayContext.hasAssignableUsers(workf
 			Liferay.Util.fetch('<%= assignURL.toString() %>', {
 				body: data,
 				method: 'POST',
-			}).then(function () {
+			}).then(() => {
 				Liferay.Util.getOpener().<portlet:namespace />refreshPortlet(
 					'<%= PortalUtil.escapeRedirect(redirect.toString()) %>'
 				);

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/workflow_task_due_date.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/workflow_task_due_date.jsp
@@ -60,7 +60,7 @@ WorkflowTask workflowTask = workflowTaskDisplayContext.getWorkflowTask();
 	var done = A.one('#<portlet:namespace />done');
 
 	if (done) {
-		done.on('click', function (event) {
+		done.on('click', (event) => {
 			var data = new FormData(
 				document.querySelector('#<portlet:namespace />updateFm')
 			);
@@ -68,7 +68,7 @@ WorkflowTask workflowTask = workflowTaskDisplayContext.getWorkflowTask();
 			Liferay.Util.fetch('<%= updateURL.toString() %>', {
 				body: data,
 				method: 'POST',
-			}).then(function () {
+			}).then(() => {
 				Liferay.Util.getOpener().<portlet:namespace />refreshPortlet(
 					'<%= PortalUtil.escapeRedirect(redirect.toString()) %>'
 				);

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
@@ -348,7 +348,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 	var previousContent = '';
 
 	if (uploadFile) {
-		uploadFile.addEventListener('change', function (evt) {
+		uploadFile.addEventListener('change', (evt) => {
 			var files = evt.target.files;
 
 			if (files) {
@@ -376,7 +376,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 	var uploadLink = document.getElementById('<portlet:namespace />uploadLink');
 
 	if (uploadLink) {
-		uploadLink.addEventListener('click', function (event) {
+		uploadLink.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			uploadFile.click();
@@ -389,7 +389,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 
 	var form = document.<portlet:namespace />fm;
 
-	Liferay.on('<portlet:namespace />publishDefinition', function (event) {
+	Liferay.on('<portlet:namespace />publishDefinition', (event) => {
 		var titleElement = Liferay.Util.getFormElement(
 			form,
 			'title_' + defaultLanguageId
@@ -410,7 +410,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 		});
 	});
 
-	Liferay.on('<portlet:namespace />saveDefinition', function (event) {
+	Liferay.on('<portlet:namespace />saveDefinition', (event) => {
 		var titleElement = Liferay.Util.getFormElement(
 			form,
 			'title_' + defaultLanguageId
@@ -431,7 +431,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 		});
 	});
 
-	Liferay.on('<portlet:namespace />undoDefinition', function (event) {
+	Liferay.on('<portlet:namespace />undoDefinition', (event) => {
 		if (contentEditor) {
 			contentEditor.set(STR_VALUE, previousContent);
 
@@ -454,7 +454,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 	var title = document.getElementById('<portlet:namespace />title');
 
 	if (title) {
-		title.addEventListener('keypress', function (event) {
+		title.addEventListener('keypress', (event) => {
 			var keycode = event.keyCode ? event.keyCode : event.which;
 
 			if (keycode == '13') {

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/advanced_styling.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/advanced_styling.jsp
@@ -64,7 +64,7 @@
 	);
 
 	if (<portlet:namespace />addId) {
-		<portlet:namespace />addId.addEventListener('click', function () {
+		<portlet:namespace />addId.addEventListener('click', () => {
 			<portlet:namespace />insertCustomCSSValue(
 				'#portlet_<%= HtmlUtil.escapeJS(portletConfigurationCSSPortletDisplayContext.getPortletResource()) %>'
 			);
@@ -76,7 +76,7 @@
 	);
 
 	if (<portlet:namespace />addClass) {
-		<portlet:namespace />addClass.addEventListener('click', function () {
+		<portlet:namespace />addClass.addEventListener('click', () => {
 			<portlet:namespace />insertCustomCSSValue(portletClasses);
 		});
 	}
@@ -107,17 +107,16 @@
 
 			portletContent
 				.getAttribute('class')
-				.replace(/(?:([\w\d-]+)-)?portlet(?:-?([\w\d-]+-?))?/g, function (
-					match,
-					subMatch1,
-					subMatch2
-				) {
-					var regexIgnoredClasses = /boundary|draggable/;
+				.replace(
+					/(?:([\w\d-]+)-)?portlet(?:-?([\w\d-]+-?))?/g,
+					(match, subMatch1, subMatch2) => {
+						var regexIgnoredClasses = /boundary|draggable/;
 
-					if (!regexIgnoredClasses.test(subMatch2)) {
-						boundaryClasses.push(match);
+						if (!regexIgnoredClasses.test(subMatch2)) {
+							boundaryClasses.push(match);
+						}
 					}
-				});
+				);
 
 			portletClasses = '.' + boundaryClasses.join('.') + portletClasses;
 

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
@@ -51,7 +51,7 @@
 				document.getElementById('<portlet:namespace />fm'),
 				'change',
 				'input[type=checkbox]',
-				function (event) {
+				(event) => {
 					var toggle = event.delegateTarget;
 
 					var disableOnChecked = toggle.dataset.disableonchecked;

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -179,7 +179,7 @@ if (Validator.isNotNull(portletConfigurationPermissionsDisplayContext.getModelRe
 	);
 
 	if (<portlet:namespace />saveButton) {
-		<portlet:namespace />saveButton.addEventListener('click', function (event) {
+		<portlet:namespace />saveButton.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			if (

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_body.jsp
@@ -45,7 +45,7 @@
 
 		Liferay.SideNavigation.initialize(addToggle);
 
-		Liferay.once('screenLoad', function () {
+		Liferay.once('screenLoad', () => {
 			Liferay.SideNavigation.destroy(addToggle);
 		});
 	</aui:script>

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_icon.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_icon.jsp
@@ -51,7 +51,7 @@ if (Validator.isNotNull(className) && (classPK > 0)) {
 
 <c:if test="<%= (assetRenderer != null) && PortletPermissionUtil.contains(permissionChecker, layout, portletId, ActionKeys.ADD_TO_PAGE) %>">
 	<aui:script>
-		Liferay.once('updatedLayout', function () {
+		Liferay.once('updatedLayout', () => {
 			Liferay.Util.navigate(
 				'<%= PortalUtil.getLayoutFullURL(layout, themeDisplay) %>'
 			);

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
@@ -199,7 +199,7 @@ LayoutsTreeDisplayContext layoutsTreeDisplayContext = new LayoutsTreeDisplayCont
 		layoutsTree,
 		'click',
 		'.view-collection-items-action-option.collection',
-		function (event) {
+		(event) => {
 			Liferay.Util.openModal({
 				id: '<portlet:namespace />viewCollectionItemsDialog',
 				title: '<liferay-ui:message key="collection-items" />',

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
@@ -107,13 +107,13 @@
 		namespace: '<portlet:namespace />',
 	});
 
-	Liferay.once('screenLoad', function () {
+	Liferay.once('screenLoad', () => {
 		simulationDevice.destroy();
 	});
 
 	A.one('.devices').delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var currentTarget = event.currentTarget;
 
 			var dataDevice = currentTarget.attr('data-device');

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -129,15 +129,15 @@ Group group = siteAdministrationPanelCategoryDisplayContext.getGroup();
 			'<portlet:namespace />pagesTreeSidenavToggleId'
 		);
 
-		pagesTreeToggle.addEventListener('click', function (event) {
+		pagesTreeToggle.addEventListener('click', (event) => {
 			Liferay.Portlet.destroy('#p_p_id<portlet:namespace />', true);
 
 			Liferay.Util.Session.set(
 				'com.liferay.product.navigation.product.menu.web_pagesTreeState',
 				'open'
-			).then(function () {
+			).then(() => {
 				Liferay.Util.fetch('<%= portletURL.toString() %>')
-					.then(function (response) {
+					.then((response) => {
 						if (!response.ok) {
 							throw new Error(
 								'<liferay-ui:message key="an-unexpected-error-occurred" />'
@@ -146,7 +146,7 @@ Group group = siteAdministrationPanelCategoryDisplayContext.getGroup();
 
 						return response.text();
 					})
-					.then(function (response) {
+					.then((response) => {
 						var sidebar = document.querySelector(
 							'.lfr-product-menu-sidebar .sidebar-body'
 						);

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_icon_sites.jspf
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_icon_sites.jspf
@@ -45,7 +45,7 @@ PortletURL itemSelectorURL = itemSelector.getItemSelectorURL(RequestBackedPortle
 		);
 
 		if (manageSitesLink) {
-			manageSitesLink.addEventListener('click', function (event) {
+			manageSitesLink.addEventListener('click', (event) => {
 				Liferay.Util.openSelectionModal({
 					customSelectEvent: true,
 					id: '<portlet:namespace />selectSite',

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
@@ -120,13 +120,13 @@ for (ProductNavigationControlMenuCategory productNavigationControlMenuCategory :
 			'#<portlet:namespace />ControlMenu [data-toggle="liferay-sidenav"]'
 		);
 
-		var sidenavInstances = Array.from(sidenavToggles).map(function (toggle) {
+		var sidenavInstances = Array.from(sidenavToggles).map((toggle) => {
 			return Liferay.SideNavigation.instance(toggle);
 		});
 
-		sidenavInstances.forEach(function (instance) {
-			instance.on('openStart.lexicon.sidenav', function (event, source) {
-				sidenavInstances.forEach(function (sidenav) {
+		sidenavInstances.forEach((instance) => {
+			instance.on('openStart.lexicon.sidenav', (event, source) => {
+				sidenavInstances.forEach((sidenav) => {
 					if (sidenav !== source) {
 						sidenav.hide();
 					}

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -100,10 +100,10 @@
 					loading = true;
 
 					Liferay.Util.fetch(modalSignInURL)
-						.then(function (response) {
+						.then((response) => {
 							return response.text();
 						})
-						.then(function (response) {
+						.then((response) => {
 							if (!loading) {
 								return;
 							}
@@ -122,7 +122,7 @@
 								setModalContent(response);
 							}
 						})
-						.catch(function () {
+						.catch(() => {
 							redirect = true;
 						});
 				};
@@ -130,7 +130,7 @@
 				signInLink.addEventListener('mouseover', fetchModalSignIn);
 				signInLink.addEventListener('focus', fetchModalSignIn);
 
-				signInLink.addEventListener('click', function (event) {
+				signInLink.addEventListener('click', (event) => {
 					event.preventDefault();
 
 					if (redirect) {

--- a/modules/apps/push-notifications/push-notifications-web/src/main/resources/META-INF/resources/test.jspf
+++ b/modules/apps/push-notifications/push-notifications-web/src/main/resources/META-INF/resources/test.jspf
@@ -71,7 +71,7 @@
 	var form = document.getElementById('<portlet:namespace />fm');
 
 	if (form) {
-		form.addEventListener('submit', function (event) {
+		form.addEventListener('submit', (event) => {
 			event.preventDefault();
 
 			var message = form.querySelector('#<portlet:namespace />message');

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -86,7 +86,7 @@ catch (Exception exception) {
 	);
 
 	if (selectRootTopicButton) {
-		selectRootTopicButton.addEventListener('click', function (event) {
+		selectRootTopicButton.addEventListener('click', (event) => {
 			Liferay.Util.openSelectionModal({
 				onSelect: function (event) {
 					var form = document.<portlet:namespace />fm;

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
@@ -159,7 +159,7 @@ RedirectManagementToolbarDisplayContext redirectManagementToolbarDisplayContext 
 		document.querySelector('#<portlet:namespace />fm'),
 		'click',
 		'.icon-shortcut',
-		function (event) {
+		(event) => {
 			var delegateTarget = event.delegateTarget;
 
 			var destinationURL = delegateTarget.dataset.href;

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_assignments.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_assignments.jsp
@@ -202,11 +202,11 @@ renderResponse.setTitle(role.getTitle(locale));
 		});
 	};
 
-	Liferay.componentReady('editRoleAssignmentsManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('creationButtonClicked', addAssignees);
-	});
+	Liferay.componentReady('editRoleAssignmentsManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('creationButtonClicked', addAssignees);
+		}
+	);
 
 	var state = window.sessionStorage.getItem(
 		'<%= RolesAdminWebKeys.MODAL_SEGMENT_STATE %>'

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions.jsp
@@ -145,7 +145,7 @@ if (!portletName.equals(PortletKeys.SERVER_ADMIN)) {
 		var getItems = function () {
 			var results = [];
 
-			permissionNavigationItems.each(function (item, index, collection) {
+			permissionNavigationItems.each((item, index, collection) => {
 				results.push({
 					data: item.text().trim(),
 					node: item,
@@ -184,7 +184,7 @@ if (!portletName.equals(PortletKeys.SERVER_ADMIN)) {
 			source: getItems(),
 		});
 
-		permissionNavigationSearch.on('query', function (event) {
+		permissionNavigationSearch.on('query', (event) => {
 			if (event.query) {
 				togglerDelegate.expandAll();
 			}
@@ -193,22 +193,18 @@ if (!portletName.equals(PortletKeys.SERVER_ADMIN)) {
 			}
 		});
 
-		permissionNavigationSearch.on('results', function (event) {
-			permissionNavigationItems.each(function (item, index, collection) {
+		permissionNavigationSearch.on('results', (event) => {
+			permissionNavigationItems.each((item, index, collection) => {
 				item.addClass('hide');
 			});
 
-			event.results.forEach(function (item, index) {
+			event.results.forEach((item, index) => {
 				item.raw.node.removeClass('hide');
 			});
 
 			var foundVisibleSection;
 
-			permissionNavigationSectionsNode.each(function (
-				item,
-				index,
-				collection
-			) {
+			permissionNavigationSectionsNode.each((item, index, collection) => {
 				var action = 'addClass';
 
 				var visibleItem = item.one(
@@ -248,7 +244,7 @@ if (!portletName.equals(PortletKeys.SERVER_ADMIN)) {
 
 		permissionContainerNode.delegate(
 			'click',
-			function (event) {
+			(event) => {
 				event.preventDefault();
 
 				var href = event.currentTarget.attr('data-resource-href');
@@ -262,7 +258,7 @@ if (!portletName.equals(PortletKeys.SERVER_ADMIN)) {
 				permissionContentContainerNode.unplug(AParseContent);
 
 				Liferay.Util.fetch(href)
-					.then(function (response) {
+					.then((response) => {
 						if (response.status === 401) {
 							window.location.reload();
 						}
@@ -275,7 +271,7 @@ if (!portletName.equals(PortletKeys.SERVER_ADMIN)) {
 							);
 						}
 					})
-					.then(function (response) {
+					.then((response) => {
 						permissionContentContainerNode.loadingmask.hide();
 
 						permissionContentContainerNode.unplug(A.LoadingMask);
@@ -296,7 +292,7 @@ if (!portletName.equals(PortletKeys.SERVER_ADMIN)) {
 
 						event.currentTarget.addClass('active');
 					})
-					.catch(function (error) {
+					.catch((error) => {
 						permissionContentContainerNode.loadingmask.hide();
 
 						permissionContentContainerNode.unplug(A.LoadingMask);
@@ -318,7 +314,7 @@ if (!portletName.equals(PortletKeys.SERVER_ADMIN)) {
 
 		permissionContainerNode.delegate(
 			'change',
-			function (event) {
+			(event) => {
 				var unselectedTargetsNode = permissionContainerNode.one(
 					'#<portlet:namespace />unselectedTargets'
 				);
@@ -327,7 +323,7 @@ if (!portletName.equals(PortletKeys.SERVER_ADMIN)) {
 
 				var form = A.one(document.<portlet:namespace />fm);
 
-				form.all('input[type=checkbox]').each(function (item, index) {
+				form.all('input[type=checkbox]').each((item, index) => {
 					var checkbox = A.one(item);
 
 					var value = checkbox.val();
@@ -352,7 +348,7 @@ if (!portletName.equals(PortletKeys.SERVER_ADMIN)) {
 		);
 	}
 
-	A.on('domready', function (event) {
+	A.on('domready', (event) => {
 		togglerDelegate = new A.TogglerDelegate({
 			container: <portlet:namespace />permissionNavigationDataContainer,
 			content: '.permission-navigation-item-content',

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_assignees.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_assignees.jsp
@@ -98,10 +98,10 @@ PortletURL portletURL = editRoleAssignmentsManagementToolbarDisplayContext.getPo
 		'<portlet:namespace />assigneesSearch'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var nodes = event.elements.currentPageSelectedElements.getDOMNodes();
 
-		var <portlet:namespace />assigneeIds = nodes.map(function (node) {
+		var <portlet:namespace />assigneeIds = nodes.map((node) => {
 			return node.value;
 		});
 

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_organization_role.jspf
@@ -161,7 +161,7 @@ else {
 
 				var delegate = delegateModule.default;
 
-				delegate(form, 'click', '.organization-selector-button', function (event) {
+				delegate(form, 'click', '.organization-selector-button', (event) => {
 					Liferay.Util.postForm(form, {
 						data: {
 							organizationId: event.delegateTarget.dataset.organizationid,

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
@@ -135,7 +135,7 @@ SearchContainer<Role> roleSearchContainer = selectRoleManagementToolbarDisplayCo
 
 				var delegate = delegateModule.default;
 
-				delegate(form, 'click', '.group-selector-button', function (event) {
+				delegate(form, 'click', '.group-selector-button', (event) => {
 					Liferay.Util.postForm(form, {
 						data: {
 							groupId: event.delegateTarget.dataset.groupid,

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -135,20 +135,20 @@ PortletURL portletURL = viewRolesManagementToolbarDisplayContext.getPortletURL()
 		deleteRoles: deleteRoles,
 	};
 
-	Liferay.componentReady('viewRolesManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('viewRolesManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('actionItemClicked', (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action](
-					Liferay.Util.listCheckedExcept(
-						document.<portlet:namespace />fm,
-						'<portlet:namespace />allRowIds'
-					)
-				);
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action](
+						Liferay.Util.listCheckedExcept(
+							document.<portlet:namespace />fm,
+							'<portlet:namespace />allRowIds'
+						)
+					);
+				}
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/roles/roles-item-selector-web/src/main/resources/META-INF/resources/role_item_selector.jsp
+++ b/modules/apps/roles/roles-item-selector-web/src/main/resources/META-INF/resources/role_item_selector.jsp
@@ -73,7 +73,7 @@ RoleItemSelectorViewDisplayContext roleItemSelectorViewDisplayContext = (RoleIte
 		document.getElementById('<portlet:namespace />roleSelectorWrapper'),
 		'change',
 		'.entry input',
-		function (event) {
+		(event) => {
 			var checked = Liferay.Util.listCheckedExcept(
 				document.getElementById(
 					'<portlet:namespace /><%= roleItemSelectorViewDisplayContext.getSearchContainerId() %>'

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/field/select_js.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/field/select_js.jsp
@@ -27,7 +27,7 @@ String selectEventName = ParamUtil.getString(request, "selectEventName");
 		'<portlet:namespace /><%= HtmlUtil.escape(searchContainerId) %>'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var allSelectedElements = event.elements.allSelectedElements;
 
 		var selectedData = [];

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
@@ -149,17 +149,17 @@ request.setAttribute("view.jsp-eventName", eventName);
 		deleteSegmentsEntries: deleteSegmentsEntries,
 	};
 
-	Liferay.componentReady('segmentsEntriesManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('segmentsEntriesManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('actionItemClicked', (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action]();
+				}
+			});
+		}
+	);
 </aui:script>
 
 <portlet:actionURL name="/segments/update_segments_entry_site_roles" var="updateSegmentsEntrySiteRolesURL">
@@ -178,7 +178,7 @@ request.setAttribute("view.jsp-eventName", eventName);
 
 	var delegate = delegateModule.default;
 
-	delegate(document, 'click', '.assign-site-roles-link', function (event) {
+	delegate(document, 'click', '.assign-site-roles-link', (event) => {
 		var link = event.target.closest('.assign-site-roles-link');
 
 		var itemSelectorURL = link.dataset.itemselectorurl;

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/script.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/script.jsp
@@ -98,7 +98,7 @@ String scriptOutput = (String)SessionMessages.get(renderRequest, "scriptOutput")
 	);
 
 	if (<portlet:namespace />selectLanguage && <portlet:namespace />textArea) {
-		<portlet:namespace />selectLanguage.addEventListener('change', function () {
+		<portlet:namespace />selectLanguage.addEventListener('change', () => {
 			<portlet:namespace />textArea.value = '';
 		});
 	}

--- a/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/button/page.jsp
+++ b/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/button/page.jsp
@@ -32,7 +32,7 @@ String buttonComponentId = randomNamespace + "shareButton";
 <aui:script>
 	var button = document.getElementById('<%= buttonComponentId %>');
 
-	button.addEventListener('click', function () {
+	button.addEventListener('click', () => {
 		<%= request.getAttribute("liferay-sharing:button:onClick") %>;
 	});
 </aui:script>

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -154,7 +154,7 @@ SiteNavigationAdminManagementToolbarDisplayContext siteNavigationAdminManagement
 		document.body,
 		'click',
 		'.<portlet:namespace />update-site-navigation-menu-action-option > a',
-		function (event) {
+		(event) => {
 			var data = event.delegateTarget.dataset;
 
 			event.preventDefault();

--- a/modules/apps/site-navigation/site-navigation-breadcrumb-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-breadcrumb-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -111,7 +111,7 @@
 	);
 
 	if (selectDisplayStyle) {
-		selectDisplayStyle.addEventListener('change', function (event) {
+		selectDisplayStyle.addEventListener('change', (event) => {
 			if (selectDisplayStyle.selectedIndex > -1) {
 				data[
 					'_<%= HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) %>_displayStyle'
@@ -128,7 +128,7 @@
 	var checkBoxes = document.getElementById('<portlet:namespace />checkBoxes');
 
 	if (checkBoxes) {
-		checkBoxes.addEventListener('change', function (event) {
+		checkBoxes.addEventListener('change', (event) => {
 			if (event.target.classList.contains('toggle-switch-check')) {
 				var target = event.target;
 
@@ -142,7 +142,7 @@
 		});
 	}
 
-	var handler = Liferay.on('portletReady', function (event) {
+	var handler = Liferay.on('portletReady', (event) => {
 		Liferay.Portlet.refresh(
 			'#p_p_id_<%= HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) %>_',
 			data
@@ -153,7 +153,7 @@
 		handler = null;
 	});
 
-	var destroyHandler = Liferay.on('destroyHandler', function (event) {
+	var destroyHandler = Liferay.on('destroyHandler', (event) => {
 		if (handler) {
 			handler.detach();
 

--- a/modules/apps/site-navigation/site-navigation-directory-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-directory-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -97,11 +97,11 @@
 	var sitesSelect = Liferay.Util.getFormElement(form, 'sites');
 
 	if (displayStyleSelect && sitesSelect) {
-		form.addEventListener('change', function () {
+		form.addEventListener('change', () => {
 			refreshPreview(displayStyleSelect.value, sitesSelect.value);
 		});
 
-		form.addEventListener('select', function () {
+		form.addEventListener('select', () => {
 			refreshPreview(displayStyleSelect.value, sitesSelect.value);
 		});
 	}

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/add_layout.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/add_layout.jsp
@@ -63,17 +63,16 @@ PortletURL portletURL = currentURLObj;
 	var layoutUuid = document.getElementById('<portlet:namespace />layoutUuid');
 
 	if (layoutUuid) {
-		Liferay.on('<portlet:namespace />selectLayout', function (event) {
+		Liferay.on('<portlet:namespace />selectLayout', (event) => {
 			var selectedItems = event.data;
 
 			if (selectedItems) {
-				var layoutUuids = selectedItems.reduce(function (
-					previousValue,
-					currentValue
-				) {
-					return previousValue.concat([currentValue.id]);
-				},
-				[]);
+				var layoutUuids = selectedItems.reduce(
+					(previousValue, currentValue) => {
+						return previousValue.concat([currentValue.id]);
+					},
+					[]
+				);
 
 				layoutUuid.value = layoutUuids.join();
 			}

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -339,7 +339,7 @@ else {
 		selectSiteNavigationMenuTypeSelect &&
 		siteNavigationMenuIdInput
 	) {
-		chooseRootMenuItemButton.addEventListener('click', function (event) {
+		chooseRootMenuItemButton.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			var uri =
@@ -394,7 +394,7 @@ else {
 		rootMenuItemNameSpan &&
 		siteNavigationMenuIdInput
 	) {
-		chooseSiteNavigationMenuButton.addEventListener('click', function (event) {
+		chooseSiteNavigationMenuButton.addEventListener('click', (event) => {
 			Liferay.Util.openSelectionModal({
 				id: '<portlet:namespace />selectSiteNavigationMenu',
 				onSelect: function (selectedItem) {
@@ -430,7 +430,7 @@ else {
 		rootMenuItemNameSpan &&
 		siteNavigationMenuIdInput
 	) {
-		removeSiteNavigationMenuButton.addEventListener('click', function (event) {
+		removeSiteNavigationMenuButton.addEventListener('click', (event) => {
 			navigationMenuName.innerText = '';
 			rootMenuItemIdInput.value = '0';
 			rootMenuItemNameSpan.innerText = '';
@@ -450,7 +450,7 @@ else {
 
 	Liferay.Util.toggleSelectBox(
 		'<portlet:namespace />rootMenuItemType',
-		function (currentValue, value) {
+		(currentValue, value) => {
 			return currentValue === 'absolute' || currentValue === 'relative';
 		},
 		'<portlet:namespace />rootMenuItemLevel'
@@ -465,7 +465,7 @@ else {
 		selectSiteNavigationMenuTypeSelect &&
 		siteNavigationMenuType
 	) {
-		selectSiteNavigationMenuTypeSelect.addEventListener('change', function () {
+		selectSiteNavigationMenuTypeSelect.addEventListener('change', () => {
 			var selectedSelectSiteNavigationMenuType = document.querySelector(
 				'#<portlet:namespace />selectSiteNavigationMenuType option:checked'
 			);
@@ -496,7 +496,7 @@ else {
 			document.<portlet:namespace />fm,
 			'change',
 			'.select-navigation',
-			function () {
+			() => {
 				var siteNavigationDisabled =
 					selectSiteNavigationMenuTypeSelect.disabled;
 

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/layout_set_merge_alert.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/layout_set_merge_alert.jsp
@@ -42,7 +42,7 @@ int mergeFailCount = SitesUtil.getMergeFailCount(layoutSetPrototype);
 		var resetButton = document.getElementById('<%= randomNamespace %>resetButton');
 
 		if (resetButton) {
-			resetButton.addEventListener('click', function (event) {
+			resetButton.addEventListener('click', (event) => {
 				<portlet:actionURL name="/site_admin/reset_merge_fail_count_and_merge" var="portletURL">
 					<portlet:param name="redirect" value="<%= redirect %>" />
 					<portlet:param name="layoutSetPrototypeId" value="<%= String.valueOf(layoutSetPrototype.getLayoutSetPrototypeId()) %>" />

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
@@ -61,7 +61,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-site-template"));
 			document.body,
 			'click',
 			'.add-site-action-button',
-			function (event) {
+			(event) => {
 				var data = event.delegateTarget.querySelector('.add-site-action-card')
 					.dataset;
 

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/default_user_associations.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/default_user_associations.jsp
@@ -147,7 +147,7 @@ for (long defaultTeamId : defaultTeamIds) {
 
 		searchContainer.get('contentBox').delegate(
 			'click',
-			function (event) {
+			(event) => {
 				var link = event.currentTarget;
 
 				searchContainer.deleteRow(
@@ -162,7 +162,7 @@ for (long defaultTeamId : defaultTeamIds) {
 	var bindSelectLink = function (config) {
 		var searchContainer = config.searchContainer;
 
-		A.one(config.linkId).on('click', function (event) {
+		A.one(config.linkId).on('click', (event) => {
 			var searchContainerData = searchContainer.getData();
 
 			if (!searchContainerData.length) {

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/details.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/details.jsp
@@ -207,9 +207,7 @@ else {
 	</div>
 
 	<aui:script use="liferay-search-container">
-		A.one('#<portlet:namespace />selectParentSiteLink').on('click', function (
-			event
-		) {
+		A.one('#<portlet:namespace />selectParentSiteLink').on('click', (event) => {
 			Liferay.Util.openSelectionModal({
 				onSelect: function (event) {
 					var searchContainer = Liferay.SearchContainer.get(
@@ -260,7 +258,7 @@ else {
 
 		searchContainer.get('contentBox').delegate(
 			'click',
-			function (event) {
+			(event) => {
 				var link = event.currentTarget;
 
 				var tr = link.ancestor('tr');

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/recycle_bin.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/recycle_bin.jsp
@@ -49,7 +49,7 @@ int trashEntriesMaxAge = PropertiesParamUtil.getInteger(groupTypeSettings, reque
 	if (trashEnabledCheckbox) {
 		var trashEnabledDefault = trashEnabledCheckbox.checked;
 
-		trashEnabledCheckbox.addEventListener('change', function (event) {
+		trashEnabledCheckbox.addEventListener('change', (event) => {
 			var trashEnabled = trashEnabledCheckbox.checked;
 
 			if (!trashEnabled && trashEnabledDefault) {

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/site_url.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site/site_url.jsp
@@ -358,14 +358,14 @@ if (privateVirtualHostnames.isEmpty()) {
 	);
 
 	if (friendlyURL) {
-		friendlyURL.addEventListener('change', function (event) {
+		friendlyURL.addEventListener('change', (event) => {
 			var value = friendlyURL.value.trim();
 
 			if (value == '/') {
 				value = '';
 			}
 			else {
-				value = value.replace(/^[^\/]|\/$/g, function (match, index) {
+				value = value.replace(/^[^\/]|\/$/g, (match, index) => {
 					var str = '';
 
 					if (index == 0) {

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_organizations.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_organizations.jsp
@@ -57,7 +57,7 @@ SelectOrganizationsDisplayContext selectOrganizationsDisplayContext = new Select
 		'<portlet:namespace />organizations'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var result = {};
 
 		var data = event.elements.allSelectedElements.getDOMNodes();

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_user_groups.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_user_groups.jsp
@@ -57,7 +57,7 @@ SelectUserGroupsDisplayContext selectUserGroupsDisplayContext = new SelectUserGr
 		'<portlet:namespace />userGroups'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var result = {};
 
 		var data = event.elements.allSelectedElements.getDOMNodes();

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_users.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_users.jsp
@@ -58,7 +58,7 @@ SelectUsersDisplayContext selectUsersDisplayContext = new SelectUsersDisplayCont
 <aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get('<portlet:namespace />users');
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var result = {};
 
 		var data = event.elements.allSelectedElements.getDOMNodes();

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/site_roles.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/site_roles.jsp
@@ -53,7 +53,7 @@ RolesDisplayContext rolesDisplayContext = new RolesDisplayContext(request, rende
 <aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get('<portlet:namespace />roles');
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(rolesDisplayContext.getEventName()) %>',
 			{

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_group_action.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_group_action.jsp
@@ -92,7 +92,7 @@ UserGroup userGroup = (UserGroup)row.getObject();
 	);
 
 	if (assignRolesLink) {
-		assignRolesLink.addEventListener('click', function (event) {
+		assignRolesLink.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			var target = event.target;
@@ -113,12 +113,12 @@ UserGroup userGroup = (UserGroup)row.getObject();
 				multiple: true,
 				onSelect: function (selectedItems) {
 					if (selectedItems) {
-						Array.prototype.forEach.call(selectedItems, function (
-							selectedItem,
-							index
-						) {
-							addUserGroupGroupRoleFm.append(selectedItem);
-						});
+						Array.prototype.forEach.call(
+							selectedItems,
+							(selectedItem, index) => {
+								addUserGroupGroupRoleFm.append(selectedItem);
+							}
+						);
 
 						submitForm(addUserGroupGroupRoleFm);
 					}
@@ -135,7 +135,7 @@ UserGroup userGroup = (UserGroup)row.getObject();
 	);
 
 	if (unassignRolesLink) {
-		unassignRolesLink.addEventListener('click', function (event) {
+		unassignRolesLink.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			var target = event.target;
@@ -156,12 +156,12 @@ UserGroup userGroup = (UserGroup)row.getObject();
 				multiple: true,
 				onSelect: function (selectedItems) {
 					if (selectedItems) {
-						Array.prototype.forEach.call(selectedItems, function (
-							selectedItem,
-							index
-						) {
-							unassignUserGroupGroupRoleFm.append(selectedItem);
-						});
+						Array.prototype.forEach.call(
+							selectedItems,
+							(selectedItem, index) => {
+								unassignUserGroupGroupRoleFm.append(selectedItem);
+							}
+						);
 
 						submitForm(unassignUserGroupGroupRoleFm);
 					}

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_groups_roles.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_groups_roles.jsp
@@ -54,7 +54,7 @@ UserGroupRolesDisplayContext userGroupRolesDisplayContext = new UserGroupRolesDi
 		'<portlet:namespace />userGroupGroupRoleRole'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(userGroupRolesDisplayContext.getEventName()) %>',
 			{

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users_roles.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users_roles.jsp
@@ -56,7 +56,7 @@ UserRolesDisplayContext userRolesDisplayContext = new UserRolesDisplayContext(re
 		'<portlet:namespace />userGroupRoleRole'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(userRolesDisplayContext.getEventName()) %>',
 			{

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/select_user_groups.jsp
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/select_user_groups.jsp
@@ -100,7 +100,7 @@ SelectUserGroupsDisplayContext selectUserGroupsDisplayContext = new SelectUserGr
 		'<portlet:namespace />userGroups'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(selectUserGroupsDisplayContext.getEventName()) %>',
 			{

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/select_users.jsp
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/select_users.jsp
@@ -88,7 +88,7 @@ SelectUsersDisplayContext selectUsersDisplayContext = new SelectUsersDisplayCont
 <aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get('<portlet:namespace />users');
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		Liferay.Util.getOpener().Liferay.fire(
 			'<%= HtmlUtil.escapeJS(selectUsersDisplayContext.getEventName()) %>',
 			{

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks_settings/page.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks_settings/page.jsp
@@ -96,11 +96,11 @@ rightList = ListUtil.sort(rightList, new KeyValuePairComparator(false, true));
 			'<portlet:namespace />currentTypes'
 		);
 
-		Liferay.after('inputmoveboxes:moveItem', function (event) {
+		Liferay.after('inputmoveboxes:moveItem', (event) => {
 			socialBookmarksTypes.value = Util.listSelect(currentTypes);
 		});
 
-		Liferay.after('inputmoveboxes:orderItem', function (event) {
+		Liferay.after('inputmoveboxes:orderItem', (event) => {
 			socialBookmarksTypes.value = Util.listSelect(currentTypes);
 		});
 	})();

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -276,7 +276,7 @@ if (liveLayout != null) {
 			var stagingToggle = document.querySelector('.staging-toggle');
 
 			if (stagingToggle) {
-				stagingToggle.addEventListener('click', function (event) {
+				stagingToggle.addEventListener('click', (event) => {
 					event.preventDefault();
 
 					staging.classList.toggle('staging-show');
@@ -298,7 +298,7 @@ if (liveLayout != null) {
 					taskExecutorClassName:
 						'<%= BackgroundTaskExecutorNames.LAYOUT_STAGING_BACKGROUND_TASK_EXECUTOR %>',
 				},
-				function (obj) {
+				(obj) => {
 					var incomplete = obj > 0;
 
 					if (incomplete) {

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
@@ -186,7 +186,7 @@ List<LayoutRevision> rootLayoutRevisions = LayoutRevisionLocalServiceUtil.getChi
 		Liferay.Util.fetch(themeDisplay.getPathMain() + '/portal/update_layout', {
 			body: Liferay.Util.objectToFormData(updateLayoutData),
 			method: 'POST',
-		}).then(function () {
+		}).then(() => {
 			var parentWindow = Liferay.Util.getOpener();
 
 			parentWindow.location = parentWindow.location.href.split('?')[0];
@@ -202,13 +202,13 @@ List<LayoutRevision> rootLayoutRevisions = LayoutRevisionLocalServiceUtil.getChi
 		);
 
 		if (layoutBranchesContainers && variationsSelector) {
-			variationsSelector.addEventListener('change', function () {
+			variationsSelector.addEventListener('change', () => {
 				var variation = variationsSelector.value;
 
 				if (variation === 'all') {
 					Array.prototype.forEach.call(
 						layoutBranchesContainers,
-						function (layoutBranchesContainer) {
+						(layoutBranchesContainer) => {
 							layoutBranchesContainer.classList.remove('hide');
 						}
 					);
@@ -216,7 +216,7 @@ List<LayoutRevision> rootLayoutRevisions = LayoutRevisionLocalServiceUtil.getChi
 				else {
 					Array.prototype.forEach.call(
 						layoutBranchesContainers,
-						function (layoutBranchesContainer) {
+						(layoutBranchesContainer) => {
 							layoutBranchesContainer.classList.add('hide');
 						}
 					);

--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/staging_configuration_exceptions.jspf
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/staging_configuration_exceptions.jspf
@@ -65,7 +65,7 @@
 			);
 
 			if (publishProcessesLink) {
-				publishProcessesLink.addEventListener('click', function (event) {
+				publishProcessesLink.addEventListener('click', (event) => {
 					Liferay.Util.openWindow({
 						id: 'publishProcesses',
 						title: '<liferay-ui:message key="initial-publish-process" />',

--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/staging_configuration_remote_options.jspf
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/staging_configuration_remote_options.jspf
@@ -82,7 +82,7 @@ if (stagingType == StagingConstants.TYPE_REMOTE_STAGING) {
 		'<portlet:namespace />remoteSiteURLContainer'
 	);
 
-	overrideRemoteSiteURLCheckbox.addEventListener('click', function () {
+	overrideRemoteSiteURLCheckbox.addEventListener('click', () => {
 		var checked = overrideRemoteSiteURLCheckbox.checked;
 
 		if (checked) {

--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/view.jsp
@@ -122,7 +122,7 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskMan
 							) {
 								var delegate = delegateModule.default;
 
-								delegate(stagingTypes, 'click', 'input', function (event) {
+								delegate(stagingTypes, 'click', 'input', (event) => {
 									var value = event.target.closest('input').value;
 
 									if (value != '<%= StagingConstants.TYPE_LOCAL_STAGING %>') {
@@ -240,8 +240,8 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskMan
 		);
 
 		if (selectAllCheckbox) {
-			selectAllCheckbox.addEventListener('change', function () {
-				Array.prototype.forEach.call(allCheckboxes, function (checkbox) {
+			selectAllCheckbox.addEventListener('change', () => {
+				Array.prototype.forEach.call(allCheckboxes, (checkbox) => {
 					checkbox.checked = selectAllCheckbox.checked;
 				});
 			});

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/navigation.jsp
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/navigation.jsp
@@ -81,7 +81,7 @@ String searchContainerId = "publishLayoutProcesses";
 		timeZoneOffset: <%= timeZoneOffset %>,
 	});
 
-	Liferay.once('destroyPortlet', function () {
+	Liferay.once('destroyPortlet', () => {
 		exportImport.destroy();
 	});
 </aui:script>

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/input_scheduler/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/input_scheduler/page.jsp
@@ -463,13 +463,13 @@
 				);
 
 				if (recurrenceTypeSelect) {
-					recurrenceTypeSelect.addEventListener('change', function (event) {
+					recurrenceTypeSelect.addEventListener('change', (event) => {
 						var selectedTableId =
 							'<portlet:namespace />' +
 							recurrenceTypeSelect[recurrenceTypeSelect.selectedIndex].id +
 							'Table';
 
-						Array.prototype.forEach.call(tables, function (table) {
+						Array.prototype.forEach.call(tables, (table) => {
 							if (table.id !== selectedTableId) {
 								table.classList.add('hide');
 							}

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/menu/staging_actions.jspf
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/menu/staging_actions.jspf
@@ -28,7 +28,7 @@
 			);
 
 			if (publishGlobalLink) {
-				publishGlobalLink.addEventListener('click', function (event) {
+				publishGlobalLink.addEventListener('click', (event) => {
 					event.preventDefault();
 
 					Liferay.Util.openWindow({
@@ -221,7 +221,7 @@
 				);
 
 				if (publishLink) {
-					publishLink.addEventListener('click', function (event) {
+					publishLink.addEventListener('click', (event) => {
 						event.preventDefault();
 
 						Liferay.Util.openWindow({
@@ -249,7 +249,7 @@
 				);
 
 				if (publishToLiveLink) {
-					publishToLiveLink.addEventListener('click', function (event) {
+					publishToLiveLink.addEventListener('click', (event) => {
 						event.preventDefault();
 
 						Liferay.Util.openWindow({
@@ -306,7 +306,7 @@
 				);
 
 				if (layoutSetBranchesLink) {
-					layoutSetBranchesLink.addEventListener('click', function (event) {
+					layoutSetBranchesLink.addEventListener('click', (event) => {
 						event.preventDefault();
 
 						Liferay.Util.openWindow({

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/popover/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/popover/page.jsp
@@ -36,7 +36,7 @@
 	</span>
 
 	<aui:script use="aui-base">
-		A.ready('aui-base', function (A) {
+		A.ready('aui-base', (A) => {
 			var popoverNode = A.one('#<%= domId %>');
 
 			var popover = popoverNode.one('.popover');

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/translate.jsp
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/translate.jsp
@@ -214,7 +214,7 @@ renderResponse.setTitle(translateDisplayContext.getTitle());
 <script>
 	var saveDraftBtn = document.getElementById('<portlet:namespace />saveDraftBtn');
 
-	saveDraftBtn.addEventListener('click', function () {
+	saveDraftBtn.addEventListener('click', () => {
 		var workflowActionInput = document.getElementById(
 			'<portlet:namespace />workflowAction'
 		);

--- a/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/empty/page.jsp
+++ b/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/empty/page.jsp
@@ -54,7 +54,7 @@ int totalEntries = GetterUtil.getInteger(request.getAttribute("liferay-trash:emp
 	var <%= namespace %>empty = document.getElementById('<%= namespace %>empty');
 
 	if (<%= namespace %>empty) {
-		<%= namespace %>empty.addEventListener('click', function (event) {
+		<%= namespace %>empty.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			if (

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/restore_entry.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/restore_entry.jsp
@@ -88,11 +88,11 @@ renderResponse.setTitle(oldName);
 		);
 
 		if (rename && newName) {
-			rename.addEventListener('click', function (event) {
+			rename.addEventListener('click', (event) => {
 				Liferay.Util.focusFormField(newName);
 			});
 
-			newName.addEventListener('focus', function (event) {
+			newName.addEventListener('focus', (event) => {
 				rename.checked = true;
 			});
 		}

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
@@ -238,9 +238,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 		clickListeners.push(delegate(element, 'click', 'input', clickHandlerFn));
 	};
 
-	registerClickHandler(<portlet:namespace />applicationPanelBody, function (
-		event
-	) {
+	registerClickHandler(<portlet:namespace />applicationPanelBody, (event) => {
 		var url = new URL(baseURL, window.location.origin);
 
 		url.searchParams.set(
@@ -252,9 +250,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 	});
 
 	<c:if test="<%= !Objects.equals(viewUADEntitiesDisplay.getApplicationKey(), UADConstants.ALL_APPLICATIONS) %>">
-		registerClickHandler(<portlet:namespace />entitiesTypePanelBody, function (
-			event
-		) {
+		registerClickHandler(<portlet:namespace />entitiesTypePanelBody, (event) => {
 			var url = new URL(baseURL, window.location.origin);
 
 			url.searchParams.set(
@@ -266,7 +262,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 		});
 	</c:if>
 
-	registerClickHandler(<portlet:namespace />scopePanelBody, function (event) {
+	registerClickHandler(<portlet:namespace />scopePanelBody, (event) => {
 		var url = new URL(baseURL, window.location.origin);
 
 		url.searchParams.set('<portlet:namespace />applicationKey', '');

--- a/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/resources/META-INF/resources/user_group_item_selector.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/resources/META-INF/resources/user_group_item_selector.jsp
@@ -102,7 +102,7 @@ PortletURL portletURL = userGroupItemSelectorViewDisplayContext.getPortletURL();
 		'<portlet:namespace />userGroups'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var allSelectedElements = event.elements.allSelectedElements;
 		var arr = [];
 

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/edit_user_group_assignments.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/edit_user_group_assignments.jsp
@@ -168,7 +168,7 @@ PortletURL portletURL = editUserGroupAssignmentsManagementToolbarDisplayContext.
 	}
 
 	Liferay.componentReady('editUserGroupAssignmentsManagementToolbar').then(
-		function (managementToolbar) {
+		(managementToolbar) => {
 			managementToolbar.on(
 				'actionItemClicked',
 				<portlet:namespace />removeUsers

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/select_user_group_users.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/select_user_group_users.jsp
@@ -103,7 +103,7 @@ SearchContainer<User> searchContainer = editUserGroupAssignmentsManagementToolba
 		'<portlet:namespace />selectUsers'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var selectedItems = event.elements.allSelectedElements;
 
 		var data = [];

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -89,57 +89,60 @@ PortletURL portletURL = viewUserGroupsManagementToolbarDisplayContext.getPortlet
 	window.<portlet:namespace />doDeleteUserGroup = function (className, ids) {
 		var status = <%= WorkflowConstants.STATUS_INACTIVE %>;
 
-		<portlet:namespace />getUsersCount(className, ids, status, function (
-			responseData
-		) {
-			var count = parseInt(responseData, 10);
+		<portlet:namespace />getUsersCount(
+			className,
+			ids,
+			status,
+			(responseData) => {
+				var count = parseInt(responseData, 10);
 
-			if (count > 0) {
-				status = <%= WorkflowConstants.STATUS_APPROVED %>;
+				if (count > 0) {
+					status = <%= WorkflowConstants.STATUS_APPROVED %>;
 
-				<portlet:namespace />getUsersCount(
-					className,
-					ids,
-					status,
-					function (responseData) {
-						count = parseInt(responseData, 10);
+					<portlet:namespace />getUsersCount(
+						className,
+						ids,
+						status,
+						(responseData) => {
+							count = parseInt(responseData, 10);
 
-						if (count > 0) {
-							if (
-								confirm(
-									'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
-								)
-							) {
-								<portlet:namespace />doDeleteUserGroups(ids);
-							}
-						}
-						else {
-							var message;
-
-							if (ids && ids.toString().split(',').length > 1) {
-								message =
-									'<%= UnicodeLanguageUtil.get(request, "one-or-more-user-groups-are-associated-with-deactivated-users.-do-you-want-to-proceed-with-deleting-the-selected-user-groups-by-automatically-unassociating-the-deactivated-users") %>';
+							if (count > 0) {
+								if (
+									confirm(
+										'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
+									)
+								) {
+									<portlet:namespace />doDeleteUserGroups(ids);
+								}
 							}
 							else {
-								message =
-									'<%= UnicodeLanguageUtil.get(request, "the-selected-user-group-is-associated-with-deactivated-users.-do-you-want-to-proceed-with-deleting-the-selected-user-group-by-automatically-unassociating-the-deactivated-users") %>';
-							}
+								var message;
 
-							if (confirm(message)) {
-								<portlet:namespace />doDeleteUserGroups(ids);
+								if (ids && ids.toString().split(',').length > 1) {
+									message =
+										'<%= UnicodeLanguageUtil.get(request, "one-or-more-user-groups-are-associated-with-deactivated-users.-do-you-want-to-proceed-with-deleting-the-selected-user-groups-by-automatically-unassociating-the-deactivated-users") %>';
+								}
+								else {
+									message =
+										'<%= UnicodeLanguageUtil.get(request, "the-selected-user-group-is-associated-with-deactivated-users.-do-you-want-to-proceed-with-deleting-the-selected-user-group-by-automatically-unassociating-the-deactivated-users") %>';
+								}
+
+								if (confirm(message)) {
+									<portlet:namespace />doDeleteUserGroups(ids);
+								}
 							}
 						}
-					}
-				);
+					);
+				}
+				else if (
+					confirm(
+						'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
+					)
+				) {
+					<portlet:namespace />doDeleteUserGroups(ids);
+				}
 			}
-			else if (
-				confirm(
-					'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
-				)
-			) {
-				<portlet:namespace />doDeleteUserGroups(ids);
-			}
-		});
+		);
 	};
 
 	function <portlet:namespace />doDeleteUserGroups(userGroupIds) {
@@ -177,10 +180,10 @@ PortletURL portletURL = viewUserGroupsManagementToolbarDisplayContext.getPortlet
 		url.searchParams.set('status', status);
 
 		Liferay.Util.fetch(url.toString())
-			.then(function (response) {
+			.then((response) => {
 				return response.text();
 			})
-			.then(function (response) {
+			.then((response) => {
 				callback(response);
 			});
 	}

--- a/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/user_item_selector.jsp
+++ b/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/user_item_selector.jsp
@@ -108,7 +108,7 @@ String displayStyle = userItemSelectorViewDisplayContext.getDisplayStyle();
 		'<portlet:namespace /><%= HtmlUtil.escape(userItemSelectorViewDisplayContext.getSearchContainerId()) %>'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var allSelectedElements = event.elements.allSelectedElements;
 		var selectedData = [];
 

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_address.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_address.jsp
@@ -152,7 +152,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 			{
 				countryId: countryId,
 			},
-			function (response, err) {
+			(response, err) => {
 				if (err) {
 					console.error(err);
 				}

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/details.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/details.jsp
@@ -148,7 +148,7 @@ if (organization != null) {
 		var typeSelect = document.getElementById('<portlet:namespace />type');
 
 		if (typeSelect) {
-			typeSelect.addEventListener('change', function (event) {
+			typeSelect.addEventListener('change', (event) => {
 				var countryDiv = document.getElementById(
 					'<portlet:namespace />countryDiv'
 				);

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/parent_organization.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/parent_organization.jsp
@@ -211,7 +211,7 @@ if (parentOrganization != null) {
 	if (selectOrganizationLink) {
 		searchContainer.get('contentBox').delegate(
 			'click',
-			function (event) {
+			(event) => {
 				var link = event.currentTarget;
 				var tr = link.ancestor('tr');
 
@@ -224,7 +224,7 @@ if (parentOrganization != null) {
 			'.modify-link'
 		);
 
-		selectOrganizationLink.on('click', function (event) {
+		selectOrganizationLink.on('click', (event) => {
 			var searchContainerData = searchContainer.getData();
 
 			Liferay.Util.openSelectionModal({

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/select_organization_users.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/select_organization_users.jsp
@@ -125,7 +125,7 @@ SearchContainer<User> userSearchContainer = selectOrganizationUsersManagementToo
 <aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get('<portlet:namespace />users');
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var selectedItems = event.elements.allSelectedElements;
 
 		var result = {};

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/organizations.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/organizations.jsp
@@ -156,7 +156,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 		searchContainerContentBox.delegate(
 			'click',
-			function (event) {
+			(event) => {
 				var link = event.currentTarget;
 
 				var rowId = link.attr('data-rowId');
@@ -196,7 +196,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 		);
 
 		if (selectOrganizationLink) {
-			selectOrganizationLink.on('click', function (event) {
+			selectOrganizationLink.on('click', (event) => {
 				Util.selectEntity(
 					{
 						dialog: {
@@ -210,7 +210,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 						uri:
 							'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_organization.jsp" /><portlet:param name="p_u_i_d" value='<%= (selUser == null) ? "0" : String.valueOf(selUser.getUserId()) %>' /></portlet:renderURL>',
 					},
-					function (event) {
+					(event) => {
 						var entityId = event.entityid;
 
 						var rowColumns = [];

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/password.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/password.jsp
@@ -190,7 +190,7 @@ else {
 		);
 
 		if (reminderQueryQuestionSelect) {
-			reminderQueryQuestionSelect.addEventListener('change', function (event) {
+			reminderQueryQuestionSelect.addEventListener('change', (event) => {
 				var customQuestion =
 					event.currentTarget.value === '<%= UsersAdmin.CUSTOM_QUESTION %>';
 

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/password_verification.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/password_verification.jsp
@@ -75,20 +75,20 @@ String eventName = ParamUtil.getString(request, "eventName", liferayPortletRespo
 				method: 'POST',
 			}
 		)
-			.then(function (response) {
+			.then((response) => {
 				if (!response.ok) {
 					throw new Error();
 				}
 
 				return response.text();
 			})
-			.then(function (response) {
+			.then((response) => {
 				var openingLiferay = Liferay.Util.getOpener().Liferay;
 
 				openingLiferay.fire('<%= HtmlUtil.escapeJS(eventName) %>');
 				openingLiferay.fire('closeModal');
 			})
-			.catch(function (error) {
+			.catch((error) => {
 				var verificationAlert = document.getElementById(
 					'<portlet:namespace />verificationAlert'
 				);

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -140,7 +140,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 			);
 
 			if (selectRegularRoleLink) {
-				selectRegularRoleLink.addEventListener('click', function (event) {
+				selectRegularRoleLink.addEventListener('click', (event) => {
 					var searchContainerName = '<portlet:namespace />rolesSearchContainer';
 
 					var searchContainer = Liferay.SearchContainer.get(searchContainerName);
@@ -342,7 +342,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 				searchContainerContentBox.delegate(
 					'click',
-					function (event) {
+					(event) => {
 						var link = event.currentTarget;
 						var tr = link.ancestor('tr');
 
@@ -385,7 +385,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 			);
 
 			if (selectOrganizationRoleLink) {
-				selectOrganizationRoleLink.addEventListener('click', function (event) {
+				selectOrganizationRoleLink.addEventListener('click', (event) => {
 					var searchContainerName =
 						'<portlet:namespace />organizationRolesSearchContainer';
 
@@ -544,7 +544,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 				searchContainerContentBox.delegate(
 					'click',
-					function (event) {
+					(event) => {
 						var link = event.currentTarget;
 						var tr = link.ancestor('tr');
 
@@ -577,7 +577,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 					'.modify-link'
 				);
 
-				A.one('#<portlet:namespace />selectSiteRoleLink').on('click', function (event) {
+				A.one('#<portlet:namespace />selectSiteRoleLink').on('click', (event) => {
 					var searchContainerName = '<portlet:namespace />siteRolesSearchContainer';
 
 					var searchContainer = Liferay.SearchContainer.get(searchContainerName);
@@ -610,7 +610,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 							uri: '<%= selectSiteRoleURL.toString() %>',
 						},
-						function (event) {
+						(event) => {
 							<portlet:namespace />selectRole(
 								event.entityid,
 								event.entityname,
@@ -740,7 +740,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 						.get('contentBox')
 						.all('.modify-link')
 						.getData()
-						.map(function (data) {
+						.map((data) => {
 							return data.groupid + '-' + data.rowid;
 						})
 				);
@@ -851,7 +851,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 			searchContainerContentBox.delegate(
 				'click',
-				function (event) {
+				(event) => {
 					var link = event.currentTarget;
 
 					var rowId = link.attr('data-rowId');

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/sites.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/sites.jsp
@@ -145,7 +145,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 		var handleOnSelect = A.one('#<portlet:namespace />selectSiteLink').on(
 			'click',
-			function (event) {
+			(event) => {
 				var searchContainerData = searchContainer.getData();
 
 				if (!searchContainerData.length) {
@@ -183,7 +183,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 						uri: '<%= groupSelectorURL.toString() %>',
 					},
-					function (event) {
+					(event) => {
 						var entityId = event.entityid;
 
 						var rowColumns = [];
@@ -217,7 +217,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 		var handleOnModifyLink = searchContainerContentBox.delegate(
 			'click',
-			function (event) {
+			(event) => {
 				var link = event.currentTarget;
 
 				var rowId = link.attr('data-rowId');
@@ -251,8 +251,8 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 		var handleEnableRemoveSite = Liferay.on(
 			'<portlet:namespace />enableRemovedSites',
-			function (event) {
-				event.selectors.each(function (item, index, collection) {
+			(event) => {
+				event.selectors.each((item, index, collection) => {
 					var groupId = item.attr('data-entityid');
 
 					if (deleteGroupIds.indexOf(groupId) != -1) {

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/user_display_data.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/user_display_data.jsp
@@ -182,10 +182,10 @@ User selUser = (User)request.getAttribute(UsersAdminWebKeys.SELECTED_USER);
 
 <c:if test="<%= selUser != null %>">
 	<aui:script use="liferay-form">
-		Liferay.once('<portlet:namespace />formReady', function () {
+		Liferay.once('<portlet:namespace />formReady', () => {
 			var form = Liferay.Form.get('<portlet:namespace />fm');
 
-			form.set('onSubmit', function (event) {
+			form.set('onSubmit', (event) => {
 				event.preventDefault();
 
 				var emailAddressInput = document.getElementById(

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/user_groups.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/user_groups.jsp
@@ -121,7 +121,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 		searchContainerContentBox.delegate(
 			'click',
-			function (event) {
+			(event) => {
 				var link = event.currentTarget;
 
 				var rowId = link.attr('data-rowId');
@@ -156,7 +156,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 			'.modify-link'
 		);
 
-		A.one('#<portlet:namespace />openUserGroupsLink').on('click', function (event) {
+		A.one('#<portlet:namespace />openUserGroupsLink').on('click', (event) => {
 			Liferay.Util.openSelectionModal({
 				onSelect: function (selectedItem) {
 					var A = AUI();

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -154,66 +154,69 @@ else {
 	) {
 		var status = <%= WorkflowConstants.STATUS_INACTIVE %>;
 
-		<portlet:namespace />getUsersCount(className, ids, status, function (
-			responseData
-		) {
-			var count = parseInt(responseData, 10);
+		<portlet:namespace />getUsersCount(
+			className,
+			ids,
+			status,
+			(responseData) => {
+				var count = parseInt(responseData, 10);
 
-			if (count > 0) {
-				status = <%= WorkflowConstants.STATUS_APPROVED %>;
+				if (count > 0) {
+					status = <%= WorkflowConstants.STATUS_APPROVED %>;
 
-				<portlet:namespace />getUsersCount(
-					className,
-					ids,
-					status,
-					function (responseData) {
-						count = parseInt(responseData, 10);
+					<portlet:namespace />getUsersCount(
+						className,
+						ids,
+						status,
+						(responseData) => {
+							count = parseInt(responseData, 10);
 
-						if (count > 0) {
-							if (
-								confirm(
-									'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
-								)
-							) {
-								<portlet:namespace />doDeleteOrganizations(
-									ids,
-									organizationsRedirect
-								);
-							}
-						}
-						else {
-							var message;
-
-							if (ids && ids.toString().split(',').length > 1) {
-								message =
-									'<%= UnicodeLanguageUtil.get(request, "one-or-more-organizations-are-associated-with-deactivated-users.-do-you-want-to-proceed-with-deleting-the-selected-organizations-by-automatically-unassociating-the-deactivated-users") %>';
+							if (count > 0) {
+								if (
+									confirm(
+										'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
+									)
+								) {
+									<portlet:namespace />doDeleteOrganizations(
+										ids,
+										organizationsRedirect
+									);
+								}
 							}
 							else {
-								message =
-									'<%= UnicodeLanguageUtil.get(request, "the-selected-organization-is-associated-with-deactivated-users.-do-you-want-to-proceed-with-deleting-the-selected-organization-by-automatically-unassociating-the-deactivated-users") %>';
-							}
+								var message;
 
-							if (confirm(message)) {
-								<portlet:namespace />doDeleteOrganizations(
-									ids,
-									organizationsRedirect
-								);
+								if (ids && ids.toString().split(',').length > 1) {
+									message =
+										'<%= UnicodeLanguageUtil.get(request, "one-or-more-organizations-are-associated-with-deactivated-users.-do-you-want-to-proceed-with-deleting-the-selected-organizations-by-automatically-unassociating-the-deactivated-users") %>';
+								}
+								else {
+									message =
+										'<%= UnicodeLanguageUtil.get(request, "the-selected-organization-is-associated-with-deactivated-users.-do-you-want-to-proceed-with-deleting-the-selected-organization-by-automatically-unassociating-the-deactivated-users") %>';
+								}
+
+								if (confirm(message)) {
+									<portlet:namespace />doDeleteOrganizations(
+										ids,
+										organizationsRedirect
+									);
+								}
 							}
 						}
-					}
-				);
+					);
+				}
+				else if (
+					confirm(
+						'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
+					)
+				) {
+					<portlet:namespace />doDeleteOrganizations(
+						ids,
+						organizationsRedirect
+					);
+				}
 			}
-			else if (
-				confirm(
-					'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
-				)
-			) {
-				<portlet:namespace />doDeleteOrganizations(
-					ids,
-					organizationsRedirect
-				);
-			}
-		});
+		);
 	}
 
 	function <portlet:namespace />doDeleteOrganizations(
@@ -251,13 +254,13 @@ else {
 				method: 'POST',
 			}
 		)
-			.then(function (response) {
+			.then((response) => {
 				return response.text();
 			})
-			.then(function (response) {
+			.then((response) => {
 				callback(response);
 			})
-			.catch(function (error) {
+			.catch((error) => {
 				Liferay.Util.openToast({
 					message: Liferay.Language.get(
 						'an-unexpected-system-error-occurred'

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_tree.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_tree.jsp
@@ -239,15 +239,15 @@ if (organization != null) {
 		selectUsers: selectUsers,
 	};
 
-	Liferay.componentReady('viewTreeManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('creationMenuItemClicked', function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('viewTreeManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('creationMenuItemClicked', (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action](itemData.organizationId);
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action](itemData.organizationId);
+				}
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/wiki/wiki-engine-input-editor-common/src/main/resources/META-INF/resources/edit_page.jsp
+++ b/modules/apps/wiki/wiki-engine-input-editor-common/src/main/resources/META-INF/resources/edit_page.jsp
@@ -53,7 +53,7 @@ WikiPage wikiPage = BaseWikiEngine.getWikiPage(request);
 				'#<%= liferayPortletResponse.getNamespace() + "toggle_id_wiki_editor_help" %>'
 			);
 
-			helpPageLink.on('click', function (event) {
+			helpPageLink.on('click', (event) => {
 				event.preventDefault();
 
 				var helpPageDialog = Liferay.Util.Window.getWindow({

--- a/modules/apps/wiki/wiki-navigation-web/src/main/resources/META-INF/resources/tree_menu/view.jsp
+++ b/modules/apps/wiki/wiki-navigation-web/src/main/resources/META-INF/resources/tree_menu/view.jsp
@@ -44,7 +44,7 @@ List<MenuItem> menuItems = MenuItem.fromWikiNode(selNodeId, depth, viewURL);
 
 				selectedChild.expand();
 
-				selectedChild.eachParent(function (node) {
+				selectedChild.eachParent((node) => {
 					if (node instanceof A.TreeNode) {
 						node.expand();
 					}

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/wiki_pages.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/wiki_pages.jsp
@@ -159,7 +159,7 @@ String searchURL = HttpUtil.removeParameter(searchBaseURL.toString(), liferayPor
 
 	searchContainerContentBox.delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var selectedItem = event.currentTarget;
 
 			var linkItem = selectedItem.one('.wiki-page');

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/edit_page_view_attachments.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/edit_page_view_attachments.jsp
@@ -65,7 +65,7 @@ if (wikiPage != null) {
 	<aui:script use="liferay-util-window">
 		var viewRemovedAttachmentsLink = A.one('#view-removed-attachments-link');
 
-		viewRemovedAttachmentsLink.on('click', function (event) {
+		viewRemovedAttachmentsLink.on('click', (event) => {
 			Liferay.Util.openWindow({
 				id: '<portlet:namespace />openRemovedPageAttachments',
 				title: '<%= LanguageUtil.get(request, "removed-attachments") %>',

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/page_iterator.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/page_iterator.jsp
@@ -274,7 +274,7 @@ for (int i = 0; i < pages.size(); i++) {
 				'input[name=<portlet:namespace />rowIds]'
 			);
 
-			Array.prototype.forEach.call(rowIdsNodes, function (rowIdsNode, index) {
+			Array.prototype.forEach.call(rowIdsNodes, (rowIdsNode, index) => {
 				if (index > 1) {
 					rowIdsNode.checked = false;
 				}
@@ -305,7 +305,7 @@ for (int i = 0; i < pages.size(); i++) {
 
 			var compareButton = document.getElementById('<portlet:namespace />compare');
 
-			compareButton.addEventListener('click', function (event) {
+			compareButton.addEventListener('click', (event) => {
 				<portlet:renderURL var="compareVersionURL">
 					<portlet:param name="mvcRenderCommandName" value="/wiki/compare_versions" />
 					<portlet:param name="backURL" value="<%= currentURL %>" />
@@ -365,7 +365,7 @@ for (int i = 0; i < pages.size(); i++) {
 				searchContainer,
 				'click',
 				'input[name=<portlet:namespace />rowIds]',
-				function (event) {
+				(event) => {
 					<portlet:namespace />updateRowsChecked(event.delegateTarget);
 				}
 			);

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_display/configuration.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_display/configuration.jsp
@@ -113,7 +113,7 @@ boolean nodeInGroup = false;
 					if (nodeIdSelect) {
 						var nodeId = nodeIdSelect.value;
 
-						nodeIdSelect.addEventListener('change', function () {
+						nodeIdSelect.addEventListener('change', () => {
 							if (pageSelectorContainer) {
 								if (nodeIdSelect.value === nodeId) {
 									pageSelectorContainer.classList.remove('hide');

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/view.jsp
@@ -60,21 +60,21 @@ String analyticsReportsPanelState = SessionClicks.get(request, "com.liferay.anal
 		analyticsReportsPanelToggle
 	);
 
-	sidenavInstance.on('open.lexicon.sidenav', function (event) {
+	sidenavInstance.on('open.lexicon.sidenav', (event) => {
 		Liferay.Util.Session.set(
 			'com.liferay.analytics.reports.web_panelState',
 			'open'
 		);
 	});
 
-	sidenavInstance.on('closed.lexicon.sidenav', function (event) {
+	sidenavInstance.on('closed.lexicon.sidenav', (event) => {
 		Liferay.Util.Session.set(
 			'com.liferay.analytics.reports.web_panelState',
 			'closed'
 		);
 	});
 
-	Liferay.once('screenLoad', function () {
+	Liferay.once('screenLoad', () => {
 		Liferay.SideNavigation.destroy(analyticsReportsPanelToggle);
 	});
 </aui:script>

--- a/modules/dxp/apps/commerce-avalara/commerce-avalara-tax-engine-fixed-web/src/main/resources/META-INF/resources/avalara_settings.jsp
+++ b/modules/dxp/apps/commerce-avalara/commerce-avalara-tax-engine-fixed-web/src/main/resources/META-INF/resources/avalara_settings.jsp
@@ -40,9 +40,7 @@ CommerceAvalaraConnectorConfiguration commerceAvalaraConnectorConfiguration = (C
 </aui:form>
 
 <aui:script>
-	Liferay.provide(window, '<portlet:namespace />verifyConnection', function (
-		evt
-	) {
+	Liferay.provide(window, '<portlet:namespace />verifyConnection', (evt) => {
 		const inputCmd = document.querySelector(
 			'#<portlet:namespace /><%= Constants.CMD %>'
 		);

--- a/modules/dxp/apps/commerce/commerce-application-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/commerce/commerce-application-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -149,7 +149,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "applications"));
 			document.body,
 			'click',
 			'#<portlet:namespace />addApplicationBrandButton',
-			function (event) {
+			(event) => {
 				modalCommands.openSimpleInputModal({
 					dialogTitle: '<liferay-ui:message key="add-brand" />',
 					formSubmitURL: '<%= editCommerceApplicationBrandActionURL %>',

--- a/modules/dxp/apps/commerce/commerce-application-item-selector-web/src/main/resources/META-INF/resources/application_model_item_selector.jsp
+++ b/modules/dxp/apps/commerce/commerce-application-item-selector-web/src/main/resources/META-INF/resources/application_model_item_selector.jsp
@@ -100,7 +100,7 @@ PortletURL portletURL = commerceApplicationModelItemSelectorViewDisplayContext.g
 		'<portlet:namespace />commerceApplicationModels'
 	);
 
-	searchContainer.on('rowToggled', function (event) {
+	searchContainer.on('rowToggled', (event) => {
 		var allSelectedElements = event.elements.allSelectedElements;
 		var arr = [];
 

--- a/modules/dxp/apps/commerce/commerce-bom-admin-web/src/main/resources/META-INF/resources/folder/models.jsp
+++ b/modules/dxp/apps/commerce/commerce-bom-admin-web/src/main/resources/META-INF/resources/folder/models.jsp
@@ -146,7 +146,7 @@ CommerceBOMFolder commerceBOMFolder = commerceBOMAdminDisplayContext.getCommerce
 	<aui:script use="liferay-item-selector-dialog">
 		window.document
 			.querySelector('#<portlet:namespace />addCommerceBOMFolderApplicationRel')
-			.addEventListener('click', function (event) {
+			.addEventListener('click', (event) => {
 				event.preventDefault();
 
 				var itemSelectorDialog = new A.LiferayItemSelectorDialog({
@@ -158,15 +158,14 @@ CommerceBOMFolder commerceBOMFolder = commerceBOMAdminDisplayContext.getCommerce
 							var selectedItems = event.newVal;
 
 							if (selectedItems) {
-								A.Array.each(selectedItems, function (
-									item,
-									index,
-									selectedItems
-								) {
-									<portlet:namespace />addCommerceApplicationModelIds.push(
-										item.commerceApplicationModelId
-									);
-								});
+								A.Array.each(
+									selectedItems,
+									(item, index, selectedItems) => {
+										<portlet:namespace />addCommerceApplicationModelIds.push(
+											item.commerceApplicationModelId
+										);
+									}
+								);
 
 								window.document.querySelector(
 									'#<portlet:namespace />commerceApplicationModelIds'

--- a/modules/dxp/apps/commerce/commerce-data-integration-talend/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/commerce/commerce-data-integration-talend/src/main/resources/META-INF/resources/view.jsp
@@ -66,7 +66,7 @@ TalendProcessTypeHelper talendProcessTypeHelper = (TalendProcessTypeHelper)reque
 <aui:script>
 	window.document
 		.querySelector('#<portlet:namespace />fileEntryRemove')
-		.addEventListener('click', function (event) {
+		.addEventListener('click', (event) => {
 			event.preventDefault();
 
 			window.document

--- a/modules/dxp/apps/commerce/commerce-data-integration-web/src/main/resources/META-INF/resources/process/details.jsp
+++ b/modules/dxp/apps/commerce/commerce-data-integration-web/src/main/resources/META-INF/resources/process/details.jsp
@@ -78,7 +78,7 @@ if (commerceDataIntegrationProcess != null) {
 	Liferay.provide(
 		window,
 		'<portlet:namespace />selectType',
-		function () {
+		() => {
 			var A = AUI();
 
 			var processType = A.one(<portlet:namespace />type).val();
@@ -116,7 +116,7 @@ if (commerceDataIntegrationProcess != null) {
 
 	contentEditor.set(STR_VALUE, content);
 
-	Liferay.on('<portlet:namespace />saveProcess', function (event) {
+	Liferay.on('<portlet:namespace />saveProcess', (event) => {
 		var form = window.document.querySelector('#<portlet:namespace />fm');
 
 		form['<portlet:namespace />typeSettings'].value = contentEditor.get(

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/organization/accounts.jsp
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/organization/accounts.jsp
@@ -43,7 +43,7 @@ CommerceOrganizationDisplayContext commerceOrganizationDisplayContext = (Commerc
 	</aui:form>
 
 	<aui:script>
-		Liferay.provide(window, 'deleteCommerceOrganizationAccount', function (id) {
+		Liferay.provide(window, 'deleteCommerceOrganizationAccount', (id) => {
 			document.querySelector('#<portlet:namespace /><%= Constants.CMD %>').value =
 				'<%= Constants.REMOVE %>';
 			document.querySelector('#<portlet:namespace />organizationId').value = id;

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/organization/suborganizations.jsp
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/organization/suborganizations.jsp
@@ -93,7 +93,7 @@ request.setAttribute("view.jsp-filterPerOrganization", false);
 	</aui:script>
 
 	<aui:script>
-		Liferay.provide(window, 'deleteCommerceOrganization', function (id) {
+		Liferay.provide(window, 'deleteCommerceOrganization', (id) => {
 			document.querySelector('#<portlet:namespace />organizationId').value = id;
 
 			submitForm(document.<portlet:namespace />organizationFm);

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/organization/users.jsp
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/organization/users.jsp
@@ -59,13 +59,13 @@ portletURL.setParameter(PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE + "backUR
 		Liferay.provide(
 			window,
 			'<portlet:namespace />openUserInvitationModal',
-			function (evt) {
+			(evt) => {
 				var userInvitationModal = Liferay.component('userInvitationModal');
 				userInvitationModal.open();
 			}
 		);
 
-		Liferay.provide(window, 'deleteCommerceOrganizationUser', function (id) {
+		Liferay.provide(window, 'deleteCommerceOrganizationUser', (id) => {
 			document.querySelector('#<portlet:namespace /><%= Constants.CMD %>').value =
 				'<%= Constants.REMOVE %>';
 			document.querySelector('#<portlet:namespace />userId').value = id;
@@ -73,24 +73,22 @@ portletURL.setParameter(PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE + "backUR
 			submitForm(document.<portlet:namespace />inviteUserFm);
 		});
 
-		Liferay.componentReady('userInvitationModal').then(function (
-			userInvitationModal
-		) {
-			userInvitationModal.on('inviteUserToAccount', function (users) {
+		Liferay.componentReady('userInvitationModal').then((userInvitationModal) => {
+			userInvitationModal.on('inviteUserToAccount', (users) => {
 				var existingUsersIds = users
-					.filter(function (el) {
+					.filter((el) => {
 						return el.userId;
 					})
-					.map(function (usr) {
+					.map((usr) => {
 						return usr.userId;
 					})
 					.join(',');
 
 				var newUsersEmails = users
-					.filter(function (el) {
+					.filter((el) => {
 						return !el.userId;
 					})
-					.map(function (usr) {
+					.map((usr) => {
 						return usr.email;
 					})
 					.join(',');

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/view.jsp
@@ -124,7 +124,7 @@ request.setAttribute("view.jsp-filterPerOrganization", false);
 		Liferay.provide(
 			window,
 			'handleAddOrganizationButtonClick',
-			function (event) {
+			(event) => {
 				event.preventDefault();
 
 				var organizationId =
@@ -176,7 +176,7 @@ request.setAttribute("view.jsp-filterPerOrganization", false);
 	</aui:script>
 
 	<aui:script>
-		Liferay.provide(window, 'deleteCommerceOrganization', function (id) {
+		Liferay.provide(window, 'deleteCommerceOrganization', (id) => {
 			document.querySelector('#<portlet:namespace /><%= Constants.CMD %>').value =
 				'<%= Constants.DELETE %>';
 			document.querySelector('#<portlet:namespace />organizationId').value = id;

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/resources/META-INF/resources/dynamic_include/view_post.jsp
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/resources/META-INF/resources/dynamic_include/view_post.jsp
@@ -27,7 +27,7 @@
 		dialogTitle
 	) {
 		Liferay.componentReady('<portlet:namespace />DocumentLibraryOpener').then(
-			function (openerOnedrive) {
+			(openerOnedrive) => {
 				openerOnedrive.createWithName({
 					dialogTitle: dialogTitle,
 					formSubmitURL: formSubmitURL,
@@ -41,7 +41,7 @@
 		dialogTitle
 	) {
 		Liferay.componentReady('<portlet:namespace />DocumentLibraryOpener').then(
-			function (openerOnedrive) {
+			(openerOnedrive) => {
 				openerOnedrive.edit({
 					formSubmitURL: formSubmitURL,
 				});
@@ -56,7 +56,7 @@
 
 	<c:if test="<%= oneDriveBackgroundTaskStatusURL != null %>">
 		Liferay.componentReady('<portlet:namespace />DocumentLibraryOpener').then(
-			function (openerOnedrive) {
+			(openerOnedrive) => {
 				openerOnedrive.open({
 					dialogMessage: '<%= dialogMessage %>',
 					statusURL: '<%= oneDriveBackgroundTaskStatusURL %>',

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
@@ -67,7 +67,7 @@ long mfaEmailOTPSetAtTime = GetterUtil.getLong(request.getAttribute(MFAEmailOTPW
 	var elapsedTime = Math.floor((Date.now() - previousSetTime) / 1000);
 
 	function <portlet:namespace />createCountdown(f, countdown, interval) {
-		return setInterval(function () {
+		return setInterval(() => {
 			--countdown;
 			f(countdown);
 		}, interval);
@@ -108,7 +108,7 @@ long mfaEmailOTPSetAtTime = GetterUtil.getLong(request.getAttribute(MFAEmailOTPW
 
 		var originalSubmitButtonText = submitEmailButton.text();
 
-		setInterval(function () {
+		setInterval(() => {
 			--failedAttemptsRetryTimeout;
 			{
 				if (failedAttemptsRetryTimeout < 1) {
@@ -127,7 +127,7 @@ long mfaEmailOTPSetAtTime = GetterUtil.getLong(request.getAttribute(MFAEmailOTPW
 		}, 1000);
 	}
 
-	A.one('#<portlet:namespace />sendEmailButton').on('click', function (event) {
+	A.one('#<portlet:namespace />sendEmailButton').on('click', (event) => {
 		sendEmailButton.setAttribute('disabled', 'disabled');
 
 		var resendDuration = <%= mfaEmailOTPConfiguration.resendEmailTimeout() %>;

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/data_source/edit_data_source.jsp
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/data_source/edit_data_source.jsp
@@ -113,17 +113,17 @@ renderResponse.setTitle((source != null) ? LanguageUtil.format(request, "edit-x"
 
 			var url = new URL(baseUrl);
 
-			searchParams.forEach(function (value, key) {
+			searchParams.forEach((value, key) => {
 				url.searchParams.append(key, value);
 			});
 
 			var id = '<portlet:namespace />databaseConnectionModal';
 
 			Liferay.Util.fetch(url)
-				.then(function (response) {
+				.then((response) => {
 					return response.text();
 				})
-				.then(function (text) {
+				.then((text) => {
 					Liferay.Util.openModal({
 						bodyHTML: text,
 						buttons: [
@@ -143,7 +143,7 @@ renderResponse.setTitle((source != null) ? LanguageUtil.format(request, "edit-x"
 						title: '<liferay-ui:message key="source" />',
 					});
 				})
-				.catch(function (error) {
+				.catch((error) => {
 					Liferay.Util.openToast({
 						message: Liferay.Language.get(
 							'an-unexpected-system-error-occurred'

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/definition/edit_definition.jsp
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/definition/edit_definition.jsp
@@ -208,7 +208,7 @@ else {
 </aui:form>
 
 <script type="text/javascript">
-	AUI().ready(function (A) {
+	AUI().ready((A) => {
 		Liferay.Report.initialize({
 			namespace: '<portlet:namespace />',
 			parameters:

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view.jsp
@@ -196,15 +196,15 @@ RankingPortletDisplayContext rankingPortletDisplayContext = (RankingPortletDispl
 		deleteResultsRankingsEntries: deleteResultsRankingsEntries,
 	};
 
-	Liferay.componentReady('resultsRankingEntriesManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('resultsRankingEntriesManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on('actionItemClicked', (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action]();
+				}
+			});
+		}
+	);
 </aui:script>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -340,7 +340,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 										var kaleoDesigner = <portlet:namespace />kaleoDesigner;
 
 										if (tabContentNode === kaleoDesigner.viewNode && kaleoDesigner.editor) {
-											setTimeout(function () {
+											setTimeout(() => {
 												kaleoDesigner.set('definition', kaleoDesigner.editor.get('value'));
 											}, 0);
 										}
@@ -493,12 +493,12 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 										}).render();
 
 										<c:if test='<%= kaleoDesignerDisplayContext.isDefinitionInputDisabled(Objects.equals(state, WorkflowWebKeys.WORKFLOW_PREVIEW_BEFORE_RESTORE_STATE) || Objects.equals(state, "view"), kaleoDefinitionVersion, permissionChecker) %>'>
-											<portlet:namespace />kaleoDesigner.after('render', function () {
+											<portlet:namespace />kaleoDesigner.after('render', () => {
 												var diagramBuilderControlElements = document.querySelectorAll(
 													'#<portlet:namespace />propertyBuilder .diagram-builder-controls'
 												);
 
-												diagramBuilderControlElements.forEach(function (element) {
+												diagramBuilderControlElements.forEach((element) => {
 													element.parentElement.removeChild(element);
 												});
 
@@ -512,7 +512,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 
 										var previousContent = '';
 
-										uploadFile.addEventListener('change', function (evt) {
+										uploadFile.addEventListener('change', (evt) => {
 											var files = evt.target.files;
 
 											if (files) {
@@ -538,7 +538,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 											}
 										});
 
-										Liferay.on('<portlet:namespace />undoDefinition', function (event) {
+										Liferay.on('<portlet:namespace />undoDefinition', (event) => {
 											<portlet:namespace />kaleoDesigner.setEditorContent(previousContent);
 
 											Liferay.KaleoDesignerDialogs.showActionUndoneSuccessMessage();
@@ -631,13 +631,13 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 
 										A.getDoc().delegate(
 											'focus',
-											function (event) {
+											(event) => {
 												var inputNode = event.currentTarget;
 
 												var inputName = inputNode.attr('name');
 
 												if (inputName == 'roleName' || inputName == 'roleNameAC') {
-													createRoleAutocomplete(inputNode, null, function (event) {
+													createRoleAutocomplete(inputNode, null, (event) => {
 														var data = event.result.raw;
 														var roleId = inputNode.next('[name=roleId]');
 
@@ -647,10 +647,10 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 													});
 												}
 												else if (inputName == 'fullName') {
-													createUserAutocomplete(inputNode, inputName, function (event) {
+													createUserAutocomplete(inputNode, inputName, (event) => {
 														var data = event.result.raw;
 
-														A.each(data, function (item, index, collection) {
+														A.each(data, (item, index, collection) => {
 															var input = inputNode
 																.siblings('[name=' + index + ']')
 																.first();
@@ -671,7 +671,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 									var inModal = window !== opener;
 
 									if (inModal && opener.document.querySelector('.loading-animation')) {
-										opener.Liferay.on('modalIframeLoaded', function () {
+										opener.Liferay.on('modalIframeLoaded', () => {
 											initializeKaleoDesigner();
 										});
 									}
@@ -686,7 +686,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 											var titlePlaceholderInput = titleComponent.get('inputPlaceholder');
 
 											if (titlePlaceholderInput) {
-												titlePlaceholderInput.after('change', function (event) {
+												titlePlaceholderInput.after('change', (event) => {
 													<portlet:namespace />kaleoDesigner.set(
 														'definitionName',
 														titleComponent.getValue()

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_kaleo_process.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_kaleo_process.jsp
@@ -111,7 +111,7 @@ renderResponse.setTitle(title);
 			var form = Liferay.Form.get('<portlet:namespace />fm');
 
 			if (form === event.form) {
-				Liferay.component('<portlet:namespace />KaleoFormsAdmin', function () {
+				Liferay.component('<portlet:namespace />KaleoFormsAdmin', () => {
 					return new Liferay.KaleoFormsAdmin({
 						currentURL: '<%= HtmlUtil.escape(currentURL) %>',
 						form: form,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/export_kaleo_process.jspf
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/export_kaleo_process.jspf
@@ -27,7 +27,7 @@
 	Liferay.provide(
 		window,
 		'<portlet:namespace />exportKaleoProcess',
-		function (url) {
+		(url) => {
 			var A = AUI();
 
 			var form = A.Node.create('<form method="post" />');

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/management_bar.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/management_bar.jsp
@@ -63,15 +63,15 @@
 		deleteKaleoProcess: deleteKaleoProcess,
 	};
 
-	Liferay.componentReady('kaleoFormsManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on(['actionItemClicked'], function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('kaleoFormsManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on(['actionItemClicked'], (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action]();
+				}
+			});
+		}
+	);
 </aui:script>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/fields.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/fields.jsp
@@ -163,7 +163,7 @@ JSONArray availableDefinitionsJSONArray = JSONFactoryUtil.createJSONArray();
 <aui:script>
 	Liferay.on(
 		'<portlet:namespace />chooseDefinition',
-		function (event) {
+		(event) => {
 			var A = AUI();
 
 			var ddmStructureId = event.ddmStructureId;
@@ -195,7 +195,7 @@ JSONArray availableDefinitionsJSONArray = JSONFactoryUtil.createJSONArray();
 	Liferay.provide(
 		window,
 		'<portlet:namespace />editStructure',
-		function (title, uri) {
+		(title, uri) => {
 			var A = AUI();
 
 			var WIN = A.config.win;
@@ -229,7 +229,7 @@ JSONArray availableDefinitionsJSONArray = JSONFactoryUtil.createJSONArray();
 
 	A.one('#p_p_id<portlet:namespace />').delegate(
 		'click',
-		function (event) {
+		(event) => {
 			var definitionId = event.target.attr('data-definition-id');
 
 			kaleoDefinitionPreview.select(definitionId);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/task_template_search_container.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/task_template_search_container.jsp
@@ -111,7 +111,7 @@ KaleoTaskFormPair initialStateKaleoTaskFormPair = KaleoFormsUtil.getInitialState
 	Liferay.provide(
 		window,
 		'<portlet:namespace />selectFormTemplate',
-		function (classPK, mode, sessionParamName) {
+		(classPK, mode, sessionParamName) => {
 			Liferay.Util.openDDMPortlet(
 				{
 					basePortletURL:
@@ -136,7 +136,7 @@ KaleoTaskFormPair initialStateKaleoTaskFormPair = KaleoFormsUtil.getInitialState
 						'<%= liferayPortletResponse.getNamespace() + "getAvailableFields" %>',
 					title: '<liferay-ui:message key="form" />',
 				},
-				function (event) {
+				(event) => {
 					var A = AUI();
 
 					var data = {};
@@ -165,7 +165,7 @@ KaleoTaskFormPair initialStateKaleoTaskFormPair = KaleoFormsUtil.getInitialState
 	Liferay.provide(
 		window,
 		'<portlet:namespace />editFormTemplate',
-		function (uri) {
+		(uri) => {
 			var A = AUI();
 
 			var WIN = A.config.win;
@@ -183,7 +183,7 @@ KaleoTaskFormPair initialStateKaleoTaskFormPair = KaleoFormsUtil.getInitialState
 	Liferay.provide(
 		window,
 		'<portlet:namespace />unassignForm',
-		function (event) {
+		(event) => {
 			var A = AUI();
 
 			var taskFormPairsParamName = event.taskFormPairsParamName;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/workflow.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/workflow.jsp
@@ -227,7 +227,7 @@ if (tabs1.equals("published")) {
 <aui:script>
 	Liferay.on(
 		'<portlet:namespace />chooseWorkflow',
-		function (event) {
+		(event) => {
 			var A = AUI();
 
 			var workflowDefinition = event.name + '@' + event.version;
@@ -256,7 +256,7 @@ if (tabs1.equals("published")) {
 	);
 
 	window['<portlet:namespace />editWorkflow'] = function (uri) {
-		AUI().use('liferay-util', function (A) {
+		AUI().use('liferay-util', (A) => {
 			var WIN = A.config.win;
 
 			Liferay.Util.openWindow({

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view_kaleo_process.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view_kaleo_process.jsp
@@ -164,7 +164,7 @@ portletURL.setParameter("kaleoProcessId", String.valueOf(kaleoProcess.getKaleoPr
 	Liferay.provide(
 		window,
 		'<portlet:namespace />openPreviewDialog',
-		function (content) {
+		(content) => {
 			var Util = Liferay.Util;
 
 			var dialog = Util.getWindow('<portlet:namespace />previewDialog');
@@ -227,17 +227,17 @@ portletURL.setParameter("kaleoProcessId", String.valueOf(kaleoProcess.getKaleoPr
 		deleteRecords: deleteRecords,
 	};
 
-	Liferay.componentReady('kaleoFormsRecordsManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on(['actionItemClicked'], function (event) {
-			var itemData = event.data.item.data;
+	Liferay.componentReady('kaleoFormsRecordsManagementToolbar').then(
+		(managementToolbar) => {
+			managementToolbar.on(['actionItemClicked'], (event) => {
+				var itemData = event.data.item.data;
 
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
+				if (itemData && itemData.action && ACTIONS[itemData.action]) {
+					ACTIONS[itemData.action]();
+				}
+			});
+		}
+	);
 </aui:script>
 
 <%

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/import_certificate.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/import_certificate.jsp
@@ -68,11 +68,11 @@ if (Validator.isNotNull(tempFileName)) {
 					'<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/admin/update_certificate"><portlet:param name="<%= Constants.CMD %>" value="<%= Constants.ADD_TEMP %>" /></liferay-portlet:resourceURL>',
 			});
 
-			liferayUpload._uploader.on('alluploadscomplete', function (event) {
+			liferayUpload._uploader.on('alluploadscomplete', (event) => {
 				toggleContinueButton();
 			});
 
-			Liferay.on('tempFileRemoved', function (event) {
+			Liferay.on('tempFileRemoved', (event) => {
 				toggleContinueButton();
 			});
 
@@ -206,7 +206,7 @@ if (Validator.isNotNull(tempFileName)) {
 				'input[name="<portlet:namespace />selectKeyStoreAlias"]'
 			);
 
-			keyStoreEntryRadios.on('click', function (event) {
+			keyStoreEntryRadios.on('click', (event) => {
 				var keyStoreEntryAlias = event.currentTarget.val();
 
 				A.all('.certificate-preview div[data-keyStoreEntryAlias]').hide();

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
@@ -27,7 +27,7 @@ SegmentsExperiment segmentsExperiment = (SegmentsExperiment)request.getAttribute
 		);
 
 		if (element) {
-			element.addEventListener('click', function (event) {
+			element.addEventListener('click', (event) => {
 				if (window.Analytics) {
 					Analytics.send('ctaClicked', 'Page', {elementId: event.target.id});
 				}

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/view.jsp
@@ -41,21 +41,21 @@
 		segmentsExperimentPanelToggle
 	);
 
-	sidenavInstance.on('open.lexicon.sidenav', function (event) {
+	sidenavInstance.on('open.lexicon.sidenav', (event) => {
 		Liferay.Util.Session.set(
 			'com.liferay.segments.experiment.web_panelState',
 			'open'
 		);
 	});
 
-	sidenavInstance.on('closed.lexicon.sidenav', function (event) {
+	sidenavInstance.on('closed.lexicon.sidenav', (event) => {
 		Liferay.Util.Session.set(
 			'com.liferay.segments.experiment.web_panelState',
 			'closed'
 		);
 	});
 
-	Liferay.once('screenLoad', function () {
+	Liferay.once('screenLoad', () => {
 		Liferay.SideNavigation.destroy(segmentsExperimentPanelToggle);
 	});
 </aui:script>

--- a/modules/package.json
+++ b/modules/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"@liferay/npm-scripts": "36.11.0",
+		"@liferay/npm-scripts": "37.0.0",
 		"acorn": "7.1.0",
 		"alloy-ui": "^3.1.0-deprecated.40",
 		"babel-plugin-incremental-dom": "3.4.0",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1538,10 +1538,10 @@
   resolved "https://registry.yarnpkg.com/@liferay/amd-loader/-/amd-loader-4.3.1.tgz#35cde6128f6e2795b7e45378e8f115f596b6cdda"
   integrity sha512-95i+LRK3gPTiBc75lJsr9OwRNFdzaamSe3B5x+kHLHYr78qS/4WD5mkDJ+WYv3CY0jFFnROTNLl3x6zCRuDMxw==
 
-"@liferay/eslint-config@21.2.1":
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/@liferay/eslint-config/-/eslint-config-21.2.1.tgz#cd29c21140098a49d566c37082467d5787aeb90b"
-  integrity sha512-fPnX6Un8zypPeAQ+GHSp67JnooBq56S39oCAQvP6fubgxOCD9vzeGG1lkeEhgMwpvo3D2zn2hNc0zlKJhtnOcA==
+"@liferay/eslint-config@21.3.0":
+  version "21.3.0"
+  resolved "https://registry.yarnpkg.com/@liferay/eslint-config/-/eslint-config-21.3.0.tgz#f7de96adb23c85d8243e2b3f8172977d2d2e40b3"
+  integrity sha512-036dX4ClIdW/IbPpsEfWHXM2XSjcpqLDuE7HiXWyng4aKbG12mAnL6w214uWvr001m3m49HEaK0mk/v3MFVqkA==
   dependencies:
     "@typescript-eslint/eslint-plugin" "4.3.0"
     "@typescript-eslint/parser" "4.3.0"
@@ -1622,10 +1622,10 @@
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-"@liferay/npm-scripts@36.11.0":
-  version "36.11.0"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-36.11.0.tgz#866418b1bd89adf612342608a37dd059a8b5889c"
-  integrity sha512-sgxfrrUbPk0+vP9ILIpm/fj3M0xHfIFI3jgS9pTKri2RC6pDMUSn/q44tqzgAD6a8Xo6wF/uRqkgkxKLb670Mw==
+"@liferay/npm-scripts@37.0.0":
+  version "37.0.0"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-37.0.0.tgz#e564e4a17bd87aa45e2b185441049d6e674d22e1"
+  integrity sha512-8xPjo7fFWjQrPujb9XhQ1qJpgKTB1sI3MxUWzHpbBbL9P5EH7WpYZf+r/ZdA96d/P8AhmtNMTNjdaW9ox1R6LQ==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"
@@ -1637,7 +1637,7 @@
     "@babel/preset-env" "^7.4.2"
     "@babel/preset-react" "^7.8.3"
     "@babel/preset-typescript" "^7.10.4"
-    "@liferay/eslint-config" "21.2.1"
+    "@liferay/eslint-config" "21.3.0"
     "@liferay/jest-junit-reporter" "1.2.0"
     "@liferay/js-toolkit-core" "3.0.1-pre.1"
     "@liferay/npm-bundler-preset-liferay-dev" "4.6.5"


### PR DESCRIPTION
Manual forward from https://github.com/liferay-frontend/liferay-portal/pull/800 due to CI infra failure; `ci:test:stable` at least is green. Sending this manually because it is a fully-automated change (easily re-doable if we have to rebase) so scope for human error is minimal.

Original message follows.

---

[Release notes](https://github.com/liferay/liferay-frontend-projects/releases/tag/npm-scripts%2Fv37.0.0).

This is going to change our lint rules when on 7.4 and above, so I am splitting this into two commits: one updates the package, and the next one applies somewhat over 1,000 autofixes.

Specifically, on 7.4 and above, we no longer need to support IE so we can enforce the same preference for arrow function callbacks in our JSPs that we do in our JS files. (The JS files could do this even on earlier branches because those get transpiled.)