### PR TITLE
LPS-139424 Removes unnecessary handleDestroyPortlet and spritemap attributes from object-web

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddListTypeDefinition.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddListTypeDefinition.tsx
@@ -22,7 +22,6 @@ import RequiredMask from './RequiredMask';
 
 interface IProps extends React.HTMLAttributes<HTMLElement> {
 	apiURL: string;
-	spritemap: string;
 }
 
 type TFormState = {
@@ -33,7 +32,7 @@ type TFormState = {
 
 const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
 
-const ModalAddListTypeDefinition: React.FC<IProps> = ({apiURL, spritemap}) => {
+const ModalAddListTypeDefinition: React.FC<IProps> = ({apiURL}) => {
 	const [visibleModal, setVisibleModal] = useState<boolean>(false);
 	const [formState, setFormState] = useState<TFormState>({
 		name_i18n: {
@@ -99,12 +98,7 @@ const ModalAddListTypeDefinition: React.FC<IProps> = ({apiURL, spritemap}) => {
 					</ClayModal.Header>
 					<ClayModal.Body>
 						{error && (
-							<ClayAlert
-								displayType="danger"
-								spritemap={spritemap}
-							>
-								{error}
-							</ClayAlert>
+							<ClayAlert displayType="danger">{error}</ClayAlert>
 						)}
 
 						<ClayForm.Group>
@@ -158,10 +152,10 @@ const ModalAddListTypeDefinition: React.FC<IProps> = ({apiURL, spritemap}) => {
 	);
 };
 
-const ModalWithProvider: React.FC<IProps> = ({apiURL, spritemap}) => {
+const ModalWithProvider: React.FC<IProps> = ({apiURL}) => {
 	return (
 		<ClayModalProvider>
-			<ModalAddListTypeDefinition apiURL={apiURL} spritemap={spritemap} />
+			<ModalAddListTypeDefinition apiURL={apiURL} />
 		</ClayModalProvider>
 	);
 };

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddListTypeEntry.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddListTypeEntry.tsx
@@ -23,7 +23,6 @@ import RequiredMask from './RequiredMask';
 
 interface IProps extends React.HTMLAttributes<HTMLElement> {
 	apiURL: string;
-	spritemap: string;
 }
 
 type TFormState = {
@@ -51,7 +50,7 @@ const availableLocales: TLocale[] = Object.keys(Liferay.Language.available).map(
 	}
 );
 
-const ModalAddListTypeEntry: React.FC<IProps> = ({apiURL, spritemap}) => {
+const ModalAddListTypeEntry: React.FC<IProps> = ({apiURL}) => {
 	const [visibleModal, setVisibleModal] = useState<boolean>(false);
 	const [formState, setFormState] = useState<TFormState>({
 		key: '',
@@ -119,12 +118,7 @@ const ModalAddListTypeEntry: React.FC<IProps> = ({apiURL, spritemap}) => {
 					</ClayModal.Header>
 					<ClayModal.Body>
 						{error && (
-							<ClayAlert
-								displayType="danger"
-								spritemap={spritemap}
-							>
-								{error}
-							</ClayAlert>
+							<ClayAlert displayType="danger">{error}</ClayAlert>
 						)}
 
 						<ClayLocalizedInput
@@ -142,7 +136,6 @@ const ModalAddListTypeEntry: React.FC<IProps> = ({apiURL, spritemap}) => {
 							}}
 							required
 							selectedLocale={selectedLocale}
-							spritemap={spritemap}
 							translations={formState.name_i18n}
 						/>
 
@@ -193,10 +186,10 @@ const ModalAddListTypeEntry: React.FC<IProps> = ({apiURL, spritemap}) => {
 	);
 };
 
-const ModalWithProvider: React.FC<IProps> = ({apiURL, spritemap}) => {
+const ModalWithProvider: React.FC<IProps> = ({apiURL}) => {
 	return (
 		<ClayModalProvider>
-			<ModalAddListTypeEntry apiURL={apiURL} spritemap={spritemap} />
+			<ModalAddListTypeEntry apiURL={apiURL} />
 		</ClayModalProvider>
 	);
 };

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddObjectDefinition.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddObjectDefinition.tsx
@@ -30,7 +30,6 @@ declare global {
 
 interface IProps extends React.HTMLAttributes<HTMLElement> {
 	apiURL: string;
-	spritemap: string;
 }
 
 type TFormState = {
@@ -60,7 +59,7 @@ const formatString: TFormatString = (str) => {
 
 const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
 
-const ModalAddObjectDefinition: React.FC<IProps> = ({apiURL, spritemap}) => {
+const ModalAddObjectDefinition: React.FC<IProps> = ({apiURL}) => {
 	const [visibleModal, setVisibleModal] = useState<boolean>(false);
 	const [formState, setFormState] = useState<TFormState>({
 		generateAutoName: true,
@@ -137,12 +136,7 @@ const ModalAddObjectDefinition: React.FC<IProps> = ({apiURL, spritemap}) => {
 					</ClayModal.Header>
 					<ClayModal.Body>
 						{error && (
-							<ClayAlert
-								displayType="danger"
-								spritemap={spritemap}
-							>
-								{error}
-							</ClayAlert>
+							<ClayAlert displayType="danger">{error}</ClayAlert>
 						)}
 
 						<ClayForm.Group>
@@ -250,10 +244,10 @@ const ModalAddObjectDefinition: React.FC<IProps> = ({apiURL, spritemap}) => {
 	);
 };
 
-const ModalWithProvider: React.FC<IProps> = ({apiURL, spritemap}) => {
+const ModalWithProvider: React.FC<IProps> = ({apiURL}) => {
 	return (
 		<ClayModalProvider>
-			<ModalAddObjectDefinition apiURL={apiURL} spritemap={spritemap} />
+			<ModalAddObjectDefinition apiURL={apiURL} />
 		</ClayModalProvider>
 	);
 };

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddObjectField.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddObjectField.tsx
@@ -27,7 +27,6 @@ import RequiredMask from './RequiredMask';
 
 interface IProps extends React.HTMLAttributes<HTMLElement> {
 	apiURL: string;
-	spritemap: string;
 }
 
 type TLocalizableLable = {
@@ -79,7 +78,7 @@ const formatName: TFormatName = (str) => {
 	return firstLetterLowercase(removeAllSpecialCharacters(join));
 };
 
-const ModalAddObjectField: React.FC<IProps> = ({apiURL, spritemap}) => {
+const ModalAddObjectField: React.FC<IProps> = ({apiURL}) => {
 	const [visibleModal, setVisibleModal] = useState<boolean>(false);
 	const [formState, setFormState] = useState<TFormState>({
 		generateAutoName: true,
@@ -153,12 +152,7 @@ const ModalAddObjectField: React.FC<IProps> = ({apiURL, spritemap}) => {
 
 					<ClayModal.Body>
 						{error && (
-							<ClayAlert
-								displayType="danger"
-								spritemap={spritemap}
-							>
-								{error}
-							</ClayAlert>
+							<ClayAlert displayType="danger">{error}</ClayAlert>
 						)}
 
 						<ClayForm.Group>
@@ -354,10 +348,10 @@ const ModalAddObjectField: React.FC<IProps> = ({apiURL, spritemap}) => {
 	);
 };
 
-const ModalWithProvider: React.FC<IProps> = ({apiURL, spritemap}) => {
+const ModalWithProvider: React.FC<IProps> = ({apiURL}) => {
 	return (
 		<ClayModalProvider>
-			<ModalAddObjectField apiURL={apiURL} spritemap={spritemap} />
+			<ModalAddObjectField apiURL={apiURL} />
 		</ClayModalProvider>
 	);
 };

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddObjectLayout.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddObjectLayout.tsx
@@ -22,7 +22,6 @@ import RequiredMask from './RequiredMask';
 
 interface IProps extends React.HTMLAttributes<HTMLElement> {
 	apiURL: string;
-	spritemap: string;
 }
 
 type TFormState = {
@@ -33,7 +32,7 @@ type TFormState = {
 
 const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
 
-const ModalAddListTypeDefinition: React.FC<IProps> = ({apiURL, spritemap}) => {
+const ModalAddListTypeDefinition: React.FC<IProps> = ({apiURL}) => {
 	const [visibleModal, setVisibleModal] = useState<boolean>(false);
 	const [formState, setFormState] = useState<TFormState>({
 		name: {
@@ -96,12 +95,7 @@ const ModalAddListTypeDefinition: React.FC<IProps> = ({apiURL, spritemap}) => {
 					</ClayModal.Header>
 					<ClayModal.Body>
 						{error && (
-							<ClayAlert
-								displayType="danger"
-								spritemap={spritemap}
-							>
-								{error}
-							</ClayAlert>
+							<ClayAlert displayType="danger">{error}</ClayAlert>
 						)}
 
 						<ClayForm.Group>
@@ -155,10 +149,10 @@ const ModalAddListTypeDefinition: React.FC<IProps> = ({apiURL, spritemap}) => {
 	);
 };
 
-const ModalWithProvider: React.FC<IProps> = ({apiURL, spritemap}) => {
+const ModalWithProvider: React.FC<IProps> = ({apiURL}) => {
 	return (
 		<ClayModalProvider>
-			<ModalAddListTypeDefinition apiURL={apiURL} spritemap={spritemap} />
+			<ModalAddListTypeDefinition apiURL={apiURL} />
 		</ClayModalProvider>
 	);
 };

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddObjectRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddObjectRelationship.tsx
@@ -28,7 +28,6 @@ import RequiredMask from './RequiredMask';
 interface IProps extends React.HTMLAttributes<HTMLElement> {
 	apiURL: string;
 	objectDefinitions: TObjectDefinition[];
-	spritemap: string;
 }
 
 type TObjectDefinition = {
@@ -70,7 +69,6 @@ const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
 const ModalAddObjectRelationship: React.FC<IProps> = ({
 	apiURL,
 	objectDefinitions,
-	spritemap,
 }) => {
 	const [visibleModal, setVisibleModal] = useState<boolean>(false);
 	const [formState, setFormState] = useState<TFormState>({
@@ -142,12 +140,7 @@ const ModalAddObjectRelationship: React.FC<IProps> = ({
 
 					<ClayModal.Body>
 						{error && (
-							<ClayAlert
-								displayType="danger"
-								spritemap={spritemap}
-							>
-								{error}
-							</ClayAlert>
+							<ClayAlert displayType="danger">{error}</ClayAlert>
 						)}
 
 						<ClayForm.Group>
@@ -300,7 +293,7 @@ const ModalAddObjectRelationship: React.FC<IProps> = ({
 	);
 };
 
-const ModalWithProvider: React.FC<IProps> = ({apiURL, spritemap}) => {
+const ModalWithProvider: React.FC<IProps> = ({apiURL}) => {
 	const [objectDefinitions, setObjectDefinitions] = useState<
 		TObjectDefinition[]
 	>([]);
@@ -335,7 +328,6 @@ const ModalWithProvider: React.FC<IProps> = ({apiURL, spritemap}) => {
 			<ModalAddObjectRelationship
 				apiURL={apiURL}
 				objectDefinitions={objectDefinitions}
-				spritemap={spritemap}
 			/>
 		</ClayModalProvider>
 	);

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/layout/index.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/layout/index.tsx
@@ -13,7 +13,6 @@
  */
 
 import ClayButton from '@clayui/button';
-import {ClayIconSpriteContext} from '@clayui/icon';
 import ClayTabs from '@clayui/tabs';
 import React, {useContext, useEffect, useState} from 'react';
 
@@ -264,19 +263,13 @@ const Layout: React.FC<React.HTMLAttributes<HTMLElement>> = () => {
 
 interface ILayoutWrapperProps extends React.HTMLAttributes<HTMLElement> {
 	objectLayoutId: string;
-	spritemap: string;
 }
 
-const LayoutWrapper: React.FC<ILayoutWrapperProps> = ({
-	objectLayoutId,
-	spritemap,
-}) => {
+const LayoutWrapper: React.FC<ILayoutWrapperProps> = ({objectLayoutId}) => {
 	return (
-		<ClayIconSpriteContext.Provider value={spritemap}>
-			<LayoutContextProvider value={{objectLayoutId}}>
-				<Layout />
-			</LayoutContextProvider>
-		</ClayIconSpriteContext.Provider>
+		<LayoutContextProvider value={{objectLayoutId}}>
+			<Layout />
+		</LayoutContextProvider>
 	);
 };
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/list_type_definitions/edit_list_type_definition.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/list_type_definitions/edit_list_type_definition.jsp
@@ -80,8 +80,6 @@ ViewListTypeEntriesDisplayContext viewListTypeEntriesDisplayContext = (ViewListT
 		props='<%=
 			HashMapBuilder.<String, Object>put(
 				"apiURL", viewListTypeEntriesDisplayContext.getAPIURL()
-			).put(
-				"spritemap", themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 			).build()
 		%>'
 	/>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/list_type_definitions/edit_list_type_definition.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/list_type_definitions/edit_list_type_definition.jsp
@@ -152,10 +152,4 @@ ViewListTypeEntriesDisplayContext viewListTypeEntriesDisplayContext = (ViewListT
 				}
 			});
 	}
-
-	function <portlet:namespace />handleDestroyPortlet() {
-		Liferay.detach('destroyPortlet', <portlet:namespace />handleDestroyPortlet);
-	}
-
-	Liferay.on('destroyPortlet', <portlet:namespace />handleDestroyPortlet);
 </script>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/list_type_definitions/view.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/list_type_definitions/view.jsp
@@ -39,8 +39,6 @@ ViewListTypeDefinitionsDisplayContext viewListTypeDefinitionsDisplayContext = (V
 		props='<%=
 			HashMapBuilder.<String, Object>put(
 				"apiURL", viewListTypeDefinitionsDisplayContext.getAPIURL()
-			).put(
-				"spritemap", themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 			).build()
 		%>'
 	/>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/list_type_definitions/view.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/list_type_definitions/view.jsp
@@ -45,11 +45,3 @@ ViewListTypeDefinitionsDisplayContext viewListTypeDefinitionsDisplayContext = (V
 		%>'
 	/>
 </div>
-
-<script>
-	function <portlet:namespace />handleDestroyPortlet() {
-		Liferay.detach('destroyPortlet', <portlet:namespace />handleDestroyPortlet);
-	}
-
-	Liferay.on('destroyPortlet', <portlet:namespace />handleDestroyPortlet);
-</script>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/edit_object_layout.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/edit_object_layout.jsp
@@ -28,8 +28,6 @@ ObjectLayout objectLayout = (ObjectLayout)request.getAttribute(ObjectWebKeys.OBJ
 		props='<%=
 			HashMapBuilder.<String, Object>put(
 				"objectLayoutId", objectLayout.getObjectLayoutId()
-			).put(
-				"spritemap", themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 			).build()
 		%>'
 	/>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/fields.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/fields.jsp
@@ -48,8 +48,6 @@ renderResponse.setTitle(objectDefinition.getShortName());
 		props='<%=
 			HashMapBuilder.<String, Object>put(
 				"apiURL", objectDefinitionsFieldsDisplayContext.getAPIURL()
-			).put(
-				"spritemap", themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 			).build()
 		%>'
 	/>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/fields.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/fields.jsp
@@ -54,11 +54,3 @@ renderResponse.setTitle(objectDefinition.getShortName());
 		%>'
 	/>
 </div>
-
-<script>
-	function <portlet:namespace />handleDestroyPortlet() {
-		Liferay.detach('destroyPortlet', <portlet:namespace />handleDestroyPortlet);
-	}
-
-	Liferay.on('destroyPortlet', <portlet:namespace />handleDestroyPortlet);
-</script>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/layouts.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/layouts.jsp
@@ -48,8 +48,6 @@ renderResponse.setTitle(objectDefinition.getShortName());
 		props='<%=
 			HashMapBuilder.<String, Object>put(
 				"apiURL", objectDefinitionsLayoutsDisplayContext.getAPIURL()
-			).put(
-				"spritemap", themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 			).build()
 		%>'
 	/>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/layouts.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/layouts.jsp
@@ -54,11 +54,3 @@ renderResponse.setTitle(objectDefinition.getShortName());
 		%>'
 	/>
 </div>
-
-<script>
-	function <portlet:namespace />handleDestroyPortlet() {
-		Liferay.detach('destroyPortlet', <portlet:namespace />handleDestroyPortlet);
-	}
-
-	Liferay.on('destroyPortlet', <portlet:namespace />handleDestroyPortlet);
-</script>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/relationships.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/relationships.jsp
@@ -48,8 +48,6 @@ renderResponse.setTitle(objectDefinition.getShortName());
 		props='<%=
 			HashMapBuilder.<String, Object>put(
 				"apiURL", objectDefinitionsRelationshipsDisplayContext.getAPIURL()
-			).put(
-				"spritemap", themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 			).build()
 		%>'
 	/>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/relationships.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/relationships.jsp
@@ -54,11 +54,3 @@ renderResponse.setTitle(objectDefinition.getShortName());
 		%>'
 	/>
 </div>
-
-<script>
-	function <portlet:namespace />handleDestroyPortlet() {
-		Liferay.detach('destroyPortlet', <portlet:namespace />handleDestroyPortlet);
-	}
-
-	Liferay.on('destroyPortlet', <portlet:namespace />handleDestroyPortlet);
-</script>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/view_object_definitions.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/view_object_definitions.jsp
@@ -39,8 +39,6 @@ ViewObjectDefinitionsDisplayContext viewObjectDefinitionsDisplayContext = (ViewO
 		props='<%=
 			HashMapBuilder.<String, Object>put(
 				"apiURL", viewObjectDefinitionsDisplayContext.getAPIURL()
-			).put(
-				"spritemap", themeDisplay.getPathThemeImages() + "/clay/icons.svg"
 			).build()
 		%>'
 	/>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/view_object_definitions.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/view_object_definitions.jsp
@@ -45,11 +45,3 @@ ViewObjectDefinitionsDisplayContext viewObjectDefinitionsDisplayContext = (ViewO
 		%>'
 	/>
 </div>
-
-<script>
-	function <portlet:namespace />handleDestroyPortlet() {
-		Liferay.detach('destroyPortlet', <portlet:namespace />handleDestroyPortlet);
-	}
-
-	Liferay.on('destroyPortlet', <portlet:namespace />handleDestroyPortlet);
-</script>

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModalAddListTypeDefinition.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModalAddListTypeDefinition.d.ts
@@ -15,7 +15,6 @@
 import React from 'react';
 interface IProps extends React.HTMLAttributes<HTMLElement> {
 	apiURL: string;
-	spritemap: string;
 }
 declare const ModalWithProvider: React.FC<IProps>;
 export default ModalWithProvider;

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModalAddListTypeEntry.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModalAddListTypeEntry.d.ts
@@ -15,7 +15,6 @@
 import React from 'react';
 interface IProps extends React.HTMLAttributes<HTMLElement> {
 	apiURL: string;
-	spritemap: string;
 }
 declare const ModalWithProvider: React.FC<IProps>;
 export default ModalWithProvider;

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModalAddObjectDefinition.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModalAddObjectDefinition.d.ts
@@ -18,7 +18,6 @@ declare global {
 }
 interface IProps extends React.HTMLAttributes<HTMLElement> {
 	apiURL: string;
-	spritemap: string;
 }
 declare const ModalWithProvider: React.FC<IProps>;
 export default ModalWithProvider;

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModalAddObjectField.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModalAddObjectField.d.ts
@@ -15,7 +15,6 @@
 import React from 'react';
 interface IProps extends React.HTMLAttributes<HTMLElement> {
 	apiURL: string;
-	spritemap: string;
 }
 declare const ModalWithProvider: React.FC<IProps>;
 export default ModalWithProvider;

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModalAddObjectLayout.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModalAddObjectLayout.d.ts
@@ -15,7 +15,6 @@
 import React from 'react';
 interface IProps extends React.HTMLAttributes<HTMLElement> {
 	apiURL: string;
-	spritemap: string;
 }
 declare const ModalWithProvider: React.FC<IProps>;
 export default ModalWithProvider;

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModalAddObjectRelationship.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModalAddObjectRelationship.d.ts
@@ -16,7 +16,6 @@ import React from 'react';
 interface IProps extends React.HTMLAttributes<HTMLElement> {
 	apiURL: string;
 	objectDefinitions: TObjectDefinition[];
-	spritemap: string;
 }
 declare type TObjectDefinition = {
 	id: string;

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/layout/index.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/layout/index.d.ts
@@ -15,7 +15,6 @@
 import React from 'react';
 interface ILayoutWrapperProps extends React.HTMLAttributes<HTMLElement> {
 	objectLayoutId: string;
-	spritemap: string;
 }
 declare const LayoutWrapper: React.FC<ILayoutWrapperProps>;
 export default LayoutWrapper;


### PR DESCRIPTION
- All `handleDestroyPortlet` cleanup functions were apparently empty. Most cleanup is done through our rendering facilities when used accordingly, so this is only really needed if you need to clean up some additional long-lived objects you've created manually.
- The spritemap attribute is unnecessary when using the react rendering facilities like `react:component`. We take care of it automatically and wrap every component in a `ClayIconContextProvider` with the right value. ClayIcons know to read from this context, so there's no need for prop drilling across the board.