### PR TITLE
LPS-118339 Fix harmless typo in regex pattern match

### DIFF
--- a/modules/apps/remote-app/remote-app-client-js/webpack.config.js
+++ b/modules/apps/remote-app/remote-app-client-js/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
 	module: {
 		rules: [
 			{
-				test: /\.ts?$/,
+				test: /\.ts$/,
 				use: 'ts-loader',
 			},
 		],


### PR DESCRIPTION
This was a copy-paste error from another place where we had this pattern:

    /\.tsx?$/

(ie. to match ".ts" or ".tsx"). We deleted the "x" because this module only has ".ts" files, but we should have deleted the "?" as well, otherwise the pattern matches both ".ts" and ".t" (the latter of which is not a valid extension).