### PR TITLE
LPS-112856 Sorts

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-api/bnd.bnd
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/bnd.bnd
@@ -3,6 +3,8 @@ Bundle-SymbolicName: com.liferay.search.experiences.api
 Bundle-Version: 1.0.0
 Export-Package:\
 	com.liferay.search.experiences.blueprint.parameter,\
+	com.liferay.search.experiences.blueprint.query,\
+	com.liferay.search.experiences.blueprint.searchrequest,\
 	com.liferay.search.experiences.constants,\
 	com.liferay.search.experiences.exception,\
 	com.liferay.search.experiences.model,\

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/blueprint/query/ClauseTranslator.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/blueprint/query/ClauseTranslator.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.blueprint.query;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.search.query.Query;
+import com.liferay.search.experiences.blueprint.parameter.SXPParameterData;
+
+import java.util.Optional;
+
+/**
+ * @author Petteri Karttunen
+ */
+public interface ClauseTranslator {
+
+	public Optional<Query> translate(
+		JSONObject jsonObject, SXPParameterData sxpParameterData);
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/blueprint/query/ConditionHandler.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/blueprint/query/ConditionHandler.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.blueprint.query;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.search.experiences.blueprint.parameter.SXPParameterData;
+
+/**
+ * @author Petteri Karttunen
+ */
+public interface ConditionHandler {
+
+	public boolean isTrue(
+		JSONObject jsonObject, SXPParameterData sxpParameterData);
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/blueprint/searchrequest/SearchRequestBodyContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/blueprint/searchrequest/SearchRequestBodyContributor.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.blueprint.searchrequest;
+
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.search.experiences.blueprint.parameter.SXPParameterData;
+import com.liferay.search.experiences.model.SXPBlueprint;
+
+/**
+ * @author Petteri Karttunen
+ */
+public interface SearchRequestBodyContributor {
+
+	public void contribute(
+		SearchRequestBuilder searchRequestBuilder, SXPBlueprint sxpBlueprint,
+		SXPParameterData sxpParameterData);
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/query/ClauseTranslatorFactory.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/query/ClauseTranslatorFactory.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.query;
+
+import com.liferay.search.experiences.blueprint.query.ClauseTranslator;
+
+/**
+ * @author Petteri Karttunen
+ */
+public interface ClauseTranslatorFactory {
+
+	public ClauseTranslator getTranslator(String name)
+		throws IllegalArgumentException;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/query/ClauseTranslatorFactoryImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/query/ClauseTranslatorFactoryImpl.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.query;
+
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.search.experiences.blueprint.query.ClauseTranslator;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(immediate = true, service = ClauseTranslatorFactory.class)
+public class ClauseTranslatorFactoryImpl implements ClauseTranslatorFactory {
+
+	@Override
+	public ClauseTranslator getTranslator(String name)
+		throws IllegalArgumentException {
+
+		ClauseTranslator clauseTranslator =
+			_clauseTranslatorServiceTrackerMap.getService(name);
+
+		if (clauseTranslator == null) {
+			throw new IllegalArgumentException(
+				"No registered clause translator " + name);
+		}
+
+		return clauseTranslator;
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_clauseTranslatorServiceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				bundleContext, ClauseTranslator.class, "name");
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_clauseTranslatorServiceTrackerMap.close();
+	}
+
+	private ServiceTrackerMap<String, ClauseTranslator>
+		_clauseTranslatorServiceTrackerMap;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/query/translator/TermClauseTranslator.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/query/translator/TermClauseTranslator.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.query.translator;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.query.Queries;
+import com.liferay.portal.search.query.Query;
+import com.liferay.portal.search.query.TermQuery;
+import com.liferay.search.experiences.blueprint.parameter.SXPParameterData;
+import com.liferay.search.experiences.blueprint.query.ClauseTranslator;
+import com.liferay.search.experiences.internal.blueprint.util.SXPJSONUtil;
+
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	immediate = true, property = "name=term", service = ClauseTranslator.class
+)
+public class TermClauseTranslator implements ClauseTranslator {
+
+	@Override
+	public Optional<Query> translate(
+		JSONObject jsonObject, SXPParameterData sxpParameterData) {
+
+		Optional<String> optional = SXPJSONUtil.getFirstKeyOptional(jsonObject);
+
+		if (!optional.isPresent()) {
+			return Optional.empty();
+		}
+
+		String field = optional.get();
+
+		Object object = jsonObject.get(field);
+
+		String keywords = null;
+
+		Float boost = null;
+
+		if (_isShortForm(object)) {
+			keywords = (String)object;
+		}
+		else {
+			JSONObject fieldJSONObject = (JSONObject)object;
+
+			keywords = fieldJSONObject.getString("value");
+
+			boost = GetterUtil.getFloat(fieldJSONObject.get("boost"));
+		}
+
+		if (Validator.isBlank(keywords)) {
+			return Optional.empty();
+		}
+
+		TermQuery termQuery = _queries.term(field, keywords);
+
+		if (boost > 0.0) {
+			termQuery.setBoost(boost);
+		}
+
+		return Optional.of(termQuery);
+	}
+
+	private boolean _isShortForm(Object object) {
+		return object instanceof String;
+	}
+
+	@Reference
+	private Queries _queries;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/query/translator/WrapperClauseTranslator.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/query/translator/WrapperClauseTranslator.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.query.translator;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.search.query.Queries;
+import com.liferay.portal.search.query.Query;
+import com.liferay.portal.search.query.WrapperQuery;
+import com.liferay.search.experiences.blueprint.parameter.SXPParameterData;
+import com.liferay.search.experiences.blueprint.query.ClauseTranslator;
+
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	immediate = true, property = "name=wrapper",
+	service = ClauseTranslator.class
+)
+public class WrapperClauseTranslator implements ClauseTranslator {
+
+	@Override
+	public Optional<Query> translate(
+		JSONObject jsonObject, SXPParameterData sxpParameterData) {
+
+		WrapperQuery wrapperQuery = _queries.wrapper(
+			jsonObject.getString("query"));
+
+		return Optional.of(wrapperQuery);
+	}
+
+	@Reference
+	private Queries _queries;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/query/util/ClauseHelper.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/query/util/ClauseHelper.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.query.util;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.search.query.Query;
+import com.liferay.search.experiences.blueprint.parameter.SXPParameterData;
+import com.liferay.search.experiences.blueprint.query.ClauseTranslator;
+import com.liferay.search.experiences.internal.blueprint.parser.SXPTemplateVariableParser;
+import com.liferay.search.experiences.internal.blueprint.query.ClauseTranslatorFactory;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(immediate = true, service = ClauseHelper.class)
+public class ClauseHelper {
+
+	public Optional<Query> getQueryOptional(
+		JSONObject jsonObject, SXPParameterData sxpParameterData) {
+
+		if (jsonObject == null) {
+			return Optional.empty();
+		}
+
+		String type = _getType(jsonObject);
+
+		try {
+			ClauseTranslator clauseTranslator =
+				_clauseTranslatorFactory.getTranslator(type);
+
+			JSONObject clauseJSONObject = _sxpTemplateVariableParser.parse(
+				jsonObject.getJSONObject(type), sxpParameterData);
+
+			if (Objects.isNull(clauseJSONObject)) {
+				return Optional.empty();
+			}
+
+			return clauseTranslator.translate(
+				clauseJSONObject, sxpParameterData);
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+			_log.error(illegalArgumentException);
+		}
+
+		return Optional.empty();
+	}
+
+	private String _getType(JSONObject jsonObject) {
+		Iterator<String> iterator = jsonObject.keys();
+
+		if (!iterator.hasNext()) {
+			return null;
+		}
+
+		return iterator.next();
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(ClauseHelper.class);
+
+	@Reference
+	private ClauseTranslatorFactory _clauseTranslatorFactory;
+
+	@Reference
+	private SXPTemplateVariableParser _sxpTemplateVariableParser;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/searchrequest/SortSearchRequestBodyContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/searchrequest/SortSearchRequestBodyContributor.java
@@ -1,0 +1,310 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.searchrequest;
+
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.searcher.SearchRequest;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.sort.ScoreSort;
+import com.liferay.portal.search.sort.Sort;
+import com.liferay.portal.search.sort.SortOrder;
+import com.liferay.portal.search.sort.Sorts;
+import com.liferay.search.experiences.blueprint.parameter.SXPParameter;
+import com.liferay.search.experiences.blueprint.parameter.SXPParameterData;
+import com.liferay.search.experiences.blueprint.searchrequest.SearchRequestBodyContributor;
+import com.liferay.search.experiences.internal.blueprint.parser.SXPTemplateVariableParser;
+import com.liferay.search.experiences.internal.blueprint.sort.SortTranslatorFactory;
+import com.liferay.search.experiences.internal.blueprint.sort.translator.SortTranslator;
+import com.liferay.search.experiences.internal.blueprint.util.SXPJSONUtil;
+import com.liferay.search.experiences.model.SXPBlueprint;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	immediate = true, property = "name=sort",
+	service = SearchRequestBodyContributor.class
+)
+public class SortSearchRequestBodyContributor
+	implements SearchRequestBodyContributor {
+
+	@Override
+	public void contribute(
+		SearchRequestBuilder searchRequestBuilder, SXPBlueprint sxpBlueprint,
+		SXPParameterData sxpParameterData) {
+
+		if (_sortsExist(searchRequestBuilder)) {
+			return;
+		}
+
+		// TODO (remove): first try to get sorts from parameter
+		// depend on Blueprint sort parameter configuration
+
+		List<Sort> sorts = _getSortsFromParameters(
+			sxpBlueprint, sxpParameterData);
+
+		if (sorts.isEmpty()) {
+			sorts = _getDefaultSorts(sxpBlueprint, sxpParameterData);
+		}
+
+		if (!sorts.isEmpty()) {
+			Stream<Sort> stream = sorts.stream();
+
+			stream.forEach(sort -> searchRequestBuilder.addSort(sort));
+		}
+	}
+
+	private Optional<Sort> _getDefaultSort(
+		Object object, SXPParameterData sxpParameterData) {
+
+		if (object instanceof String) {
+			return _sortFromString((String)object, null);
+		}
+
+		JSONObject jsonObject = _sxpTemplateVariableParser.parse(
+			(JSONObject)object, sxpParameterData);
+
+		if (Objects.isNull(jsonObject)) {
+			return Optional.empty();
+		}
+
+		return _sortFromObject(jsonObject);
+	}
+
+	private List<Sort> _getDefaultSorts(
+		SXPBlueprint sxpBlueprint, SXPParameterData sxpParameterData) {
+
+		List<Sort> sorts = new ArrayList<>();
+
+		// TODO get default sort configuration from DTO
+
+		Optional<JSONArray> optional1 = Optional.empty();
+
+		if (!optional1.isPresent()) {
+			return sorts;
+		}
+
+		JSONArray jsonArray = optional1.get();
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			Optional<Sort> optional2 = _getDefaultSort(
+				jsonArray.get(i), sxpParameterData);
+
+			if (optional2.isPresent()) {
+				sorts.add(optional2.get());
+			}
+		}
+
+		return sorts;
+	}
+
+	private Optional<Sort> _getSort(
+		JSONObject jsonObject, String key, SortOrder sortOrder) {
+
+		try {
+			SortTranslator sortTranslator;
+			String field;
+
+			if (_fixedTypes.contains(key)) {
+				sortTranslator = _sortTranslatorFactory.getTranslator(key);
+				field = null;
+			}
+			else {
+				sortTranslator = _sortTranslatorFactory.getTranslator("field");
+				field = key;
+			}
+
+			return sortTranslator.translate(field, jsonObject, sortOrder);
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+			_log.error(illegalArgumentException);
+		}
+
+		return Optional.empty();
+	}
+
+	private Optional<Sort> _getSortFromParameter(
+		JSONObject jsonObject, String key, SXPParameterData sxpParameterData) {
+
+		JSONObject configurationJSONObject = jsonObject.getJSONObject(key);
+
+		JSONObject parsedJSONObject = _sxpTemplateVariableParser.parse(
+			configurationJSONObject, sxpParameterData);
+
+		if (Objects.isNull(parsedJSONObject)) {
+			return Optional.empty();
+		}
+
+		SortOrder sortOrder = _getSortOrderFromParameter(
+			parsedJSONObject, sxpParameterData);
+
+		if (sortOrder == null) {
+			return Optional.empty();
+		}
+
+		return _getSort(parsedJSONObject, key, sortOrder);
+	}
+
+	private SortOrder _getSortOrder(String s) {
+		try {
+			return SortOrder.valueOf(StringUtil.toUpperCase(s));
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+			_log.error(
+				illegalArgumentException.getMessage(),
+				illegalArgumentException);
+		}
+
+		return null;
+	}
+
+	private SortOrder _getSortOrderFromParameter(
+		JSONObject jsonObject, SXPParameterData sxpParameterData) {
+
+		String parameterName = jsonObject.getString("parameter_name");
+
+		if (Validator.isBlank(parameterName)) {
+			return null;
+		}
+
+		SXPParameter sxpParameter = sxpParameterData.getSXPParameterByName(
+			parameterName);
+
+		if (Objects.isNull(sxpParameter)) {
+			return null;
+		}
+
+		return _getSortOrder(GetterUtil.getString(sxpParameter.getValue()));
+	}
+
+	private List<Sort> _getSortsFromParameters(
+		SXPBlueprint sxpBlueprint, SXPParameterData sxpParameterData) {
+
+		List<Sort> sorts = new ArrayList<>();
+
+		// TODO get sort parameter configuration from DTO
+
+		Optional<JSONObject> optional1 = Optional.empty();
+
+		if (!optional1.isPresent()) {
+			return sorts;
+		}
+
+		JSONObject jsonObject = optional1.get();
+
+		Set<String> keySet = jsonObject.keySet();
+
+		keySet.forEach(
+			key -> {
+				Optional<Sort> optional2 = _getSortFromParameter(
+					jsonObject, key, sxpParameterData);
+
+				if (optional2.isPresent()) {
+					sorts.add(optional2.get());
+				}
+			});
+
+		return sorts;
+	}
+
+	private Optional<Sort> _sortFromObject(JSONObject jsonObject) {
+		Optional<String> optional = SXPJSONUtil.getFirstKeyOptional(jsonObject);
+
+		if (!optional.isPresent()) {
+			return Optional.empty();
+		}
+
+		String key = optional.get();
+
+		Object object = jsonObject.get(key);
+
+		if (object instanceof String) {
+			return _sortFromString(key, _getSortOrder((String)object));
+		}
+
+		JSONObject configurationJSONObject = (JSONObject)object;
+
+		return _getSort(
+			jsonObject, key,
+			_getSortOrder(configurationJSONObject.getString("order")));
+	}
+
+	private Optional<Sort> _sortFromString(String s, SortOrder sortOrder) {
+		if (s.equals("_score")) {
+			ScoreSort sort = _sorts.score();
+
+			if (sortOrder != null) {
+				sort.setSortOrder(sortOrder);
+			}
+
+			return Optional.of(sort);
+		}
+
+		Sort sort = _sorts.field(s);
+
+		if (sortOrder != null) {
+			sort.setSortOrder(sortOrder);
+		}
+
+		return Optional.of(sort);
+	}
+
+	// TODO (remove) if sorts already exists (set in a widget), don't overwrite
+
+	private boolean _sortsExist(SearchRequestBuilder searchRequestBuilder) {
+		return searchRequestBuilder.withSearchContextGet(
+			searchContext -> {
+				SearchRequest searchRequest =
+					(SearchRequest)searchContext.getAttribute("search.request");
+
+				List<Sort> sorts = searchRequest.getSorts();
+
+				return !sorts.isEmpty();
+			});
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SortSearchRequestBodyContributor.class);
+
+	private static final List<String> _fixedTypes = new ArrayList<>(
+		Arrays.asList("_geo_distance", "_script", "_score"));
+
+	@Reference
+	private Sorts _sorts;
+
+	@Reference
+	private SortTranslatorFactory _sortTranslatorFactory;
+
+	@Reference
+	private SXPTemplateVariableParser _sxpTemplateVariableParser;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/sort/SortTranslatorFactory.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/sort/SortTranslatorFactory.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.sort;
+
+import com.liferay.search.experiences.internal.blueprint.sort.translator.SortTranslator;
+
+/**
+ * @author Petteri Karttunen
+ */
+public interface SortTranslatorFactory {
+
+	public SortTranslator getTranslator(String name)
+		throws IllegalArgumentException;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/sort/SortTranslatorFactoryImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/sort/SortTranslatorFactoryImpl.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.sort;
+
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.search.experiences.internal.blueprint.sort.translator.SortTranslator;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(immediate = true, service = SortTranslatorFactory.class)
+public class SortTranslatorFactoryImpl implements SortTranslatorFactory {
+
+	@Override
+	public SortTranslator getTranslator(String name)
+		throws IllegalArgumentException {
+
+		SortTranslator sortTranslator =
+			_sortTranslatorServiceTrackerMap.getService(name);
+
+		if (sortTranslator == null) {
+			throw new IllegalArgumentException(
+				"No registered translator  " + name);
+		}
+
+		return sortTranslator;
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_sortTranslatorServiceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				bundleContext, SortTranslator.class, "name");
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_sortTranslatorServiceTrackerMap.close();
+	}
+
+	private ServiceTrackerMap<String, SortTranslator>
+		_sortTranslatorServiceTrackerMap;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/sort/translator/FieldSortTranslator.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/sort/translator/FieldSortTranslator.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.sort.translator;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.query.Query;
+import com.liferay.portal.search.sort.FieldSort;
+import com.liferay.portal.search.sort.NestedSort;
+import com.liferay.portal.search.sort.Sort;
+import com.liferay.portal.search.sort.SortMode;
+import com.liferay.portal.search.sort.SortOrder;
+import com.liferay.portal.search.sort.Sorts;
+import com.liferay.search.experiences.internal.blueprint.parameter.SXPParameterDataImpl;
+import com.liferay.search.experiences.internal.blueprint.query.util.ClauseHelper;
+import com.liferay.search.experiences.internal.blueprint.util.SetterHelper;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	immediate = true, property = "name=field", service = SortTranslator.class
+)
+public class FieldSortTranslator implements SortTranslator {
+
+	@Override
+	public Optional<Sort> translate(
+		String field, JSONObject jsonObject, SortOrder sortOrder) {
+
+		FieldSort fieldSort = _sorts.field(field, sortOrder);
+
+		_setterHelper.setObjectValue(
+			jsonObject, "missing", fieldSort::setMissing);
+
+		if (jsonObject.has("mode")) {
+			fieldSort.setSortMode(_getSortMode(jsonObject));
+		}
+
+		if (jsonObject.has("nested")) {
+			fieldSort.setNestedSort(_getNestedSort(jsonObject));
+		}
+
+		return Optional.of(fieldSort);
+	}
+
+	private NestedSort _getNestedSort(JSONObject jsonObject) {
+		JSONObject nestedJSONObject = jsonObject.getJSONObject("nested");
+
+		String path = nestedJSONObject.getString("path");
+
+		NestedSort nestedSort = _sorts.nested(path);
+
+		if (jsonObject.has("filter")) {
+			
+			Optional<Query> optional = _clauseHelper.getQueryOptional(
+				jsonObject, new SXPParameterDataImpl("", Collections.emptySet()));
+
+			if (optional.isPresent()) {
+				nestedSort.setFilterQuery(optional.get());
+			}
+		}
+
+		if (nestedJSONObject.has("nested")) {
+			nestedSort.setNestedSort(_getNestedSort(nestedJSONObject));
+		}
+
+		return nestedSort;
+	}
+
+	private SortMode _getSortMode(JSONObject jsonObject) {
+		String s = jsonObject.getString("mode");
+
+		return SortMode.valueOf(StringUtil.toUpperCase(s));
+	}
+
+	@Reference
+	private ClauseHelper _clauseHelper;
+
+	@Reference
+	private SetterHelper _setterHelper;
+
+	@Reference
+	private Sorts _sorts;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/sort/translator/GeoDistanceSortTranslator.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/sort/translator/GeoDistanceSortTranslator.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.sort.translator;
+
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.geolocation.DistanceUnit;
+import com.liferay.portal.search.geolocation.GeoBuilders;
+import com.liferay.portal.search.geolocation.GeoDistanceType;
+import com.liferay.portal.search.sort.GeoDistanceSort;
+import com.liferay.portal.search.sort.Sort;
+import com.liferay.portal.search.sort.SortMode;
+import com.liferay.portal.search.sort.SortOrder;
+import com.liferay.portal.search.sort.Sorts;
+
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	immediate = true, property = "name=_geo_distance",
+	service = SortTranslator.class
+)
+public class GeoDistanceSortTranslator implements SortTranslator {
+
+	@Override
+	public Optional<Sort> translate(
+		String field, JSONObject jsonObject, SortOrder sortOrder) {
+
+		JSONArray jsonArray = jsonObject.getJSONArray("locations");
+
+		if ((jsonArray == null) || (jsonArray.length() == 0)) {
+			return Optional.empty();
+		}
+
+		GeoDistanceSort geoDistanceSort = _sorts.geoDistance(field);
+
+		geoDistanceSort.setSortOrder(sortOrder);
+
+		_setLocations(geoDistanceSort, jsonObject);
+
+		_setDistanceUnit(geoDistanceSort, jsonObject);
+
+		_setGeoDistanceType(geoDistanceSort, jsonObject);
+
+		_setSortMode(geoDistanceSort, jsonObject);
+
+		return Optional.of(geoDistanceSort);
+	}
+
+	private void _setDistanceUnit(
+		GeoDistanceSort geoDistanceSort, JSONObject jsonObject) {
+
+		String geoDistanceUnit = jsonObject.getString("unit");
+
+		if (Validator.isBlank(geoDistanceUnit)) {
+			return;
+		}
+
+		geoDistanceUnit = StringUtil.toLowerCase(geoDistanceUnit);
+
+		for (DistanceUnit distanceUnit : DistanceUnit.values()) {
+			String unit = distanceUnit.getUnit();
+
+			if (unit.equals(geoDistanceUnit)) {
+				geoDistanceSort.setDistanceUnit(distanceUnit);
+
+				break;
+			}
+		}
+	}
+
+	private void _setGeoDistanceType(
+		GeoDistanceSort geoDistanceSort, JSONObject jsonObject) {
+
+		String distanceType = jsonObject.getString(
+			"distance_type", GeoDistanceType.ARC.name());
+
+		if (Validator.isBlank(distanceType)) {
+			return;
+		}
+
+		try {
+			geoDistanceSort.setGeoDistanceType(
+				GeoDistanceType.valueOf(StringUtil.toUpperCase(distanceType)));
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+			_log.error(illegalArgumentException);
+		}
+	}
+
+	private void _setLocations(
+		GeoDistanceSort geoDistanceSort, JSONObject jsonObject) {
+
+		JSONArray locationsJSONArray = jsonObject.getJSONArray("locations");
+
+		for (int i = 0; i < locationsJSONArray.length(); i++) {
+			JSONArray locationJSONArray = locationsJSONArray.getJSONArray(i);
+
+			if (locationJSONArray.length() != 2) {
+				continue;
+			}
+
+			geoDistanceSort.addGeoLocationPoints(
+				_geoBuilders.geoLocationPoint(
+					locationJSONArray.getDouble(0),
+					locationJSONArray.getDouble(1)));
+		}
+	}
+
+	private void _setSortMode(
+		GeoDistanceSort geoDistanceSort, JSONObject jsonObject) {
+
+		String mode = jsonObject.getString("mode");
+
+		if (Validator.isBlank(mode)) {
+			return;
+		}
+
+		geoDistanceSort.setSortMode(
+			SortMode.valueOf(StringUtil.toUpperCase(mode)));
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GeoDistanceSortTranslator.class);
+
+	@Reference
+	private GeoBuilders _geoBuilders;
+
+	@Reference
+	private Sorts _sorts;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/sort/translator/ScoreSortTranslator.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/sort/translator/ScoreSortTranslator.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.sort.translator;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.search.sort.Sort;
+import com.liferay.portal.search.sort.SortOrder;
+import com.liferay.portal.search.sort.Sorts;
+
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	immediate = true, property = "name=_score", service = SortTranslator.class
+)
+public class ScoreSortTranslator implements SortTranslator {
+
+	@Override
+	public Optional<Sort> translate(
+		String field, JSONObject jsonObject, SortOrder sortOrder) {
+
+		Sort sort = _sorts.score();
+
+		sort.setSortOrder(sortOrder);
+
+		return Optional.of(sort);
+	}
+
+	@Reference
+	private Sorts _sorts;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/sort/translator/ScriptSortTranslator.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/sort/translator/ScriptSortTranslator.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.sort.translator;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.script.Script;
+import com.liferay.portal.search.sort.ScriptSort;
+import com.liferay.portal.search.sort.Sort;
+import com.liferay.portal.search.sort.SortOrder;
+import com.liferay.portal.search.sort.Sorts;
+import com.liferay.search.experiences.internal.blueprint.util.ScriptHelper;
+
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	immediate = true, property = "name=_script", service = SortTranslator.class
+)
+public class ScriptSortTranslator implements SortTranslator {
+
+	@Override
+	public Optional<Sort> translate(
+		String field, JSONObject jsonObject, SortOrder sortOrder) {
+
+		Optional<Script> optional = _scriptHelper.getScript(
+			jsonObject.get("script"));
+
+		if (!optional.isPresent()) {
+			return Optional.empty();
+		}
+
+		ScriptSort scriptSort = _sorts.script(
+			optional.get(), _getScriptSortType(jsonObject));
+
+		scriptSort.setSortOrder(sortOrder);
+
+		return Optional.of(scriptSort);
+	}
+
+	private ScriptSort.ScriptSortType _getScriptSortType(
+		JSONObject jsonObject) {
+
+		String s = jsonObject.getString("type");
+
+		return ScriptSort.ScriptSortType.valueOf(StringUtil.toUpperCase(s));
+	}
+
+	@Reference
+	private ScriptHelper _scriptHelper;
+
+	@Reference
+	private Sorts _sorts;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/sort/translator/SortTranslator.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/sort/translator/SortTranslator.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.sort.translator;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.search.sort.Sort;
+import com.liferay.portal.search.sort.SortOrder;
+
+import java.util.Optional;
+
+/**
+ * @author Petteri Karttunen
+ */
+public interface SortTranslator {
+
+	public Optional<Sort> translate(
+		String field, JSONObject jsonObject, SortOrder sortOrder);
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/util/HighlightHelper.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/util/HighlightHelper.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.util;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.search.highlight.FieldConfig;
+import com.liferay.portal.search.highlight.FieldConfigBuilder;
+import com.liferay.portal.search.highlight.FieldConfigBuilderFactory;
+import com.liferay.portal.search.highlight.Highlight;
+import com.liferay.portal.search.highlight.HighlightBuilder;
+import com.liferay.portal.search.highlight.HighlightBuilderFactory;
+import com.liferay.search.experiences.blueprint.parameter.SXPParameterData;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(immediate = true, service = HighlightHelper.class)
+public class HighlightHelper {
+
+	public Optional<Highlight> getHighlight(
+		JSONObject jsonObject, SXPParameterData sxpParameterData) {
+
+		HighlightBuilder highlightBuilder = _highlightBuilderFactory.builder();
+
+		_setterHelper.setIntegerValue(
+			jsonObject, "fragment_size", highlightBuilder::fragmentSize);
+
+		_setterHelper.setIntegerValue(
+			jsonObject, "number_of_fragments",
+			highlightBuilder::numOfFragments);
+
+		_setterHelper.setStringArrayValue(
+			jsonObject, "post_tags", highlightBuilder::postTags);
+
+		_setterHelper.setStringArrayValue(
+			jsonObject, "pre_tags", highlightBuilder::preTags);
+
+		_setterHelper.setBooleanValue(
+			jsonObject, "require_field_match",
+			highlightBuilder::requireFieldMatch);
+
+		_setterHelper.setStringValue(
+			jsonObject, "type", highlightBuilder::highlighterType);
+
+		_setFieldConfigs(highlightBuilder, jsonObject);
+
+		return Optional.of(highlightBuilder.build());
+	}
+
+	private FieldConfig _getFieldConfig(
+		JSONObject fieldsJSONObject, String key) {
+
+		JSONObject fieldJSONObject = fieldsJSONObject.getJSONObject(key);
+
+		FieldConfigBuilder fieldConfigBuilder =
+			_fieldConfigBuilderFactory.builder(key);
+
+		_setterHelper.setIntegerValue(
+			fieldJSONObject, "fragment_offset",
+			fieldConfigBuilder::fragmentOffset);
+
+		_setterHelper.setIntegerValue(
+			fieldJSONObject, "fragment_size", fieldConfigBuilder::fragmentSize);
+
+		_setterHelper.setIntegerValue(
+			fieldJSONObject, "number_of_fragments",
+			fieldConfigBuilder::numFragments);
+
+		return fieldConfigBuilder.build();
+	}
+
+	private void _setFieldConfigs(
+		HighlightBuilder highlightBuilder, JSONObject jsonObject) {
+
+		JSONObject fieldsJSONObject = jsonObject.getJSONObject("fields");
+
+		if (fieldsJSONObject == null) {
+			return;
+		}
+
+		Set<String> keySet = fieldsJSONObject.keySet();
+
+		Stream<String> stream = keySet.stream();
+
+		stream.forEach(
+			key -> highlightBuilder.addFieldConfig(
+				_getFieldConfig(fieldsJSONObject, key)));
+	}
+
+	@Reference
+	private FieldConfigBuilderFactory _fieldConfigBuilderFactory;
+
+	@Reference
+	private HighlightBuilderFactory _highlightBuilderFactory;
+
+	@Reference
+	private SetterHelper _setterHelper;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/util/SXPJSONUtil.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/util/SXPJSONUtil.java
@@ -1,0 +1,323 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.util;
+
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class SXPJSONUtil {
+
+	public static Optional<Boolean> getBooleanOptional(
+		Object object, String... paths) {
+
+		Object value = getValue(object, paths);
+
+		if (value == null) {
+			return Optional.empty();
+		}
+
+		return Optional.of(GetterUtil.getBoolean(value));
+	}
+
+	public static Optional<Double> getDoubleOptional(
+		Object object, String... paths) {
+
+		Object value = getValue(object, paths);
+
+		if (value == null) {
+			return Optional.empty();
+		}
+
+		return Optional.of(GetterUtil.getDouble(value));
+	}
+
+	public static Optional<String> getFirstKeyOptional(JSONObject jsonObject) {
+		if (jsonObject == null) {
+			return Optional.empty();
+		}
+
+		Iterator<String> iterator = jsonObject.keys();
+
+		if (iterator.hasNext()) {
+			return Optional.of(iterator.next());
+		}
+
+		return Optional.empty();
+	}
+
+	public static Optional<Float> getFloatOptional(
+		Object object, String... paths) {
+
+		Object value = getValue(object, paths);
+
+		if (value == null) {
+			return Optional.empty();
+		}
+
+		return Optional.of(GetterUtil.getFloat(value));
+	}
+
+	public static Optional<Integer[]> getIntegerArrayOptional(
+		JSONObject jsonObject, String key) {
+
+		int[] arr = toIntArray(jsonObject.getJSONArray(key));
+
+		if ((arr == null) || (arr.length == 0)) {
+			return Optional.empty();
+		}
+
+		IntStream intStream = Arrays.stream(arr);
+
+		Integer[] boxedArray = intStream.boxed(
+		).toArray(
+			Integer[]::new
+		);
+
+		return Optional.of(boxedArray);
+	}
+
+	public static Optional<Integer> getIntegerOptional(
+		Object object, String... paths) {
+
+		Object value = getValue(object, paths);
+
+		if (value == null) {
+			return Optional.empty();
+		}
+
+		return Optional.of(GetterUtil.getInteger(value));
+	}
+
+	public static Optional<JSONArray> getJSONArrayOptional(
+		Object object, String... paths) {
+
+		Object value = getValue(object, paths);
+
+		if (value == null) {
+			return Optional.empty();
+		}
+
+		return Optional.of((JSONArray)value);
+	}
+
+	public static Optional<JSONObject> getJSONObjectOptional(
+		Object object, String... paths) {
+
+		Object value = getValue(object, paths);
+
+		if (value == null) {
+			return Optional.empty();
+		}
+
+		return Optional.of((JSONObject)value);
+	}
+
+	public static Optional<Long[]> getLongArrayOptional(
+		JSONObject jsonObject, String key) {
+
+		long[] arr = toLongArray(jsonObject.getJSONArray(key));
+
+		if ((arr == null) || (arr.length == 0)) {
+			return Optional.empty();
+		}
+
+		LongStream longStream = Arrays.stream(arr);
+
+		Long[] boxedArray = longStream.boxed(
+		).toArray(
+			Long[]::new
+		);
+
+		return Optional.of(boxedArray);
+	}
+
+	public static Optional<Long> getLongOptional(
+		Object object, String... paths) {
+
+		Object value = getValue(object, paths);
+
+		if (value == null) {
+			return Optional.empty();
+		}
+
+		return Optional.of(GetterUtil.getLong(value));
+	}
+
+	public static Optional<String[]> getStringArrayOptional(
+		JSONObject jsonObject, String key) {
+
+		String[] stringArray = jsonArrayToStringArray(
+			jsonObject.getJSONArray(key));
+
+		if ((stringArray == null) || (stringArray.length == 0)) {
+			return Optional.empty();
+		}
+
+		return Optional.of(stringArray);
+	}
+
+	public static Optional<String> getStringOptional(
+		Object object, String... paths) {
+
+		Object value = getValue(object, paths);
+
+		if (value == null) {
+			return Optional.empty();
+		}
+
+		return Optional.of(String.valueOf(value));
+	}
+
+	public static Object getValue(Object object, String... paths) {
+		if (object == null) {
+			return null;
+		}
+
+		Object value = null;
+
+		String[] parts = paths[0].split("/");
+
+		String type = parts[0];
+		String key = parts[1];
+
+		if (type.equals("JSONArray")) {
+			JSONObject jsonObject = (JSONObject)object;
+
+			value = jsonObject.getJSONArray(key);
+		}
+		else if (type.equals("JSONObject")) {
+			JSONObject jsonObject = (JSONObject)object;
+
+			value = jsonObject.getJSONObject(key);
+		}
+		else if (type.equals("Object")) {
+			if (object instanceof JSONArray) {
+				JSONArray jsonArray = (JSONArray)object;
+
+				value = jsonArray.get(GetterUtil.getInteger(key));
+			}
+			else if (object instanceof JSONObject) {
+				JSONObject jsonObject = (JSONObject)object;
+
+				value = jsonObject.get(key);
+			}
+		}
+
+		if (paths.length == 1) {
+			return value;
+		}
+
+		if (value == null) {
+			return null;
+		}
+
+		return getValue(value, Arrays.copyOfRange(paths, 1, paths.length));
+	}
+
+	public static double[] jsonArrayToDoubleArray(JSONArray jsonArray) {
+		if (jsonArray == null) {
+			return new double[0];
+		}
+
+		double[] values = new double[jsonArray.length()];
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			values[i] = jsonArray.getDouble(i);
+		}
+
+		return values;
+	}
+
+	public static String[] jsonArrayToStringArray(JSONArray jsonArray) {
+		if ((jsonArray == null) || (jsonArray.length() == 0)) {
+			return new String[0];
+		}
+
+		String[] stringArray = new String[jsonArray.length()];
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			stringArray[i] = jsonArray.getString(i);
+		}
+
+		return stringArray;
+	}
+
+	public static double[] toDoubleArray(JSONArray jsonArray) {
+		if (jsonArray == null) {
+			return new double[0];
+		}
+
+		double[] arr = new double[jsonArray.length()];
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			arr[i] = jsonArray.getDouble(i);
+		}
+
+		return arr;
+	}
+
+	public static int[] toIntArray(JSONArray jsonArray) {
+		if ((jsonArray == null) || (jsonArray.length() == 0)) {
+			return new int[0];
+		}
+
+		int[] arr = new int[jsonArray.length()];
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			arr[i] = jsonArray.getInt(i);
+		}
+
+		return arr;
+	}
+
+	public static long[] toLongArray(JSONArray jsonArray) {
+		if ((jsonArray == null) || (jsonArray.length() == 0)) {
+			return new long[0];
+		}
+
+		long[] arr = new long[jsonArray.length()];
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			arr[i] = jsonArray.getLong(i);
+		}
+
+		return arr;
+	}
+
+	public static String[] toStringArray(JSONArray jsonArray) {
+		if ((jsonArray == null) || (jsonArray.length() == 0)) {
+			return new String[0];
+		}
+
+		String[] arr = new String[jsonArray.length()];
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			arr[i] = jsonArray.getString(i);
+		}
+
+		return arr;
+	}
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/util/ScriptHelper.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/util/ScriptHelper.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.util;
+
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.script.Script;
+import com.liferay.portal.search.script.ScriptBuilder;
+import com.liferay.portal.search.script.ScriptType;
+import com.liferay.portal.search.script.Scripts;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(immediate = true, service = ScriptHelper.class)
+public class ScriptHelper {
+
+	public Optional<Script> getScript(Object object) {
+		if (Objects.isNull(object)) {
+			return Optional.empty();
+		}
+
+		if (object instanceof String) {
+			return _getStringScript((String)object);
+		}
+		else if (object instanceof JSONObject) {
+			return _getObjectScript((JSONObject)object);
+		}
+
+		return Optional.empty();
+	}
+
+	private Optional<Script> _getObjectScript(JSONObject jsonObject) {
+		if (jsonObject.length() == 0) {
+			return Optional.empty();
+		}
+
+		ScriptBuilder scriptBuilder = _scripts.builder();
+
+		_setIdOrSource(scriptBuilder, jsonObject);
+
+		_setterHelper.setStringValue(
+			jsonObject, "lang", scriptBuilder::language);
+
+		_setOptions(scriptBuilder, jsonObject);
+
+		_setParams(scriptBuilder, jsonObject);
+
+		return Optional.of(scriptBuilder.build());
+	}
+
+	private Optional<Script> _getStringScript(String scriptString) {
+		if (Validator.isBlank(scriptString)) {
+			return Optional.empty();
+		}
+
+		ScriptBuilder scriptBuilder = _scripts.builder();
+
+		scriptBuilder.idOrCode(
+			scriptString
+		).scriptType(
+			ScriptType.INLINE
+		).language(
+			"painless"
+		);
+
+		return Optional.of(scriptBuilder.build());
+	}
+
+	private void _setIdOrSource(
+		ScriptBuilder scriptBuilder, JSONObject jsonObject) {
+
+		String id = jsonObject.getString("id");
+		String source = jsonObject.getString("source");
+
+		if (!Validator.isBlank(id)) {
+			scriptBuilder.idOrCode(
+				id
+			).scriptType(
+				ScriptType.STORED
+			);
+		}
+		else if (!Validator.isBlank(source)) {
+			scriptBuilder.idOrCode(
+				source
+			).scriptType(
+				ScriptType.INLINE
+			);
+		}
+	}
+
+	private void _setOptions(
+		ScriptBuilder scriptBuilder, JSONObject jsonObject) {
+
+		JSONObject optionsJSONObject = jsonObject.getJSONObject("options");
+
+		if (optionsJSONObject == null) {
+			return;
+		}
+
+		optionsJSONObject.keySet(
+		).stream(
+		).forEach(
+			key -> scriptBuilder.putParameter(key, optionsJSONObject.get(key))
+		);
+	}
+
+	private void _setParams(
+		ScriptBuilder scriptBuilder, JSONObject jsonObject) {
+
+		JSONObject paramsJSONObject = jsonObject.getJSONObject("params");
+
+		if (paramsJSONObject == null) {
+			return;
+		}
+
+		paramsJSONObject.keySet(
+		).stream(
+		).forEach(
+			key -> scriptBuilder.putParameter(key, paramsJSONObject.get(key))
+		);
+	}
+
+	@Reference
+	private Scripts _scripts;
+
+	@Reference
+	private SetterHelper _setterHelper;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/util/SetterHelper.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/util/SetterHelper.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.internal.blueprint.util;
+
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.sort.FieldSort;
+import com.liferay.portal.search.sort.SortOrder;
+import com.liferay.portal.search.sort.Sorts;
+import com.liferay.search.experiences.internal.problem.ProblemUtil;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(immediate = true, service = SetterHelper.class)
+public class SetterHelper {
+
+	public void setBooleanValue(
+		JSONObject jsonObject, String key, Consumer<Boolean> setter) {
+
+		if (!jsonObject.has(key)) {
+			return;
+		}
+
+		setter.accept(jsonObject.getBoolean(key));
+	}
+
+	public void setDoubleArrayValue(
+		JSONObject jsonObject, String key, Consumer<double[]> setter) {
+
+		if (!jsonObject.has(key)) {
+			return;
+		}
+
+		setter.accept(SXPJSONUtil.toDoubleArray(jsonObject.getJSONArray(key)));
+	}
+
+	public void setDoubleValue(
+		JSONObject jsonObject, String key, Consumer<Double> setter) {
+
+		if (!jsonObject.has(key)) {
+			return;
+		}
+
+		setter.accept(jsonObject.getDouble(key));
+	}
+
+	public void setFieldSorts(
+		JSONObject jsonObject, Consumer<FieldSort[]> setter) {
+
+		if (!jsonObject.has("sort")) {
+			return;
+		}
+
+		JSONArray sortJSONArray = jsonObject.getJSONArray("sort");
+
+		List<FieldSort> sorts = new ArrayList<>();
+
+		for (int i = 0; i < sortJSONArray.length(); i++) {
+			JSONObject orderJSONObject = sortJSONArray.getJSONObject(i);
+
+			Iterator<String> iterator = orderJSONObject.keys();
+
+			String field = iterator.next();
+
+			JSONObject fieldJSONObject = orderJSONObject.getJSONObject(field);
+
+			if (fieldJSONObject.has("order")) {
+				_addFieldSortWithOrder(
+					sorts, field, jsonObject, fieldJSONObject);
+			}
+			else {
+				sorts.add(_sorts.field(field));
+			}
+
+			setter.accept(sorts.toArray(new FieldSort[0]));
+		}
+	}
+
+	public void setFloatValue(
+		JSONObject jsonObject, String key, Consumer<Float> setter) {
+
+		if (!jsonObject.has(key)) {
+			return;
+		}
+
+		setter.accept(GetterUtil.getFloat(jsonObject.get(key)));
+	}
+
+	public void setIntegerValue(
+		JSONObject jsonObject, String key, Consumer<Integer> setter) {
+
+		if (!jsonObject.has(key)) {
+			return;
+		}
+
+		setter.accept(jsonObject.getInt(key));
+	}
+
+	public void setLongValue(
+		JSONObject jsonObject, String key, Consumer<Long> setter) {
+
+		if (!jsonObject.has(key)) {
+			return;
+		}
+
+		setter.accept(jsonObject.getLong(key));
+	}
+
+	public void setObjectValue(
+		JSONObject jsonObject, String key, Consumer<Object> setter) {
+
+		if (!jsonObject.has(key)) {
+			return;
+		}
+
+		setter.accept(jsonObject.get(key));
+	}
+
+	public void setStringArrayValue(
+		JSONObject jsonObject, String key, Consumer<String[]> setter) {
+
+		if (!jsonObject.has(key)) {
+			return;
+		}
+
+		setter.accept(JSONUtil.toStringArray(jsonObject.getJSONArray(key)));
+	}
+
+	public void setStringValue(
+		JSONObject jsonObject, String key, Consumer<String> setter) {
+
+		if (!jsonObject.has(key)) {
+			return;
+		}
+
+		setter.accept(jsonObject.getString(key));
+	}
+
+	private void _addFieldSortWithOrder(
+		List<FieldSort> sorts, String fieldName, JSONObject jsonObject,
+		JSONObject fieldJSONObject) {
+
+		String order = fieldJSONObject.getString("order");
+
+		try {
+			SortOrder sortOrder = SortOrder.valueOf(
+				StringUtil.toUpperCase(order));
+
+			sorts.add(_sorts.field(fieldName, sortOrder));
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+			_log.error(illegalArgumentException);
+
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(SetterHelper.class);
+
+	@Reference
+	private Sorts _sorts;
+
+}


### PR DESCRIPTION
About the next PR:

We are enclosing building the actual ES search request. This contains translation and adding sorts to searchrequestbuilder.  After I get your changes downstream, I'll send you the same kind of set for aggregations, query and highlight. Clause translators are included because sorts depend on those.

About the SearchRequestBodyContributor interface: It's for modeling and constructing the different parts (like "query", "aggs", "sorts", "highlight") of ES search request body.

Notes: 

1) The SearchRequestBodyContributors has TODOs for getting the configuration DTO

2) Why all these helpers (HighlightHelper, ScriptHelper, ClauseHelper)? Because of the cross-dependencies. Both aggregation and sort translators need Script building. Clauses and sorts need clause (query) building. Highlights and aggregations need highlight building.

3) SetterHelper util is used heavily from all of the 46 aggregation translators. 

4) Why am i using "clause" instead of "query"? Because of semantics: to underline that in the end all queries built from a Blueprint will be clauses in the main Boolean query and because there's already a QueryBuilder interface in portal search API. It could be called "query", because in the end, a clause is a query in search context.