### PR TITLE
LPS-137592 Using fetchObjectEntry method to avoid NoSuchObjectEntryException

### DIFF
--- a/modules/apps/object/object-dynamic-data-mapping/src/main/java/com/liferay/object/dynamic/data/mapping/internal/storage/ObjectDDMStorageAdapter.java
+++ b/modules/apps/object/object-dynamic-data-mapping/src/main/java/com/liferay/object/dynamic/data/mapping/internal/storage/ObjectDDMStorageAdapter.java
@@ -49,6 +49,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 
@@ -85,11 +86,14 @@ public class ObjectDDMStorageAdapter implements DDMStorageAdapter {
 		throws StorageException {
 
 		try {
-			ObjectEntry objectEntry = _objectEntryManager.getObjectEntry(
-				_getDTOConverterContext(null, null, null),
+			ObjectEntry objectEntry = _objectEntryManager.fetchObjectEntry(
+				_getDTOConverterContext(
+					null, null, LocaleUtil.getSiteDefault()),
 				ddmStorageAdapterDeleteRequest.getPrimaryKey());
 
-			_objectEntryManager.deleteObjectEntry(objectEntry.getId());
+			if (objectEntry != null) {
+				_objectEntryManager.deleteObjectEntry(objectEntry.getId());
+			}
 
 			return DDMStorageAdapterDeleteResponse.Builder.newBuilder(
 			).build();

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
@@ -48,6 +48,9 @@ public interface ObjectEntryManager {
 			ObjectDefinition objectDefinition, String scopeKey)
 		throws Exception;
 
+	public ObjectEntry fetchObjectEntry(
+		DTOConverterContext dtoConverterContext, long objectEntryId);
+
 	public Page<ObjectEntry> getObjectEntries(
 			long companyId, ObjectDefinition objectDefinition, String scopeKey,
 			Aggregation aggregation, DTOConverterContext dtoConverterContext,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryManagerImpl.java
@@ -130,6 +130,22 @@ public class ObjectEntryManagerImpl implements ObjectEntryManager {
 	}
 
 	@Override
+	public ObjectEntry fetchObjectEntry(
+		DTOConverterContext dtoConverterContext, long objectEntryId) {
+
+		com.liferay.object.model.ObjectEntry objectEntry =
+			_objectEntryLocalService.fetchObjectEntry(objectEntryId);
+
+		if (objectEntry != null) {
+			return _toObjectEntry(
+				dtoConverterContext,
+				_objectEntryLocalService.fetchObjectEntry(objectEntryId));
+		}
+
+		return null;
+	}
+
+	@Override
 	public Page<ObjectEntry> getObjectEntries(
 			long companyId, ObjectDefinition objectDefinition, String scopeKey,
 			Aggregation aggregation, DTOConverterContext dtoConverterContext,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -53,6 +53,7 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -239,7 +240,9 @@ public class ObjectDefinitionLocalServiceImpl
 			ObjectDefinition objectDefinition)
 		throws PortalException {
 
-		if (!PortalRunMode.isTestMode() && objectDefinition.isApproved()) {
+		if (!CompanyThreadLocal.isDeleteInProcess() &&
+			!PortalRunMode.isTestMode() && objectDefinition.isApproved()) {
+
 			throw new RequiredObjectDefinitionException();
 		}
 


### PR DESCRIPTION
CI is not working well, tried to run in this [PR](https://github.com/liferay-objects/liferay-portal/pull/131) yesterday but it still [running](https://test-1-25.liferay.com/job/test-portal-acceptance-pullrequest(master)/296/) with duration of more than 12 hours.

Related tickets:
[LPS-138366](https://issues.liferay.com/browse/LPS-138366) It is not possible to delete a Virtual Instance when creating an Object and adding an entry to it (through Forms)
[LPS-139468](https://issues.liferay.com/browse/LPS-139468) RequiredObjectDefinitionException is null