### PR TITLE
LRQA-69847 Use tar.gz bundle if 7z not available. Sorted so that the 7z bundle is used when both are present

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -11734,7 +11734,7 @@ ANT_OPTS=${env.ANT_OPTS}</echo>
 								input="${bundle.content}"
 								override="true"
 								property="bundle.zip.name"
-								regexp="[\S\s]*href=\&quot;(liferay-[^\&quot;]+tomcat[^\&quot;]+\.(7z|zip))\&quot;[\S\s]*"
+								regexp="[\S\s]*href=\&quot;(liferay-[^\&quot;]+tomcat[^\&quot;]+\.(tar.gz|7z|zip))\&quot;[\S\s]*"
 								replace="\1"
 							/>
 


### PR DESCRIPTION
Can go back to 7.0.x

@michaelhashimoto fix for running mock release build