### PR TITLE
COMMERCE-5972

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/jaxrs/context/provider/SortContextProvider.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/jaxrs/context/provider/SortContextProvider.java
@@ -14,7 +14,6 @@
 
 package com.liferay.frontend.taglib.clay.internal.jaxrs.context.provider;
 
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -46,12 +45,7 @@ public class SortContextProvider implements ContextProvider<Sort> {
 			httpServletRequest, "sort.field");
 
 		if (Validator.isNull(sortString)) {
-			sortString = ParamUtil.getString(httpServletRequest, "sort");
-
-			String[] sortArray = StringUtil.split(sortString, StringPool.COLON);
-
-			return SortFactoryUtil.create(
-				StringUtil.trim(sortArray[0]), sortArray[1].equals("desc"));
+			return null;
 		}
 
 		String sortDir = ParamUtil.getString(httpServletRequest, "sort.dir");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/jaxrs/context/provider/SortContextProvider.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/jaxrs/context/provider/SortContextProvider.java
@@ -48,11 +48,10 @@ public class SortContextProvider implements ContextProvider<Sort> {
 		if (Validator.isNull(sortString)) {
 			sortString = ParamUtil.getString(httpServletRequest, "sort");
 
-			String[] sortStringArray = StringUtil.split(sortString, StringPool.COLON);
+			String[] sortArray = StringUtil.split(sortString, StringPool.COLON);
 
 			return SortFactoryUtil.create(
-				StringUtil.trim(sortStringArray[0]),
-				sortStringArray[1].equals("desc"));
+				StringUtil.trim(sortArray[0]), sortArray[1].equals("desc"));
 		}
 
 		String sortDir = ParamUtil.getString(httpServletRequest, "sort.dir");


### PR DESCRIPTION
Hey @brianchandotcom, I'm directly sending you this revert to address https://issues.liferay.com/browse/COMMERCE-5972 which is currently blocking commerce (or at least is marked as it is).

Yesterday's fix misses some cases where the `sort` param is not set and looking at it closer I think it also misses other use cases (multiple sortings) that we might want to take into account while we're at it.

Just reverting for now to allow the teams to work normally and will resend a complete solution next week.

Thanks!

/cc @fortunatomaldonado