### PR TITLE
LPS-143134 search-experiences-web: Fix field autocompletion missing localizable fields

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/FieldRow.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/FieldRow.js
@@ -67,9 +67,7 @@ function AutocompleteItem({indexField, match = '', onClick}) {
 				indexField.name
 			)}
 
-			{indexField.language_id_position > -1 && (
-				<ClayIcon symbol="globe" />
-			)}
+			{indexField.languageIdPosition > -1 && <ClayIcon symbol="globe" />}
 
 			<span className="type">{indexField.type}</span>
 		</ClayDropDown.Item>
@@ -81,7 +79,7 @@ function AutocompleteItem({indexField, match = '', onClick}) {
  *
  * Example index field object:
  * {
- * 	language_id_position: -1,
+ * 	languageIdPosition: -1,
  * 	name: 'ddmTemplateKey',
  * 	type: 'keyword'
  * }
@@ -120,8 +118,8 @@ function FieldRow({
 	const _handleFieldChange = (event) => {
 		const indexField = _getIndexField(event.target.value) || {};
 
-		let languageIdPosition = isDefined(indexField.language_id_position)
-			? indexField.language_id_position
+		let languageIdPosition = isDefined(indexField.languageIdPosition)
+			? indexField.languageIdPosition
 			: -1;
 
 		if (indexField.locale && languageIdPosition === -1) {
@@ -141,23 +139,23 @@ function FieldRow({
 		// non-localized option.
 		//
 		// For example 'title':
-		// {name: 'title', type: 'text', language_id_position: 5}
-		// {name: 'title', type: 'text', language_id_position: -1}
+		// {name: 'title', type: 'text', languageIdPosition: 5}
+		// {name: 'title', type: 'text', languageIdPosition: -1}
 		//
 		// Reset the locale to "no localization" if the non-localized field
 		// is autocompleted to.
 
-		if (indexField.language_id_position === -1) {
+		if (indexField.languageIdPosition === -1) {
 			onChange({
 				field: indexField.name,
-				languageIdPosition: indexField.language_id_position,
+				languageIdPosition: indexField.languageIdPosition,
 				locale: '',
 			});
 		}
 		else {
 			onChange({
 				field: indexField.name,
-				languageIdPosition: indexField.language_id_position,
+				languageIdPosition: indexField.languageIdPosition,
 			});
 		}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/mocks/data.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/mocks/data.js
@@ -58,52 +58,52 @@ export const ENTITY_JSON = {
 
 export const INDEX_FIELDS = [
 	{
-		language_id_position: -1,
+		languageIdPosition: -1,
 		name: 'ddmTemplateKey',
 		type: 'keyword',
 	},
 	{
-		language_id_position: -1,
+		languageIdPosition: -1,
 		name: 'entryClassPK',
 		type: 'keyword',
 	},
 	{
-		language_id_position: -1,
+		languageIdPosition: -1,
 		name: 'publishDate',
 		type: 'date',
 	},
 	{
-		language_id_position: -1,
+		languageIdPosition: -1,
 		name: 'configurationModelFactoryPid',
 		type: 'keyword',
 	},
 	{
-		language_id_position: 11,
+		languageIdPosition: 11,
 		name: 'description',
 		type: 'text',
 	},
 	{
-		language_id_position: -1,
+		languageIdPosition: -1,
 		name: 'discussion',
 		type: 'keyword',
 	},
 	{
-		language_id_position: -1,
+		languageIdPosition: -1,
 		name: 'screenName',
 		type: 'keyword',
 	},
 	{
-		language_id_position: 15,
+		languageIdPosition: 15,
 		name: 'localized_title',
 		type: 'text',
 	},
 	{
-		language_id_position: -1,
+		languageIdPosition: -1,
 		name: 'catalogBasePriceList',
 		type: 'text',
 	},
 	{
-		language_id_position: -1,
+		languageIdPosition: -1,
 		name: 'path',
 		type: 'keyword',
 	},


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-143134 - Field autocompletion in Blueprint editing view doesn't recognize localizable fields

Simple fix for the autocomplete fields not working! It looks like the variable `language_id_position` just needed to be updated to `languageIdPosition`, to match what is in the rest endpoint information.

@thektan