### PR TITLE
LPS-143239 FIX: Blank string under uiConfigurationValues payload (keywords: "") should not be persisted as empty object server side (keywords: {})

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/util/UnpackUtil.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/util/UnpackUtil.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Collection;
 import java.util.Map;
@@ -41,6 +42,10 @@ public class UnpackUtil {
 		}
 
 		if (value instanceof String) {
+			if (Validator.isNull((String)value)) {
+				return value;
+			}
+
 			try {
 				return JSONFactoryUtil.createJSONObject((String)value);
 			}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/test/java/com/liferay/search/experiences/rest/dto/v1_0/util/SXPBlueprintUtilTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/test/java/com/liferay/search/experiences/rest/dto/v1_0/util/SXPBlueprintUtilTest.java
@@ -14,6 +14,8 @@
 
 package com.liferay.search.experiences.rest.dto.v1_0.util;
 
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.search.experiences.rest.dto.v1_0.SXPBlueprint;
@@ -45,6 +47,11 @@ public class SXPBlueprintUtilTest {
 		}
 	}
 
+	private String _formatJSON(Object object) throws Exception {
+		return JSONUtil.toString(
+			JSONFactoryUtil.createJSONObject(String.valueOf(object)));
+	}
+
 	private void _testToSXPBlueprint(String fileName) throws Exception {
 		String json = StringUtil.read(
 			getClass(),
@@ -53,8 +60,8 @@ public class SXPBlueprintUtilTest {
 		SXPBlueprint sxpBlueprint = SXPBlueprintUtil.toSXPBlueprint(json);
 
 		Assert.assertEquals(
-			fileName, sxpBlueprint.toString(),
-			String.valueOf(
+			fileName, _formatJSON(json),
+			_formatJSON(
 				SXPBlueprintUtil.toSXPBlueprint(sxpBlueprint.toString())));
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-143239