### PR TITLE
LPS-140520 Have lingering environment acceptance tests properly marked as common failure

### DIFF
--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceSmoke.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceSmoke.testcase
@@ -58,7 +58,7 @@ definition {
 
 	test PublishSimpleProduct {
 		property environment.acceptance = "true";
-		property portal.acceptance = "false";
+		property portal.acceptance = "true";
 
 		CommerceNavigator.gotoPortlet(
 			category = "Product Management",

--- a/portal-impl/test.properties
+++ b/portal-impl/test.properties
@@ -21,16 +21,19 @@
     #
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
-        ((environment.acceptance == true) AND \
         (\
-            (app.server.types == null) OR \
-            (app.server.types ~ "tomcat")\
-        ) AND \
+            (environment.acceptance == true) AND \
+            (portal.acceptance == true) AND \
+            (\
+                (app.server.types == null) OR \
+                (app.server.types ~ "tomcat")\
+            ) AND \
+            (\
+                (database.types == null) OR \
+                (database.types ~ "mysql")\
+            )\
+        ) OR \
         (\
-            (database.types == null) OR \
-            (database.types ~ "mysql")\
-        )) OR \
-        ((portal.acceptance == true) AND \
-        (\
+            (portal.acceptance == true) AND \
             (testray.main.component.name ~ "Database Partitioning")\
-        ))
+        )

--- a/portal-kernel/test.properties
+++ b/portal-kernel/test.properties
@@ -14,19 +14,22 @@
     #
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
-        ((environment.acceptance == true) AND \
         (\
-            (app.server.types == null) OR \
-            (app.server.types ~ "tomcat")\
-        ) AND \
+            (environment.acceptance == true) AND \
+            (portal.acceptance == true) AND \
+            (\
+                (app.server.types == null) OR \
+                (app.server.types ~ "tomcat")\
+            ) AND \
+            (\
+                (database.types == null) OR \
+                (database.types ~ "mysql")\
+            )\
+        ) OR \
         (\
-            (database.types == null) OR \
-            (database.types ~ "mysql")\
-        )) OR \
-        ((portal.acceptance == true) AND \
-        (\
+            (portal.acceptance == true) AND \
             (testray.main.component.name ~ "Database Partitioning")\
-        ))
+        )
 
     test.batch.run.property.query[functional-upgrade-tomcat*-mysql*-jdk8][relevant]=\
         (portal.upgrades == true) AND \

--- a/portal-web/test.properties
+++ b/portal-web/test.properties
@@ -15,6 +15,7 @@
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
         (environment.acceptance == true) AND \
+        (portal.acceptance == true) AND \
         (\
             (app.server.types == null) OR \
             (app.server.types ~ "tomcat")\


### PR DESCRIPTION
Manually forwarding since `ci:test:relevant` will always mark PublishSimpleProduct as unique until this fix gets in. The other integration test failure is unrelated and a known issue: https://github.com/liferay-frontend/liferay-portal/pull/1565#issuecomment-939157810

**Description**
Only portal.acceptance is tracked for unique failure comparison logic. The following patches a couple issues on testcase and test.properties file level discovered by PR: https://github.com/liferay-frontend/liferay-portal/pull/1562#issuecomment-938760724

**Test Plan**
Will follow up on this after merge
- [x] Follow up on Testray that PublishSimpleProduct is included in acceptance development - [verified here](https://testray.liferay.com/home/-/testray/case_results/1567960325?redirect=https%3A%2F%2Ftestray.liferay.com%2Fhome%2F-%2Ftestray%2Fcases%2F1314987311%2Fview%3Fcur%3D1%26delta%3D200%26testrayCaseId%3D1314987311%26orderByCol%3DcreateDate_sortable%26orderByType%3Ddesc)
- [x] Further failing PR tests with PublishSimpleProduct are marked as common failure
![CommerceProductTest_MarkedAsCommon](https://user-images.githubusercontent.com/35235266/136843383-a64e4a18-fde3-408e-b89d-a828763cb557.gif)


**JIRA Ticket**
https://issues.liferay.com/browse/LPS-140520

cc/ @vicnate5 @Pietro69