### PR TITLE
LPS-138282 Add method to get a filter from a filterString to be used by the TaxonomyVocabularyResource API

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/build.gradle
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.10.5.1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.dependencymanager", version: "4.6.0"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
@@ -12,6 +13,7 @@ dependencies {
 	compileOnly project(":apps:headless:headless-delivery:headless-delivery-api")
 	compileOnly project(":apps:journal:journal-api")
 	compileOnly project(":apps:object:object-admin-rest-api")
+	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:style-book:style-book-api")

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -52,8 +53,15 @@ import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.filter.expression.ExpressionVisitException;
 import com.liferay.portal.vulcan.multipart.BinaryFile;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.site.exception.InitializationException;
 import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.style.book.zip.processor.StyleBookEntryZipProcessor;
@@ -87,6 +95,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 		DefaultDDMStructureHelper defaultDDMStructureHelper,
 		DocumentFolderResource.Factory documentFolderResourceFactory,
 		DocumentResource.Factory documentResourceFactory,
+		ExpressionConvert<Filter> expressionConvert,
+		FilterParserProvider filterParserProvider,
 		FragmentsImporter fragmentsImporter,
 		GroupLocalService groupLocalService, JSONFactory jsonFactory,
 		ObjectDefinitionResource.Factory objectDefinitionResourceFactory,
@@ -101,6 +111,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 		_defaultDDMStructureHelper = defaultDDMStructureHelper;
 		_documentFolderResourceFactory = documentFolderResourceFactory;
 		_documentResourceFactory = documentResourceFactory;
+		_expressionConvert = expressionConvert;
+		_filterParserProvider = filterParserProvider;
 		_fragmentsImporter = fragmentsImporter;
 		_groupLocalService = groupLocalService;
 		_jsonFactory = jsonFactory;
@@ -478,6 +490,52 @@ public class BundleSiteInitializer implements SiteInitializer {
 			"/site-initializer/taxonomy-vocabularies/group", serviceContext);
 	}
 
+	private Filter _getFilter(
+			String filterString, ServiceContext serviceContext)
+		throws Exception {
+
+		if (Validator.isNull(filterString)) {
+			return null;
+		}
+
+		TaxonomyVocabularyResource.Builder taxonomyVocabularyResourceBuilder =
+			_taxonomyVocabularyResourceFactory.create();
+
+		User user = serviceContext.fetchUser();
+
+		TaxonomyVocabularyResource taxonomyVocabularyResource =
+			taxonomyVocabularyResourceBuilder.user(
+				user
+			).build();
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)taxonomyVocabularyResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(null);
+
+		try {
+			FilterParser filterParser = _filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return _expressionConvert.convert(
+				oDataFilter.getExpression(),
+				LocaleUtil.fromLanguageId(user.getLanguageId()), entityModel);
+		}
+		catch (ExpressionVisitException expressionVisitException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to create filter from " + filterString,
+					expressionVisitException);
+			}
+		}
+
+		return null;
+	}
+
 	private String _read(String resourcePath) throws Exception {
 		InputStream inputStream = _servletContext.getResourceAsStream(
 			resourcePath);
@@ -510,6 +568,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 	private final DefaultDDMStructureHelper _defaultDDMStructureHelper;
 	private final DocumentFolderResource.Factory _documentFolderResourceFactory;
 	private final DocumentResource.Factory _documentResourceFactory;
+	private final ExpressionConvert<Filter> _expressionConvert;
+	private final FilterParserProvider _filterParserProvider;
 	private final FragmentsImporter _fragmentsImporter;
 	private final GroupLocalService _groupLocalService;
 	private final JSONFactory _jsonFactory;

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtender.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtender.java
@@ -23,10 +23,13 @@ import com.liferay.headless.delivery.resource.v1_0.DocumentFolderResource;
 import com.liferay.headless.delivery.resource.v1_0.DocumentResource;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectDefinitionResource;
 import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.style.book.zip.processor.StyleBookEntryZipProcessor;
 
 import java.util.List;
@@ -68,7 +71,8 @@ public class SiteInitializerExtender
 				bundle, _bundleContext, _ddmStructureLocalService,
 				_ddmTemplateLocalService, _defaultDDMStructureHelper,
 				_documentFolderResourceFactory, _documentResourceFactory,
-				_fragmentsImporter, _groupLocalService, _jsonFactory,
+				_expressionConvert, _filterParserProvider, _fragmentsImporter,
+				_groupLocalService, _jsonFactory,
 				_objectDefinitionResourceFactory, _portal,
 				_styleBookEntryZipProcessor, _taxonomyVocabularyResourceFactory,
 				_userLocalService);
@@ -124,6 +128,12 @@ public class SiteInitializerExtender
 
 	@Reference
 	private DocumentResource.Factory _documentResourceFactory;
+
+	@Reference
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
 
 	@Reference
 	private FragmentsImporter _fragmentsImporter;

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtension.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtension.java
@@ -23,9 +23,12 @@ import com.liferay.headless.delivery.resource.v1_0.DocumentFolderResource;
 import com.liferay.headless.delivery.resource.v1_0.DocumentResource;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectDefinitionResource;
 import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.style.book.zip.processor.StyleBookEntryZipProcessor;
 
 import javax.servlet.ServletContext;
@@ -49,6 +52,8 @@ public class SiteInitializerExtension {
 		DefaultDDMStructureHelper defaultDDMStructureHelper,
 		DocumentFolderResource.Factory documentFolderResourceFactory,
 		DocumentResource.Factory documentResourceFactory,
+		ExpressionConvert<Filter> expressionConvert,
+		FilterParserProvider filterParserProvider,
 		FragmentsImporter fragmentsImporter,
 		GroupLocalService groupLocalService, JSONFactory jsonFactory,
 		ObjectDefinitionResource.Factory objectDefinitionResourceFactory,
@@ -65,10 +70,10 @@ public class SiteInitializerExtension {
 				bundle, bundleContext, ddmStructureLocalService,
 				ddmTemplateLocalService, defaultDDMStructureHelper,
 				documentFolderResourceFactory, documentResourceFactory,
-				fragmentsImporter, groupLocalService, jsonFactory,
-				objectDefinitionResourceFactory, portal,
-				styleBookEntryZipProcessor, taxonomyVocabularyResourceFactory,
-				userLocalService));
+				expressionConvert, filterParserProvider, fragmentsImporter,
+				groupLocalService, jsonFactory, objectDefinitionResourceFactory,
+				portal, styleBookEntryZipProcessor,
+				taxonomyVocabularyResourceFactory, userLocalService));
 
 		ServiceDependency serviceDependency =
 			_dependencyManager.createServiceDependency();

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerRegistrar.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerRegistrar.java
@@ -23,10 +23,13 @@ import com.liferay.headless.delivery.resource.v1_0.DocumentFolderResource;
 import com.liferay.headless.delivery.resource.v1_0.DocumentResource;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectDefinitionResource;
 import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.style.book.zip.processor.StyleBookEntryZipProcessor;
 
@@ -48,6 +51,8 @@ public class SiteInitializerRegistrar {
 		DefaultDDMStructureHelper defaultDDMStructureHelper,
 		DocumentFolderResource.Factory documentFolderResourceFactory,
 		DocumentResource.Factory documentResourceFactory,
+		ExpressionConvert<Filter> expressionConvert,
+		FilterParserProvider filterParserProvider,
 		FragmentsImporter fragmentsImporter,
 		GroupLocalService groupLocalService, JSONFactory jsonFactory,
 		ObjectDefinitionResource.Factory objectDefinitionResourceFactory,
@@ -62,6 +67,8 @@ public class SiteInitializerRegistrar {
 		_defaultDDMStructureHelper = defaultDDMStructureHelper;
 		_documentFolderResourceFactory = documentFolderResourceFactory;
 		_documentResourceFactory = documentResourceFactory;
+		_expressionConvert = expressionConvert;
+		_filterParserProvider = filterParserProvider;
 		_fragmentsImporter = fragmentsImporter;
 		_groupLocalService = groupLocalService;
 		_jsonFactory = jsonFactory;
@@ -82,11 +89,11 @@ public class SiteInitializerRegistrar {
 			new BundleSiteInitializer(
 				_bundle, _ddmStructureLocalService, _ddmTemplateLocalService,
 				_defaultDDMStructureHelper, _documentFolderResourceFactory,
-				_documentResourceFactory, _fragmentsImporter,
-				_groupLocalService, _jsonFactory,
-				_objectDefinitionResourceFactory, _portal, _servletContext,
-				_styleBookEntryZipProcessor, _taxonomyVocabularyResourceFactory,
-				_userLocalService),
+				_documentResourceFactory, _expressionConvert,
+				_filterParserProvider, _fragmentsImporter, _groupLocalService,
+				_jsonFactory, _objectDefinitionResourceFactory, _portal,
+				_servletContext, _styleBookEntryZipProcessor,
+				_taxonomyVocabularyResourceFactory, _userLocalService),
 			MapUtil.singletonDictionary(
 				"site.initializer.key", _bundle.getSymbolicName()));
 	}
@@ -102,6 +109,8 @@ public class SiteInitializerRegistrar {
 	private final DefaultDDMStructureHelper _defaultDDMStructureHelper;
 	private final DocumentFolderResource.Factory _documentFolderResourceFactory;
 	private final DocumentResource.Factory _documentResourceFactory;
+	private final ExpressionConvert<Filter> _expressionConvert;
+	private final FilterParserProvider _filterParserProvider;
 	private final FragmentsImporter _fragmentsImporter;
 	private final GroupLocalService _groupLocalService;
 	private final JSONFactory _jsonFactory;


### PR DESCRIPTION
As I have some lack of context, I've created a private method name `_getFilter` with the way I think it is more convenient to get a Filter from a filterString inside the BundleSiteInitializer class.

Finally, I follow the same approach we take at https://github.com/liferay/liferay-portal/blob/master/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/item/BatchEngineTaskItemDelegateExecutor.java#L100

Depending on where it is used it may be better to inline the method and some variables can be reused from somewhere else (as taxonomyVocabularyResourceBuilder, user, and taxonomyVocabularyResource).

We can discuss in the PR if something doesn't fit you to find a better way