### PR TITLE
LPS-143383 Fix bug with several blueprint configurations

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -348,7 +348,7 @@ function EditSXPBlueprintForm({
 	const formik = useFormik({
 		initialValues: {
 			advancedConfig: JSON.stringify(
-				initialConfiguration.advanced,
+				initialConfiguration.advancedConfiguration,
 				null,
 				'\t'
 			),
@@ -366,14 +366,14 @@ function EditSXPBlueprintForm({
 					id: index,
 				})
 			),
-			frameworkConfig: initialConfiguration.general || {},
+			frameworkConfig: initialConfiguration.generalConfiguration || {},
 			highlightConfig: JSON.stringify(
-				initialConfiguration.highlight,
+				initialConfiguration.highlightConfiguration,
 				null,
 				'\t'
 			),
 			parameterConfig: JSON.stringify(
-				initialConfiguration.parameters,
+				initialConfiguration.parameterConfiguration,
 				null,
 				'\t'
 			),


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-143383 - Searchable Types should render selections from blueprint payload

Quick fix to have the configuration names match. This was preventing the UI from rendering some of the payload.

@thektan