### PR TITLE
LPS-127020 Move autoFocus functionality to the management toolbar taglib

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/management_toolbars.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/management_toolbars.jsp
@@ -31,6 +31,7 @@ ClaySampleManagementToolbarsDisplayContext managementToolbarsDisplayContext = ne
 	filterDropdownItems="<%= managementToolbarsDisplayContext.getFilterDropdownItems() %>"
 	searchActionURL="mySearchActionURL?key1=val1&key2=val2&key3=val3"
 	searchFormName="mySearchName"
+	searchInputAutoFocus="<%= true %>"
 	searchInputName="mySearchInputName"
 	selectable="<%= true %>"
 	sortingOrder="desc"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/display/context/ManagementToolbarDefaults.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/display/context/ManagementToolbarDefaults.java
@@ -47,6 +47,10 @@ public class ManagementToolbarDefaults {
 		return false;
 	}
 
+	public static Boolean isSearchInputAutoFocus() {
+		return false;
+	}
+
 	public static Boolean isSelectable() {
 		return true;
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -310,6 +310,18 @@ public class ManagementToolbarTag extends BaseContainerTag {
 		return _disabled;
 	}
 
+	public Boolean isSearchInputAutoFocus() {
+		if (_searchInputAutoFocus == null) {
+			if (_managementToolbarDisplayContext != null) {
+				_managementToolbarDisplayContext.isSearchInputAutoFocus();
+			}
+
+			return ManagementToolbarDefaults.isSearchInputAutoFocus();
+		}
+
+		return _searchInputAutoFocus;
+	}
+
 	public Boolean isSelectable() {
 		if (_selectable == null) {
 			if (_managementToolbarDisplayContext != null) {
@@ -465,6 +477,10 @@ public class ManagementToolbarTag extends BaseContainerTag {
 		_searchFormName = searchFormName;
 	}
 
+	public void setSearchInputAutoFocus(Boolean searchInputAutoFocus) {
+		_searchInputAutoFocus = searchInputAutoFocus;
+	}
+
 	public void setSearchInputName(String searchInputName) {
 		_searchInputName = searchInputName;
 	}
@@ -566,6 +582,7 @@ public class ManagementToolbarTag extends BaseContainerTag {
 		_searchContainerId = null;
 		_searchFormMethod = null;
 		_searchFormName = null;
+		_searchInputAutoFocus = null;
 		_searchInputName = null;
 		_searchValue = null;
 		_selectable = null;
@@ -624,6 +641,7 @@ public class ManagementToolbarTag extends BaseContainerTag {
 
 		props.put("searchFormMethod", searchFormMethod);
 		props.put("searchFormName", _namespace(namespace, getSearchFormName()));
+		props.put("searchInputAutoFocus", isSearchInputAutoFocus());
 		props.put(
 			"searchInputName", _namespace(namespace, getSearchInputName()));
 		props.put("searchValue", getSearchValue());
@@ -1166,6 +1184,7 @@ public class ManagementToolbarTag extends BaseContainerTag {
 	private String _searchContainerId;
 	private String _searchFormMethod;
 	private String _searchFormName;
+	private Boolean _searchInputAutoFocus;
 	private String _searchInputName;
 	private String _searchValue;
 	private Boolean _selectable;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/display/context/ManagementToolbarDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/display/context/ManagementToolbarDisplayContext.java
@@ -138,6 +138,10 @@ public interface ManagementToolbarDisplayContext {
 		return false;
 	}
 
+	public default Boolean isSearchInputAutoFocus() {
+		return ManagementToolbarDefaults.isSearchInputAutoFocus();
+	}
+
 	public default Boolean isSelectable() {
 		return true;
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1757,6 +1757,12 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>searchInputAutoFocus</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>searchInputName</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -53,6 +53,7 @@ function ManagementToolbar({
 	searchData,
 	searchFormMethod,
 	searchFormName,
+	searchInputAutoFocus,
 	searchInputName,
 	searchValue,
 	selectAllURL,
@@ -116,6 +117,7 @@ function ManagementToolbar({
 						searchData={searchData}
 						searchFormMethod={searchFormMethod}
 						searchFormName={searchFormName}
+						searchInputAutoFocus={searchInputAutoFocus}
 						searchInputName={searchInputName}
 						searchMobile={searchMobile}
 						searchValue={searchValue}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
@@ -23,6 +23,7 @@ const SearchControls = ({
 	searchData,
 	searchFormMethod,
 	searchFormName,
+	searchInputAutoFocus,
 	searchInputName,
 	searchMobile,
 	searchValue,
@@ -39,6 +40,7 @@ const SearchControls = ({
 				<ClayInput.Group>
 					<ClayInput.GroupItem>
 						<ClayInput
+							autoFocus={searchInputAutoFocus}
 							className="form-control input-group-inset input-group-inset-after"
 							defaultValue={searchValue}
 							disabled={disabled}


### PR DESCRIPTION
Manual forward from: https://github.com/liferay-frontend/liferay-portal/pull/833

CI [was green here](https://github.com/liferay-frontend/liferay-portal/pull/833#issuecomment-784412273), other than the known-issue upstream failure (`LocalFile.WebContentWithCustomStructures#AddWebContentWithRepeatableRichTextField`) that was fixed yesterday.

Original PR description follows.

---

Task ticket: https://issues.liferay.com/browse/LPS-127020
Related discussions:
- https://github.com/liferay/clay/issues/3895
- https://github.com/liferay-frontend/liferay-portal/pull/826

Notes:
- By default, we are not auto-focusing the search input. This is because Lexicon does not state this behavior and vast majorities on usages in DXP do not auto-focus. See https://github.com/liferay-frontend/liferay-portal/pull/826#issuecomment-784141719
- There is an ongoing discussion about how to name the attribute, see https://github.com/liferay-frontend/liferay-portal/pull/826#issuecomment-784148077. In this PR I chose `searchInputAutoFocus` because
```jsp
<clay:management-toolbar
	searchInputAutoFocus="<%= true %>"
	searchInputName="mySearchInputName"
/>
```
rhymes with
```js
<ClayInput
	autoFocus={searchInputAutoFocus}
	name={searchInputName}
/>
```
- Intrestingly, React's `autoFocus`, capital `F`, is quite different from HTML `autofocus`. To prevent cross-browser inconsistencies, [they are using a polyfill to call .focus()](https://github.com/facebook/react/issues/11851#issuecomment-351672131).

/cc @wincent @4lejandrito @jbalsas @julien @jonmak08 @ambrinchaudhary 

Test sample in clay-sample-web:

![after](https://user-images.githubusercontent.com/5435511/108858763-cf903c00-75ec-11eb-913c-3b9e44dff5d8.gif)

