### PR TITLE
Lps 143095: SXPBlueprint and SXPElement searchability through REST

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SXPBlueprintResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SXPBlueprintResource.java
@@ -14,6 +14,7 @@
 
 package com.liferay.search.experiences.rest.resource.v1_0;
 
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -58,7 +59,7 @@ public interface SXPBlueprintResource {
 	}
 
 	public Page<SXPBlueprint> getSXPBlueprintsPage(
-			String search, Pagination pagination)
+			String search, Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception;
 
 	public SXPBlueprint postSXPBlueprint(SXPBlueprint sxpBlueprint)

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SXPElementResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SXPElementResource.java
@@ -14,6 +14,7 @@
 
 package com.liferay.search.experiences.rest.resource.v1_0;
 
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -58,7 +59,7 @@ public interface SXPElementResource {
 	}
 
 	public Page<SXPElement> getSXPElementsPage(
-			String search, Pagination pagination)
+			String search, Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception;
 
 	public SXPElement postSXPElement(SXPElement sxpElement) throws Exception;

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SXPBlueprintResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SXPBlueprintResource.java
@@ -41,11 +41,13 @@ public interface SXPBlueprintResource {
 	}
 
 	public Page<SXPBlueprint> getSXPBlueprintsPage(
-			String search, Pagination pagination)
+			String search, String filterString, Pagination pagination,
+			String sortString)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse getSXPBlueprintsPageHttpResponse(
-			String search, Pagination pagination)
+			String search, String filterString, Pagination pagination,
+			String sortString)
 		throws Exception;
 
 	public SXPBlueprint postSXPBlueprint(SXPBlueprint sxpBlueprint)
@@ -184,11 +186,13 @@ public interface SXPBlueprintResource {
 		implements SXPBlueprintResource {
 
 		public Page<SXPBlueprint> getSXPBlueprintsPage(
-				String search, Pagination pagination)
+				String search, String filterString, Pagination pagination,
+				String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getSXPBlueprintsPageHttpResponse(search, pagination);
+				getSXPBlueprintsPageHttpResponse(
+					search, filterString, pagination, sortString);
 
 			String content = httpResponse.getContent();
 
@@ -228,7 +232,8 @@ public interface SXPBlueprintResource {
 		}
 
 		public HttpInvoker.HttpResponse getSXPBlueprintsPageHttpResponse(
-				String search, Pagination pagination)
+				String search, String filterString, Pagination pagination,
+				String sortString)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -256,11 +261,19 @@ public interface SXPBlueprintResource {
 				httpInvoker.parameter("search", String.valueOf(search));
 			}
 
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
 			if (pagination != null) {
 				httpInvoker.parameter(
 					"page", String.valueOf(pagination.getPage()));
 				httpInvoker.parameter(
 					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
 			}
 
 			httpInvoker.path(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SXPElementResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SXPElementResource.java
@@ -41,11 +41,13 @@ public interface SXPElementResource {
 	}
 
 	public Page<SXPElement> getSXPElementsPage(
-			String search, Pagination pagination)
+			String search, String filterString, Pagination pagination,
+			String sortString)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse getSXPElementsPageHttpResponse(
-			String search, Pagination pagination)
+			String search, String filterString, Pagination pagination,
+			String sortString)
 		throws Exception;
 
 	public SXPElement postSXPElement(SXPElement sxpElement) throws Exception;
@@ -178,11 +180,13 @@ public interface SXPElementResource {
 	public static class SXPElementResourceImpl implements SXPElementResource {
 
 		public Page<SXPElement> getSXPElementsPage(
-				String search, Pagination pagination)
+				String search, String filterString, Pagination pagination,
+				String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getSXPElementsPageHttpResponse(search, pagination);
+				getSXPElementsPageHttpResponse(
+					search, filterString, pagination, sortString);
 
 			String content = httpResponse.getContent();
 
@@ -222,7 +226,8 @@ public interface SXPElementResource {
 		}
 
 		public HttpInvoker.HttpResponse getSXPElementsPageHttpResponse(
-				String search, Pagination pagination)
+				String search, String filterString, Pagination pagination,
+				String sortString)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -250,11 +255,19 @@ public interface SXPElementResource {
 				httpInvoker.parameter("search", String.valueOf(search));
 			}
 
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
 			if (pagination != null) {
 				httpInvoker.parameter(
 					"page", String.valueOf(pagination.getPage()));
 				httpInvoker.parameter(
 					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
 			}
 
 			httpInvoker.path(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
@@ -693,6 +693,10 @@ paths:
             operationId: getSXPBlueprintsPage
             parameters:
                 - in: query
+                  name: filter
+                  schema:
+                      type: string
+                - in: query
                   name: page
                   schema:
                       type: integer
@@ -702,6 +706,10 @@ paths:
                       type: integer
                 - in: query
                   name: search
+                  schema:
+                      type: string
+                - in: query
+                  name: sort
                   schema:
                       type: string
             responses:
@@ -872,6 +880,10 @@ paths:
             operationId: getSXPElementsPage
             parameters:
                 - in: query
+                  name: filter
+                  schema:
+                      type: string
+                - in: query
                   name: page
                   schema:
                       type: integer
@@ -881,6 +893,10 @@ paths:
                       type: integer
                 - in: query
                   name: search
+                  schema:
+                      type: string
+                - in: query
+                  name: sort
                   schema:
                       type: string
             responses:

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/graphql/query/v1_0/Query.java
@@ -216,13 +216,15 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sXPBlueprints(page: ___, pageSize: ___, search: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sXPBlueprints(filter: ___, page: ___, pageSize: ___, search: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public SXPBlueprintPage sXPBlueprints(
 			@GraphQLName("search") String search,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page)
+			@GraphQLName("page") int page,
+			@GraphQLName("sort") String sortsString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -230,7 +232,11 @@ public class Query {
 			this::_populateResourceContext,
 			sxpBlueprintResource -> new SXPBlueprintPage(
 				sxpBlueprintResource.getSXPBlueprintsPage(
-					search, Pagination.of(page, pageSize))));
+					search,
+					_filterBiFunction.apply(sxpBlueprintResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortsBiFunction.apply(
+						sxpBlueprintResource, sortsString))));
 	}
 
 	/**
@@ -270,13 +276,15 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sXPElements(page: ___, pageSize: ___, search: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sXPElements(filter: ___, page: ___, pageSize: ___, search: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public SXPElementPage sXPElements(
 			@GraphQLName("search") String search,
+			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
-			@GraphQLName("page") int page)
+			@GraphQLName("page") int page,
+			@GraphQLName("sort") String sortsString)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -284,7 +292,10 @@ public class Query {
 			this::_populateResourceContext,
 			sxpElementResource -> new SXPElementPage(
 				sxpElementResource.getSXPElementsPage(
-					search, Pagination.of(page, pageSize))));
+					search,
+					_filterBiFunction.apply(sxpElementResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortsBiFunction.apply(sxpElementResource, sortsString))));
 	}
 
 	/**

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPBlueprintEntityModel.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPBlueprintEntityModel.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.rest.internal.odata.entity.v1_0;
+
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.odata.entity.DateTimeEntityField;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.entity.IntegerEntityField;
+import com.liferay.portal.odata.entity.StringEntityField;
+
+import java.util.Map;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class SXPBlueprintEntityModel implements EntityModel {
+
+	public SXPBlueprintEntityModel() {
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
+			new DateTimeEntityField(
+				"createDate",
+				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
+				locale -> Field.CREATE_DATE),
+			new StringEntityField(
+				"description",
+				locale -> LocalizationUtil.getLocalizedName(
+					Field.DESCRIPTION, LocaleUtil.toLanguageId(locale))),
+			new DateTimeEntityField(
+				"modifiedDate",
+				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
+				locale -> Field.MODIFIED_DATE),
+			new IntegerEntityField("status", locale -> Field.STATUS),
+			new StringEntityField(
+				"title",
+				locale -> Field.getSortableFieldName(
+					LocalizationUtil.getLocalizedName(
+						Field.TITLE, LocaleUtil.toLanguageId(locale)))));
+	}
+
+	@Override
+	public Map<String, EntityField> getEntityFieldsMap() {
+		return _entityFieldsMap;
+	}
+
+	private final Map<String, EntityField> _entityFieldsMap;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPElementEntityModel.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPElementEntityModel.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.rest.internal.odata.entity.v1_0;
+
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.odata.entity.BooleanEntityField;
+import com.liferay.portal.odata.entity.DateTimeEntityField;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.entity.StringEntityField;
+
+import java.util.Map;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class SXPElementEntityModel implements EntityModel {
+
+	public SXPElementEntityModel() {
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
+			new DateTimeEntityField(
+				"createDate",
+				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
+				locale -> Field.CREATE_DATE),
+			new StringEntityField(
+				"description",
+				locale -> LocalizationUtil.getLocalizedName(
+					Field.DESCRIPTION, LocaleUtil.toLanguageId(locale))),
+			new BooleanEntityField("hidden", locale -> Field.HIDDEN),
+			new DateTimeEntityField(
+				"modifiedDate",
+				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
+				locale -> Field.MODIFIED_DATE),
+			new BooleanEntityField("readOnly", locale -> "readOnly"),
+			new StringEntityField(
+				"title",
+				locale -> Field.getSortableFieldName(
+					LocalizationUtil.getLocalizedName(
+						Field.TITLE, LocaleUtil.toLanguageId(locale)))));
+	}
+
+	@Override
+	public Map<String, EntityField> getEntityFieldsMap() {
+		return _entityFieldsMap;
+	}
+
+	private final Map<String, EntityField> _entityFieldsMap;
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
@@ -82,11 +82,19 @@ public abstract class BaseSXPBlueprintResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "page"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
 			)
 		}
 	)
@@ -101,7 +109,9 @@ public abstract class BaseSXPBlueprintResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("search")
 			String search,
-			@javax.ws.rs.core.Context Pagination pagination)
+			@javax.ws.rs.core.Context Filter filter,
+			@javax.ws.rs.core.Context Pagination pagination,
+			@javax.ws.rs.core.Context Sort[] sorts)
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
@@ -441,7 +451,7 @@ public abstract class BaseSXPBlueprintResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getSXPBlueprintsPage(search, pagination);
+		return getSXPBlueprintsPage(search, filter, pagination, sorts);
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
@@ -82,11 +82,19 @@ public abstract class BaseSXPElementResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "page"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
 			)
 		}
 	)
@@ -101,7 +109,9 @@ public abstract class BaseSXPElementResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("search")
 			String search,
-			@javax.ws.rs.core.Context Pagination pagination)
+			@javax.ws.rs.core.Context Filter filter,
+			@javax.ws.rs.core.Context Pagination pagination,
+			@javax.ws.rs.core.Context Sort[] sorts)
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
@@ -437,7 +447,7 @@ public abstract class BaseSXPElementResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getSXPElementsPage(search, pagination);
+		return getSXPElementsPage(search, filter, pagination, sorts);
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPBlueprintResourceImpl.java
@@ -16,21 +16,35 @@ package com.liferay.search.experiences.rest.internal.resource.v1_0;
 
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.WildcardQuery;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.search.generic.MatchQuery;
+import com.liferay.portal.kernel.search.generic.MultiMatchQuery;
+import com.liferay.portal.kernel.search.generic.WildcardQueryImpl;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 import com.liferay.search.experiences.rest.dto.v1_0.SXPBlueprint;
 import com.liferay.search.experiences.rest.dto.v1_0.util.ElementInstanceUtil;
 import com.liferay.search.experiences.rest.dto.v1_0.util.SXPBlueprintUtil;
 import com.liferay.search.experiences.rest.internal.dto.v1_0.converter.SXPBlueprintDTOConverter;
+import com.liferay.search.experiences.rest.internal.odata.entity.v1_0.SXPBlueprintEntityModel;
 import com.liferay.search.experiences.rest.internal.resource.v1_0.util.TitleMapUtil;
 import com.liferay.search.experiences.rest.resource.v1_0.SXPBlueprintResource;
 import com.liferay.search.experiences.service.SXPBlueprintService;
@@ -39,6 +53,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
 import org.osgi.service.component.annotations.Component;
@@ -53,11 +68,17 @@ import org.osgi.service.component.annotations.ServiceScope;
 	properties = "OSGI-INF/liferay/rest/v1_0/sxp-blueprint.properties",
 	scope = ServiceScope.PROTOTYPE, service = SXPBlueprintResource.class
 )
-public class SXPBlueprintResourceImpl extends BaseSXPBlueprintResourceImpl {
+public class SXPBlueprintResourceImpl
+	extends BaseSXPBlueprintResourceImpl implements EntityModelResource {
 
 	@Override
 	public void deleteSXPBlueprint(Long sxpBlueprintId) throws Exception {
 		_sxpBlueprintService.deleteSXPBlueprint(sxpBlueprintId);
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
+		return _entityEntityModel;
 	}
 
 	@Override
@@ -110,26 +131,58 @@ public class SXPBlueprintResourceImpl extends BaseSXPBlueprintResourceImpl {
 
 	@Override
 	public Page<SXPBlueprint> getSXPBlueprintsPage(
-			String search, Pagination pagination)
+			String search, Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(
 			Collections.emptyMap(),
-			booleanQuery -> {
+			booleanQuery1 -> {
+				if (!Validator.isBlank(search)) {
+					BooleanQuery booleanQuery2 = new BooleanQueryImpl() {
+						{
+							MultiMatchQuery multiMatchQuery =
+								new MultiMatchQuery(search);
+
+							multiMatchQuery.addFields(
+								Arrays.asList(
+									LocalizationUtil.getLocalizedName(
+										Field.DESCRIPTION,
+										contextAcceptLanguage.
+											getPreferredLanguageId()),
+									LocalizationUtil.getLocalizedName(
+										Field.TITLE,
+										contextAcceptLanguage.
+											getPreferredLanguageId())));
+							multiMatchQuery.setType(
+								MultiMatchQuery.Type.PHRASE_PREFIX);
+							multiMatchQuery.setOperator(
+								MatchQuery.Operator.AND);
+
+							add(multiMatchQuery, BooleanClauseOccur.SHOULD);
+
+							WildcardQuery wildcardQuery = new WildcardQueryImpl(
+								Field.USER_NAME, search + "*");
+
+							add(wildcardQuery, BooleanClauseOccur.SHOULD);
+						}
+					};
+
+					booleanQuery1.add(booleanQuery2, BooleanClauseOccur.MUST);
+				}
 			},
-			null,
+			filter,
 			com.liferay.search.experiences.model.SXPBlueprint.class.getName(),
 			search, pagination,
 			queryConfig -> queryConfig.setSelectedFieldNames(
 				Field.ENTRY_CLASS_PK),
 			searchContext -> {
+				if (!Validator.isBlank(search)) {
+					searchContext.setKeywords("");
+				}
 
-				// TODO Set the relevant search context attributes
-
-				searchContext.setAttribute(Field.DESCRIPTION, search);
 				searchContext.setCompanyId(contextCompany.getCompanyId());
 			},
-			null,
+			sorts,
 			document -> _sxpBlueprintDTOConverter.toDTO(
 				new DefaultDTOConverterContext(
 					contextAcceptLanguage.isAcceptAllLanguages(),
@@ -239,6 +292,9 @@ public class SXPBlueprintResourceImpl extends BaseSXPBlueprintResourceImpl {
 
 	@Reference
 	private DTOConverterRegistry _dtoConverterRegistry;
+
+	private final SXPBlueprintEntityModel _entityEntityModel =
+		new SXPBlueprintEntityModel();
 
 	@Reference
 	private JSONFactory _jsonFactory;

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/SXPBlueprintIndexer.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/SXPBlueprintIndexer.java
@@ -60,7 +60,7 @@ public class SXPBlueprintIndexer extends BaseIndexer<SXPBlueprint> {
 		setDefaultSelectedFieldNames(
 			Field.COMPANY_ID, Field.ENTRY_CLASS_NAME, Field.ENTRY_CLASS_PK,
 			Field.GROUP_ID, Field.MODIFIED_DATE, Field.SCOPE_GROUP_ID,
-			Field.UID);
+			Field.STATUS, Field.UID);
 		setDefaultSelectedLocalizedFieldNames(Field.DESCRIPTION, Field.TITLE);
 		setFilterSearch(true);
 		setPermissionAware(true);
@@ -108,8 +108,7 @@ public class SXPBlueprintIndexer extends BaseIndexer<SXPBlueprint> {
 
 		String[] localizedFieldNames =
 			_searchLocalizationHelper.getLocalizedFieldNames(
-				new String[] {Field.CONTENT, Field.DESCRIPTION, Field.TITLE},
-				searchContext);
+				new String[] {Field.DESCRIPTION, Field.TITLE}, searchContext);
 
 		queryConfig.addHighlightFieldNames(localizedFieldNames);
 	}
@@ -131,6 +130,7 @@ public class SXPBlueprintIndexer extends BaseIndexer<SXPBlueprint> {
 		Document document = getBaseModelDocument(CLASS_NAME, sxpBlueprint);
 
 		document.addDate(Field.MODIFIED_DATE, sxpBlueprint.getModifiedDate());
+		document.addKeyword(Field.STATUS, sxpBlueprint.getStatus());
 
 		for (Locale locale :
 				LanguageUtil.getCompanyAvailableLocales(
@@ -142,13 +142,8 @@ public class SXPBlueprintIndexer extends BaseIndexer<SXPBlueprint> {
 				LocalizationUtil.getLocalizedName(
 					Field.DESCRIPTION, languageId),
 				sxpBlueprint.getDescription(locale));
-			document.addText(
-				LocalizationUtil.getLocalizedName(
-					"localized_" + Field.TITLE, languageId),
-				sxpBlueprint.getTitle(locale));
 			document.addTextSortable(
-				LocalizationUtil.getLocalizedName(
-					"localized_" + Field.TITLE, languageId),
+				LocalizationUtil.getLocalizedName(Field.TITLE, languageId),
 				sxpBlueprint.getTitle(locale));
 		}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/SXPElementIndexer.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/SXPElementIndexer.java
@@ -59,8 +59,8 @@ public class SXPElementIndexer extends BaseIndexer<SXPElement> {
 	public SXPElementIndexer() {
 		setDefaultSelectedFieldNames(
 			Field.COMPANY_ID, Field.ENTRY_CLASS_NAME, Field.ENTRY_CLASS_PK,
-			Field.GROUP_ID, Field.MODIFIED_DATE, Field.SCOPE_GROUP_ID,
-			Field.UID, "hidden", "readOnly");
+			Field.GROUP_ID, Field.HIDDEN, Field.MODIFIED_DATE,
+			Field.SCOPE_GROUP_ID, Field.UID, "readOnly");
 		setDefaultSelectedLocalizedFieldNames(Field.DESCRIPTION, Field.TITLE);
 		setFilterSearch(true);
 		setPermissionAware(true);
@@ -108,8 +108,7 @@ public class SXPElementIndexer extends BaseIndexer<SXPElement> {
 
 		String[] localizedFieldNames =
 			_searchLocalizationHelper.getLocalizedFieldNames(
-				new String[] {Field.CONTENT, Field.DESCRIPTION, Field.TITLE},
-				searchContext);
+				new String[] {Field.DESCRIPTION, Field.TITLE}, searchContext);
 
 		queryConfig.addHighlightFieldNames(localizedFieldNames);
 	}
@@ -128,8 +127,8 @@ public class SXPElementIndexer extends BaseIndexer<SXPElement> {
 		Document document = getBaseModelDocument(CLASS_NAME, sxpElement);
 
 		document.addDate(Field.MODIFIED_DATE, sxpElement.getModifiedDate());
-		document.addNumber(Field.TYPE, sxpElement.getType());
-		document.addKeyword("hidden", sxpElement.isHidden());
+		document.addKeyword(Field.HIDDEN, sxpElement.isHidden());
+		document.addKeyword(Field.TYPE, sxpElement.getType());
 		document.addKeyword("readOnly", sxpElement.isReadOnly());
 
 		for (Locale locale :
@@ -142,13 +141,8 @@ public class SXPElementIndexer extends BaseIndexer<SXPElement> {
 				LocalizationUtil.getLocalizedName(
 					Field.DESCRIPTION, languageId),
 				sxpElement.getDescription(locale));
-			document.addText(
-				LocalizationUtil.getLocalizedName(
-					"localized_" + Field.TITLE, languageId),
-				sxpElement.getTitle(locale));
 			document.addTextSortable(
-				LocalizationUtil.getLocalizedName(
-					"localized_" + Field.TITLE, languageId),
+				LocalizationUtil.getLocalizedName(Field.TITLE, languageId),
 				sxpElement.getTitle(locale));
 		}
 


### PR DESCRIPTION
Add support for sorting and filtering SXPBlueprint and SXPElement search. Fix minor indexing issues. Use prefix queries for searchable fields with operator AND.