### PR TITLE
LPS-128549 Add properties for Liferay Online

### DIFF
--- a/portal-impl/src/portal-liferay-online.properties
+++ b/portal-impl/src/portal-liferay-online.properties
@@ -1,0 +1,362 @@
+data.limit.dl.storage.max.size=1073741824
+data.limit.mail.message.max.count=200
+data.limit.mail.message.max.period=1
+data.limit.model.max.count[com.liferay.blogs.model.BlogEntry]=200
+data.limit.model.max.count[com.liferay.document.library.kernel.model.DLFileEntry]=200
+data.limit.model.max.count[com.liferay.document.library.kernel.model.DLFolder]=100
+data.limit.model.max.count[com.liferay.journal.model.JournalArticle]=300
+data.limit.model.max.count[com.liferay.journal.model.JournalFolder]=100
+data.limit.model.max.count[com.liferay.knowledge.base.model.KBArticle]=200
+data.limit.model.max.count[com.liferay.knowledge.base.model.KBFolder]=100
+data.limit.model.max.count[com.liferay.message.boards.model.MBCategory]=100
+data.limit.model.max.count[com.liferay.message.boards.model.MBMessage]=200
+data.limit.model.max.count[com.liferay.portal.kernel.model.Group]=20
+data.limit.model.max.count[com.liferay.portal.kernel.model.Layout]=50
+data.limit.model.max.count[com.liferay.portal.kernel.model.Organization]=50
+data.limit.model.max.count[com.liferay.portal.kernel.model.Role]=100
+data.limit.model.max.count[com.liferay.portal.kernel.model.Team]=50
+data.limit.model.max.count[com.liferay.portal.kernel.model.User]=100
+data.limit.model.max.count[com.liferay.site.navigation.model.SiteNavigationMenu]=40
+data.limit.model.max.count[com.liferay.site.navigation.model.SiteNavigationMenuItem]=20
+data.limit.model.max.count[com.liferay.wiki.model.WikiNode]=100
+data.limit.model.max.count[com.liferay.wiki.model.WikiPage]=200
+data.limit.site.max.count=20
+
+database.partition.enabled=true
+layout.user.private.layouts.enabled=false
+layout.user.public.layouts.enabled=false
+jsonws.web.service.api.discoverable=false
+jsonws.servlet.hosts.allowed=127.0.0.1
+trash.search.limit=200
+trash.entry.check.interval=300
+
+dl.store.impl=com.liferay.portal.store.file.system.AdvancedFileSystemStore
+configuration.override.com.liferay.portal.store.file.system.configuration.AdvancedFileSystemStoreConfiguration_rootDir="data/document_library"
+
+configuration.override.com.liferay.document.library.configuration.DLConfiguration_fileExtensions=[ \
+    "doc", \
+    "docx", \
+    "jpeg", \
+    "jpg", \
+    "pdf", \
+    "png", \
+    "ppt", \
+    "pptx", \
+    "tiff", \
+    "txt", \
+    "xls", \
+    "xlsx", \
+    ]
+configuration.override.com.liferay.dynamic.data.mapping.data.provider.configuration.DDMDataProviderConfiguration_accessLocalNetwork=B"false"
+configuration.override.com.liferay.dynamic.data.mapping.form.web.internal.configuration.DDMFormWebConfiguration_guestUploadMaximumFileSize=I"10"
+configuration.override.com.liferay.dynamic.data.mapping.form.web.internal.configuration.DDMFormWebConfiguration_maximumRepetitionsForUploadFields=I"5"
+configuration.override.com.liferay.dynamic.data.mapping.form.web.internal.configuration.DDMFormWebConfiguration_maximumSubmissionsForGuestUploadFields=I"3"
+configuration.override.com.liferay.dynamic.data.mapping.form.web.internal.configuration.DDMFormWebConfiguration_guestUploadFileExtensions=[ \
+    "doc", \
+    "docx", \
+    "jpeg", \
+    "jpg", \
+    "pdf", \
+    "png", \
+    "ppt", \
+    "pptx", \
+    "tiff", \
+    "txt", \
+    "xls", \
+    "xlsx", \
+    ]
+configuration.override.com.liferay.journal.configuration.JournalServiceConfiguration_indexAllArticleVersionsEnabled=B"false"
+configuration.override.com.liferay.journal.configuration.JournalServiceConfiguration_journalArticleMaxVersionCount=I"30"
+
+configuration.override.com.liferay.portal.bundle.blacklist.internal.configuration.BundleBlacklistConfiguration_blacklistBundleSymbolicNames=[ \
+    "com.liferay.account.admin.web", \
+    "com.liferay.announcements.web", \
+    "com.liferay.calendar.web", \
+    "com.liferay.change.tracking.web", \
+    "com.liferay.commerce.account.admin.web", \
+    "com.liferay.commerce.account.api", \
+    "com.liferay.commerce.account.group.admin.web", \
+    "com.liferay.commerce.account.item.selector.api", \
+    "com.liferay.commerce.account.item.selector.web", \
+    "com.liferay.commerce.account.service", \
+    "com.liferay.commerce.account.web", \
+    "com.liferay.commerce.address.content.web", \
+    "com.liferay.commerce.address.web", \
+    "com.liferay.commerce.api", \
+    "com.liferay.commerce.application.admin.web", \
+    "com.liferay.commerce.application.api", \
+    "com.liferay.commerce.application.item.selector.api", \
+    "com.liferay.commerce.application.item.selector.web", \
+    "com.liferay.commerce.application.list", \
+    "com.liferay.commerce.application.service", \
+    "com.liferay.commerce.availability.estimate.web", \
+    "com.liferay.commerce.avalara.connector", \
+    "com.liferay.commerce.avalara.connector.api", \
+    "com.liferay.commerce.avalara.lang", \
+    "com.liferay.commerce.avalara.tax.engine.fixed", \
+    "com.liferay.commerce.avalara.tax.engine.fixed.web", \
+    "com.liferay.commerce.bom.admin.web", \
+    "com.liferay.commerce.bom.api", \
+    "com.liferay.commerce.bom.service", \
+    "com.liferay.commerce.bom.web", \
+    "com.liferay.commerce.cart.content.web", \
+    "com.liferay.commerce.cart.taglib", \
+    "com.liferay.commerce.catalog.web", \
+    "com.liferay.commerce.channel.web", \
+    "com.liferay.commerce.checkout.web", \
+    "com.liferay.commerce.currency.api", \
+    "com.liferay.commerce.currency.service", \
+    "com.liferay.commerce.currency.web", \
+    "com.liferay.commerce.dashboard.web", \
+    "com.liferay.commerce.data.integration.web", \
+    "com.liferay.commerce.discount.api", \
+    "com.liferay.commerce.discount.content.web", \
+    "com.liferay.commerce.discount.service", \
+    "com.liferay.commerce.elasticsearch7", \
+    "com.liferay.commerce.frontend.api", \
+    "com.liferay.commerce.frontend.impl", \
+    "com.liferay.commerce.frontend.js", \
+    "com.liferay.commerce.frontend.taglib", \
+    "com.liferay.commerce.geocoder.bing", \
+    "com.liferay.commerce.google.merchant", \
+    "com.liferay.commerce.health.status.web", \
+    "com.liferay.commerce.initializer.util", \
+    "com.liferay.commerce.inventory.api", \
+    "com.liferay.commerce.inventory.service", \
+    "com.liferay.commerce.inventory.web", \
+    "com.liferay.commerce.item.selector.api", \
+    "com.liferay.commerce.item.selector.web", \
+    "com.liferay.commerce.lang", \
+    "com.liferay.commerce.machine.learning.api", \
+    "com.liferay.commerce.machine.learning.forecast.alert.api", \
+    "com.liferay.commerce.machine.learning.forecast.alert.lang", \
+    "com.liferay.commerce.machine.learning.forecast.alert.service", \
+    "com.liferay.commerce.machine.learning.forecast.alert.web", \
+    "com.liferay.commerce.machine.learning.impl", \
+    "com.liferay.commerce.media.api", \
+    "com.liferay.commerce.media.impl", \
+    "com.liferay.commerce.notification.api", \
+    "com.liferay.commerce.notification.service", \
+    "com.liferay.commerce.notification.web", \
+    "com.liferay.commerce.order.content.web", \
+    "com.liferay.commerce.order.web", \
+    "com.liferay.commerce.organization.api", \
+    "com.liferay.commerce.organization.web", \
+    "com.liferay.commerce.payment.api", \
+    "com.liferay.commerce.payment.method.authorize.net", \
+    "com.liferay.commerce.payment.method.mercanet", \
+    "com.liferay.commerce.payment.method.money.order", \
+    "com.liferay.commerce.payment.method.paypal", \
+    "com.liferay.commerce.payment.service", \
+    "com.liferay.commerce.payment.web", \
+    "com.liferay.commerce.price.list.api", \
+    "com.liferay.commerce.price.list.service", \
+    "com.liferay.commerce.pricing.api", \
+    "com.liferay.commerce.pricing.service", \
+    "com.liferay.commerce.pricing.web", \
+    "com.liferay.commerce.product.api", \
+    "com.liferay.commerce.product.asset.categories.navigation.web", \
+    "com.liferay.commerce.product.asset.categories.web", \
+    "com.liferay.commerce.product.content.api", \
+    "com.liferay.commerce.product.content.category.web", \
+    "com.liferay.commerce.product.content.search.web", \
+    "com.liferay.commerce.product.content.web", \
+    "com.liferay.commerce.product.ddm.api", \
+    "com.liferay.commerce.product.ddm.impl", \
+    "com.liferay.commerce.product.definitions.web", \
+    "com.liferay.commerce.product.item.selector.api", \
+    "com.liferay.commerce.product.item.selector.web", \
+    "com.liferay.commerce.product.measurement.unit.web", \
+    "com.liferay.commerce.product.options.web", \
+    "com.liferay.commerce.product.service", \
+    "com.liferay.commerce.product.subscription.type.web", \
+    "com.liferay.commerce.product.taglib", \
+    "com.liferay.commerce.product.tax.category.web", \
+    "com.liferay.commerce.product.type.grouped.api", \
+    "com.liferay.commerce.product.type.grouped.service", \
+    "com.liferay.commerce.product.type.grouped.web", \
+    "com.liferay.commerce.product.type.simple", \
+    "com.liferay.commerce.product.type.virtual.api", \
+    "com.liferay.commerce.product.type.virtual.order.api", \
+    "com.liferay.commerce.product.type.virtual.order.content.web", \
+    "com.liferay.commerce.product.type.virtual.order.service", \
+    "com.liferay.commerce.product.type.virtual.service", \
+    "com.liferay.commerce.product.type.virtual.web", \
+    "com.liferay.commerce.punchout.api", \
+    "com.liferay.commerce.punchout.lang", \
+    "com.liferay.commerce.punchout.oauth2.provider.api", \
+    "com.liferay.commerce.punchout.oauth2.provider.rest", \
+    "com.liferay.commerce.punchout.portal.security.auto.login", \
+    "com.liferay.commerce.punchout.service", \
+    "com.liferay.commerce.punchout.web", \
+    "com.liferay.commerce.salesforce.connector.talend.job.deployer", \
+    "com.liferay.commerce.service", \
+    "com.liferay.commerce.shipment.content.web", \
+    "com.liferay.commerce.shipment.web", \
+    "com.liferay.commerce.shipping.engine.fedex", \
+    "com.liferay.commerce.shipping.engine.fixed.api", \
+    "com.liferay.commerce.shipping.engine.fixed.service", \
+    "com.liferay.commerce.shipping.engine.fixed.web", \
+    "com.liferay.commerce.shipping.origin.locator", \
+    "com.liferay.commerce.shipping.origin.locator.api", \
+    "com.liferay.commerce.shipping.web", \
+    "com.liferay.commerce.subscription.web", \
+    "com.liferay.commerce.taglib", \
+    "com.liferay.commerce.talend.job.deployer.api", \
+    "com.liferay.commerce.tax.api", \
+    "com.liferay.commerce.tax.engine.fixed.api", \
+    "com.liferay.commerce.tax.engine.fixed.service", \
+    "com.liferay.commerce.tax.engine.fixed.web", \
+    "com.liferay.commerce.tax.engine.remote", \
+    "com.liferay.commerce.tax.service", \
+    "com.liferay.commerce.tax.web", \
+    "com.liferay.commerce.theme.minium.api", \
+    "com.liferay.commerce.theme.minium.full.site.initializer", \
+    "com.liferay.commerce.theme.minium.impl", \
+    "com.liferay.commerce.theme.minium.site.initializer", \
+    "com.liferay.commerce.theme.speedwell.site.initializer", \
+    "com.liferay.commerce.warehouse.web", \
+    "com.liferay.commerce.wish.list.api", \
+    "com.liferay.commerce.wish.list.service", \
+    "com.liferay.commerce.wish.list.web", \
+    "com.liferay.configuration.admin.web", \
+    "com.liferay.connected.app.web", \
+    "com.liferay.contacts.web", \
+    "com.liferay.content.dashboard.web", \
+    "com.liferay.depot.web", \
+    "com.liferay.dispatch.talend.web", \
+    "com.liferay.dispatch.web", \
+    "com.liferay.exportimport.web", \
+    "com.liferay.flags.web", \
+    "com.liferay.headless.commerce.admin.account.api", \
+    "com.liferay.headless.commerce.admin.account.client", \
+    "com.liferay.headless.commerce.admin.account.impl", \
+    "com.liferay.headless.commerce.admin.catalog.api", \
+    "com.liferay.headless.commerce.admin.catalog.client", \
+    "com.liferay.headless.commerce.admin.catalog.impl", \
+    "com.liferay.headless.commerce.admin.channel.api", \
+    "com.liferay.headless.commerce.admin.channel.client", \
+    "com.liferay.headless.commerce.admin.channel.impl", \
+    "com.liferay.headless.commerce.admin.inventory.api", \
+    "com.liferay.headless.commerce.admin.inventory.client", \
+    "com.liferay.headless.commerce.admin.inventory.impl", \
+    "com.liferay.headless.commerce.admin.order.api", \
+    "com.liferay.headless.commerce.admin.order.client", \
+    "com.liferay.headless.commerce.admin.order.impl", \
+    "com.liferay.headless.commerce.admin.pricing.api", \
+    "com.liferay.headless.commerce.admin.pricing.client", \
+    "com.liferay.headless.commerce.admin.pricing.impl", \
+    "com.liferay.headless.commerce.admin.site.setting.api", \
+    "com.liferay.headless.commerce.admin.site.setting.client", \
+    "com.liferay.headless.commerce.admin.site.setting.impl", \
+    "com.liferay.headless.commerce.bom.api", \
+    "com.liferay.headless.commerce.bom.impl", \
+    "com.liferay.headless.commerce.core.api", \
+    "com.liferay.headless.commerce.core.impl", \
+    "com.liferay.headless.commerce.delivery.cart.api", \
+    "com.liferay.headless.commerce.delivery.cart.client", \
+    "com.liferay.headless.commerce.delivery.cart.impl", \
+    "com.liferay.headless.commerce.delivery.catalog.api", \
+    "com.liferay.headless.commerce.delivery.catalog.client", \
+    "com.liferay.headless.commerce.delivery.catalog.impl", \
+    "com.liferay.headless.commerce.machine.learning.api", \
+    "com.liferay.headless.commerce.machine.learning.impl", \
+    "com.liferay.headless.commerce.punchout.api", \
+    "com.liferay.headless.commerce.punchout.impl", \
+    "com.liferay.headless.discovery.web", \
+    "com.liferay.hello.velocity.web", \
+    "com.liferay.invitation.invite.members.web", \
+    "com.liferay.knowledge.base.item.selector.web", \
+    "com.liferay.knowledge.base.web", \
+    "com.liferay.layout.set.prototype.web", \
+    "com.liferay.lcs.api", \
+    "com.liferay.lcs.client.api", \
+    "com.liferay.lcs.client.impl", \
+    "com.liferay.lcs.client.web", \
+    "com.liferay.lcs.keystore", \
+    "com.liferay.lcs.messaging", \
+    "com.liferay.lcs.security", \
+    "com.liferay.login.authentication.facebook.connect.web", \
+    "com.liferay.login.authentication.openid.connect.web", \
+    "com.liferay.login.authentication.opensso.web", \
+    "com.liferay.marketplace.app.manager.web", \
+    "com.liferay.marketplace.store.web", \
+    "com.liferay.microblogs.web", \
+    "com.liferay.mobile.device.rules.web", \
+    "com.liferay.monitoring.web", \
+    "com.liferay.multi.factor.authentication.email.otp.web", \
+    "com.liferay.multi.factor.authentication.fido2.web", \
+    "com.liferay.multi.factor.authentication.timebased.otp.web", \
+    "com.liferay.multi.factor.authentication.web", \
+    "com.liferay.my.subscriptions.web", \
+    "com.liferay.nested.portlets.web", \
+    "com.liferay.notifications.web", \
+    "com.liferay.oauth2.provider.web", \
+    "com.liferay.organizations.item.selector.web", \
+    "com.liferay.password.policies.admin.web", \
+    "com.liferay.plugins.admin.web", \
+    "com.liferay.polls.web", \
+    "com.liferay.portal.reports.engine.console.web", \
+    "com.liferay.portal.search.tuning.rankings.web", \
+    "com.liferay.portal.search.tuning.synonyms.web", \
+    "com.liferay.portal.security.audit.web", \
+    "com.liferay.portal.security.service.access.policy.web", \
+    "com.liferay.portal.security.sso.cas.api", \
+    "com.liferay.portal.security.sso.cas.impl", \
+    "com.liferay.portal.security.sso.facebook.connect.api", \
+    "com.liferay.portal.security.sso.facebook.connect.impl", \
+    "com.liferay.portal.security.sso.google.api", \
+    "com.liferay.portal.security.sso.google.impl", \
+    "com.liferay.portal.security.sso.google.login.authentication.web", \
+    "com.liferay.portal.security.sso.google.settings.authentication.web", \
+    "com.liferay.portal.security.sso.ntlm.api", \
+    "com.liferay.portal.security.sso.ntlm.impl", \
+    "com.liferay.portal.security.sso.ntlm.settings.authentication.web", \
+    "com.liferay.portal.security.sso.openid.connect.api", \
+    "com.liferay.portal.security.sso.openid.connect.impl", \
+    "com.liferay.portal.security.sso.opensso.api", \
+    "com.liferay.portal.security.sso.opensso.impl", \
+    "com.liferay.portal.security.sso.token.api", \
+    "com.liferay.portal.security.sso.token.imp", \
+    "com.liferay.portal.security.sso.token.impl", \
+    "com.liferay.portal.settings.authentication.cas.web", \
+    "com.liferay.portal.settings.authentication.facebook.connect.web", \
+    "com.liferay.portal.settings.authentication.ldap.web", \
+    "com.liferay.portal.settings.authentication.openid.connect.web", \
+    "com.liferay.portal.settings.authentication.opensso.web", \
+    "com.liferay.portal.settings.authentication.token.web", \
+    "com.liferay.portal.settings.web", \
+    "com.liferay.portal.workflow.kaleo.designer.web", \
+    "com.liferay.portal.workflow.kaleo.forms.web", \
+    "com.liferay.portal.workflow.metrics.web", \
+    "com.liferay.portal.workflow.task.web", \
+    "com.liferay.portal.workflow.web", \
+    "com.liferay.push.notifications.web", \
+    "com.liferay.questions.web", \
+    "com.liferay.redirect.web", \
+    "com.liferay.remote.app.admin.web", \
+    "com.liferay.remote.app.support.web", \
+    "com.liferay.roles.admin.web", \
+    "com.liferay.roles.item.selector.web", \
+    "com.liferay.roles.selector.web", \
+    "com.liferay.rss.web", \
+    "com.liferay.saml.addon.keep.alive.web", \
+    "com.liferay.saml.web", \
+    "com.liferay.segments.experiment.web", \
+    "com.liferay.segments.simulation.web", \
+    "com.liferay.segments.web", \
+    "com.liferay.sharepoint.rest.oauth2.web", \
+    "com.liferay.site.admin.web", \
+    "com.liferay.site.browser.web", \
+    "com.liferay.site.memberships.web", \
+    "com.liferay.site.my.sites.web", \
+    "com.liferay.site.teams.web", \
+    "com.liferay.social.activities.web", \
+    "com.liferay.staging.bar.web", \
+    "com.liferay.staging.configuration.web", \
+    "com.liferay.staging.processes.web", \
+    "com.liferay.user.associated.data.web", \
+    "com.liferay.user.groups.admin.item.selector.web", \
+    "com.liferay.user.groups.admin.web", \
+    "com.liferay.users.admin.item.selector.web", \
+    ]


### PR DESCRIPTION
Hey @brianchandotcom,

@zsoltbalogh and I think that this could be a simple way to define and maintain Liferay Online specific settings. Any thoughts?
The file contains the values that @vicnate5 and @achaparro added to build-test.xml (see #99365). I still have to include some additional limitations to this list, but it's a good starting point.

If you like the idea, I'll ask them to remove the Liferay Online properties from build-text.xml, and load them from the new properties file. Also @zsoltbalogh would be able to use -Dexternal.properties=portal-liferay-online.properties to run the DXP image on SaaS with the Liferay Online settings. 