### PR TITLE
LPS-136637 We use org.apache.log4j.layout.Log4j1XmlLayout as XML outp…

### DIFF
--- a/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
+++ b/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
@@ -400,13 +400,11 @@ public class PortalLog4jTest {
 
 		// <log4j:message>...</log4j:message>
 
-		if (expectedThrowable != null) {
-			Assert.assertEquals(
-				StringBundler.concat(
-					"<log4j:message><![CDATA[", expectedMessage,
-					"]]></log4j:message>"),
-				outputLines[1]);
-		}
+		Assert.assertEquals(
+			StringBundler.concat(
+				"<log4j:message><![CDATA[", expectedMessage,
+				"]]></log4j:message>"),
+			outputLines[1]);
 
 		// <log4j:throwable>...</log4j:throwable>
 


### PR DESCRIPTION
…ut and it always output <log4j:message> content. Please see formatTo(..) of Log4j1XmlLayout.