### PR TITLE
LPS-127039 Run baseline task for frontend-taglib

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 2.5.0
+version 2.7.0


### PR DESCRIPTION
Manual forward from https://github.com/liferay-frontend/liferay-portal/pull/830 seeing as we see multiple PRs with the same obviously unrelated "unique" failure:

- https://github.com/liferay-frontend/liferay-portal/pull/828#issuecomment-784155909
- https://github.com/liferay-frontend/liferay-portal/pull/828#issuecomment-784211180
- https://github.com/liferay-frontend/liferay-portal/pull/830#issuecomment-784196923
- https://github.com/liferay-frontend/liferay-portal/pull/829#issuecomment-784199514

Original description follows.

---

ie. `cd modules/apps/frontend-taglib/frontend-taglib && gradlew baseline`