### PR TITLE
LPS-130905 The add and remove row button doesn't work [Bug regression]

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
@@ -167,7 +167,7 @@ AUI.add(
 
 						trigger.placeAfter(list);
 
-						list.append(palette.cloneNode(true));
+						list.append(palette);
 					}
 
 					if (instance.url) {


### PR DESCRIPTION
Hi @brianchandotcom, 

this is a manual forward for https://github.com/liferay-frontend/liferay-portal/pull/987. CI errors are not related, and this is a revert of one single commit that was causing a potencial release blocker (FP4)

Thanks! 



 **Step to reproduce:**

1. Navigate to Categories admin
2. Add a vocabulary
3. Add a category
4. Click the ellipsis button of category entry > Edit > Properties tab
5. Click the plus icon button

**Before the fix:**
Nothing happens. Additionally, the following error is shown in Browser Console.
```Uncaught TypeError: cannot read property 'cleanNode' of null```

**After the fix:**
There should be a second property shown.

<img width="835" alt="Screenshot 2021-04-21 at 12 57 27" src="https://user-images.githubusercontent.com/8373764/115543262-73bafa00-a2a1-11eb-85c4-46321212d33b.png">
