### PR TITLE
LPS-133994 Remove destination usage in DispatchMessageListenerTest to…

### DIFF
--- a/modules/apps/dispatch/dispatch-test/build.gradle
+++ b/modules/apps/dispatch/dispatch-test/build.gradle
@@ -3,6 +3,8 @@ dependencies {
 	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testIntegrationCompile project(":apps:dispatch:dispatch-api")
 	testIntegrationCompile project(":apps:layout:layout-test-util")
+	testIntegrationCompile project(":core:petra:petra-concurrent")
+	testIntegrationCompile project(":core:petra:petra-executor")
 	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")


### PR DESCRIPTION
… make sure the task execution status can be reliably asserted

I am not sure which scheduler usage was being complained, but searching through the codebase for tests with scheduler usage by author "Igor Beslic", I think, it is the DispatchMessageListenerTest.
The DispatchMessageListenerTest is doing something quite unusual. It requires deterministic results which is asking sync execution. Also it asserts "overlapping" timestamps which is asking for async execution. Our test framework can not provide both out of box. To me the "testDoReceiveOverlapAllowed" asserting create/end timestamp is very questionable way to test things.
But anyway, I am not changing the test logic, only modifying the execution logic to make it asyncly running to mimic overlapping, while still able to assert in sync way.

CC @jpince @igorbeslic