### PR TITLE
LPS-112856 search-experiences-web: Blueprint and element view pages

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/build.gradle
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/build.gradle
@@ -1,4 +1,21 @@
 dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly group: "org.slf4j", name: "slf4j-api", version: "1.7.26"
+	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":dxp:apps:search-experiences:search-experiences-api")
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/application/list/SearchExperiencesPanelCategory.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/application/list/SearchExperiencesPanelCategory.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.web.internal.application.list;
+
+import com.liferay.application.list.BasePanelCategory;
+import com.liferay.application.list.PanelCategory;
+import com.liferay.application.list.constants.PanelCategoryKeys;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.search.experiences.constants.SXPPanelCategoryKeys;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Kevin Tan
+ */
+@Component(
+	immediate = true,
+	property = {
+		"panel.category.key=" + PanelCategoryKeys.APPLICATIONS_MENU_APPLICATIONS,
+		"panel.category.order:Integer=500"
+	},
+	service = PanelCategory.class
+)
+public class SearchExperiencesPanelCategory extends BasePanelCategory {
+
+	@Override
+	public String getKey() {
+		return SXPPanelCategoryKeys.CONTROL_PANEL_SEARCH_EXPERIENCES;
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
+			"content.Language", locale, getClass());
+
+		return LanguageUtil.get(resourceBundle, "search-experiences");
+	}
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/application/list/SXPBlueprintPanelApp.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/application/list/SXPBlueprintPanelApp.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.web.internal.blueprint.application.list;
+
+import com.liferay.application.list.BasePanelApp;
+import com.liferay.application.list.PanelApp;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.search.engine.SearchEngineInformation;
+import com.liferay.search.experiences.constants.SXPPanelCategoryKeys;
+import com.liferay.search.experiences.constants.SXPPortletKeys;
+
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	immediate = true,
+	property = {
+		"panel.app.order:Integer=100",
+		"panel.category.key=" + SXPPanelCategoryKeys.CONTROL_PANEL_SEARCH_EXPERIENCES
+	},
+	service = PanelApp.class
+)
+public class SXPBlueprintPanelApp extends BasePanelApp {
+
+	@Override
+	public String getPortletId() {
+		return SXPPortletKeys.SXP_BLUEPRINT;
+	}
+
+	@Override
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
+		throws PortalException {
+
+		if (Objects.equals(searchEngineInformation.getVendorString(), "Solr")) {
+			return false;
+		}
+
+		return super.isShow(permissionChecker, group);
+	}
+
+	@Override
+	@Reference(
+		target = "(javax.portlet.name=" + SXPPortletKeys.SXP_BLUEPRINT + ")",
+		unbind = "-"
+	)
+	public void setPortlet(Portlet portlet) {
+		super.setPortlet(portlet);
+	}
+
+	@Reference
+	protected SearchEngineInformation searchEngineInformation;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/constants/SXPBlueprintMVCCommandNames.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/constants/SXPBlueprintMVCCommandNames.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.web.internal.blueprint.constants;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class SXPBlueprintMVCCommandNames {
+
+	public static final String VIEW_SXP_BLUEPRINTS =
+		"/blueprint/sxp_blueprints";
+
+	public static final String VIEW_SXP_ELEMENTS = "/blueprint/sxp_elements";
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/constants/SXPBlueprintTabNames.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/constants/SXPBlueprintTabNames.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.web.internal.blueprint.constants;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class SXPBlueprintTabNames {
+
+	public static final String SXP_BLUEPRINTS = "sxpBlueprints";
+
+	public static final String SXP_ELEMENTS = "sxpElements";
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/constants/SXPBlueprintWebKeys.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/constants/SXPBlueprintWebKeys.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.web.internal.blueprint.constants;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class SXPBlueprintWebKeys {
+
+	public static final String ERROR = "error";
+
+	public static final String HIDDEN = "hidden";
+
+	public static final String TAB = "tab";
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/portlet/SXPBlueprintPortlet.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/portlet/SXPBlueprintPortlet.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.web.internal.blueprint.portlet;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.search.experiences.constants.SXPPortletKeys;
+
+import javax.portlet.Portlet;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	immediate = true,
+	property = {
+		"com.liferay.portlet.add-default-resource=true",
+		"com.liferay.portlet.css-class-wrapper=portlet-sxp-blueprint",
+		"com.liferay.portlet.display-category=category.hidden",
+		"com.liferay.portlet.header-portlet-css=/css/main.css",
+		"com.liferay.portlet.use-default-template=true",
+		"javax.portlet.expiration-cache=0",
+		"javax.portlet.init-param.template-path=/META-INF/resources/",
+		"javax.portlet.init-param.view-template=/view.jsp",
+		"javax.portlet.name=" + SXPPortletKeys.SXP_BLUEPRINT,
+		"javax.portlet.resource-bundle=content.Language",
+		"javax.portlet.security-role-ref=administrator"
+	},
+	service = Portlet.class
+)
+public class SXPBlueprintPortlet extends MVCPortlet {
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/portlet/action/ViewSXPBlueprintsMVCRenderCommand.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/portlet/action/ViewSXPBlueprintsMVCRenderCommand.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.web.internal.blueprint.portlet.action;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.search.experiences.constants.SXPPortletKeys;
+import com.liferay.search.experiences.web.internal.blueprint.constants.SXPBlueprintMVCCommandNames;
+
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + SXPPortletKeys.SXP_BLUEPRINT,
+		"mvc.command.name=" + SXPBlueprintMVCCommandNames.VIEW_SXP_BLUEPRINTS,
+		"mvc.command.name=/"
+	},
+	service = MVCRenderCommand.class
+)
+public class ViewSXPBlueprintsMVCRenderCommand implements MVCRenderCommand {
+
+	@Override
+	public String render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws PortletException {
+
+		return "/view.jsp";
+	}
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/portlet/action/ViewSXPElementsMVCRenderCommand.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/portlet/action/ViewSXPElementsMVCRenderCommand.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.web.internal.blueprint.portlet.action;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.search.experiences.constants.SXPPortletKeys;
+import com.liferay.search.experiences.web.internal.blueprint.constants.SXPBlueprintMVCCommandNames;
+
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + SXPPortletKeys.SXP_BLUEPRINT,
+		"mvc.command.name=" + SXPBlueprintMVCCommandNames.VIEW_SXP_ELEMENTS
+	},
+	service = MVCRenderCommand.class
+)
+public class ViewSXPElementsMVCRenderCommand implements MVCRenderCommand {
+
+	@Override
+	public String render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws PortletException {
+
+		return "/view.jsp";
+	}
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/portlet.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/portlet.properties
@@ -1,0 +1,7 @@
+include-and-override=portlet-ext.properties
+
+#
+# Input a list of comma delimited resource action configurations that will be
+# read from the class path.
+#
+resource.actions.configs=resource-actions/default.xml

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resource-actions/default.xml
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resource-actions/default.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!DOCTYPE resource-action-mapping PUBLIC "-//Liferay//DTD Resource Action Mapping 7.4.0//EN" "http://www.liferay.com/dtd/liferay-resource-action-mapping_7_4_0.dtd">
+
+<resource-action-mapping>
+	<portlet-resource>
+		<portlet-name>com_liferay_search_experiences_web_internal_blueprint_portlet_SXPBlueprintPortlet</portlet-name>
+		<permissions>
+			<supports>
+				<action-key>ACCESS_IN_CONTROL_PANEL</action-key>
+				<action-key>CONFIGURATION</action-key>
+				<action-key>VIEW</action-key>
+			</supports>
+			<guest-unsupported>
+				<action-key>ACCESS_IN_CONTROL_PANEL</action-key>
+				<action-key>CONFIGURATION</action-key>
+				<action-key>VIEW</action-key>
+			</guest-unsupported>
+		</permissions>
+	</portlet-resource>
+</resource-action-mapping>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,41 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+--%>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
+taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
+
+<%@ page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.JSPNavigationItemList" %><%@
+page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+page import="com.liferay.portal.kernel.servlet.SessionErrors" %><%@
+page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
+page import="com.liferay.search.experiences.web.internal.blueprint.constants.SXPBlueprintMVCCommandNames" %><%@
+page import="com.liferay.search.experiences.web.internal.blueprint.constants.SXPBlueprintTabNames" %><%@
+page import="com.liferay.search.experiences.web.internal.blueprint.constants.SXPBlueprintWebKeys" %>
+
+<%@ page import="javax.portlet.PortletURL" %>
+
+<liferay-frontend:defineObjects />
+
+<liferay-theme:defineObjects />
+
+<portlet:defineObjects />

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,0 +1,58 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-ui:error key="<%= SXPBlueprintWebKeys.ERROR %>">
+	<liferay-ui:message arguments="<%= SessionErrors.get(liferayPortletRequest, SXPBlueprintWebKeys.ERROR) %>" key="error-x" />
+</liferay-ui:error>
+
+<%
+final String tab = ParamUtil.getString(request, SXPBlueprintWebKeys.TAB, SXPBlueprintTabNames.SXP_BLUEPRINTS);
+
+PortletURL renderURL = renderResponse.createRenderURL();
+%>
+
+<clay:navigation-bar
+	inverted="<%= false %>"
+	navigationItems='<%=
+		new JSPNavigationItemList(pageContext) {
+			{
+				add(
+					navigationItem -> {
+						navigationItem.setActive(tab.equals(SXPBlueprintTabNames.SXP_BLUEPRINTS));
+						navigationItem.setHref(renderURL, SXPBlueprintWebKeys.TAB, SXPBlueprintTabNames.SXP_BLUEPRINTS, "mvcRenderCommandName", SXPBlueprintMVCCommandNames.VIEW_SXP_BLUEPRINTS);
+						navigationItem.setLabel(LanguageUtil.get(request, "blueprints"));
+					});
+				add(
+					navigationItem -> {
+						navigationItem.setActive(tab.equals(SXPBlueprintTabNames.SXP_ELEMENTS));
+						navigationItem.setHref(renderURL, SXPBlueprintWebKeys.TAB, SXPBlueprintTabNames.SXP_ELEMENTS, "mvcRenderCommandName", SXPBlueprintMVCCommandNames.VIEW_SXP_ELEMENTS, SXPBlueprintWebKeys.HIDDEN, Boolean.FALSE);
+						navigationItem.setLabel(LanguageUtil.get(request, "elements"));
+					});
+			}
+		}
+	%>'
+/>
+
+<c:choose>
+	<c:when test="<%= tab.equals(SXPBlueprintTabNames.SXP_ELEMENTS) %>">
+		<liferay-util:include page="/view_sxp_elements.jsp" servletContext="<%= application %>" />
+	</c:when>
+	<c:otherwise>
+		<liferay-util:include page="/view_sxp_blueprints.jsp" servletContext="<%= application %>" />
+	</c:otherwise>
+</c:choose>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/view_sxp_blueprints.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/view_sxp_blueprints.jsp
@@ -1,0 +1,17 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+--%>
+
+<%@ include file="/init.jsp" %>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/view_sxp_elements.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/view_sxp_elements.jsp
@@ -1,0 +1,17 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+--%>
+
+<%@ include file="/init.jsp" %>


### PR DESCRIPTION
Divided the commits into smaller chunks.

- Adds "Search Experiences" category and "Blueprints" app to the Application Menu
- Adds Blueprints and Elements tabs with blank view pages