### PR TITLE
LPS-112856 Unlock ability to see results of plain JSON Blueprints using the standard Search Page, while visual editor and preview are underway

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/SXPBlueprintSearchRequestContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/SXPBlueprintSearchRequestContributor.java
@@ -17,6 +17,8 @@ package com.liferay.search.experiences.internal.blueprint.search.spi.searcher;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.searcher.SearchRequest;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
@@ -44,33 +46,78 @@ public class SXPBlueprintSearchRequestContributor
 		SearchRequestBuilder searchRequestBuilder =
 			_searchRequestBuilderFactory.builder(searchRequest);
 
-		long sxpBlueprintId = searchRequestBuilder.withSearchContextGet(
-			searchContext -> GetterUtil.getLong(
-				searchContext.getAttribute("search.experiences.blueprint.id")));
-
-		if (_log.isDebugEnabled()) {
-			_log.debug("Search experiences blueprint ID " + sxpBlueprintId);
-		}
-
-		if (sxpBlueprintId == 0) {
-			return searchRequest;
-		}
-
-		SXPBlueprint sxpBlueprint = _sxpBlueprintLocalService.fetchSXPBlueprint(
-			sxpBlueprintId);
-
-		if (_log.isDebugEnabled()) {
-			_log.debug("Search experiences blueprint " + sxpBlueprint);
-		}
-
-		if (sxpBlueprint == null) {
-			return searchRequest;
-		}
-
-		_sxpBlueprintSearchRequestEnhancer.enhance(
-			searchRequestBuilder, sxpBlueprint);
+		_contributeId(searchRequestBuilder);
+		_contributeJSON(searchRequestBuilder);
 
 		return searchRequestBuilder.build();
+	}
+
+	private void _contributeId(SearchRequestBuilder searchRequestBuilder) {
+		Object object = searchRequestBuilder.withSearchContextGet(
+			searchContext -> searchContext.getAttribute(
+				"search.experiences.blueprint.id"));
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Search experiences blueprint ID " + object);
+		}
+
+		if (object == null) {
+			return;
+		}
+
+		if (object instanceof Number) {
+			_enhance(searchRequestBuilder, GetterUtil.getLong(object));
+
+			return;
+		}
+
+		if (object instanceof String) {
+			if (Validator.isNotNull((String)object)) {
+				_enhance(
+					searchRequestBuilder,
+					GetterUtil.getLongValues(StringUtil.split((String)object)));
+			}
+
+			return;
+		}
+
+		throw new IllegalArgumentException("Invalid blueprint ID " + object);
+	}
+
+	private void _contributeJSON(SearchRequestBuilder searchRequestBuilder) {
+		String sxpBlueprintJSON = searchRequestBuilder.withSearchContextGet(
+			searchContext -> GetterUtil.getString(
+				searchContext.getAttribute(
+					"search.experiences.blueprint.json")));
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Search experiences blueprint JSON " + sxpBlueprintJSON);
+		}
+
+		if (Validator.isNotNull(sxpBlueprintJSON)) {
+			_sxpBlueprintSearchRequestEnhancer.enhance(
+				searchRequestBuilder, sxpBlueprintJSON);
+		}
+	}
+
+	private void _enhance(
+		SearchRequestBuilder searchRequestBuilder, long... sxpBlueprintIds) {
+
+		for (long sxpBlueprintId : sxpBlueprintIds) {
+			if (sxpBlueprintId != 0) {
+				SXPBlueprint sxpBlueprint =
+					_sxpBlueprintLocalService.fetchSXPBlueprint(sxpBlueprintId);
+
+				if (_log.isDebugEnabled()) {
+					_log.debug("Search experiences blueprint " + sxpBlueprint);
+				}
+
+				if (sxpBlueprint != null) {
+					_sxpBlueprintSearchRequestEnhancer.enhance(
+						searchRequestBuilder, sxpBlueprint);
+				}
+			}
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
Also: combine partial blueprints together with a comma separated list of ids

https://issues.liferay.com/browse/LPS-112856