### PR TITLE
LPS-132741 Isolate Portlet Topper in all ootb themes

### DIFF
--- a/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/src/css/_imports.scss
+++ b/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/src/css/_imports.scss
@@ -5,6 +5,7 @@
 @import 'mixins';
 
 @import 'clay/atlas-variables';
+@import 'clay/cadmin-variables';
 
 @import 'main_variables';
 

--- a/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/src/templates/portlet.ftl
+++ b/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/src/templates/portlet.ftl
@@ -20,7 +20,7 @@
 		/>
 
 		<#if (portlet_configuration_icons?has_content || portlet_title_menus?has_content)>
-			<header class="portlet-topper">
+			<header class="cadmin portlet-topper">
 				<svg width="18" height="10" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M2 0H0v2h2V0zM0 4h2v2H0V4zm4 0h2v2H4V4zm6 0H8v2h2V4zm2 0h2v2h-2V4zm6 0h-2v2h2V4zM0 8h2v2H0V8zm6 0H4v2h2V8zm2 0h2v2H8V8zm6 0h-2v2h2V8zm2 0h2v2h-2V8zM4 0h2v2H4V0zm6 0H8v2h2V0zm2 0h2v2h-2V0zm6 0h-2v2h2V0z" fill="#fff"/></svg>
 			</header>
 
@@ -31,13 +31,15 @@
 			<div class="portlet-topper-toolbar-wrapper">
 				<#foreach portletTitleMenu in portlet_title_menus>
 					<menu class="portlet-topper-toolbar" id="portlet-title-menu_${portlet_id}_${portletTitleMenu_index}" type="toolbar">
+						${portletTitleMenu.setDirection("right cadmin")}
+
 						<@liferay_ui["menu"] menu=portletTitleMenu />
 					</menu>
 				</#foreach>
 
 				<#if portlet_configuration_icons?has_content>
 					<menu class="portlet-topper-toolbar" id="portlet-topper-toolbar_${portlet_id}" type="toolbar">
-						<@liferay_portlet["icon-options"] portletConfigurationIcons=portlet_configuration_icons />
+						<@liferay_portlet["icon-options"] direction="right cadmin" portletConfigurationIcons=portlet_configuration_icons />
 					</menu>
 				</#if>
 			</div>

--- a/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/src/templates/portlet.ftl
+++ b/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/src/templates/portlet.ftl
@@ -39,7 +39,10 @@
 
 				<#if portlet_configuration_icons?has_content>
 					<menu class="portlet-topper-toolbar" id="portlet-topper-toolbar_${portlet_id}" type="toolbar">
-						<@liferay_portlet["icon-options"] direction="right cadmin" portletConfigurationIcons=portlet_configuration_icons />
+						<@liferay_portlet["icon-options"]
+							direction="right cadmin"
+							portletConfigurationIcons=portlet_configuration_icons
+						/>
 					</menu>
 				</#if>
 			</div>

--- a/modules/apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell/src/templates/portlet.ftl
+++ b/modules/apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell/src/templates/portlet.ftl
@@ -20,7 +20,7 @@
 		/>
 
 		<#if (portlet_configuration_icons?has_content || portlet_title_menus?has_content)>
-			<header class="portlet-topper">
+			<header class="cadmin portlet-topper">
 				<svg width="18" height="10" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M2 0H0v2h2V0zM0 4h2v2H0V4zm4 0h2v2H4V4zm6 0H8v2h2V4zm2 0h2v2h-2V4zm6 0h-2v2h2V4zM0 8h2v2H0V8zm6 0H4v2h2V8zm2 0h2v2H8V8zm6 0h-2v2h2V8zm2 0h2v2h-2V8zM4 0h2v2H4V0zm6 0H8v2h2V0zm2 0h2v2h-2V0zm6 0h-2v2h2V0z" fill="#fff"/></svg>
 			</header>
 
@@ -31,13 +31,15 @@
 			<div class="portlet-topper-toolbar-wrapper">
 				<#foreach portletTitleMenu in portlet_title_menus>
 					<menu class="portlet-topper-toolbar" id="portlet-title-menu_${portlet_id}_${portletTitleMenu_index}" type="toolbar">
+						${portletTitleMenu.setDirection("right cadmin")}
+
 						<@liferay_ui["menu"] menu=portletTitleMenu />
 					</menu>
 				</#foreach>
 
 				<#if portlet_configuration_icons?has_content>
 					<menu class="portlet-topper-toolbar" id="portlet-topper-toolbar_${portlet_id}" type="toolbar">
-						<@liferay_portlet["icon-options"] portletConfigurationIcons=portlet_configuration_icons />
+						<@liferay_portlet["icon-options"] direction="right cadmin" portletConfigurationIcons=portlet_configuration_icons />
 					</menu>
 				</#if>
 			</div>

--- a/modules/apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell/src/templates/portlet.ftl
+++ b/modules/apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell/src/templates/portlet.ftl
@@ -39,7 +39,10 @@
 
 				<#if portlet_configuration_icons?has_content>
 					<menu class="portlet-topper-toolbar" id="portlet-topper-toolbar_${portlet_id}" type="toolbar">
-						<@liferay_portlet["icon-options"] direction="right cadmin" portletConfigurationIcons=portlet_configuration_icons />
+						<@liferay_portlet["icon-options"]
+							direction="right cadmin"
+							portletConfigurationIcons=portlet_configuration_icons
+						/>
 					</menu>
 				</#if>
 			</div>

--- a/modules/apps/frontend-theme/frontend-theme-admin/src/css/_imports.scss
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/css/_imports.scss
@@ -1,1 +1,2 @@
 @import 'clay/atlas-variables';
+@import 'clay/cadmin-variables';

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_imports.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_imports.scss
@@ -1,1 +1,2 @@
 @import 'clay/atlas-variables';
+@import 'clay/cadmin-variables';

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/portlet/_portlet.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/portlet/_portlet.scss
@@ -1,3 +1,71 @@
+html#{$cadmin-selector} {
+	.portlet {
+		&:hover,
+		&.open {
+			> .cadmin.portlet-topper {
+				z-index: 999;
+			}
+		}
+
+		> .cadmin.portlet-topper {
+			font-size: 13.92px;
+			padding: 0 4px 0 8px;
+
+			@include media-breakpoint-up(md) {
+				display: block;
+				white-space: nowrap;
+			}
+
+			@include media-breakpoint-up(sm) {
+				right: auto;
+			}
+
+			.portlet-title-default {
+				display: inline-block;
+				line-height: 24px;
+				vertical-align: middle;
+			}
+
+			.portlet-name-text {
+				margin-right: 12px;
+			}
+
+			.portlet-topper-toolbar {
+				display: inline-block;
+				vertical-align: middle;
+			}
+
+			.portlet-topper-toolbar,
+			.icon-monospaced {
+				height: 24px;
+				line-height: 24px;
+				width: 24px;
+			}
+
+			.portlet-topper-toolbar .component-action {
+				font-size: 14px;
+				height: 24px;
+				margin-top: -2px;
+				width: 24px;
+			}
+		}
+	}
+
+	.portlet-dropzone {
+		box-shadow: 0 0 0 1px transparent inset;
+		transition: box-shadow 300ms ease-in-out;
+		will-change: box-shadow;
+	}
+
+	.yui3-dd-drop-active-valid .portlet-dropzone {
+		box-shadow: 0 0 0 1px rgba($cadmin-primary-d2, 0.2) inset;
+	}
+
+	.yui3-dd-drop-over .portlet-dropzone {
+		box-shadow: 0 0 0 4px $cadmin-primary-d2 inset;
+	}
+}
+
 .portlet-layout {
 	.portlet {
 		.management-bar,
@@ -16,74 +84,5 @@
 			margin-bottom: 0;
 			text-transform: uppercase;
 		}
-	}
-}
-
-.portlet {
-	> .portlet-topper {
-		font-size: 0.87rem;
-		padding: 0 4px 0 8px;
-
-		@include media-breakpoint-up(md) {
-			display: block;
-			white-space: nowrap;
-		}
-
-		@include media-breakpoint-up(sm) {
-			right: auto;
-		}
-
-		.portlet-title-default {
-			display: inline-block;
-			line-height: 1.5rem;
-			vertical-align: middle;
-		}
-
-		.portlet-name-text {
-			margin-right: 0.75rem;
-		}
-
-		.portlet-topper-toolbar {
-			display: inline-block;
-			vertical-align: middle;
-		}
-
-		.portlet-topper-toolbar,
-		.icon-monospaced {
-			height: 1.5rem;
-			line-height: 1.5rem;
-			width: 1.5rem;
-		}
-
-		.portlet-topper-toolbar .component-action {
-			height: 1.5rem;
-			width: 1.5rem;
-		}
-
-		.lexicon-icon {
-			height: 0.875rem;
-			width: 0.875rem;
-		}
-	}
-
-	&:hover,
-	&.open {
-		> .portlet-topper {
-			z-index: 999;
-		}
-	}
-}
-
-.portlet-dropzone {
-	box-shadow: 0 0 0 1px transparent inset;
-	transition: box-shadow 300ms ease-in-out;
-	will-change: box-shadow;
-
-	.yui3-dd-drop-active-valid & {
-		box-shadow: 0 0 0 1px rgba($primary-d2, 0.2) inset;
-	}
-
-	.yui3-dd-drop-over & {
-		box-shadow: 0 0 0 4px $primary-d2 inset;
 	}
 }

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/portlet/_portlet.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/portlet/_portlet.scss
@@ -86,3 +86,72 @@ html#{$cadmin-selector} {
 		}
 	}
 }
+
+.portlet {
+	> .portlet-topper {
+		font-size: 0.87rem;
+		padding: 0 4px 0 8px;
+
+		@include media-breakpoint-up(md) {
+			display: block;
+			white-space: nowrap;
+		}
+
+		@include media-breakpoint-up(sm) {
+			right: auto;
+		}
+
+		.portlet-title-default {
+			display: inline-block;
+			line-height: 1.5rem;
+			vertical-align: middle;
+		}
+
+		.portlet-name-text {
+			margin-right: 0.75rem;
+		}
+
+		.portlet-topper-toolbar {
+			display: inline-block;
+			vertical-align: middle;
+		}
+
+		.portlet-topper-toolbar,
+		.icon-monospaced {
+			height: 1.5rem;
+			line-height: 1.5rem;
+			width: 1.5rem;
+		}
+
+		.portlet-topper-toolbar .component-action {
+			height: 1.5rem;
+			width: 1.5rem;
+		}
+
+		.lexicon-icon {
+			height: 0.875rem;
+			width: 0.875rem;
+		}
+	}
+
+	&:hover,
+	&.open {
+		> .portlet-topper {
+			z-index: 999;
+		}
+	}
+}
+
+.portlet-dropzone {
+	box-shadow: 0 0 0 1px transparent inset;
+	transition: box-shadow 300ms ease-in-out;
+	will-change: box-shadow;
+
+	.yui3-dd-drop-active-valid & {
+		box-shadow: 0 0 0 1px rgba($primary-d2, 0.2) inset;
+	}
+
+	.yui3-dd-drop-over & {
+		box-shadow: 0 0 0 4px $primary-d2 inset;
+	}
+}

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portlet.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portlet.ftl
@@ -20,13 +20,15 @@
 		/>
 
 		<#if (portlet_configuration_icons?has_content || portlet_title_menus?has_content)>
-			<header class="portlet-topper">
+			<header class="cadmin portlet-topper">
 				<div class="portlet-title-default">
 					<span class="portlet-name-text">${portlet_display_name}</span>
 				</div>
 
 				<#foreach portletTitleMenu in portlet_title_menus>
 					<menu class="portlet-topper-toolbar" id="portlet-title-menu_${portlet_id}_${portletTitleMenu_index}" type="toolbar">
+						${portletTitleMenu.setDirection("right cadmin")}
+
 						<@liferay_ui["menu"] menu=portletTitleMenu />
 					</menu>
 				</#foreach>
@@ -34,7 +36,10 @@
 				<#if portlet_configuration_icons?has_content>
 					<#if (portlet_configuration_icons?size > 1)>
 						<menu class="portlet-topper-toolbar" id="portlet-topper-toolbar_${portlet_id}" type="toolbar">
-							<@liferay_portlet["icon-options"] portletConfigurationIcons=portlet_configuration_icons />
+							<@liferay_portlet["icon-options"]
+								direction="right cadmin"
+								portletConfigurationIcons=portlet_configuration_icons
+							/>
 						</menu>
 					<#else>
 						<menu class="portlet-topper-toolbar" id="portlet-topper-toolbar_${portlet_id}" type="toolbar">

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/_imports.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/_imports.scss
@@ -1,3 +1,5 @@
 @import 'bourbon';
 
 @import 'clay/base-variables';
+
+@import 'clay/_cadmin-variables';

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_drag_drop.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_drag_drop.scss
@@ -74,3 +74,77 @@ html#{$cadmin-selector} {
 		z-index: 1110 !important;
 	}
 }
+
+.portlet-layout.dragging {
+	border-collapse: separate;
+}
+
+.drop-area {
+	background-color: #d3dadd;
+}
+
+.active-area {
+	background: #ffc;
+}
+
+.portlet-boundary.yui3-dd-dragging {
+	opacity: 0.6;
+
+	.portlet {
+		border: 2px dashed #ccc;
+	}
+}
+
+.sortable-layout-proxy {
+	opacity: 1;
+
+	.portlet-topper {
+		background-image: none;
+	}
+}
+
+.proxy {
+	cursor: move;
+
+	opacity: 0.65;
+
+	position: absolute;
+
+	&.generic-portlet {
+		height: 200px;
+		width: 300px;
+
+		.portlet-title {
+			padding: 10px;
+		}
+	}
+
+	&.not-intersecting .forbidden-action {
+		background: url(../images/application/forbidden_action.png) no-repeat;
+		display: block;
+		height: 32px;
+		position: absolute;
+		right: -15px;
+		top: -15px;
+		width: 32px;
+	}
+}
+
+.resizable-proxy {
+	border: 1px dashed #828f95;
+	position: absolute;
+	visibility: hidden;
+}
+
+.sortable-proxy {
+	background: #727c81;
+	margin-top: 1px;
+}
+
+.sortable-layout-drag-target-indicator {
+	margin: 2px 0;
+}
+
+.yui3-dd-proxy {
+	z-index: 1110 !important;
+}

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_drag_drop.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_drag_drop.scss
@@ -1,73 +1,76 @@
-.portlet-layout.dragging {
-	border-collapse: separate;
-}
-
-.drop-area {
-	background-color: #d3dadd;
-}
-
-.active-area {
-	background: #ffc;
-}
-
-.portlet-boundary.yui3-dd-dragging {
-	opacity: 0.6;
-
-	.portlet {
-		border: 2px dashed #ccc;
+html#{$cadmin-selector} {
+	.portlet-layout.dragging {
+		border-collapse: separate;
 	}
-}
 
-.sortable-layout-proxy {
-	opacity: 1;
-
-	.portlet-topper {
-		background-image: none;
+	.drop-area {
+		background-color: #d3dadd;
 	}
-}
 
-.proxy {
-	cursor: move;
+	.active-area {
+		background: #ffc;
+	}
 
-	opacity: 0.65;
+	.portlet-boundary.yui3-dd-dragging {
+		opacity: 0.6;
 
-	position: absolute;
-
-	&.generic-portlet {
-		height: 200px;
-		width: 300px;
-
-		.portlet-title {
-			padding: 10px;
+		.portlet {
+			border: 2px dashed #ccc;
 		}
 	}
 
-	&.not-intersecting .forbidden-action {
-		background: url(../images/application/forbidden_action.png) no-repeat;
-		display: block;
-		height: 32px;
-		position: absolute;
-		right: -15px;
-		top: -15px;
-		width: 32px;
+	.sortable-layout-proxy {
+		opacity: 1;
+
+		.portlet-topper {
+			background-image: none;
+		}
 	}
-}
 
-.resizable-proxy {
-	border: 1px dashed #828f95;
-	position: absolute;
-	visibility: hidden;
-}
+	.proxy {
+		cursor: move;
 
-.sortable-proxy {
-	background: #727c81;
-	margin-top: 1px;
-}
+		opacity: 0.65;
 
-.sortable-layout-drag-target-indicator {
-	margin: 2px 0;
-}
+		position: absolute;
 
-.yui3-dd-proxy {
-	z-index: 1110 !important;
+		&.generic-portlet {
+			height: 200px;
+			width: 300px;
+
+			.portlet-title {
+				padding: 10px;
+			}
+		}
+
+		&.not-intersecting .forbidden-action {
+			background: url(../images/application/forbidden_action.png)
+				no-repeat;
+			display: block;
+			height: 32px;
+			position: absolute;
+			right: -15px;
+			top: -15px;
+			width: 32px;
+		}
+	}
+
+	.resizable-proxy {
+		border: 1px dashed #828f95;
+		position: absolute;
+		visibility: hidden;
+	}
+
+	.sortable-proxy {
+		background: #727c81;
+		margin-top: 1px;
+	}
+
+	.sortable-layout-drag-target-indicator {
+		margin: 2px 0;
+	}
+
+	.yui3-dd-proxy {
+		z-index: 1110 !important;
+	}
 }

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_dropdowns.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_dropdowns.scss
@@ -1,3 +1,10 @@
+html#{$cadmin-selector} {
+	.overlay-content .open > .cadmin.dropdown-menu {
+		display: block;
+		position: static;
+	}
+}
+
 .dropdown.open > .dropdown-menu,
 .overlay-content .open > .dropdown-menu {
 	display: block;

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
@@ -26,6 +26,21 @@ body.portlet {
 	margin-top: -2px;
 }
 
+.portlet-topper {
+	position: relative;
+
+	.portlet-topper-toolbar {
+		.portlet-icon-back {
+			background: url(../images/arrows/12_left.png) no-repeat 0 50%;
+			padding: 5px 5px 5px 18px;
+		}
+
+		.portlet-options .lfr-icon-menu-text {
+			display: none;
+		}
+	}
+}
+
 .portlet-title-editable {
 	cursor: pointer;
 }

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
@@ -1,24 +1,29 @@
+html#{$cadmin-selector} {
+	.cadmin {
+		&.portlet-topper {
+			position: relative;
+
+			.portlet-topper-toolbar {
+				.portlet-icon-back {
+					background: url(../images/arrows/12_left.png) no-repeat 0
+						50%;
+					padding: 5px 5px 5px 18px;
+				}
+
+				.portlet-options .lfr-icon-menu-text {
+					display: none;
+				}
+			}
+		}
+	}
+}
+
 body.portlet {
 	border-width: 0;
 }
 
 .portlet-icon-back {
 	margin-top: -2px;
-}
-
-.portlet-topper {
-	position: relative;
-
-	.portlet-topper-toolbar {
-		.portlet-icon-back {
-			background: url(../images/arrows/12_left.png) no-repeat 0 50%;
-			padding: 5px 5px 5px 18px;
-		}
-
-		.portlet-options .lfr-icon-menu-text {
-			display: none;
-		}
-	}
 }
 
 .portlet-title-editable {

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_topper.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_topper.scss
@@ -132,15 +132,17 @@ html#{$cadmin-selector} {
 			}
 		}
 
-		.cadmin.portlet-topper {
-			@include media-breakpoint-down(sm) {
-				display: box;
-				display: flex;
+		.cadmin {
+			&.portlet-topper {
+				@include media-breakpoint-down(sm) {
+					display: box;
+					display: flex;
+				}
 			}
-		}
 
-		.portlet-topper-toolbar {
-			display: block;
+			.portlet-topper-toolbar {
+				display: block;
+			}
 		}
 	}
 }
@@ -152,6 +154,45 @@ html#{$cadmin-selector} {
 	> .portlet-content-editable {
 		border-color: transparent;
 	}
+
+	> .portlet-topper {
+		display: none;
+
+		@include media-breakpoint-up(md) {
+			display: flex;
+			left: 0;
+			opacity: 0;
+			position: absolute;
+			right: 0;
+
+			@include transition(opacity 0.25s, transform 0.25s);
+
+			top: 0;
+		}
+	}
+}
+
+.controls-visible {
+	.portlet {
+		&:hover,
+		&.open,
+		&.focus {
+			> .portlet-content-editable {
+				@include media-breakpoint-up(md) {
+					border-color: $portlet-topper-border;
+					border-top-left-radius: 0;
+					border-top-right-radius: 0;
+				}
+			}
+
+			> .portlet-topper {
+				@include media-breakpoint-up(md) {
+					opacity: 1;
+					transform: translateY(-97%);
+				}
+			}
+		}
+	}
 }
 
 .portlet-content-editable {
@@ -159,4 +200,112 @@ html#{$cadmin-selector} {
 	border-radius: $portlet-content-border-radius;
 	border-style: solid;
 	border-width: $portlet-content-border-width;
+}
+
+// ---------- Portlet topper ----------
+
+.portlet-actions {
+	float: right;
+}
+
+.portlet-name-text {
+	font-size: 0.875rem;
+	font-weight: 600;
+}
+
+.portlet-options {
+	display: inline-block;
+}
+
+.portlet-title-default {
+	flex: 1 1 auto;
+	line-height: 2;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.portlet-title-menu {
+	flex: 0 1 auto;
+
+	> span > a {
+		display: inline-block;
+		text-decoration: none;
+	}
+}
+
+.portlet-topper {
+	background-color: $portlet-topper-bg;
+	border-color: $portlet-topper-border;
+	border-radius: $portlet-topper-border-radius;
+	border-style: solid;
+	border-width: $portlet-topper-border-width;
+	color: $portlet-topper-color;
+	display: box;
+	display: flex;
+	padding: 3px 12px 3px 24px;
+	position: relative;
+}
+
+.portlet-topper-toolbar {
+	margin: 0;
+	padding-left: 0;
+
+	> a,
+	> span > a,
+	.lfr-icon-menu > a {
+		color: $portlet-topper-link-color;
+	}
+
+	> a {
+		&:focus,
+		&:hover {
+			text-decoration: none;
+		}
+	}
+}
+
+.lfr-configurator-visibility {
+	@include media-breakpoint-down(sm) {
+		opacity: 0.5;
+	}
+
+	@include media-breakpoint-up(sm) {
+		.portlet {
+			&:hover,
+			&.focus,
+			&.open {
+				.portlet-topper {
+					opacity: 0.5;
+				}
+			}
+		}
+
+		.portlet-content-editable {
+			opacity: 0.5;
+		}
+	}
+}
+
+// ---------- Portlet controls in mobile ----------
+
+.controls-visible {
+	.portlet-content-editable {
+		@include media-breakpoint-down(sm) {
+			border-color: $portlet-topper-border;
+			border-top-left-radius: 0;
+			border-top-right-radius: 0;
+		}
+	}
+
+	.portlet-topper {
+		@include media-breakpoint-down(sm) {
+			display: box;
+			display: flex;
+		}
+	}
+
+	.portlet-topper-toolbar {
+		display: block;
+	}
 }

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_topper.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_topper.scss
@@ -1,12 +1,18 @@
-.portlet {
-	margin-bottom: 10px;
-	position: relative;
-
-	> .portlet-content-editable {
-		border-color: transparent;
+html#{$cadmin-selector} {
+	.cadmin.portlet-topper {
+		background-color: $portlet-topper-bg;
+		border-color: $portlet-topper-border;
+		border-radius: $portlet-topper-border-radius;
+		border-style: solid;
+		border-width: $portlet-topper-border-width;
+		color: $portlet-topper-color;
+		display: box;
+		display: flex;
+		padding: 3px 12px 3px 24px;
+		position: relative;
 	}
 
-	> .portlet-topper {
+	.portlet > .cadmin.portlet-topper {
 		display: none;
 
 		@include media-breakpoint-up(md) {
@@ -21,28 +27,130 @@
 			top: 0;
 		}
 	}
-}
 
-.controls-visible {
-	.portlet {
-		&:hover,
-		&.open,
-		&.focus {
-			> .portlet-content-editable {
-				@include media-breakpoint-up(md) {
-					border-color: $portlet-topper-border;
-					border-top-left-radius: 0;
-					border-top-right-radius: 0;
-				}
+	.cadmin {
+		.portlet-actions {
+			float: right;
+		}
+
+		.portlet-options {
+			display: inline-block;
+		}
+
+		.portlet-title-menu {
+			flex: 0 1 auto;
+
+			> span > a {
+				display: inline-block;
+				text-decoration: none;
+			}
+		}
+
+		.portlet-topper-toolbar {
+			margin: 0;
+			padding-left: 0;
+
+			> a,
+			> span > a,
+			.lfr-icon-menu > a {
+				color: $portlet-topper-link-color;
 			}
 
-			> .portlet-topper {
-				@include media-breakpoint-up(md) {
-					opacity: 1;
-					transform: translateY(-97%);
+			> a {
+				&:focus,
+				&:hover {
+					text-decoration: none;
 				}
 			}
 		}
+
+		.portlet-name-text {
+			font-size: 14px;
+			font-weight: 600;
+		}
+
+		.portlet-title-default {
+			flex: 1 1 auto;
+			line-height: 2;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+	}
+
+	.lfr-configurator-visibility {
+		@include media-breakpoint-down(sm) {
+			opacity: 0.5;
+		}
+
+		@include media-breakpoint-up(sm) {
+			.portlet {
+				&:hover,
+				&.focus,
+				&.open {
+					.portlet-topper {
+						opacity: 0.5;
+					}
+				}
+			}
+
+			.portlet-content-editable {
+				opacity: 0.5;
+			}
+		}
+	}
+
+	.controls-visible {
+		.portlet {
+			&:hover,
+			&.open,
+			&.focus {
+				> .portlet-content-editable {
+					@include media-breakpoint-up(md) {
+						border-color: $portlet-topper-border;
+						border-top-left-radius: 0;
+						border-top-right-radius: 0;
+					}
+				}
+
+				> .cadmin.portlet-topper {
+					@include media-breakpoint-up(md) {
+						opacity: 1;
+						transform: translateY(-97%);
+					}
+				}
+			}
+		}
+	}
+
+	.controls-visible {
+		.portlet-content-editable {
+			@include media-breakpoint-down(sm) {
+				border-color: $portlet-topper-border;
+				border-top-left-radius: 0;
+				border-top-right-radius: 0;
+			}
+		}
+
+		.cadmin.portlet-topper {
+			@include media-breakpoint-down(sm) {
+				display: box;
+				display: flex;
+			}
+		}
+
+		.portlet-topper-toolbar {
+			display: block;
+		}
+	}
+}
+
+.portlet {
+	margin-bottom: 10px;
+	position: relative;
+
+	> .portlet-content-editable {
+		border-color: transparent;
 	}
 }
 
@@ -51,112 +159,4 @@
 	border-radius: $portlet-content-border-radius;
 	border-style: solid;
 	border-width: $portlet-content-border-width;
-}
-
-// ---------- Portlet topper ----------
-
-.portlet-actions {
-	float: right;
-}
-
-.portlet-name-text {
-	font-size: 0.875rem;
-	font-weight: 600;
-}
-
-.portlet-options {
-	display: inline-block;
-}
-
-.portlet-title-default {
-	flex: 1 1 auto;
-	line-height: 2;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.portlet-title-menu {
-	flex: 0 1 auto;
-
-	> span > a {
-		display: inline-block;
-		text-decoration: none;
-	}
-}
-
-.portlet-topper {
-	background-color: $portlet-topper-bg;
-	border-color: $portlet-topper-border;
-	border-radius: $portlet-topper-border-radius;
-	border-style: solid;
-	border-width: $portlet-topper-border-width;
-	color: $portlet-topper-color;
-	display: box;
-	display: flex;
-	padding: 3px 12px 3px 24px;
-	position: relative;
-}
-
-.portlet-topper-toolbar {
-	margin: 0;
-	padding-left: 0;
-
-	> a,
-	> span > a,
-	.lfr-icon-menu > a {
-		color: $portlet-topper-link-color;
-	}
-
-	> a {
-		&:focus,
-		&:hover {
-			text-decoration: none;
-		}
-	}
-}
-
-.lfr-configurator-visibility {
-	@include media-breakpoint-down(sm) {
-		opacity: 0.5;
-	}
-
-	@include media-breakpoint-up(sm) {
-		.portlet {
-			&:hover,
-			&.focus,
-			&.open {
-				.portlet-topper {
-					opacity: 0.5;
-				}
-			}
-		}
-
-		.portlet-content-editable {
-			opacity: 0.5;
-		}
-	}
-}
-
-// ---------- Portlet controls in mobile ----------
-
-.controls-visible {
-	.portlet-content-editable {
-		@include media-breakpoint-down(sm) {
-			border-color: $portlet-topper-border;
-			border-top-left-radius: 0;
-			border-top-right-radius: 0;
-		}
-	}
-
-	.portlet-topper {
-		@include media-breakpoint-down(sm) {
-			display: box;
-			display: flex;
-		}
-	}
-
-	.portlet-topper-toolbar {
-		display: block;
-	}
 }

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portlet.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portlet.ftl
@@ -35,7 +35,10 @@
 
 				<#if portlet_configuration_icons?has_content>
 					<menu class="portlet-topper-toolbar" id="portlet-topper-toolbar_${portlet_id}" type="toolbar">
-						<@liferay_portlet["icon-options"] direction="right cadmin" portletConfigurationIcons=portlet_configuration_icons />
+						<@liferay_portlet["icon-options"]
+							direction="right cadmin"
+							portletConfigurationIcons=portlet_configuration_icons
+						/>
 					</menu>
 				</#if>
 			</header>

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portlet.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portlet.ftl
@@ -20,20 +20,22 @@
 		/>
 
 		<#if (portlet_configuration_icons?has_content || portlet_title_menus?has_content)>
-			<header class="portlet-topper">
+			<header class="cadmin portlet-topper">
 				<div class="portlet-title-default">
 					<span class="portlet-name-text">${portlet_display_name}</span>
 				</div>
 
 				<#foreach portletTitleMenu in portlet_title_menus>
 					<menu class="portlet-title-menu portlet-topper-toolbar" id="portlet-title-menu_${portlet_id}_${portletTitleMenu_index + 1}" type="toolbar">
+						${portletTitleMenu.setDirection("right cadmin")}
+
 						<@liferay_ui["menu"] menu=portletTitleMenu />
 					</menu>
 				</#foreach>
 
 				<#if portlet_configuration_icons?has_content>
 					<menu class="portlet-topper-toolbar" id="portlet-topper-toolbar_${portlet_id}" type="toolbar">
-						<@liferay_portlet["icon-options"] portletConfigurationIcons=portlet_configuration_icons />
+						<@liferay_portlet["icon-options"] direction="right cadmin" portletConfigurationIcons=portlet_configuration_icons />
 					</menu>
 				</#if>
 			</header>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Portlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Portlet.path
@@ -2,11 +2,13 @@
 <head>
 <title>Portlet</title>
 </head>
+
 <body>
-<table cellpadding="1" cellspacing="1" border="1">
+<table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Portlet</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>APPLICATION_DECORATOR_SELECT</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Portlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Portlet.path
@@ -2,13 +2,11 @@
 <head>
 <title>Portlet</title>
 </head>
-
 <body>
-<table border="1" cellpadding="1" cellspacing="1">
+<table cellpadding="1" cellspacing="1" border="1">
 <thead>
 <tr><td rowspan="1" colspan="3">Portlet</td></tr>
 </thead>
-
 <tbody>
 <tr>
 	<td>APPLICATION_DECORATOR_SELECT</td>
@@ -132,7 +130,7 @@
 </tr>
 <tr>
 	<td>SPECIFIC_BORDERLESS_ELLIPSIS_ICON</td>
-	<td>//header[@class='portlet-topper' and contains(.,'${key_portletName}')]//div[contains(@class,'portlet-options')]/a</td>
+	<td>//header[contains(@class,'portlet-topper') and contains(.,'${key_portletName}')]//div[contains(@class,'portlet-options')]/a</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/util/Home.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/util/Home.path
@@ -449,7 +449,7 @@
 </tr>
 <tr>
 	<td>PAGE_COLUMN_PORTLET_HEADER_ELLIPSIS</td>
-	<td>//div[@id='column-${key_columnNumber}']//header[@class='portlet-topper' and contains(.,'${key_portletName}')]//div[contains(@class,'portlet-options')]/a</td>
+	<td>//div[@id='column-${key_columnNumber}']//header[contains(@class,'portlet-topper') and contains(.,'${key_portletName}')]//div[contains(@class,'portlet-options')]/a</td>
 	<td></td>
 </tr>
 <tr>
@@ -573,7 +573,7 @@
 </tr>
 <tr>
 	<td>PORTLET_HEADER</td>
-	<td>//section[contains(@id, '${key_portletTitleName}')]//header[@class='portlet-topper']</td>
+	<td>//section[contains(@id, '${key_portletTitleName}')]//header[contains(@class,'portlet-topper')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
Sending directly following QA recommendations.

/cc @pat270

https://issues.liferay.com/browse/LPS-132741

This PR isolates portlet toppers and their dropdown menus. This is potentially a breaking change. I know liferay.com modified their edit controls. This would conflict with their custom styles.

The CSS I'm using to test:

```html
<style>
html {
  font-size: 20px;
}

#senna_surface1 h1,
#senna_surface1 h2,
#senna_surface1 h3,
#senna_surface1 h4,
#senna_surface1 h5,
#senna_surface1 h6 {
  background-color: #282828;
  border: 4px solid #00ff66;
  color: #00ff66;
  font-family: Georgia;
  font-size: 50px;
  font-style: italic;
  font-variant: small-caps
  font-weight: bold;
  line-height: 100px;
  letter-spacing: 2px;
  margin: 10px 0;
  padding: 10px;
  text-align: center;
  text-shadow: 1px 1px 0 #fff;
  text-transform: uppercase;
  white-space: nowrap;
}

#senna_surface1 .btn {
  background-color: #282828;
  border: 4px solid #00ff66;
  color: #00ff66;
  font-family: Georgia;
  font-size: 50px;
  font-style: italic;
  font-variant: small-caps
  font-weight: bold;
  line-height: 100px;
  letter-spacing: 2px;
  margin: 10px 0;
  padding: 10px;
  text-align: center;
  text-shadow: 1px 1px 0 #fff;
  text-transform: uppercase;
  white-space: nowrap;
}

#senna_surface1 .btn:hover {
  background-color: #000;
  color: #ffcc00;
  letter-spacing: 4px;
  font-size: 40px;
}

#senna_surface1 a {
  background-color: #282828;
  border: 4px solid #00ff66;
  color: #00ff66;
  font-family: Georgia;
  font-size: 50px;
  font-style: italic;
  font-variant: small-caps
  font-weight: bold;
  line-height: 100px;
  letter-spacing: 2px;
  margin: 10px 0;
  padding: 10px;
  text-align: center;
  text-shadow: 1px 1px 0 #fff;
  text-transform: uppercase;
  white-space: nowrap;
}

#senna_surface1 a:hover {
  background-color: #000;
  color: #ffcc00;
  letter-spacing: 4px;
  font-size: 40px;
}
</style>
```

Screenshot:
![portlet-topper1](https://user-images.githubusercontent.com/788266/124040191-45e8e480-d9b9-11eb-995a-e606da76b24a.jpg)
