### PR TITLE
LPS-131649 use Pure java

### DIFF
--- a/modules/apps/digital-signature/digital-signature-impl/build.gradle
+++ b/modules/apps/digital-signature/digital-signature-impl/build.gradle
@@ -1,7 +1,4 @@
 dependencies {
-	compileInclude group: "org.bouncycastle", name: "bcpkix-jdk15on", version: "1.64"
-	compileInclude group: "org.bouncycastle", name: "bcprov-jdk15on", version: "1.64"
-
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"

--- a/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/http/DSHttp.java
+++ b/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/http/DSHttp.java
@@ -29,20 +29,31 @@ import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 
+import java.io.InputStream;
 import java.io.StringReader;
+import java.math.BigInteger;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
+import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.Signature;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
 
+import java.security.spec.RSAPrivateCrtKeySpec;
+import java.security.spec.RSAPrivateKeySpec;
 import java.util.Base64;
+
 
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+
 
 /**
  * @author Brian Wing Shun Chan
@@ -175,19 +186,15 @@ public class DSHttp {
 
 	private PrivateKey _readPrivateKey() throws Exception {
 
-		// TODO Replace with native Java
+		Class<?> clazz = DSHttp.class;
 
-		JcaPEMKeyConverter jcaPEMKeyConverter = new JcaPEMKeyConverter();
+		InputStream inputStream = clazz.getResourceAsStream(
+			"dependencies/private_key.txt");
 
-		PEMParser pemParser = new PEMParser(
-			new StringReader(
-				StringUtil.read(getClass(), "dependencies/private_key.txt")));
+		PrivateKeyReader privateKeyReader = new PrivateKeyReader(inputStream);
 
-		PEMKeyPair pemKeyPair = (PEMKeyPair)pemParser.readObject();
+		return privateKeyReader.getPrivateKey();
 
-		KeyPair keyPair = jcaPEMKeyConverter.getKeyPair(pemKeyPair);
-
-		return keyPair.getPrivate();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(DSHttp.class);

--- a/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/http/PrivateKeyReader.java
+++ b/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/http/PrivateKeyReader.java
@@ -1,0 +1,436 @@
+package com.liferay.digital.signature.internal.http;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.KeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPrivateCrtKeySpec;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PrivateKeyReader {
+
+	// Private key file using PKCS #1 encoding
+	public static final String P1_BEGIN_MARKER
+		= "-----BEGIN RSA PRIVATE KEY"; //$NON-NLS-1$
+	public static final String P1_END_MARKER
+		= "-----END RSA PRIVATE KEY"; //$NON-NLS-1$
+
+	// Private key file using PKCS #8 encoding
+	public static final String P8_BEGIN_MARKER
+		= "-----BEGIN PRIVATE KEY"; //$NON-NLS-1$
+	public static final String P8_END_MARKER
+		= "-----END PRIVATE KEY"; //$NON-NLS-1$
+
+	private static Map<String, PrivateKey> keyCache =
+		Collections.synchronizedMap(new HashMap<String, PrivateKey>());
+
+	private final InputStream _inputStream;
+
+	/**
+	 * Create a PEM private key file reader.
+	 */
+	public PrivateKeyReader(InputStream inputStream) {
+		this._inputStream = inputStream;
+	}
+
+	/**
+	 * Get a Private Key for the file.
+	 *
+	 * @return Private key
+	 * @throws IOException
+	 */
+
+	public PrivateKey getPrivateKey() throws IOException,
+		GeneralSecurityException
+	{
+		PrivateKey key = null;
+		FileInputStream fis = null;
+		boolean isRSAKey = false;
+		try {
+
+			BufferedReader br = new BufferedReader(new InputStreamReader(_inputStream));
+			StringBuilder builder = new StringBuilder();
+			boolean inKey = false;
+			for (String line = br.readLine(); line != null; line = br.readLine()) {
+				if (!inKey) {
+					if (line.startsWith("-----BEGIN ") &&
+						line.endsWith(" PRIVATE KEY-----")) {
+						inKey = true;
+						isRSAKey = line.contains("RSA");
+					}
+					continue;
+				}
+				else {
+					if (line.startsWith("-----END ") &&
+						line.endsWith(" PRIVATE KEY-----")) {
+						inKey = false;
+						isRSAKey = line.contains("RSA");
+						break;
+					}
+					builder.append(line);
+				}
+			}
+			KeySpec keySpec = null;
+			byte[] encoded = DatatypeConverter.parseBase64Binary(builder.toString());
+			if (isRSAKey)
+			{
+				keySpec = getRSAKeySpec(encoded);
+			}
+			else
+			{
+				keySpec = new PKCS8EncodedKeySpec(encoded);
+			}
+			KeyFactory kf = KeyFactory.getInstance("RSA");
+			key = kf.generatePrivate(keySpec);
+		} finally {
+			if (fis != null)
+				try { fis.close(); } catch (Exception ign) {}  }
+		return key;
+	}
+
+
+	/**
+	 * Convert PKCS#1 encoded private key into RSAPrivateCrtKeySpec.
+	 *
+	 * <p/>The ASN.1 syntax for the private key with CRT is
+	 *
+	 * <pre>
+	 * --
+	 * -- Representation of RSA private key with information for the CRT algorithm.
+	 * --
+	 * RSAPrivateKey ::= SEQUENCE {
+	 *   version           Version,
+	 *   modulus           INTEGER,  -- n
+	 *   publicExponent    INTEGER,  -- e
+	 *   privateExponent   INTEGER,  -- d
+	 *   prime1            INTEGER,  -- p
+	 *   prime2            INTEGER,  -- q
+	 *   exponent1         INTEGER,  -- d mod (p-1)
+	 *   exponent2         INTEGER,  -- d mod (q-1)
+	 *   coefficient       INTEGER,  -- (inverse of q) mod p
+	 *   otherPrimeInfos   OtherPrimeInfos OPTIONAL
+	 * }
+	 * </pre>
+	 *
+	 * @param keyBytes PKCS#1 encoded key
+	 * @return KeySpec
+	 * @throws IOException
+	 */
+
+	private RSAPrivateCrtKeySpec getRSAKeySpec(byte[] keyBytes) throws IOException  {
+
+		DerParser parser = new DerParser(keyBytes);
+
+		Asn1Object sequence = parser.read();
+		if (sequence.getType() != DerParser.SEQUENCE)
+			throw new IOException("Invalid DER: not a sequence"); //$NON-NLS-1$
+
+		// Parse inside the sequence
+		parser = sequence.getParser();
+
+		parser.read(); // Skip version
+		BigInteger modulus = parser.read().getInteger();
+		BigInteger publicExp = parser.read().getInteger();
+		BigInteger privateExp = parser.read().getInteger();
+		BigInteger prime1 = parser.read().getInteger();
+		BigInteger prime2 = parser.read().getInteger();
+		BigInteger exp1 = parser.read().getInteger();
+		BigInteger exp2 = parser.read().getInteger();
+		BigInteger crtCoef = parser.read().getInteger();
+
+		RSAPrivateCrtKeySpec keySpec = new RSAPrivateCrtKeySpec(
+			modulus, publicExp, privateExp, prime1, prime2,
+			exp1, exp2, crtCoef);
+
+		return keySpec;
+	}
+}
+
+/**
+ * A bare-minimum ASN.1 DER decoder, just having enough functions to
+ * decode PKCS#1 private keys. Especially, it doesn't handle explicitly
+ * tagged types with an outer tag.
+ *
+ * <p/>This parser can only handle one layer. To parse nested constructs,
+ * get a new parser for each layer using <code>Asn1Object.getParser()</code>.
+ *
+ * <p/>There are many DER decoders in JRE but using them will tie this
+ * program to a specific JCE/JVM.
+ *
+ * @author zhang
+ *
+ */
+class DerParser {
+
+	// Classes
+	public final static int UNIVERSAL = 0x00;
+	public final static int APPLICATION = 0x40;
+	public final static int CONTEXT = 0x80;
+	public final static int PRIVATE = 0xC0;
+
+	// Constructed Flag
+	public final static int CONSTRUCTED = 0x20;
+
+	// Tag and data types
+	public final static int ANY = 0x00;
+	public final static int BOOLEAN = 0x01;
+	public final static int INTEGER = 0x02;
+	public final static int BIT_STRING = 0x03;
+	public final static int OCTET_STRING = 0x04;
+	public final static int NULL = 0x05;
+	public final static int OBJECT_IDENTIFIER = 0x06;
+	public final static int REAL = 0x09;
+	public final static int ENUMERATED = 0x0a;
+	public final static int RELATIVE_OID = 0x0d;
+
+	public final static int SEQUENCE = 0x10;
+	public final static int SET = 0x11;
+
+	public final static int NUMERIC_STRING = 0x12;
+	public final static int PRINTABLE_STRING = 0x13;
+	public final static int T61_STRING = 0x14;
+	public final static int VIDEOTEX_STRING = 0x15;
+	public final static int IA5_STRING = 0x16;
+	public final static int GRAPHIC_STRING = 0x19;
+	public final static int ISO646_STRING = 0x1A;
+	public final static int GENERAL_STRING = 0x1B;
+
+	public final static int UTF8_STRING = 0x0C;
+	public final static int UNIVERSAL_STRING = 0x1C;
+	public final static int BMP_STRING = 0x1E;
+
+	public final static int UTC_TIME = 0x17;
+	public final static int GENERALIZED_TIME = 0x18;
+
+	protected InputStream in;
+
+	/**
+	 * Create a new DER decoder from an input stream.
+	 *
+	 * @param in
+	 *            The DER encoded stream
+	 */
+	public DerParser(InputStream in) throws IOException {
+		this.in = in;
+	}
+
+	/**
+	 * Create a new DER decoder from a byte array.
+	 *
+	 *            encoded bytes
+	 * @throws IOException
+	 */
+	public DerParser(byte[] bytes) throws IOException {
+		this(new ByteArrayInputStream(bytes));
+	}
+
+	/**
+	 * Read next object. If it's constructed, the value holds
+	 * encoded content and it should be parsed by a new
+	 * parser from <code>Asn1Object.getParser</code>.
+	 *
+	 * @return A object
+	 * @throws IOException
+	 */
+	public Asn1Object read() throws IOException {
+		int tag = in.read();
+
+		if (tag == -1)
+			throw new IOException("Invalid DER: stream too short, missing tag"); //$NON-NLS-1$
+
+		int length = getLength();
+
+		byte[] value = new byte[length];
+		int n = in.read(value);
+		if (n < length)
+			throw new IOException("Invalid DER: stream too short, missing value"); //$NON-NLS-1$
+
+		Asn1Object o = new Asn1Object(tag, length, value);
+
+		return o;
+	}
+
+	/**
+	 * Decode the length of the field. Can only support length
+	 * encoding up to 4 octets.
+	 *
+	 * <p/>In BER/DER encoding, length can be encoded in 2 forms,
+	 * <ul>
+	 * <li>Short form. One octet. Bit 8 has value "0" and bits 7-1
+	 * give the length.
+	 * <li>Long form. Two to 127 octets (only 4 is supported here).
+	 * Bit 8 of first octet has value "1" and bits 7-1 give the
+	 * number of additional length octets. Second and following
+	 * octets give the length, base 256, most significant digit first.
+	 * </ul>
+	 * @return The length as integer
+	 * @throws IOException
+	 */
+	private int getLength() throws IOException {
+
+		int i = in.read();
+		if (i == -1)
+			throw new IOException("Invalid DER: length missing"); //$NON-NLS-1$
+
+		// A single byte short length
+		if ((i & ~0x7F) == 0)
+			return i;
+
+		int num = i & 0x7F;
+
+		// We can't handle length longer than 4 bytes
+		if ( i >= 0xFF || num > 4)
+			throw new IOException("Invalid DER: length field too big (" //$NON-NLS-1$
+								  + i + ")"); //$NON-NLS-1$
+
+		byte[] bytes = new byte[num];
+		int n = in.read(bytes);
+		if (n < num)
+			throw new IOException("Invalid DER: length too short"); //$NON-NLS-1$
+
+		return new BigInteger(1, bytes).intValue();
+	}
+
+}
+
+
+/**
+ * An ASN.1 TLV. The object is not parsed. It can
+ * only handle integers and strings.
+ *
+ * @author zhang
+ *
+ */
+class Asn1Object {
+
+	protected final int type;
+	protected final int length;
+	protected final byte[] value;
+	protected final int tag;
+
+	/**
+	 * Construct a ASN.1 TLV. The TLV could be either a
+	 * constructed or primitive entity.
+	 *
+	 * <p/>The first byte in DER encoding is made of following fields,
+	 * <pre>
+	 *-------------------------------------------------
+	 *|Bit 8|Bit 7|Bit 6|Bit 5|Bit 4|Bit 3|Bit 2|Bit 1|
+	 *-------------------------------------------------
+	 *|  Class    | CF  |     +      Type             |
+	 *-------------------------------------------------
+	 * </pre>
+	 * <ul>
+	 * <li>Class: Universal, Application, Context or Private
+	 * <li>CF: Constructed flag. If 1, the field is constructed.
+	 * <li>Type: This is actually called tag in ASN.1. It
+	 * indicates data type (Integer, String) or a construct
+	 * (sequence, choice, set).
+	 * </ul>
+	 *
+	 * @param tag Tag or Identifier
+	 * @param length Length of the field
+	 * @param value Encoded octet string for the field.
+	 */
+	public Asn1Object(int tag, int length, byte[] value) {
+		this.tag = tag;
+		this.type = tag & 0x1F;
+		this.length = length;
+		this.value = value;
+	}
+
+	public int getType() {
+		return type;
+	}
+
+	public int getLength() {
+		return length;
+	}
+
+	public byte[] getValue() {
+		return value;
+	}
+
+	public boolean isConstructed() {
+		return  (tag & DerParser.CONSTRUCTED) == DerParser.CONSTRUCTED;
+	}
+
+	/**
+	 * For constructed field, return a parser for its content.
+	 *
+	 * @return A parser for the construct.
+	 * @throws IOException
+	 */
+	public DerParser getParser() throws IOException {
+		if (!isConstructed())
+			throw new IOException("Invalid DER: can't parse primitive entity"); //$NON-NLS-1$
+
+		return new DerParser(value);
+	}
+
+	/**
+	 * Get the value as integer
+	 *
+	 * @return BigInteger
+	 * @throws IOException
+	 */
+	public BigInteger getInteger() throws IOException {
+		if (type != DerParser.INTEGER)
+			throw new IOException("Invalid DER: object is not integer"); //$NON-NLS-1$
+
+		return new BigInteger(value);
+	}
+
+	/**
+	 * Get value as string. Most strings are treated
+	 * as Latin-1.
+	 *
+	 * @return Java string
+	 * @throws IOException
+	 */
+	public String getString() throws IOException {
+
+		String encoding;
+
+		switch (type) {
+
+			// Not all are Latin-1 but it's the closest thing
+			case DerParser.NUMERIC_STRING:
+			case DerParser.PRINTABLE_STRING:
+			case DerParser.VIDEOTEX_STRING:
+			case DerParser.IA5_STRING:
+			case DerParser.GRAPHIC_STRING:
+			case DerParser.ISO646_STRING:
+			case DerParser.GENERAL_STRING:
+				encoding = "ISO-8859-1"; //$NON-NLS-1$
+				break;
+
+			case DerParser.BMP_STRING:
+				encoding = "UTF-16BE"; //$NON-NLS-1$
+				break;
+
+			case DerParser.UTF8_STRING:
+				encoding = "UTF-8"; //$NON-NLS-1$
+				break;
+
+			case DerParser.UNIVERSAL_STRING:
+				throw new IOException("Invalid DER: can't handle UCS-4 string"); //$NON-NLS-1$
+
+			default:
+				throw new IOException("Invalid DER: object is not a string"); //$NON-NLS-1$
+		}
+
+		return new String(value, encoding);
+	}
+}


### PR DESCRIPTION
Hey @brianchandotcom.

So, the kind of key that we are using for connecting to the service is called PCKS1. Java only gives support to PCKS8 out-of-the-box so we need to do some converting before we properly use it, that's why it took so long.

You will see i created a PrivateKeyReader class( [this is the one i got externally](https://stackoverflow.com/questions/15344125/load-a-rsa-private-key-in-java-algid-parse-error-not-a-sequence/29827944#29827944)). The code that really matters( for the PCKS1 key) is inside getRSAKeySpec method. Since it uses nested classes from PrivateKeyReader i mantained it all. 

In theory we can do just what this code does, like [this](https://www.programcreek.com/java-api-examples/?api=java.security.spec.RSAPrivateCrtKeySpec), look example two, but we would need to use sun.security.util.* classes to do it and and i couldnt get the bundle to deploy with them even explicitly importing the package in bnd.

Let me know if you have some doubt.

