### PR TITLE
LPS-121905 Migrate v2 usages in roles/roles-selector-web

### DIFF
--- a/modules/apps/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -173,10 +173,9 @@ clearResultsURL.setParameter("keywords", StringPool.BLANK);
 SearchContainer<?> searchContainer = (SearchContainer<?>)request.getAttribute("liferay-ui:search:searchContainer");
 %>
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	clearResultsURL="<%= clearResultsURL.toString() %>"
 	itemsTotal="<%= searchContainer.getTotal() %>"
-	namespace="<%= liferayPortletResponse.getNamespace() %>"
 	searchActionURL="<%= portletURL.toString() %>"
 	selectable="<%= false %>"
 	showCreationMenu="<%= false %>"


### PR DESCRIPTION
Manual forward of https://github.com/drewbrokke/liferay-portal/pull/1321 since the changes are minimal and we've agreed to do so to reduce @drewbrokkes workload on reviewing these PRs.

--- 

The <clay:management-toolbar-v2 /> tag has been replaced with the <clay:management-toolbar /> tag (which uses clay v3).

![screenshot](https://user-images.githubusercontent.com/5572/109637823-98baa880-7b4d-11eb-9bc9-0b989155b5ca.gif)

**Test plan**:
- Form the global menu, select the **Control Panel** tab
- Click on **Users and Organizations**
- Select the **Organizations** tab
- Create a new **Organization**
- Add a user to the new Organization
- Navigate back to the **Organizations** page
- Click on the dropdown menu to the right of the organization's name and
select **Assign Organization Roles**
- Select a **Role**
- In the **Avaible** tab, select a user and click on **Update
Associations**