### PR TITLE
[TECHNICAL SUPPORT] LPS-127302 Site scope setting of Asset Publisher portlet does not work properly using Safari with disabled SPA 

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -352,6 +352,12 @@
 			if (currentElement) {
 				const url = currentElement.getAttribute('href');
 
+				// LPS-127302
+
+				if (url === 'javascript:;') {
+					return;
+				}
+
 				const newWindow =
 					currentElement.getAttribute('target') == '_blank';
 


### PR DESCRIPTION
Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/856 to avoid extra ci cycles.

--- 

This change makes it so we return early if we don't have a valid url to use at submitForm

If we don't, our default submitForm handler will set the form action to the `javascript:;` value which eventually goes nowhere.

This caused a bug in Safari which apparently aborts form submission if done in quick succession making it fail where other browsers apparently go through the first submission.

--- 

More context:

### The problem

We're apparently doing some double submission for some reason I fail to understand. The thing is:

- [IconTag](https://github.com/liferay/liferay-portal/blob/master/util-taglib/src/com/liferay/taglib/ui/IconTag.java#L312-L322) generates a specific `onClick` payload to trigger a `submitForm` 
- At the same time, it [registers an icon](https://github.com/liferay/liferay-portal/blob/master/portal-web/docroot/html/taglib/ui/icon/page.jsp#L79-L95) which will listen to clicks in `document` and will trigger another [`submitForm`](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js#L364) via [`forcePost`](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/icon.js#L30)

So, for some reason we actually attempt to do a double form submission every time we click on those icons when SPA is disabled which fails in Safari. I haven't seen obvious changes in the past years that indicate that this behaviour is new other than the fact that we [moved from explicit listener declaration to a delegation mechanism](https://github.com/liferay/liferay-portal/commit/e3804a1cc77c7a323d14ea61b113e1f17a5c9d32) but I doubt this was the case.

Now, the trick part is that in this case, the second submission goes through the [`Liferay.Util.forcePost`](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js#L349-L367) method, which does:

```javascript
const url = currentElement.getAttribute('href');

[…]

submitForm(hrefFm, url, !newWindow);
```

Which, based on [IconTag](https://github.com/liferay/liferay-portal/blob/master/util-taglib/src/com/liferay/taglib/ui/IconTag.java#L344)'s processing, turns out to be `javascript:;`.

From this I infer that Safari will abort the first submission (the one that's actually correct and defined in the link `onClick` attribute) and attempt the second one which unfortunately goes nowhere as `action` becomes `javascript:;`.

Hope this provides more context as to what the problem seems to be.

I think [the fix](https://github.com/liferay/liferay-portal/commit/dd1aa05593c8a98015ff164491b52f9e2746a62f) for [Duplicate entry errors when using certain portlet functions](https://issues.liferay.com/browse/LPS-48018) likely caused this, but the fact that this is only appearing now might hint to some changes in Safari lately, so it's hard to tell.

Another option is to simply set `forcePost` to `false` inside `liferay-ui:icon` since we're already making an explicit `submitForm` call in its `onclick` attribute. This would in turn improve our code, but the implications are harder to foresee.

Forwarding as is based on @wincent's similar analysis:

> As you say, so many layers of legacy and history here that it is nigh on impossible to understand the ramifications of any particular change. If we didn't have a GA release just around the corner, I would be inclined to just push your suggested fix (forcePost → false) and see what breaks. But given that the GA is supposedly around the corner, I also think that this PR is relatively benign. It seems unlikely to make things worse (other than being a bit krufty and brittle), and it supposedly works around the issue. As this lives in frontend-js-aui-web, it makes it easier to tolerate the "kruft", to some degree... We could also split the difference (ship this know, then switch to the deeper/riskier fix after the GA).