### PR TITLE
LPS-127322 Remove override of getAssetEntry method

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/java/com/liferay/app/builder/web/internal/asset/model/AppBuilderAppAssetRendererFactory.java
+++ b/modules/apps/app-builder/app-builder-web/src/main/java/com/liferay/app/builder/web/internal/asset/model/AppBuilderAppAssetRendererFactory.java
@@ -20,7 +20,6 @@ import com.liferay.app.builder.model.AppBuilderAppDataRecordLink;
 import com.liferay.app.builder.portlet.tab.AppBuilderAppPortletTab;
 import com.liferay.app.builder.service.AppBuilderAppDataRecordLinkLocalService;
 import com.liferay.app.builder.service.AppBuilderAppLocalService;
-import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.model.BaseAssetRendererFactory;
@@ -69,11 +68,6 @@ public class AppBuilderAppAssetRendererFactory
 		setPortletId(AppBuilderPortletKeys.APPS);
 		setSearchable(false);
 		setSelectable(false);
-	}
-
-	@Override
-	public AssetEntry getAssetEntry(long assetEntryId) throws PortalException {
-		return getAssetEntry(getClassName(), assetEntryId);
 	}
 
 	@Override


### PR DESCRIPTION
This PR was already tested here: https://github.com/liferay-workflow/liferay-portal/pull/260

The failures are not related. There is an intermittent error on App Builder impacting all the tests: [LPS-128165](https://issues.liferay.com/browse/LPS-128165).

I'm manually sending it to save CI resources.

cc: @MarinhoFeliphe @rafaprax