### PR TITLE
LRQA-65865 We only need to get the poshi name if its a functional test

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -5851,7 +5851,12 @@ war.path=${app.server.portal.dir}/</echo>
 
 	<macrodef name="wait-for-license-activation">
 		<sequential>
-			<get-poshi-method-name />
+			<if>
+				<isset property="test.class" />
+				<then>
+					<get-poshi-method-name />
+				</then>
+			</if>
 
 			<get-commerce-license-product-name />
 


### PR DESCRIPTION
Fixes issue running release backend tests. Also for 7.3.x. CC @yichenroy @jpince @suilin