### PR TITLE
LPS-130153 Update @liferay/npm-scripts to v42.1.0

### DIFF
--- a/modules/.prettierignore
+++ b/modules/.prettierignore
@@ -12,7 +12,6 @@
     build/**
     classes/**
     css/clay/**
-    types/**/*.d.ts
 
 ##
 ## Template Files

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useEventListener.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useEventListener.d.ts
@@ -11,6 +11,7 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 /**
  * Hook for adding an event listener on mount and removing it on
  * unmount.
@@ -21,4 +22,9 @@
  * outside of your component's DOM (eg. attaching a "scroll" or "resize"
  * listener to the `window`).
  */
-export default function useEventListener(eventName: string, handler: EventListenerOrEventListenerObject, phase: boolean, target: Node): void;
+export default function useEventListener(
+	eventName: string,
+	handler: EventListenerOrEventListenerObject,
+	phase: boolean,
+	target: Node
+): void;

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useInterval.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useInterval.d.ts
@@ -11,8 +11,12 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 /**
  * Hook for scheduling a repeating function call with the specified
  * interval (in milliseconds).
  */
-export default function useInterval(): (fn: () => void, ms: number | undefined) => () => void;
+export default function useInterval(): (
+	fn: () => void,
+	ms: number | undefined
+) => () => void;

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useIsMounted.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useIsMounted.d.ts
@@ -11,6 +11,7 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 /**
  * Hook for determining whether a component is still mounted.
  *

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useLiferayState.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useLiferayState.d.ts
@@ -11,7 +11,9 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-import type { Atom, Immutable, Selector } from '@liferay/frontend-js-state-web';
+
+import type {Atom, Immutable, Selector} from '@liferay/frontend-js-state-web';
+
 /**
  * Hook-based abstraction over `State.read()`, `State.write()`, and
  * `State.subscribe()` that allows you to conveniently read/update/watch atoms
@@ -24,4 +26,6 @@ import type { Atom, Immutable, Selector } from '@liferay/frontend-js-state-web';
  * (Note, however, that actually trying to update a selector will throw
  * an error because selectors are read-only.)
  */
-export default function useLiferayState<T>(atomOrSelector: Atom<T> | Selector<T>): [value: Immutable<T>, setValue: (newValue: T) => void];
+export default function useLiferayState<T>(
+	atomOrSelector: Atom<T> | Selector<T>
+): [value: Immutable<T>, setValue: (newValue: T) => void];

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/usePrevious.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/usePrevious.d.ts
@@ -11,6 +11,7 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 /**
  * Hook for comparing current and previous values (of state, props or any
  * arbitrary value).

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useStateSafe.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useStateSafe.d.ts
@@ -11,8 +11,11 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 /**
  * Wrapper for `useState` that does an `isMounted()` check behind the scenes
  * before triggering side-effects.
  */
-export default function useStateSafe<T = unknown>(initialValue: T | (() => T)): readonly [T, (newValue: T | ((previousValue: T) => T)) => void];
+export default function useStateSafe<T = unknown>(
+	initialValue: T | (() => T)
+): readonly [T, (newValue: T | ((previousValue: T) => T)) => void];

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useThunk.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useThunk.d.ts
@@ -11,10 +11,18 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 import React from 'react';
+
 /**
  * "Middleware" hook intended to wrap `useReducer` that enables you to dispatch
  * thunks (ie. functions that dispatch actions) as well as plain actions (ie.
  * objects).
  */
-export default function useThunk<R extends React.Reducer<any, any>>([state, dispatch,]: [React.ReducerState<R>, React.Dispatch<React.ReducerAction<R>>]): (React.ReducerState<R> | ((action: any) => any))[];
+export default function useThunk<R extends React.Reducer<any, any>>([
+	state,
+	dispatch,
+]: [React.ReducerState<R>, React.Dispatch<React.ReducerAction<R>>]): (
+	| React.ReducerState<R>
+	| ((action: any) => any)
+)[];

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useTimeout.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/hooks/useTimeout.d.ts
@@ -11,8 +11,12 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 /**
  * Hook for delaying a function call by the specified interval (in
  * milliseconds).
  */
-export default function useTimeout(): (fn: () => void, ms: number | undefined) => () => void;
+export default function useTimeout(): (
+	fn: () => void,
+	ms: number | undefined
+) => () => void;

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/index.d.ts
@@ -11,12 +11,13 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-export { default as render } from './render';
-export { default as useEventListener } from './hooks/useEventListener';
-export { default as useInterval } from './hooks/useInterval';
-export { default as useIsMounted } from './hooks/useIsMounted';
-export { default as useLiferayState } from './hooks/useLiferayState';
-export { default as usePrevious } from './hooks/usePrevious';
-export { default as useStateSafe } from './hooks/useStateSafe';
-export { default as useThunk } from './hooks/useThunk';
-export { default as useTimeout } from './hooks/useTimeout';
+
+export {default as render} from './render';
+export {default as useEventListener} from './hooks/useEventListener';
+export {default as useInterval} from './hooks/useInterval';
+export {default as useIsMounted} from './hooks/useIsMounted';
+export {default as useLiferayState} from './hooks/useLiferayState';
+export {default as usePrevious} from './hooks/usePrevious';
+export {default as useStateSafe} from './hooks/useStateSafe';
+export {default as useThunk} from './hooks/useThunk';
+export {default as useTimeout} from './hooks/useTimeout';

--- a/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/render.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/src/main/resources/META-INF/resources/js/render.d.ts
@@ -11,7 +11,9 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 import React from 'react';
+
 /**
  * Wrapper for ReactDOM render that automatically:
  *
@@ -29,8 +31,15 @@ import React from 'react';
  *
  * @see https://reactjs.org/docs/react-dom.html#render
  */
-export default function render(renderable: NonNullable<React.ReactNode> | NonNullable<React.ForwardRefExoticComponent<any>> | (() => NonNullable<React.ReactNode>), renderData: {
-    componentId?: string;
-    portletId?: string;
-    [key: string]: unknown;
-}, container: Element | DocumentFragment): void;
+export default function render(
+	renderable:
+		| NonNullable<React.ReactNode>
+		| NonNullable<React.ForwardRefExoticComponent<any>>
+		| (() => NonNullable<React.ReactNode>),
+	renderData: {
+		componentId?: string;
+		portletId?: string;
+		[key: string]: unknown;
+	},
+	container: Element | DocumentFragment
+): void;

--- a/modules/apps/frontend-js/frontend-js-react-web/types/test/js/hooks/useInterval.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/test/js/hooks/useInterval.d.ts
@@ -11,4 +11,5 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 export {};

--- a/modules/apps/frontend-js/frontend-js-react-web/types/test/js/hooks/useIsMounted.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/test/js/hooks/useIsMounted.d.ts
@@ -11,4 +11,5 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 export {};

--- a/modules/apps/frontend-js/frontend-js-react-web/types/test/js/hooks/useLiferayState.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/test/js/hooks/useLiferayState.d.ts
@@ -11,4 +11,5 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 export {};

--- a/modules/apps/frontend-js/frontend-js-react-web/types/test/js/hooks/useStateSafe.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/test/js/hooks/useStateSafe.d.ts
@@ -11,4 +11,5 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 export {};

--- a/modules/apps/frontend-js/frontend-js-react-web/types/test/js/hooks/useTimeout.d.ts
+++ b/modules/apps/frontend-js/frontend-js-react-web/types/test/js/hooks/useTimeout.d.ts
@@ -11,4 +11,5 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 export {};

--- a/modules/apps/frontend-js/frontend-js-state-web/types/src/main/resources/META-INF/resources/State.d.ts
+++ b/modules/apps/frontend-js/frontend-js-state-web/types/src/main/resources/META-INF/resources/State.d.ts
@@ -11,194 +11,237 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-import type { Immutable } from './types';
+
+import type {Immutable} from './types';
 declare const ATOM: unique symbol;
 declare const SELECTOR: unique symbol;
 interface Getter {
-    <T>(atomOrSelector: Atom<T> | Selector<T>): Immutable<T>;
+	<T>(atomOrSelector: Atom<T> | Selector<T>): Immutable<T>;
 }
 export declare type Atom<T> = Immutable<{
-    [ATOM]: true;
-    default: T;
-    key: string;
+	[ATOM]: true;
+	default: T;
+	key: string;
 }>;
 export declare type Selector<T> = Immutable<{
-    [SELECTOR]: true;
-    deriveValue: (get: Getter) => T;
-    key: string;
+	[SELECTOR]: true;
+	deriveValue: (get: Getter) => T;
+	key: string;
 }>;
 declare const State: {
-    __internal__: {
-        debug: {
-            readonly atoms: {
-                readonly default: Readonly<unknown>;
-                readonly key: string;
-                readonly [ATOM]: true;
-            }[];
-            readonly selectors: {
-                readonly deriveValue: (get: Getter) => unknown;
-                readonly key: string;
-                readonly [SELECTOR]: true;
-            }[];
-        };
-        reset(): void;
-    };
-    /**
-     * Methods in the `__unsafe__` namespace are provided as an escape hatch to
-     * allow interacting with global state from places where it may not be
-     * practical or possible to obtain a reference to a concrete atom or
-     * selector (for example, from within JSPs). These methods all take a string
-     * key and use it to look up the corresponding atom or selector.
-     *
-     * This usage is considered unsafe because it bypasses the static type
-     * checking provided by the main API (`read()`, `write()` etc). Given that
-     * the integrity of global shared state largely depends on the values being
-     * of a predictable and correct type, you should use the `__unsafe__` API
-     * only as a last resort. Instead, consider moving legacy code out of JSPs
-     * and into places where it can fully participate in the module-loading
-     * system and thus access concrete atoms and selectors by importing them. At
-     * the same time, moving legacy code into React components provides access
-     * to the `useLiferayState()` hook and other conveniences.
-     */
-    __unsafe__: {
-        readKey(key: string): unknown;
-        subscribeKey(key: string, callback: (value: unknown) => void): {
-            dispose: () => void;
-        };
-        writeKey(key: string, value: unknown): void;
-    };
-    _invalidateDependencies(atomOrSelector: Atom<unknown> | Selector<unknown>, invalidated: Array<Selector<unknown>>): void;
-    _notify<T_1>(callback: (value: T_1) => void, value: T_1): void;
-    _readSelector<T_2>(selector: {
-        readonly deriveValue: (get: Getter) => T_2;
-        readonly key: string;
-        readonly [SELECTOR]: true;
-    }, seen: Set<Selector<unknown>>): Immutable<T_2>;
-    /**
-     * Register a unit of shared state called an "atom". Atoms have a unique
-     * string key, a type `T`, and a default value. Atoms themselves are
-     * immutable, but are each associated with a corresponding "current" value
-     * that can be read, updated, and observed.
-     *
-     * Given an atom, you can interact with the current value associated with it
-     * in these ways:
-     *
-     * - Read it with `read()` or `readAtom()`.
-     * - Update it with `write()` or `writeAtom()`.
-     * - Subscribe to be notified of changes with `subscribe()`.
-     * - In React components, the `useLiferayState()` hook does all the above.
-     */
-    atom<T_3>(key: string, value: T_3): {
-        readonly default: Immutable<T_3>;
-        readonly key: string;
-        readonly [ATOM]: true;
-    };
-    /**
-     * Read the current value associated with the provided atom or selector.
-     *
-     * This is a convenience wrapper around `readAtom()` and `readSelector()`.
-     */
-    read<T_4>(atomOrSelector: {
-        readonly default: Immutable<T_4>;
-        readonly key: string;
-        readonly [ATOM]: true;
-    } | {
-        readonly deriveValue: (get: Getter) => T_4;
-        readonly key: string;
-        readonly [SELECTOR]: true;
-    }): Immutable<T_4>;
-    /**
-     * Read the current value associated with the provided atom.
-     */
-    readAtom<T_5>(atom: {
-        readonly default: Immutable<T_5>;
-        readonly key: string;
-        readonly [ATOM]: true;
-    }): Immutable<T_5>;
-    /**
-     * Read the current value associated with the provided selector.
-     */
-    readSelector<T_6>(selector: {
-        readonly deriveValue: (get: Getter) => T_6;
-        readonly key: string;
-        readonly [SELECTOR]: true;
-    }): Immutable<T_6>;
-    /**
-     * Register a shared unit of derived state called a "selector", identified
-     * by a unique string key. Selectors derive their values via a "pure"
-     * function that reads atoms and/or other selectors. Selectors form a
-     * dependency graph, which means that when upstream atoms or selectors
-     * change, the dependent selectors get automatically and efficiently
-     * recomputed.
-     *
-     * Given a selector, you can interact with the current value associated with
-     * it in these ways:
-     *
-     * - Read it with `read()` or `readSelector()`.
-     * - Subscribe to be notified of changes with `subscribe()`.
-     * - In React components, the `useLiferayState()` hook does all the above.
-     *
-     * Note that, unlike atoms, you cannot `write()` directly to a selector;
-     * instead, you update them by changing their upstream atoms, which causes
-     * the affected selectors to re-derive their updated values.
-     */
-    selector<T_7>(key: string, deriveValue: (get: Getter) => T_7): {
-        readonly [SELECTOR]: true;
-        readonly deriveValue: (get: Getter) => T_7;
-        readonly key: string;
-    };
-    /**
-     * Subscribe to be notified of changes to an atom or selector.
-     *
-     * The supplied `callback()` function will be invoked with the new value
-     * whenever it changes. To unsubscribe, use the `dispose()` function that is
-     * returned.
-     *
-     * In the context of a React component, the `useLiferayState()` hook can be
-     * used to observe and trigger state changes in a way that is analagous to
-     * the built-in `useState()` hook.
-     */
-    subscribe<T_8 extends unknown>(atomOrSelector: {
-        readonly default: Immutable<T_8>;
-        readonly key: string;
-        readonly [ATOM]: true;
-    } | {
-        readonly deriveValue: (get: Getter) => T_8;
-        readonly key: string;
-        readonly [SELECTOR]: true;
-    }, callback: (value: Immutable<T_8>) => void): {
-        dispose: () => void;
-    };
-    /**
-     * Attempt to update the value associated with the provided atom or
-     * selector.
-     *
-     * Note that this is just a convenience wrapper around `writeAtom()` that
-     * serves principally to streamline calls (for example, from the
-     * `useLiferayState()` hook), and in practice it is an error to attempt a
-     * direct update to a selector (instead, the upstream atoms that it depends
-     * on should be updated).
-     */
-    write<T_9>(atomOrSelector: {
-        readonly default: Immutable<T_9>;
-        readonly key: string;
-        readonly [ATOM]: true;
-    } | {
-        readonly deriveValue: (get: Getter) => T_9;
-        readonly key: string;
-        readonly [SELECTOR]: true;
-    }, value: T_9): void;
-    /**
-     * Update the value associated with the provided atom, notifying any
-     * downstream subscribers (of the atom itself, or selectors that depend on
-     * it).
-     */
-    writeAtom<T_10>(atom: {
-        readonly default: Immutable<T_10>;
-        readonly key: string;
-        readonly [ATOM]: true;
-    }, value: T_10): void;
+	__internal__: {
+		debug: {
+			readonly atoms: {
+				readonly default: Readonly<unknown>;
+				readonly key: string;
+				readonly [ATOM]: true;
+			}[];
+			readonly selectors: {
+				readonly deriveValue: (get: Getter) => unknown;
+				readonly key: string;
+				readonly [SELECTOR]: true;
+			}[];
+		};
+		reset(): void;
+	};
+
+	/**
+	 * Methods in the `__unsafe__` namespace are provided as an escape hatch to
+	 * allow interacting with global state from places where it may not be
+	 * practical or possible to obtain a reference to a concrete atom or
+	 * selector (for example, from within JSPs). These methods all take a string
+	 * key and use it to look up the corresponding atom or selector.
+	 *
+	 * This usage is considered unsafe because it bypasses the static type
+	 * checking provided by the main API (`read()`, `write()` etc). Given that
+	 * the integrity of global shared state largely depends on the values being
+	 * of a predictable and correct type, you should use the `__unsafe__` API
+	 * only as a last resort. Instead, consider moving legacy code out of JSPs
+	 * and into places where it can fully participate in the module-loading
+	 * system and thus access concrete atoms and selectors by importing them. At
+	 * the same time, moving legacy code into React components provides access
+	 * to the `useLiferayState()` hook and other conveniences.
+	 */
+	__unsafe__: {
+		readKey(key: string): unknown;
+		subscribeKey(
+			key: string,
+			callback: (value: unknown) => void
+		): {
+			dispose: () => void;
+		};
+		writeKey(key: string, value: unknown): void;
+	};
+	_invalidateDependencies(
+		atomOrSelector: Atom<unknown> | Selector<unknown>,
+		invalidated: Array<Selector<unknown>>
+	): void;
+	_notify<T_1>(callback: (value: T_1) => void, value: T_1): void;
+	_readSelector<T_2>(
+		selector: {
+			readonly deriveValue: (get: Getter) => T_2;
+			readonly key: string;
+			readonly [SELECTOR]: true;
+		},
+		seen: Set<Selector<unknown>>
+	): Immutable<T_2>;
+
+	/**
+	 * Register a unit of shared state called an "atom". Atoms have a unique
+	 * string key, a type `T`, and a default value. Atoms themselves are
+	 * immutable, but are each associated with a corresponding "current" value
+	 * that can be read, updated, and observed.
+	 *
+	 * Given an atom, you can interact with the current value associated with it
+	 * in these ways:
+	 *
+	 * - Read it with `read()` or `readAtom()`.
+	 * - Update it with `write()` or `writeAtom()`.
+	 * - Subscribe to be notified of changes with `subscribe()`.
+	 * - In React components, the `useLiferayState()` hook does all the above.
+	 */
+	atom<T_3>(
+		key: string,
+		value: T_3
+	): {
+		readonly default: Immutable<T_3>;
+		readonly key: string;
+		readonly [ATOM]: true;
+	};
+
+	/**
+	 * Read the current value associated with the provided atom or selector.
+	 *
+	 * This is a convenience wrapper around `readAtom()` and `readSelector()`.
+	 */
+	read<T_4>(
+		atomOrSelector:
+			| {
+					readonly default: Immutable<T_4>;
+					readonly key: string;
+					readonly [ATOM]: true;
+			  }
+			| {
+					readonly deriveValue: (get: Getter) => T_4;
+					readonly key: string;
+					readonly [SELECTOR]: true;
+			  }
+	): Immutable<T_4>;
+
+	/**
+	 * Read the current value associated with the provided atom.
+	 */
+	readAtom<T_5>(atom: {
+		readonly default: Immutable<T_5>;
+		readonly key: string;
+		readonly [ATOM]: true;
+	}): Immutable<T_5>;
+
+	/**
+	 * Read the current value associated with the provided selector.
+	 */
+	readSelector<T_6>(selector: {
+		readonly deriveValue: (get: Getter) => T_6;
+		readonly key: string;
+		readonly [SELECTOR]: true;
+	}): Immutable<T_6>;
+
+	/**
+	 * Register a shared unit of derived state called a "selector", identified
+	 * by a unique string key. Selectors derive their values via a "pure"
+	 * function that reads atoms and/or other selectors. Selectors form a
+	 * dependency graph, which means that when upstream atoms or selectors
+	 * change, the dependent selectors get automatically and efficiently
+	 * recomputed.
+	 *
+	 * Given a selector, you can interact with the current value associated with
+	 * it in these ways:
+	 *
+	 * - Read it with `read()` or `readSelector()`.
+	 * - Subscribe to be notified of changes with `subscribe()`.
+	 * - In React components, the `useLiferayState()` hook does all the above.
+	 *
+	 * Note that, unlike atoms, you cannot `write()` directly to a selector;
+	 * instead, you update them by changing their upstream atoms, which causes
+	 * the affected selectors to re-derive their updated values.
+	 */
+	selector<T_7>(
+		key: string,
+		deriveValue: (get: Getter) => T_7
+	): {
+		readonly [SELECTOR]: true;
+		readonly deriveValue: (get: Getter) => T_7;
+		readonly key: string;
+	};
+
+	/**
+	 * Subscribe to be notified of changes to an atom or selector.
+	 *
+	 * The supplied `callback()` function will be invoked with the new value
+	 * whenever it changes. To unsubscribe, use the `dispose()` function that is
+	 * returned.
+	 *
+	 * In the context of a React component, the `useLiferayState()` hook can be
+	 * used to observe and trigger state changes in a way that is analagous to
+	 * the built-in `useState()` hook.
+	 */
+	subscribe<T_8 extends unknown>(
+		atomOrSelector:
+			| {
+					readonly default: Immutable<T_8>;
+					readonly key: string;
+					readonly [ATOM]: true;
+			  }
+			| {
+					readonly deriveValue: (get: Getter) => T_8;
+					readonly key: string;
+					readonly [SELECTOR]: true;
+			  },
+		callback: (value: Immutable<T_8>) => void
+	): {
+		dispose: () => void;
+	};
+
+	/**
+	 * Attempt to update the value associated with the provided atom or
+	 * selector.
+	 *
+	 * Note that this is just a convenience wrapper around `writeAtom()` that
+	 * serves principally to streamline calls (for example, from the
+	 * `useLiferayState()` hook), and in practice it is an error to attempt a
+	 * direct update to a selector (instead, the upstream atoms that it depends
+	 * on should be updated).
+	 */
+	write<T_9>(
+		atomOrSelector:
+			| {
+					readonly default: Immutable<T_9>;
+					readonly key: string;
+					readonly [ATOM]: true;
+			  }
+			| {
+					readonly deriveValue: (get: Getter) => T_9;
+					readonly key: string;
+					readonly [SELECTOR]: true;
+			  },
+		value: T_9
+	): void;
+
+	/**
+	 * Update the value associated with the provided atom, notifying any
+	 * downstream subscribers (of the atom itself, or selectors that depend on
+	 * it).
+	 */
+	writeAtom<T_10>(
+		atom: {
+			readonly default: Immutable<T_10>;
+			readonly key: string;
+			readonly [ATOM]: true;
+		},
+		value: T_10
+	): void;
 };
+
 /**
  * Boilerplate to satisfy TypeScript and prevent: "TS2669: Augmentations
  * for the global scope can only be directly nested in external modules or
@@ -206,9 +249,9 @@ declare const State: {
  */
 export default State;
 declare global {
-    interface Window {
-        Liferay: {
-            State: typeof State;
-        };
-    }
+	interface Window {
+		Liferay: {
+			State: typeof State;
+		};
+	}
 }

--- a/modules/apps/frontend-js/frontend-js-state-web/types/src/main/resources/META-INF/resources/SubscriberMap.d.ts
+++ b/modules/apps/frontend-js/frontend-js-state-web/types/src/main/resources/META-INF/resources/SubscriberMap.d.ts
@@ -11,8 +11,10 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-import type { Atom, Selector } from './State';
-import type { Immutable } from './types';
+
+import type {Atom, Selector} from './State';
+import type {Immutable} from './types';
+
 /**
  * `Map` wrapper for type safety. While a vanilla `Map` is totally adequate for
  * our needs in terms of implementation, at the type-system level the declared
@@ -22,10 +24,18 @@ import type { Immutable } from './types';
  * concrete type is, only that it is the same within each key/value pair).
  */
 export default class SubscriberMap {
-    _id: number;
-    _subscribers: Map<Atom<unknown> | Selector<unknown>, Map<number, (value: unknown) => void>>;
-    constructor();
-    clear(): void;
-    getCallbacks<T>(atomOrSelector: Atom<T> | Selector<T>): Map<number, (value: Immutable<T>) => void>;
-    addCallback<T extends unknown>(atomOrSelector: Atom<T> | Selector<T>, callback: (value: Immutable<T>) => void): () => void;
+	_id: number;
+	_subscribers: Map<
+		Atom<unknown> | Selector<unknown>,
+		Map<number, (value: unknown) => void>
+	>;
+	constructor();
+	clear(): void;
+	getCallbacks<T>(
+		atomOrSelector: Atom<T> | Selector<T>
+	): Map<number, (value: Immutable<T>) => void>;
+	addCallback<T extends unknown>(
+		atomOrSelector: Atom<T> | Selector<T>,
+		callback: (value: Immutable<T>) => void
+	): () => void;
 }

--- a/modules/apps/frontend-js/frontend-js-state-web/types/src/main/resources/META-INF/resources/deepFreeze.d.ts
+++ b/modules/apps/frontend-js/frontend-js-state-web/types/src/main/resources/META-INF/resources/deepFreeze.d.ts
@@ -11,5 +11,6 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-import type { Immutable } from './types';
+
+import type {Immutable} from './types';
 export default function deepFreeze<T>(value: T): Immutable<T>;

--- a/modules/apps/frontend-js/frontend-js-state-web/types/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-state-web/types/src/main/resources/META-INF/resources/index.d.ts
@@ -11,6 +11,7 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-export { default as State } from './State';
-export type { Atom, Selector } from './State';
-export type { Immutable } from './types';
+
+export {default as State} from './State';
+export type {Atom, Selector} from './State';
+export type {Immutable} from './types';

--- a/modules/apps/frontend-js/frontend-js-state-web/types/src/main/resources/META-INF/resources/types.d.ts
+++ b/modules/apps/frontend-js/frontend-js-state-web/types/src/main/resources/META-INF/resources/types.d.ts
@@ -11,14 +11,41 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-declare type Primitive = bigint | boolean | null | number | string | symbol | undefined;
+
+declare type Primitive =
+	| bigint
+	| boolean
+	| null
+	| number
+	| string
+	| symbol
+	| undefined;
 declare type Builtin = Date | Error | Function | Primitive | RegExp;
+
 /**
  * A local "DeepReadonly" until TypeScript bundles one out of the box.
  *
  * See: https://github.com/microsoft/TypeScript/issues/13923
  */
-export declare type Immutable<T> = T extends Builtin ? T : T extends Map<infer K, infer V> ? ReadonlyMap<Immutable<K>, Immutable<V>> : T extends ReadonlyMap<infer K, infer V> ? ReadonlyMap<Immutable<K>, Immutable<V>> : T extends WeakMap<infer K, infer V> ? WeakMap<Immutable<K>, Immutable<V>> : T extends Set<infer U> ? ReadonlySet<Immutable<U>> : T extends ReadonlySet<infer U> ? ReadonlySet<Immutable<U>> : T extends WeakSet<infer U> ? WeakSet<Immutable<U>> : T extends Promise<infer U> ? Promise<Immutable<U>> : T extends {} ? {
-    readonly [K in keyof T]: Immutable<T[K]>;
-} : Readonly<T>;
+export declare type Immutable<T> = T extends Builtin
+	? T
+	: T extends Map<infer K, infer V>
+	? ReadonlyMap<Immutable<K>, Immutable<V>>
+	: T extends ReadonlyMap<infer K, infer V>
+	? ReadonlyMap<Immutable<K>, Immutable<V>>
+	: T extends WeakMap<infer K, infer V>
+	? WeakMap<Immutable<K>, Immutable<V>>
+	: T extends Set<infer U>
+	? ReadonlySet<Immutable<U>>
+	: T extends ReadonlySet<infer U>
+	? ReadonlySet<Immutable<U>>
+	: T extends WeakSet<infer U>
+	? WeakSet<Immutable<U>>
+	: T extends Promise<infer U>
+	? Promise<Immutable<U>>
+	: T extends {}
+	? {
+			readonly [K in keyof T]: Immutable<T[K]>;
+	  }
+	: Readonly<T>;
 export {};

--- a/modules/apps/frontend-js/frontend-js-state-web/types/test/State.d.ts
+++ b/modules/apps/frontend-js/frontend-js-state-web/types/test/State.d.ts
@@ -11,4 +11,5 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 export {};

--- a/modules/apps/frontend-js/frontend-js-state-web/types/test/deepFreeze.d.ts
+++ b/modules/apps/frontend-js/frontend-js-state-web/types/test/deepFreeze.d.ts
@@ -11,4 +11,5 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 export {};

--- a/modules/apps/frontend-js/frontend-js-state-web/types/test/helpers.d.ts
+++ b/modules/apps/frontend-js/frontend-js-state-web/types/test/helpers.d.ts
@@ -11,4 +11,8 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-export declare function withEnv(env: 'production' | 'development', callback: Function): void;
+
+export declare function withEnv(
+	env: 'production' | 'development',
+	callback: Function
+): void;

--- a/modules/package.json
+++ b/modules/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"@liferay/npm-scripts": "42.0.0",
+		"@liferay/npm-scripts": "42.1.0",
 		"acorn": "7.1.0",
 		"alloy-ui": "^3.1.0-deprecated.40",
 		"babel-plugin-incremental-dom": "3.4.0",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1620,10 +1620,10 @@
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-"@liferay/npm-scripts@42.0.0":
-  version "42.0.0"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-42.0.0.tgz#2f403b828f409762d57a9a54b80f9edeb215170d"
-  integrity sha512-XqAs5p0Ef6IgeLZaLJ8GiDxk9pPoo0VIRpfet9ymeAs3qMsO18HfiMAiYPmLr79DWQjAuYS3n2WLnLA5H7tctQ==
+"@liferay/npm-scripts@42.1.0":
+  version "42.1.0"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-42.1.0.tgz#41ebb3a1fbc90b1a288be8b6a899e722927c1a86"
+  integrity sha512-W8M8ixqym1nx1ntqrgAbuU7ffUQiUm0Nr4M5qoK34O7yFOYd8TWjVIxIKjxTaBvZcReGquhyfWRlU4pB8O3a2w==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"


### PR DESCRIPTION
From [the release notes](https://github.com/liferay/liferay-frontend-projects/releases/tag/npm-scripts%2Fv42.1.0):

- We'll format autogenerated `.d.ts` files now.

- You can run `yarn run liferay-npm-scripts format` in a project that doesn't have a `package.json` file and it will run frontend formatting (eg. of JS in JSP files); basically, it walks up until it finds the closest `package.json` _or_ `build.gradle` and treats that as a project root.