### PR TITLE
LPS-139169 Fix broken SF

### DIFF
--- a/portal-impl/test/unit/com/liferay/portal/json/jabsorb/serializer/LiferayJSONSerializerTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/json/jabsorb/serializer/LiferayJSONSerializerTest.java
@@ -42,7 +42,7 @@ public class LiferayJSONSerializerTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void getClassFromHint() throws Exception {
+	public void testGetClassFromHint() throws Exception {
 		ClassLoaderPool.register(
 			"TestClassLoader",
 			new ClassLoader() {


### PR DESCRIPTION
Hi @brianchandotcom,

The SF is failing right now because Test methods annotated with the `@Test` annotation must begin with the word "test" (see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/JavaTestMethodAnnotationsCheck.java#L60).