### PR TITLE
LRDOCS-10028 remove mention of read uncommitted and serializable settings

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1631,9 +1631,8 @@
     # "portal" transaction isolation level is not a real isolation level. It is
     # just a pointer to a real isolation level that can be configured by setting
     # this property. Set the value to -1 to use the database's default isolation
-    # level. Set the value to 2 to use "read committed". Set the value to 1 to
-    # use "read uncommitted". Set the value to 4 to use "repeatable read". Set
-    # the value to 8 to use "serializable".
+    # level. Set the value to 2 to use "read committed". Set the value to 4 to
+    # use "repeatable read".
     #
     # Env: LIFERAY_TRANSACTION_PERIOD_ISOLATION_PERIOD_PORTAL
     #


### PR DESCRIPTION
I removed mention of read uncommitted and serializable settings because we don't want people to use them.

Background: We included these settings to fully implement the API, but we don't recommend using them. A customer tried using the serializable setting and ran into problems - https://issues.liferay.com/browse/LPP-42861