### PR TITLE
LPS-128383 & LPS-128385 Using site settings inheritance for PageAudit

### DIFF
--- a/modules/apps/layout/layout-reports-test/src/testIntegration/java/com/liferay/layout/reports/web/internal/portlet/action/test/LayoutReportsDataMVCResourceCommandTest.java
+++ b/modules/apps/layout/layout-reports-test/src/testIntegration/java/com/liferay/layout/reports/web/internal/portlet/action/test/LayoutReportsDataMVCResourceCommandTest.java
@@ -23,9 +23,9 @@ import com.liferay.info.item.InfoItemClassDetails;
 import com.liferay.info.item.InfoItemDetails;
 import com.liferay.info.item.InfoItemFieldValues;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
+import com.liferay.layout.reports.web.internal.util.LayoutReportsTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
@@ -48,7 +47,6 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapDictionary;
-import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -94,231 +92,197 @@ public class LayoutReportsDataMVCResourceCommandTest {
 
 	@Test
 	public void testGetData() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
+		LayoutReportsTestUtil.
+			withLayoutReportsGooglePageSpeedGroupConfiguration(
+				RandomTestUtil.randomString(), true, _group.getGroupId(),
+				() -> {
+					Layout layout = LayoutTestUtil.addLayout(
+						_group.getGroupId());
 
-		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
-				new ConfigurationTemporarySwapper(
-					"com.liferay.layout.reports.web.internal.configuration." +
-						"LayoutReportsGooglePageSpeedCompanyConfiguration",
-					HashMapDictionaryBuilder.<String, Object>put(
-						"apiKey", RandomTestUtil.randomString()
-					).put(
-						"enabled", true
-					).build())) {
+					GroupTestUtil.updateDisplaySettings(
+						_group.getGroupId(),
+						Arrays.asList(LocaleUtil.BRAZIL, LocaleUtil.SPAIN),
+						LocaleUtil.SPAIN);
 
-			Layout layout = LayoutTestUtil.addLayout(_group.getGroupId());
+					JSONObject jsonObject = _serveResource(layout);
 
-			GroupTestUtil.updateDisplaySettings(
-				_group.getGroupId(),
-				Arrays.asList(LocaleUtil.BRAZIL, LocaleUtil.SPAIN),
-				LocaleUtil.SPAIN);
+					JSONArray pageURLsJSONArray = jsonObject.getJSONArray(
+						"pageURLs");
 
-			JSONObject jsonObject = _serveResource(layout);
+					Assert.assertEquals(
+						String.valueOf(pageURLsJSONArray), 2,
+						pageURLsJSONArray.length());
 
-			JSONArray pageURLsJSONArray = jsonObject.getJSONArray("pageURLs");
+					JSONObject pageURLJSONObject1 =
+						pageURLsJSONArray.getJSONObject(0);
 
-			Assert.assertEquals(
-				String.valueOf(pageURLsJSONArray), 2,
-				pageURLsJSONArray.length());
+					String imagesPath = jsonObject.getString("imagesPath");
 
-			JSONObject pageURLJSONObject1 = pageURLsJSONArray.getJSONObject(0);
+					Assert.assertTrue(imagesPath.contains("images"));
 
-			String imagesPath = jsonObject.getString("imagesPath");
+					Assert.assertEquals(
+						LocaleUtil.toW3cLanguageId(LocaleUtil.SPAIN),
+						pageURLJSONObject1.getString("languageId"));
+					Assert.assertEquals(
+						layout.getName(LocaleUtil.SPAIN),
+						pageURLJSONObject1.getString("title"));
 
-			Assert.assertTrue(imagesPath.contains("images"));
+					JSONObject pageURLJSONObject2 =
+						pageURLsJSONArray.getJSONObject(1);
 
-			Assert.assertEquals(
-				LocaleUtil.toW3cLanguageId(LocaleUtil.SPAIN),
-				pageURLJSONObject1.getString("languageId"));
-			Assert.assertEquals(
-				layout.getName(LocaleUtil.SPAIN),
-				pageURLJSONObject1.getString("title"));
+					Assert.assertEquals(
+						LocaleUtil.toW3cLanguageId(LocaleUtil.BRAZIL),
+						pageURLJSONObject2.getString("languageId"));
 
-			JSONObject pageURLJSONObject2 = pageURLsJSONArray.getJSONObject(1);
+					Assert.assertEquals(
+						layout.getName(LocaleUtil.BRAZIL),
+						pageURLJSONObject1.getString("title"));
 
-			Assert.assertEquals(
-				LocaleUtil.toW3cLanguageId(LocaleUtil.BRAZIL),
-				pageURLJSONObject2.getString("languageId"));
+					String configureGooglePageSpeedURL = jsonObject.getString(
+						"configureGooglePageSpeedURL");
 
-			Assert.assertEquals(
-				layout.getName(LocaleUtil.BRAZIL),
-				pageURLJSONObject1.getString("title"));
+					Assert.assertTrue(
+						configureGooglePageSpeedURL.contains(
+							"configuration_admin"));
 
-			String configureGooglePageSpeedURL = jsonObject.getString(
-				"configureGooglePageSpeedURL");
+					Assert.assertEquals(
+						LocaleUtil.toW3cLanguageId(LocaleUtil.SPAIN),
+						jsonObject.getString("defaultLanguageId"));
 
-			Assert.assertTrue(
-				configureGooglePageSpeedURL.contains("configuration_admin"));
-
-			Assert.assertEquals(
-				LocaleUtil.toW3cLanguageId(LocaleUtil.SPAIN),
-				jsonObject.getString("defaultLanguageId"));
-
-			Assert.assertTrue(jsonObject.getBoolean("validConnection"));
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-
-			ServiceContextThreadLocal.pushServiceContext(serviceContext);
-		}
+					Assert.assertTrue(jsonObject.getBoolean("validConnection"));
+				});
 	}
 
 	@Test
 	public void testGetDataWithApiKeyInSiteConfiguration() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
+		LayoutReportsTestUtil.
+			withLayoutReportsGooglePageSpeedGroupConfiguration(
+				RandomTestUtil.randomString(), true, _group.getGroupId(),
+				() -> {
+					Layout layout = LayoutTestUtil.addLayout(
+						_group.getGroupId());
 
-		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
-				new ConfigurationTemporarySwapper(
-					"com.liferay.layout.reports.web.internal.configuration." +
-						"LayoutReportsGooglePageSpeedGroupConfiguration",
-					HashMapDictionaryBuilder.<String, Object>put(
-						"apiKey", RandomTestUtil.randomString()
-					).put(
-						"enabled", true
-					).build())) {
+					JSONObject jsonObject = _serveResource(layout);
 
-			Layout layout = LayoutTestUtil.addLayout(_group.getGroupId());
-
-			JSONObject jsonObject = _serveResource(layout);
-
-			Assert.assertTrue(jsonObject.getBoolean("validConnection"));
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-
-			ServiceContextThreadLocal.pushServiceContext(serviceContext);
-		}
+					Assert.assertTrue(jsonObject.getBoolean("validConnection"));
+				});
 	}
 
 	@Test
 	public void testGetDataWithLayoutTypeAssetDisplay() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
+		LayoutReportsTestUtil.
+			withLayoutReportsGooglePageSpeedGroupConfiguration(
+				RandomTestUtil.randomString(), true, _group.getGroupId(),
+				() -> {
+					Bundle bundle = FrameworkUtil.getBundle(
+						LayoutReportsDataMVCResourceCommandTest.class);
 
-		Bundle bundle = FrameworkUtil.getBundle(
-			LayoutReportsDataMVCResourceCommandTest.class);
+					BundleContext bundleContext = bundle.getBundleContext();
 
-		BundleContext bundleContext = bundle.getBundleContext();
+					ServiceRegistration<InfoItemFieldValuesProvider<?>>
+						infoItemFieldValuesProviderServiceRegistration =
+							bundleContext.registerService(
+								(Class<InfoItemFieldValuesProvider<?>>)
+									(Class<?>)InfoItemFieldValuesProvider.class,
+								new MockInfoItemFieldValuesProvider(),
+								new HashMapDictionary<>());
 
-		ServiceRegistration<InfoItemFieldValuesProvider<?>>
-			infoItemFieldValuesProviderServiceRegistration =
-				bundleContext.registerService(
-					(Class<InfoItemFieldValuesProvider<?>>)
-						(Class<?>)InfoItemFieldValuesProvider.class,
-					new MockInfoItemFieldValuesProvider(),
-					new HashMapDictionary<>());
+					try {
+						Layout layout = LayoutTestUtil.addLayout(_group);
 
-		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
-				new ConfigurationTemporarySwapper(
-					"com.liferay.layout.reports.web.internal.configuration." +
-						"LayoutReportsGooglePageSpeedCompanyConfiguration",
-					HashMapDictionaryBuilder.<String, Object>put(
-						"apiKey", RandomTestUtil.randomString()
-					).put(
-						"enabled", true
-					).build())) {
+						layout.setType(LayoutConstants.TYPE_ASSET_DISPLAY);
 
-			Layout layout = LayoutTestUtil.addLayout(_group);
+						layout = _layoutLocalService.updateLayout(layout);
 
-			layout.setType(LayoutConstants.TYPE_ASSET_DISPLAY);
+						GroupTestUtil.updateDisplaySettings(
+							_group.getGroupId(),
+							Arrays.asList(LocaleUtil.BRAZIL, LocaleUtil.SPAIN),
+							LocaleUtil.SPAIN);
 
-			layout = _layoutLocalService.updateLayout(layout);
+						InfoItemClassDetails infoItemClassDetails =
+							new InfoItemClassDetails(
+								MockObject.class.getName());
 
-			GroupTestUtil.updateDisplaySettings(
-				_group.getGroupId(),
-				Arrays.asList(LocaleUtil.BRAZIL, LocaleUtil.SPAIN),
-				LocaleUtil.SPAIN);
+						InfoItemDetails infoItemDetails = new InfoItemDetails(
+							infoItemClassDetails, null);
 
-			InfoItemClassDetails infoItemClassDetails =
-				new InfoItemClassDetails(MockObject.class.getName());
+						JSONObject jsonObject = _serveResource(
+							layout,
+							new ObjectValuePair[] {
+								new ObjectValuePair<>(
+									InfoDisplayWebKeys.INFO_ITEM_DETAILS,
+									infoItemDetails),
+								new ObjectValuePair<>(
+									InfoDisplayWebKeys.INFO_ITEM,
+									new MockObject())
+							});
 
-			InfoItemDetails infoItemDetails = new InfoItemDetails(
-				infoItemClassDetails, null);
+						JSONArray pageURLsJSONArray = jsonObject.getJSONArray(
+							"pageURLs");
 
-			JSONObject jsonObject = _serveResource(
-				layout,
-				new ObjectValuePair[] {
-					new ObjectValuePair<>(
-						InfoDisplayWebKeys.INFO_ITEM_DETAILS, infoItemDetails),
-					new ObjectValuePair<>(
-						InfoDisplayWebKeys.INFO_ITEM, new MockObject())
+						Assert.assertEquals(
+							String.valueOf(pageURLsJSONArray), 2,
+							pageURLsJSONArray.length());
+
+						JSONObject pageURLJSONObject1 =
+							pageURLsJSONArray.getJSONObject(0);
+
+						Assert.assertEquals(
+							LocaleUtil.toW3cLanguageId(LocaleUtil.SPAIN),
+							pageURLJSONObject1.get("languageId"));
+						Assert.assertEquals(
+							"defaultMappedTitle",
+							pageURLJSONObject1.get("title"));
+
+						JSONObject pageURLJSONObject2 =
+							pageURLsJSONArray.getJSONObject(1);
+
+						String imagesPath = jsonObject.getString("imagesPath");
+
+						Assert.assertTrue(imagesPath.contains("images"));
+
+						Assert.assertEquals(
+							LocaleUtil.toW3cLanguageId(LocaleUtil.BRAZIL),
+							pageURLJSONObject2.getString("languageId"));
+						Assert.assertEquals(
+							"defaultMappedTitle",
+							pageURLJSONObject2.getString("title"));
+
+						String configureGooglePageSpeedURL =
+							jsonObject.getString("configureGooglePageSpeedURL");
+
+						Assert.assertTrue(
+							configureGooglePageSpeedURL.contains(
+								"configuration_admin"));
+
+						Assert.assertEquals(
+							LocaleUtil.toW3cLanguageId(LocaleUtil.SPAIN),
+							jsonObject.getString("defaultLanguageId"));
+
+						Assert.assertTrue(
+							jsonObject.getBoolean("validConnection"));
+					}
+					finally {
+						infoItemFieldValuesProviderServiceRegistration.
+							unregister();
+					}
 				});
-
-			JSONArray pageURLsJSONArray = jsonObject.getJSONArray("pageURLs");
-
-			Assert.assertEquals(
-				String.valueOf(pageURLsJSONArray), 2,
-				pageURLsJSONArray.length());
-
-			JSONObject pageURLJSONObject1 = pageURLsJSONArray.getJSONObject(0);
-
-			Assert.assertEquals(
-				LocaleUtil.toW3cLanguageId(LocaleUtil.SPAIN),
-				pageURLJSONObject1.get("languageId"));
-			Assert.assertEquals(
-				"defaultMappedTitle", pageURLJSONObject1.get("title"));
-
-			JSONObject pageURLJSONObject2 = pageURLsJSONArray.getJSONObject(1);
-
-			String imagesPath = jsonObject.getString("imagesPath");
-
-			Assert.assertTrue(imagesPath.contains("images"));
-
-			Assert.assertEquals(
-				LocaleUtil.toW3cLanguageId(LocaleUtil.BRAZIL),
-				pageURLJSONObject2.getString("languageId"));
-			Assert.assertEquals(
-				"defaultMappedTitle", pageURLJSONObject2.getString("title"));
-
-			String configureGooglePageSpeedURL = jsonObject.getString(
-				"configureGooglePageSpeedURL");
-
-			Assert.assertTrue(
-				configureGooglePageSpeedURL.contains("configuration_admin"));
-
-			Assert.assertEquals(
-				LocaleUtil.toW3cLanguageId(LocaleUtil.SPAIN),
-				jsonObject.getString("defaultLanguageId"));
-
-			Assert.assertTrue(jsonObject.getBoolean("validConnection"));
-		}
-		finally {
-			infoItemFieldValuesProviderServiceRegistration.unregister();
-
-			ServiceContextThreadLocal.popServiceContext();
-
-			ServiceContextThreadLocal.pushServiceContext(serviceContext);
-		}
 	}
 
 	@Test
 	public void testGetDataWithoutApiKey() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
+		LayoutReportsTestUtil.
+			withLayoutReportsGooglePageSpeedGroupConfiguration(
+				StringPool.BLANK, true, _group.getGroupId(),
+				() -> {
+					Layout layout = LayoutTestUtil.addLayout(
+						_group.getGroupId());
 
-		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
-				new ConfigurationTemporarySwapper(
-					"com.liferay.layout.reports.web.internal.configuration." +
-						"LayoutReportsGooglePageSpeedCompanyConfiguration",
-					HashMapDictionaryBuilder.<String, Object>put(
-						"apiKey", StringPool.BLANK
-					).put(
-						"enabled", true
-					).build())) {
+					JSONObject jsonObject = _serveResource(layout);
 
-			Layout layout = LayoutTestUtil.addLayout(_group.getGroupId());
-
-			JSONObject jsonObject = _serveResource(layout);
-
-			Assert.assertFalse(jsonObject.getBoolean("validConnection"));
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-
-			ServiceContextThreadLocal.pushServiceContext(serviceContext);
-		}
+					Assert.assertFalse(
+						jsonObject.getBoolean("validConnection"));
+				});
 	}
 
 	private MockLiferayResourceRequest _getMockLiferayResourceRequest(
@@ -390,9 +354,6 @@ public class LayoutReportsDataMVCResourceCommandTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
-
-	@Inject
-	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/layout/layout-reports-test/src/testIntegration/java/com/liferay/layout/reports/web/internal/product/navigation/control/menu/test/LayoutReportsProductNavigationControlMenuEntryTest.java
+++ b/modules/apps/layout/layout-reports-test/src/testIntegration/java/com/liferay/layout/reports/web/internal/product/navigation/control/menu/test/LayoutReportsProductNavigationControlMenuEntryTest.java
@@ -15,23 +15,21 @@
 package com.liferay.layout.reports.web.internal.product.navigation.control.menu.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.reports.web.internal.util.LayoutReportsTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
-import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
-import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -72,31 +70,12 @@ public class LayoutReportsProductNavigationControlMenuEntryTest {
 
 	@Test
 	public void testIsShow() throws Exception {
-		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
-				new ConfigurationTemporarySwapper(
-					"com.liferay.layout.reports.web.internal.configuration." +
-						"LayoutReportsGooglePageSpeedConfiguration",
-					HashMapDictionaryBuilder.<String, Object>put(
-						"enabled", true
-					).build())) {
-
-			try (CompanyConfigurationTemporarySwapper
-					companyConfigurationTemporarySwapper =
-						new CompanyConfigurationTemporarySwapper(
-							_group.getCompanyId(),
-							"com.liferay.layout.reports.web.internal." +
-								"configuration.LayoutReportsGooglePageSpeed" +
-									"CompanyConfiguration",
-							HashMapDictionaryBuilder.<String, Object>put(
-								"enabled", true
-							).build(),
-							_settingsFactory)) {
-
-				Assert.assertTrue(
+		LayoutReportsTestUtil.
+			withLayoutReportsGooglePageSpeedGroupConfiguration(
+				StringPool.BLANK, true, _group.getGroupId(),
+				() -> Assert.assertTrue(
 					_productNavigationControlMenuEntry.isShow(
-						_getHttpServletRequest()));
-			}
-		}
+						_getHttpServletRequest())));
 	}
 
 	@Test
@@ -105,36 +84,31 @@ public class LayoutReportsProductNavigationControlMenuEntryTest {
 
 		_layout = _layoutLocalService.updateLayout(_layout);
 
-		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
-				new ConfigurationTemporarySwapper(
-					"com.liferay.layout.reports.web.internal.configuration." +
-						"LayoutReportsGooglePageSpeedConfiguration",
-					HashMapDictionaryBuilder.<String, Object>put(
-						"apiKey", RandomTestUtil.randomString()
-					).put(
-						"enabled", true
-					).build())) {
-
-			Assert.assertTrue(
-				_productNavigationControlMenuEntry.isShow(
-					_getHttpServletRequest()));
-		}
+		LayoutReportsTestUtil.
+			withLayoutReportsGooglePageSpeedGroupConfiguration(
+				RandomTestUtil.randomString(), true, _group.getGroupId(),
+				() -> Assert.assertTrue(
+					_productNavigationControlMenuEntry.isShow(
+						_getHttpServletRequest())));
 	}
 
 	@Test
-	public void testIsShowWithoutEnableConfiguration() throws Exception {
-		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
-				new ConfigurationTemporarySwapper(
-					"com.liferay.layout.reports.web.internal.configuration." +
-						"LayoutReportsGooglePageSpeedConfiguration",
-					HashMapDictionaryBuilder.<String, Object>put(
-						"enabled", false
-					).build())) {
+	public void testIsShowWithoutEnableCompanyConfiguration() throws Exception {
+		LayoutReportsTestUtil.
+			withLayoutReportsGooglePageSpeedCompanyConfiguration(
+				_group.getCompanyId(), false,
+				() -> Assert.assertFalse(
+					_productNavigationControlMenuEntry.isShow(
+						_getHttpServletRequest())));
+	}
 
-			Assert.assertFalse(
+	@Test
+	public void testIsShowWithoutEnableSystemConfiguration() throws Exception {
+		LayoutReportsTestUtil.withLayoutReportsGooglePageSpeedConfiguration(
+			false,
+			() -> Assert.assertFalse(
 				_productNavigationControlMenuEntry.isShow(
-					_getHttpServletRequest()));
-		}
+					_getHttpServletRequest())));
 	}
 
 	private HttpServletRequest _getHttpServletRequest() throws PortalException {
@@ -173,8 +147,5 @@ public class LayoutReportsProductNavigationControlMenuEntryTest {
 	)
 	private ProductNavigationControlMenuEntry
 		_productNavigationControlMenuEntry;
-
-	@Inject
-	private SettingsFactory _settingsFactory;
 
 }

--- a/modules/apps/layout/layout-reports-test/src/testIntegration/java/com/liferay/layout/reports/web/internal/util/LayoutReportsTestUtil.java
+++ b/modules/apps/layout/layout-reports-test/src/testIntegration/java/com/liferay/layout/reports/web/internal/util/LayoutReportsTestUtil.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.reports.web.internal.util;
+
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
+import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
+import com.liferay.portal.configuration.test.util.GroupConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.settings.SettingsFactoryUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+
+/**
+ * @author AlejandroTardín
+ */
+public class LayoutReportsTestUtil {
+
+	public static void withLayoutReportsGooglePageSpeedCompanyConfiguration(
+			long companyId, boolean enabled,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						companyId,
+						"com.liferay.layout.reports.web.internal." +
+							"configuration.LayoutReportsGooglePageSpeed" +
+								"CompanyConfiguration",
+						HashMapDictionaryBuilder.<String, Object>put(
+							"enabled", enabled
+						).build(),
+						SettingsFactoryUtil.getSettingsFactory())) {
+
+			unsafeRunnable.run();
+		}
+	}
+
+	public static void withLayoutReportsGooglePageSpeedConfiguration(
+			boolean enabled, UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					"com.liferay.layout.reports.web.internal.configuration." +
+						"LayoutReportsGooglePageSpeedConfiguration",
+					HashMapDictionaryBuilder.<String, Object>put(
+						"enabled", enabled
+					).build())) {
+
+			unsafeRunnable.run();
+		}
+	}
+
+	public static void withLayoutReportsGooglePageSpeedGroupConfiguration(
+			String apiKey, boolean enabled, long groupId,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try (GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						groupId,
+						"com.liferay.layout.reports.web.internal." +
+							"configuration.LayoutReportsGooglePageSpeed" +
+								"GroupConfiguration",
+						HashMapDictionaryBuilder.<String, Object>put(
+							"apiKey", apiKey
+						).put(
+							"enabled", enabled
+						).build(),
+						SettingsFactoryUtil.getSettingsFactory())) {
+
+			unsafeRunnable.run();
+		}
+	}
+
+}

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/configuration/LayoutReportsGooglePageSpeedCompanyConfiguration.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/configuration/LayoutReportsGooglePageSpeedCompanyConfiguration.java
@@ -16,7 +16,6 @@ package com.liferay.layout.reports.web.internal.configuration;
 
 import aQute.bnd.annotation.metatype.Meta;
 
-import com.liferay.portal.configuration.metatype.annotations.ExtendedAttributeDefinition;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 
 /**
@@ -35,20 +34,5 @@ public interface LayoutReportsGooglePageSpeedCompanyConfiguration {
 
 	@Meta.AD(deflt = "true", name = "enable-google-pagespeed", required = false)
 	public boolean enabled();
-
-	@ExtendedAttributeDefinition(
-		descriptionArguments = "https://developers.google.com/speed/docs/insights/v5/get-started"
-	)
-	@Meta.AD(
-		description = "api-key-description", name = "api-key", required = false
-	)
-	public String apiKey();
-
-	@Meta.AD(
-		deflt = "MOBILE", description = "strategy-description",
-		name = "strategy", optionLabels = {"mobile", "desktop"},
-		optionValues = {"MOBILE", "DESKTOP"}, required = false
-	)
-	public String strategy();
 
 }

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/configuration/provider/LayoutReportsGooglePageSpeedConfigurationProvider.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/configuration/provider/LayoutReportsGooglePageSpeedConfigurationProvider.java
@@ -55,7 +55,14 @@ public class LayoutReportsGooglePageSpeedConfigurationProvider {
 					LayoutReportsGooglePageSpeedGroupConfiguration.class,
 					group.getGroupId());
 
-		return layoutReportsGooglePageSpeedGroupConfiguration.strategy();
+		String strategy =
+			layoutReportsGooglePageSpeedGroupConfiguration.strategy();
+
+		if (!strategy.equals("DESKTOP") && !strategy.equals("MOBILE")) {
+			return "DESKTOP";
+		}
+
+		return strategy;
 	}
 
 	public boolean isEnabled() {

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/configuration/provider/LayoutReportsGooglePageSpeedConfigurationProvider.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/configuration/provider/LayoutReportsGooglePageSpeedConfigurationProvider.java
@@ -21,7 +21,6 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
-import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Map;
 
@@ -46,13 +45,7 @@ public class LayoutReportsGooglePageSpeedConfigurationProvider {
 					LayoutReportsGooglePageSpeedGroupConfiguration.class,
 					group.getGroupId());
 
-		String apiKey = layoutReportsGooglePageSpeedGroupConfiguration.apiKey();
-
-		if (Validator.isNotNull(apiKey)) {
-			return apiKey;
-		}
-
-		return _getApiKey(group.getCompanyId());
+		return layoutReportsGooglePageSpeedGroupConfiguration.apiKey();
 	}
 
 	public String getStrategy(Group group) throws ConfigurationException {
@@ -62,20 +55,7 @@ public class LayoutReportsGooglePageSpeedConfigurationProvider {
 					LayoutReportsGooglePageSpeedGroupConfiguration.class,
 					group.getGroupId());
 
-		String strategy =
-			layoutReportsGooglePageSpeedGroupConfiguration.strategy();
-
-		if (Validator.isNotNull(strategy)) {
-			return strategy;
-		}
-
-		LayoutReportsGooglePageSpeedCompanyConfiguration
-			layoutReportsGooglePageSpeedCompanyConfiguration =
-				_configurationProvider.getCompanyConfiguration(
-					LayoutReportsGooglePageSpeedCompanyConfiguration.class,
-					group.getCompanyId());
-
-		return layoutReportsGooglePageSpeedCompanyConfiguration.strategy();
+		return layoutReportsGooglePageSpeedGroupConfiguration.strategy();
 	}
 
 	public boolean isEnabled() {
@@ -83,17 +63,17 @@ public class LayoutReportsGooglePageSpeedConfigurationProvider {
 	}
 
 	public boolean isEnabled(Group group) throws ConfigurationException {
+		if (!isEnabled(group.getCompanyId())) {
+			return false;
+		}
+
 		LayoutReportsGooglePageSpeedGroupConfiguration
 			layoutReportsGooglePageSpeedGroupConfiguration =
 				_configurationProvider.getGroupConfiguration(
 					LayoutReportsGooglePageSpeedGroupConfiguration.class,
 					group.getGroupId());
 
-		if (!layoutReportsGooglePageSpeedGroupConfiguration.enabled()) {
-			return false;
-		}
-
-		return isEnabled(group.getCompanyId());
+		return layoutReportsGooglePageSpeedGroupConfiguration.enabled();
 	}
 
 	public boolean isEnabled(long companyId) throws ConfigurationException {
@@ -120,16 +100,6 @@ public class LayoutReportsGooglePageSpeedConfigurationProvider {
 		_layoutReportsGooglePageSpeedConfiguration =
 			ConfigurableUtil.createConfigurable(
 				LayoutReportsGooglePageSpeedConfiguration.class, properties);
-	}
-
-	private String _getApiKey(long companyId) throws ConfigurationException {
-		LayoutReportsGooglePageSpeedCompanyConfiguration
-			layoutReportsGooglePageSpeedCompanyConfiguration =
-				_configurationProvider.getCompanyConfiguration(
-					LayoutReportsGooglePageSpeedCompanyConfiguration.class,
-					companyId);
-
-		return layoutReportsGooglePageSpeedCompanyConfiguration.apiKey();
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/portlet/action/LayoutReportsDataMVCResourceCommand.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/portlet/action/LayoutReportsDataMVCResourceCommand.java
@@ -19,7 +19,6 @@ import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.info.item.InfoItemDetails;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
-import com.liferay.layout.reports.web.internal.configuration.LayoutReportsGooglePageSpeedCompanyConfiguration;
 import com.liferay.layout.reports.web.internal.configuration.LayoutReportsGooglePageSpeedGroupConfiguration;
 import com.liferay.layout.reports.web.internal.configuration.provider.LayoutReportsGooglePageSpeedConfigurationProvider;
 import com.liferay.layout.reports.web.internal.constants.LayoutReportsPortletKeys;
@@ -181,49 +180,50 @@ public class LayoutReportsDataMVCResourceCommand
 		}
 	}
 
+	private String _getConfigurationAdminPortletId(ThemeDisplay themeDisplay) {
+		if (_isOmniAdmin()) {
+			return ConfigurationAdminPortletKeys.SYSTEM_SETTINGS;
+		}
+
+		if (_isCompanyAdmin()) {
+			return ConfigurationAdminPortletKeys.INSTANCE_SETTINGS;
+		}
+
+		if (_isSiteAdmin(themeDisplay.getScopeGroupId())) {
+			return ConfigurationAdminPortletKeys.SITE_SETTINGS;
+		}
+
+		return null;
+	}
+
 	private String _getConfigureGooglePageSpeedURL(
 		PortletRequest portletRequest) {
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		if (_isCompanyAdmin()) {
-			return PortletURLBuilder.create(
-				_portal.getControlPanelPortletURL(
-					portletRequest,
-					ConfigurationAdminPortletKeys.INSTANCE_SETTINGS,
-					PortletRequest.RENDER_PHASE)
-			).setMVCRenderCommandName(
-				"/configuration_admin/edit_configuration"
-			).setRedirect(
-				_getCompleteURL(portletRequest)
-			).setParameter(
-				"factoryPid",
-				LayoutReportsGooglePageSpeedCompanyConfiguration.class.getName()
-			).setParameter(
-				"pid",
-				LayoutReportsGooglePageSpeedCompanyConfiguration.class.getName()
-			).buildString();
-		}
-		else if (_isSiteAdmin(themeDisplay.getScopeGroupId())) {
-			return PortletURLBuilder.create(
-				_portal.getControlPanelPortletURL(
-					portletRequest, ConfigurationAdminPortletKeys.SITE_SETTINGS,
-					PortletRequest.RENDER_PHASE)
-			).setMVCRenderCommandName(
-				"/configuration_admin/edit_configuration"
-			).setRedirect(
-				_getCompleteURL(portletRequest)
-			).setParameter(
-				"factoryPid",
-				LayoutReportsGooglePageSpeedGroupConfiguration.class.getName()
-			).setParameter(
-				"pid",
-				LayoutReportsGooglePageSpeedGroupConfiguration.class.getName()
-			).buildString();
+		String configurationAdminPortletId = _getConfigurationAdminPortletId(
+			themeDisplay);
+
+		if (Validator.isNull(configurationAdminPortletId)) {
+			return null;
 		}
 
-		return null;
+		return PortletURLBuilder.create(
+			_portal.getControlPanelPortletURL(
+				portletRequest, configurationAdminPortletId,
+				PortletRequest.RENDER_PHASE)
+		).setMVCRenderCommandName(
+			"/configuration_admin/edit_configuration"
+		).setRedirect(
+			_getCompleteURL(portletRequest)
+		).setParameter(
+			"factoryPid",
+			LayoutReportsGooglePageSpeedGroupConfiguration.class.getName()
+		).setParameter(
+			"pid",
+			LayoutReportsGooglePageSpeedGroupConfiguration.class.getName()
+		).buildString();
 	}
 
 	private Locale _getDefaultLocale(Layout layout) {
@@ -374,6 +374,13 @@ public class LayoutReportsDataMVCResourceCommand
 			PermissionThreadLocal.getPermissionChecker();
 
 		return permissionChecker.isCompanyAdmin();
+	}
+
+	private boolean _isOmniAdmin() {
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		return permissionChecker.isOmniadmin();
 	}
 
 	private boolean _isSiteAdmin(long groupId) {

--- a/modules/apps/portal-configuration/portal-configuration-test-util/bnd.bnd
+++ b/modules/apps/portal-configuration/portal-configuration-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Portal Configuration Test Utilities
 Bundle-SymbolicName: com.liferay.portal.configuration.test.util
-Bundle-Version: 5.1.2
+Bundle-Version: 5.2.0
 Export-Package: com.liferay.portal.configuration.test.util

--- a/modules/apps/portal-configuration/portal-configuration-test-util/src/main/java/com/liferay/portal/configuration/test/util/GroupConfigurationTemporarySwapper.java
+++ b/modules/apps/portal-configuration/portal-configuration-test-util/src/main/java/com/liferay/portal/configuration/test/util/GroupConfigurationTemporarySwapper.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.test.util;
+
+import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
+import com.liferay.portal.kernel.settings.ModifiableSettings;
+import com.liferay.portal.kernel.settings.Settings;
+import com.liferay.portal.kernel.settings.SettingsFactory;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+
+import java.util.Dictionary;
+import java.util.Enumeration;
+
+/**
+ * @author Alejandro Tardín
+ */
+public class GroupConfigurationTemporarySwapper implements AutoCloseable {
+
+	public GroupConfigurationTemporarySwapper(
+			long groupId, String pid, Dictionary<String, Object> properties,
+			SettingsFactory settingsFactory)
+		throws Exception {
+
+		_groupId = groupId;
+		_pid = pid;
+		_settingsFactory = settingsFactory;
+
+		Settings settings = _settingsFactory.getSettings(
+			new GroupServiceSettingsLocator(_groupId, _pid));
+
+		ModifiableSettings modifiableSettings =
+			settings.getModifiableSettings();
+
+		_initialProperties = new HashMapDictionary();
+
+		Enumeration<String> keysEnumeration = properties.keys();
+
+		while (keysEnumeration.hasMoreElements()) {
+			String key = keysEnumeration.nextElement();
+
+			_initialProperties.put(key, modifiableSettings.getValue(key, null));
+
+			modifiableSettings.setValue(
+				key, String.valueOf(properties.get(key)));
+		}
+
+		modifiableSettings.store();
+	}
+
+	@Override
+	public void close() throws Exception {
+		Settings settings = _settingsFactory.getSettings(
+			new GroupServiceSettingsLocator(_groupId, _pid));
+
+		ModifiableSettings modifiableSettings =
+			settings.getModifiableSettings();
+
+		Enumeration<String> keysEnumeration = _initialProperties.keys();
+
+		while (keysEnumeration.hasMoreElements()) {
+			String key = keysEnumeration.nextElement();
+
+			modifiableSettings.setValue(
+				key, String.valueOf(_initialProperties.get(key)));
+		}
+
+		modifiableSettings.store();
+	}
+
+	private final long _groupId;
+	private final Dictionary<String, Object> _initialProperties;
+	private final String _pid;
+	private final SettingsFactory _settingsFactory;
+
+}

--- a/modules/apps/portal-configuration/portal-configuration-test-util/src/main/resources/com/liferay/portal/configuration/test/util/packageinfo
+++ b/modules/apps/portal-configuration/portal-configuration-test-util/src/main/resources/com/liferay/portal/configuration/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0


### PR DESCRIPTION
Site settings now allows inheriting values from System and Instance settings. This allows us to simplify our settings hierarchy by leveraging said inheritance. Now:

* `Api Key` and `Strategy` will only live in GroupSettings. If we set a value for the in System (or Instance) settings it will be inherited by all the sites at those scopes.
* We'll keep the `enabled` check in System and Company to allow admins to fully disable the feature at those levels.