### PR TITLE
LPS-139546 portal-configuration-metatype-api: Fix Eclipse compile error

### DIFF
--- a/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/main/java/com/liferay/portal/configuration/metatype/bnd/util/ConfigurableUtil.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/main/java/com/liferay/portal/configuration/metatype/bnd/util/ConfigurableUtil.java
@@ -258,7 +258,7 @@ public class ConfigurableUtil {
 		}
 
 		return HashMapBuilder.create(
-			properties
+			(Map)properties
 		).putAll(
 			overrideProperties
 		).build();


### PR DESCRIPTION
"The method putAll(Dictionary<? extends capture#45-of ?,? extends capture#46-of ?>) in the type HashMapBuilder.HashMapWrapper<capture#45-of ?,capture#46-of ?> is not applicable for the arguments (Map<String,Object>)"

https://issues.liferay.com/browse/LPS-139546