### PR TITLE
LPS-139261 Fix property name

### DIFF
--- a/modules/apps/object/object-dynamic-data-mapping/src/main/java/com/liferay/object/dynamic/data/mapping/internal/form/field/type/ObjectRelationshipDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/object/object-dynamic-data-mapping/src/main/java/com/liferay/object/dynamic/data/mapping/internal/form/field/type/ObjectRelationshipDDMFormFieldTemplateContextContributor.java
@@ -60,7 +60,7 @@ public class ObjectRelationshipDDMFormFieldTemplateContextContributor
 
 		try {
 			return HashMapBuilder.<String, Object>put(
-				"apiUrl", _getAPIURL(ddmFormField, ddmFormFieldRenderingContext)
+				"apiURL", _getAPIURL(ddmFormField, ddmFormFieldRenderingContext)
 			).put(
 				"initialLabel", ddmFormFieldRenderingContext.getValue()
 			).put(


### PR DESCRIPTION
I'm sorry, this commit was supposed to be in the last one I sent you. (https://github.com/brianchandotcom/liferay-portal/pull/107311)
I fixed the logic on the frontend side in the last PR so we can maintain the property name as 'apiURL'.