### PR TITLE
LPS-132030 ObjectEntry Search

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -120,7 +120,7 @@ public class ObjectEntryModelDocumentContributor
 				continue;
 			}
 
-			boolean indexedAsKeyword = objectField.isIndexedAsKeyword();
+			boolean indexedAsKeyword = objectField.isIndexedAsKeyword(); //TODO
 
 			if (indexedAsKeyword) {
 				_addNestedField(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -15,18 +15,28 @@
 package com.liferay.object.internal.search.spi.model.index.contributor;
 
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.FieldArray;
+import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 
 import java.io.Serializable;
 
 import java.math.BigDecimal;
 
+import java.text.Format;
+
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -59,6 +69,14 @@ public class ObjectEntryModelDocumentContributor
 		}
 	}
 
+	private void _addNestedField(
+		FieldArray fieldArray, String fieldName, String valueFieldName,
+		String value) {
+
+		fieldArray.addField(
+			_createNestedField(fieldName, valueFieldName, value));
+	}
+
 	private void _contribute(Document document, ObjectEntry objectEntry)
 		throws Exception {
 
@@ -70,12 +88,26 @@ public class ObjectEntryModelDocumentContributor
 		document.addKeyword(
 			"objectDefinitionId", objectEntry.getObjectDefinitionId());
 
+		FieldArray fieldArray = (FieldArray)document.getField(
+			"nestedFieldArray");
+
+		if (fieldArray == null) {
+			fieldArray = new FieldArray("nestedFieldArray");
+
+			document.add(fieldArray);
+		}
+
 		Map<String, Serializable> values = _objectEntryLocalService.getValues(
 			objectEntry.getObjectEntryId());
 
-		for (Map.Entry<String, Serializable> entry : values.entrySet()) {
-			String name = entry.getKey();
-			Object value = entry.getValue();
+		List<ObjectField> objectFields =
+			_objectFieldLocalService.getObjectFields(
+				objectEntry.getObjectDefinitionId());
+
+		for (ObjectField objectField : objectFields) {
+			String name = objectField.getName();
+
+			Object value = values.get(name);
 
 			if (value == null) {
 				if (_log.isDebugEnabled()) {
@@ -88,29 +120,44 @@ public class ObjectEntryModelDocumentContributor
 				continue;
 			}
 
-			if (value instanceof BigDecimal) {
-				document.addNumber(name, (BigDecimal)value);
+			boolean indexedAsKeyword = objectField.isIndexedAsKeyword();
+
+			if (indexedAsKeyword) {
+				_addNestedField(
+					fieldArray, name, "value_keyword",
+					StringUtil.lowerCase(String.valueOf(value)));
+			}
+			else if (value instanceof BigDecimal) {
+				_addNestedField(
+					fieldArray, name, "value_double", String.valueOf(value));
 			}
 			else if (value instanceof Boolean) {
-				document.addKeyword(name, (Boolean)value);
+				_addNestedField(
+					fieldArray, name, "value_boolean", String.valueOf(value));
 			}
 			else if (value instanceof Date) {
-				document.addDate(name, (Date)value);
+				_addNestedField(
+					fieldArray, name, "value_date", _getDateString(value));
 			}
 			else if (value instanceof Double) {
-				document.addNumber(name, (Double)value);
+				_addNestedField(
+					fieldArray, name, "value_double", String.valueOf(value));
 			}
 			else if (value instanceof Integer) {
-				document.addNumber(name, (Integer)value);
+				_addNestedField(
+					fieldArray, name, "value_integer", String.valueOf(value));
 			}
 			else if (value instanceof Long) {
-				document.addNumber(name, (Long)value);
+				_addNestedField(
+					fieldArray, name, "value_long", String.valueOf(value));
 			}
 			else if (value instanceof String) {
-				document.addText(name, (String)value);
+				_addNestedField(fieldArray, name, "value_text", (String)value);
 			}
 			else if (value instanceof byte[]) {
-				document.addText(name, new String((byte[])value));
+				_addNestedField(
+					fieldArray, name, "value_binary",
+					Base64.encode((byte[])value));
 			}
 			else {
 				if (_log.isWarnEnabled()) {
@@ -124,10 +171,32 @@ public class ObjectEntryModelDocumentContributor
 		}
 	}
 
+	private Field _createNestedField(
+		String fieldName, String valueFieldName, String value) {
+
+		Field field = new Field("");
+
+		field.addField(new Field("fieldName", fieldName));
+		field.addField(new Field("valueFieldName", valueFieldName));
+		field.addField(new Field(valueFieldName, value));
+
+		return field;
+	}
+
+	private String _getDateString(Object value) {
+		Format dateFormat = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyyMMddHHmmss");
+
+		return dateFormat.format(value);
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntryModelDocumentContributor.class);
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.search.FieldArray;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 
 import java.io.Serializable;
@@ -105,6 +106,12 @@ public class ObjectEntryModelDocumentContributor
 				objectEntry.getObjectDefinitionId());
 
 		for (ObjectField objectField : objectFields) {
+			boolean indexed = true; //objectField.isIndexed(); //TODO
+
+			if (!indexed) {
+				continue;
+			}
+
 			String name = objectField.getName();
 
 			Object value = values.get(name);
@@ -120,7 +127,17 @@ public class ObjectEntryModelDocumentContributor
 				continue;
 			}
 
-			boolean indexedAsKeyword = objectField.isIndexedAsKeyword(); //TODO
+			boolean indexedAsKeyword =
+				name.equals("emailAddress") ||
+				name.equals("emailAddressDomain"); //objectField.isIndexedAsKeyword(); //TODO
+
+			String localeString = ""; //objectField.getLocaleString(); //TODO
+
+			if (indexedAsKeyword && !Validator.isBlank(localeString)) {
+				throw new IllegalArgumentException(
+					"Field " + name +
+						" is indexed as a keyword and should not be localized");
+			}
 
 			if (indexedAsKeyword) {
 				_addNestedField(
@@ -152,7 +169,15 @@ public class ObjectEntryModelDocumentContributor
 					fieldArray, name, "value_long", String.valueOf(value));
 			}
 			else if (value instanceof String) {
-				_addNestedField(fieldArray, name, "value_text", (String)value);
+				if (!Validator.isBlank(localeString)) {
+					_addNestedField(
+						fieldArray, name, "value_" + localeString,
+						(String)value);
+				}
+				else {
+					_addNestedField(
+						fieldArray, name, "value_text", (String)value);
+				}
 			}
 			else if (value instanceof byte[]) {
 				_addNestedField(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -24,9 +24,12 @@ import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.ParseException;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.facet.util.RangeParserUtil;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.search.generic.MatchQuery;
 import com.liferay.portal.kernel.search.generic.NestedQuery;
 import com.liferay.portal.kernel.search.generic.TermQueryImpl;
+import com.liferay.portal.kernel.search.generic.TermRangeQueryImpl;
 import com.liferay.portal.kernel.search.generic.WildcardQueryImpl;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -36,6 +39,7 @@ import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContrib
 import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -83,18 +87,28 @@ public class ObjectEntryKeywordQueryContributor
 			_objectFieldLocalService.getObjectFields(objectDefinitionId);
 
 		for (ObjectField objectField : objectFields) {
-			String name = objectField.getName();
-			boolean indexedAsKeyword = objectField.isIndexedAsKeyword(); //TODO
+			boolean indexed = true; //objectField.isIndexed(); //TODO
 
-			if (_log.isDebugEnabled()) {
-				_log.debug("Add search term for object field " + name);
+			if (!indexed) {
+				continue;
 			}
 
-			if (indexedAsKeyword) {
-				try {
-					keywords = StringUtil.toLowerCase(keywords);
+			String name = objectField.getName();
+			String type = objectField.getType();
+			String localeString = ""; //objectField.getLocaleString(); //TODO
+			boolean indexedAsKeyword = //objectField.isIndexedAsKeyword(); //TODO
+				(name.equals("emailAddress") ||
+				name.equals("emailAddressDomain"));
 
-					BooleanQuery nestedBooleanQuery = new BooleanQueryImpl();
+			if (_log.isDebugEnabled()) {
+				_log.debug("Add search query for object field " + name);
+			}
+
+			try {
+				BooleanQuery nestedBooleanQuery = new BooleanQueryImpl();
+
+				if (indexedAsKeyword) {
+					keywords = StringUtil.toLowerCase(keywords);
 
 					nestedBooleanQuery.add(
 						new WildcardQueryImpl(
@@ -106,7 +120,69 @@ public class ObjectEntryKeywordQueryContributor
 						new TermQueryImpl(
 							"nestedFieldArray.value_keyword", keywords),
 						BooleanClauseOccur.SHOULD);
+				}
+				else if (type.equals("BigDecimal")) {
+					_addRangeQuery(
+						keywords, nestedBooleanQuery,
+						"nestedFieldArray.value_double");
+				}
+				else if (type.equals("Blob")) {
+					if (_log.isDebugEnabled()) {
+						_log.debug("Blob field " + name + " is not searchable");
+					}
+				}
+				else if (type.equals("Boolean")) {
+					if (StringUtil.equalsIgnoreCase(keywords, "true") ||
+						StringUtil.equalsIgnoreCase(keywords, "false")) {
 
+						nestedBooleanQuery.add(
+							new TermQueryImpl(
+								"nestedFieldArray.value_boolean",
+								StringUtil.toLowerCase(keywords)),
+							BooleanClauseOccur.MUST);
+					}
+				}
+				else if (type.equals("Date")) {
+					_addRangeQuery(
+						keywords, nestedBooleanQuery,
+						"nestedFieldArray.value_date");
+				}
+				else if (type.equals("Double")) {
+					_addRangeQuery(
+						keywords, nestedBooleanQuery,
+						"nestedFieldArray.value_double");
+				}
+				else if (type.equals("Integer")) {
+					_addRangeQuery(
+						keywords, nestedBooleanQuery,
+						"nestedFieldArray.value_integer");
+				}
+				else if (type.equals("Long")) {
+					_addRangeQuery(
+						keywords, nestedBooleanQuery,
+						"nestedFieldArray.value_long");
+				}
+				else if (type.equals("String")) {
+					Locale locale = searchContext.getLocale();
+
+					if (!Validator.isBlank(localeString) &&
+						localeString.equals(locale.toString())) {
+
+						nestedBooleanQuery.add(
+							new MatchQuery(
+								"nestedFieldArray.value_" + localeString,
+								keywords),
+							BooleanClauseOccur.MUST);
+					}
+					else {
+						nestedBooleanQuery.add(
+							new MatchQuery(
+								"nestedFieldArray.value_text", keywords),
+							BooleanClauseOccur.MUST);
+					}
+				}
+
+				if (nestedBooleanQuery.hasClauses()) {
 					nestedBooleanQuery.add(
 						new TermQueryImpl("nestedFieldArray.fieldName", name),
 						BooleanClauseOccur.MUST);
@@ -116,14 +192,26 @@ public class ObjectEntryKeywordQueryContributor
 
 					booleanQuery.add(nestedQuery, BooleanClauseOccur.SHOULD);
 				}
-				catch (ParseException parseException) {
-					throw new SystemException(parseException);
-				}
 			}
-			else {
-				_queryHelper.addSearchTerm(
-					booleanQuery, searchContext, name, false);
+			catch (ParseException parseException) {
+				throw new SystemException(parseException);
 			}
+		}
+	}
+
+	private void _addRangeQuery(
+			String keywords, BooleanQuery booleanQuery, String field)
+		throws ParseException {
+
+		String[] range = RangeParserUtil.parserRange(keywords);
+
+		String lowerTerm = range[0];
+		String upperTerm = range[1];
+
+		if ((lowerTerm != null) && (upperTerm != null)) {
+			booleanQuery.add(
+				new TermRangeQueryImpl(field, lowerTerm, upperTerm, true, true),
+				BooleanClauseOccur.MUST);
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -16,11 +16,20 @@ package com.liferay.object.internal.search.spi.model.query.contributor;
 
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.ParseException;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.search.generic.NestedQuery;
+import com.liferay.portal.kernel.search.generic.TermQueryImpl;
+import com.liferay.portal.kernel.search.generic.WildcardQueryImpl;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.query.QueryHelper;
 import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
@@ -74,14 +83,47 @@ public class ObjectEntryKeywordQueryContributor
 			_objectFieldLocalService.getObjectFields(objectDefinitionId);
 
 		for (ObjectField objectField : objectFields) {
+			String name = objectField.getName();
+			boolean indexedAsKeyword = objectField.isIndexedAsKeyword();
+
 			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"Add search term for object field " +
-						objectField.getName());
+				_log.debug("Add search term for object field " + name);
 			}
 
-			_queryHelper.addSearchTerm(
-				booleanQuery, searchContext, objectField.getName(), false);
+			if (indexedAsKeyword) {
+				try {
+					keywords = StringUtil.toLowerCase(keywords);
+
+					BooleanQuery nestedBooleanQuery = new BooleanQueryImpl();
+
+					nestedBooleanQuery.add(
+						new WildcardQueryImpl(
+							"nestedFieldArray.value_keyword",
+							keywords + StringPool.STAR),
+						BooleanClauseOccur.MUST);
+
+					nestedBooleanQuery.add(
+						new TermQueryImpl(
+							"nestedFieldArray.value_keyword", keywords),
+						BooleanClauseOccur.SHOULD);
+
+					nestedBooleanQuery.add(
+						new TermQueryImpl("nestedFieldArray.fieldName", name),
+						BooleanClauseOccur.MUST);
+
+					NestedQuery nestedQuery = new NestedQuery(
+						"nestedFieldArray", nestedBooleanQuery);
+
+					booleanQuery.add(nestedQuery, BooleanClauseOccur.SHOULD);
+				}
+				catch (ParseException parseException) {
+					throw new SystemException(parseException);
+				}
+			}
+			else {
+				_queryHelper.addSearchTerm(
+					booleanQuery, searchContext, name, false);
+			}
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -84,7 +84,7 @@ public class ObjectEntryKeywordQueryContributor
 
 		for (ObjectField objectField : objectFields) {
 			String name = objectField.getName();
-			boolean indexedAsKeyword = objectField.isIndexedAsKeyword();
+			boolean indexedAsKeyword = objectField.isIndexedAsKeyword(); //TODO
 
 			if (_log.isDebugEnabled()) {
 				_log.debug("Add search term for object field " + name);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -800,7 +800,7 @@ public class ObjectEntryLocalServiceTest {
 		ObjectField objectField = ObjectFieldLocalServiceUtil.createObjectField(
 			0);
 
-		objectField.setIndexedAsKeyword(indexedAsKeyword);
+		objectField.setIndexedAsKeyword(indexedAsKeyword); //TODO
 		objectField.setName(name);
 		objectField.setType(type);
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -481,6 +481,7 @@ public class ObjectEntryLocalServiceTest {
 		Map<String, Serializable> values = _getValues(objectEntries.get(0));
 
 		Assert.assertEquals("peter@liferay.com", values.get("emailAddress"));
+		Assert.assertEquals("@liferay.com", values.get("emailAddressDomain"));
 		Assert.assertEquals("Peter", values.get("firstName"));
 		Assert.assertEquals(values.toString(), 14, values.size());
 
@@ -503,12 +504,14 @@ public class ObjectEntryLocalServiceTest {
 		values = _getValues(objectEntries.get(0));
 
 		Assert.assertEquals("peter@liferay.com", values.get("emailAddress"));
+		Assert.assertEquals("@liferay.com", values.get("emailAddressDomain"));
 		Assert.assertEquals("Peter", values.get("firstName"));
 		Assert.assertEquals(values.toString(), 14, values.size());
 
 		values = _getValues(objectEntries.get(1));
 
 		Assert.assertEquals("james@liferay.com", values.get("emailAddress"));
+		Assert.assertEquals("@liferay.com", values.get("emailAddressDomain"));
 		Assert.assertEquals("James", values.get("firstName"));
 		Assert.assertEquals(values.toString(), 14, values.size());
 
@@ -531,18 +534,21 @@ public class ObjectEntryLocalServiceTest {
 		values = _getValues(objectEntries.get(0));
 
 		Assert.assertEquals("peter@liferay.com", values.get("emailAddress"));
+		Assert.assertEquals("@liferay.com", values.get("emailAddressDomain"));
 		Assert.assertEquals("Peter", values.get("firstName"));
 		Assert.assertEquals(values.toString(), 14, values.size());
 
 		values = _getValues(objectEntries.get(1));
 
 		Assert.assertEquals("james@liferay.com", values.get("emailAddress"));
+		Assert.assertEquals("@liferay.com", values.get("emailAddressDomain"));
 		Assert.assertEquals("James", values.get("firstName"));
 		Assert.assertEquals(values.toString(), 14, values.size());
 
 		values = _getValues(objectEntries.get(2));
 
 		Assert.assertEquals("john@liferay.com", values.get("emailAddress"));
+		Assert.assertEquals("@liferay.com", values.get("emailAddressDomain"));
 		Assert.assertEquals("John", values.get("firstName"));
 		Assert.assertEquals(values.toString(), 14, values.size());
 
@@ -800,7 +806,7 @@ public class ObjectEntryLocalServiceTest {
 		ObjectField objectField = ObjectFieldLocalServiceUtil.createObjectField(
 			0);
 
-		objectField.setIndexedAsKeyword(indexedAsKeyword); //TODO
+		//objectField.setIndexedAsKeyword(indexedAsKeyword); //TODO
 		objectField.setName(name);
 		objectField.setType(type);
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -95,7 +95,8 @@ public class ObjectEntryLocalServiceTest {
 					_createObjectField("ageOfDeath", "Long"),
 					_createObjectField("authorOfGospel", "Boolean"),
 					_createObjectField("birthday", "Date"),
-					_createObjectField("emailAddress", "String"),
+					_createObjectField("emailAddress", "String", true),
+					_createObjectField("emailAddressDomain", "String", true),
 					_createObjectField("firstName", "String"),
 					_createObjectField("height", "Double"),
 					_createObjectField("lastName", "String"),
@@ -241,7 +242,7 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals("peter@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("Peter", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		_addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
@@ -262,13 +263,13 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals("peter@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("Peter", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		values = _getValues(objectEntries.get(1));
 
 		Assert.assertEquals("james@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("James", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		_addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
@@ -289,19 +290,19 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals("peter@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("Peter", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		values = _getValues(objectEntries.get(1));
 
 		Assert.assertEquals("james@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("James", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		values = _getValues(objectEntries.get(2));
 
 		Assert.assertEquals("john@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("John", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		objectEntries = ObjectEntryLocalServiceUtil.getObjectEntries(
 			_irrelevantObjectDefinition.getObjectDefinitionId(),
@@ -337,7 +338,7 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals(0D, values.get("weight"));
 		Assert.assertEquals(
 			objectEntry.getObjectEntryId(), values.get("testId"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		try {
 			ObjectEntryLocalServiceUtil.getValues(0);
@@ -381,7 +382,7 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals("peter@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("Peter", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		_addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
@@ -402,13 +403,13 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals("peter@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("Peter", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		values = valuesList.get(1);
 
 		Assert.assertEquals("james@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("James", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		_addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
@@ -429,19 +430,19 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals("peter@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("Peter", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		values = valuesList.get(1);
 
 		Assert.assertEquals("james@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("James", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		values = valuesList.get(2);
 
 		Assert.assertEquals("john@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("John", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		valuesList = ObjectEntryLocalServiceUtil.getValuesList(
 			_irrelevantObjectDefinition.getObjectDefinitionId(), null,
@@ -465,6 +466,8 @@ public class ObjectEntryLocalServiceTest {
 			HashMapBuilder.<String, Serializable>put(
 				"emailAddress", "peter@liferay.com"
 			).put(
+				"emailAddressDomain", "@liferay.com"
+			).put(
 				"firstName", "Peter"
 			).build());
 
@@ -479,11 +482,13 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals("peter@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("Peter", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		_addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				"emailAddress", "james@liferay.com"
+			).put(
+				"emailAddressDomain", "@liferay.com"
 			).put(
 				"firstName", "James"
 			).build());
@@ -499,17 +504,19 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals("peter@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("Peter", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		values = _getValues(objectEntries.get(1));
 
 		Assert.assertEquals("james@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("James", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		_addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				"emailAddress", "john@liferay.com"
+			).put(
+				"emailAddressDomain", "@liferay.com"
 			).put(
 				"firstName", "John"
 			).build());
@@ -525,25 +532,30 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals("peter@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("Peter", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		values = _getValues(objectEntries.get(1));
 
 		Assert.assertEquals("james@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("James", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		values = _getValues(objectEntries.get(2));
 
 		Assert.assertEquals("john@liferay.com", values.get("emailAddress"));
 		Assert.assertEquals("John", values.get("firstName"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		// With keywords
 
-		//_assertKeywords("@ liferay.com", 3);
-		//_assertKeywords("@-liferay.com", 0);
-		//_assertKeywords("@liferay.com", 3);
+		_assertKeywords("@ liferay.com", 0);
+		_assertKeywords("@-liferay.com", 0);
+		_assertKeywords("@liferay.com", 3);
+		_assertKeywords("@liferay", 3);
+		_assertKeywords("@life", 3);
+		_assertKeywords("liferay.com", 0);
+		_assertKeywords("liferay", 0);
+		_assertKeywords("life", 0);
 		_assertKeywords("Peter", 1);
 		_assertKeywords("j0hn", 0);
 		_assertKeywords("john", 1);
@@ -599,7 +611,7 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals(0D, values.get("weight"));
 		Assert.assertEquals(
 			objectEntry.getObjectEntryId(), values.get("testId"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		Calendar calendar = new GregorianCalendar();
 
@@ -650,7 +662,7 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals(60D, values.get("weight"));
 		Assert.assertEquals(
 			objectEntry.getObjectEntryId(), values.get("testId"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		ObjectEntryLocalServiceUtil.updateObjectEntry(
 			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
@@ -679,7 +691,7 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals(65D, values.get("weight"));
 		Assert.assertEquals(
 			objectEntry.getObjectEntryId(), values.get("testId"));
-		Assert.assertEquals(values.toString(), 13, values.size());
+		Assert.assertEquals(values.toString(), 14, values.size());
 
 		try {
 			ObjectEntryLocalServiceUtil.updateObjectEntry(
@@ -779,9 +791,16 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	private ObjectField _createObjectField(String name, String type) {
+		return _createObjectField(name, type, false);
+	}
+
+	private ObjectField _createObjectField(
+		String name, String type, boolean indexedAsKeyword) {
+
 		ObjectField objectField = ObjectFieldLocalServiceUtil.createObjectField(
 			0);
 
+		objectField.setIndexedAsKeyword(indexedAsKeyword);
 		objectField.setName(name);
 		objectField.setType(type);
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -725,6 +725,42 @@
 				"store": true,
 				"type": "date"
 			},
+			"nestedFieldArray": {
+				"properties": {
+					"fieldName": {
+						"type": "keyword"
+					},
+					"valueFieldName": {
+						"type": "keyword"
+					},
+					"value_binary": {
+						"type": "binary"
+					},
+					"value_boolean": {
+						"type": "boolean"
+					},
+					"value_date": {
+						"format": "yyyyMMddHHmmss",
+						"type": "date"
+					},
+					"value_double": {
+						"type": "double"
+					},
+					"value_integer": {
+						"type": "integer"
+					},
+					"value_keyword": {
+						"type": "keyword"
+					},
+					"value_long": {
+						"type": "long"
+					},
+					"value_text": {
+						"type": "text"
+					}
+				},
+				"type": "nested"
+			},
 			"nodeId": {
 				"store": true,
 				"type": "keyword"


### PR DESCRIPTION
heres the fix so far, a few notes:

-it allows the fields to be mapped to their corresponding type in the search index (by using type mappings, not the Document API)
-it uses nested fields so that field names become values instead of keys, preventing mapping explosions regardless of how many unique field names there are. it also prevents the need for namespacing (the mapping is determined on a per field basis, even if the field name is not unique).
-in regards to searching for a substring on the emailAddress field, this fix follows the same pattern they used in https://github.com/brianchandotcom/liferay-portal/pull/101430/commits/720e7d180c508ef81fe5e5227c241d0330a261f4. an additional field that only holds the domain is indexed, and substring matching is replaced by prefix matching

before going further i wanted to touch base because we need some kind of flag to determine if a given field gets indexed with the "keyword" type. to me, additional API in `ObjectField` seemed like it would work best, but what do you think? https://github.com/BryanEngler/liferay-portal/commit/d83c6867f8458a45eec8f25364bd9fc01f14862a

also, i started to add some support for opting out of indexing, and also for localization. curious if you have any thoughts on how localization is going to be handled with ObjectEntries?