### PR TITLE
LPS-143571 REST builder should escape string values for Jackson consumption (quotes, backslashes) in properties of type string or object 

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.util.ObjectMapperUtil;
@@ -293,7 +294,7 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 					}
 					else if (${propertyName} instanceof String) {
 						sb.append("\"");
-						sb.append((String)${propertyName});
+						sb.append(_escape((String)${propertyName}));
 						sb.append("\"");
 					}
 					else {
@@ -408,9 +409,9 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 	</#list>
 
 	private static String _escape(Object object) {
-		String string = String.valueOf(object);
-
-		return string.replaceAll("\"", "\\\\\"");
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
 	}
 
 	private static boolean _isArray(Object value) {
@@ -436,7 +437,7 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 			Map.Entry<String, ?> entry = iterator.next();
 
 			sb.append("\"");
-			sb.append(entry.getKey());
+			sb.append(_escape(entry.getKey()));
 			sb.append("\": ");
 
 			Object value = entry.getValue();
@@ -468,7 +469,7 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 			}
 			else if (value instanceof String) {
 				sb.append("\"");
-				sb.append(value);
+				sb.append(_escape(value));
 				sb.append("\"");
 			}
 			else {
@@ -484,5 +485,10 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 
 		return sb.toString();
 	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-143571