### PR TITLE
LRQA-64634 Create new test suite for license cluster tests since they require usage of the ci slaves with 32gb of ram

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -2587,6 +2587,55 @@ include-and-override=portal-liferay-online.properties</echo>
 		</sequential>
 	</macrodef>
 
+	<macrodef name="prepare-portal-licenses">
+		<sequential>
+			<get-testcase-property property.name="dxp.license.file" />
+
+			<if>
+				<isset property="dxp.license.file" />
+				<then>
+					<delete failonerror="false" file="${liferay.home}/deploy/license.xml" verbose="true" />
+
+					<copy
+						file="${project.dir}/portal-web/test/functional/com/liferay/portalweb/dependencies/license/${dxp.license.file}"
+						todir="${liferay.home}/deploy"
+					/>
+				</then>
+			</if>
+
+			<get-testcase-property property.name="commerce.enabled" />
+			<get-testcase-property property.name="commerce.license.file" />
+
+			<if>
+				<equals arg1="${commerce.enabled}" arg2="false" />
+				<then>
+					<delete failonerror="false" file="${liferay.home}/deploy/portal-commerce-license.xml" verbose="true" />
+				</then>
+				<else>
+					<if>
+						<isset property="commerce.license.file" />
+						<then>
+							<swap-commerce-license commerce.license.file="${commerce.license.file}" />
+						</then>
+					</if>
+				</else>
+			</if>
+
+			<get-testcase-property property.name="deploy.lcs.token.file" />
+
+			<if>
+				<equals arg1="${deploy.lcs.token.file}" arg2="true" />
+				<then>
+					<delete failonerror="false" file="${liferay.home}/deploy/license.xml" verbose="true" />
+
+					<antcall target="deploy-lcs-environment-token" />
+				</then>
+			</if>
+
+			<antcall target="deploy-license-xml-to-osgi-directory" />
+		</sequential>
+	</macrodef>
+
 	<macrodef name="prepare-portal-search-osgi-configuration">
 		<sequential>
 			<echo file="${liferay.home}/osgi/configs/com.liferay.portal.search.internal.index.configuration.IndexStatusManagerInternalConfiguration.config">suppressIndexReadOnly=B"true"</echo>
@@ -4467,51 +4516,6 @@ org.apache.catalina.startup.ClassLoaderFactory.level=INFO]]>
 							<echo file="${test.app.server.deploy.dir}/ROOT.war.dodeploy"></echo>
 						</then>
 					</if>
-
-					<get-testcase-property property.name="dxp.license.file" />
-
-					<if>
-						<isset property="dxp.license.file" />
-						<then>
-							<delete failonerror="false" file="${liferay.home}/deploy/license.xml" verbose="true" />
-
-							<copy
-								file="${project.dir}/portal-web/test/functional/com/liferay/portalweb/dependencies/license/${dxp.license.file}"
-								todir="${liferay.home}/deploy"
-							/>
-						</then>
-					</if>
-
-					<get-testcase-property property.name="commerce.enabled" />
-					<get-testcase-property property.name="commerce.license.file" />
-
-					<if>
-						<equals arg1="${commerce.enabled}" arg2="false" />
-						<then>
-							<delete failonerror="false" file="${liferay.home}/deploy/portal-commerce-license.xml" verbose="true" />
-						</then>
-						<else>
-							<if>
-								<isset property="commerce.license.file" />
-								<then>
-									<swap-commerce-license commerce.license.file="${commerce.license.file}" />
-								</then>
-							</if>
-						</else>
-					</if>
-
-					<get-testcase-property property.name="deploy.lcs.token.file" />
-
-					<if>
-						<equals arg1="${deploy.lcs.token.file}" arg2="true" />
-						<then>
-							<delete failonerror="false" file="${liferay.home}/deploy/license.xml" verbose="true" />
-
-							<antcall target="deploy-lcs-environment-token" />
-						</then>
-					</if>
-
-					<antcall target="deploy-license-xml-to-osgi-directory" />
 
 					<get-testcase-property property.name="portal.version" />
 
@@ -13387,6 +13391,8 @@ module.framework.properties.blacklist.portal.profile.names=${blacklist.portal.pr
 				<antcall target="deploy-osgi-module-configurations" />
 			</then>
 		</if>
+
+		<prepare-portal-licenses />
 
 		<get-testcase-property property.name="app.server.bundles.size" />
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -4468,6 +4468,20 @@ org.apache.catalina.startup.ClassLoaderFactory.level=INFO]]>
 						</then>
 					</if>
 
+					<get-testcase-property property.name="dxp.license.file" />
+
+					<if>
+						<isset property="dxp.license.file" />
+						<then>
+							<delete failonerror="false" file="${liferay.home}/deploy/license.xml" verbose="true" />
+
+							<copy
+								file="${project.dir}/portal-web/test/functional/com/liferay/portalweb/dependencies/license/${dxp.license.file}"
+								todir="${liferay.home}/deploy"
+							/>
+						</then>
+					</if>
+
 					<get-testcase-property property.name="commerce.enabled" />
 					<get-testcase-property property.name="commerce.license.file" />
 

--- a/ci.properties
+++ b/ci.properties
@@ -67,6 +67,7 @@ ci.test.available.suites=\
     knowledge-base,\
     ldap,\
     license,\
+    license-cluster,\
     lima,\
     lpkg,\
     message-boards,\
@@ -144,6 +145,8 @@ ci.test.suite.description[headless-acceptance]=Test headless team acceptance tes
 ci.test.suite.description[jdk11]=Test acceptance, smoke, and upgrade functional tests against JDK11.
 ci.test.suite.description[jsf]=Test Liferay Faces tests.
 ci.test.suite.description[ldap]=Test LDAP tests.
+ci.test.suite.description[license]=Compile a release bundle and execute tests for licensing.
+ci.test.suite.description[license-cluster]=Compile a release bundle and execute tests for cluster licensing on 32GB slaves.
 ci.test.suite.description[lima]=Test Lima tests.
 ci.test.suite.description[lpkg]=Test LPKG tests.
 ci.test.suite.description[oauth2]=Test OAuth 2 tests.

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceLicense.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceLicense.testcase
@@ -1,6 +1,7 @@
 @component-name = "portal-commerce"
 definition {
 
+	property license.required = "true";
 	property portal.release = "true";
 	property portal.upstream = "false";
 	property test.run.environment = "EE";

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/license/dxp-license-virtual-cluster.xml
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/license/dxp-license-virtual-cluster.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<license>
+	<account-name>Liferay.com</account-name>
+	<owner>Liferay.com</owner>
+	<description>Liferay.com</description>
+	<product-name>Portal Cluster</product-name>
+	<product-version>7.3</product-version>
+	<license-name>Portal Cluster</license-name>
+	<license-type>virtual-cluster</license-type>
+	<license-version>4</license-version>
+	<start-date>Friday, April 29, 2020 5:42:58 PM GMT</start-date>
+	<expiration-date>Friday, January 1, 2120 5:42:58 PM GMT</expiration-date>
+	<max-cluster-nodes>2</max-cluster-nodes>
+	<key>INVALID</key>
+</license>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringLicense.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringLicense.testcase
@@ -3,6 +3,7 @@ definition {
 
 	property app.server.bundles.size = "2";
 	property cluster.enabled = "true";
+	property license.required = "true";
 	property portal.release = "true";
 	property portal.upstream = "false";
 	property remote.elasticsearch.enabled = "true";
@@ -25,8 +26,8 @@ definition {
 
 	@priority = "5"
 	test ViewNodeLimit {
+		property commerce.enabled = "false";
 		property dxp.license.file = "dxp-license-virtual-cluster.xml";
-		property license.required = "true";
 
 		Clustering.viewClusterStatusInConsole();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringLicense.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringLicense.testcase
@@ -41,12 +41,23 @@ definition {
 		Page.assertNodePortPG(nodePort = "9080");
 
 		Clustering.viewTextPresentOnSpecificNode(
-			expectedText = "You have exceeded the maximum number of cluster nodes in cluster",
+			expectedText = "You have exceeded the maximum number of cluster nodes in cluster, overloaded nodes will be deactivated in 2 hours",
 			nodePort = "10080");
+
+		User.loginPG(
+			nodePort = "10080",
+			password = "test",
+			userEmailAddress = "test@liferay.com");
+
+		Page.assertNodePortPG(nodePort = "10080");
+
+		// TODO Assert message to Admin in the UI when node is scheduled to deactivate
+
+		Pause(locator1 = "300000");
 
 		Navigator.openSpecificURL(url = "http://localhost:10080");
 
-		Alert.viewErrorMessage(errorMessage = "This instance is not registered.");
+		Alert.viewErrorMessage(errorMessage = "You have exceeded the maximum number of cluster nodes in cluster, please shutdown nodes to recover or register a new license.");
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringLicense.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringLicense.testcase
@@ -1,0 +1,51 @@
+@component-name = "portal-clustering"
+definition {
+
+	property app.server.bundles.size = "2";
+	property cluster.enabled = "true";
+	property portal.release = "true";
+	property portal.upstream = "false";
+	property remote.elasticsearch.enabled = "true";
+	property test.run.environment = "EE";
+	property testray.main.component.name = "Clustering";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = "5"
+	test ViewNodeLimit {
+		property dxp.license.file = "dxp-license-virtual-cluster.xml";
+		property license.required = "true";
+
+		Clustering.viewClusterStatusInConsole();
+
+		Page.assertNodePortPG(nodePort = "8080");
+
+		User.loginPG(
+			nodePort = "9080",
+			password = "test",
+			userEmailAddress = "test@liferay.com");
+
+		Page.assertNodePortPG(nodePort = "9080");
+
+		Clustering.viewTextPresentOnSpecificNode(
+			expectedText = "You have exceeded the maximum number of cluster nodes in cluster",
+			nodePort = "10080");
+
+		Navigator.openSpecificURL(url = "http://localhost:10080");
+
+		Alert.viewErrorMessage(errorMessage = "This instance is not registered.");
+	}
+
+}

--- a/test.properties
+++ b/test.properties
@@ -3528,7 +3528,7 @@
         functional-tomcat90-mysql57-jdk8
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][license]=\
-        (commerce.enabled == true OR commerce.enabled == false) OR \
+        (license.required == true) OR \
         (\
             (app.server.types == null OR app.server.types ~ tomcat) AND \
             (database.types == null OR database.types ~ mysql) AND \
@@ -5493,6 +5493,7 @@
         legacy.database.dump,\
         legacy.plugin.includes,\
         legacy.plugins.social.office.version,\
+        license.required,\
         liferay.dependency.jars,\
         liferay.dependency.wars,\
         liferay.training.dependency.jars,\

--- a/test.properties
+++ b/test.properties
@@ -3528,12 +3528,29 @@
         functional-tomcat90-mysql57-jdk8
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][license]=\
-        (license.required == true) OR \
+        (license.required == true AND testray.main.component.name != "Clustering") OR \
         (\
             (app.server.types == null OR app.server.types ~ tomcat) AND \
             (database.types == null OR database.types ~ mysql) AND \
             (portal.smoke == true)\
         )
+
+    #
+    # License Cluster
+    #
+
+    dist.type[license-cluster]=release
+
+    test.batch.dist.app.servers[license-cluster]=tomcat
+
+    test.batch.minimum.slave.ram[functional-tomcat*-mysql*-jdk8][license-cluster]=32
+
+    test.batch.names[license-cluster]=\
+        functional-tomcat90-mysql57-jdk8
+
+    test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][license-cluster]=\
+        (license.required == true) AND \
+        (testray.main.component.name == "Clustering")
 
     #
     # Lima

--- a/test.properties
+++ b/test.properties
@@ -3320,9 +3320,9 @@
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][gauntlet]=\
         (app.server.types == null OR app.server.types ~ tomcat) AND \
-        (commerce.enabled == null)  AND \
         (database.types == null OR database.types ~ mysql) AND \
         (deploy.lcs.token.file != true) AND \
+        (license.required != true)  AND \
         (portal.release == true)
 
     #

--- a/test.properties
+++ b/test.properties
@@ -5474,6 +5474,7 @@
         deploy.license.osgi.directory,\
         direct.deploy.enabled,\
         dummy.socket.proxy.disabled,\
+        dxp.license.file,\
         elastic.pki.authentication.enabled,\
         elastic.xpack.enabled,\
         elasticsearch.ccr.enabled,\


### PR DESCRIPTION
@tinatian Automated Test coverage for Cluster Licensing. Run with new suite "ci test license-cluster". I needed to make a new suite because the cluster testing requires a CI slave with more resources than the default