### PR TITLE
LPS-128125 Run baseline task for frontend-js-loader-modules-extender-api

### DIFF
--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/resources/com/liferay/frontend/js/loader/modules/extender/npm/packageinfo
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/resources/com/liferay/frontend/js/loader/modules/extender/npm/packageinfo
@@ -1,1 +1,1 @@
-version 3.5.0
+version 3.5.1


### PR DESCRIPTION
Manual forward from https://github.com/liferay-frontend/liferay-portal/pull/828 seeing as we see multiple PRs with the same obviously unrelated "unique" failure:

- https://github.com/liferay-frontend/liferay-portal/pull/828#issuecomment-784155909
- https://github.com/liferay-frontend/liferay-portal/pull/828#issuecomment-784211180
- https://github.com/liferay-frontend/liferay-portal/pull/830#issuecomment-784196923
- https://github.com/liferay-frontend/liferay-portal/pull/829#issuecomment-784199514

Original description follows.

---

ie. `cd modules/apps/frontend-js/frontend-js-loader-modules-extender-api && gradlew baseline`