### PR TITLE
LPS-130796 Update `@liferay/npm-scripts` to v44.0.0

### DIFF
--- a/modules/npmscripts.config.js
+++ b/modules/npmscripts.config.js
@@ -424,5 +424,13 @@ module.exports = {
 	global: {
 		check: CHECK_AND_FIX_GLOBS,
 		fix: CHECK_AND_FIX_GLOBS,
+		rules: {
+			'allowed-named-scope-exceptions': [
+
+				// LPS-129670: https://issues.liferay.com/browse/LPS-129670
+
+				'map-common',
+			],
+		},
 	},
 };

--- a/modules/package.json
+++ b/modules/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"@liferay/npm-scripts": "43.0.0",
+		"@liferay/npm-scripts": "44.0.0",
 		"acorn": "7.1.0",
 		"alloy-ui": "^3.1.0-deprecated.40",
 		"babel-plugin-incremental-dom": "3.4.0",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1620,10 +1620,10 @@
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-"@liferay/npm-scripts@43.0.0":
-  version "43.0.0"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-43.0.0.tgz#afd697e1724200b1df0fc8a81f8c9489dc0cf735"
-  integrity sha512-SDUF3ZB3YsgbgtW96IzqPQ9tov/yTdinp/Piszzas1pxBIUQ8tVDQU1FbhB67fubMc2FUKZfGYlzqeq29m+0bQ==
+"@liferay/npm-scripts@44.0.0":
+  version "44.0.0"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-44.0.0.tgz#6c8730b9e12436ae723f8ab115f8f25fc90e3411"
+  integrity sha512-exV+64dtrihN6nA9yFwHXrenv7cw1KuyjKPV7Iafav2mpWUSHqNtme2T6H0VJ0jEg4Ng9v/wmmfZKwqQKcx7lg==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"


### PR DESCRIPTION
Manual forward from [liferay-frontend#980](https://github.com/liferay-frontend/liferay-portal/pull/980) because these are just lint changes, yet we see different unrelated failures across CI runs (eg. a session experiation, a failure to activate an OSGi bundle etc).

Original message follows.

---

[Release notes](https://github.com/liferay/liferay-frontend-projects/releases/tag/npm-scripts%2Fv44.0.0).

Most noteworthy:

- We are enforcing the use of the `@liferay` named scope to guard against dependency confusion attacks. We haven't actually renamed all the packages yet, but we have reserved placeholder packages with those names to keep them safe. In the meantime, we have an "allow list" internally that stops our formatter from complaining about those names only.

~⚠️ **But note: Will need to bump 4 theme versions due to a little mishap when publishing placeholder packages, [as explained here](https://github.com/liferay/liferay-frontend-projects/pull/500#issuecomment-822615093).**~

~The affected themes are:~

- ~`apps/commerce/commerce-theme-minium/commerce-theme-minium`~
- ~`apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell`~
- ~`apps/frontend-theme/frontend-theme-styled`~
- ~`apps/frontend-theme/frontend-theme-unstyled`~

~Basically, we need to bump the "patch" version component of each of those, or the next attempt at publishing them will fail. I've already messaged Brian via Slack to let him know, in case this interferes with the release.~