### PR TITLE
[TS] LPS-141727 Change css class name to avoid conflict with aui_deprecated.css

### DIFF
--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/css/main.scss
@@ -269,7 +269,7 @@ $section-header-bg: #cce6f7;
 			display: none;
 		}
 
-		.field-group .lexicon-icon-pencil {
+		.lfr-field-group .lexicon-icon-pencil {
 			display: none;
 		}
 	}
@@ -533,7 +533,7 @@ $section-header-bg: #cce6f7;
 		overflow: hidden;
 	}
 
-	.my-profile .field-group {
+	.my-profile .lfr-field-group {
 		position: relative;
 
 		&.user-tags-wrapper {

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/user/view_user_information.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/user/view_user_information.jsp
@@ -31,7 +31,7 @@ if (assetTags.isEmpty() || Validator.isNull(user2.getComments())) {
 %>
 
 <c:if test="<%= showComments && Validator.isNotNull(user2.getComments()) %>">
-	<div class="field-group lfr-user-comments section" data-title="<%= LanguageUtil.get(request, "introduction") %>">
+	<div class="lfr-field-group lfr-user-comments section" data-title="<%= LanguageUtil.get(request, "introduction") %>">
 
 		<%
 		PortletURL editCommentsURL = PortletURLFactoryUtil.create(request, PortletKeys.MY_ACCOUNT, embeddedPersonalApplicationLayout, PortletRequest.RENDER_PHASE);
@@ -62,7 +62,7 @@ if (phones.isEmpty()) {
 %>
 
 <c:if test="<%= showPhones && !phones.isEmpty() %>">
-	<div class="field-group lfr-user-phones section" data-title="<%= LanguageUtil.get(request, "phone-numbers") %>">
+	<div class="lfr-field-group lfr-user-phones section" data-title="<%= LanguageUtil.get(request, "phone-numbers") %>">
 
 		<%
 		PortletURL editPhonesURL = PortletURLBuilder.create(
@@ -110,7 +110,7 @@ if (emailAddresses.isEmpty()) {
 %>
 
 <c:if test="<%= showAdditionalEmailAddresses && !emailAddresses.isEmpty() %>">
-	<div class="field-group lfr-user-email-addresses section" data-title="<%= LanguageUtil.get(request, "additional-email-addresses") %>">
+	<div class="lfr-field-group lfr-user-email-addresses section" data-title="<%= LanguageUtil.get(request, "additional-email-addresses") %>">
 
 		<%
 		PortletURL editAdditionalEmailAddressesURL = PortletURLBuilder.create(
@@ -160,7 +160,7 @@ if (Validator.isNull(jabberSn) && Validator.isNull(skypeSn)) {
 %>
 
 <c:if test="<%= showInstantMessenger && (Validator.isNotNull(jabberSn) || Validator.isNotNull(skypeSn)) %>">
-	<div class="field-group section" data-title="<%= LanguageUtil.get(request, "instant-messenger") %>">
+	<div class="lfr-field-group section" data-title="<%= LanguageUtil.get(request, "instant-messenger") %>">
 		<liferay-ui:icon
 			icon="pencil"
 			markupView="lexicon"
@@ -206,7 +206,7 @@ if (addresses.isEmpty()) {
 %>
 
 <c:if test="<%= showAddresses && !addresses.isEmpty() %>">
-	<div class="field-group lfr-user-addresses section" data-title="<%= LanguageUtil.get(request, "addresses") %>">
+	<div class="lfr-field-group lfr-user-addresses section" data-title="<%= LanguageUtil.get(request, "addresses") %>">
 
 		<%
 		PortletURL editAddressesURL = PortletURLBuilder.create(
@@ -258,7 +258,7 @@ if (websites.isEmpty()) {
 %>
 
 <c:if test="<%= showWebsites && !websites.isEmpty() %>">
-	<div class="field-group lfr-user-websites section" data-title="<%= LanguageUtil.get(request, "websites") %>">
+	<div class="lfr-field-group lfr-user-websites section" data-title="<%= LanguageUtil.get(request, "websites") %>">
 
 		<%
 		PortletURL editWebsitesURL = PortletURLBuilder.create(
@@ -309,7 +309,7 @@ if (Validator.isNull(facebook) && Validator.isNull(twitter)) {
 %>
 
 <c:if test="<%= showSocialNetwork && (Validator.isNotNull(facebook) || Validator.isNotNull(twitter)) %>">
-	<div class="field-group lfr-user-social-network section" data-title="<%= LanguageUtil.get(request, "social-network") %>">
+	<div class="lfr-field-group lfr-user-social-network section" data-title="<%= LanguageUtil.get(request, "social-network") %>">
 
 		<%
 		PortletURL editSocialNetworkURL = PortletURLBuilder.create(
@@ -356,7 +356,7 @@ if (Validator.isNull(contact2.getSmsSn())) {
 %>
 
 <c:if test="<%= showSMS && Validator.isNotNull(contact2.getSmsSn()) %>">
-	<div class="field-group lfr-user-sms section" data-title="<%= LanguageUtil.get(request, "sms") %>">
+	<div class="lfr-field-group lfr-user-sms section" data-title="<%= LanguageUtil.get(request, "sms") %>">
 
 		<%
 		PortletURL editSmsURL = PortletURLBuilder.create(

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/view_user.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/view_user.jsp
@@ -144,7 +144,7 @@ request.setAttribute("view_user.jsp-user", user2);
 				</clay:col>
 			</clay:row>
 
-			<div class="field-group lfr-detail-info" data-title="<%= LanguageUtil.get(request, "details") %>">
+			<div class="lfr-detail-info lfr-field-group" data-title="<%= LanguageUtil.get(request, "details") %>">
 
 				<%
 				PortletURL editDetailsURL = PortletURLFactoryUtil.create(request, PortletKeys.MY_ACCOUNT, embeddedPersonalApplicationLayout, PortletRequest.RENDER_PHASE);
@@ -299,7 +299,7 @@ request.setAttribute("view_user.jsp-user", user2);
 
 									<c:choose>
 										<c:when test="<%= !assetTags.isEmpty() %>">
-											<div class="field-group user-tags-wrapper" data-title="<%= LanguageUtil.get(request, "tags") %>">
+											<div class="lfr-field-group user-tags-wrapper" data-title="<%= LanguageUtil.get(request, "tags") %>">
 
 												<%
 												PortletURL editCategorizationURL = PortletURLFactoryUtil.create(request, PortletKeys.MY_ACCOUNT, embeddedPersonalApplicationLayout, PortletRequest.RENDER_PHASE);


### PR DESCRIPTION
Manual forward from https://github.com/liferay-usm/liferay-portal/pull/344

> Hi Team,
> 
> Notes from @noornajj:
> 
> https://issues.liferay.com/browse/LPS-141727
> 
> The issue here is that a user's additional information in Members portlet is not visible in Firefox due to css issue with float.
> 
> It was caused by a conflict of the css class name field-group with the file aui_deprecated.css. The issue was fixed by changing the class name to lfr-field-group.
> 
> This issue is no longer reproducible in Master because aui_deprecated.css has been removed. However, we are committing these changes to master to insure consistency between Master and 7.3.x
> 
> Please let us know if you have any questions.
> Thanks!