### PR TITLE
LPS-112782 Account roles should support scoping site-level resources and permissions

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/security/permission/contributor/AccountRoleContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/security/permission/contributor/AccountRoleContributor.java
@@ -15,8 +15,11 @@
 package com.liferay.account.internal.security.permission.contributor;
 
 import com.liferay.account.constants.AccountRoleConstants;
+import com.liferay.account.manager.CurrentAccountEntryManager;
 import com.liferay.account.model.AccountEntry;
+import com.liferay.account.model.AccountRole;
 import com.liferay.account.service.AccountEntryUserRelLocalService;
+import com.liferay.account.service.AccountRoleLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -28,6 +31,7 @@ import com.liferay.portal.kernel.security.permission.contributor.RoleContributor
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
@@ -52,17 +56,33 @@ public class AccountRoleContributor implements RoleContributor {
 			if (!Objects.equals(
 					AccountEntry.class.getName(), group.getClassName())) {
 
-				return;
+				User user = roleCollection.getUser();
+
+				AccountEntry currentAccountEntry =
+					_currentAccountEntryManager.getCurrentAccountEntry(
+						roleCollection.getGroupId(), user.getUserId());
+
+				if (currentAccountEntry.getAccountEntryId() > 0) {
+					List<AccountRole> accountRoles =
+						_accountRoleLocalService.getAccountRoles(
+							currentAccountEntry.getAccountEntryId(),
+							user.getUserId());
+
+					for (AccountRole accountRole : accountRoles) {
+						roleCollection.addRoleId(accountRole.getRoleId());
+					}
+				}
 			}
+			else {
+				User user = roleCollection.getUser();
 
-			User user = roleCollection.getUser();
+				if (_accountEntryUserRelLocalService.hasAccountEntryUserRel(
+						group.getClassPK(), user.getUserId())) {
 
-			if (_accountEntryUserRelLocalService.hasAccountEntryUserRel(
-					group.getClassPK(), user.getUserId())) {
-
-				_addRoleId(
-					roleCollection,
-					AccountRoleConstants.REQUIRED_ROLE_NAME_ACCOUNT_MEMBER);
+					_addRoleId(
+						roleCollection,
+						AccountRoleConstants.REQUIRED_ROLE_NAME_ACCOUNT_MEMBER);
+				}
 			}
 		}
 		catch (PortalException portalException) {
@@ -84,6 +104,12 @@ public class AccountRoleContributor implements RoleContributor {
 
 	@Reference
 	private AccountEntryUserRelLocalService _accountEntryUserRelLocalService;
+
+	@Reference
+	private AccountRoleLocalService _accountRoleLocalService;
+
+	@Reference
+	private CurrentAccountEntryManager _currentAccountEntryManager;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/account/account-test/build.gradle
+++ b/modules/apps/account/account-test/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
 	testIntegrationCompile group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	testIntegrationCompile project(":apps:account:account-api")
+	testIntegrationCompile project(":apps:blogs:blogs-api")
+	testIntegrationCompile project(":apps:blogs:blogs-test-util")
 	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationCompile project(":apps:portal-search:portal-search-test-util")
 	testIntegrationCompile project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/internal/security/permission/contributor/test/AccountRoleContributorTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/internal/security/permission/contributor/test/AccountRoleContributorTest.java
@@ -15,17 +15,31 @@
 package com.liferay.account.internal.security.permission.contributor.test;
 
 import com.liferay.account.constants.AccountRoleConstants;
+import com.liferay.account.manager.CurrentAccountEntryManager;
 import com.liferay.account.model.AccountEntry;
+import com.liferay.account.model.AccountRole;
 import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryUserRelLocalService;
+import com.liferay.account.service.AccountRoleLocalService;
 import com.liferay.account.service.test.util.AccountEntryTestUtil;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.blogs.test.util.BlogsTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -70,6 +84,98 @@ public class AccountRoleContributorTest {
 		Assert.assertTrue(ArrayUtil.contains(roleIds, role.getRoleId()));
 	}
 
+	@Test
+	public void testSelectedAccountPermission() throws Exception {
+		AccountEntry accountEntry1 = AccountEntryTestUtil.addAccountEntry(
+			_accountEntryLocalService);
+
+		AccountRole accountRole = _accountRoleLocalService.addAccountRole(
+			TestPropsValues.getUserId(), accountEntry1.getAccountEntryId(),
+			RandomTestUtil.randomString(), null, null);
+
+		Group group = GroupTestUtil.addGroup();
+
+		GroupedModel groupedModel = BlogsTestUtil.addEntryWithWorkflow(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(), true,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		User user = UserTestUtil.addUser();
+
+		_accountEntryUserRelLocalService.addAccountEntryUserRel(
+			accountEntry1.getAccountEntryId(), user.getUserId());
+
+		_accountRoleLocalService.associateUser(
+			accountEntry1.getAccountEntryId(), accountRole.getAccountRoleId(),
+			user.getUserId());
+
+		AccountEntry accountEntry2 = AccountEntryTestUtil.addAccountEntry(
+			_accountEntryLocalService);
+
+		_accountEntryUserRelLocalService.addAccountEntryUserRel(
+			accountEntry2.getAccountEntryId(), user.getUserId());
+
+		_currentAccountEntryManager.setCurrentAccountEntry(
+			accountEntry1.getAccountEntryId(), group.getGroupId(),
+			user.getUserId());
+
+		_testSelectedAccountPermission(
+			groupedModel, user, ActionKeys.UPDATE, false);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			groupedModel.getCompanyId(), groupedModel.getModelClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(groupedModel.getPrimaryKeyObj()),
+			accountRole.getRoleId(), new String[] {ActionKeys.UPDATE});
+
+		_testSelectedAccountPermission(
+			groupedModel, user, ActionKeys.UPDATE, true);
+
+		_currentAccountEntryManager.setCurrentAccountEntry(
+			accountEntry2.getAccountEntryId(), group.getGroupId(),
+			user.getUserId());
+
+		_testSelectedAccountPermission(
+			groupedModel, user, ActionKeys.UPDATE, false);
+
+		_currentAccountEntryManager.setCurrentAccountEntry(
+			accountEntry1.getAccountEntryId(), group.getGroupId(),
+			user.getUserId());
+
+		_testSelectedAccountPermission(
+			groupedModel, user, ActionKeys.DELETE, false);
+
+		_resourcePermissionLocalService.addResourcePermission(
+			groupedModel.getCompanyId(), groupedModel.getModelClassName(),
+			ResourceConstants.SCOPE_GROUP,
+			String.valueOf(groupedModel.getGroupId()), accountRole.getRoleId(),
+			ActionKeys.DELETE);
+
+		_testSelectedAccountPermission(
+			groupedModel, user, ActionKeys.DELETE, true);
+
+		_currentAccountEntryManager.setCurrentAccountEntry(
+			accountEntry2.getAccountEntryId(), group.getGroupId(),
+			user.getUserId());
+
+		_testSelectedAccountPermission(
+			groupedModel, user, ActionKeys.DELETE, false);
+	}
+
+	private void _testSelectedAccountPermission(
+			GroupedModel groupedModel, User user, String actionKey,
+			boolean hasPermission)
+		throws Exception {
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(user);
+
+		Assert.assertEquals(
+			hasPermission,
+			permissionChecker.hasPermission(
+				groupedModel.getGroupId(), groupedModel.getModelClassName(),
+				String.valueOf(groupedModel.getPrimaryKeyObj()), actionKey));
+	}
+
 	@Inject
 	private AccountEntryLocalService _accountEntryLocalService;
 
@@ -77,7 +183,16 @@ public class AccountRoleContributorTest {
 	private AccountEntryUserRelLocalService _accountEntryUserRelLocalService;
 
 	@Inject
+	private AccountRoleLocalService _accountRoleLocalService;
+
+	@Inject
+	private CurrentAccountEntryManager _currentAccountEntryManager;
+
+	@Inject
 	private PermissionCheckerFactory _permissionCheckerFactory;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 	@Inject
 	private RoleLocalService _roleLocalService;

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/manager/test/CurrentAccountEntryManagerTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/manager/test/CurrentAccountEntryManagerTest.java
@@ -23,8 +23,6 @@ import com.liferay.account.service.test.util.AccountEntryTestUtil;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserConstants;
-import com.liferay.portal.kernel.servlet.PortalSessionContext;
-import com.liferay.portal.kernel.servlet.PortalSessionThreadLocal;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -32,19 +30,11 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.List;
 
-import javax.servlet.http.HttpSession;
-
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.springframework.mock.web.MockHttpSession;
 
 /**
  * @author Pei-Jung Lan
@@ -56,31 +46,6 @@ public class CurrentAccountEntryManagerTest {
 	@Rule
 	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
 		new LiferayIntegrationTestRule();
-
-	@BeforeClass
-	public static void setUpClass() {
-		_originalHttpSession = PortalSessionThreadLocal.getHttpSession();
-	}
-
-	@AfterClass
-	public static void tearDownClass() {
-		if (_originalHttpSession != null) {
-			PortalSessionThreadLocal.setHttpSession(_originalHttpSession);
-		}
-	}
-
-	@Before
-	public void setUp() {
-		_httpSession = new MockHttpSession();
-
-		PortalSessionContext.put(_httpSession.getId(), _httpSession);
-		PortalSessionThreadLocal.setHttpSession(_httpSession);
-	}
-
-	@After
-	public void tearDown() {
-		PortalSessionContext.remove(_httpSession.getId());
-	}
 
 	@Test
 	public void testGetCurrentAccountEntry() throws Exception {
@@ -149,9 +114,6 @@ public class CurrentAccountEntryManagerTest {
 			_currentAccountEntryManager.getCurrentAccountEntry(
 				TestPropsValues.getGroupId(), TestPropsValues.getUserId()));
 	}
-
-	private static HttpSession _httpSession;
-	private static HttpSession _originalHttpSession;
 
 	@Inject
 	private AccountEntryLocalService _accountEntryLocalService;


### PR DESCRIPTION
Manual forward from https://github.com/liferay-usm/liferay-portal/pull/230:

> This is an update for [LPS-112782](https://issues.liferay.com/browse/LPS-112782).
> 
> This pull adds two main things:
> 
> - An update to the AccountRoleContributor that contributes account roles based on the currently selected account.
> - An update to the CurrentAccountManager implementation that tries to retrieve the current account in this order:
>    - session
>    - portlet preferences
>    - default account
>    This allows us to more easily use the CurrentAccountManager in tests, where a session is not available.
> 
> This pull does not include any UI updates, so there is currently no way to add group or company scoped permissions to an AccountRole in the UI. However the functionality is demonstrated programatically in the `AccountRoleContributorTest#testSelectedAccountPermission` test case.
> 
> /cc @pei-jung @alee8888 @ChrisKian @drewbrokke @lr-leo

✔️ ci:test:sf - 1 out of 1 jobs passed in 3 minutes
❌ ci:test:stable - 8 out of 10 jobs passed
❌ ci:test:relevant - 16 out of 22 jobs passed in 2 hours 11 minutes

Stable and Relevant failures are not related.