### PR TITLE
LPS-128194 Delete author information from general Layouts Content Performance Panel. 

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-layout-impl/src/main/java/com/liferay/analytics/reports/layout/internal/info/item/LayoutAnalyticsReportsInfoItem.java
+++ b/modules/dxp/apps/analytics/analytics-reports-layout-impl/src/main/java/com/liferay/analytics/reports/layout/internal/info/item/LayoutAnalyticsReportsInfoItem.java
@@ -17,24 +17,19 @@ package com.liferay.analytics.reports.layout.internal.info.item;
 import com.liferay.analytics.reports.info.item.AnalyticsReportsInfoItem;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.type.WebImage;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -60,50 +55,17 @@ public class LayoutAnalyticsReportsInfoItem
 
 	@Override
 	public String getAuthorName(Layout layout) {
-		return _getUserOptional(
-			layout
-		).map(
-			User::getFullName
-		).orElse(
-			StringPool.BLANK
-		);
+		return null;
 	}
 
 	@Override
 	public long getAuthorUserId(Layout layout) {
-		return _getUserOptional(
-			layout
-		).map(
-			User::getUserId
-		).orElse(
-			0L
-		);
+		return 0L;
 	}
 
 	@Override
 	public WebImage getAuthorWebImage(Layout layout, Locale locale) {
-		ThemeDisplay themeDisplay = _getThemeDisplay();
-
-		if (themeDisplay == null) {
-			return new WebImage(StringPool.BLANK);
-		}
-
-		Optional<User> userOptional = _getUserOptional(layout);
-
-		return userOptional.map(
-			user -> {
-				try {
-					return new WebImage(user.getPortraitURL(themeDisplay));
-				}
-				catch (PortalException portalException) {
-					_log.error(portalException, portalException);
-
-					return new WebImage(StringPool.BLANK);
-				}
-			}
-		).orElse(
-			new WebImage(StringPool.BLANK)
-		);
+		return null;
 	}
 
 	@Override
@@ -173,22 +135,6 @@ public class LayoutAnalyticsReportsInfoItem
 		}
 
 		return true;
-	}
-
-	private ThemeDisplay _getThemeDisplay() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getThemeDisplay();
-		}
-
-		return null;
-	}
-
-	private Optional<User> _getUserOptional(Layout layout) {
-		return Optional.ofNullable(
-			_userLocalService.fetchUser(layout.getUserId()));
 	}
 
 	private boolean _hasEditPermission(

--- a/modules/dxp/apps/analytics/analytics-reports-layout-test/src/testIntegration/java/com/liferay/analytics/reports/layout/internal/info/item/test/LayoutAnalyticsReportsInfoItemTest.java
+++ b/modules/dxp/apps/analytics/analytics-reports-layout-test/src/testIntegration/java/com/liferay/analytics/reports/layout/internal/info/item/test/LayoutAnalyticsReportsInfoItemTest.java
@@ -85,31 +85,11 @@ public class LayoutAnalyticsReportsInfoItemTest {
 				StringPool.BLANK,
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
-			Assert.assertEquals(
-				user.getFullName(),
-				_analyticsReportsInfoItem.getAuthorName(layout));
+			Assert.assertNull(_analyticsReportsInfoItem.getAuthorName(layout));
 		}
 		finally {
 			_userLocalService.deleteUser(user);
 		}
-	}
-
-	@Test
-	public void testGetAuthorNameWithDeletedUser() throws Exception {
-		User user = UserTestUtil.addUser(_group.getGroupId());
-
-		Layout layout = _layoutLocalService.addLayout(
-			user.getUserId(), _group.getGroupId(), false,
-			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			StringPool.BLANK, LayoutConstants.TYPE_CONTENT, false,
-			StringPool.BLANK,
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		_userLocalService.deleteUser(user);
-
-		Assert.assertEquals(
-			StringPool.BLANK, _analyticsReportsInfoItem.getAuthorName(layout));
 	}
 
 	@Test
@@ -126,30 +106,11 @@ public class LayoutAnalyticsReportsInfoItemTest {
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 			Assert.assertEquals(
-				user.getUserId(),
-				_analyticsReportsInfoItem.getAuthorUserId(layout));
+				0L, _analyticsReportsInfoItem.getAuthorUserId(layout));
 		}
 		finally {
 			_userLocalService.deleteUser(user);
 		}
-	}
-
-	@Test
-	public void testGetAuthorUserIdWithDeletedUser() throws Exception {
-		User user = UserTestUtil.addUser(_group.getGroupId());
-
-		Layout layout = _layoutLocalService.addLayout(
-			user.getUserId(), _group.getGroupId(), false,
-			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			StringPool.BLANK, LayoutConstants.TYPE_CONTENT, false,
-			StringPool.BLANK,
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		_userLocalService.deleteUser(user);
-
-		Assert.assertEquals(
-			0L, _analyticsReportsInfoItem.getAuthorUserId(layout));
 	}
 
 	@Test

--- a/modules/dxp/apps/analytics/analytics-reports-test/src/testIntegration/java/com/liferay/analytics/reports/web/internal/portlet/action/test/GetDataMVCResourceCommandTest.java
+++ b/modules/dxp/apps/analytics/analytics-reports-test/src/testIntegration/java/com/liferay/analytics/reports/web/internal/portlet/action/test/GetDataMVCResourceCommandTest.java
@@ -98,10 +98,6 @@ public class GetDataMVCResourceCommandTest {
 			).analyticsReportsInfoItem(
 				MockAnalyticsReportsInfoItem.builder(
 				).build()
-			).layoutDisplayPageProvider(
-				MockLayoutDisplayPageProvider.builder(
-					_classNameLocalService
-				).build()
 			).build(),
 			() -> {
 				MockLiferayResourceRequest mockLiferayResourceRequest =
@@ -130,10 +126,7 @@ public class GetDataMVCResourceCommandTest {
 				JSONObject contextJSONObject = jsonObject.getJSONObject(
 					"context");
 
-				JSONObject authorJSONObject = contextJSONObject.getJSONObject(
-					"author");
-
-				Assert.assertNull(authorJSONObject.get("url"));
+				Assert.assertNull(contextJSONObject.getJSONObject("author"));
 			});
 	}
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
@@ -94,11 +94,13 @@ function BasicInformation({
 				</ClayLayout.ContentCol>
 			</ClayLayout.ContentRow>
 
-			<ClayLayout.ContentRow>
-				<ClayLayout.ContentCol expand>
-					<Author author={author} />
-				</ClayLayout.ContentCol>
-			</ClayLayout.ContentRow>
+			{author && (
+				<ClayLayout.ContentRow>
+					<ClayLayout.ContentCol expand>
+						<Author author={author} />
+					</ClayLayout.ContentCol>
+				</ClayLayout.ContentRow>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
**Problems with CI**

Trying to send it using ci:forward [here](https://github.com/liferay-tango/liferay-portal/pull/962), but has been imposible, we have other 2 PR on hold until this one is merged :(.

We have runned the test in the CI in https://test-1-3.liferay.com/userContent/jobs/test-portal-acceptance-pullrequest(master)/builds/9230/jenkins-report.html (and everything was green)

We rebase with Brian's master, trying to avoid future conflicts, and since that point, we have not been able to get a green CI, result (but we have confirmed that the broken tests are not related with this PR https://test-1-9.liferay.com/userContent/jobs/test-portal-acceptance-pullrequest(master)/builds/4456/jenkins-report.html)

/cc @pyoo47

**Motivation**

The content performance panel for widget and content will be the same that the web content's DPT, except for:
the author's field, that will be removed

**Proposed solution**

1. The Layout implementation of AnalyticsReportsInfoItem won't return the author information
2. The GetDataMVCCommand won't return the "author" information when this is not provided in the AnalyticsReportsInfoItem.
3. We should avoid display the author's ContentRow in JS.

![Screenshot 2021-03-02 at 22 43 10](https://user-images.githubusercontent.com/5776822/109719399-e284ac80-7ba8-11eb-95bd-97d8b16db7b7.png)
 
 /cc @dgarciasarai I have followed the idea you mentioned by author, we are not able to work into hide the reads, but we can try to hide the Author for the Layouts right now.