### PR TITLE
LPS-140995 search-experiences-web: Add view search container

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/build.gradle
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/build.gradle
@@ -13,9 +13,11 @@ dependencies {
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:petra:petra-portlet-url-builder")
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 	compileOnly project(":dxp:apps:search-experiences:search-experiences-api")
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/constants/SXPBlueprintWebKeys.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/constants/SXPBlueprintWebKeys.java
@@ -18,4 +18,11 @@ package com.liferay.search.experiences.web.internal.constants;
  * @author Petteri Karttunen
  */
 public class SXPBlueprintWebKeys {
+
+	public static final String VIEW_SXP_BLUEPRINTS_DISPLAY_CONTEXT =
+		"VIEW_SXP_BLUEPRINTS_DISPLAY_CONTEXT";
+
+	public static final String VIEW_SXP_ELEMENTS_DISPLAY_CONTEXT =
+		"VIEW_SXP_ELEMENTS_DISPLAY_CONTEXT";
+
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/BaseDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/BaseDisplayContext.java
@@ -39,9 +39,9 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * @author Petteri Karttunen
  */
-public abstract class ViewEntriesDisplayContext<R> {
+public abstract class BaseDisplayContext<R> {
 
-	public ViewEntriesDisplayContext(
+	public BaseDisplayContext(
 		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse) {
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewEntriesDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewEntriesDisplayContext.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.web.internal.display.context;
+
+import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.search.experiences.constants.SXPPortletKeys;
+
+import java.util.Objects;
+
+import javax.portlet.PortletException;
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Petteri Karttunen
+ */
+public abstract class ViewEntriesDisplayContext<R> {
+
+	public ViewEntriesDisplayContext(
+		LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
+
+		this.liferayPortletRequest = liferayPortletRequest;
+		this.liferayPortletResponse = liferayPortletResponse;
+
+		httpServletRequest = liferayPortletRequest.getHttpServletRequest();
+		portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
+			liferayPortletRequest);
+		tabs1 = ParamUtil.getString(
+			liferayPortletRequest, "tabs1", "sxpBlueprints");
+		themeDisplay = (ThemeDisplay)liferayPortletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	public String getDisplayStyle() {
+		String displayStyle = ParamUtil.getString(
+			liferayPortletRequest, "displayStyle");
+
+		String preferenceName = "entries-display-style-" + tabs1;
+
+		if (Validator.isNull(displayStyle)) {
+			return portalPreferences.getValue(
+				SXPPortletKeys.SXP_BLUEPRINT_ADMIN, preferenceName,
+				"descriptive");
+		}
+
+		portalPreferences.setValue(
+			SXPPortletKeys.SXP_BLUEPRINT_ADMIN, preferenceName, displayStyle);
+
+		httpServletRequest.setAttribute(
+			WebKeys.SINGLE_PAGE_APPLICATION_CLEAR_CACHE, Boolean.TRUE);
+
+		return displayStyle;
+	}
+
+	protected PortletURL getIteratorURL() {
+		return PortletURLBuilder.createRenderURL(
+			liferayPortletResponse
+		).setMVCRenderCommandName(
+			getMVCRenderCommandName()
+		).setTabs1(
+			tabs1
+		).build();
+	}
+
+	protected String getMVCRenderCommandName() {
+		if (tabs1.equals("sxpElements")) {
+			return "/sxp_blueprint_admin/view_sxp_elements";
+		}
+
+		return "/sxp_blueprint_admin/view_sxp_blueprints";
+	}
+
+	protected String getOrderByCol() {
+		return ParamUtil.getString(
+			liferayPortletRequest, "orderByCol", Field.MODIFIED_DATE);
+	}
+
+	protected String getOrderByType() {
+		String orderByType = ParamUtil.getString(
+			liferayPortletRequest, "orderByType");
+
+		if (Validator.isNotNull(orderByType)) {
+			return orderByType;
+		}
+
+		if (Objects.equals(getOrderByCol(), Field.TITLE)) {
+			return "asc";
+		}
+
+		return "desc";
+	}
+
+	protected SearchContainer<R> getSearchContainer()
+		throws PortalException, PortletException {
+
+		SearchContainer<R> searchContainer = new SearchContainer<>(
+			liferayPortletRequest, getIteratorURL(), null,
+			"no-entries-were-found");
+
+		searchContainer.setOrderByCol(getOrderByCol());
+
+		searchContainer.setOrderByType(getOrderByType());
+
+		searchContainer.setRowChecker(
+			new EmptyOnClickRowChecker(liferayPortletResponse));
+
+		return searchContainer;
+	}
+
+	protected final HttpServletRequest httpServletRequest;
+	protected final LiferayPortletRequest liferayPortletRequest;
+	protected final LiferayPortletResponse liferayPortletResponse;
+	protected final PortalPreferences portalPreferences;
+	protected final String tabs1;
+	protected final ThemeDisplay themeDisplay;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPBlueprintsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPBlueprintsDisplayContext.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.web.internal.display.context;
+
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.search.experiences.model.SXPBlueprint;
+import com.liferay.search.experiences.web.internal.security.permission.resource.SXPBlueprintEntryPermission;
+import com.liferay.search.experiences.web.internal.util.SXPBlueprintUtil;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.portlet.PortletException;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class ViewSXPBlueprintsDisplayContext
+	extends ViewEntriesDisplayContext<SXPBlueprint> {
+
+	public ViewSXPBlueprintsDisplayContext(
+		LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
+
+		super(liferayPortletRequest, liferayPortletResponse);
+	}
+
+	public List<String> getAvailableActions(SXPBlueprint sxpBlueprint)
+		throws PortalException {
+
+		if (SXPBlueprintEntryPermission.contains(
+				themeDisplay.getPermissionChecker(), sxpBlueprint,
+				ActionKeys.DELETE)) {
+
+			return Collections.singletonList("deleteEntries");
+		}
+
+		return Collections.emptyList();
+	}
+
+	public SearchContainer<SXPBlueprint> getSearchContainer()
+		throws PortalException, PortletException {
+
+		SearchContainer<SXPBlueprint> searchContainer =
+			super.getSearchContainer();
+
+		SXPBlueprintUtil.populateSXPBlueprintSearchContainer(
+			liferayPortletRequest, themeDisplay.getCompanyGroupId(),
+			WorkflowConstants.STATUS_APPROVED, searchContainer, getOrderByCol(),
+			getOrderByType());
+
+		return searchContainer;
+	}
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPBlueprintsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPBlueprintsDisplayContext.java
@@ -34,21 +34,26 @@ import java.util.List;
 
 import javax.portlet.PortletException;
 
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-
 /**
  * @author Petteri Karttunen
  */
-@Component(immediate = true, service = {})
 public class ViewSXPBlueprintsDisplayContext
 	extends BaseDisplayContext<SXPBlueprint> {
 
 	public ViewSXPBlueprintsDisplayContext(
 		LiferayPortletRequest liferayPortletRequest,
-		LiferayPortletResponse liferayPortletResponse) {
+		LiferayPortletResponse liferayPortletResponse, Queries queries,
+		Searcher searcher,
+		SearchRequestBuilderFactory searchRequestBuilderFactory, Sorts sorts,
+		SXPBlueprintService sxpBlueprintService) {
 
 		super(liferayPortletRequest, liferayPortletResponse);
+
+		_queries = queries;
+		_searcher = searcher;
+		_searchRequestBuilderFactory = searchRequestBuilderFactory;
+		_sorts = sorts;
+		_sxpBlueprintService = sxpBlueprintService;
 	}
 
 	public List<String> getAvailableActions(SXPBlueprint sxpBlueprint)
@@ -79,39 +84,10 @@ public class ViewSXPBlueprintsDisplayContext
 		return searchContainer;
 	}
 
-	@Reference(unbind = "-")
-	protected void setQueries(Queries queries) {
-		_queries = queries;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSearcher(Searcher searcher) {
-		_searcher = searcher;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSearchRequestBuilderFactory(
-		SearchRequestBuilderFactory searchRequestBuilderFactory) {
-
-		_searchRequestBuilderFactory = searchRequestBuilderFactory;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSorts(Sorts sorts) {
-		_sorts = sorts;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSXPBlueprintService(
-		SXPBlueprintService sxpBlueprintService) {
-
-		_sxpBlueprintService = sxpBlueprintService;
-	}
-
-	private Queries _queries;
-	private Searcher _searcher;
-	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
-	private Sorts _sorts;
-	private SXPBlueprintService _sxpBlueprintService;
+	private final Queries _queries;
+	private final Searcher _searcher;
+	private final SearchRequestBuilderFactory _searchRequestBuilderFactory;
+	private final Sorts _sorts;
+	private final SXPBlueprintService _sxpBlueprintService;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPBlueprintsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPBlueprintsDisplayContext.java
@@ -33,7 +33,7 @@ import javax.portlet.PortletException;
  * @author Petteri Karttunen
  */
 public class ViewSXPBlueprintsDisplayContext
-	extends ViewEntriesDisplayContext<SXPBlueprint> {
+	extends BaseDisplayContext<SXPBlueprint> {
 
 	public ViewSXPBlueprintsDisplayContext(
 		LiferayPortletRequest liferayPortletRequest,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPBlueprintsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPBlueprintsDisplayContext.java
@@ -20,7 +20,12 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.query.Queries;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.sort.Sorts;
 import com.liferay.search.experiences.model.SXPBlueprint;
+import com.liferay.search.experiences.service.SXPBlueprintService;
 import com.liferay.search.experiences.web.internal.security.permission.resource.SXPBlueprintEntryPermission;
 import com.liferay.search.experiences.web.internal.util.SXPBlueprintUtil;
 
@@ -29,9 +34,13 @@ import java.util.List;
 
 import javax.portlet.PortletException;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Petteri Karttunen
  */
+@Component(immediate = true, service = {})
 public class ViewSXPBlueprintsDisplayContext
 	extends BaseDisplayContext<SXPBlueprint> {
 
@@ -62,11 +71,47 @@ public class ViewSXPBlueprintsDisplayContext
 			super.getSearchContainer();
 
 		SXPBlueprintUtil.populateSXPBlueprintSearchContainer(
-			liferayPortletRequest, themeDisplay.getCompanyGroupId(),
-			WorkflowConstants.STATUS_APPROVED, searchContainer, getOrderByCol(),
-			getOrderByType());
+			themeDisplay.getCompanyGroupId(), getOrderByCol(), getOrderByType(),
+			liferayPortletRequest, _queries, _searcher, searchContainer,
+			_searchRequestBuilderFactory, _sorts,
+			WorkflowConstants.STATUS_APPROVED, _sxpBlueprintService);
 
 		return searchContainer;
 	}
+
+	@Reference(unbind = "-")
+	protected void setQueries(Queries queries) {
+		_queries = queries;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSearcher(Searcher searcher) {
+		_searcher = searcher;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSearchRequestBuilderFactory(
+		SearchRequestBuilderFactory searchRequestBuilderFactory) {
+
+		_searchRequestBuilderFactory = searchRequestBuilderFactory;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSorts(Sorts sorts) {
+		_sorts = sorts;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSXPBlueprintService(
+		SXPBlueprintService sxpBlueprintService) {
+
+		_sxpBlueprintService = sxpBlueprintService;
+	}
+
+	private Queries _queries;
+	private Searcher _searcher;
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+	private Sorts _sorts;
+	private SXPBlueprintService _sxpBlueprintService;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPElementsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPElementsDisplayContext.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.web.internal.display.context;
+
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.search.experiences.model.SXPElement;
+import com.liferay.search.experiences.web.internal.security.permission.resource.SXPElementEntryPermission;
+import com.liferay.search.experiences.web.internal.util.SXPBlueprintUtil;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.portlet.PortletException;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class ViewSXPElementsDisplayContext
+	extends ViewEntriesDisplayContext<SXPElement> {
+
+	public ViewSXPElementsDisplayContext(
+		LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
+
+		super(liferayPortletRequest, liferayPortletResponse);
+	}
+
+	public List<String> getAvailableActions(SXPElement sxpElement)
+		throws PortalException {
+
+		if (SXPElementEntryPermission.contains(
+				themeDisplay.getPermissionChecker(), sxpElement,
+				ActionKeys.DELETE)) {
+
+			return Collections.singletonList("deleteEntries");
+		}
+
+		return Collections.emptyList();
+	}
+
+	public SearchContainer<SXPElement> getSearchContainer()
+		throws PortalException, PortletException {
+
+		SearchContainer<SXPElement> searchContainer =
+			super.getSearchContainer();
+
+		SXPBlueprintUtil.populateSXPElementSearchContainer(
+			liferayPortletRequest, themeDisplay.getCompanyGroupId(),
+			WorkflowConstants.STATUS_ANY, searchContainer, getOrderByCol(),
+			getOrderByType());
+
+		return searchContainer;
+	}
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPElementsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPElementsDisplayContext.java
@@ -33,7 +33,7 @@ import javax.portlet.PortletException;
  * @author Petteri Karttunen
  */
 public class ViewSXPElementsDisplayContext
-	extends ViewEntriesDisplayContext<SXPElement> {
+	extends BaseDisplayContext<SXPElement> {
 
 	public ViewSXPElementsDisplayContext(
 		LiferayPortletRequest liferayPortletRequest,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPElementsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPElementsDisplayContext.java
@@ -34,21 +34,26 @@ import java.util.List;
 
 import javax.portlet.PortletException;
 
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-
 /**
  * @author Petteri Karttunen
  */
-@Component(immediate = true, service = {})
 public class ViewSXPElementsDisplayContext
 	extends BaseDisplayContext<SXPElement> {
 
 	public ViewSXPElementsDisplayContext(
 		LiferayPortletRequest liferayPortletRequest,
-		LiferayPortletResponse liferayPortletResponse) {
+		LiferayPortletResponse liferayPortletResponse, Queries queries,
+		Searcher searcher,
+		SearchRequestBuilderFactory searchRequestBuilderFactory, Sorts sorts,
+		SXPElementService sxpElementService) {
 
 		super(liferayPortletRequest, liferayPortletResponse);
+
+		_queries = queries;
+		_searcher = searcher;
+		_searchRequestBuilderFactory = searchRequestBuilderFactory;
+		_sorts = sorts;
+		_sxpElementService = sxpElementService;
 	}
 
 	public List<String> getAvailableActions(SXPElement sxpElement)
@@ -79,37 +84,10 @@ public class ViewSXPElementsDisplayContext
 		return searchContainer;
 	}
 
-	@Reference(unbind = "-")
-	protected void setQueries(Queries queries) {
-		_queries = queries;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSearcher(Searcher searcher) {
-		_searcher = searcher;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSearchRequestBuilderFactory(
-		SearchRequestBuilderFactory searchRequestBuilderFactory) {
-
-		_searchRequestBuilderFactory = searchRequestBuilderFactory;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSorts(Sorts sorts) {
-		_sorts = sorts;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSXPElementService(SXPElementService sxpElementService) {
-		_sxpElementService = sxpElementService;
-	}
-
-	private Queries _queries;
-	private Searcher _searcher;
-	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
-	private Sorts _sorts;
-	private SXPElementService _sxpElementService;
+	private final Queries _queries;
+	private final Searcher _searcher;
+	private final SearchRequestBuilderFactory _searchRequestBuilderFactory;
+	private final Sorts _sorts;
+	private final SXPElementService _sxpElementService;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPElementsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/display/context/ViewSXPElementsDisplayContext.java
@@ -20,7 +20,12 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.query.Queries;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.sort.Sorts;
 import com.liferay.search.experiences.model.SXPElement;
+import com.liferay.search.experiences.service.SXPElementService;
 import com.liferay.search.experiences.web.internal.security.permission.resource.SXPElementEntryPermission;
 import com.liferay.search.experiences.web.internal.util.SXPBlueprintUtil;
 
@@ -29,9 +34,13 @@ import java.util.List;
 
 import javax.portlet.PortletException;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Petteri Karttunen
  */
+@Component(immediate = true, service = {})
 public class ViewSXPElementsDisplayContext
 	extends BaseDisplayContext<SXPElement> {
 
@@ -62,11 +71,45 @@ public class ViewSXPElementsDisplayContext
 			super.getSearchContainer();
 
 		SXPBlueprintUtil.populateSXPElementSearchContainer(
-			liferayPortletRequest, themeDisplay.getCompanyGroupId(),
-			WorkflowConstants.STATUS_ANY, searchContainer, getOrderByCol(),
-			getOrderByType());
+			themeDisplay.getCompanyGroupId(), getOrderByCol(), getOrderByType(),
+			liferayPortletRequest, _queries, _searcher, searchContainer,
+			_searchRequestBuilderFactory, _sorts,
+			WorkflowConstants.STATUS_APPROVED, _sxpElementService);
 
 		return searchContainer;
 	}
+
+	@Reference(unbind = "-")
+	protected void setQueries(Queries queries) {
+		_queries = queries;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSearcher(Searcher searcher) {
+		_searcher = searcher;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSearchRequestBuilderFactory(
+		SearchRequestBuilderFactory searchRequestBuilderFactory) {
+
+		_searchRequestBuilderFactory = searchRequestBuilderFactory;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSorts(Sorts sorts) {
+		_sorts = sorts;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSXPElementService(SXPElementService sxpElementService) {
+		_sxpElementService = sxpElementService;
+	}
+
+	private Queries _queries;
+	private Searcher _searcher;
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+	private Sorts _sorts;
+	private SXPElementService _sxpElementService;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/portlet/action/ViewSXPBlueprintsMVCRenderCommand.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/portlet/action/ViewSXPBlueprintsMVCRenderCommand.java
@@ -15,13 +15,17 @@
 package com.liferay.search.experiences.web.internal.portlet.action;
 
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.search.experiences.constants.SXPPortletKeys;
+import com.liferay.search.experiences.web.internal.constants.SXPBlueprintWebKeys;
+import com.liferay.search.experiences.web.internal.display.context.ViewSXPBlueprintsDisplayContext;
 
 import javax.portlet.PortletException;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Petteri Karttunen
@@ -42,7 +46,25 @@ public class ViewSXPBlueprintsMVCRenderCommand implements MVCRenderCommand {
 			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws PortletException {
 
+		ViewSXPBlueprintsDisplayContext viewSXPBlueprintsDisplayContext =
+			_getViewBlueprintsDisplayContext(renderRequest, renderResponse);
+
+		renderRequest.setAttribute(
+			SXPBlueprintWebKeys.VIEW_SXP_BLUEPRINTS_DISPLAY_CONTEXT,
+			viewSXPBlueprintsDisplayContext);
+
 		return "/sxp_blueprint_admin/view.jsp";
 	}
+
+	private ViewSXPBlueprintsDisplayContext _getViewBlueprintsDisplayContext(
+		RenderRequest renderRequest, RenderResponse renderResponse) {
+
+		return new ViewSXPBlueprintsDisplayContext(
+			_portal.getLiferayPortletRequest(renderRequest),
+			_portal.getLiferayPortletResponse(renderResponse));
+	}
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/portlet/action/ViewSXPBlueprintsMVCRenderCommand.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/portlet/action/ViewSXPBlueprintsMVCRenderCommand.java
@@ -16,7 +16,12 @@ package com.liferay.search.experiences.web.internal.portlet.action;
 
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.search.query.Queries;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.sort.Sorts;
 import com.liferay.search.experiences.constants.SXPPortletKeys;
+import com.liferay.search.experiences.service.SXPBlueprintService;
 import com.liferay.search.experiences.web.internal.constants.SXPBlueprintWebKeys;
 import com.liferay.search.experiences.web.internal.display.context.ViewSXPBlueprintsDisplayContext;
 
@@ -56,15 +61,52 @@ public class ViewSXPBlueprintsMVCRenderCommand implements MVCRenderCommand {
 		return "/sxp_blueprint_admin/view.jsp";
 	}
 
+	@Reference(unbind = "-")
+	protected void setQueries(Queries queries) {
+		_queries = queries;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSearcher(Searcher searcher) {
+		_searcher = searcher;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSearchRequestBuilderFactory(
+		SearchRequestBuilderFactory searchRequestBuilderFactory) {
+
+		_searchRequestBuilderFactory = searchRequestBuilderFactory;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSorts(Sorts sorts) {
+		_sorts = sorts;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSXPBlueprintService(
+		SXPBlueprintService sxpBlueprintService) {
+
+		_sxpBlueprintService = sxpBlueprintService;
+	}
+
 	private ViewSXPBlueprintsDisplayContext _getViewBlueprintsDisplayContext(
 		RenderRequest renderRequest, RenderResponse renderResponse) {
 
 		return new ViewSXPBlueprintsDisplayContext(
 			_portal.getLiferayPortletRequest(renderRequest),
-			_portal.getLiferayPortletResponse(renderResponse));
+			_portal.getLiferayPortletResponse(renderResponse), _queries,
+			_searcher, _searchRequestBuilderFactory, _sorts,
+			_sxpBlueprintService);
 	}
 
 	@Reference
 	private Portal _portal;
+
+	private Queries _queries;
+	private Searcher _searcher;
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+	private Sorts _sorts;
+	private SXPBlueprintService _sxpBlueprintService;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/portlet/action/ViewSXPElementsMVCRenderCommand.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/portlet/action/ViewSXPElementsMVCRenderCommand.java
@@ -16,7 +16,12 @@ package com.liferay.search.experiences.web.internal.portlet.action;
 
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.search.query.Queries;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.sort.Sorts;
 import com.liferay.search.experiences.constants.SXPPortletKeys;
+import com.liferay.search.experiences.service.SXPElementService;
 import com.liferay.search.experiences.web.internal.constants.SXPBlueprintWebKeys;
 import com.liferay.search.experiences.web.internal.display.context.ViewSXPElementsDisplayContext;
 
@@ -55,15 +60,50 @@ public class ViewSXPElementsMVCRenderCommand implements MVCRenderCommand {
 		return "/sxp_blueprint_admin/view.jsp";
 	}
 
+	@Reference(unbind = "-")
+	protected void setQueries(Queries queries) {
+		_queries = queries;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSearcher(Searcher searcher) {
+		_searcher = searcher;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSearchRequestBuilderFactory(
+		SearchRequestBuilderFactory searchRequestBuilderFactory) {
+
+		_searchRequestBuilderFactory = searchRequestBuilderFactory;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSorts(Sorts sorts) {
+		_sorts = sorts;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSXPElementService(SXPElementService sxpElementService) {
+		_sxpElementService = sxpElementService;
+	}
+
 	private ViewSXPElementsDisplayContext _getViewElementsDisplayContext(
 		RenderRequest renderRequest, RenderResponse renderResponse) {
 
 		return new ViewSXPElementsDisplayContext(
 			_portal.getLiferayPortletRequest(renderRequest),
-			_portal.getLiferayPortletResponse(renderResponse));
+			_portal.getLiferayPortletResponse(renderResponse), _queries,
+			_searcher, _searchRequestBuilderFactory, _sorts,
+			_sxpElementService);
 	}
 
 	@Reference
 	private Portal _portal;
+
+	private Queries _queries;
+	private Searcher _searcher;
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+	private Sorts _sorts;
+	private SXPElementService _sxpElementService;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/portlet/action/ViewSXPElementsMVCRenderCommand.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/portlet/action/ViewSXPElementsMVCRenderCommand.java
@@ -15,13 +15,17 @@
 package com.liferay.search.experiences.web.internal.portlet.action;
 
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.search.experiences.constants.SXPPortletKeys;
+import com.liferay.search.experiences.web.internal.constants.SXPBlueprintWebKeys;
+import com.liferay.search.experiences.web.internal.display.context.ViewSXPElementsDisplayContext;
 
 import javax.portlet.PortletException;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Petteri Karttunen
@@ -41,7 +45,25 @@ public class ViewSXPElementsMVCRenderCommand implements MVCRenderCommand {
 			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws PortletException {
 
+		ViewSXPElementsDisplayContext viewSXPElementsDisplayContext =
+			_getViewElementsDisplayContext(renderRequest, renderResponse);
+
+		renderRequest.setAttribute(
+			SXPBlueprintWebKeys.VIEW_SXP_ELEMENTS_DISPLAY_CONTEXT,
+			viewSXPElementsDisplayContext);
+
 		return "/sxp_blueprint_admin/view.jsp";
 	}
+
+	private ViewSXPElementsDisplayContext _getViewElementsDisplayContext(
+		RenderRequest renderRequest, RenderResponse renderResponse) {
+
+		return new ViewSXPElementsDisplayContext(
+			_portal.getLiferayPortletRequest(renderRequest),
+			_portal.getLiferayPortletResponse(renderResponse));
+	}
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/security/permission/resource/SXPBlueprintEntryPermission.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/security/permission/resource/SXPBlueprintEntryPermission.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.web.internal.security.permission.resource;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.search.experiences.model.SXPBlueprint;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(immediate = true, service = SXPBlueprintEntryPermission.class)
+public class SXPBlueprintEntryPermission {
+
+	public static boolean contains(
+			PermissionChecker permissionChecker, long entryId, String actionKey)
+		throws PortalException {
+
+		return _sxpBlueprintEntryModelResourcePermission.contains(
+			permissionChecker, entryId, actionKey);
+	}
+
+	public static boolean contains(
+			PermissionChecker permissionChecker, SXPBlueprint entry,
+			String actionKey)
+		throws PortalException {
+
+		return _sxpBlueprintEntryModelResourcePermission.contains(
+			permissionChecker, entry, actionKey);
+	}
+
+	@Reference(
+		target = "(model.class.name=com.liferay.search.experiences.model.SXPBlueprint)",
+		unbind = "-"
+	)
+	protected void setEntryModelPermission(
+		ModelResourcePermission<SXPBlueprint> modelResourcePermission) {
+
+		_sxpBlueprintEntryModelResourcePermission = modelResourcePermission;
+	}
+
+	private static ModelResourcePermission<SXPBlueprint>
+		_sxpBlueprintEntryModelResourcePermission;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/security/permission/resource/SXPElementEntryPermission.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/security/permission/resource/SXPElementEntryPermission.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.web.internal.security.permission.resource;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.search.experiences.model.SXPElement;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(immediate = true, service = SXPElementEntryPermission.class)
+public class SXPElementEntryPermission {
+
+	public static boolean contains(
+			PermissionChecker permissionChecker, long entryId, String actionKey)
+		throws PortalException {
+
+		return _sxpElementEntryModelResourcePermission.contains(
+			permissionChecker, entryId, actionKey);
+	}
+
+	public static boolean contains(
+			PermissionChecker permissionChecker, SXPElement entry,
+			String actionKey)
+		throws PortalException {
+
+		return _sxpElementEntryModelResourcePermission.contains(
+			permissionChecker, entry, actionKey);
+	}
+
+	@Reference(
+		target = "(model.class.name=com.liferay.search.experiences.model.SXPElement)",
+		unbind = "-"
+	)
+	protected void setEntryModelPermission(
+		ModelResourcePermission<SXPElement> modelResourcePermission) {
+
+		_sxpElementEntryModelResourcePermission = modelResourcePermission;
+	}
+
+	private static ModelResourcePermission<SXPElement>
+		_sxpElementEntryModelResourcePermission;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/util/SXPBlueprintUtil.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/util/SXPBlueprintUtil.java
@@ -1,0 +1,416 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.web.internal.util;
+
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.query.BooleanQuery;
+import com.liferay.portal.search.query.Queries;
+import com.liferay.portal.search.query.Query;
+import com.liferay.portal.search.query.TermQuery;
+import com.liferay.portal.search.searcher.SearchRequest;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.sort.Sort;
+import com.liferay.portal.search.sort.SortOrder;
+import com.liferay.portal.search.sort.Sorts;
+import com.liferay.search.experiences.model.SXPBlueprint;
+import com.liferay.search.experiences.model.SXPElement;
+import com.liferay.search.experiences.service.SXPBlueprintService;
+import com.liferay.search.experiences.service.SXPElementService;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.portlet.PortletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(immediate = true, service = {})
+public class SXPBlueprintUtil {
+
+	public static void populateSXPBlueprintSearchContainer(
+		PortletRequest portletRequest, long groupId, int status,
+		SearchContainer<SXPBlueprint> searchContainer, String orderByCol,
+		String orderByType) {
+
+		_populateSXPBlueprintSearchContainer(
+			portletRequest, groupId, status, searchContainer, orderByCol,
+			orderByType);
+	}
+
+	public static void populateSXPElementSearchContainer(
+		PortletRequest portletRequest, long groupId, int status,
+		SearchContainer<SXPElement> searchContainer, String orderByCol,
+		String orderByType) {
+
+		_populateSXPElementSearchContainer(
+			portletRequest, groupId, status, searchContainer, orderByCol,
+			orderByType);
+	}
+
+	@Reference(unbind = "-")
+	protected void setQueries(Queries queries) {
+		_queries = queries;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSearcher(Searcher searcher) {
+		_searcher = searcher;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSearchRequestBuilderFactory(
+		SearchRequestBuilderFactory searchRequestBuilderFactory) {
+
+		_searchRequestBuilderFactory = searchRequestBuilderFactory;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSorts(Sorts sorts) {
+		_sorts = sorts;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSXPBlueprintService(
+		SXPBlueprintService sxpBlueprintService) {
+
+		_sxpSXPBlueprintService = sxpBlueprintService;
+	}
+
+	@Reference(unbind = "-")
+	protected void setSXPElementService(SXPElementService sxpElementService) {
+		_sxpElementService = sxpElementService;
+	}
+
+	private static void _addGroupFilterClause(
+		BooleanQuery booleanQuery, long groupId) {
+
+		TermQuery groupQuery = _queries.term(Field.GROUP_ID, groupId);
+
+		booleanQuery.addFilterQueryClauses(groupQuery);
+	}
+
+	private static void _addReadOnlyFilterClause(
+		BooleanQuery booleanQuery, PortletRequest portletRequest) {
+
+		if (!Validator.isBlank(
+				ParamUtil.getString(portletRequest, "readOnly"))) {
+
+			booleanQuery.addFilterQueryClauses(
+				_queries.term(
+					"readOnly",
+					ParamUtil.getBoolean(portletRequest, "readOnly")));
+		}
+	}
+
+	private static void _addSearchClauses(
+		BooleanQuery booleanQuery, String keywords, String languageId) {
+
+		if (Validator.isBlank(keywords)) {
+			booleanQuery.addMustQueryClauses(_queries.matchAll());
+		}
+		else {
+			booleanQuery.addMustQueryClauses(
+				_queries.multiMatch(keywords, _getSearchFields(languageId)));
+		}
+	}
+
+	private static void _addStatusFilterClause(
+		BooleanQuery booleanQuery, int status) {
+
+		booleanQuery.addFilterQueryClauses(_queries.term(Field.STATUS, status));
+	}
+
+	private static void _addVisibilityFilterClause(
+		BooleanQuery booleanQuery, PortletRequest portletRequest) {
+
+		if (ParamUtil.getString(portletRequest, "hidden") != null) {
+			booleanQuery.addFilterQueryClauses(
+				_queries.term(
+					"hidden", ParamUtil.getBoolean(portletRequest, "hidden")));
+		}
+	}
+
+	private static SearchRequest _createElementSearchRequest(
+		PortletRequest portletRequest, long groupId, int status, int type,
+		int start, int size, String orderByCol, String orderByType) {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		String languageId = themeDisplay.getLanguageId();
+
+		return _searchRequestBuilderFactory.builder(
+		).companyId(
+			themeDisplay.getCompanyId()
+		).from(
+			start
+		).modelIndexerClasses(
+			SXPElement.class
+		).query(
+			_getSXPElementSearchQuery(
+				portletRequest, type, groupId, status, languageId)
+		).size(
+			size
+		).addSort(
+			_getSort(orderByCol, orderByType, languageId)
+		).build();
+	}
+
+	private static SearchRequest _createSXPBlueprintSearchRequest(
+		PortletRequest portletRequest, long groupId, int status, int start,
+		int size, String orderByCol, String orderByType) {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		String languageId = themeDisplay.getLanguageId();
+
+		return _searchRequestBuilderFactory.builder(
+		).companyId(
+			themeDisplay.getCompanyId()
+		).from(
+			start
+		).modelIndexerClasses(
+			SXPBlueprint.class
+		).query(
+			_getSXPBlueprintSearchQuery(
+				ParamUtil.getString(portletRequest, "keywords"), groupId,
+				status, languageId)
+		).size(
+			size
+		).addSort(
+			_getSort(orderByCol, orderByType, languageId)
+		).build();
+	}
+
+	private static long _getEntryClassPK(SearchHit searchHit) {
+		Document document = searchHit.getDocument();
+
+		return document.getLong(Field.ENTRY_CLASS_PK);
+	}
+
+	private static Set<String> _getSearchFields(String languageId) {
+		Set<String> fields = new HashSet<>();
+
+		fields.add(_getTitleField(languageId));
+		fields.add(
+			LocalizationUtil.getLocalizedName(Field.DESCRIPTION, languageId));
+
+		return fields;
+	}
+
+	private static Sort _getSort(
+		String orderByCol, String orderByType, String languageId) {
+
+		SortOrder sortOrder = SortOrder.ASC;
+
+		if (orderByType.equals("desc")) {
+			sortOrder = SortOrder.DESC;
+		}
+
+		if (Objects.equals(orderByCol, Field.TITLE)) {
+			return _sorts.field(
+				_getTitleField(languageId) + "_String_sortable", sortOrder);
+		}
+
+		return _sorts.field(orderByCol, sortOrder);
+	}
+
+	private static Query _getSXPBlueprintSearchQuery(
+		String keywords, long groupId, int status, String languageId) {
+
+		BooleanQuery booleanQuery = _queries.booleanQuery();
+
+		_addGroupFilterClause(booleanQuery, groupId);
+
+		_addStatusFilterClause(booleanQuery, status);
+
+		_addSearchClauses(booleanQuery, keywords, languageId);
+
+		return booleanQuery;
+	}
+
+	private static Query _getSXPElementSearchQuery(
+		PortletRequest portletRequest, long type, long groupId, int status,
+		String languageId) {
+
+		BooleanQuery booleanQuery = _queries.booleanQuery();
+
+		_addGroupFilterClause(booleanQuery, groupId);
+
+		if (type > 0) {
+			booleanQuery.addFilterQueryClauses(_queries.term(Field.TYPE, type));
+		}
+
+		if (status != WorkflowConstants.STATUS_ANY) {
+			_addStatusFilterClause(booleanQuery, status);
+		}
+
+		_addVisibilityFilterClause(booleanQuery, portletRequest);
+
+		_addReadOnlyFilterClause(booleanQuery, portletRequest);
+
+		_addSearchClauses(
+			booleanQuery, ParamUtil.getString(portletRequest, "keywords"),
+			languageId);
+
+		return booleanQuery;
+	}
+
+	private static String _getTitleField(String languageId) {
+		return LocalizationUtil.getLocalizedName(
+			"localized_" + Field.TITLE, languageId);
+	}
+
+	private static void _populateSXPBlueprintSearchContainer(
+		PortletRequest portletRequest, long groupId, int status,
+		SearchContainer<SXPBlueprint> searchContainer, String orderByCol,
+		String orderByType) {
+
+		SearchRequest searchRequest = _createSXPBlueprintSearchRequest(
+			portletRequest, groupId, status, searchContainer.getStart(),
+			searchContainer.getDelta(), orderByCol, orderByType);
+
+		SearchResponse searchResponse = _searcher.search(searchRequest);
+
+		SearchHits searchHits = searchResponse.getSearchHits();
+
+		searchContainer.setTotal(
+			GetterUtil.getInteger(searchHits.getTotalHits()));
+
+		List<SearchHit> hits = searchHits.getSearchHits();
+
+		Stream<SearchHit> stream = hits.stream();
+
+		searchContainer.setResults(
+			stream.map(
+				searchHit -> _toSXPBlueprintOptional(searchHit)
+			).filter(
+				Optional::isPresent
+			).map(
+				Optional::get
+			).collect(
+				Collectors.toList()
+			));
+	}
+
+	private static void _populateSXPElementSearchContainer(
+		PortletRequest portletRequest, long groupId, int status,
+		SearchContainer<SXPElement> searchContainer, String orderByCol,
+		String orderByType) {
+
+		SearchRequest searchRequest = _createElementSearchRequest(
+			portletRequest, groupId, status,
+			ParamUtil.getInteger(portletRequest, "sxpElementType"),
+			searchContainer.getStart(), searchContainer.getDelta(), orderByCol,
+			orderByType);
+
+		SearchResponse searchResponse = _searcher.search(searchRequest);
+
+		SearchHits searchHits = searchResponse.getSearchHits();
+
+		searchContainer.setTotal(
+			GetterUtil.getInteger(searchHits.getTotalHits()));
+
+		List<SearchHit> hits = searchHits.getSearchHits();
+
+		Stream<SearchHit> stream = hits.stream();
+
+		searchContainer.setResults(
+			stream.map(
+				searchHit -> _toSXPElementOptional(searchHit)
+			).filter(
+				Optional::isPresent
+			).map(
+				Optional::get
+			).collect(
+				Collectors.toList()
+			));
+	}
+
+	private static Optional<SXPBlueprint> _toSXPBlueprintOptional(
+		SearchHit searchHit) {
+
+		long entryClassPK = _getEntryClassPK(searchHit);
+
+		try {
+			return Optional.of(
+				_sxpSXPBlueprintService.getSXPBlueprint(entryClassPK));
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Search index is stale and contains a non-existent " +
+						"SXPBlueprint entry " + entryClassPK);
+			}
+		}
+
+		return Optional.empty();
+	}
+
+	private static Optional<SXPElement> _toSXPElementOptional(
+		SearchHit searchHit) {
+
+		long entryClassPK = _getEntryClassPK(searchHit);
+
+		try {
+			return Optional.of(_sxpElementService.getSXPElement(entryClassPK));
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Search index is stale and contains a non-existent " +
+						"SXPElement entry " + entryClassPK);
+			}
+		}
+
+		return Optional.empty();
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SXPBlueprintUtil.class);
+
+	private static Queries _queries;
+	private static Searcher _searcher;
+	private static SearchRequestBuilderFactory _searchRequestBuilderFactory;
+	private static Sorts _sorts;
+	private static SXPElementService _sxpElementService;
+	private static SXPBlueprintService _sxpSXPBlueprintService;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/init.jsp
@@ -18,14 +18,35 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+taglib uri="http://liferay.com/tld/security" prefix="liferay-security" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.JSPNavigationItemList" %><%@
+page import="com.liferay.petra.string.StringPool" %><%@
+page import="com.liferay.portal.kernel.dao.search.ResultRow" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
-page import="com.liferay.portal.kernel.util.ParamUtil" %>
+page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
+page import="com.liferay.portal.kernel.security.permission.ActionKeys" %><%@
+page import="com.liferay.portal.kernel.util.Constants" %><%@
+page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
+page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
+page import="com.liferay.portal.kernel.util.Validator" %><%@
+page import="com.liferay.portal.kernel.util.WebKeys" %><%@
+page import="com.liferay.search.experiences.constants.SXPActionKeys" %><%@
+page import="com.liferay.search.experiences.model.SXPBlueprint" %><%@
+page import="com.liferay.search.experiences.model.SXPElement" %><%@
+page import="com.liferay.search.experiences.web.internal.constants.SXPBlueprintWebKeys" %><%@
+page import="com.liferay.search.experiences.web.internal.display.context.ViewSXPBlueprintsDisplayContext" %><%@
+page import="com.liferay.search.experiences.web.internal.display.context.ViewSXPElementsDisplayContext" %><%@
+page import="com.liferay.search.experiences.web.internal.security.permission.resource.SXPBlueprintEntryPermission" %><%@
+page import="com.liferay.search.experiences.web.internal.security.permission.resource.SXPElementEntryPermission" %>
+
+<%@ page import="java.util.Date" %>
 
 <liferay-frontend:defineObjects />
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/sxp_blueprint_actions.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/sxp_blueprint_actions.jsp
@@ -1,0 +1,97 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+ResultRow row = (ResultRow)request.getAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
+
+SXPBlueprint sxpBlueprint = (SXPBlueprint)row.getObject();
+
+long sxpBlueprintId = sxpBlueprint.getSXPBlueprintId();
+%>
+
+<liferay-ui:icon-menu
+	direction="left-side"
+	icon="<%= StringPool.BLANK %>"
+	markupView="lexicon"
+	message="<%= StringPool.BLANK %>"
+	showWhenSingleIcon="<%= true %>"
+>
+	<c:if test="<%= SXPBlueprintEntryPermission.contains(permissionChecker, sxpBlueprint, ActionKeys.UPDATE) %>">
+		<portlet:renderURL var="editEntryURL">
+			<portlet:param name="mvcRenderCommandName" value="/sxp_blueprint_admin/edit_sxp_blueprint" />
+			<portlet:param name="redirect" value="<%= currentURL %>" />
+			<portlet:param name="sxpBlueprintId" value="<%= String.valueOf(sxpBlueprintId) %>" />
+		</portlet:renderURL>
+
+		<liferay-ui:icon
+			message="edit"
+			url="<%= editEntryURL %>"
+		/>
+	</c:if>
+
+	<c:if test="<%= SXPBlueprintEntryPermission.contains(permissionChecker, themeDisplay.getCompanyGroupId(), SXPActionKeys.ADD_SXP_BLUEPRINT) %>">
+		<portlet:actionURL name="/sxp_blueprint_admin/copy_sxp_blueprint" var="copyEntryURL">
+			<portlet:param name="redirect" value="<%= currentURL %>" />
+			<portlet:param name="sxpBlueprintId" value="<%= String.valueOf(sxpBlueprintId) %>" />
+		</portlet:actionURL>
+
+		<liferay-ui:icon
+			message="copy"
+			url="<%= copyEntryURL %>"
+		/>
+	</c:if>
+
+	<portlet:resourceURL id="/sxp_blueprint_admin/export_sxp_blueprint" var="exportEntryURL">
+		<portlet:param name="redirect" value="<%= currentURL %>" />
+		<portlet:param name="sxpBlueprintId" value="<%= String.valueOf(sxpBlueprintId) %>" />
+	</portlet:resourceURL>
+
+	<liferay-ui:icon
+		message="export"
+		url="<%= exportEntryURL %>"
+	/>
+
+	<c:if test="<%= SXPBlueprintEntryPermission.contains(permissionChecker, themeDisplay.getCompanyGroupId(), ActionKeys.PERMISSIONS) %>">
+		<liferay-security:permissionsURL
+			modelResource="<%= SXPBlueprint.class.getName() %>"
+			modelResourceDescription="<%= sxpBlueprint.getTitle(locale) %>"
+			resourcePrimKey="<%= String.valueOf(sxpBlueprintId) %>"
+			var="permissionsURL"
+			windowState="<%= LiferayWindowState.POP_UP.toString() %>"
+		/>
+
+		<liferay-ui:icon
+			label="<%= true %>"
+			message="permissions"
+			method="get"
+			url="<%= permissionsURL %>"
+			useDialog="<%= true %>"
+		/>
+	</c:if>
+
+	<c:if test="<%= SXPBlueprintEntryPermission.contains(permissionChecker, sxpBlueprint, ActionKeys.DELETE) %>">
+		<portlet:actionURL name="/sxp_blueprint_admin/delete_sxp_blueprint" var="deleteEntryURL">
+			<portlet:param name="redirect" value="<%= currentURL %>" />
+			<portlet:param name="sxpBlueprintId" value="<%= String.valueOf(sxpBlueprintId) %>" />
+		</portlet:actionURL>
+
+		<liferay-ui:icon-delete
+			url="<%= deleteEntryURL %>"
+		/>
+	</c:if>
+</liferay-ui:icon-menu>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/sxp_blueprint_search_columns.jspf
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/sxp_blueprint_search_columns.jspf
@@ -1,0 +1,150 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+--%>
+
+<portlet:renderURL var="editEntryURL">
+	<portlet:param name="mvcRenderCommandName" value="/sxp_blueprint_admin/edit_sxp_blueprints" />
+	<portlet:param name="redirect" value="<%= currentURL %>" />
+	<portlet:param name="sxpBlueprintId" value="<%= String.valueOf(entry.getSXPBlueprintId()) %>" />
+</portlet:renderURL>
+
+<%
+String entryTitle = entry.getTitle(locale);
+String entryDescription = entry.getDescription(locale);
+
+String[] languageIds = entry.getAvailableLanguageIds();
+
+for (int i = 0; Validator.isNull(entryTitle) && (i < languageIds.length); i++) {
+	entryTitle = entry.getTitle(languageIds[i]);
+	entryDescription = entry.getDescription(languageIds[i]);
+}
+%>
+
+<c:choose>
+	<c:when test='<%= viewSXPBlueprintsDisplayContext.getDisplayStyle().equals("descriptive") %>'>
+		<liferay-ui:search-container-column-user
+			showDetails="<%= false %>"
+			userId="<%= entry.getUserId() %>"
+		/>
+
+		<liferay-ui:search-container-column-text
+			colspan="<%= 2 %>"
+		>
+			<c:choose>
+				<c:when test="<%= SXPBlueprintEntryPermission.contains(permissionChecker, entry, ActionKeys.UPDATE) %>">
+					<h4>
+						<aui:a href="<%= editEntryURL %>">
+							<%= HtmlUtil.escape(entryTitle) %>
+						</aui:a>
+					</h4>
+				</c:when>
+				<c:otherwise>
+					<h4>
+						<%= HtmlUtil.escape(entryTitle) %>
+					</h4>
+				</c:otherwise>
+			</c:choose>
+
+			<h5 class="text-default text-truncate-inline" title="<%= HtmlUtil.escape(entryDescription) %>">
+				<%= (entryDescription.length() > 300) ? HtmlUtil.escape(entryDescription.substring(0, 300).concat("...")) : HtmlUtil.escape(entryDescription) %>
+			</h5>
+
+			<%
+			Date modified = entry.getModifiedDate();
+			%>
+
+			<h5 class="text-default text-truncate">
+				<span class="id-text">
+					<liferay-ui:message arguments="<%= String.valueOf(entry.getSXPBlueprintId()) %>" key="id-x" />
+				</span>
+				<span class="id-text">
+					<liferay-ui:message arguments='<%= (themeDisplay.getDefaultUserId() == entry.getUserId()) ? "system" : entry.getUserName() %>' key="created-by-x" />
+				</span>
+				<span class="id-text">
+					<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modified.getTime(), true) %>" key="modified-x-ago" />
+				</span>
+			</h5>
+		</liferay-ui:search-container-column-text>
+
+		<liferay-ui:search-container-column-jsp
+			path="/sxp_blueprint_actions.jsp"
+		/>
+	</c:when>
+	<c:otherwise>
+		<c:choose>
+			<c:when test="<%= SXPBlueprintEntryPermission.contains(permissionChecker, entry, ActionKeys.UPDATE) %>">
+				<liferay-ui:search-container-column-text
+					cssClass="table-cell-expand table-cell-minw-200 table-title"
+					href="<%= editEntryURL %>"
+					name="title"
+					value="<%= HtmlUtil.escape(entryTitle) %>"
+				/>
+
+				<liferay-ui:search-container-column-text
+					cssClass="table-cell-expand table-cell-minw-200"
+					name="description"
+					value="<%= HtmlUtil.escape(entryDescription) %>"
+				/>
+
+				<liferay-ui:search-container-column-text
+					href="<%= editEntryURL %>"
+					name="id"
+					value="<%= String.valueOf(entry.getSXPBlueprintId()) %>"
+				/>
+			</c:when>
+			<c:otherwise>
+				<liferay-ui:search-container-column-text
+					cssClass="table-cell-expand table-cell-minw-200 table-title"
+					name="title"
+					value="<%= HtmlUtil.escape(entryTitle) %>"
+				/>
+
+				<liferay-ui:search-container-column-text
+					cssClass="table-cell-expand table-cell-minw-200"
+					name="description"
+					value="<%= HtmlUtil.escape(entryDescription) %>"
+				/>
+
+				<liferay-ui:search-container-column-text
+					name="id"
+					value="<%= String.valueOf(entry.getSXPBlueprintId()) %>"
+				/>
+			</c:otherwise>
+		</c:choose>
+
+		<liferay-ui:search-container-column-user
+			name="author"
+			showDetails="<%= false %>"
+			userId="<%= entry.getUserId() %>"
+		/>
+
+		<liferay-ui:search-container-column-date
+			cssClass="table-cell-minw-150"
+			name="created"
+			property="createDate"
+		/>
+
+		<liferay-ui:search-container-column-date
+			cssClass="table-cell-minw-150"
+			name="modified"
+			property="modifiedDate"
+		/>
+
+		<liferay-ui:search-container-column-jsp
+			name="actions"
+			path="/sxp_blueprint_admin/sxp_blueprint_actions.jsp"
+		/>
+	</c:otherwise>
+</c:choose>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/sxp_element_actions.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/sxp_element_actions.jsp
@@ -1,0 +1,113 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+ResultRow row = (ResultRow)request.getAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
+
+SXPElement sxpElement = (SXPElement)row.getObject();
+
+long sxpElementId = sxpElement.getSXPElementId();
+
+long companyGroupId = themeDisplay.getCompanyGroupId();
+%>
+
+<liferay-ui:icon-menu
+	direction="left-side"
+	icon="<%= StringPool.BLANK %>"
+	markupView="lexicon"
+	message="<%= StringPool.BLANK %>"
+	showWhenSingleIcon="<%= true %>"
+>
+	<c:if test="<%= SXPElementEntryPermission.contains(permissionChecker, sxpElement, ActionKeys.UPDATE) %>">
+		<portlet:renderURL var="editEntryURL">
+			<portlet:param name="mvcRenderCommandName" value="/sxp_blueprint_admin/edit_sxp_element" />
+			<portlet:param name="redirect" value="<%= currentURL %>" />
+			<portlet:param name="sxpElementId" value="<%= String.valueOf(sxpElementId) %>" />
+		</portlet:renderURL>
+
+		<liferay-ui:icon
+			message='<%= sxpElement.getReadOnly() ? "view" : "edit" %>'
+			url="<%= editEntryURL %>"
+		/>
+	</c:if>
+
+	<c:if test="<%= SXPElementEntryPermission.contains(permissionChecker, companyGroupId, SXPActionKeys.ADD_SXP_ELEMENT) %>">
+		<portlet:actionURL name="/sxp_blueprint_admin/copy_sxp_element" var="copyEntryURL">
+			<portlet:param name="redirect" value="<%= currentURL %>" />
+			<portlet:param name="sxpElementId" value="<%= String.valueOf(sxpElementId) %>" />
+		</portlet:actionURL>
+
+		<liferay-ui:icon
+			message="copy"
+			url="<%= copyEntryURL %>"
+		/>
+	</c:if>
+
+	<portlet:resourceURL id="/sxp_blueprint_admin/export_sxp_element" var="exportEntryURL">
+		<portlet:param name="redirect" value="<%= currentURL %>" />
+		<portlet:param name="sxpElementId" value="<%= String.valueOf(sxpElementId) %>" />
+	</portlet:resourceURL>
+
+	<liferay-ui:icon
+		message="export"
+		url="<%= exportEntryURL %>"
+	/>
+
+	<c:if test="<%= SXPElementEntryPermission.contains(permissionChecker, companyGroupId, ActionKeys.PERMISSIONS) %>">
+		<liferay-security:permissionsURL
+			modelResource="<%= SXPElement.class.getName() %>"
+			modelResourceDescription="<%= sxpElement.getTitle(locale) %>"
+			resourcePrimKey="<%= String.valueOf(sxpElementId) %>"
+			var="permissionsURL"
+			windowState="<%= LiferayWindowState.POP_UP.toString() %>"
+		/>
+
+		<liferay-ui:icon
+			label="<%= true %>"
+			message="permissions"
+			method="get"
+			url="<%= permissionsURL %>"
+			useDialog="<%= true %>"
+		/>
+	</c:if>
+
+	<c:if test="<%= SXPElementEntryPermission.contains(permissionChecker, sxpElement, ActionKeys.UPDATE) %>">
+		<portlet:actionURL name="/sxp_blueprint_admin/edit_sxp_element" var="hideEntryURL">
+			<portlet:param name="redirect" value="<%= currentURL %>" />
+			<portlet:param name="sxpElementId" value="<%= String.valueOf(sxpElementId) %>" />
+			<portlet:param name="<%= Constants.CMD %>" value="hide" />
+			<portlet:param name="hidden" value="<%= String.valueOf(!sxpElement.getHidden()) %>" />
+		</portlet:actionURL>
+
+		<liferay-ui:icon
+			message='<%= sxpElement.getHidden() ? "show" : "hide" %>'
+			url="<%= hideEntryURL %>"
+		/>
+	</c:if>
+
+	<c:if test="<%= SXPElementEntryPermission.contains(permissionChecker, sxpElement, ActionKeys.DELETE) && !sxpElement.getReadOnly() %>">
+		<portlet:actionURL name="/sxp_blueprint_admin/element_sxp_element" var="deleteEntryURL">
+			<portlet:param name="redirect" value="<%= currentURL %>" />
+			<portlet:param name="sxpElementId" value="<%= String.valueOf(sxpElementId) %>" />
+		</portlet:actionURL>
+
+		<liferay-ui:icon-delete
+			url="<%= deleteEntryURL %>"
+		/>
+	</c:if>
+</liferay-ui:icon-menu>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/sxp_element_search_columns.jspf
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/sxp_element_search_columns.jspf
@@ -1,0 +1,138 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+--%>
+
+<portlet:renderURL var="editEntryURL">
+	<portlet:param name="mvcRenderCommandName" value="/sxp_blueprint_admin/edit_sxp_element" />
+	<portlet:param name="redirect" value="<%= currentURL %>" />
+	<portlet:param name="sxpElementId" value="<%= String.valueOf(entry.getSXPElementId()) %>" />
+</portlet:renderURL>
+
+<%
+String entryTitle = entry.getTitle(locale);
+String entryDescription = entry.getDescription(locale);
+
+String[] languageIds = entry.getAvailableLanguageIds();
+
+for (int i = 0; Validator.isNull(entryTitle) && (i < languageIds.length); i++) {
+	entryTitle = entry.getTitle(languageIds[i]);
+	entryDescription = entry.getDescription(languageIds[i]);
+}
+%>
+
+<c:choose>
+	<c:when test='<%= viewSXPElementsDisplayContext.getDisplayStyle().equals("descriptive") %>'>
+		<liferay-ui:search-container-column-text
+			colspan="<%= 2 %>"
+		>
+			<h4>
+				<c:choose>
+					<c:when test="<%= SXPElementEntryPermission.contains(permissionChecker, entry, ActionKeys.UPDATE) %>">
+						<aui:a href="<%= editEntryURL %>">
+							<%= HtmlUtil.escape(entryTitle) %>
+						</aui:a>
+					</c:when>
+					<c:otherwise>
+						<%= HtmlUtil.escape(entryTitle) %>
+					</c:otherwise>
+				</c:choose>
+
+				<c:if test="<%= entry.getReadOnly() %>">
+					<liferay-ui:icon
+						icon="lock"
+						iconCssClass="ml-1 text-muted"
+						markupView="lexicon"
+						message="read-only"
+					/>
+				</c:if>
+			</h4>
+
+			<h5 class="text-default text-truncate" title="<%= HtmlUtil.escape(entryDescription) %>">
+				<%= HtmlUtil.escape(entryDescription) %>
+			</h5>
+
+			<h5 class="text-default text-truncate">
+				<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - entry.getModifiedDate().getTime(), true) %>" key="modified-x-ago" />
+			</h5>
+		</liferay-ui:search-container-column-text>
+
+		<liferay-ui:search-container-column-jsp
+			path="/sxp_element_actions.jsp"
+		/>
+	</c:when>
+	<c:otherwise>
+		<liferay-ui:search-container-column-text
+			cssClass="table-cell-expand table-cell-minw-200 table-title"
+			name="title"
+		>
+			<c:choose>
+				<c:when test="<%= SXPElementEntryPermission.contains(permissionChecker, entry, ActionKeys.UPDATE) %>">
+					<aui:a href="<%= editEntryURL %>">
+						<%= HtmlUtil.escape(entryTitle) %>
+
+						<c:if test="<%= entry.getReadOnly() %>">
+							<liferay-ui:icon
+								icon="lock"
+								iconCssClass="ml-1 text-muted"
+								markupView="lexicon"
+								message="read-only"
+							/>
+						</c:if>
+					</aui:a>
+				</c:when>
+				<c:otherwise>
+					<%= HtmlUtil.escape(entryTitle) %>
+
+					<c:if test="<%= entry.getReadOnly() %>">
+						<liferay-ui:icon
+							icon="lock"
+							iconCssClass="ml-1 text-muted"
+							markupView="lexicon"
+							message="read-only"
+						/>
+					</c:if>
+				</c:otherwise>
+			</c:choose>
+		</liferay-ui:search-container-column-text>
+
+		<liferay-ui:search-container-column-text
+			cssClass="table-cell-expand table-cell-minw-200"
+			name="description"
+			value="<%= HtmlUtil.escape(entryDescription) %>"
+		/>
+
+		<liferay-ui:search-container-column-user
+			name="author"
+			showDetails="<%= false %>"
+			userId="<%= entry.getUserId() %>"
+		/>
+
+		<liferay-ui:search-container-column-date
+			cssClass="table-cell-minw-150"
+			name="created"
+			property="createDate"
+		/>
+
+		<liferay-ui:search-container-column-date
+			cssClass="table-cell-minw-150"
+			name="modified"
+			property="modifiedDate"
+		/>
+
+		<liferay-ui:search-container-column-jsp
+			path="/sxp_blueprint_admin/sxp_element_actions.jsp"
+		/>
+	</c:otherwise>
+</c:choose>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/view_sxp_blueprints.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/view_sxp_blueprints.jsp
@@ -15,3 +15,32 @@
 --%>
 
 <%@ include file="/init.jsp" %>
+
+<%
+ViewSXPBlueprintsDisplayContext viewSXPBlueprintsDisplayContext = (ViewSXPBlueprintsDisplayContext)request.getAttribute(SXPBlueprintWebKeys.VIEW_SXP_BLUEPRINTS_DISPLAY_CONTEXT);
+%>
+
+<clay:container-fluid>
+	<aui:form method="post" name="fm">
+		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+
+		<liferay-ui:search-container
+			cssClass="sxp-blueprints-search-container"
+			id="sxpBlueprintEntries"
+			searchContainer="<%= viewSXPBlueprintsDisplayContext.getSearchContainer() %>"
+		>
+			<liferay-ui:search-container-row
+				className="com.liferay.search.experiences.model.SXPBlueprint"
+				keyProperty="sxpBlueprintId"
+				modelVar="entry"
+			>
+				<%@ include file="/sxp_blueprint_admin/sxp_blueprint_search_columns.jspf" %>
+			</liferay-ui:search-container-row>
+
+			<liferay-ui:search-iterator
+				displayStyle="<%= viewSXPBlueprintsDisplayContext.getDisplayStyle() %>"
+				markupView="lexicon"
+			/>
+		</liferay-ui:search-container>
+	</aui:form>
+</clay:container-fluid>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/view_sxp_elements.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/view_sxp_elements.jsp
@@ -15,3 +15,32 @@
 --%>
 
 <%@ include file="/init.jsp" %>
+
+<%
+ViewSXPElementsDisplayContext viewSXPElementsDisplayContext = (ViewSXPElementsDisplayContext)request.getAttribute(SXPBlueprintWebKeys.VIEW_SXP_ELEMENTS_DISPLAY_CONTEXT);
+%>
+
+<clay:container-fluid>
+	<aui:form method="post" name="fm">
+		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+
+		<liferay-ui:search-container
+			cssClass="blueprints-search-container"
+			id="sxpElementEntries"
+			searchContainer="<%= viewSXPElementsDisplayContext.getSearchContainer() %>"
+		>
+			<liferay-ui:search-container-row
+				className="com.liferay.search.experiences.model.SXPElement"
+				keyProperty="sxpElementId"
+				modelVar="entry"
+			>
+				<%@ include file="/sxp_blueprint_admin/sxp_element_search_columns.jspf" %>
+			</liferay-ui:search-container-row>
+
+			<liferay-ui:search-iterator
+				displayStyle="<%= viewSXPElementsDisplayContext.getDisplayStyle() %>"
+				markupView="lexicon"
+			/>
+		</liferay-ui:search-container>
+	</aui:form>
+</clay:container-fluid>


### PR DESCRIPTION
Updated with:

- Renaming `ViewEntriesDisplayContext` to `BaseDisplayContext`
- Moving `@Reference` out of `SXPBlueprintUtil.java`

As a note, when I moved the `@Reference` to the Display Context, the `@Reference` values were returning null and I was getting the errors:
```
Constructor with 0 arguments not found. Component will fail.
```
```
Error during instantiation of the implementation object: Constructor not found.
```

I noticed some `RenderCommands` ([mobile-device-rules/../EditRuleMVCRenderCommand](https://github.com/liferay/liferay-portal/blob/master/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/portlet/action/EditRuleMVCRenderCommand.java#L91-L107), [social-requests-web/../ViewMVCRenderCommand](https://github.com/liferay/liferay-portal/blob/master/modules/apps/archived/social-requests-web/src/main/java/com/liferay/social/requests/web/internal/portlet/action/ViewMVCRenderCommand.java#L99-L118) ) using `@Reference` and moving the values there seem to work. I separated changes in 2 separate commits. 60d3573 and fdec6c4

If this isn't appropriate, I'd like to circle back to this after moving the rest of the `search-experiences-web` module code since there's still a good amount to add.