### PR TITLE
LPS-125811 Wait for the ckeditor to load before typing

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/WikiPage.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WikiPage.macro
@@ -299,10 +299,8 @@ definition {
 			locator1 = "Wiki#FRONTPAGE_DEFAULT_MESSAGE",
 			value1 = "${emptyPageMessage}");
 
-		SelectFrame.selectFrameNoLoading(locator1 = "CKEditor#BODY_FIELD_IFRAME");
-
-		Type(
-			locator1 = "CKEditor#BODY",
+		Type.typeCKEditorWaitForCKEditor(
+			locator1 = "CKEditor#BODY_FIELD",
 			value1 = "${wikiPageContent}");
 
 		if ("${rtl}" == "true") {
@@ -311,6 +309,8 @@ definition {
 		else {
 			var textDirection = "ltr";
 		}
+
+		SelectFrame.selectFrameNoLoading(locator1 = "CKEditor#BODY_FIELD_IFRAME");
 
 		AssertElementPresent(locator1 = "//body[contains(@class,'cke_contents_${textDirection}')]");
 


### PR DESCRIPTION
Manual forward from [liferay-frontend#827](https://github.com/liferay-frontend/liferay-portal/pull/827).

[QA review](https://github.com/liferay-frontend/liferay-portal/pull/827#issuecomment-783739297) shows [failure](https://github.com/liferay-frontend/liferay-portal/pull/827#issuecomment-783670237) is unrelated, plus [additional sign off from QA here](https://github.com/liferay-frontend/liferay-portal/pull/827#issuecomment-784009895).

Original PR description follows:

---

**Description**
This fixes the failing test WYSIWYGUsecase#ViewWikiFrontPageRightToLeft due to a timing issue waiting for CKEditor to load on wiki portlet

**Test Plan**
- :heavy_check_mark: Failing test WYSIWYGUsecase#ViewWikiFrontPageRightToLeft passes: https://github.com/john-co/liferay-portal/pull/380

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-125811
