### PR TITLE
LPS-112143 - You do not have permission to configure Search Insights widget in virtual instance

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/insights/portlet/SearchInsightsPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/insights/portlet/SearchInsightsPortlet.java
@@ -116,7 +116,7 @@ public class SearchInsightsPortlet extends MVCPortlet {
 				searchInsightsPortletPreferences.
 					getFederatedSearchKeyOptional());
 
-		if (isOmniadmin() &&
+		if (isCompanyAdmin() &&
 			(isRequestStringPresent(searchResponse) ||
 			 isResponseStringPresent(searchResponse))) {
 
@@ -155,11 +155,11 @@ public class SearchInsightsPortlet extends MVCPortlet {
 		return language.get(resourceBundle, "search-insights-help");
 	}
 
-	protected boolean isOmniadmin() {
+	protected boolean isCompanyAdmin() {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
-		return permissionChecker.isOmniadmin();
+		return permissionChecker.isCompanyAdmin();
 	}
 
 	protected boolean isRequestStringPresent(SearchResponse searchResponse) {

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/insights/portlet/action/SearchInsightsConfigurationAction.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/insights/portlet/action/SearchInsightsConfigurationAction.java
@@ -42,7 +42,7 @@ public class SearchInsightsConfigurationAction
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
-		if (!permissionChecker.isOmniadmin()) {
+		if (!permissionChecker.isCompanyAdmin()) {
 			SessionErrors.add(
 				httpServletRequest, PrincipalException.class.getName());
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/error.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/error.jsp
@@ -21,13 +21,13 @@
 <%@ page import="com.liferay.portal.kernel.security.auth.PrincipalException" %><%@
 page import="com.liferay.portal.kernel.servlet.SessionErrors" %>
 
-<liferay-ui:header
-	showBackURL="<%= false %>"
-	title="error"
-/>
-
-<c:if test="<%= SessionErrors.contains(request, PrincipalException.getNestedClasses()) %>">
-	<liferay-ui:message key="you-do-not-have-permission-to-view-this-page" />
-</c:if>
-
-<liferay-ui:error exception="<%= PrincipalException.class %>" message="you-do-not-have-permission-to-view-this-page" />
+<div class="container-fluid container-fluid-max-xl container-form-lg">
+	<c:choose>
+		<c:when test="<%= SessionErrors.contains(request, PrincipalException.getNestedClasses()) %>">
+			<liferay-ui:error exception="<%= PrincipalException.class %>" message="you-do-not-have-permission-to-view-this-page" />
+		</c:when>
+		<c:otherwise>
+			<liferay-ui:message key="an-unexpected-error-occurred" />
+		</c:otherwise>
+	</c:choose>
+</div>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-112143

Manually forwarding this PR since it already failed forward several times with unrelated failures.

Test Results:

- ✔️ ci:test:sf - [1 out of 1 jobs passed in 4 minutes](https://github.com/liferay-search/liferay-portal/pull/213#issuecomment-922067991)
- ❌ ci:test:search - [8 out of 13 jobs passed in 2 hours 29 minutes](https://github.com/liferay-search/liferay-portal/pull/213#issuecomment-922129579)
  - All failures here are consistent with what's in the Search canary run 
- ✔️ ci:test:stable - [11 out of 11 jobs passed](https://github.com/liferay-search/liferay-portal/pull/213#issuecomment-925199461)
- ❌ ci:test:relevant - [22 out of 24 jobs passed in 1 hour 34 minutes](https://github.com/liferay-search/liferay-portal/pull/213#issuecomment-925199461)
  - Only unique failure is caused by [LPS-139530](https://issues.liferay.com/browse/LPS-139530)