### PR TITLE
LPS-127752 Collapse icon is not initially displayed correctly in server admin

### DIFF
--- a/portal-web/docroot/html/taglib/ui/panel/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/panel/lexicon/start.jsp
@@ -36,7 +36,7 @@ if (persistState) {
 <div class="panel <%= cssClass %>" id="<%= id %>">
 	<c:choose>
 		<c:when test="<%= collapsible %>">
-			<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon collapsed panel-header panel-header-link <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-parent="#<%= id %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
+			<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon panel-header panel-header-link <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-parent="#<%= id %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
 				<span class="panel-title" id="<%= id %>Header">
 					<c:if test="<%= Validator.isNotNull(iconCssClass) %>">
 						<i class="<%= iconCssClass %>"></i>


### PR DESCRIPTION
Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/908 to avoid CI retesting since it's a pretty straightforward change and the failures look unrelated.

--- 

Fixes [LPS-127752](https://issues.liferay.com/browse/LPS-127752).

Pretty simple, took me a bit to figure out where it is located, etc. I've just removed the extra `collapsed` class that was unconditionally added to the element.