### PR TITLE
LPS-121921 Migrate v2 usages in user-associated-data-web

### DIFF
--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
@@ -60,10 +60,9 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 				}
 				%>
 
-				<clay:management-toolbar-v2
+				<clay:management-toolbar
 					disabled="<%= disableManagementBar %>"
 					itemsTotal="<%= uadApplicationExportDisplayList.size() %>"
-					namespace="<%= liferayPortletResponse.getNamespace() %>"
 					searchContainerId="uadApplicationExportDisplay"
 					selectable="<%= true %>"
 					showSearch="<%= false %>"

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_entities.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_entities.jsp
@@ -36,8 +36,8 @@ if (parentContainerId > 0) {
 long[] groupIds = viewUADEntitiesDisplay.getGroupIds();
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= new ViewUADEntitiesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, viewUADEntitiesDisplay) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new ViewUADEntitiesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, viewUADEntitiesDisplay) %>"
 />
 
 <aui:form method="post" name="viewUADEntitiesFm">

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_export_processes.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_export_processes.jsp
@@ -45,8 +45,8 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 	%>'
 />
 
-<clay:management-toolbar-v2
-	displayContext="<%= uadExportProcessManagementToolbarDisplayContext %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= uadExportProcessManagementToolbarDisplayContext %>"
 />
 
 <aui:form cssClass="container-fluid container-fluid-max-xl">


### PR DESCRIPTION
Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/877 since it was green and has minimal changes. Agreed with @drewbrokke to do so to reduce his workload a bit.

--- 

First time migrator here 👋 
I tested everything locally, made minimal changes and everything seem to work just as it did before, with an addition of better selected item information in the `add_uad_export_processes.jsp` page - showing the number of selected and total number as well as the `Clear` and `Select All` buttons which weren't present in the `v2` variant.

## Testing

1. Add a new user with the `Administrator` role
Note: You need to add `company.security.strangers.verify=false` to your `portal-ext.properties` if you're asked for a validation token
2. Log into that new user and create some content (blog, bookmark, etc.)
3. Log back into your Test user
4. Go back to Users and Administration, click on the actions menu for your new user and click `Export Personal Data`
5. Add content types that you created as the temporary user
Note: When choosing what content to export you can find the `add_uad_export_processes.jsp` file to test.
6. When you add the content types you'll be taken to the page with a list of exported processes
Note: Here you can test the `view_uad_export_processes.jsp` file.
7. Go one step back, to the view of the Users and Organisations page, click on the actions menu and `Delete Personal Data`.
Note: This leads you to a page where you can test the `view_uad_entities.jsp`.
