### PR TITLE
LPS-112856: SearchTestRule

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/build.gradle
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.12.4"
 	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationCompile project(":apps:portal-odata:portal-odata-api")
+	testIntegrationCompile project(":apps:portal-search:portal-search-test-util")
 	testIntegrationCompile project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationCompile project(":dxp:apps:search-experiences:search-experiences-api")
 	testIntegrationCompile project(":dxp:apps:search-experiences:search-experiences-rest-api")


### PR DESCRIPTION
Adds missing dependency causing generated integration tests to fail.