### PR TITLE
LPS-143418 Do not trigger host bundle refresh when a fragment bundle …

### DIFF
--- a/modules/apps/portal/portal-fragment-bundle-watcher/src/main/java/com/liferay/portal/fragment/bundle/watcher/internal/PortalFragmentBundleWatcher.java
+++ b/modules/apps/portal/portal-fragment-bundle-watcher/src/main/java/com/liferay/portal/fragment/bundle/watcher/internal/PortalFragmentBundleWatcher.java
@@ -74,7 +74,8 @@ public class PortalFragmentBundleWatcher {
 			if (((bundleEvent.getType() == BundleEvent.INSTALLED) &&
 				 (bundleEventBundle.getState() != Bundle.UNINSTALLED) &&
 				 _isFragment(bundleEventBundle)) ||
-				(bundleEvent.getType() == BundleEvent.RESOLVED)) {
+				((bundleEvent.getType() == BundleEvent.RESOLVED) &&
+				 !_isFragment(bundleEventBundle))) {
 
 				Map<Bundle, String> installedFragmentBundles =
 					_installedFragmentBundleTracker.getTracked();


### PR DESCRIPTION
…is resolved: 1) From OSGi spec "A Fragment bundle must enter the resolved state only if it has been successfully attached to at least one host bundle." Thus, when a fragment bundle is resolved, no need to refresh its host as they are already wired up; 2) a fragment should not depend on another fragment based on OSGi spec "A Fragment bundle can not be required by another bundle with the Require-Bundle header.", this means a resolved event of a fragment won't affect the status of other fragments, thus no need to trigger the refresh of host bundles.