### PR TITLE
LPS-143522 search-experiences-rest-impl: Add IP address to search context in Blueprint preview

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SearchResponseResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SearchResponseResourceImpl.java
@@ -86,6 +86,10 @@ public class SearchResponseResourceImpl extends BaseSearchResponseResourceImpl {
 						queryString
 					).size(
 						pagination.getPageSize()
+					).withSearchContext(
+						searchContext -> searchContext.setAttribute(
+							"search.experiences.ipaddress",
+							contextHttpServletRequest.getRemoteAddr())
 					).withSearchRequestBuilder(
 						searchRequestBuilder -> {
 							if (sxpBlueprint != null) {


### PR DESCRIPTION
No other SXP REST endpoints should not need this contribution at the moment. Adding PortletSharedSearchContributor as soon as Blueprint Options widget (https://issues.liferay.com/browse/LPS-141119) is available.