### PR TITLE
LPS-130155 revert | master

### DIFF
--- a/modules/apps/frontend-view-state/app.bnd
+++ b/modules/apps/frontend-view-state/app.bnd
@@ -1,6 +1,6 @@
 Liferay-Releng-App-Description: %liferay-releng-app-description
 Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix} Frontend View State
-Liferay-Releng-Bundle: false
+Liferay-Releng-Bundle: true
 Liferay-Releng-Category: Utility
 Liferay-Releng-Demo-Url:
 Liferay-Releng-Deprecated: false


### PR DESCRIPTION
Reverts commit from https://github.com/brianchandotcom/liferay-portal/pull/102078. This change is unnecessary because the app is already excluded by `.lfrbuild-releng-ignore`. Also, bundle should be set to true so lpkg tests will run and app.bnd properties are set for a future release of this app.