### PR TITLE
LPS-136723 Use felix dependency manager to create dynamic registrar c…

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/build.gradle
+++ b/modules/apps/site-initializer/site-initializer-extender/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.dependencymanager", version: "4.6.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:site:site-api")

--- a/modules/apps/site-initializer/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -22,6 +22,8 @@ import com.liferay.site.initializer.SiteInitializer;
 import java.util.Dictionary;
 import java.util.Locale;
 
+import javax.servlet.ServletContext;
+
 import org.osgi.framework.Bundle;
 
 /**
@@ -29,8 +31,9 @@ import org.osgi.framework.Bundle;
  */
 public class BundleSiteInitializer implements SiteInitializer {
 
-	public BundleSiteInitializer(Bundle bundle) {
+	public BundleSiteInitializer(Bundle bundle, ServletContext servletContext) {
 		_bundle = bundle;
+		_servletContext = servletContext;
 	}
 
 	@Override
@@ -66,5 +69,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 	}
 
 	private final Bundle _bundle;
+	private final ServletContext _servletContext;
 
 }

--- a/modules/apps/site-initializer/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtender.java
+++ b/modules/apps/site-initializer/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtender.java
@@ -14,17 +14,13 @@
 
 package com.liferay.site.initializer.extender.internal;
 
-import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.site.initializer.SiteInitializer;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
-import org.osgi.framework.ServiceRegistration;
 import org.osgi.framework.wiring.BundleCapability;
 import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.service.component.annotations.Activate;
@@ -38,10 +34,10 @@ import org.osgi.util.tracker.BundleTrackerCustomizer;
  */
 @Component(immediate = true, service = {})
 public class SiteInitializerExtender
-	implements BundleTrackerCustomizer<List<ServiceRegistration<?>>> {
+	implements BundleTrackerCustomizer<SiteInitializerExtension> {
 
 	@Override
-	public List<ServiceRegistration<?>> addingBundle(
+	public SiteInitializerExtension addingBundle(
 		Bundle bundle, BundleEvent bundleEvent) {
 
 		BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
@@ -53,30 +49,26 @@ public class SiteInitializerExtender
 			return null;
 		}
 
-		return Collections.singletonList(
-			_bundleContext.registerService(
-				SiteInitializer.class, new BundleSiteInitializer(bundle),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"site.initializer.key", bundle.getSymbolicName()
-				).build()));
+		SiteInitializerExtension siteInitializerExtension =
+			new SiteInitializerExtension(bundle, _bundleContext);
+
+		siteInitializerExtension.start();
+
+		return siteInitializerExtension;
 	}
 
 	@Override
 	public void modifiedBundle(
 		Bundle bundle, BundleEvent bundleEvent,
-		List<ServiceRegistration<?>> serviceRegistrations) {
+		SiteInitializerExtension siteInitializerExtension) {
 	}
 
 	@Override
 	public void removedBundle(
 		Bundle bundle, BundleEvent bundleEvent,
-		List<ServiceRegistration<?>> serviceRegistrations) {
+		SiteInitializerExtension siteInitializerExtension) {
 
-		for (ServiceRegistration<?> serviceRegistration :
-				serviceRegistrations) {
-
-			serviceRegistration.unregister();
-		}
+		siteInitializerExtension.destroy();
 	}
 
 	@Activate

--- a/modules/apps/site-initializer/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtension.java
+++ b/modules/apps/site-initializer/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtension.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.site.initializer.extender.internal;
+
+import javax.servlet.ServletContext;
+
+import org.apache.felix.dm.Component;
+import org.apache.felix.dm.DependencyManager;
+import org.apache.felix.dm.ServiceDependency;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+
+/**
+ * @author Preston Crary
+ */
+public class SiteInitializerExtension {
+
+	public SiteInitializerExtension(
+		Bundle bundle, BundleContext bundleContext) {
+
+		_dependencyManager = new DependencyManager(bundle.getBundleContext());
+
+		_component = _dependencyManager.createComponent();
+
+		_component.setImplementation(
+			new SiteInitializerRegistrar(bundle, bundleContext));
+
+		ServiceDependency serviceDependency =
+			_dependencyManager.createServiceDependency();
+
+		serviceDependency.setCallbacks("setServletContext", null);
+		serviceDependency.setRequired(true);
+		serviceDependency.setService(
+			ServletContext.class,
+			"(osgi.web.symbolicname=" + bundle.getSymbolicName() + ")");
+
+		_component.add(serviceDependency);
+	}
+
+	public void destroy() {
+		_dependencyManager.remove(_component);
+	}
+
+	public void start() {
+		_dependencyManager.add(_component);
+	}
+
+	private final Component _component;
+	private final DependencyManager _dependencyManager;
+
+}

--- a/modules/apps/site-initializer/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerRegistrar.java
+++ b/modules/apps/site-initializer/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerRegistrar.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.site.initializer.extender.internal;
+
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.site.initializer.SiteInitializer;
+
+import javax.servlet.ServletContext;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Preston Crary
+ */
+public class SiteInitializerRegistrar {
+
+	public SiteInitializerRegistrar(
+		Bundle bundle, BundleContext bundleContext) {
+
+		_bundle = bundle;
+		_bundleContext = bundleContext;
+	}
+
+	protected void setServletContext(ServletContext servletContext) {
+		_servletContext = servletContext;
+	}
+
+	protected void start() {
+		_serviceRegistration = _bundleContext.registerService(
+			SiteInitializer.class,
+			new BundleSiteInitializer(_bundle, _servletContext),
+			MapUtil.singletonDictionary(
+				"site.initializer.key", _bundle.getSymbolicName()));
+	}
+
+	protected void stop() {
+		_serviceRegistration.unregister();
+	}
+
+	private final Bundle _bundle;
+	private final BundleContext _bundleContext;
+	private ServiceRegistration<?> _serviceRegistration;
+	private ServletContext _servletContext;
+
+}


### PR DESCRIPTION
…omponents.

Need to set a Web-ContextPath for the extended bundles so that the other extender creates/registers the ServletContext so SiteInitializerRegistrar.start() is called.

I ended up with something like:
```
Provide-Capability:\
	liferay.site.initializer;\
		liferay.site.initializer="${Bundle-SymbolicName}"
Web-ContextPath: ...
```

so that the provide capability didn't try to make Web-ContextPath part of it attributes.