### PR TITLE
LRCI-2084 Remove update-plugins from patching tool process | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -1533,7 +1533,6 @@ jdbc.counter.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_T
 					<execute dir="@{patching.tool.dir}" failonerror="true">
 						patching-tool${file.suffix.bat} auto-discovery
 						patching-tool${file.suffix.bat} install -force
-						patching-tool${file.suffix.bat} update-plugins
 					</execute>
 				</then>
 				<else>
@@ -1544,7 +1543,6 @@ war.path=${app.server.portal.dir}/</echo>
 
 					<execute dir="@{patching.tool.dir}" failonerror="true">
 						patching-tool${file.suffix.bat} install -force
-						patching-tool${file.suffix.bat} update-plugins
 					</execute>
 				</else>
 			</if>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2084

@brianchandotcom - Sorry for the direct pull, but I believe this one is kind of urgent.  It only needs to be backported to `7.3.x`.  The backport is actually more urgent than `master`.  Please let me know if you have any questions.  Thanks!