### PR TITLE
LPS-139170 The boolean field values are not counting as one in form entries (Summary) when form has translations

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/js/components/card/CardList.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/js/components/card/CardList.es.js
@@ -41,7 +41,6 @@ const chartFactory = ({
 					totalEntries={totalEntries}
 				/>
 			);
-
 		case 'numeric': {
 			if (Array.isArray(values)) {
 				return (
@@ -57,7 +56,6 @@ const chartFactory = ({
 				return '';
 			}
 		}
-
 		case 'grid': {
 			return (
 				<MultiBarChart
@@ -68,7 +66,6 @@ const chartFactory = ({
 				/>
 			);
 		}
-
 		case 'object-relationship':
 		case 'radio':
 		case 'select': {


### PR DESCRIPTION
- LRQA-71470 Investigate CI failure of FormsDateField
- LPS-140525 Add CanAccessCustomObjectWithAccessPermission Test
- LPS-140529 Add CannotDeleteObjectEntryWithoutDeletePermission Test
- LPS-140526 Add CannotAddObjectEntryWithoutAddPermission Test
- LPS-140527 Add CanAddObjectEntryWithAddPermission Test
- LPS-140528 Add CannotViewOtherUsersEntryWithOnlyAddPermission Test
- LPS-140530 Add CanDeleteObjectEntryWithDeletePermission Test
- LPS-141194 Copy the display page entry when copying an article
- LPS-141194 Sort
- LRAC-9659 Fix CanPaginateSegmentProfileInMembershipList Test
- LRQA-69719 Create test to assert that blocked domains are exclusive to the instance
- LRQA-69719 Change macros to use JSON and navigate through URL to optimize speed of test
- LPS-141978 check the existence of the file by the filename to prevent the try of the creation of a file with the same name when editing an image from the item selector
- LPS-139239 Assert Title, URL, Views and Traffic
- LPS-139239 SF
- LPS-139239 add path
- LPS-137499 select the elements 'input type = Submit' as a click target
- LPS-137499 SF
- LPS-123151 Implement SF rule
- LPS-123151 Read table class to verify column names
- LPS-123151 Create documentation
- LPS-123151 Generated
- LPS-123151 Fix alterTableClassPattern
- LPS-123151 Adjust documentation
- LPS-123151 Remove file reading redundancy
- LPS-123151 Apply SF changes
- LPS-123151 SF
- LPS-141894 Publishing without title is allowed when editing structure default values
- LPS-141896 Add popup and fix submit form
- LPS-141875 Add alert when the web content is published without title
- LPS-141894 Do async submit only if feature flag is enabled
- LPS-141217 Avoid losing OrganizationId when getting error
- LPS-141217 users-admin-web: only check for the other parameter if the first one is not found
- LRQA-71363 Add addLanguageManageTranslations macro
- LRQA-71363 Test Fix LocalizedFieldsetsWebContent#LocalizedFieldsetWithDifferentInstanceLanguage
- LRQA-71363 Test Fix LocalizedNestedFieldsStructure#DefaultTitleIsDisplayedUponLocaleChange
- LRQA-71363 Test Fix LocalizedSimpleFieldsetsStructure#DefaultTitleIsDisplayedUponLocaleChange
- LRQA-71363 Test Fix LocalizedSimpleFieldsetsStructure#DefaultTitlePersistsUponFirstlyTranslatingForAnotherLocale
- LRQA-71363 Test Fix RichTextField#LocalizationOfRichTextPersists
- LRQA-71363 Test Fix LocalizedNestedFieldsStructure#TranslateStructureWithAllFieldsNested
- LRQA-71363 Test Fix LocalizedNestedFieldsWebContent#AddAndEditTranslatedFieldsWithOptions
- LRQA-71363 Test Fix LocalizedNestedFieldsWebContent#CheckDuplicatedRepeatableStructureOnWebContent
- LRQA-71363 Test Fix LocalizedSimpleFieldsWebContent#CreateEditAndDeleteLocalizedWebContent
- LRQA-71363 Test Fix LocalizedSimpleFieldsetsStructure#TranslateFieldsetToNLanguages
- LRQA-71363 Test Fix LocalizedSimpleFieldsetsStructure#TranslateFieldsetWithNNestedNTranslation
- LRQA-71363 Test Fix LocalizedSimpleFieldsetsStructure#TranslateFieldsetWithNestedNTranslations
- LRQA-71363 Test Fix LocalizedSimpleFieldsetsStructure#TranslateStructureWithFieldsetAndNested
- LRQA-71363 Test Fix LocalizedSimpleFieldsWebContent#TranslationDoesNotChangeAnotherAndPersistsAfterEditingAnother
- LRQA-71363 Test Fix LocalizedFieldsetsWebContent
- Revert "7.4.3.5 GA5 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, click-to-chat, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, digital-signature, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, google-places, headless, iframe, image-uploader, image, imageio-plugins, info, invitation, item-selector, journal, json-storage, knowledge-base, layout, learn, license-manager, list-type, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, object, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, release-feature-flag, remote-app, roles, rss, segments, server, sharing, site-initializer, site-navigation, site, social, staging, style-book, subscription, template, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream"
- Revert "7.4.13 Update 1 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, click-to-chat, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, digital-signature, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, google-places, headless, iframe, image-uploader, image, imageio-plugins, info, invitation, item-selector, journal, json-storage, knowledge-base, layout, learn, license-manager, list-type, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, object, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, release-feature-flag, remote-app, roles, rss, segments, server, sharing, site-initializer, site-navigation, site, social, staging, style-book, subscription, template, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream, antivirus, enterprise-product-notification, multi-factor-authentication, portal-search-elasticsearch-cross-cluster-replication, portal-search-elasticsearch-monitoring, portal-search-learning-to-rank, portal-search-similar-results, portal-search-tuning, saml"
- artifact:ignore commerce-pricing-service 4.0.15 change log
- artifact:ignore commerce-pricing-service 4.0.15 prep next
- artifact:ignore commerce-pricing-service 4.0.15 artifact properties
- artifact:ignore content-dashboard-web 2.0.25 change log
- artifact:ignore content-dashboard-web 2.0.25 prep next
- artifact:ignore content-dashboard-web 2.0.25 artifact properties
- artifact:ignore data-engine-js-components-web 1.0.28 change log
- artifact:ignore data-engine-js-components-web 1.0.28 prep next
- artifact:ignore data-engine-js-components-web 1.0.28 artifact properties
- artifact:ignore dispatch-web 3.0.16 change log
- artifact:ignore dispatch-web 3.0.16 prep next
- artifact:ignore dispatch-web 3.0.16 artifact properties
- artifact:ignore document-library-web 6.0.43 change log
- artifact:ignore document-library-web 6.0.43 prep next
- artifact:ignore document-library-web 6.0.43 artifact properties
- artifact:ignore dynamic-data-mapping-form-field-type 6.0.52 change log
- artifact:ignore dynamic-data-mapping-form-field-type 6.0.52 prep next
- artifact:ignore dynamic-data-mapping-form-field-type 6.0.52 artifact properties
- artifact:ignore dynamic-data-mapping-service 6.0.34 change log
- artifact:ignore dynamic-data-mapping-service 6.0.34 prep next
- artifact:ignore dynamic-data-mapping-service 6.0.34 artifact properties
- artifact:ignore journal-service 7.0.31 change log
- artifact:ignore journal-service 7.0.31 prep next
- artifact:ignore journal-service 7.0.31 artifact properties
- artifact:ignore journal-web 5.0.37 change log
- artifact:ignore journal-web 5.0.37 prep next
- artifact:ignore journal-web 5.0.37 artifact properties
- artifact:ignore product-navigation-control-menu-theme-contributor 6.0.12 change log
- artifact:ignore product-navigation-control-menu-theme-contributor 6.0.12 prep next
- artifact:ignore product-navigation-control-menu-theme-contributor 6.0.12 artifact properties
- artifact:ignore product-navigation-control-menu-web 6.0.18 change log
- artifact:ignore product-navigation-control-menu-web 6.0.18 prep next
- artifact:ignore product-navigation-control-menu-web 6.0.18 artifact properties
- artifact:ignore segments-web 3.0.21 change log
- artifact:ignore segments-web 3.0.21 prep next
- artifact:ignore segments-web 3.0.21 artifact properties
- artifact:ignore users-admin-web 6.0.23 change log
- artifact:ignore users-admin-web 6.0.23 prep next
- artifact:ignore users-admin-web 6.0.23 artifact properties
- build.gradle auto SF
- artifact:ignore dynamic-data-mapping-form-web 4.0.41 change log
- artifact:ignore dynamic-data-mapping-form-web 4.0.41 prep next
- artifact:ignore dynamic-data-mapping-form-web 4.0.41 artifact properties
- build.gradle auto SF
- artifact:ignore portal-workflow-kaleo-forms-web 5.0.19 change log
- artifact:ignore portal-workflow-kaleo-forms-web 5.0.19 prep next
- artifact:ignore portal-workflow-kaleo-forms-web 5.0.19 artifact properties
- build.gradle auto SF
- 7.4.3.5 GA5 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, click-to-chat, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, digital-signature, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, google-places, headless, iframe, image-uploader, image, imageio-plugins, info, invitation, item-selector, journal, json-storage, knowledge-base, layout, learn, license-manager, list-type, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, object, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, release-feature-flag, remote-app, roles, rss, segments, server, sharing, site-initializer, site-navigation, site, social, staging, style-book, subscription, template, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream
- 7.4.13 Update 1 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, click-to-chat, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, digital-signature, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, google-places, headless, iframe, image-uploader, image, imageio-plugins, info, invitation, item-selector, journal, json-storage, knowledge-base, layout, learn, license-manager, list-type, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, object, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, release-feature-flag, remote-app, roles, rss, segments, server, sharing, site-initializer, site-navigation, site, social, staging, style-book, subscription, template, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream, antivirus, enterprise-product-notification, multi-factor-authentication, portal-search-elasticsearch-cross-cluster-replication, portal-search-elasticsearch-monitoring, portal-search-learning-to-rank, portal-search-similar-results, portal-search-tuning, saml
- LPS-123151 prep next
- LPS-123151 prep next
- LPS-141589 Adds a property to decide if is in view mode
- LPS-141589 Add viewMode props and disable the button
- LPS-141589 Adapt tests
- LPS-142020 Add option for capturing errors in export/import layouts test
- LPS-142020 Use new option at existing places - no logical changes
- LPS-142020 Capture logs when we expect the tests to fail
- LPS-142020 baseline
- LPS-140206 Add permission checker method on the display contexts
- LPS-140206 Pass PORTLET_DISPLAY_CONTEXT as request attribute
- LPS-140206 Check permissions on the layout screens
- LPS-140206 Check permission in the actions, fields, picklist, relationship and details screens
- LPS-140206 SF
- LRQA-69924 Add CanSaveAsDraft testcase
- LRQA-69925 Add SubmitForPublicationButtonIsAvaliable testcase
- LRQA-69926 Add ArticleStatusIsPendingAfterSubmitForPublication testcase
- LRQA-69927 Add CanApproveBasicArticle testcase
- LRQA-69928 Add CanEditApprovedBasicArticle testcase
- LRQA-69929 Add CanRejectBasicArticle testcase
- LRQA-69930 Add ChildArticleStatusIsPendingAfterSubmitForPublication test
- POSHI-209 Convert from poshi XML to poshi script
- POSHI-209 SF
- LRCI-2599 Do not set a blank environment variable to prevent unit test failures
- LRCI-2600 When using locally, copy the top level build-database.json over to the default location in order to work with workspaces
- LRCI-2599 SF
- LRCI-2599 prep next
- LPS-141989 We don't need to change definition of project template bnd.bnd
- LPS-141989 prep next
- LRQA-70077 Refactor search reindex request
- LRQA-70077 Misc renames
- LRQA-70077 Include navigation to the search admin page within the reindex macro
- LRQA-70077 Update retry logic to be more clear
- LRQA-70077 Use a different method for initial executiion of the while loop
- LRQA-70077 Update refresh logic and remove redundant navigation
- LRQA-70077 Move screenshot to more appropriate location
- LRQA-70077 Apply changes
- LRQA-71476 Move navigation macro to more appropriate location
- LRQA-71476 Use search admin direct navigation macro where needed
- COMMERCE-7730 - If a product is not shippable and the Commerce Site Type is B2C, the Billing Address step is not shown during the checkout
- LPS-136907 Bump Xerces version saperately
- LPS-136907 Bump rest libs version
- LPS-136907 Correct order is enforced since 1.6.0
- LRQA-71007 Add test to view web content title no XSS in Asset Publisher portlet
- LPS-136773 Add SelectFrame and condition for typing a cover image caption
- LPS-136773 Add test to check that XSS cannot be executed in the cover image caption
- LPS-136772 Add macro to edit cover image caption
- LPS-136772 Add test to check that cover image caption can be deleted
- LPS-136772 Navigate via URL
- LPS-136772 No need to navigate back to the same place
- LPS-136772 Move to BlogsEntry.macro
- LPS-136772 Move publish action outside of macro to make it more reusable
- LRQA-70817 Remove steps to add additional business accounts since it is covered in setup
- LRQA-70817 Implement poshi tasks for better organization
- LRQA-70817 Remove creation of 2nd Person account
- LRQA-71461 Remove Bookmark part
- LPS-142039 Fix the initial state of successPageSettings
- LPS-142113 Update case
- LPS-134717 Add macro for navigating by breadcrumb
- LPS-134717 Add navigation for the depot translation processes
- LPS-134717 Add test for the depot application
- LPS-141188 Break test into two tests
- LPS-141356 Remove unnecessary step
- LPS-141356 Add a macro to view no asset type
- LPS-141356 Combine three tests into one
- LPS-141356 Use macro to assert no collections
- LPS-141356 Assert images are excluded
- LPS-141356 Remove unnecessary step
- LPS-141356 Update test name to make more sense
- LPS-141356 Add more assertions
- LPS-141356 Select part of web contents
- LPS-141356 Duplicate with SelectWCFromAllScopesDynamically
- LPS-141356 Update the macro to ensure that the collection is added in a different way
- LPS-141356 Cover by adding collections cases
- LPS-141356 Rename tests
- LPS-141356 Reorder tests
- LPS-141356 Update annotations
- LPS-139170 Translates boolean options on front-end
- LPS-140646 Remove deleteStatsUser method
- LPS-140646 Remove deleteStatsUserByGroupId method and usages
- LPS-140646 Remove deleteStatsUserByUserId method and usages
- LPS-140646 Remove getCompanyStatsUsers methods
- LPS-140646 Remove getCompanyStatsUsersCount method
- LPS-140646 Remove unused getGroupStatsUsers method
- LPS-140646 Remove unused getGroupStatsUsersCount method
- LPS-140646 Remove unused getOrganizationStatsUsers method
- LPS-140646 Remove unused getOrganizationStatsUsersCount method
- LPS-140646 Remove unused updateStatsUser method
- LPS-140646 Remove updateStatsUser(groupId, userId, displayDate) method and usages
- LPS-140646 Remove updateStatsUser(groupId, userId, ratingsTotalEntries, ratingsTotalScore, ratingsAverageScore) method and usages
- LPS-140646 Remove fetchStatsUser method and replace usages
- LPS-140646 Remove unused deleteStatsUser method
- LPS-140646 Create BlogsStatsUserDAO
- LPS-140646 Replace getGroupsStatsUsers, getGroupStatsUsers, and getStatsUser method implementations with DSL query
- LPS-140646 Refactor getOrganizationStatsUsers to use DSL Query
- LPS-140646 Fix getOrganizationStatsUsers query
- LPS-140646 Refactor BlogStatsUser usages in blogs-recent-bloggers-web
- LPS-140646 Refactor BlogStatsUser usages in BlogsStatsUserLocalServiceTest
- LPS-140646 Build Service
- LPS-140646 Remove BlogsStatsUser columns from service.xml
- LPS-140646 Delete BlogsStatsUserUtil.java, BlogsStatsUserPersistence.java, BlogsStatsUserPersistenceImpl.java, BlogsStatsUserPersistenceTest.java
- LPS-140646 Delete BlogsStatsUserTable.java, BlogsStatsUser.java, BlogsStatsUserModel.java, and their related files
- LPS-140646 Remove unused BlogsStatsUserLocalService references
- LPS-140646 Remove BlogsStatsUserFinder query bindings from default.xml
- LPS-140646 Rename BlogsStatsUserDAO to BlogsStatsUser
- LPS-140646 Rename getUserId to getStatsUserId in BlogsStatsUser
- LPS-140646 Create upgrade to drop BlogsStatsUser table
- LPS-140646 Versioning
- LPS-140646 Clean up queries
- LPS-140646 Extract blogsStatsUsers collection
- LPS-140646 Update Release reference in BlogsPortletDisplayTemplateHandler
- LPS-140646 Prevent IndexOutOfBoundsException.
- LPS-140646 Make projections consistent.
- LPS-140646 Reuse common part of the queries.
- LPS-140646 Inline fields now only used once.
- LPS-140646 Fix order and let GetterUtil supply defaults and perform casting.
- LPS-140646 Match method name.
- LPS-140646 Sorted by name.
- LPS-140646 Match projection to contstructor.
- LPS-140646 SF
- COMMERCE-7564 batch-planner-web - SaveTemplate refactoring
- COMMERCE-7564 batch-planner-web - SF
- COMMERCE-7564 batch-planner-web - JSP - fix action names (do not change this)
- COMMERCE-7564 batch-planner-web - namespace misses
- COMMERCE-7564 batch-planner-web - SF - make source formatter happy
- COMMERCE-7564 batch-planner-web - Fix Bugs - submitted content is not json but form-data, responseContent does not exist
- COMMERCE-7564 batch-planner-web - remove - service layer does validation and sanitization
- COMMERCE-7564 batch-planner-web - tell frontend about error (otherwise modal does not close)
- POSHI-210 Account for resources from 'com.liferay:com.liferay.poshi.runner.resources'
- POSHI-210 prep next
- LPS-140042 Extract common logic to a base class
- LPS-140042 Trigger kaleoInstance reindex when index kaleoInstanceToken documents
- LPS-140042 Populate kaleoInstance documents with assetTitle, assetDescription and classPK attributes to be able to use instance documents instead instanceTokens ones when search
- LPS-140042 Add search criteria to added attributes
- LPS-140042 Use the kaleoInstance search layer instead of the kaleoInstanceToken one
- LPS-140042 Build service
- LPS-140042 Semver
- LPS-140042 Add integration test
- LPS-140042 SF
- LPS-142119 Kanba
- Revert "LPS-136907 Correct order is enforced since 1.6.0"
- Revert "LPS-136907 Bump rest libs version"
- Revert "LPS-136907 Bump Xerces version saperately"
- LPS-140206 auto SF
- POSHI-209 prep next
- LPS-141475 Create `frontend-data-set-web` module
- LPS-141475 Move Data Set frontend to the `frontend-data-set-web` module. Expose `DataSet` as a React component. Expose used JS utilities.
- LPS-141475 Use `DataSet` component in `<clay:*data-set-display>` tags
- LPS-141475 Import exposed component and utilities
- LPS-141475 Update CI tests
- auto SF
- LPS-141937 search-experiences-service: SXPBlueprint workflow handler
- LPS-141937 search-experiences-service: Start workflow instance
- LPS-141937 Our usual order for _startWorkflowInstance
- LPS-128990 Fetching all the vocabularies
- LPS-128990 Avoiding refetchs of each vocabulary with the wrong group id
- LPS-128990 Appending the group name to the vocabulary title
- LPS-128990 Deduplicating
- LPS-128990 Replacing these usages too
- LPS-128990 Create VocabulariesSelectionBox component
- LPS-128990 Add CSS to VocabulariesSelectionBox component
- LPS-128990 Disable non selectable vocabularies using mocked data
- LPS-128990 Send selected vocabularies on form submit
- LPS-128990 Show descriptive text before the vocabulary selection
- LPS-128990 Add tests for VocabulariesSelectionBox component
- LPS-128990 Auto SF
- LPS-128990 Fixing copyright
- LPS-128990 Simplifying with hashmapbuilder
- LPS-128990 Passing the groupId too
- LPS-128990 Indicating whether group is global or not
- LPS-128990 Fix VocabulariesSelectionBox component and tests after props renaming
- LPS-128990 Add test for two vocabularies from the same site (not global site) and some source formatting
- LPS-128990 Minor fix in retrieving current vocabularies used in ContentDashboard configuration so non-global vocabularies are also retrieved
- LPS-128990 Returning non-global vocabularies to be shown in contentDashboard Graph and Table
- LPS-128990 Refactoring to use vocabularyId as unique identifier instead of vocabulary name
- LPS-128990 Send vocabularyId with value key instead of id
- LPS-128990 Remove file with specific preferences for the ContentDashboardAdminPortlet
- LPS-128990 Removing unnecessary companyIds/groupIds as the AssetVocabularies are retrieves by vocabularyId now
- LPS-128990 Refactoring to use vocabularyId as unique identifier instead of vocabulary name in the frontend
- LPS-128990 sf
- LPS-128990 Tests fixed using vocabularyId as unique identifier instead of vocabularyName
- LPS-128990 Change text in vocabularies selection modal
- LPS-128990 Add spinner to vocabularies selection component
- LPS-128990 Refactor and small fix in code for disabling options
- LPS-128990 Fix HTML layout to prevent errors in the browser
- LPS-128990 Keeping previous behaviour when initializing the content dashboard
- LPS-128990 Create new test with non-global vocabularies and minor fix in other test
- LPS-128990 This was renamed by accident, not related
- LPS-128990 Auto SF
- LPS-128990 Simplifying
- LPS-128990 Centralising vocabularyIds retrieval
- LPS-128990 sf
- LPS-128990 Test fixing
- LPS-128990 Line breaks here don't add any information
- LPS-128990 Inline
- LPS-128990 Rename
- LPS-128990 regen
- LPS-128990 You need to replace the older translation or else buildLang will pick up the second one
- LPS-128990 regen
- LPS-141702 search-experiences-service: Import OOTB Elements into new instance so Blueprint Editor can display them
- LPS-112856 Fix compile error
- LPS-112856 Use existing util that does the same thing
- LPS-112856 If you don't set one, it'll prepopulate it. Only set it if you want a specific UUID.
- LPS-112856 Add find by company ID
- LPS-112856 regen
- LPS-112856 We still need to make this a smarter search, but at least this will work with virtual instances. You need to grab all and scan by company ID. But yes, let's make this a search or a smarter finder.
- LPS-112856 Delete unit test. Convert them to integration tests. Yes, unit tests are faster... but when they make the actual more complicated and harder to maintain, use integration tests. Simplicty matters more than speed. See the next commit.
- LPS-112856 Get rid of strange interfaces that pollute the actual impl. Simplicity over test speed.
- LPS-112856 This adds nothing
- LPS-112856 Rename
- LPS-112856 Simplify
- LPS-112856 Simplify
- LPS-112856 Simplify
- LPS-112856 Simplify
- LPS-112856 Our usual name when there is a conflict between SB and REST
- LPS-112856 Simplify
- LPS-112856 We won't need this once we use an integration tests
- LPS-112856 Simplify
- LPS-112856 Not used
- LPS-112856 Rename and run SF
- LPS-112856 Simplify
- LPS-112856 Titles should follow rules for book titles. See https://capitalizemytitle.com.
- LPS-112856 Descriptions should follow the rules for complete sentences. See https://examples.yourdictionary.com/reference/examples/examples-of-complete-sentences.html.
- LPS-112856 add a TODO
- LPS-105380 Account for renamed annotations in JUnit 5
- LPS-105380 Update documentation
- LPS-142081 Remove unused dataDefinitionReducer
- COMMERCE-7410 fixed and / or labels i18n
- COMMERCE-7400 country localization fix
- LRQA-69931 Add CanApproveBasicChildArticle testcase
- LRQA-69933 Add CanApproveBasicArticleWhenChildPending testcase
- LRAC-9653 Enable AC smoke tests for DXP release job
- LRAC-9653 SF
- LRCI-2595 Add ability to find the cohort name from a job & batch
- LRCI-2595 prep next
- LPS-141258 Ignore case when comparing table names
- LPS-141258 Create and drop test tables before and after the unit tests
- LPS-141258 Separate SQL calls
- LPS-141258 Rename column field
- LPS-141258 SF
- LRQA-71405 Add smoke upgrade tests from 7.4.13 GA1
- LRQA-71405 Add 7.4 upgrade smoke to relevant
- LRQA-68762 Give template unique name to prevent the test from choosing the wrong template
- LRQA-68762 Prevent test from giving false positive for instance creation and add to acceptance
- LRQA-68408 Add refresh for upgrade tests only
- LPS-142131 Remove AtomPub support
- LPS-142131 Deprecated in DTD
- LPS-142131 Semantic versioning
- LPS-142131 Remove libs
- LPS-142131 IDEs
- LPS-142131 lib versions
- LRQA-71496 Simplify
- LRQA-71496 Support ability to choose the base Portal URL
- LRQA-71496 Pass in base URL of second Portal cluster node
- LRQA-71486 Investigate CI failure of DEImageField#CanRemoveDuplicatedField
- LRQA-71488 Investigate CI failure of DENumericField#CanSetDecimalOrInteger
- LRAC-9615 Add isLessThan macro
- LRAC-9615 Fix CheckGeneralEventsForUnknownUser testcase
- LRAC-9615 Fix CheckPageEventsTriggeredAgainAfterHardRefresh testcase
- LRAC-9615 Fix CheckPageEventsTriggeredAgainAfterRefresh testcase
- LRAC-9615 Fix CheckPageLoadedWhenViewPage testcase
- LRAC-9615 Fix CheckPageUnLoadedWhenLeavePage testcase
- LPS-141058 (account-service) - add new methods to AccountEntryOrganizationRelService
- LPS-141058 Regen
- LPS-141058 (account-admin-web) - replace AccountEntryOrganizationRelLocalService with AccountEntryOrganizationRelService
- LPS-141058 (account-service) - add new methods to AccountEntryUserRelService
- LPS-141058 Regen
- LPS-141058 (account-admin-web) - replace AccountEntryUserRelLocalService with AccountEntryUserRelService
- LPS-141058 (account-service) - add new methods to AccountEntryService
- LPS-141058 (account-service) - remove redundant helper method and use the one available from the base class
- LPS-141058 Regen
- LPS-141058 (account-admin-web) - replace AccountEntryLocalService with AccountEntryService
- LPS-141058 (account-admin-web) - add permission checks to action commands for add, delete, and update account addresses
- LPS-141058 (account-admin-web) - add permission check to account address's creation menu and action dropdown menu
- LPS-141058 (account-admin-web) - don't show edit link and action items for account addresses if user doesn't have update account permission
- LPS-141058 Change 'Long' to 'long' and run remove deprecated methods
- LPS-141058 Regen
- LPS-141058 SF
- LPS-141058 Simplify
- LPS-138868 Supply host and port parameters to Gogo shell client
- LPS-138868 Rename
- LPS-140846 Create _assetAssetVocabularies
- LPS-142121 Create _assertAssetCategories
- LPS-142121 SF
- LPS-142121 Rename
- LPS-142121 Rename
- LPS-142121 Rename
- LPS-141058 my bad
- LPS-139877 Bump santurio
- LPS-140878 Add ObjectReappearsProcessBuilderWhenReactivated Test
- LPS-140878 SF
- LPS-140878 Small improvement
- LPS-140879 Add ObjectReappearsWorkflowSiteMenuWhenReactivated test
- LPS-140879 SF
- LRQA-70154 Remove downloading sidecar binaries for each WebSphere and Weblogic test
- LRQA-70155 Copy entire sidecar bundle
- LPS-136907 Bump Xerces version saperately
- LPS-136907 Bump rest libs version
- LPS-136907 Correct order is enforced since 1.6.0
- LRCI-2601 Moved release notifications from #d-quality-assurance to #rle-ci
- LPS-141058 fix compile
- LPS-141058 SF
- LPS-139947 Execute several search queries to avoid hitting the index.max_result_window Elasticsearch limit
- LPS-139947 Created test to retrieve more than 10k users
- LPS-139947 Fail in case we cannot retrieve the sorted field from the last document
- LPS-139947 Add the entryClassName and entryClassPk to all the Liferay indexed entities
- LPS-139947 rename
- LPS-139947 inline
- LPS-139947 rename
- LPS-139947 as used
- LPS-139947 rename
- LPS-139947 rename
- LPS-139947 auto SF
- LPS-139947 Normalize user and group creation in UserODataRetrieverTest
- LPS-139947 Execute all integration tests in a new company
- LPS-139947 Create the new company with a Elasticsearch index max_result_window configuration to 10, to reproduce the issue in an easier way, with a lower number of users
- LPS-139947 Set INDEX_SEARCH_LIMIT to _ELASTICSEARCH_MAX_RESULT_WINDOW for all the UserODataRetrieverTest tests as we have changed the Elasticsearch max_result_window limit
- LPS-139947 Change test to create only 30 users as now Elasticsearch max_result_window is 10, so we will force to retrieve three pages of users
- LPS-139947 It is not necessary to create the group as it is created in the setUp(). Create a random firstName as it is done in other tests
- LPS-139947 SF
- LPS-139947 Minor SF
- LPS-139947 Rename
- LPS-139947 Rename
- LPS-142088 Adds missing property in page definition
- COMMERCE-6525 - It has already been checked if layoutUuid equals layout.getUuid()
- LPS-141924 Uses PreparedStatement
- LPS-141924 SF reuses PreparedStatements
- LPS-141924 SF rename
- LPS-141924 SF inline
- LPS-142108 use the class item-preview-editable only to count the items on the preview view on the item selector and not use item-preview only to previewed files
- LPS-141975 add the possibility of contain the label on the template to the pattern to extract the variable name
- LPS-141975 Add test to check the new behavior on the LayoutSEOTemplateProcessor
- LPS-141975 Add the descriptive label on the input/textarea when the user click on the Add Field button
- LPS-141975 Update test to check for the new template with key:label
- LPS-141975 Trim input value after the new fieldVariable is added and update the test
- LPS-141975 Add test to check the sanitization of the field label
- LPS-141975 Wordsmith
- LPS-142066 Also take into consideration styles when importing widget structure items
- artifact:ignore portal-impl 9.0.0 prep next
- artifact:ignore portal-impl 9.0.0 releng
- artifact:ignore portal-kernel 18.0.0 prep next
- artifact:ignore portal-kernel 18.0.0 releng
- artifact:ignore portal-web 5.0.62 prep next
- artifact:ignore portal-web 5.0.62 releng
- build.gradle auto SF
- artifact:ignore account-api 5.0.0 change log
- artifact:ignore account-api 5.0.0 prep next
- artifact:ignore account-api 5.0.0 artifact properties
- artifact:ignore asset-categories-service 5.0.11 change log
- artifact:ignore asset-categories-service 5.0.11 prep next
- artifact:ignore asset-categories-service 5.0.11 artifact properties
- artifact:ignore blogs-api 9.0.0 change log
- artifact:ignore blogs-api 9.0.0 prep next
- artifact:ignore blogs-api 9.0.0 artifact properties
- artifact:ignore data-engine-js-components-web 1.0.29 change log
- artifact:ignore data-engine-js-components-web 1.0.29 prep next
- artifact:ignore data-engine-js-components-web 1.0.29 artifact properties
- artifact:ignore data-engine-service 3.0.16 change log
- artifact:ignore data-engine-service 3.0.16 prep next
- artifact:ignore data-engine-service 3.0.16 artifact properties
- artifact:ignore document-library-service 6.0.25 change log
- artifact:ignore document-library-service 6.0.25 prep next
- artifact:ignore document-library-service 6.0.25 artifact properties
- artifact:ignore dynamic-data-mapping-form-builder 4.0.21 change log
- artifact:ignore dynamic-data-mapping-form-builder 4.0.21 prep next
- artifact:ignore dynamic-data-mapping-form-builder 4.0.21 artifact properties
- artifact:ignore export-import-test-util 4.1.0 change log
- artifact:ignore export-import-test-util 4.1.0 prep next
- artifact:ignore export-import-test-util 4.1.0 artifact properties
- artifact:ignore frontend-data-set-web 1.0.0 prep next
- artifact:ignore frontend-data-set-web 1.0.0 artifact properties
- artifact:ignore frontend-data-set-web 1.0.0 change log
- artifact:ignore frontend-data-set-web 1.0.0 prep next
- artifact:ignore frontend-data-set-web 1.0.0 artifact properties
- artifact:ignore frontend-taglib-clay 8.0.0 change log
- artifact:ignore frontend-taglib-clay 8.0.0 prep next
- artifact:ignore frontend-taglib-clay 8.0.0 artifact properties
- artifact:ignore journal-service 7.0.32 change log
- artifact:ignore journal-service 7.0.32 prep next
- artifact:ignore journal-service 7.0.32 artifact properties
- artifact:ignore layout-page-template-service 4.0.17 change log
- artifact:ignore layout-page-template-service 4.0.17 prep next
- artifact:ignore layout-page-template-service 4.0.17 artifact properties
- artifact:ignore layout-seo-service 3.0.17 change log
- artifact:ignore layout-seo-service 3.0.17 prep next
- artifact:ignore layout-seo-service 3.0.17 artifact properties
- artifact:ignore organizations-service 4.0.15 change log
- artifact:ignore organizations-service 4.0.15 prep next
- artifact:ignore organizations-service 4.0.15 artifact properties
- artifact:ignore portal-language-lang 1.0.30 change log
- artifact:ignore portal-language-lang 1.0.30 prep next
- artifact:ignore portal-language-lang 1.0.30 artifact properties
- artifact:ignore portal-security-antisamy 6.0.14 change log
- artifact:ignore portal-security-antisamy 6.0.14 prep next
- artifact:ignore portal-security-antisamy 6.0.14 artifact properties
- artifact:ignore portal-workflow-kaleo-api 9.1.0 change log
- artifact:ignore portal-workflow-kaleo-api 9.1.0 prep next
- artifact:ignore portal-workflow-kaleo-api 9.1.0 artifact properties
- artifact:ignore segments-service 3.0.15 change log
- artifact:ignore segments-service 3.0.15 prep next
- artifact:ignore segments-service 3.0.15 artifact properties
- artifact:ignore site-initializer-kanban 1.0.0 prep next
- artifact:ignore site-initializer-kanban 1.0.0 artifact properties
- artifact:ignore site-initializer-kanban 1.0.0 change log
- artifact:ignore site-initializer-kanban 1.0.0 prep next
- artifact:ignore site-initializer-kanban 1.0.0 artifact properties
- artifact:ignore user-groups-admin-impl 5.0.6 change log
- artifact:ignore user-groups-admin-impl 5.0.6 prep next
- artifact:ignore user-groups-admin-impl 5.0.6 artifact properties
- artifact:ignore commerce-theme-minium 5.0.13 change log
- artifact:ignore commerce-theme-minium 5.0.13 prep next
- artifact:ignore commerce-theme-minium 5.0.13 artifact properties
- artifact:ignore commerce-theme-speedwell 4.0.15 change log
- artifact:ignore commerce-theme-speedwell 4.0.15 prep next
- artifact:ignore commerce-theme-speedwell 4.0.15 artifact properties
- build.gradle auto SF
- artifact:ignore account-service 2.0.21 change log
- artifact:ignore account-service 2.0.21 prep next
- artifact:ignore account-service 2.0.21 artifact properties
- artifact:ignore blogs-service 5.0.18 change log
- artifact:ignore blogs-service 5.0.18 prep next
- artifact:ignore blogs-service 5.0.18 artifact properties
- artifact:ignore dynamic-data-mapping-service 6.0.35 change log
- artifact:ignore dynamic-data-mapping-service 6.0.35 prep next
- artifact:ignore dynamic-data-mapping-service 6.0.35 artifact properties
- artifact:ignore frontend-taglib 6.2.5 change log
- artifact:ignore frontend-taglib 6.2.5 prep next
- artifact:ignore frontend-taglib 6.2.5 artifact properties
- artifact:ignore portal-workflow-kaleo-service 6.0.16 change log
- artifact:ignore portal-workflow-kaleo-service 6.0.16 prep next
- artifact:ignore portal-workflow-kaleo-service 6.0.16 artifact properties
- build.gradle auto SF
- artifact:ignore account-admin-web 2.0.14 change log
- artifact:ignore account-admin-web 2.0.14 prep next
- artifact:ignore account-admin-web 2.0.14 artifact properties
- artifact:ignore asset-categories-navigation-web 6.0.10 change log
- artifact:ignore asset-categories-navigation-web 6.0.10 prep next
- artifact:ignore asset-categories-navigation-web 6.0.10 artifact properties
- artifact:ignore batch-planner-web 1.0.11 change log
- artifact:ignore batch-planner-web 1.0.11 prep next
- artifact:ignore batch-planner-web 1.0.11 artifact properties
- artifact:ignore blogs-recent-bloggers-web 6.0.11 change log
- artifact:ignore blogs-recent-bloggers-web 6.0.11 prep next
- artifact:ignore blogs-recent-bloggers-web 6.0.11 artifact properties
- artifact:ignore commerce-checkout-web 5.0.16 change log
- artifact:ignore commerce-checkout-web 5.0.16 prep next
- artifact:ignore commerce-checkout-web 5.0.16 artifact properties
- artifact:ignore commerce-frontend-js 4.0.22 change log
- artifact:ignore commerce-frontend-js 4.0.22 prep next
- artifact:ignore commerce-frontend-js 4.0.22 artifact properties
- artifact:ignore commerce-payment-web 4.0.11 change log
- artifact:ignore commerce-payment-web 4.0.11 prep next
- artifact:ignore commerce-payment-web 4.0.11 artifact properties
- artifact:ignore commerce-product-service 6.0.22 change log
- artifact:ignore commerce-product-service 6.0.22 prep next
- artifact:ignore commerce-product-service 6.0.22 artifact properties
- artifact:ignore content-dashboard-web 2.0.26 change log
- artifact:ignore content-dashboard-web 2.0.26 prep next
- artifact:ignore content-dashboard-web 2.0.26 artifact properties
- artifact:ignore data-engine-taglib 3.3.10 change log
- artifact:ignore data-engine-taglib 3.3.10 prep next
- artifact:ignore data-engine-taglib 3.3.10 artifact properties
- artifact:ignore dynamic-data-mapping-form-report-web 2.0.12 change log
- artifact:ignore dynamic-data-mapping-form-report-web 2.0.12 prep next
- artifact:ignore dynamic-data-mapping-form-report-web 2.0.12 artifact properties
- artifact:ignore flags-taglib 6.0.17 change log
- artifact:ignore flags-taglib 6.0.17 prep next
- artifact:ignore flags-taglib 6.0.17 artifact properties
- artifact:ignore item-selector-taglib 5.1.18 change log
- artifact:ignore item-selector-taglib 5.1.18 prep next
- artifact:ignore item-selector-taglib 5.1.18 artifact properties
- artifact:ignore layout-page-template-admin-web 2.0.25 change log
- artifact:ignore layout-page-template-admin-web 2.0.25 prep next
- artifact:ignore layout-page-template-admin-web 2.0.25 artifact properties
- artifact:ignore layout-seo-web 2.0.23 change log
- artifact:ignore layout-seo-web 2.0.23 prep next
- artifact:ignore layout-seo-web 2.0.23 artifact properties
- artifact:ignore object-web 1.0.17 change log
- artifact:ignore object-web 1.0.17 prep next
- artifact:ignore object-web 1.0.17 artifact properties
- build.gradle auto SF
- artifact:ignore blogs-web 6.0.22 change log
- artifact:ignore blogs-web 6.0.22 prep next
- artifact:ignore blogs-web 6.0.22 artifact properties
- artifact:ignore commerce-pricing-web 4.0.17 change log
- artifact:ignore commerce-pricing-web 4.0.17 prep next
- artifact:ignore commerce-pricing-web 4.0.17 artifact properties
- artifact:ignore dynamic-data-mapping-form-web 4.0.42 change log
- artifact:ignore dynamic-data-mapping-form-web 4.0.42 prep next
- artifact:ignore dynamic-data-mapping-form-web 4.0.42 artifact properties
- build.gradle auto SF
- artifact:ignore commerce-shop-by-diagram-web 1.0.20 change log
- artifact:ignore commerce-shop-by-diagram-web 1.0.20 prep next
- artifact:ignore commerce-shop-by-diagram-web 1.0.20 artifact properties
- artifact:ignore saml-opensaml-integration 5.3.10 change log
- artifact:ignore saml-opensaml-integration 5.3.10 prep next
- artifact:ignore saml-opensaml-integration 5.3.10 artifact properties
- build.gradle auto SF
- LPS-142139 Do throw Exception.
- LPS-142139 Not needed index since finder was removed in commit 32be88f5d9e7a19503cf92169ae4a0000db271ab. Besides causes an SQLException because name is used as key without key length.
- LPS-141353 Take into account fragment compositions when exporting dropzone unallowed fragments
- LPS-142118 Enable hidden pages selection for preview
- LPS-125976 Update Heading fragment icon
- LPS-142079 Add tooltip to truncated text
- artifact:ignore list-type-service 1.0.7 change log
- artifact:ignore list-type-service 1.0.7 prep next
- artifact:ignore list-type-service 1.0.7 artifact properties
- artifact:ignore portal-spring-extender-impl 4.0.8 change log
- artifact:ignore portal-spring-extender-impl 4.0.8 prep next
- artifact:ignore portal-spring-extender-impl 4.0.8 artifact properties
- artifact:ignore product-navigation-control-menu-web 6.0.19 change log
- artifact:ignore product-navigation-control-menu-web 6.0.19 prep next
- artifact:ignore product-navigation-control-menu-web 6.0.19 artifact properties
- artifact:ignore segments-web 3.0.22 change log
- artifact:ignore segments-web 3.0.22 prep next
- artifact:ignore segments-web 3.0.22 artifact properties
- artifact:ignore style-book-web 2.0.16 change log
- artifact:ignore style-book-web 2.0.16 prep next
- artifact:ignore style-book-web 2.0.16 artifact properties
- artifact:ignore fragment-collection-contributor-basic-component 3.0.16 change log
- artifact:ignore fragment-collection-contributor-basic-component 3.0.16 prep next
- artifact:ignore fragment-collection-contributor-basic-component 3.0.16 artifact properties
- artifact:ignore headless-delivery-impl 5.0.32 change log
- artifact:ignore headless-delivery-impl 5.0.32 prep next
- artifact:ignore headless-delivery-impl 5.0.32 artifact properties
- build.gradle auto SF
- LPS-142141 checkout-private-projects is no longer used
- LPS-142141 depth of 1 is enough
- LPS-142141 Copy logic from build-working-dir.xml and simplify
- LPS-142141 Not used
- LPS-141956 Remove redundant macro
- LPS-141956 Modify macro to define the Number of Slides
- LPS-141956 Remove redundant locators
- LPS-141956 Remove deprecated macro
- LPS-141956 Refactor macro
- LPS-141956 Update usages
- LPS-141956 Add locator for any button with aria label
- LPS-141956 Add macro to focus slide
- LPS-141956 Group in task block
- LPS-141956 Add case to increase number of slides in Slider
- LPS-141956 Add case to increase number of slides in Banner Slider
- Revert "LRQA-71486 Investigate CI failure of DEImageField#CanRemoveDuplicatedField"
- LPS-142143 Modify locator to make it robust
- LPS-141956 Add case to decrease number of slides in Slider
- LPS-141956 Add case to decrease number of slides in Banner Slider
- LPS-142141 no longer using git-commit-portal-private
- LPS-142111 Add callback event only when the event ID list is not null and not empty
- LPS-141196 Pass fragmentCollectionId as parameter
- LPS-141196 Sort, please resend this to use ResourceURLBuilder (note you will have to add portlet 3.0 support to the portlet via a property
- LPS-141905 SF simplify
- LPS-141905 SF don't need it, theme display scopeGroup is the default value.
- LPS-141905 Stylebooks preview must use the item of the group where we are editing.
- LPS-141905 SF moves the variables near to where are used
- LPS-141905 Adds groupId criteria to layout page template entry selection
- LPS-141905 Baseline
- LPS-141905 Passing ItemSelectorCriterion to ItemSelectorViewDescriptor instead just a field
- LPS-141905 Uses the groupId criteria if is sets, instead of theme display scopeGroupId.
- LPS-141905 Adds groupId criteria to layout page template entries item selectors.
- LPS-141905 SF inline
- LPS-141905 SF
- LPS-139170 Fixes case formating
