### PR TITLE
LPS-127468 Fix lang key

### DIFF
--- a/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/Violation.tsx
+++ b/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/Violation.tsx
@@ -92,7 +92,7 @@ function Violation({
 						<ClayList className="list-group-flush">
 							{nodes.map((_occurrence, index) => {
 								const occurrenceName = `${Liferay.Language.get(
-									'occurrence'
+									'occurrence-x'
 								)} ${String(index + 1)}`;
 
 								return (


### PR DESCRIPTION
The usage of '[occurrence](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/META-INF/resources/Violation.tsx#L95)' doesn't match with the lang key '[occurrence-x](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-a11y-web/src/main/resources/content/Language.properties#L22)'.  I think this only needs to be fixed on the code side if the language keys are fine.

cc @diegonvs @matuzalemsteles