### PR TITLE
LPS-124898 Increase column size for some OIDC providers

### DIFF
--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/main/java/com/liferay/portal/security/sso/openid/connect/persistence/model/impl/OpenIdConnectSessionModelImpl.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/main/java/com/liferay/portal/security/sso/openid/connect/persistence/model/impl/OpenIdConnectSessionModelImpl.java
@@ -86,7 +86,7 @@ public class OpenIdConnectSessionModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table OpenIdConnectSession (mvccVersion LONG default 0 not null,openIdConnectSessionId LONG not null primary key,companyId LONG,modifiedDate DATE null,accessToken VARCHAR(2048) null,idToken VARCHAR(2048) null,providerName VARCHAR(75) null,refreshToken VARCHAR(512) null)";
+		"create table OpenIdConnectSession (mvccVersion LONG default 0 not null,openIdConnectSessionId LONG not null primary key,companyId LONG,modifiedDate DATE null,accessToken VARCHAR(3000) null,idToken VARCHAR(3999) null,providerName VARCHAR(75) null,refreshToken VARCHAR(2000) null)";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table OpenIdConnectSession";

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -7,14 +7,14 @@
 		<field name="companyId" type="long" />
 		<field name="modifiedDate" type="Date" />
 		<field name="accessToken" type="String">
-			<hint name="max-length">2048</hint>
+			<hint name="max-length">3000</hint>
 		</field>
 		<field name="idToken" type="String">
-			<hint name="max-length">2048</hint>
+			<hint name="max-length">3999</hint>
 		</field>
 		<field name="providerName" type="String" />
 		<field name="refreshToken" type="String">
-			<hint name="max-length">512</hint>
+			<hint name="max-length">2000</hint>
 		</field>
 	</model>
 </model-hints>

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/main/resources/META-INF/sql/tables.sql
@@ -3,8 +3,8 @@ create table OpenIdConnectSession (
 	openIdConnectSessionId LONG not null primary key,
 	companyId LONG,
 	modifiedDate DATE null,
-	accessToken VARCHAR(2048) null,
-	idToken VARCHAR(2048) null,
+	accessToken VARCHAR(3000) null,
+	idToken VARCHAR(3999) null,
 	providerName VARCHAR(75) null,
-	refreshToken VARCHAR(512) null
+	refreshToken VARCHAR(2000) null
 );


### PR DESCRIPTION
Some certain providers may send back tokens whose sizes are bigger than we configured right now.
Also in order to keep VARCHAR type, 3999 is the maximum.