### PR TITLE
LPS-128227 | Links inside liferay-ui:icon-menu should contain `dropdown-item` css class

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/menu/staging_actions.jspf
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/menu/staging_actions.jspf
@@ -167,7 +167,7 @@
 						<ul class="dropdown-menu" role="menu">
 							<c:if test="<%= !layoutRevision.isIncomplete() %>">
 								<li>
-									<a class="dropdown-icon" href="javascript:Liferay.fire('<%= liferayPortletResponse.getNamespace() %>viewHistory', {layoutRevisionId: '<%= layoutRevision.getLayoutRevisionId() %>', layoutSetBranchId: '<%= layoutRevision.getLayoutSetBranchId() %>'}); void(0);">
+									<a class="dropdown-item" href="javascript:Liferay.fire('<%= liferayPortletResponse.getNamespace() %>viewHistory', {layoutRevisionId: '<%= layoutRevision.getLayoutRevisionId() %>', layoutSetBranchId: '<%= layoutRevision.getLayoutSetBranchId() %>'}); void(0);">
 										<liferay-ui:message key="history" />
 									</a>
 								</li>
@@ -176,7 +176,7 @@
 							<c:if test="<%= !hasWorkflowTask %>">
 								<c:if test="<%= !layoutRevision.isMajor() && (layoutRevision.getParentLayoutRevisionId() != LayoutRevisionConstants.DEFAULT_PARENT_LAYOUT_REVISION_ID) %>">
 									<li>
-										<a class="dropdown-icon" href="javascript:Liferay.fire('<%= liferayPortletResponse.getNamespace() %>undo', {layoutRevisionId: '<%= layoutRevision.getLayoutRevisionId() %>', layoutSetBranchId: '<%= layoutRevision.getLayoutSetBranchId() %>'}); void(0);">
+										<a class="dropdown-item" href="javascript:Liferay.fire('<%= liferayPortletResponse.getNamespace() %>undo', {layoutRevisionId: '<%= layoutRevision.getLayoutRevisionId() %>', layoutSetBranchId: '<%= layoutRevision.getLayoutSetBranchId() %>'}); void(0);">
 											<liferay-ui:message key="undo" />
 										</a>
 									</li>
@@ -192,7 +192,7 @@
 
 									<c:if test="<%= firstChildLayoutRevision.isInactive() %>">
 										<li>
-											<a class="dropdown-icon" href="javascript:Liferay.fire('<%= liferayPortletResponse.getNamespace() %>redo', {layoutRevisionId: '<%= firstChildLayoutRevision.getLayoutRevisionId() %>', layoutSetBranchId: '<%= firstChildLayoutRevision.getLayoutSetBranchId() %>'}); void(0);">
+											<a class="dropdown-item" href="javascript:Liferay.fire('<%= liferayPortletResponse.getNamespace() %>redo', {layoutRevisionId: '<%= firstChildLayoutRevision.getLayoutRevisionId() %>', layoutSetBranchId: '<%= firstChildLayoutRevision.getLayoutSetBranchId() %>'}); void(0);">
 												<liferay-ui:message key="redo" />
 											</a>
 										</li>

--- a/portal-web/docroot/html/taglib/ui/icon/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/init.jsp
@@ -91,6 +91,10 @@ if (toolTip) {
 	cssClass += " lfr-portal-tooltip";
 }
 
+if (iconMenuIconCount != null) {
+	linkCssClass += " dropdown-item";
+}
+
 linkCssClass += " lfr-icon-item taglib-icon";
 %>
 

--- a/portal-web/docroot/html/taglib/ui/icon/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/init.jsp
@@ -91,10 +91,6 @@ if (toolTip) {
 	cssClass += " lfr-portal-tooltip";
 }
 
-if (Validator.isNull(linkCssClass)) {
-	linkCssClass = "dropdown-item";
-}
-
 linkCssClass += " lfr-icon-item taglib-icon";
 %>
 

--- a/portal-web/docroot/html/taglib/ui/icon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/page.jsp
@@ -26,9 +26,7 @@ boolean urlIsNotNull = Validator.isNotNull(url);
 			<c:choose>
 				<c:when test="<%= urlIsNotNull %>">
 					<aui:a ariaRole="menuitem" cssClass="<%= linkCssClass %>" data="<%= data %>" href="<%= url %>" id="<%= id %>" lang="<%= lang %>" onClick="<%= onClick %>" target="<%= target %>">
-						<span class="c-inner" tabindex="-1">
-							<%@ include file="/html/taglib/ui/icon/link_content.jspf" %>
-						</span>
+						<%@ include file="/html/taglib/ui/icon/link_content.jspf" %>
 					</aui:a>
 				</c:when>
 				<c:otherwise>
@@ -42,9 +40,7 @@ boolean urlIsNotNull = Validator.isNotNull(url);
 			<c:choose>
 				<c:when test="<%= urlIsNotNull %>">
 					<aui:a ariaRole="menuitem" cssClass="<%= linkCssClass %>" data="<%= data %>" href="<%= url %>" id="<%= id %>" lang="<%= lang %>" onClick="<%= onClick %>" target="<%= target %>">
-						<span class="c-inner" tabindex="-1">
-							<%@ include file="/html/taglib/ui/icon/link_content.jspf" %>
-						</span>
+						<%@ include file="/html/taglib/ui/icon/link_content.jspf" %>
 					</aui:a>
 				</c:when>
 				<c:otherwise>

--- a/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
@@ -107,7 +107,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					%>
 
 						<li>
-							<a class="dropdown-icon" href="<%= HtmlUtil.escapeHREF(curDeltaURL) %>" onClick="<%= forcePost ? _getOnClick(namespace, deltaParam, curDelta) : "" %>">
+							<a class="dropdown-item" href="<%= HtmlUtil.escapeHREF(curDeltaURL) %>" onClick="<%= forcePost ? _getOnClick(namespace, deltaParam, curDelta) : "" %>">
 								<%= String.valueOf(curDelta) %>
 
 								<span class="sr-only"><liferay-ui:message key="entries-per-page" /></span>
@@ -181,7 +181,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 								%>
 
 									<li>
-										<a class="dropdown-icon" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
+										<a class="dropdown-item" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
 									</li>
 
 								<%
@@ -214,7 +214,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 								%>
 
 									<li>
-										<a class="dropdown-icon" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
+										<a class="dropdown-item" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
 									</li>
 
 								<%
@@ -256,7 +256,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					%>
 
 						<li class="page-item">
-							<a class="dropdown-icon page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
+							<a class="dropdown-item page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
 						</li>
 
 					<%
@@ -304,7 +304,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					%>
 
 						<li class="page-item">
-							<a class="dropdown-icon page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
+							<a class="dropdown-item page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
 						</li>
 
 					<%


### PR DESCRIPTION
This is basically a different way to add `dropdown-item` classes to icons within icon menus to prevent the class from being accidentally set in icons causing the issue described in [Login Modal create account and forgot password links are styled incorrectly](https://issues.liferay.com/browse/LPS-128227)

![wiki-portlet](https://user-images.githubusercontent.com/905006/109946858-9e8cc700-7cd0-11eb-9ea0-b6ceed772fc7.jpg)