### PR TITLE
LPS-141055 re-add constructor to avoid a major baseline change in ope…

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 9.2.2
+Bundle-Version: 9.3.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/openapi/DTOProperty.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/openapi/DTOProperty.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.vulcan.openapi;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -29,6 +30,14 @@ public class DTOProperty {
 		_extensions = extensions;
 		_name = name;
 		_type = type;
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x)
+	 */
+	@Deprecated
+	public DTOProperty(String name, String type) {
+		this(new HashMap<>(), name, type);
 	}
 
 	public List<DTOProperty> getDTOProperties() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/openapi/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/openapi/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0


### PR DESCRIPTION
…napi package, that has caused problems in the past

Without the constructor OpenAPI package will bump to 2.0.0 and Vulcan to 10.0.0
