### PR TITLE
COMMERCE-6399 Translated label for AccountSelector

### DIFF
--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/account_selector/views/AccountsListView.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/account_selector/views/AccountsListView.js
@@ -62,7 +62,7 @@ function AccountsListView({
 						if (!items || !items.length) {
 							return (
 								<EmptyListView
-									caption="no-accounts-were-found"
+									caption={Liferay.Language.get("no-accounts-were-found")}
 									loading={loading}
 								/>
 							);


### PR DESCRIPTION
A non-translated label in the AccountSelector component is having a functional test fail:
https://issues.liferay.com/browse/COMMERCE-6399