### PR TITLE
LPS-129243 Remove unnecessary metal imports

### DIFF
--- a/modules/apps/commerce/commerce-cart-taglib/package.json
+++ b/modules/apps/commerce/commerce-cart-taglib/package.json
@@ -1,8 +1,6 @@
 {
 	"dependencies": {
 		"clay-icon": "2.22.2",
-		"metal-component": "2.16.8",
-		"metal-soy": "2.16.9",
 		"metal-state": "2.16.8"
 	},
 	"name": "commerce-cart-taglib",

--- a/modules/apps/fragment/fragment-web/package.json
+++ b/modules/apps/fragment/fragment-web/package.json
@@ -4,7 +4,6 @@
 		"@clayui/tabs": "3.3.5",
 		"codemirror": "^5.52.0",
 		"frontend-js-web": "*",
-		"metal-component": "2.16.8",
 		"metal-state": "2.16.8"
 	},
 	"name": "fragment-web",

--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/package.json
@@ -2,7 +2,6 @@
 	"dependencies": {
 		"@clayui/tooltip": "3.4.5",
 		"@liferay/frontend-js-react-web": "*",
-		"metal-position": "2.1.2",
 		"react": "16.12.0"
 	},
 	"name": "frontend-js-tooltip-support-web",

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -76,7 +76,6 @@
 		"clay-tooltip": "2.22.2",
 		"date-fns": "^1.30.1",
 		"frontend-js-web": "*",
-		"metal-component": "2.16.8",
 		"metal-soy": "2.16.9",
 		"metal-state": "2.16.8",
 		"prop-types": "15.7.2",

--- a/modules/apps/journal/journal-article-dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/journal/journal-article-dynamic-data-mapping-form-field-type/package.json
@@ -4,8 +4,6 @@
 		"@clayui/form": "3.14.4",
 		"dynamic-data-mapping-form-field-type": "*",
 		"frontend-js-web": "*",
-		"metal-component": "2.16.8",
-		"metal-soy": "2.16.9",
 		"react": "16.12.0"
 	},
 	"name": "journal-article-dynamic-data-mapping-form-field-type",

--- a/modules/apps/layout/layout-admin-web/package.json
+++ b/modules/apps/layout/layout-admin-web/package.json
@@ -13,7 +13,6 @@
 		"@clayui/popover": "3.5.5",
 		"classnames": "2.2.6",
 		"frontend-js-web": "*",
-		"metal-component": "2.16.8",
 		"metal-state": "2.16.8",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",

--- a/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/package.json
@@ -4,8 +4,6 @@
 		"@clayui/form": "3.14.4",
 		"dynamic-data-mapping-form-field-type": "*",
 		"frontend-js-web": "*",
-		"metal-component": "2.16.8",
-		"metal-soy": "2.16.9",
 		"react": "16.12.0"
 	},
 	"name": "layout-dynamic-data-mapping-form-field-type",


### PR DESCRIPTION
Manual forward from [liferay-frontend#910](https://github.com/liferay-frontend/liferay-portal/pull/91) due to [spurious CI failure](https://github.com/liferay-frontend/liferay-portal/pull/910#issuecomment-800961124).

cc @kresimir-coko

Original message follows:

---

Fixes [LPS-129243](https://issues.liferay.com/browse/LPS-129243).

Super simple, removes `metal-soy` and `metal-component` dependencies from modules that no longer use them, as listed in the task. 

