### PR TITLE
LPS-140133 visual adjustments to TranslationAdmin to match Figma design

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -656,7 +656,7 @@ AUI.add(
 					'<input id="{namespace}{id}_{value}" name="{namespace}{fieldNamePrefix}{name}_{value}{fieldNameSuffix}" type="hidden" value="" />',
 
 				TRANSLATION_STATUS_TEMPLATE:
-					'{languageId} <span class="label label-{translationStatusCssClass}">{translationStatus}</span>',
+					'{languageId} <span class="dropdown-item-indicator-end w-auto"><span class="label label-{translationStatusCssClass}">{translationStatus}</span></span>',
 
 				TRIGGER_TEMPLATE:
 					'<span class="inline-item">{flag}</span><span class="btn-section">{languageId}</span>',

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
@@ -79,14 +79,18 @@ const TranslationAdminContent = ({
 							<ClayInput.Group>
 								<ClayInput.GroupItem>
 									<ClayInput
-										aria-label={Liferay.Language.get('search')}
+										aria-label={Liferay.Language.get(
+											'search'
+										)}
 										insetAfter={true}
 										onChange={(event) => {
 											const {value} = event.target;
 
 											setSearchValue(value);
 										}}
-										placeholder={Liferay.Language.get('search')}
+										placeholder={Liferay.Language.get(
+											'search'
+										)}
 										value={searchValue}
 									/>
 
@@ -118,21 +122,25 @@ const TranslationAdminContent = ({
 								onActiveChange={setCreationMenuActive}
 								trigger={
 									<ClayButtonWithIcon
-									disabled={availableLocales.length === 0}
-									small
-									symbol="plus"
+										disabled={availableLocales.length === 0}
+										small
+										symbol="plus"
 									/>
 								}
-								>
+							>
 								<ClayDropDown.ItemList>
 									{availableLocales.map((availableLocale) => {
 										return (
 											<ClayDropDown.Item
-											key={availableLocale.label}
-											onClick={() => {
-												onAddLocale(availableLocale.id);
-											}}
-											symbolLeft={availableLocale.symbol}
+												key={availableLocale.label}
+												onClick={() => {
+													onAddLocale(
+														availableLocale.id
+													);
+												}}
+												symbolLeft={
+													availableLocale.symbol
+												}
 											>
 												{availableLocale.label}
 											</ClayDropDown.Item>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
@@ -70,65 +70,69 @@ const TranslationAdminContent = ({
 				{Liferay.Language.get('manage-translations')}
 			</ClayModal.Header>
 
-			<ClayInput.Group className="align-items-center p-3 pl-4 pr-4">
-				<ClayInput.GroupItem>
-					<ClayInput
-						aria-label={Liferay.Language.get('search')}
-						insetAfter={true}
-						onChange={(event) => {
-							const {value} = event.target;
+			<ClayModal.Header withTitle={false}>
+				<ClayModal.Title>
+					<ClayInput.Group className="align-items-center">
+						<ClayInput.GroupItem>
+							<ClayInput
+								aria-label={Liferay.Language.get('search')}
+								insetAfter={true}
+								onChange={(event) => {
+									const {value} = event.target;
 
-							setSearchValue(value);
-						}}
-						placeholder={Liferay.Language.get('search')}
-						value={searchValue}
-					/>
-
-					<ClayInput.GroupInsetItem after tag="span">
-						<ClayButtonWithIcon
-							aria-label={Liferay.Language.get('search')}
-							displayType="unstyled"
-							onClick={() => {
-								setSearchValue('');
-							}}
-							symbol={searchValue ? 'times' : 'search'}
-						/>
-					</ClayInput.GroupInsetItem>
-				</ClayInput.GroupItem>
-
-				<ClayInput.GroupItem shrink>
-					<ClayDropDown
-						active={
-							creationMenuActive && availableLocales.length > 0
-						}
-						hasLeftSymbols
-						onActiveChange={setCreationMenuActive}
-						trigger={
-							<ClayButtonWithIcon
-								disabled={availableLocales.length === 0}
-								small
-								symbol="plus"
+									setSearchValue(value);
+								}}
+								placeholder={Liferay.Language.get('search')}
+								value={searchValue}
 							/>
-						}
-					>
-						<ClayDropDown.ItemList>
-							{availableLocales.map((availableLocale) => {
-								return (
-									<ClayDropDown.Item
-										key={availableLocale.label}
-										onClick={() => {
-											onAddLocale(availableLocale.id);
-										}}
-										symbolLeft={availableLocale.symbol}
-									>
-										{availableLocale.label}
-									</ClayDropDown.Item>
-								);
-							})}
-						</ClayDropDown.ItemList>
-					</ClayDropDown>
-				</ClayInput.GroupItem>
-			</ClayInput.Group>
+
+							<ClayInput.GroupInsetItem after tag="span">
+								<ClayButtonWithIcon
+									aria-label={Liferay.Language.get('search')}
+									displayType="unstyled"
+									onClick={() => {
+										setSearchValue('');
+									}}
+									symbol={searchValue ? 'times' : 'search'}
+								/>
+							</ClayInput.GroupInsetItem>
+						</ClayInput.GroupItem>
+
+						<ClayInput.GroupItem shrink>
+							<ClayDropDown
+								active={
+									creationMenuActive && availableLocales.length > 0
+								}
+								hasLeftSymbols
+								onActiveChange={setCreationMenuActive}
+								trigger={
+									<ClayButtonWithIcon
+										disabled={availableLocales.length === 0}
+										small
+										symbol="plus"
+									/>
+								}
+							>
+								<ClayDropDown.ItemList>
+									{availableLocales.map((availableLocale) => {
+										return (
+											<ClayDropDown.Item
+												key={availableLocale.label}
+												onClick={() => {
+													onAddLocale(availableLocale.id);
+												}}
+												symbolLeft={availableLocale.symbol}
+											>
+												{availableLocale.label}
+											</ClayDropDown.Item>
+										);
+									})}
+								</ClayDropDown.ItemList>
+							</ClayDropDown>
+						</ClayInput.GroupItem>
+					</ClayInput.Group>
+				</ClayModal.Title>
+			</ClayModal.Header>
 
 			<ClayModal.Body className="pb-0 pt-3" scrollable>
 				<ClayTable>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
@@ -17,7 +17,6 @@ import ClayDropDown from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
-import ClayManagementToolbar from '@clayui/management-toolbar';
 import ClayModal from '@clayui/modal';
 import ClayTable from '@clayui/table';
 import PropTypes from 'prop-types';
@@ -70,88 +69,66 @@ const TranslationAdminContent = ({
 			<ClayModal.Header>
 				{Liferay.Language.get('manage-translations')}
 			</ClayModal.Header>
-			<ClayModal.Header withTitle={false}>
-				<ClayModal.Title>
-					<ClayManagementToolbar
-						aria-label={ariaLabels.managementToolbar}
+
+			<ClayInput.Group className="align-items-center p-3 pl-4 pr-4">
+				<ClayInput.GroupItem>
+					<ClayInput
+						aria-label={Liferay.Language.get('search')}
+						insetAfter={true}
+						onChange={(event) => {
+							const {value} = event.target;
+
+							setSearchValue(value);
+						}}
+						placeholder={Liferay.Language.get('search')}
+						value={searchValue}
+					/>
+
+					<ClayInput.GroupInsetItem after tag="span">
+						<ClayButtonWithIcon
+							aria-label={Liferay.Language.get('search')}
+							displayType="unstyled"
+							onClick={() => {
+								setSearchValue('');
+							}}
+							symbol={searchValue ? 'times' : 'search'}
+						/>
+					</ClayInput.GroupInsetItem>
+				</ClayInput.GroupItem>
+
+				<ClayInput.GroupItem shrink>
+					<ClayDropDown
+						active={
+							creationMenuActive && availableLocales.length > 0
+						}
+						hasLeftSymbols
+						onActiveChange={setCreationMenuActive}
+						trigger={
+							<ClayButtonWithIcon
+								disabled={availableLocales.length === 0}
+								small
+								symbol="plus"
+							/>
+						}
 					>
-						<ClayManagementToolbar.Search showMobile={true}>
-							<ClayInput.Group>
-								<ClayInput.GroupItem>
-									<ClayInput
-										aria-label={Liferay.Language.get(
-											'search'
-										)}
-										insetAfter={true}
-										onChange={(event) => {
-											const {value} = event.target;
-
-											setSearchValue(value);
+						<ClayDropDown.ItemList>
+							{availableLocales.map((availableLocale) => {
+								return (
+									<ClayDropDown.Item
+										key={availableLocale.label}
+										onClick={() => {
+											onAddLocale(availableLocale.id);
 										}}
-										placeholder={Liferay.Language.get(
-											'search'
-										)}
-										value={searchValue}
-									/>
-
-									<ClayInput.GroupInsetItem after tag="span">
-										<ClayButtonWithIcon
-											aria-label={Liferay.Language.get(
-												'search'
-											)}
-											displayType="unstyled"
-											onClick={() => {
-												setSearchValue('');
-											}}
-											symbol={
-												searchValue ? 'times' : 'search'
-											}
-										/>
-									</ClayInput.GroupInsetItem>
-								</ClayInput.GroupItem>
-							</ClayInput.Group>
-						</ClayManagementToolbar.Search>
-
-						<ClayManagementToolbar.ItemList>
-							<ClayDropDown
-								active={
-									creationMenuActive &&
-									availableLocales.length > 0
-								}
-								hasLeftSymbols
-								onActiveChange={setCreationMenuActive}
-								trigger={
-									<ClayButtonWithIcon
-										disabled={availableLocales.length === 0}
-										small
-										symbol="plus"
-									/>
-								}
-							>
-								<ClayDropDown.ItemList>
-									{availableLocales.map((availableLocale) => {
-										return (
-											<ClayDropDown.Item
-												key={availableLocale.label}
-												onClick={() => {
-													onAddLocale(
-														availableLocale.id
-													);
-												}}
-												symbolLeft={
-													availableLocale.symbol
-												}
-											>
-												{availableLocale.label}
-											</ClayDropDown.Item>
-										);
-									})}
-								</ClayDropDown.ItemList>
-							</ClayDropDown>
-						</ClayManagementToolbar.ItemList>
-					</ClayManagementToolbar>
-				</ClayModal.Title>
-			</ClayModal.Header>
+										symbolLeft={availableLocale.symbol}
+									>
+										{availableLocale.label}
+									</ClayDropDown.Item>
+								);
+							})}
+						</ClayDropDown.ItemList>
+					</ClayDropDown>
+				</ClayInput.GroupItem>
+			</ClayInput.Group>
 
 			<ClayModal.Body className="pb-0 pt-3" scrollable>
 				<ClayTable>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
@@ -70,78 +70,82 @@ const TranslationAdminContent = ({
 			<ClayModal.Header>
 				{Liferay.Language.get('manage-translations')}
 			</ClayModal.Header>
+			<ClayModal.Header withTitle={false}>
+				<ClayModal.Title>
+					<ClayManagementToolbar
+						aria-label={ariaLabels.managementToolbar}
+					>
+						<ClayManagementToolbar.Search showMobile={true}>
+							<ClayInput.Group>
+								<ClayInput.GroupItem>
+									<ClayInput
+										aria-label={Liferay.Language.get('search')}
+										insetAfter={true}
+										onChange={(event) => {
+											const {value} = event.target;
 
-			<ClayModal.Body scrollable>
-				<ClayManagementToolbar
-					aria-label={ariaLabels.managementToolbar}
-				>
-					<ClayManagementToolbar.Search showMobile={true}>
-						<ClayInput.Group>
-							<ClayInput.GroupItem>
-								<ClayInput
-									aria-label={Liferay.Language.get('search')}
-									insetAfter={true}
-									onChange={(event) => {
-										const {value} = event.target;
-
-										setSearchValue(value);
-									}}
-									placeholder={Liferay.Language.get('search')}
-									value={searchValue}
-								/>
-
-								<ClayInput.GroupInsetItem after tag="span">
-									<ClayButtonWithIcon
-										aria-label={Liferay.Language.get(
-											'search'
-										)}
-										displayType="unstyled"
-										onClick={() => {
-											setSearchValue('');
+											setSearchValue(value);
 										}}
-										symbol={
-											searchValue ? 'times' : 'search'
-										}
+										placeholder={Liferay.Language.get('search')}
+										value={searchValue}
 									/>
-								</ClayInput.GroupInsetItem>
-							</ClayInput.GroupItem>
-						</ClayInput.Group>
-					</ClayManagementToolbar.Search>
 
-					<ClayManagementToolbar.ItemList>
-						<ClayDropDown
-							active={
-								creationMenuActive &&
-								availableLocales.length > 0
-							}
-							hasLeftSymbols
-							onActiveChange={setCreationMenuActive}
-							trigger={
-								<ClayButtonWithIcon
+									<ClayInput.GroupInsetItem after tag="span">
+										<ClayButtonWithIcon
+											aria-label={Liferay.Language.get(
+												'search'
+											)}
+											displayType="unstyled"
+											onClick={() => {
+												setSearchValue('');
+											}}
+											symbol={
+												searchValue ? 'times' : 'search'
+											}
+										/>
+									</ClayInput.GroupInsetItem>
+								</ClayInput.GroupItem>
+							</ClayInput.Group>
+						</ClayManagementToolbar.Search>
+
+						<ClayManagementToolbar.ItemList>
+							<ClayDropDown
+								active={
+									creationMenuActive &&
+									availableLocales.length > 0
+								}
+								hasLeftSymbols
+								onActiveChange={setCreationMenuActive}
+								trigger={
+									<ClayButtonWithIcon
 									disabled={availableLocales.length === 0}
+									small
 									symbol="plus"
-								/>
-							}
-						>
-							<ClayDropDown.ItemList>
-								{availableLocales.map((availableLocale) => {
-									return (
-										<ClayDropDown.Item
+									/>
+								}
+								>
+								<ClayDropDown.ItemList>
+									{availableLocales.map((availableLocale) => {
+										return (
+											<ClayDropDown.Item
 											key={availableLocale.label}
 											onClick={() => {
 												onAddLocale(availableLocale.id);
 											}}
 											symbolLeft={availableLocale.symbol}
-										>
-											{availableLocale.label}
-										</ClayDropDown.Item>
-									);
-								})}
-							</ClayDropDown.ItemList>
-						</ClayDropDown>
-					</ClayManagementToolbar.ItemList>
-				</ClayManagementToolbar>
+											>
+												{availableLocale.label}
+											</ClayDropDown.Item>
+										);
+									})}
+								</ClayDropDown.ItemList>
+							</ClayDropDown>
+						</ClayManagementToolbar.ItemList>
+					</ClayManagementToolbar>
+				</ClayModal.Title>
+			</ClayModal.Header>
 
+			<ClayModal.Body className="pb-0 pt-3" scrollable>
 				<ClayTable>
 					<ClayTable.Head>
 						<ClayTable.Row>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
@@ -101,7 +101,8 @@ const TranslationAdminContent = ({
 						<ClayInput.GroupItem shrink>
 							<ClayDropDown
 								active={
-									creationMenuActive && availableLocales.length > 0
+									creationMenuActive &&
+									availableLocales.length > 0
 								}
 								hasLeftSymbols
 								onActiveChange={setCreationMenuActive}
@@ -119,9 +120,13 @@ const TranslationAdminContent = ({
 											<ClayDropDown.Item
 												key={availableLocale.label}
 												onClick={() => {
-													onAddLocale(availableLocale.id);
+													onAddLocale(
+														availableLocale.id
+													);
 												}}
-												symbolLeft={availableLocale.symbol}
+												symbolLeft={
+													availableLocale.symbol
+												}
 											>
 												{availableLocale.label}
 											</ClayDropDown.Item>

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -198,7 +198,9 @@
 							>
 								<%= StringUtil.replace(curLanguageId, '_', '-') %>
 
-								<span class="label label-<%= translationStatusCssClass %>"><%= translationStatus %></span>
+								<span class="dropdown-item-indicator-end w-auto">
+									<span class="label label-<%= translationStatusCssClass %>"><%= translationStatus %></span>
+								</span>
 							</liferay-util:buffer>
 
 							<liferay-ui:icon

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -223,9 +223,11 @@
 							<li aria-hidden="true" class="dropdown-divider" role="presentation"></li>
 							<li>
 								<button class="dropdown-item" id="manage-translations">
-									<svg class="lexicon-icon lexicon-icon-automatic-translate" role="presentation">
-										<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#automatic-translate" />
-									</svg>
+									<span class="inline-item inline-item-before">
+										<svg class="lexicon-icon lexicon-icon-automatic-translate" role="presentation">
+											<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#automatic-translate" />
+										</svg>
+									</span>
 
 									<span><liferay-ui:message key="manage-translations" /></span>
 								</button>

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -228,7 +228,6 @@
 											<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#automatic-translate" />
 										</svg>
 									</span>
-
 									<span><liferay-ui:message key="manage-translations" /></span>
 								</button>
 							</li>


### PR DESCRIPTION
Forwarding since encountered flaky tests:
Reviewed. Test failures are unrelated. :heavy_check_mark: 
https://github.com/liferay-frontend/liferay-portal/pull/1582#issuecomment-947558338

cc/ @tinycarol

----
### References

- [LPS-140133](https://issues.liferay.com/browse/LPS-140133)

### What is the goal?

Update TranslationAdmin to match Figma design
* Align dropdown translations status labels to the right
* Use small icon for search bar `+` sign 
* Restructure `TranslationAdminContent`:
   * Add another `ClayModal.Header` without close icon and move the search bar there
   * Fix paddings for specific components
      * The Clay team will add a border-top to `ClayModal.Body` when there's content between `ClayModal.Header` and `ClayModal.Body` so we don't need multiple `ClayModal.Header`s 


### A picture is worth a thousand words

|Where|Dropdown|Modal | Video
---|---|---|---
[Figma](https://www.figma.com/file/I1gFWSJ9gHIubnC4SsIl9h/lexi-1236-review-delete-translations?node-id=43%3A82) |<img width="395" alt="image" src="https://user-images.githubusercontent.com/6642927/137748011-34ec8854-2e02-4ad8-8202-063bc86c7eab.png"> | <img width="638" alt="image" src="https://user-images.githubusercontent.com/6642927/137738102-e0c706ea-f361-4a59-9e0c-3719e7d12343.png"> | -
Before PR | <img width="267" alt="image" src="https://user-images.githubusercontent.com/6642927/137747954-2ce06ac2-9bd4-45aa-985e-0226879344ef.png">| <img width="614" alt="image" src="https://user-images.githubusercontent.com/6642927/137739844-300ab016-5373-421b-a316-0e997e210fb7.png"> | https://user-images.githubusercontent.com/6642927/137739718-149311b9-b2f9-4296-a9bb-834b96120541.mov
After PR | <img width="261" alt="image" src="https://user-images.githubusercontent.com/6642927/137747851-5dcc3400-9186-4d21-bdbc-eca51bbe97ae.png">|<img width="628" alt="image" src="https://user-images.githubusercontent.com/6642927/137769811-072b77ef-88ce-41f0-8dc8-a9a7cbfb050f.png"> | https://user-images.githubusercontent.com/6642927/137741926-6fe24622-8b7f-425b-a94a-0d54821a1959.mov






### How to replicate
* Go to Content & Data > Web Content
* Create at least two new Basic Web Contents
* Open translation dropdown
   * See that the `Manage translations` icon's spacing is the same as the language flags
   * See that the translation statuses are now aligned to the right
* Click on `Manage translations`
   * See that the search is bar now displayed in a separate section
   * See that if you add many languages and you scroll the table, the search bar is still visible
   * See that the `+` icon to the right of the search bar is now smaller 

### Checklist

- ~~[ ] I have made corresponding changes to the documentation~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked this works in the corresponding browser