### PR TITLE
LRQA-69864, LPS-130148 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/Elasticsearch7EE.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/Elasticsearch7EE.testcase
@@ -75,6 +75,7 @@ definition {
 		AssertConsoleTextNotPresent(value1 = "The portal instance needs to be restarted");
 	}
 
+	@ignore = "true"
 	@priority = "5"
 	test LearningToRankSmoke {
 		property elastic.override.version = "7.9.0";


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-69864
https://issues.liferay.com/browse/LPS-130148

Trivial change to disable Learning to Rank functional test until the third-party LTR plugin for Elasticsearch 7.14 is released.