### PR TITLE
LPS-111992 marketplace-store-web - turns CLIENT_BUILD constant up to 11

### DIFF
--- a/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/internal/constants/MarketplaceConstants.java
+++ b/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/internal/constants/MarketplaceConstants.java
@@ -19,6 +19,6 @@ package com.liferay.marketplace.store.web.internal.constants;
  */
 public class MarketplaceConstants {
 
-	public static final int CLIENT_BUILD = 10;
+	public static final int CLIENT_BUILD = 11;
 
 }


### PR DESCRIPTION
This is an update for [LPS-111992](https://issues.liferay.com/browse/LPS-111992).

/cc @drewbrokke

No specific failure found on original pr [liferay-usm/liferay-portal#79](https://github.com/liferay-usm/liferay-portal/pull/79), manually forward the commit.