### PR TITLE
LPS-135706

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -585,18 +585,18 @@ public class DLReferencesExportImportContentProcessor
 				String urlWithoutUUID = url.substring(
 					0, url.lastIndexOf(StringPool.SLASH));
 
-				String exportedReferenceWithUUID =
-					"[$dl-reference=" + path + "$,$include-uuid=false$]";
 				String exportedReferenceWithoutUUID =
+					"[$dl-reference=" + path + "$,$include-uuid=false$]";
+				String exportedReferenceWithUUID =
 					"[$dl-reference=" + path + "$,$include-uuid=true$]";
 
 				if (content.startsWith("[#dl-reference=", endPos)) {
 					endPos = content.indexOf("#,#include-uuid=", beginPos) + 2;
 
-					exportedReferenceWithUUID =
+					exportedReferenceWithoutUUID =
 						content.substring(beginPos, endPos) +
 							"#include-uuid=false#]";
-					exportedReferenceWithoutUUID =
+					exportedReferenceWithUUID =
 						content.substring(beginPos, endPos) +
 							"#include-uuid=true#]";
 				}


### PR DESCRIPTION
I'm not sure which variable you want first, but if you decide to re-sort it, please make sure the same variable name corresponds to the same value as it is right now. The variable name "*withoutUUID" should correspond to the value that has "include-uuid=false". And the variable name "*withUUID" should correspond to the value that has "include-uuid=true". Thanks!

I tested the previously failing test after applying this commit and it's passing again.

https://issues.liferay.com/browse/LPS-135706
https://issues.liferay.com/browse/LRQA-68937