### PR TITLE
LPS-132566 Language keys are missing for MB user moderation in workflow configuration

### DIFF
--- a/modules/apps/message-boards/message-boards-moderation/build.gradle
+++ b/modules/apps/message-boards/message-boards-moderation/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:message-boards:message-boards-moderation-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-kaleo-api")

--- a/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/instance/lifecycle/AddMBModerationWorkflowDefinitionPortalInstanceLifecycleListener.java
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/instance/lifecycle/AddMBModerationWorkflowDefinitionPortalInstanceLifecycleListener.java
@@ -18,10 +18,17 @@ import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.moderation.internal.constants.MBModerationConstants;
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowDefinitionManager;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -57,10 +64,34 @@ public class AddMBModerationWorkflowDefinitionPortalInstanceLifecycleListener
 
 		_workflowDefinitionManager.deployWorkflowDefinition(
 			company.getCompanyId(), defaultUserId,
-			MBModerationConstants.WORKFLOW_DEFINITION_NAME,
+			LocalizationUtil.getXml(
+				_getTitleMap(company.getCompanyId()),
+				_language.getLanguageId(company.getLocale()), "title"),
 			MBModerationConstants.WORKFLOW_DEFINITION_NAME,
 			MBMessage.class.getName(), content.getBytes());
 	}
+
+	private Map<String, String> _getTitleMap(long companyId) {
+		Map<String, String> titleMap = new HashMap<>();
+
+		for (Locale locale : _language.getCompanyAvailableLocales(companyId)) {
+			titleMap.put(
+				_language.getLanguageId(locale),
+				_language.get(
+					_resourceBundleLoader.loadResourceBundle(locale),
+					MBModerationConstants.WORKFLOW_DEFINITION_NAME));
+		}
+
+		return titleMap;
+	}
+
+	@Reference
+	private Language _language;
+
+	@Reference(
+		target = "(bundle.symbolic.name=com.liferay.message.boards.moderation)"
+	)
+	private ResourceBundleLoader _resourceBundleLoader;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ar.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_bg.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ca.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_cs.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_da.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_da.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_de.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_de.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_el.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_el.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_en.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_en.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_en_AU.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_en_GB.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_es.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_es.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_et.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_et.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_eu.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fa.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fi.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fr.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fr_CA.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_gl.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_hi_IN.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_hr.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_hu.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_in.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_in.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_it.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_it.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_iw.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ja.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_kk.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ko.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_lo.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_lt.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ms.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_nb.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_nl.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_nl_BE.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_pl.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_pt_BR.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_pt_PT.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ro.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ru.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sk.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sl.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sr_RS.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sv.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ta_IN.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_th.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_th.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_tr.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_uk.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_vi.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_zh_CN.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_zh_TW.properties
@@ -1,0 +1,1 @@
+message-boards-user-stats-moderation=Message Boards User Stats Moderation (Automatic Copy)


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-132566

Hi @brianchandotcom 
resending this pull directly to you since after a few retries we confirmed this pull is not related to any of the failing tests in https://github.com/liferay-lima/liferay-portal/pull/1997, thanks!