### PR TITLE
LPS-138566 Add support to Asset Category Properties on Headless Admin Taxonomy API

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/Property.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/Property.java
@@ -1,0 +1,253 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.admin.taxonomy.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@GraphQLName(description = "The category's properties.", value = "Property")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "Property")
+public class Property implements Serializable {
+
+	public static Property toDTO(String json) {
+		return ObjectMapperUtil.readValue(Property.class, json);
+	}
+
+	@Schema(description = "The taxonomy category property's key.")
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	@JsonIgnore
+	public void setKey(UnsafeSupplier<String, Exception> keyUnsafeSupplier) {
+		try {
+			key = keyUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The taxonomy category property's key.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String key;
+
+	@Schema(description = "The taxonomy category property's value.")
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	@JsonIgnore
+	public void setValue(
+		UnsafeSupplier<String, Exception> valueUnsafeSupplier) {
+
+		try {
+			value = valueUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The taxonomy category property's value.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String value;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Property)) {
+			return false;
+		}
+
+		Property property = (Property)object;
+
+		return Objects.equals(toString(), property.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		if (key != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"key\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(key));
+
+			sb.append("\"");
+		}
+
+		if (value != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"value\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(value));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.admin.taxonomy.dto.v1_0.Property",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		return string.replaceAll("\"", "\\\\\"");
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(value);
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyCategory.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyCategory.java
@@ -488,6 +488,35 @@ public class TaxonomyCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected ParentTaxonomyVocabulary parentTaxonomyVocabulary;
 
+	@Schema(description = "The category's properties.")
+	@Valid
+	public Property[] getProperties() {
+		return properties;
+	}
+
+	public void setProperties(Property[] properties) {
+		this.properties = properties;
+	}
+
+	@JsonIgnore
+	public void setProperties(
+		UnsafeSupplier<Property[], Exception> propertiesUnsafeSupplier) {
+
+		try {
+			properties = propertiesUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The category's properties.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Property[] properties;
+
 	@Schema
 	public Integer getTaxonomyCategoryUsageCount() {
 		return taxonomyCategoryUsageCount;
@@ -768,6 +797,26 @@ public class TaxonomyCategory implements Serializable {
 			sb.append("\"parentTaxonomyVocabulary\": ");
 
 			sb.append(String.valueOf(parentTaxonomyVocabulary));
+		}
+
+		if (properties != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"properties\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < properties.length; i++) {
+				sb.append(String.valueOf(properties[i]));
+
+				if ((i + 1) < properties.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		if (taxonomyCategoryUsageCount != null) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/Property.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/Property.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.admin.taxonomy.client.dto.v1_0;
+
+import com.liferay.headless.admin.taxonomy.client.function.UnsafeSupplier;
+import com.liferay.headless.admin.taxonomy.client.serdes.v1_0.PropertySerDes;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class Property implements Cloneable, Serializable {
+
+	public static Property toDTO(String json) {
+		return PropertySerDes.toDTO(json);
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	public void setKey(UnsafeSupplier<String, Exception> keyUnsafeSupplier) {
+		try {
+			key = keyUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String key;
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	public void setValue(
+		UnsafeSupplier<String, Exception> valueUnsafeSupplier) {
+
+		try {
+			value = valueUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String value;
+
+	@Override
+	public Property clone() throws CloneNotSupportedException {
+		return (Property)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Property)) {
+			return false;
+		}
+
+		Property property = (Property)object;
+
+		return Objects.equals(toString(), property.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return PropertySerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/TaxonomyCategory.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/TaxonomyCategory.java
@@ -340,6 +340,27 @@ public class TaxonomyCategory implements Cloneable, Serializable {
 
 	protected ParentTaxonomyVocabulary parentTaxonomyVocabulary;
 
+	public Property[] getProperties() {
+		return properties;
+	}
+
+	public void setProperties(Property[] properties) {
+		this.properties = properties;
+	}
+
+	public void setProperties(
+		UnsafeSupplier<Property[], Exception> propertiesUnsafeSupplier) {
+
+		try {
+			properties = propertiesUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Property[] properties;
+
 	public Integer getTaxonomyCategoryUsageCount() {
 		return taxonomyCategoryUsageCount;
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/PropertySerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/PropertySerDes.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.admin.taxonomy.client.serdes.v1_0;
+
+import com.liferay.headless.admin.taxonomy.client.dto.v1_0.Property;
+import com.liferay.headless.admin.taxonomy.client.json.BaseJSONParser;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class PropertySerDes {
+
+	public static Property toDTO(String json) {
+		PropertyJSONParser propertyJSONParser = new PropertyJSONParser();
+
+		return propertyJSONParser.parseToDTO(json);
+	}
+
+	public static Property[] toDTOs(String json) {
+		PropertyJSONParser propertyJSONParser = new PropertyJSONParser();
+
+		return propertyJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(Property property) {
+		if (property == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (property.getKey() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"key\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(property.getKey()));
+
+			sb.append("\"");
+		}
+
+		if (property.getValue() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"value\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(property.getValue()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		PropertyJSONParser propertyJSONParser = new PropertyJSONParser();
+
+		return propertyJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(Property property) {
+		if (property == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (property.getKey() == null) {
+			map.put("key", null);
+		}
+		else {
+			map.put("key", String.valueOf(property.getKey()));
+		}
+
+		if (property.getValue() == null) {
+			map.put("value", null);
+		}
+		else {
+			map.put("value", String.valueOf(property.getValue()));
+		}
+
+		return map;
+	}
+
+	public static class PropertyJSONParser extends BaseJSONParser<Property> {
+
+		@Override
+		protected Property createDTO() {
+			return new Property();
+		}
+
+		@Override
+		protected Property[] createDTOArray(int size) {
+			return new Property[size];
+		}
+
+		@Override
+		protected void setField(
+			Property property, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "key")) {
+				if (jsonParserFieldValue != null) {
+					property.setKey((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "value")) {
+				if (jsonParserFieldValue != null) {
+					property.setValue((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			Class<?> valueClass = value.getClass();
+
+			if (value instanceof Map) {
+				sb.append(_toJSON((Map)value));
+			}
+			else if (valueClass.isArray()) {
+				Object[] values = (Object[])value;
+
+				sb.append("[");
+
+				for (int i = 0; i < values.length; i++) {
+					sb.append("\"");
+					sb.append(_escape(values[i]));
+					sb.append("\"");
+
+					if ((i + 1) < values.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(entry.getValue()));
+				sb.append("\"");
+			}
+			else {
+				sb.append(String.valueOf(entry.getValue()));
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyCategorySerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyCategorySerDes.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.admin.taxonomy.client.serdes.v1_0;
 
+import com.liferay.headless.admin.taxonomy.client.dto.v1_0.Property;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.TaxonomyCategory;
 import com.liferay.headless.admin.taxonomy.client.json.BaseJSONParser;
 
@@ -25,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Stream;
 
 import javax.annotation.Generated;
 
@@ -247,6 +249,26 @@ public class TaxonomyCategorySerDes {
 				String.valueOf(taxonomyCategory.getParentTaxonomyVocabulary()));
 		}
 
+		if (taxonomyCategory.getProperties() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"properties\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < taxonomyCategory.getProperties().length; i++) {
+				sb.append(String.valueOf(taxonomyCategory.getProperties()[i]));
+
+				if ((i + 1) < taxonomyCategory.getProperties().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (taxonomyCategory.getTaxonomyCategoryUsageCount() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -413,6 +435,14 @@ public class TaxonomyCategorySerDes {
 				String.valueOf(taxonomyCategory.getParentTaxonomyVocabulary()));
 		}
 
+		if (taxonomyCategory.getProperties() == null) {
+			map.put("properties", null);
+		}
+		else {
+			map.put(
+				"properties", String.valueOf(taxonomyCategory.getProperties()));
+		}
+
 		if (taxonomyCategory.getTaxonomyCategoryUsageCount() == null) {
 			map.put("taxonomyCategoryUsageCount", null);
 		}
@@ -547,6 +577,18 @@ public class TaxonomyCategorySerDes {
 					taxonomyCategory.setParentTaxonomyVocabulary(
 						ParentTaxonomyVocabularySerDes.toDTO(
 							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "properties")) {
+				if (jsonParserFieldValue != null) {
+					taxonomyCategory.setProperties(
+						Stream.of(
+							toStrings((Object[])jsonParserFieldValue)
+						).map(
+							object -> PropertySerDes.toDTO((String)object)
+						).toArray(
+							size -> new Property[size]
+						));
 				}
 			}
 			else if (Objects.equals(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:asset:asset-category-property-api")
 	compileOnly project(":apps:headless:headless-admin-taxonomy:headless-admin-taxonomy-api")
 	compileOnly project(":apps:headless:headless-common-spi")
 	compileOnly project(":apps:portal-odata:portal-odata-api")

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -217,6 +217,24 @@ components:
                             type: string
                     readOnly: true
                     type: object
+                properties:
+                    # @review
+                    description:
+                        The category's properties.
+                    items:
+                        properties:
+                            key:
+                                # @review
+                                description:
+                                    The taxonomy category property's key.
+                                type: string
+                            value:
+                                # @review
+                                description:
+                                    The taxonomy category property's value.
+                                type: string
+                        type: object
+                    type: array
                 taxonomyCategoryUsageCount:
                     readOnly: true
                     type: integer

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
@@ -14,6 +14,8 @@
 
 package com.liferay.headless.admin.taxonomy.internal.dto.v1_0.converter;
 
+import com.liferay.asset.category.property.model.AssetCategoryProperty;
+import com.liferay.asset.category.property.service.AssetCategoryPropertyLocalService;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
@@ -22,6 +24,7 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyService;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.ParentTaxonomyCategory;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.ParentTaxonomyVocabulary;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.Property;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyCategory;
 import com.liferay.headless.admin.taxonomy.internal.dto.v1_0.util.CreatorUtil;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -31,6 +34,9 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -157,12 +163,42 @@ public class TaxonomyCategoryDTOConverter
 							assetCategory.getParentCategory(),
 							dtoConverterContext);
 					});
+
+				setProperties(
+					() -> {
+						List<AssetCategoryProperty> assetCategoryProperties =
+							_assetCategoryPropertyLocalService.
+								getCategoryProperties(
+									assetCategory.getCategoryId());
+
+						if (assetCategoryProperties.isEmpty()) {
+							return null;
+						}
+
+						Stream<AssetCategoryProperty> stream =
+							assetCategoryProperties.stream();
+
+						return stream.map(
+							assetCategoryProperty -> new Property() {
+								{
+									key = assetCategoryProperty.getKey();
+									value = assetCategoryProperty.getValue();
+								}
+							}
+						).toArray(
+							Property[]::new
+						);
+					});
 			}
 		};
 	}
 
 	@Reference
 	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Reference
+	private AssetCategoryPropertyLocalService
+		_assetCategoryPropertyLocalService;
 
 	@Reference
 	private AssetCategoryService _assetCategoryService;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
@@ -262,7 +262,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {taxonomyCategory(taxonomyCategoryId: ___){actions, availableLanguages, creator, dateCreated, dateModified, description, description_i18n, externalReferenceCode, id, name, name_i18n, numberOfTaxonomyCategories, parentTaxonomyCategory, parentTaxonomyVocabulary, taxonomyCategoryUsageCount, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {taxonomyCategory(taxonomyCategoryId: ___){actions, availableLanguages, creator, dateCreated, dateModified, description, description_i18n, externalReferenceCode, id, name, name_i18n, numberOfTaxonomyCategories, parentTaxonomyCategory, parentTaxonomyVocabulary, properties, taxonomyCategoryUsageCount, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves a taxonomy category.")
 	public TaxonomyCategory taxonomyCategory(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -157,7 +157,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "properties": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@Consumes({"application/json", "application/xml"})
 	@Operation(description = "Inserts a new child taxonomy category.")
@@ -264,7 +264,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "properties": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@Consumes({"application/json", "application/xml"})
 	@Operation(
@@ -354,7 +354,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "properties": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@Consumes({"application/json", "application/xml"})
 	@Operation(
@@ -554,7 +554,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories' -d $'{"description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "properties": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@Consumes({"application/json", "application/xml"})
 	@Operation(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -334,7 +334,14 @@ public class TaxonomyCategoryResourceImpl
 			assetCategory.getCategoryId(), ActionKeys.UPDATE);
 
 		return _toTaxonomyCategory(
-			_assetCategoryLocalService.updateAssetCategory(assetCategory));
+			_assetCategoryLocalService.updateCategory(
+				contextUser.getUserId(), assetCategory.getCategoryId(),
+				assetCategory.getParentCategoryId(), titleMap, descriptionMap,
+				assetCategory.getVocabularyId(),
+				_toCategoryProperties(taxonomyCategory.getProperties()),
+				ServiceContextRequestUtil.createServiceContext(
+					assetCategory.getGroupId(), contextHttpServletRequest,
+					taxonomyCategory.getViewableByAsString())));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -14,6 +14,8 @@
 
 package com.liferay.headless.admin.taxonomy.internal.resource.v1_0;
 
+import com.liferay.asset.category.property.model.AssetCategoryProperty;
+import com.liferay.asset.category.property.service.AssetCategoryPropertyLocalService;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetVocabulary;
@@ -65,9 +67,13 @@ import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.ws.rs.BadRequestException;
@@ -270,7 +276,17 @@ public class TaxonomyCategoryResourceImpl
 			assetCategory.getCategoryId(), ActionKeys.UPDATE);
 
 		return _toTaxonomyCategory(
-			_assetCategoryLocalService.updateAssetCategory(assetCategory));
+			_assetCategoryLocalService.updateCategory(
+				contextUser.getUserId(), assetCategory.getCategoryId(),
+				assetCategory.getParentCategoryId(),
+				assetCategory.getTitleMap(), assetCategory.getDescriptionMap(),
+				assetCategory.getVocabularyId(),
+				_mergeProperties(
+					assetCategory.getCategoryId(),
+					taxonomyCategory.getProperties()),
+				ServiceContextRequestUtil.createServiceContext(
+					assetCategory.getGroupId(), contextHttpServletRequest,
+					taxonomyCategory.getViewableByAsString())));
 	}
 
 	@Override
@@ -490,6 +506,40 @@ public class TaxonomyCategoryResourceImpl
 		return _assetCategoryLocalService.dynamicQueryCount(dynamicQuery);
 	}
 
+	private String[] _mergeProperties(long categoryId, Property[] properties) {
+		List<AssetCategoryProperty> assetCategoryProperties =
+			_assetCategoryPropertyLocalService.getCategoryProperties(
+				categoryId);
+
+		Stream<Property> stream = Arrays.stream(
+			Optional.ofNullable(
+				properties
+			).orElse(
+				new Property[0]
+			));
+
+		Map<String, String> propertiesMap = stream.collect(
+			Collectors.toMap(Property::getKey, Property::getValue));
+
+		for (AssetCategoryProperty assetCategoryProperty :
+				assetCategoryProperties) {
+
+			propertiesMap.putIfAbsent(
+				assetCategoryProperty.getKey(),
+				assetCategoryProperty.getValue());
+		}
+
+		Set<Map.Entry<String, String>> entries = propertiesMap.entrySet();
+
+		Stream<Map.Entry<String, String>> entriesStream = entries.stream();
+
+		return entriesStream.map(
+			entry -> entry.getKey() + ":" + entry.getValue()
+		).toArray(
+			String[]::new
+		);
+	}
+
 	private AssetCategory _toAssetCategory(Object[] assetCategory) {
 		return new AssetCategoryImpl() {
 			{
@@ -563,6 +613,10 @@ public class TaxonomyCategoryResourceImpl
 
 	@Reference
 	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Reference
+	private AssetCategoryPropertyLocalService
+		_assetCategoryPropertyLocalService;
 
 	@Reference
 	private AssetCategoryService _assetCategoryService;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetCategoryService;
 import com.liferay.asset.kernel.service.AssetVocabularyService;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.Property;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyCategory;
 import com.liferay.headless.admin.taxonomy.internal.dto.v1_0.converter.TaxonomyCategoryDTOConverter;
 import com.liferay.headless.admin.taxonomy.internal.odata.entity.v1_0.CategoryEntityModel;
@@ -61,11 +62,13 @@ import com.liferay.portlet.asset.service.permission.AssetCategoryPermission;
 
 import java.sql.Timestamp;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.MultivaluedMap;
@@ -370,7 +373,8 @@ public class TaxonomyCategoryResourceImpl
 
 		AssetCategory assetCategory = _assetCategoryService.addCategory(
 			groupId, taxonomyCategoryId, titleMap, descriptionMap,
-			taxonomyVocabularyId, null,
+			taxonomyVocabularyId,
+			_toCategoryProperties(taxonomyCategory.getProperties()),
 			ServiceContextRequestUtil.createServiceContext(
 				groupId, contextHttpServletRequest,
 				taxonomyCategory.getViewableByAsString()));
@@ -492,6 +496,20 @@ public class TaxonomyCategoryResourceImpl
 				setUserId((long)assetCategory[8]);
 			}
 		};
+	}
+
+	private String[] _toCategoryProperties(Property[] properties) {
+		if (properties == null) {
+			return null;
+		}
+
+		Stream<Property> stream = Arrays.stream(properties);
+
+		return stream.map(
+			property -> property.getKey() + ":" + property.getValue()
+		).toArray(
+			String[]::new
+		);
 	}
 
 	private Date _toDate(Timestamp timestamp) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -1487,6 +1487,14 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("properties", additionalAssertFieldName)) {
+				if (taxonomyCategory.getProperties() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals(
 					"taxonomyCategoryUsageCount", additionalAssertFieldName)) {
 
@@ -1762,6 +1770,17 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("properties", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						taxonomyCategory1.getProperties(),
+						taxonomyCategory2.getProperties())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals(
 					"taxonomyCategoryUsageCount", additionalAssertFieldName)) {
 
@@ -2019,6 +2038,11 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		}
 
 		if (entityFieldName.equals("parentTaxonomyVocabulary")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("properties")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
 		}


### PR DESCRIPTION
Finish the support for creating, updating, patching, and reading asset category properties through the TaxonomyCategory endpoints on the Headless Admin Taxonomy API.

Once you agree with the naming and code I will send you a follow-up adding integration tests.

Copying text from the first PR below, that is included in this one and I will close.

--------------------------------------------------------------------------------------------------------------------------

I've added a "properties" property to the TaxonomyCategory entity, which has the "key" and "value" properties. With this code, they are already included in every GET response to TaxonomyCategory endpoints.

A JSON response example is

{
  "actions": {
    "get": {
      "method": "GET",
      "href": "http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/42253/taxonomy-categories"
    }
  },
  "facets": [],
  "items": [
    {
      "actions": {
        "add-category": {
          "method": "POST",
          "href": "http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/42254/taxonomy-categories"
        },
        "get": {
          "method": "GET",
          "href": "http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/42254"
        },
        "replace": {
          "method": "PUT",
          "href": "http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/42254"
        },
        "update": {
          "method": "PATCH",
          "href": "http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/42254"
        },
        "delete": {
          "method": "DELETE",
          "href": "http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/42254"
        }
      },
      "availableLanguages": [
        "en-US"
      ],
      "creator": {
        "additionalName": "",
        "contentType": "UserAccount",
        "familyName": "Test",
        "givenName": "Test",
        "id": 20127,
        "name": "Test Test",
        "profileURL": "/web/test"
      },
      "dateCreated": "2021-09-02T12:38:54Z",
      "dateModified": "2021-09-02T12:38:54Z",
      "description": "",
      "description_i18n": {},
      "externalReferenceCode": "",
      "id": "42254",
      "name": "TestCategory",
      "name_i18n": {
        "en-US": "TestCategory"
      },
      "numberOfTaxonomyCategories": 0,
      "parentTaxonomyVocabulary": {
        "id": 42253,
        "name": "TestVocabulary"
      },
      "taxonomyCategoryUsageCount": 0
    },
    {
      "actions": {
        "add-category": {
          "method": "POST",
          "href": "http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/42304/taxonomy-categories"
        },
        "get": {
          "method": "GET",
          "href": "http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/42304"
        },
        "replace": {
          "method": "PUT",
          "href": "http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/42304"
        },
        "update": {
          "method": "PATCH",
          "href": "http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/42304"
        },
        "delete": {
          "method": "DELETE",
          "href": "http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/42304"
        }
      },
      "availableLanguages": [
        "en-US"
      ],
      "creator": {
        "additionalName": "",
        "contentType": "UserAccount",
        "familyName": "Test",
        "givenName": "Test",
        "id": 20127,
        "name": "Test Test",
        "profileURL": "/web/test"
      },
      "dateCreated": "2021-09-02T13:24:35Z",
      "dateModified": "2021-09-02T13:24:54Z",
      "description": "",
      "description_i18n": {},
      "externalReferenceCode": "",
      "id": "42304",
      "name": "TestCategoryWithProperties",
      "name_i18n": {
        "en-US": "TestCategoryWithProperties"
      },
      "numberOfTaxonomyCategories": 0,
      "parentTaxonomyVocabulary": {
        "id": 42253,
        "name": "TestVocabulary"
      },
      "properties": [
        {
          "key": "it",
          "value": "works!"
        }
      ],
      "taxonomyCategoryUsageCount": 0
    }
  ],
  "lastPage": 1,
  "page": 1,
  "pageSize": 20,
  "totalCount": 2
}
My doubt is if you would prefer to prefix some of the property names with taxonomyCategory. I think this way is better for the API consumer experience, as the context of the "properties" property is clear