### PR TITLE
LPS-134141 | Taglib aui:fieldset does not include legend when markupView is lexicon

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
@@ -28,7 +28,7 @@ else if (collapsible) {
 }
 %>
 
-<fieldset aria-labelledby="<%= id %>Title" class="<%= collapsible ? "panel" : StringPool.BLANK %> <%= cssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> <%= Validator.isNotNull(id) ? "id=\"" + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> role="group">
+<fieldset class="<%= collapsible ? "panel" : StringPool.BLANK %> <%= cssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> <%= Validator.isNotNull(id) ? "id=\"" + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
 	<c:choose>
 		<c:when test="<%= Validator.isNotNull(label) %>">
 			<liferay-util:buffer

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
@@ -47,28 +47,20 @@ else if (collapsible) {
 						<%= header %>
 					</legend>
 
-					<div class="panel-heading" id="<%= id %>Header" role="presentation">
-						<div id="<%= id %>Title">
-							<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon <%= collapsed ? "collapsed" : StringPool.BLANK %> sheet-subtitle" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
-								<span aria-hidden="true">
-									<%= header %>
-								</span>
+					<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon <%= collapsed ? "collapsed" : StringPool.BLANK %> sheet-subtitle" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
+						<span aria-hidden="true">
+							<%= header %>
+						</span>
 
-								<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
+						<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
 
-								<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
-							</a>
-						</div>
-					</div>
+						<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
+					</a>
 				</c:when>
 				<c:otherwise>
 					<legend class="fieldset-legend">
 						<span class="legend">
-							<div class="panel-heading" id="<%= id %>Header" role="presentation">
-								<div id="<%= id %>Title">
-									<h3 class="sheet-subtitle"><%= header %></h3>
-								</div>
-							</div>
+							<h3 class="sheet-subtitle"><%= header %></h3>
 						</span>
 					</legend>
 				</c:otherwise>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
@@ -59,9 +59,7 @@ else if (collapsible) {
 				</c:when>
 				<c:otherwise>
 					<legend class="fieldset-legend">
-						<span class="legend">
-							<h3 class="sheet-subtitle"><%= header %></h3>
-						</span>
+						<h3 class="legend sheet-subtitle"><%= header %></h3>
 					</legend>
 				</c:otherwise>
 			</c:choose>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
@@ -66,7 +66,7 @@ else if (collapsible) {
 		</c:when>
 		<c:otherwise>
 			<legend class="sr-only">
-				<%= portletDisplay.getTitle() %>
+				<%= HtmlUtil.escape(portletDisplay.getTitle()) %>
 			</legend>
 		</c:otherwise>
 	</c:choose>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
@@ -73,5 +73,5 @@ else if (collapsible) {
 		</c:otherwise>
 	</c:choose>
 
-	<div aria-labelledby="<%= id %>Header" class="<%= !collapsed ? "show" : StringPool.BLANK %> <%= collapsible ? "panel-collapse collapse" : StringPool.BLANK %> <%= column ? "row" : StringPool.BLANK %>" id="<%= id %>Content" role="presentation">
+	<div class="<%= !collapsed ? "show" : StringPool.BLANK %> <%= collapsible ? "panel-collapse collapse" : StringPool.BLANK %> <%= column ? "row" : StringPool.BLANK %>" id="<%= id %>Content" role="presentation">
 		<div class="<%= collapsible ? "panel-body" : StringPool.BLANK %>">

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
@@ -29,38 +29,57 @@ else if (collapsible) {
 %>
 
 <fieldset aria-labelledby="<%= id %>Title" class="<%= collapsible ? "panel" : StringPool.BLANK %> <%= cssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> <%= Validator.isNotNull(id) ? "id=\"" + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> role="group">
-	<c:if test="<%= Validator.isNotNull(label) %>">
-		<liferay-util:buffer
-			var="header"
-		>
-			<liferay-ui:message key="<%= label %>" localizeKey="<%= localizeLabel %>" />
+	<c:choose>
+		<c:when test="<%= Validator.isNotNull(label) %>">
+			<liferay-util:buffer
+				var="header"
+			>
+				<liferay-ui:message key="<%= label %>" localizeKey="<%= localizeLabel %>" />
 
-			<c:if test="<%= Validator.isNotNull(helpMessage) %>">
-				<liferay-ui:icon-help message="<%= helpMessage %>" />
-			</c:if>
+				<c:if test="<%= Validator.isNotNull(helpMessage) %>">
+					<liferay-ui:icon-help message="<%= helpMessage %>" />
+				</c:if>
+			</liferay-util:buffer>
 
-			<c:if test="<%= collapsible %>">
-				<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
+			<c:choose>
+				<c:when test="<%= collapsible %>">
+					<legend class="sr-only">
+						<%= header %>
+					</legend>
 
-				<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
-			</c:if>
-		</liferay-util:buffer>
+					<div class="panel-heading" id="<%= id %>Header" role="presentation">
+						<div id="<%= id %>Title">
+							<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon <%= collapsed ? "collapsed" : StringPool.BLANK %> sheet-subtitle" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
+								<span aria-hidden="true">
+									<%= header %>
+								</span>
 
-		<div class="panel-heading" id="<%= id %>Header" role="presentation">
-			<div id="<%= id %>Title">
-				<c:choose>
-					<c:when test="<%= collapsible %>">
-						<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon <%= collapsed ? "collapsed" : StringPool.BLANK %> sheet-subtitle" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
-							<%= header %>
-						</a>
-					</c:when>
-					<c:otherwise>
-						<h3 class="sheet-subtitle"><%= header %></h3>
-					</c:otherwise>
-				</c:choose>
-			</div>
-		</div>
-	</c:if>
+								<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
+
+								<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
+							</a>
+						</div>
+					</div>
+				</c:when>
+				<c:otherwise>
+					<legend class="fieldset-legend">
+						<span class="legend">
+							<div class="panel-heading" id="<%= id %>Header" role="presentation">
+								<div id="<%= id %>Title">
+									<h3 class="sheet-subtitle"><%= header %></h3>
+								</div>
+							</div>
+						</span>
+					</legend>
+				</c:otherwise>
+			</c:choose>
+		</c:when>
+		<c:otherwise>
+			<legend class="sr-only">
+				<%= portletDisplay.getTitle() %>
+			</legend>
+		</c:otherwise>
+	</c:choose>
 
 	<div aria-labelledby="<%= id %>Header" class="<%= !collapsed ? "show" : StringPool.BLANK %> <%= collapsible ? "panel-collapse collapse" : StringPool.BLANK %> <%= column ? "row" : StringPool.BLANK %>" id="<%= id %>Content" role="presentation">
 		<div class="<%= collapsible ? "panel-body" : StringPool.BLANK %>">

--- a/portal-web/docroot/html/taglib/aui/fieldset/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/lexicon/start.jsp
@@ -83,5 +83,5 @@ if (Validator.isNull(panelHeaderLinkCssClass)) {
 		</c:otherwise>
 	</c:choose>
 
-	<div aria-labelledby="<%= id %>Header" class="<%= !collapsed ? "show" : StringPool.BLANK %> <%= collapsible ? "panel-collapse collapse" : StringPool.BLANK %> <%= column ? "row" : StringPool.BLANK %>" id="<%= id %>Content" role="presentation">
+	<div class="<%= !collapsed ? "show" : StringPool.BLANK %> <%= collapsible ? "panel-collapse collapse" : StringPool.BLANK %> <%= column ? "row" : StringPool.BLANK %>" id="<%= id %>Content" role="presentation">
 		<div class="panel-body">

--- a/portal-web/docroot/html/taglib/aui/fieldset/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/lexicon/start.jsp
@@ -37,36 +37,51 @@ if (Validator.isNull(panelHeaderLinkCssClass)) {
 %>
 
 <fieldset aria-labelledby="<%= id %>Title" class="<%= cssClass %>" <%= Validator.isNotNull(id) ? "id=\"" + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> role="group">
-	<c:if test="<%= Validator.isNotNull(label) %>">
-		<liferay-util:buffer
-			var="header"
-		>
-			<liferay-ui:message key="<%= label %>" localizeKey="<%= localizeLabel %>" />
+	<c:choose>
+		<c:when test="<%= Validator.isNotNull(label) %>">
+			<liferay-util:buffer
+				var="header"
+			>
+				<liferay-ui:message key="<%= label %>" localizeKey="<%= localizeLabel %>" />
 
-			<c:if test="<%= Validator.isNotNull(helpMessage) %>">
-				<liferay-ui:icon-help message="<%= helpMessage %>" />
-			</c:if>
+				<c:if test="<%= Validator.isNotNull(helpMessage) %>">
+					<liferay-ui:icon-help message="<%= helpMessage %>" />
+				</c:if>
+			</liferay-util:buffer>
 
-			<c:if test="<%= collapsible %>">
-				<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
-
-				<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
-			</c:if>
-		</liferay-util:buffer>
-
-		<c:choose>
-			<c:when test="<%= collapsible %>">
-				<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon collapse-icon-middle <%= panelHeaderLinkCssClass %> <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
-					<span class="c-inner" tabindex="-1">
+			<c:choose>
+				<c:when test="<%= collapsible %>">
+					<legend class="sr-only">
 						<%= header %>
-					</span>
-				</a>
-			</c:when>
-			<c:otherwise>
-				<%= header %>
-			</c:otherwise>
-		</c:choose>
-	</c:if>
+					</legend>
+
+					<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon collapse-icon-middle <%= panelHeaderLinkCssClass %> <%= collapsed ? "collapsed" : StringPool.BLANK %>" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
+						<span class="c-inner" tabindex="-1">
+							<span aria-hidden="true">
+								<%= header %>
+							</span>
+
+							<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
+
+							<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
+						</span>
+					</a>
+				</c:when>
+				<c:otherwise>
+					<legend class="fieldset-legend">
+						<span class="legend">
+							<%= header %>
+						</span>
+					</legend>
+				</c:otherwise>
+			</c:choose>
+		</c:when>
+		<c:otherwise>
+			<legend class="sr-only">
+				<%= portletDisplay.getTitle() %>
+			</legend>
+		</c:otherwise>
+	</c:choose>
 
 	<div aria-labelledby="<%= id %>Header" class="<%= !collapsed ? "show" : StringPool.BLANK %> <%= collapsible ? "panel-collapse collapse" : StringPool.BLANK %> <%= column ? "row" : StringPool.BLANK %>" id="<%= id %>Content" role="presentation">
 		<div class="panel-body">

--- a/portal-web/docroot/html/taglib/aui/fieldset/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/lexicon/start.jsp
@@ -36,7 +36,7 @@ if (Validator.isNull(panelHeaderLinkCssClass)) {
 }
 %>
 
-<fieldset aria-labelledby="<%= id %>Title" class="<%= cssClass %>" <%= Validator.isNotNull(id) ? "id=\"" + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> role="group">
+<fieldset class="<%= cssClass %>" <%= Validator.isNotNull(id) ? "id=\"" + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
 	<c:choose>
 		<c:when test="<%= Validator.isNotNull(label) %>">
 			<liferay-util:buffer

--- a/portal-web/docroot/html/taglib/aui/fieldset/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/lexicon/start.jsp
@@ -78,7 +78,7 @@ if (Validator.isNull(panelHeaderLinkCssClass)) {
 		</c:when>
 		<c:otherwise>
 			<legend class="sr-only">
-				<%= portletDisplay.getTitle() %>
+				<%= HtmlUtil.escape(portletDisplay.getTitle()) %>
 			</legend>
 		</c:otherwise>
 	</c:choose>


### PR DESCRIPTION
-- Sending manually because ci failures are unrelated to the PR

Hi @liferay-frontend,

This pr tries to fix [LPS-134141](https://issues.liferay.com/browse/LPS-134141) to include the tag `<legend>` inside `<fieldset>` when invoked via the taglib `<aui:fieldset>` when `markupView` is `"lexicon"`. 

This solution is related or complementary to that of [LPS-133314](https://issues.liferay.com/browse/LPS-133314) (cc @georgel-pop-lr). 

Notes:
1. The tag `<legend>` should be an immediate child of `<fieldset>` (see for example, https://html.spec.whatwg.org/multipage/form-elements.html#the-legend-element). This means that `<legend>` cannot be included inside another element such as `<a>`.
2. Since the label of collapsible fieldsets are shown inside an `<a>` element, it's necessary for the `<legend>` to include an `sr-only` label and for the `header` to include `aria-hidden="true"` to avoid redundancy. 
3. When `label` doesn't exist, we show `<legend>` with the portlet title.
4. [LPS-126737](https://issues.liferay.com/browse/LPS-126737) removed a couple of `<div>`'s in `portal-web` but not in `frontend-taglib`. I've chosen to remove those elements as well in `frontend-taglib` but please correct this if it's not ok.
5. Deletion of these `<div>`'s in LPS-126737 deleted two `id`'s that another two `aria-labelledby` where pointing to. I've deleted those `aria-labelledby` since they're not needed any longer.
6. Since we're using the strategy of `<fieldset>` plus `<legend>` instead of `role=group` plus `aria-labelledby`, I've deleted uses of `role=gorup`. (The probably shoud have been removed in [LPS-64310](https://issues.liferay.com/browse/LPS-64310) when `<fieldset>` was used instead o `<div>`.)
7. It's remarked in some places (for example in https://www.w3.org/WAI/tutorials/forms/grouping/) about the element `<legend>` that  
  > Depending on the configuration, some screen readers read out the legend either with every form element, once, or, rarely, not at all.
In my tests with ChromeVox this screen reader won't reader the text in `<legend>` but I think it's best to have a theoretically correct markup rather than trying to accommodate to one particular screen reader. Please let me know if this isn't the right choice. 

Thanks!