### PR TITLE
LPS-141351 site navigation menu item type for each display page implementation

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 8.0.3
+Bundle-Version: 8.1.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.data,\
 	com.liferay.frontend.taglib.clay.data.set,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -90,5 +90,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "8.0.3"
+	"version": "8.1.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownItemListBuilder.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownItemListBuilder.java
@@ -17,6 +17,8 @@ package com.liferay.frontend.taglib.clay.servlet.taglib.util;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeSupplier;
 
+import java.util.List;
+
 /**
  * @author Hugo Huijser
  */
@@ -56,6 +58,15 @@ public class DropdownItemListBuilder {
 			new DropdownItemListWrapper();
 
 		return dropdownItemListWrapper.add(unsafeSupplier, unsafeConsumer);
+	}
+
+	public static DropdownItemListWrapper addAll(
+		List<DropdownItem> dropdownItems) {
+
+		DropdownItemListWrapper dropdownItemListWrapper =
+			new DropdownItemListWrapper();
+
+		return dropdownItemListWrapper.addAll(dropdownItems);
 	}
 
 	public static DropdownItemListWrapper addCheckbox(
@@ -179,6 +190,18 @@ public class DropdownItemListBuilder {
 			}
 			catch (Exception exception) {
 				throw new RuntimeException(exception);
+			}
+
+			return this;
+		}
+
+		public DropdownItemListWrapper addAll(
+			List<DropdownItem> dropdownItems) {
+
+			for (DropdownItem dropdownItem : dropdownItems) {
+				if (dropdownItem != null) {
+					_dropdownItemList.add(dropdownItem);
+				}
 			}
 
 			return this;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/util/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.10.0
+version 3.11.0

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/display/context/SiteNavigationAdminDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/display/context/SiteNavigationAdminDisplayContext.java
@@ -15,6 +15,7 @@
 package com.liferay.site.navigation.admin.web.internal.display.context;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemList;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringPool;
@@ -122,14 +123,8 @@ public class SiteNavigationAdminDisplayContext {
 
 		return DropdownItemList.of(
 			stream.map(
-				siteNavigationMenuItemType -> {
-					DropdownItem dropdownItem = new DropdownItem();
-
-					_applyDropdownItem(
-						dropdownItem, siteNavigationMenuItemType, themeDisplay);
-
-					return dropdownItem;
-				}
+				siteNavigationMenuItemType -> _getDropdownItem(
+					siteNavigationMenuItemType, themeDisplay)
 			).toArray(
 				DropdownItem[]::new
 			));
@@ -404,42 +399,6 @@ public class SiteNavigationAdminDisplayContext {
 		return _updatePermission;
 	}
 
-	private void _applyDropdownItem(
-		DropdownItem dropdownItem,
-		SiteNavigationMenuItemType siteNavigationMenuItemType,
-		ThemeDisplay themeDisplay) {
-
-		dropdownItem.setData(
-			HashMapBuilder.<String, Object>put(
-				"addItemURL",
-				() -> {
-					if (!siteNavigationMenuItemType.isItemSelector()) {
-						return null;
-					}
-
-					RenderRequest renderRequest =
-						(RenderRequest)_httpServletRequest.getAttribute(
-							JavaConstants.JAVAX_PORTLET_REQUEST);
-					RenderResponse renderResponse =
-						(RenderResponse)_httpServletRequest.getAttribute(
-							JavaConstants.JAVAX_PORTLET_RESPONSE);
-
-					PortletURL addURL = siteNavigationMenuItemType.getAddURL(
-						renderRequest, renderResponse);
-
-					return addURL.toString();
-				}
-			).put(
-				"href", _getAddURL(siteNavigationMenuItemType)
-			).put(
-				"itemSelector", siteNavigationMenuItemType.isItemSelector()
-			).put(
-				"siteNavigationMenuId", getSiteNavigationMenuId()
-			).build());
-		dropdownItem.setLabel(
-			siteNavigationMenuItemType.getLabel(themeDisplay.getLocale()));
-	}
-
 	private String _getAddURL(
 		SiteNavigationMenuItemType siteNavigationMenuItemType) {
 
@@ -492,6 +451,42 @@ public class SiteNavigationAdminDisplayContext {
 		}
 
 		return addURL.toString();
+	}
+
+	private DropdownItem _getDropdownItem(
+		SiteNavigationMenuItemType siteNavigationMenuItemType,
+		ThemeDisplay themeDisplay) {
+
+		return DropdownItemBuilder.setData(
+			HashMapBuilder.<String, Object>put(
+				"addItemURL",
+				() -> {
+					if (!siteNavigationMenuItemType.isItemSelector()) {
+						return null;
+					}
+
+					RenderRequest renderRequest =
+						(RenderRequest)_httpServletRequest.getAttribute(
+							JavaConstants.JAVAX_PORTLET_REQUEST);
+					RenderResponse renderResponse =
+						(RenderResponse)_httpServletRequest.getAttribute(
+							JavaConstants.JAVAX_PORTLET_RESPONSE);
+
+					PortletURL addURL = siteNavigationMenuItemType.getAddURL(
+						renderRequest, renderResponse);
+
+					return addURL.toString();
+				}
+			).put(
+				"href", _getAddURL(siteNavigationMenuItemType)
+			).put(
+				"itemSelector", siteNavigationMenuItemType.isItemSelector()
+			).put(
+				"siteNavigationMenuId", getSiteNavigationMenuId()
+			).build()
+		).setLabel(
+			siteNavigationMenuItemType.getLabel(themeDisplay.getLocale())
+		).build();
 	}
 
 	private JSONArray _getSiteNavigationMenuItemsJSONArray(

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/display/context/SiteNavigationAdminDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/display/context/SiteNavigationAdminDisplayContext.java
@@ -16,7 +16,7 @@ package com.liferay.site.navigation.admin.web.internal.display.context;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemBuilder;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemList;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
@@ -61,6 +61,7 @@ import com.liferay.staging.StagingGroupHelperUtil;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.portlet.PortletURL;
@@ -121,13 +122,14 @@ public class SiteNavigationAdminDisplayContext {
 		Stream<SiteNavigationMenuItemType> stream =
 			siteNavigationMenuItemTypes.stream();
 
-		return DropdownItemList.of(
+		return DropdownItemListBuilder.addAll(
 			stream.map(
 				siteNavigationMenuItemType -> _getDropdownItem(
 					siteNavigationMenuItemType, themeDisplay)
-			).toArray(
-				DropdownItem[]::new
-			));
+			).collect(
+				Collectors.toList()
+			)
+		).build();
 	}
 
 	public String getDisplayStyle() {

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/build.gradle
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:asset:asset-display-page-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
@@ -17,6 +18,7 @@ dependencies {
 	compileOnly project(":apps:item-selector:item-selector-taglib")
 	compileOnly project(":apps:layout:layout-display-page-api")
 	compileOnly project(":apps:layout:layout-item-selector-api")
+	compileOnly project(":apps:layout:layout-page-template-api")
 	compileOnly project(":apps:petra:petra-portlet-url-builder")
 	compileOnly project(":apps:site-navigation:site-navigation-admin-api")
 	compileOnly project(":apps:site-navigation:site-navigation-api")

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/configuration/FFDisplayPageSiteNavigationMenuItemConfiguration.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/configuration/FFDisplayPageSiteNavigationMenuItemConfiguration.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.site.navigation.menu.item.display.page.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@ExtendedObjectClassDefinition(generateUI = false)
+@Meta.OCD(
+	id = "com.liferay.site.navigation.menu.item.display.page.internal.configuration.FFDisplayPageSiteNavigationMenuItemConfiguration"
+)
+public interface FFDisplayPageSiteNavigationMenuItemConfiguration {
+
+	@Meta.AD(deflt = "false", required = false)
+	public boolean displayPageTypesEnabled();
+
+}

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/configuration/FFDisplayPageSiteNavigationMenuItemConfigurationUtil.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/configuration/FFDisplayPageSiteNavigationMenuItemConfigurationUtil.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.site.navigation.menu.item.display.page.internal.configuration;
+
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@Component(
+	configurationPid = "com.liferay.site.navigation.menu.item.display.page.internal.configuration.FFDisplayPageSiteNavigationMenuItemConfiguration",
+	immediate = true, service = {}
+)
+public class FFDisplayPageSiteNavigationMenuItemConfigurationUtil {
+
+	public static boolean displayPageTypesEnabled() {
+		return _ffDisplayPageSiteNavigationMenuItemConfiguration.
+			displayPageTypesEnabled();
+	}
+
+	@Activate
+	@Modified
+	protected void activate(Map<String, Object> properties) {
+		_ffDisplayPageSiteNavigationMenuItemConfiguration =
+			ConfigurableUtil.createConfigurable(
+				FFDisplayPageSiteNavigationMenuItemConfiguration.class,
+				properties);
+	}
+
+	private static volatile FFDisplayPageSiteNavigationMenuItemConfiguration
+		_ffDisplayPageSiteNavigationMenuItemConfiguration;
+
+}

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/constants/SiteNavigationMenuItemTypeDisplayPageWebKeys.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/constants/SiteNavigationMenuItemTypeDisplayPageWebKeys.java
@@ -19,16 +19,13 @@ package com.liferay.site.navigation.menu.item.display.page.internal.constants;
  */
 public class SiteNavigationMenuItemTypeDisplayPageWebKeys {
 
-	public static final String INFO_ITEM_CLASS_DETAILS =
-		"INFO_ITEM_CLASS_DETAILS";
+	public static final String DISPLAY_PAGE_TYPE_CONTEXT =
+		"DISPLAY_PAGE_TYPE_CONTEXT";
 
 	public static final String INFO_ITEM_SERVICE_TRACKER =
 		"INFO_ITEM_SERVICE_TRACKER";
 
 	public static final String ITEM_SELECTOR = "ITEM_SELECTOR";
-
-	public static final String LAYOUT_DISPLAY_PAGE_PROVIDER =
-		"LAYOUT_DISPLAY_PAGE_PROVIDER";
 
 	public static final String LAYOUT_DISPLAY_PAGE_PROVIDER_TRACKER =
 		"LAYOUT_DISPLAY_PAGE_PROVIDER_TRACKER";

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/constants/SiteNavigationMenuItemTypeDisplayPageWebKeys.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/constants/SiteNavigationMenuItemTypeDisplayPageWebKeys.java
@@ -19,10 +19,16 @@ package com.liferay.site.navigation.menu.item.display.page.internal.constants;
  */
 public class SiteNavigationMenuItemTypeDisplayPageWebKeys {
 
+	public static final String INFO_ITEM_CLASS_DETAILS =
+		"INFO_ITEM_CLASS_DETAILS";
+
 	public static final String INFO_ITEM_SERVICE_TRACKER =
 		"INFO_ITEM_SERVICE_TRACKER";
 
 	public static final String ITEM_SELECTOR = "ITEM_SELECTOR";
+
+	public static final String LAYOUT_DISPLAY_PAGE_PROVIDER =
+		"LAYOUT_DISPLAY_PAGE_PROVIDER";
 
 	public static final String LAYOUT_DISPLAY_PAGE_PROVIDER_TRACKER =
 		"LAYOUT_DISPLAY_PAGE_PROVIDER_TRACKER";

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/display/context/DisplayPageTypeSiteNavigationMenuTypeDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/display/context/DisplayPageTypeSiteNavigationMenuTypeDisplayContext.java
@@ -52,6 +52,10 @@ public class DisplayPageTypeSiteNavigationMenuTypeDisplayContext {
 			WebKeys.THEME_DISPLAY);
 	}
 
+	public String getClassName() {
+		return _displayPageTypeContext.getClassName();
+	}
+
 	public long getClassNameId() {
 		if (_classNameId != null) {
 			return _classNameId;

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/display/context/DisplayPageTypeSiteNavigationMenuTypeDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/display/context/DisplayPageTypeSiteNavigationMenuTypeDisplayContext.java
@@ -1,0 +1,233 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.site.navigation.menu.item.display.page.internal.display.context;
+
+import com.liferay.info.item.InfoItemFormVariation;
+import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
+import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.site.navigation.constants.SiteNavigationWebKeys;
+import com.liferay.site.navigation.menu.item.display.page.internal.constants.SiteNavigationMenuItemTypeDisplayPageWebKeys;
+import com.liferay.site.navigation.menu.item.display.page.internal.type.DisplayPageTypeContext;
+import com.liferay.site.navigation.model.SiteNavigationMenuItem;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class DisplayPageTypeSiteNavigationMenuTypeDisplayContext {
+
+	public DisplayPageTypeSiteNavigationMenuTypeDisplayContext(
+		HttpServletRequest httpServletRequest) {
+
+		_displayPageTypeContext =
+			(DisplayPageTypeContext)httpServletRequest.getAttribute(
+				SiteNavigationMenuItemTypeDisplayPageWebKeys.
+					DISPLAY_PAGE_TYPE_CONTEXT);
+		_siteNavigationMenuItem =
+			(SiteNavigationMenuItem)httpServletRequest.getAttribute(
+				SiteNavigationWebKeys.SITE_NAVIGATION_MENU_ITEM);
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	public long getClassNameId() {
+		if (_classNameId != null) {
+			return _classNameId;
+		}
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				_siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		_classNameId = GetterUtil.getLong(
+			typeSettingsUnicodeProperties.get("classNameId"));
+
+		return _classNameId;
+	}
+
+	public long getClassPK() {
+		if (_classPK != null) {
+			return _classPK;
+		}
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				_siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		_classPK = GetterUtil.getLong(
+			typeSettingsUnicodeProperties.get("classPK"));
+
+		return _classPK;
+	}
+
+	public long getClassTypeId() {
+		if (_classTypeId != null) {
+			return _classTypeId;
+		}
+
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+			_getLayoutDisplayPageObjectProvider();
+
+		if (layoutDisplayPageObjectProvider != null) {
+			_classTypeId = layoutDisplayPageObjectProvider.getClassTypeId();
+		}
+		else {
+			UnicodeProperties typeSettingsUnicodeProperties =
+				UnicodePropertiesBuilder.fastLoad(
+					_siteNavigationMenuItem.getTypeSettings()
+				).build();
+
+			_classTypeId = GetterUtil.getLong(
+				typeSettingsUnicodeProperties.get("classTypeId"));
+		}
+
+		return _classTypeId;
+	}
+
+	public String getItemSubtype() {
+		InfoItemFormVariationsProvider<?> infoItemFormVariationsProvider =
+			_displayPageTypeContext.getInfoItemFormVariationsProvider();
+
+		if (infoItemFormVariationsProvider == null) {
+			return StringPool.BLANK;
+		}
+
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+			_getLayoutDisplayPageObjectProvider();
+
+		if (layoutDisplayPageObjectProvider == null) {
+			return StringPool.BLANK;
+		}
+
+		InfoItemFormVariation infoItemFormVariation =
+			infoItemFormVariationsProvider.getInfoItemFormVariation(
+				layoutDisplayPageObjectProvider.getGroupId(),
+				String.valueOf(getClassTypeId()));
+
+		if (infoItemFormVariation != null) {
+			return infoItemFormVariation.getLabel(_themeDisplay.getLocale());
+		}
+
+		return StringPool.BLANK;
+	}
+
+	public String getItemType() {
+		return _displayPageTypeContext.getLabel(_themeDisplay.getLocale());
+	}
+
+	public String getItemTypeURL(
+		LiferayPortletResponse liferayPortletResponse) {
+
+		LiferayPortletURL itemTypeURL =
+			(LiferayPortletURL)liferayPortletResponse.createResourceURL();
+
+		itemTypeURL.setCopyCurrentRenderParameters(false);
+		itemTypeURL.setResourceID("/navigation_menu/get_item_type");
+
+		return itemTypeURL.toString();
+	}
+
+	public String getOriginalTitle() {
+		if (Validator.isNotNull(_originalTitle)) {
+			return _originalTitle;
+		}
+
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+			_getLayoutDisplayPageObjectProvider();
+
+		if (layoutDisplayPageObjectProvider == null) {
+			UnicodeProperties typeSettingsUnicodeProperties =
+				UnicodePropertiesBuilder.fastLoad(
+					_siteNavigationMenuItem.getTypeSettings()
+				).build();
+
+			_originalTitle = typeSettingsUnicodeProperties.getProperty("title");
+		}
+		else {
+			_originalTitle = layoutDisplayPageObjectProvider.getTitle(
+				_themeDisplay.getLocale());
+		}
+
+		return _originalTitle;
+	}
+
+	public String getTitle() {
+		if (Validator.isNotNull(_title)) {
+			return _title;
+		}
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				_siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		_title = typeSettingsUnicodeProperties.get("title");
+
+		return _title;
+	}
+
+	public String getType() {
+		if (Validator.isNotNull(_type)) {
+			return _type;
+		}
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				_siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		_type = typeSettingsUnicodeProperties.get("type");
+
+		return _type;
+	}
+
+	private LayoutDisplayPageObjectProvider<?>
+		_getLayoutDisplayPageObjectProvider() {
+
+		if (_layoutDisplayPageObjectProvider != null) {
+			return _layoutDisplayPageObjectProvider;
+		}
+
+		_layoutDisplayPageObjectProvider =
+			_displayPageTypeContext.getLayoutDisplayPageObjectProvider(
+				getClassPK());
+
+		return _layoutDisplayPageObjectProvider;
+	}
+
+	private Long _classNameId;
+	private Long _classPK;
+	private Long _classTypeId;
+	private final DisplayPageTypeContext _displayPageTypeContext;
+	private LayoutDisplayPageObjectProvider<?> _layoutDisplayPageObjectProvider;
+	private String _originalTitle;
+	private final SiteNavigationMenuItem _siteNavigationMenuItem;
+	private final ThemeDisplay _themeDisplay;
+	private String _title;
+	private String _type;
+
+}

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/portlet/action/AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/portlet/action/AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand.java
@@ -28,10 +28,10 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.navigation.admin.constants.SiteNavigationAdminPortletKeys;
 import com.liferay.site.navigation.exception.SiteNavigationMenuItemNameException;
-import com.liferay.site.navigation.menu.item.layout.constants.SiteNavigationMenuItemTypeConstants;
 import com.liferay.site.navigation.service.SiteNavigationMenuItemService;
 
 import javax.portlet.ActionRequest;
@@ -65,8 +65,12 @@ public class AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand
 		long classPK = ParamUtil.getLong(actionRequest, "classPK");
 		long siteNavigationMenuId = ParamUtil.getLong(
 			actionRequest, "siteNavigationMenuId");
+		String siteNavigationMenuItemType = ParamUtil.getString(
+			actionRequest, "siteNavigationMenuItemType");
 
-		if ((classNameId > 0) && (classPK > 0) && (siteNavigationMenuId > 0)) {
+		if ((classNameId > 0) && (classPK > 0) && (siteNavigationMenuId > 0) &&
+			Validator.isNotNull(siteNavigationMenuItemType)) {
+
 			UnicodeProperties curTypeSettingsUnicodeProperties =
 				new UnicodeProperties(true);
 
@@ -92,7 +96,7 @@ public class AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand
 			try {
 				_siteNavigationMenuItemService.addSiteNavigationMenuItem(
 					themeDisplay.getScopeGroupId(), siteNavigationMenuId, 0,
-					SiteNavigationMenuItemTypeConstants.DISPLAY_PAGE,
+					siteNavigationMenuItemType,
 					curTypeSettingsUnicodeProperties.toString(),
 					serviceContext);
 			}

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/portlet/action/AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/portlet/action/AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand.java
@@ -14,6 +14,7 @@
 
 package com.liferay.site.navigation.menu.item.display.page.internal.portlet.action;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -115,6 +116,22 @@ public class AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand
 						_portal.getHttpServletRequest(actionRequest),
 						"an-unexpected-error-occurred"));
 			}
+		}
+		else {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"Unable to add SiteNavigationMenuItem for classNameId ",
+						classNameId, ", classPK ", classPK,
+						" siteNavigationMenuId ", siteNavigationMenuId,
+						" and type ", siteNavigationMenuItemType));
+			}
+
+			jsonObject.put(
+				"errorMessage",
+				LanguageUtil.get(
+					_portal.getHttpServletRequest(actionRequest),
+					"an-unexpected-error-occurred"));
 		}
 
 		JSONPortletResponseUtil.writeJSON(

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/portlet/action/AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/portlet/action/AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.site.navigation.menu.item.display.page.internal.portlet.action;
+
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextFactory;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.site.navigation.admin.constants.SiteNavigationAdminPortletKeys;
+import com.liferay.site.navigation.exception.SiteNavigationMenuItemNameException;
+import com.liferay.site.navigation.menu.item.layout.constants.SiteNavigationMenuItemTypeConstants;
+import com.liferay.site.navigation.service.SiteNavigationMenuItemService;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + SiteNavigationAdminPortletKeys.SITE_NAVIGATION_ADMIN,
+		"mvc.command.name=/navigation_menu/add_display_page_type_site_navigation_menu_item"
+	},
+	service = MVCActionCommand.class
+)
+public class AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand
+	extends BaseMVCActionCommand {
+
+	@Override
+	protected void doProcessAction(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+
+		long classNameId = ParamUtil.getLong(actionRequest, "classNameId");
+		long classPK = ParamUtil.getLong(actionRequest, "classPK");
+		long siteNavigationMenuId = ParamUtil.getLong(
+			actionRequest, "siteNavigationMenuId");
+
+		if ((classNameId > 0) && (classPK > 0) && (siteNavigationMenuId > 0)) {
+			UnicodeProperties curTypeSettingsUnicodeProperties =
+				new UnicodeProperties(true);
+
+			curTypeSettingsUnicodeProperties.setProperty(
+				"classNameId", String.valueOf(classNameId));
+			curTypeSettingsUnicodeProperties.setProperty(
+				"classTypeId",
+				String.valueOf(
+					ParamUtil.getLong(actionRequest, "classTypeId")));
+			curTypeSettingsUnicodeProperties.setProperty(
+				"classPK", String.valueOf(classPK));
+			curTypeSettingsUnicodeProperties.setProperty(
+				"title", ParamUtil.getString(actionRequest, "title"));
+			curTypeSettingsUnicodeProperties.setProperty(
+				"type", ParamUtil.getString(actionRequest, "type"));
+
+			ServiceContext serviceContext = ServiceContextFactory.getInstance(
+				actionRequest);
+
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
+
+			try {
+				_siteNavigationMenuItemService.addSiteNavigationMenuItem(
+					themeDisplay.getScopeGroupId(), siteNavigationMenuId, 0,
+					SiteNavigationMenuItemTypeConstants.DISPLAY_PAGE,
+					curTypeSettingsUnicodeProperties.toString(),
+					serviceContext);
+			}
+			catch (SiteNavigationMenuItemNameException
+						siteNavigationMenuItemNameException) {
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						siteNavigationMenuItemNameException,
+						siteNavigationMenuItemNameException);
+				}
+
+				jsonObject.put(
+					"errorMessage",
+					LanguageUtil.get(
+						_portal.getHttpServletRequest(actionRequest),
+						"an-unexpected-error-occurred"));
+			}
+		}
+
+		JSONPortletResponseUtil.writeJSON(
+			actionRequest, actionResponse, jsonObject);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AddDisplayPageTypeSiteNavigationMenuItemMVCActionCommand.class);
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private SiteNavigationMenuItemService _siteNavigationMenuItemService;
+
+}

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageSiteNavigationMenuItemTypeRegistrar.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageSiteNavigationMenuItemTypeRegistrar.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.site.navigation.menu.item.display.page.internal.type;
+
+import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
+import com.liferay.frontend.taglib.servlet.taglib.util.JSPRenderer;
+import com.liferay.info.item.InfoItemClassDetails;
+import com.liferay.info.item.InfoItemServiceTracker;
+import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
+import com.liferay.item.selector.ItemSelector;
+import com.liferay.layout.display.page.LayoutDisplayPageProvider;
+import com.liferay.layout.display.page.LayoutDisplayPageProviderTracker;
+import com.liferay.layout.page.template.info.item.capability.DisplayPageInfoItemCapability;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.site.navigation.menu.item.display.page.internal.configuration.FFDisplayPageSiteNavigationMenuItemConfigurationUtil;
+import com.liferay.site.navigation.type.SiteNavigationMenuItemType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletContext;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@Component(immediate = true, service = {})
+public class DisplayPageSiteNavigationMenuItemTypeRegistrar {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceRegistrations = new HashMap<>();
+
+		if (!FFDisplayPageSiteNavigationMenuItemConfigurationUtil.
+				displayPageTypesEnabled()) {
+
+			return;
+		}
+
+		int ranking = 300;
+
+		for (InfoItemClassDetails infoItemClassDetails :
+				_infoItemServiceTracker.getInfoItemClassDetails(
+					DisplayPageInfoItemCapability.KEY)) {
+
+			LayoutDisplayPageProvider<?> layoutDisplayPageProvider =
+				_layoutDisplayPageProviderTracker.
+					getLayoutDisplayPageProviderByClassName(
+						infoItemClassDetails.getClassName());
+
+			if (layoutDisplayPageProvider == null) {
+				continue;
+			}
+
+			_serviceRegistrations.put(
+				infoItemClassDetails.getClassName(),
+				bundleContext.registerService(
+					SiteNavigationMenuItemType.class,
+					new DisplayPageTypeSiteNavigationMenuItemType(
+						_assetDisplayPageFriendlyURLProvider,
+						new DisplayPageTypeContext(
+							infoItemClassDetails,
+							_infoItemServiceTracker.getFirstInfoItemService(
+								InfoItemFormVariationsProvider.class,
+								infoItemClassDetails.getClassName()),
+							layoutDisplayPageProvider),
+						_itemSelector, _jspRenderer, _portal, _servletContext),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"service.ranking:Integer", ranking
+					).put(
+						"site.navigation.menu.item.type",
+						infoItemClassDetails.getClassName()
+					).build()));
+
+			ranking += 10;
+		}
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		for (ServiceRegistration<?> serviceRegistration :
+				_serviceRegistrations.values()) {
+
+			serviceRegistration.unregister();
+		}
+	}
+
+	@Reference
+	private AssetDisplayPageFriendlyURLProvider
+		_assetDisplayPageFriendlyURLProvider;
+
+	@Reference
+	private InfoItemServiceTracker _infoItemServiceTracker;
+
+	@Reference
+	private ItemSelector _itemSelector;
+
+	@Reference
+	private JSPRenderer _jspRenderer;
+
+	@Reference
+	private LayoutDisplayPageProviderTracker _layoutDisplayPageProviderTracker;
+
+	@Reference
+	private Portal _portal;
+
+	private Map<String, ServiceRegistration<?>> _serviceRegistrations;
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.site.navigation.menu.item.display.page)",
+		unbind = "-"
+	)
+	private ServletContext _servletContext;
+
+}

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeContext.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeContext.java
@@ -16,6 +16,7 @@ package com.liferay.site.navigation.menu.item.display.page.internal.type;
 
 import com.liferay.info.item.InfoItemClassDetails;
 import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 
@@ -28,9 +29,11 @@ public class DisplayPageTypeContext {
 
 	public DisplayPageTypeContext(
 		InfoItemClassDetails infoItemClassDetails,
+		InfoItemFormVariationsProvider<?> infoItemFormVariationsProvider,
 		LayoutDisplayPageProvider layoutDisplayPageProvider) {
 
 		_infoItemClassDetails = infoItemClassDetails;
+		_infoItemFormVariationsProvider = infoItemFormVariationsProvider;
 		_layoutDisplayPageProvider = layoutDisplayPageProvider;
 	}
 
@@ -40,6 +43,12 @@ public class DisplayPageTypeContext {
 
 	public InfoItemClassDetails getInfoItemClassDetails() {
 		return _infoItemClassDetails;
+	}
+
+	public InfoItemFormVariationsProvider<?>
+		getInfoItemFormVariationsProvider() {
+
+		return _infoItemFormVariationsProvider;
 	}
 
 	public String getLabel(Locale locale) {
@@ -59,6 +68,8 @@ public class DisplayPageTypeContext {
 	}
 
 	private final InfoItemClassDetails _infoItemClassDetails;
+	private final InfoItemFormVariationsProvider<?>
+		_infoItemFormVariationsProvider;
 	private final LayoutDisplayPageProvider<?> _layoutDisplayPageProvider;
 
 }

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeContext.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeContext.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.site.navigation.menu.item.display.page.internal.type;
+
+import com.liferay.info.item.InfoItemClassDetails;
+import com.liferay.info.item.InfoItemReference;
+import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
+import com.liferay.layout.display.page.LayoutDisplayPageProvider;
+
+import java.util.Locale;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class DisplayPageTypeContext {
+
+	public DisplayPageTypeContext(
+		InfoItemClassDetails infoItemClassDetails,
+		LayoutDisplayPageProvider layoutDisplayPageProvider) {
+
+		_infoItemClassDetails = infoItemClassDetails;
+		_layoutDisplayPageProvider = layoutDisplayPageProvider;
+	}
+
+	public String getClassName() {
+		return _infoItemClassDetails.getClassName();
+	}
+
+	public InfoItemClassDetails getInfoItemClassDetails() {
+		return _infoItemClassDetails;
+	}
+
+	public String getLabel(Locale locale) {
+		return _infoItemClassDetails.getLabel(locale);
+	}
+
+	public LayoutDisplayPageObjectProvider<?>
+		getLayoutDisplayPageObjectProvider(long classPK) {
+
+		return _layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+			new InfoItemReference(
+				_infoItemClassDetails.getClassName(), classPK));
+	}
+
+	public LayoutDisplayPageProvider<?> getLayoutDisplayPageProvider() {
+		return _layoutDisplayPageProvider;
+	}
+
+	private final InfoItemClassDetails _infoItemClassDetails;
+	private final LayoutDisplayPageProvider<?> _layoutDisplayPageProvider;
+
+}

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeSiteNavigationMenuItemType.java
@@ -127,7 +127,9 @@ public class DisplayPageTypeSiteNavigationMenuItemType
 		return PortletURLBuilder.createActionURL(
 			renderResponse
 		).setActionName(
-			"/navigation_menu/add_display_page_site_navigation_menu_item"
+			"/navigation_menu/add_display_page_type_site_navigation_menu_item"
+		).setParameter(
+			"siteNavigationMenuItemType", getType()
 		).buildPortletURL();
 	}
 
@@ -325,7 +327,7 @@ public class DisplayPageTypeSiteNavigationMenuItemType
 
 		_jspRenderer.renderJSP(
 			_servletContext, httpServletRequest, httpServletResponse,
-			"/edit_display_page.jsp");
+			"/edit_display_page_type.jsp");
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeSiteNavigationMenuItemType.java
@@ -1,0 +1,387 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.site.navigation.menu.item.display.page.internal.type;
+
+import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.frontend.taglib.servlet.taglib.util.JSPRenderer;
+import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.item.InfoItemServiceTracker;
+import com.liferay.item.selector.ItemSelector;
+import com.liferay.item.selector.criteria.InfoItemItemSelectorReturnType;
+import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
+import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
+import com.liferay.layout.display.page.LayoutDisplayPageProvider;
+import com.liferay.layout.display.page.LayoutDisplayPageProviderTracker;
+import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ClassedModel;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.site.navigation.constants.SiteNavigationWebKeys;
+import com.liferay.site.navigation.menu.item.display.page.internal.constants.SiteNavigationMenuItemTypeDisplayPageWebKeys;
+import com.liferay.site.navigation.menu.item.layout.constants.SiteNavigationMenuItemTypeConstants;
+import com.liferay.site.navigation.model.SiteNavigationMenuItem;
+import com.liferay.site.navigation.type.SiteNavigationMenuItemType;
+
+import java.io.IOException;
+
+import java.util.Locale;
+import java.util.Map;
+
+import javax.portlet.PortletURL;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class DisplayPageTypeSiteNavigationMenuItemType
+	implements SiteNavigationMenuItemType {
+
+	public DisplayPageTypeSiteNavigationMenuItemType(
+		AssetDisplayPageFriendlyURLProvider assetDisplayPageFriendlyURLProvider,
+		InfoItemServiceTracker infoItemServiceTracker,
+		ItemSelector itemSelector, JSPRenderer jspRenderer,
+		LayoutDisplayPageProviderTracker layoutDisplayPageProviderTracker,
+		Portal portal, ServletContext servletContext) {
+
+		_assetDisplayPageFriendlyURLProvider =
+			assetDisplayPageFriendlyURLProvider;
+		_infoItemServiceTracker = infoItemServiceTracker;
+		_itemSelector = itemSelector;
+		_jspRenderer = jspRenderer;
+		_layoutDisplayPageProviderTracker = layoutDisplayPageProviderTracker;
+		_portal = portal;
+		_servletContext = servletContext;
+	}
+
+	@Override
+	public boolean exportData(
+		PortletDataContext portletDataContext,
+		Element siteNavigationMenuItemElement,
+		SiteNavigationMenuItem siteNavigationMenuItem) {
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		long classNameId = GetterUtil.getLong(
+			typeSettingsUnicodeProperties.get("classNameId"));
+
+		if (classNameId <= 0) {
+			return false;
+		}
+
+		String className = _portal.getClassName(classNameId);
+
+		LayoutDisplayPageProvider<?> layoutDisplayPageProvider =
+			_layoutDisplayPageProviderTracker.
+				getLayoutDisplayPageProviderByClassName(className);
+
+		if (layoutDisplayPageProvider == null) {
+			return false;
+		}
+
+		long classPK = GetterUtil.getLong(
+			typeSettingsUnicodeProperties.get("classPK"));
+
+		try {
+			LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+				layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+					new InfoItemReference(className, classPK));
+
+			siteNavigationMenuItemElement.addAttribute(
+				"display-page-class-name", className);
+			siteNavigationMenuItemElement.addAttribute(
+				"display-page-class-pk", String.valueOf(classPK));
+
+			portletDataContext.addReferenceElement(
+				siteNavigationMenuItem, siteNavigationMenuItemElement,
+				(ClassedModel)
+					layoutDisplayPageObjectProvider.getDisplayObject(),
+				PortletDataContext.REFERENCE_TYPE_DEPENDENCY, false);
+
+			return true;
+		}
+		catch (RuntimeException runtimeException) {
+			_log.error(runtimeException, runtimeException);
+		}
+
+		return false;
+	}
+
+	@Override
+	public PortletURL getAddURL(
+		RenderRequest renderRequest, RenderResponse renderResponse) {
+
+		return PortletURLBuilder.createActionURL(
+			renderResponse
+		).setActionName(
+			"/navigation_menu/add_display_page_site_navigation_menu_item"
+		).buildPortletURL();
+	}
+
+	@Override
+	public String getIcon() {
+		return "page";
+	}
+
+	@Override
+	public String getItemSelectorURL(HttpServletRequest httpServletRequest) {
+		RenderResponse renderResponse =
+			(RenderResponse)httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_RESPONSE);
+
+		InfoItemItemSelectorCriterion itemSelectorCriterion =
+			new InfoItemItemSelectorCriterion();
+
+		itemSelectorCriterion.setDesiredItemSelectorReturnTypes(
+			new InfoItemItemSelectorReturnType());
+
+		PortletURL infoItemSelectorURL = _itemSelector.getItemSelectorURL(
+			RequestBackedPortletURLFactoryUtil.create(httpServletRequest),
+			renderResponse.getNamespace() + "selectItem",
+			itemSelectorCriterion);
+
+		if (infoItemSelectorURL == null) {
+			return StringPool.BLANK;
+		}
+
+		return infoItemSelectorURL.toString();
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		return LanguageUtil.get(locale, "display-page");
+	}
+
+	@Override
+	public String getRegularURL(
+			HttpServletRequest httpServletRequest,
+			SiteNavigationMenuItem siteNavigationMenuItem)
+		throws Exception {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		if (themeDisplay == null) {
+			return StringPool.BLANK;
+		}
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		String friendlyURL =
+			_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
+				_portal.getClassName(
+					GetterUtil.getLong(
+						typeSettingsUnicodeProperties.get("classNameId"))),
+				GetterUtil.getLong(
+					typeSettingsUnicodeProperties.get("classPK")),
+				themeDisplay);
+
+		if (Validator.isNotNull(friendlyURL)) {
+			return friendlyURL;
+		}
+
+		return themeDisplay.getURLCurrent() + StringPool.POUND;
+	}
+
+	@Override
+	public String getSubtitle(
+		SiteNavigationMenuItem siteNavigationMenuItem, Locale locale) {
+
+		return LanguageUtil.get(locale, "display-page");
+	}
+
+	@Override
+	public String getTarget(SiteNavigationMenuItem siteNavigationMenuItem) {
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		boolean useNewTab = GetterUtil.getBoolean(
+			typeSettingsUnicodeProperties.getProperty(
+				"useNewTab", Boolean.FALSE.toString()));
+
+		if (!useNewTab) {
+			return StringPool.BLANK;
+		}
+
+		return "target=\"_blank\"";
+	}
+
+	@Override
+	public String getTitle(
+		SiteNavigationMenuItem siteNavigationMenuItem, Locale locale) {
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+			_getLayoutDisplayPageObjectProvider(typeSettingsUnicodeProperties);
+
+		if (layoutDisplayPageObjectProvider == null) {
+			return typeSettingsUnicodeProperties.getProperty("title");
+		}
+
+		return layoutDisplayPageObjectProvider.getTitle(locale);
+	}
+
+	@Override
+	public String getType() {
+		return SiteNavigationMenuItemTypeConstants.DISPLAY_PAGE;
+	}
+
+	@Override
+	public boolean importData(
+		PortletDataContext portletDataContext,
+		SiteNavigationMenuItem siteNavigationMenuItem,
+		SiteNavigationMenuItem importedSiteNavigationMenuItem) {
+
+		Element element = portletDataContext.getImportDataElement(
+			siteNavigationMenuItem);
+
+		String className = element.attributeValue("display-page-class-name");
+		long classPK = GetterUtil.getLong(
+			element.attributeValue("display-page-class-pk"));
+
+		if (Validator.isNull(className) || (classPK <= 0)) {
+			return false;
+		}
+
+		Map<Long, Long> newClassPKsMap =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(className);
+
+		importedSiteNavigationMenuItem.setTypeSettings(
+			UnicodePropertiesBuilder.fastLoad(
+				siteNavigationMenuItem.getTypeSettings()
+			).put(
+				"classNameId", String.valueOf(_portal.getClassNameId(className))
+			).put(
+				"classPK",
+				String.valueOf(
+					MapUtil.getLong(newClassPKsMap, classPK, classPK))
+			).buildString());
+
+		return true;
+	}
+
+	@Override
+	public boolean isBrowsable(SiteNavigationMenuItem siteNavigationMenuItem) {
+		return true;
+	}
+
+	@Override
+	public boolean isItemSelector() {
+		return true;
+	}
+
+	@Override
+	public void renderAddPage(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException {
+	}
+
+	@Override
+	public void renderEditPage(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse,
+			SiteNavigationMenuItem siteNavigationMenuItem)
+		throws IOException {
+
+		httpServletRequest.setAttribute(
+			SiteNavigationMenuItemTypeDisplayPageWebKeys.
+				INFO_ITEM_SERVICE_TRACKER,
+			_infoItemServiceTracker);
+		httpServletRequest.setAttribute(
+			SiteNavigationMenuItemTypeDisplayPageWebKeys.ITEM_SELECTOR,
+			_itemSelector);
+		httpServletRequest.setAttribute(
+			SiteNavigationMenuItemTypeDisplayPageWebKeys.
+				LAYOUT_DISPLAY_PAGE_PROVIDER_TRACKER,
+			_layoutDisplayPageProviderTracker);
+		httpServletRequest.setAttribute(
+			SiteNavigationWebKeys.SITE_NAVIGATION_MENU_ITEM,
+			siteNavigationMenuItem);
+
+		_jspRenderer.renderJSP(
+			_servletContext, httpServletRequest, httpServletResponse,
+			"/edit_display_page.jsp");
+	}
+
+	private LayoutDisplayPageObjectProvider<?>
+		_getLayoutDisplayPageObjectProvider(
+			UnicodeProperties typeSettingsUnicodeProperties) {
+
+		long classNameId = GetterUtil.getLong(
+			typeSettingsUnicodeProperties.get("classNameId"));
+
+		String className = _portal.getClassName(classNameId);
+
+		LayoutDisplayPageProvider<?> layoutDisplayPageProvider =
+			_layoutDisplayPageProviderTracker.
+				getLayoutDisplayPageProviderByClassName(className);
+
+		if (layoutDisplayPageProvider == null) {
+			return null;
+		}
+
+		long classPK = GetterUtil.getLong(
+			typeSettingsUnicodeProperties.get("classPK"));
+
+		return layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+			new InfoItemReference(className, classPK));
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DisplayPageTypeSiteNavigationMenuItemType.class);
+
+	private final AssetDisplayPageFriendlyURLProvider
+		_assetDisplayPageFriendlyURLProvider;
+	private final InfoItemServiceTracker _infoItemServiceTracker;
+	private final ItemSelector _itemSelector;
+	private final JSPRenderer _jspRenderer;
+	private final LayoutDisplayPageProviderTracker
+		_layoutDisplayPageProviderTracker;
+	private final Portal _portal;
+	private final ServletContext _servletContext;
+
+}

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeSiteNavigationMenuItemType.java
@@ -26,7 +26,6 @@ import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ClassedModel;
@@ -43,7 +42,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.site.navigation.constants.SiteNavigationWebKeys;
 import com.liferay.site.navigation.menu.item.display.page.internal.constants.SiteNavigationMenuItemTypeDisplayPageWebKeys;
-import com.liferay.site.navigation.menu.item.layout.constants.SiteNavigationMenuItemTypeConstants;
 import com.liferay.site.navigation.model.SiteNavigationMenuItem;
 import com.liferay.site.navigation.type.SiteNavigationMenuItemType;
 
@@ -166,7 +164,7 @@ public class DisplayPageTypeSiteNavigationMenuItemType
 
 	@Override
 	public String getLabel(Locale locale) {
-		return LanguageUtil.get(locale, "display-page");
+		return _infoItemClassDetails.getLabel(locale);
 	}
 
 	@Override
@@ -206,7 +204,7 @@ public class DisplayPageTypeSiteNavigationMenuItemType
 	public String getSubtitle(
 		SiteNavigationMenuItem siteNavigationMenuItem, Locale locale) {
 
-		return LanguageUtil.get(locale, "display-page");
+		return _infoItemClassDetails.getLabel(locale);
 	}
 
 	@Override
@@ -252,7 +250,7 @@ public class DisplayPageTypeSiteNavigationMenuItemType
 
 	@Override
 	public String getType() {
-		return SiteNavigationMenuItemTypeConstants.DISPLAY_PAGE;
+		return _infoItemClassDetails.getClassName();
 	}
 
 	@Override

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeSiteNavigationMenuItemType.java
@@ -149,6 +149,7 @@ public class DisplayPageTypeSiteNavigationMenuItemType
 
 		itemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new InfoItemItemSelectorReturnType());
+		itemSelectorCriterion.setItemType(_infoItemClassDetails.getClassName());
 
 		PortletURL infoItemSelectorURL = _itemSelector.getItemSelectorURL(
 			RequestBackedPortletURLFactoryUtil.create(httpServletRequest),

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/resources/META-INF/resources/edit_display_page_type.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/resources/META-INF/resources/edit_display_page_type.jsp
@@ -1,0 +1,93 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+DisplayPageSiteNavigationMenuTypeDisplayContext displayPageSiteNavigationMenuTypeDisplayContext = new DisplayPageSiteNavigationMenuTypeDisplayContext(request);
+%>
+
+<aui:input id="classNameId" name="TypeSettingsProperties--classNameId--" type="hidden" value="<%= displayPageSiteNavigationMenuTypeDisplayContext.getClassNameId() %>">
+	<aui:validator name="required" />
+</aui:input>
+
+<aui:input id="classPK" name="TypeSettingsProperties--classPK--" type="hidden" value="<%= displayPageSiteNavigationMenuTypeDisplayContext.getClassPK() %>">
+	<aui:validator name="required" />
+</aui:input>
+
+<aui:input id="classTypeId" name="TypeSettingsProperties--classTypeId--" type="hidden" value="<%= displayPageSiteNavigationMenuTypeDisplayContext.getClassTypeId() %>" />
+
+<aui:input id="title" name="TypeSettingsProperties--title--" type="hidden" value="<%= displayPageSiteNavigationMenuTypeDisplayContext.getTitle() %>" />
+
+<aui:input id="type" name="TypeSettingsProperties--type--" type="hidden" value="<%= displayPageSiteNavigationMenuTypeDisplayContext.getType() %>" />
+
+<aui:input autoFocus="<%= true %>" disabled="<%= true %>" label="title" localized="<%= false %>" name="originalTitle" placeholder="title" type="text" value="<%= displayPageSiteNavigationMenuTypeDisplayContext.getOriginalTitle() %>" />
+
+<div>
+	<p class="list-group-title">
+		<liferay-ui:message key="item-type" />
+	</p>
+
+	<p class="small" id="<portlet:namespace />itemTypeLabel">
+		<%= HtmlUtil.escape(displayPageSiteNavigationMenuTypeDisplayContext.getItemType()) %>
+	</p>
+</div>
+
+<%
+String itemSubtype = displayPageSiteNavigationMenuTypeDisplayContext.getItemSubtype();
+%>
+
+<div class="<%= Validator.isNull(itemSubtype) ? "d-none" : "" %>" id="<portlet:namespace />itemSubtype">
+	<div>
+		<p class="list-group-title">
+			<liferay-ui:message key="item-subtype" />
+		</p>
+
+		<p class="small" id="<portlet:namespace />itemSubtypeLabel">
+			<%= HtmlUtil.escape(itemSubtype) %>
+		</p>
+	</div>
+</div>
+
+<%
+String eventName = liferayPortletResponse.getNamespace() + "selectInfoItem";
+
+ItemSelector itemSelector = (ItemSelector)request.getAttribute(SiteNavigationMenuItemTypeDisplayPageWebKeys.ITEM_SELECTOR);
+
+InfoItemItemSelectorCriterion itemSelectorCriterion = new InfoItemItemSelectorCriterion();
+
+itemSelectorCriterion.setDesiredItemSelectorReturnTypes(new InfoItemItemSelectorReturnType());
+
+PortletURL infoItemSelectorURL = itemSelector.getItemSelectorURL(RequestBackedPortletURLFactoryUtil.create(request), liferayPortletResponse.getNamespace() + "selectInfoItem", itemSelectorCriterion);
+%>
+
+<clay:button
+	additionalProps='<%=
+		HashMapBuilder.<String, Object>put(
+			"eventName", eventName
+		).put(
+			"getItemTypeURL", displayPageSiteNavigationMenuTypeDisplayContext.getItemTypeURL(liferayPortletResponse)
+		).put(
+			"itemSelectorURL", infoItemSelectorURL.toString()
+		).build()
+	%>'
+	cssClass="mb-4"
+	displayType="secondary"
+	id='<%= liferayPortletResponse.getNamespace() + "chooseInfoItem" %>'
+	label='<%= LanguageUtil.get(resourceBundle, "choose") %>'
+	propsTransformer="js/ChooseInfoItemButtonPropsTransformer"
+	small="<%= true %>"
+/>

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/resources/META-INF/resources/edit_display_page_type.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/resources/META-INF/resources/edit_display_page_type.jsp
@@ -17,24 +17,24 @@
 <%@ include file="/init.jsp" %>
 
 <%
-DisplayPageSiteNavigationMenuTypeDisplayContext displayPageSiteNavigationMenuTypeDisplayContext = new DisplayPageSiteNavigationMenuTypeDisplayContext(request);
+DisplayPageTypeSiteNavigationMenuTypeDisplayContext displayPageTypeSiteNavigationMenuTypeDisplayContext = new DisplayPageTypeSiteNavigationMenuTypeDisplayContext(request);
 %>
 
-<aui:input id="classNameId" name="TypeSettingsProperties--classNameId--" type="hidden" value="<%= displayPageSiteNavigationMenuTypeDisplayContext.getClassNameId() %>">
+<aui:input id="classNameId" name="TypeSettingsProperties--classNameId--" type="hidden" value="<%= displayPageTypeSiteNavigationMenuTypeDisplayContext.getClassNameId() %>">
 	<aui:validator name="required" />
 </aui:input>
 
-<aui:input id="classPK" name="TypeSettingsProperties--classPK--" type="hidden" value="<%= displayPageSiteNavigationMenuTypeDisplayContext.getClassPK() %>">
+<aui:input id="classPK" name="TypeSettingsProperties--classPK--" type="hidden" value="<%= displayPageTypeSiteNavigationMenuTypeDisplayContext.getClassPK() %>">
 	<aui:validator name="required" />
 </aui:input>
 
-<aui:input id="classTypeId" name="TypeSettingsProperties--classTypeId--" type="hidden" value="<%= displayPageSiteNavigationMenuTypeDisplayContext.getClassTypeId() %>" />
+<aui:input id="classTypeId" name="TypeSettingsProperties--classTypeId--" type="hidden" value="<%= displayPageTypeSiteNavigationMenuTypeDisplayContext.getClassTypeId() %>" />
 
-<aui:input id="title" name="TypeSettingsProperties--title--" type="hidden" value="<%= displayPageSiteNavigationMenuTypeDisplayContext.getTitle() %>" />
+<aui:input id="title" name="TypeSettingsProperties--title--" type="hidden" value="<%= displayPageTypeSiteNavigationMenuTypeDisplayContext.getTitle() %>" />
 
-<aui:input id="type" name="TypeSettingsProperties--type--" type="hidden" value="<%= displayPageSiteNavigationMenuTypeDisplayContext.getType() %>" />
+<aui:input id="type" name="TypeSettingsProperties--type--" type="hidden" value="<%= displayPageTypeSiteNavigationMenuTypeDisplayContext.getType() %>" />
 
-<aui:input autoFocus="<%= true %>" disabled="<%= true %>" label="title" localized="<%= false %>" name="originalTitle" placeholder="title" type="text" value="<%= displayPageSiteNavigationMenuTypeDisplayContext.getOriginalTitle() %>" />
+<aui:input autoFocus="<%= true %>" disabled="<%= true %>" label="title" localized="<%= false %>" name="originalTitle" placeholder="title" type="text" value="<%= displayPageTypeSiteNavigationMenuTypeDisplayContext.getOriginalTitle() %>" />
 
 <div>
 	<p class="list-group-title">
@@ -42,12 +42,12 @@ DisplayPageSiteNavigationMenuTypeDisplayContext displayPageSiteNavigationMenuTyp
 	</p>
 
 	<p class="small" id="<portlet:namespace />itemTypeLabel">
-		<%= HtmlUtil.escape(displayPageSiteNavigationMenuTypeDisplayContext.getItemType()) %>
+		<%= HtmlUtil.escape(displayPageTypeSiteNavigationMenuTypeDisplayContext.getItemType()) %>
 	</p>
 </div>
 
 <%
-String itemSubtype = displayPageSiteNavigationMenuTypeDisplayContext.getItemSubtype();
+String itemSubtype = displayPageTypeSiteNavigationMenuTypeDisplayContext.getItemSubtype();
 %>
 
 <div class="<%= Validator.isNull(itemSubtype) ? "d-none" : "" %>" id="<portlet:namespace />itemSubtype">
@@ -70,6 +70,7 @@ ItemSelector itemSelector = (ItemSelector)request.getAttribute(SiteNavigationMen
 InfoItemItemSelectorCriterion itemSelectorCriterion = new InfoItemItemSelectorCriterion();
 
 itemSelectorCriterion.setDesiredItemSelectorReturnTypes(new InfoItemItemSelectorReturnType());
+itemSelectorCriterion.setItemType(displayPageTypeSiteNavigationMenuTypeDisplayContext.getClassName());
 
 PortletURL infoItemSelectorURL = itemSelector.getItemSelectorURL(RequestBackedPortletURLFactoryUtil.create(request), liferayPortletResponse.getNamespace() + "selectInfoItem", itemSelectorCriterion);
 %>
@@ -79,7 +80,7 @@ PortletURL infoItemSelectorURL = itemSelector.getItemSelectorURL(RequestBackedPo
 		HashMapBuilder.<String, Object>put(
 			"eventName", eventName
 		).put(
-			"getItemTypeURL", displayPageSiteNavigationMenuTypeDisplayContext.getItemTypeURL(liferayPortletResponse)
+			"getItemTypeURL", displayPageTypeSiteNavigationMenuTypeDisplayContext.getItemTypeURL(liferayPortletResponse)
 		).put(
 			"itemSelectorURL", infoItemSelectorURL.toString()
 		).build()

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/resources/META-INF/resources/edit_display_page_type.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/resources/META-INF/resources/edit_display_page_type.jsp
@@ -62,29 +62,8 @@ String itemSubtype = displayPageTypeSiteNavigationMenuTypeDisplayContext.getItem
 	</div>
 </div>
 
-<%
-String eventName = liferayPortletResponse.getNamespace() + "selectInfoItem";
-
-ItemSelector itemSelector = (ItemSelector)request.getAttribute(SiteNavigationMenuItemTypeDisplayPageWebKeys.ITEM_SELECTOR);
-
-InfoItemItemSelectorCriterion itemSelectorCriterion = new InfoItemItemSelectorCriterion();
-
-itemSelectorCriterion.setDesiredItemSelectorReturnTypes(new InfoItemItemSelectorReturnType());
-itemSelectorCriterion.setItemType(displayPageTypeSiteNavigationMenuTypeDisplayContext.getClassName());
-
-PortletURL infoItemSelectorURL = itemSelector.getItemSelectorURL(RequestBackedPortletURLFactoryUtil.create(request), liferayPortletResponse.getNamespace() + "selectInfoItem", itemSelectorCriterion);
-%>
-
 <clay:button
-	additionalProps='<%=
-		HashMapBuilder.<String, Object>put(
-			"eventName", eventName
-		).put(
-			"getItemTypeURL", displayPageTypeSiteNavigationMenuTypeDisplayContext.getItemTypeURL(liferayPortletResponse)
-		).put(
-			"itemSelectorURL", infoItemSelectorURL.toString()
-		).build()
-	%>'
+	additionalProps="<%= displayPageTypeSiteNavigationMenuTypeDisplayContext.getChooseInfoItemButtonContext(request, liferayPortletResponse) %>"
 	cssClass="mb-4"
 	displayType="secondary"
 	id='<%= liferayPortletResponse.getNamespace() + "chooseInfoItem" %>'

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/resources/META-INF/resources/init.jsp
@@ -31,7 +31,8 @@ page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.site.navigation.menu.item.display.page.internal.constants.SiteNavigationMenuItemTypeDisplayPageWebKeys" %><%@
-page import="com.liferay.site.navigation.menu.item.display.page.internal.display.context.DisplayPageSiteNavigationMenuTypeDisplayContext" %>
+page import="com.liferay.site.navigation.menu.item.display.page.internal.display.context.DisplayPageSiteNavigationMenuTypeDisplayContext" %><%@
+page import="com.liferay.site.navigation.menu.item.display.page.internal.display.context.DisplayPageTypeSiteNavigationMenuTypeDisplayContext" %>
 
 <%@ page import="javax.portlet.PortletURL" %>
 


### PR DESCRIPTION
Previous PR: https://github.com/brianchandotcom/liferay-portal/pull/110022

Hi @brianchandotcom,

Sorry for the delay, but I found source formatter issues. 

Finally, I realized that when you use lambda expressions with more than one line, the source formatter doesn't catch the neediness to use a builder. 

So, when I tried to optimize the code, after using DropdownItemList.of, the source formatter said that I must use the Builder.

I tidy my last commit to using DropdownItemList.of but I think that that lambda is really ugly. So I pushed a few commits more to simplify the code adding a new method to the builder that accepts a list.

I think the new method will be useful in other places too.

Please, let me know if there is a better approach that I didn't see

I also tidy some previous commit with your formatter tips that I am able to still remember.

Thanks!

Regards