### PR TITLE
LRQA-59737 Remove checksum assert in smoke test as this validator has been removed

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/portalsmoke/PortalSmoke.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/portalsmoke/PortalSmoke.testcase
@@ -43,10 +43,6 @@ definition {
 
 		Smoke.runSmoke();
 
-		// Assert mismatching checksum for release bundles
-
-		AssertConsoleTextNotPresent(value1 = "Running validation because of mismatched checksum");
-
 		// Assert all bundles installed
 
 		AssertConsoleTextNotPresent(value1 = "The portal instance needs to be restarted to complete the installation");


### PR DESCRIPTION
This can go back to 7.2.x