### PR TITLE
LPS-138412 Disable isolation from modals created from render_portlet

### DIFF
--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -481,7 +481,8 @@ if (urlConfiguration != null) {
 	StringBundler urlConfigurationJSSB = new StringBundler(PropsValues.PORTLET_CONFIG_SHOW_PORTLET_ID ? 14 : 12);
 
 	urlConfigurationJSSB.append("Liferay.Portlet.openModal({");
-	urlConfigurationJSSB.append("namespace: '");
+	urlConfigurationJSSB.append("iframeBodyCssClass: '");
+	urlConfigurationJSSB.append("', namespace: '");
 	urlConfigurationJSSB.append(portletDisplay.getNamespace());
 	urlConfigurationJSSB.append("', portletSelector: '#p_p_id_");
 	urlConfigurationJSSB.append(portletDisplay.getId());


### PR DESCRIPTION
From: https://github.com/liferay-frontend/liferay-portal/pull/1431

CI failed with unrelated errors and this bug is a 7.4-blocker. See https://github.com/liferay-frontend/liferay-portal/pull/1431#issuecomment-912699587