### PR TITLE
 LPS-142346 LPS-141242 Fix DDM value override on language change

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -51,7 +51,7 @@ const RichText = ({
 			editor.setData(contents);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [editingLanguageId]);
+	}, [editingLanguageId, predefinedValue]);
 
 	return (
 		<FieldBase

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -48,8 +48,9 @@ const RichText = ({
 
 			editor.config.contentsLanguage = editingLanguageId;
 
-			editor.setData(editor.getData());
+			editor.setData(contents);
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [editingLanguageId]);
 
 	return (

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
@@ -34,7 +34,7 @@ if (editorData != null) {
 	editorConfigJSONObject = (JSONObject)editorData.get("editorConfig");
 }
 %>
-
+q
 <div>
 	<react:component
 		module="editor/ClassicEditor"

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_classic.jsp
@@ -34,7 +34,7 @@ if (editorData != null) {
 	editorConfigJSONObject = (JSONObject)editorData.get("editorConfig");
 }
 %>
-q
+
 <div>
 	<react:component
 		module="editor/ClassicEditor"

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -105,7 +105,6 @@ const ClassicEditor = React.forwardRef(
 						toolbar: initialToolbarSet,
 						...editorConfig,
 					}}
-					data={contents}
 					name={name}
 					onBeforeLoad={(CKEDITOR) => {
 						CKEDITOR.disableAutoInline = true;
@@ -136,6 +135,14 @@ const ClassicEditor = React.forwardRef(
 								return editor.pasteFilter.check(name);
 							}
 						}
+					}}
+					onInstanceReady={({editor}) => {
+						editor.setData(contents, {
+							callback: () => {
+								editor.resetUndo();
+							},
+							noSnapshot: true,
+						});
 					}}
 					ref={editorRefsCallback}
 					{...otherProps}


### PR DESCRIPTION
Manually forwarding since tests failures are unrelated.
[liferay-frontend#1652 (comment)](https://github.com/liferay-frontend/liferay-portal/pull/1652#issuecomment-967288584)

### Notes

This PR re-applies changes from #1628 , go there for more info. 

### References

- [LPS-142346](https://issues.liferay.com/browse/LPS-142346)
- [LPS-141242](https://issues.liferay.com/browse/LPS-141242)

### What is the goal?

* Fix CKEditor allowing undo on first render and showing `undefined` after undo
* Fix bug caused by this ^. Selecting another language was overriding that language's value with the previous one.

### A picture is worth a thousand words

#### Before PR

https://user-images.githubusercontent.com/6642927/141296077-f6befa51-934d-4e34-ab4d-c01189d86ea5.mov


#### After PR

https://user-images.githubusercontent.com/6642927/141295361-cb1db586-c51e-4e71-810b-947d473357b5.mov


### How to replicate
* Go to Content & Data > Web Content
* Add new content
* Wait for content editor to be ready
* Write something in the content editor
* Select another language in the translation manager dropdown
* Write something different in the content editor
* Go back to the previous language
* See that the content shows what you had written for that language
* Go back to the new language
* See that the content shows what you had written for that language

### Checklist

- ~~[ ] I have made corresponding changes to the documentation~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked this works in the corresponding browser