### PR TITLE
[TS] LPS-131067 Remove redundant aria-labelledby attributes in Menu Navigation ADTs

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/navigation.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/navigation.ftl
@@ -15,7 +15,7 @@
 			</#if>
 
 			<li class="${nav_item_css_class}" id="layout_${nav_item.getLayoutId()}" role="presentation">
-				<a aria-labelledby="layout_${nav_item.getLayoutId()}" ${nav_item_attr_has_popup} href="${nav_item.getURL()}" ${nav_item.getTarget()} role="menuitem"><span><@liferay_theme["layout-icon"] layout=nav_item_layout /> ${nav_item.getName()}</span></a>
+				<a ${nav_item_attr_has_popup} href="${nav_item.getURL()}" ${nav_item.getTarget()} role="menuitem"><span><@liferay_theme["layout-icon"] layout=nav_item_layout /> ${nav_item.getName()}</span></a>
 
 				<#if nav_item.hasChildren()>
 					<ul class="child-menu" role="menu">
@@ -31,7 +31,7 @@
 							</#if>
 
 							<li class="${nav_child_css_class}" id="layout_${nav_child.getLayoutId()}" role="presentation">
-								<a aria-labelledby="layout_${nav_child.getLayoutId()}" href="${nav_child.getURL()}" ${nav_child.getTarget()} role="menuitem">${nav_child.getName()}</a>
+								<a href="${nav_child.getURL()}" ${nav_child.getTarget()} role="menuitem">${nav_child.getName()}</a>
 							</li>
 						</#list>
 					</ul>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_nav_pills.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_nav_pills.ftl
@@ -49,7 +49,7 @@
 					</#if>
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
-						<a aria-labelledby="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
+						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
 							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
 						</a>
 

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_nav_pills_justified.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_nav_pills_justified.ftl
@@ -49,7 +49,7 @@
 					</#if>
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
-						<a aria-labelledby="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
+						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
 							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
 						</a>
 

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_nav_pills_stacked.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_nav_pills_stacked.ftl
@@ -49,7 +49,7 @@
 					</#if>
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
-						<a aria-labelledby="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
+						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
 							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
 						</a>
 

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_nav_tabs.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_nav_tabs.ftl
@@ -49,7 +49,7 @@
 					</#if>
 
 					<li class="nav-item ${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
-						<a aria-labelledby="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" ${nav_item_attr_has_popup} class="nav-link ${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
+						<a ${nav_item_attr_has_popup} class="nav-link ${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
 							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
 						</a>
 

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_nav_tabs_justified.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_nav_tabs_justified.ftl
@@ -49,7 +49,7 @@
 					</#if>
 
 					<li class="nav-item ${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
-						<a aria-labelledby="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" ${nav_item_attr_has_popup} class="nav-link ${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
+						<a ${nav_item_attr_has_popup} class="nav-link ${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
 							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
 						</a>
 

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_navbar_blank.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_navbar_blank.ftl
@@ -58,7 +58,7 @@
 					</#if>
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
-						<a aria-labelledby="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
+						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
 							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
 						</a>
 

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_navbar_blank_justified.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_navbar_blank_justified.ftl
@@ -53,7 +53,7 @@
 					</#if>
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
-						<a aria-labelledby="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
+						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
 							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
 						</a>
 

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_navbar_default.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_navbar_default.ftl
@@ -49,7 +49,7 @@
 					</#if>
 
 					<li class="${nav_item_css_class}" id="layout_${portletDisplay.getId()}_${portletDisplay.getId()}_${navItem.getLayoutId()}" role="presentation">
-						<a aria-labelledby="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
+						<a ${nav_item_attr_has_popup} class="${nav_item_link_css_class}" ${nav_item_href_link} ${navItem.getTarget()} role="menuitem">
 							<span class="text-truncate"><@liferay_theme["layout-icon"] layout=navItem.getLayout() /> ${navItem.getName()} ${nav_item_caret}</span>
 						</a>
 

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_navigation_menu_macro.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_navigation_menu_macro.ftl
@@ -20,7 +20,7 @@
 
 		<li class="${nav_child_css_class}" id="layout_${portletDisplay.getId()}_${childNavigationItem.getLayoutId()}" role="presentation">
 			<#if childNavigationItem.isBrowsable()>
-				<a aria-labelledby="layout_${portletDisplay.getId()}_${childNavigationItem.getLayoutId()}" class="dropdown-item" href="${childNavigationItem.getURL()}" ${childNavigationItem.getTarget()} role="menuitem">${childNavigationItem.getName()}</a>
+				<a class="dropdown-item" href="${childNavigationItem.getURL()}" ${childNavigationItem.getTarget()} role="menuitem">${childNavigationItem.getName()}</a>
 			<#else>
 				<span class="dropdown-item font-weight-semi-bold navigation-menu__submenu">${childNavigationItem.getName()}</span>
 			</#if>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_split_button_dropdowns.ftl
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_split_button_dropdowns.ftl
@@ -43,7 +43,7 @@
 							<div class="btn-group">
 						</#if>
 
-						<a aria-labelledby="layout_${portletDisplay.getId()}_${navItem.getLayoutId()}" class="${nav_item_css_class} btn btn-secondary" ${nav_item_href_link}><span>${navItem.getName()}</span></a>
+						<a class="${nav_item_css_class} btn btn-secondary" ${nav_item_href_link}><span>${navItem.getName()}</span></a>
 
 						<#if showChildrenNavItems>
 							<button aria-expanded="false" aria-haspopup="true" class="${nav_item_css_class} btn btn-secondary c-px-2 dropdown-toggle" data-toggle="liferay-dropdown" type="button">

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-reference-support-test/src/testIntegration/resources/exploded-test-theme/templates/navigation.ftl
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-reference-support-test/src/testIntegration/resources/exploded-test-theme/templates/navigation.ftl
@@ -19,7 +19,7 @@
 			</#if>
 
 			<li ${nav_item_attr_selected} class="${nav_item_css_class}" id="layout_${nav_item.getLayoutId()}" role="presentation">
-				<a aria-labelledby="layout_${nav_item.getLayoutId()}" ${nav_item_attr_has_popup} href="${nav_item.getURL()}" ${nav_item.getTarget()} role="menuitem"><span><@liferay_theme["layout-icon"] layout=nav_item_layout /> ${nav_item.getName()}</span></a>
+				<a ${nav_item_attr_has_popup} href="${nav_item.getURL()}" ${nav_item.getTarget()} role="menuitem"><span><@liferay_theme["layout-icon"] layout=nav_item_layout /> ${nav_item.getName()}</span></a>
 
 				<#if nav_item.hasChildren()>
 					<ul class="child-menu" role="menu">
@@ -37,7 +37,7 @@
 							</#if>
 
 							<li ${nav_child_attr_selected} class="${nav_child_css_class}" id="layout_${nav_child.getLayoutId()}" role="presentation">
-								<a aria-labelledby="layout_${nav_child.getLayoutId()}" href="${nav_child.getURL()}" ${nav_child.getTarget()} role="menuitem">${nav_child.getName()}</a>
+								<a href="${nav_child.getURL()}" ${nav_child.getTarget()} role="menuitem">${nav_child.getName()}</a>
 							</li>
 						</#list>
 					</ul>

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/test-theme.war/templates/navigation.ftl
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/test-theme.war/templates/navigation.ftl
@@ -17,7 +17,7 @@
 			</#if>
 
 			<li class="${nav_item_css_class}" id="layout_${nav_item.getLayoutId()}" role="presentation">
-				<a aria-labelledby="layout_${nav_item.getLayoutId()}" ${nav_item_attr_has_popup} href="${nav_item.getURL()}" ${nav_item.getTarget()} role="menuitem"><span><@liferay_theme["layout-icon"] layout=nav_item_layout /> ${nav_item.getName()}</span></a>
+				<a ${nav_item_attr_has_popup} href="${nav_item.getURL()}" ${nav_item.getTarget()} role="menuitem"><span><@liferay_theme["layout-icon"] layout=nav_item_layout /> ${nav_item.getName()}</span></a>
 
 				<#if nav_item.hasChildren()>
 					<ul class="child-menu" role="menu">
@@ -33,7 +33,7 @@
 							</#if>
 
 							<li class="${nav_child_css_class}" id="layout_${nav_child.getLayoutId()}" role="presentation">
-								<a aria-labelledby="layout_${nav_child.getLayoutId()}" href="${nav_child.getURL()}" ${nav_child.getTarget()} role="menuitem">${nav_child.getName()}</a>
+								<a href="${nav_child.getURL()}" ${nav_child.getTarget()} role="menuitem">${nav_child.getName()}</a>
 							</li>
 						</#list>
 					</ul>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/navigation/NavigationMenusWidget.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/navigation/NavigationMenusWidget.path
@@ -40,7 +40,7 @@
 </tr>
 <tr>
 	<td>DROPDOWN_MENU_ITEM</td>
-	<td>//a[contains(@aria-labelledby,'SiteNavigationMenuPortlet')][normalize-space(text())='${key_itemName}']</td>
+	<td>//ul/li[contains(@id,'SiteNavigationMenuPortlet')]/a[normalize-space(text())='${key_itemName}']</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
Manual forward from [liferay-frontend#995](https://github.com/liferay-frontend/liferay-portal/pull/995) because of a spurious failure in `LocalFile.WorkflowMetrics#ViewReports` (that has since [been quarantined](https://github.com/brianchandotcom/liferay-portal/pull/101154)).

> ### ✔️ ci:test:stable - 9 out of 9 jobs passed
> ### ❌ ci:test:relevant - 21 out of 24 jobs passed in 5 hours

Original PR summary follows:

---

Hi team, please review this PR where I tried to apply the conclusions obtained in PTR-2396. If you think that this PR should be reviewed by some other team, please let me know. Thanks in advance

---

cc author: @dacousalr, reviewer: @marcoscv-work