### PR TITLE
LPS-135071 Avoid possible sync problems adding synchronized to ObjectDefinitionDeployerImpl deploy and undeploy methods (as they heavily used the map we need to protect)

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -52,7 +52,7 @@ import org.osgi.service.component.annotations.Reference;
 public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	@Override
-	public List<ServiceRegistration<?>> deploy(
+	public synchronized List<ServiceRegistration<?>> deploy(
 		ObjectDefinition objectDefinition) {
 
 		List<ServiceRegistration<?>> serviceRegistrations = new ArrayList<>();
@@ -169,7 +169,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	}
 
 	@Override
-	public void undeploy(ObjectDefinition objectDefinition) {
+	public synchronized void undeploy(ObjectDefinition objectDefinition) {
 		Map<Long, ObjectDefinition> objectDefinitions =
 			_objectDefinitionsMap.get(objectDefinition.getRESTContextPath());
 


### PR DESCRIPTION
As the map is heavily used in the deploy and undeploy methods, I think it is better to synchronize the methods.

I didn't synchronize the getObjectDefinition method, because it will be called in every Object API call affecting performance. There can be cases when it fails, returning an already undeployed ObjectDefinition, but will be very few cases, and the failure would not be dramatic

cc @nhpatt
