### PR TITLE
LPS-130722 Using rowId as part of id HTML attribute for every row incase is defined through rowIdProperty attribute in search-container-row taglib

### DIFF
--- a/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
@@ -45,4 +45,6 @@ List resultRows = searchContainer.getResultRows();
 String summary = searchContainer.getSummary();
 
 JSONArray primaryKeysJSONArray = JSONFactoryUtil.createJSONArray();
+
+String rowIdProperty = (String)request.getAttribute("rowIdProperty");
 %>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
@@ -276,7 +276,14 @@ if (fixedHeader) {
 					}
 				%>
 
-					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" <%= AUIUtil.buildData(data) %>>
+					<c:choose>
+						<c:when test="<%= Validator.isNotNull(rowIdProperty) %>">
+							<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" id="<portlet:namespace /><%= id %>_<%= row.getRowId() %>" <%= AUIUtil.buildData(data) %>>
+						</c:when>
+						<c:otherwise>
+							<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" <%= AUIUtil.buildData(data) %>>
+						</c:otherwise>
+					</c:choose>
 
 						<%
 						for (int j = 0; j < entries.size(); j++) {

--- a/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
@@ -243,7 +243,14 @@ if (iteratorURL != null) {
 			Map<String, Object> data = row.getData();
 		%>
 
-			<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" <%= AUIUtil.buildData(data) %>>
+			<c:choose>
+				<c:when test="<%= Validator.isNotNull(rowIdProperty) %>">
+					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" id="<portlet:namespace /><%= id %>_<%= row.getRowId() %>" <%= AUIUtil.buildData(data) %>>
+				</c:when>
+				<c:otherwise>
+					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" <%= AUIUtil.buildData(data) %>>
+				</c:otherwise>
+			</c:choose>
 
 			<%
 			for (int j = 0; j < entries.size(); j++) {

--- a/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
@@ -331,6 +331,8 @@ public class SearchContainerRowTag<R>
 					FriendlyURLNormalizerUtil.normalizeWithPeriodsAndSlashes(
 						String.valueOf(rowIdObject));
 			}
+
+			request.setAttribute("rowIdProperty", rowId);
 		}
 
 		_resultRow = new com.liferay.taglib.search.ResultRow(


### PR DESCRIPTION
Manual forward from [liferay-frontend#986](https://github.com/liferay-frontend/liferay-portal/pull/986) due to [spurious test failure](https://github.com/liferay-frontend/liferay-portal/pull/986#issuecomment-824707271) (`LocalFile.WorkflowMetrics#ViewReports`) which was already fixed in https://github.com/brianchandotcom/liferay-portal/pull/100995

> ### ✔️ ci:test:stable - 9 out of 9 jobs passed
> ### ❌ ci:test:relevant - 19 out of 21 jobs passed in 1 hour 52 minutes

Original PR description follows:

---

Hi guys,

This is a new clean pull request for liferay-frontend#975 where I'm trying to follow your suggestions:

- We are only adding the id in case rowIdProperty has been informed.
- Such id is including portlet:namespace, searchContainerId and rowId.
- Such id is a valid id HTML value.

Let me know if you need anything else.

Thanks.

Regards.

---

cc @antonio-ortega