### PR TITLE
LPS-143171 FIX: Unable to save a blueprint with element "org.json.JSONException: Expected a ':' after a key" when field value is a json array of objects

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/util/UnpackUtil.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/util/UnpackUtil.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -27,6 +28,10 @@ import java.util.Map;
 public class UnpackUtil {
 
 	public static Object unpack(Object value) {
+		if (value instanceof Collection) {
+			return JSONFactoryUtil.createJSONArray((Collection<?>)value);
+		}
+
 		if (value instanceof Map) {
 			return JSONFactoryUtil.createJSONObject((Map<?, ?>)value);
 		}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPBlueprintResourceImpl.java
@@ -186,6 +186,8 @@ public class SXPBlueprintResourceImpl
 	public SXPBlueprint postSXPBlueprint(SXPBlueprint sxpBlueprint)
 		throws Exception {
 
+		SXPBlueprintUtil.unpack(sxpBlueprint);
+
 		return _sxpBlueprintDTOConverter.toDTO(
 			new DefaultDTOConverterContext(
 				contextAcceptLanguage.isAcceptAllLanguages(), new HashMap<>(),

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/SXPBlueprintResourceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/SXPBlueprintResourceTest.java
@@ -61,7 +61,10 @@ public class SXPBlueprintResourceTest extends BaseSXPBlueprintResourceTestCase {
 		SXPBlueprint postSXPBlueprint = testPostSXPBlueprint_addSXPBlueprint(
 			sxpBlueprint);
 
+		sxpBlueprint.setCreateDate(postSXPBlueprint.getCreateDate());
 		sxpBlueprint.setId(postSXPBlueprint.getId());
+		sxpBlueprint.setModifiedDate(postSXPBlueprint.getModifiedDate());
+		sxpBlueprint.setUserName(postSXPBlueprint.getUserName());
 
 		Assert.assertEquals(
 			sxpBlueprint.toString(), postSXPBlueprint.toString());


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-143171
