### PR TITLE
LPS-141119 portal-search-web: Set IP address to search context for SXP

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/low/level/search/options/portlet/shared/search/LowLevelSearchOptionsPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/low/level/search/options/portlet/shared/search/LowLevelSearchOptionsPortletSharedSearchContributor.java
@@ -16,6 +16,7 @@ package com.liferay.portal.search.web.internal.low.level.search.options.portlet.
 
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.web.internal.low.level.search.options.constants.LowLevelSearchOptionsPortletKeys;
 import com.liferay.portal.search.web.internal.low.level.search.options.portlet.preferences.LowLevelSearchOptionsPortletPreferences;
@@ -28,7 +29,10 @@ import java.io.Serializable;
 
 import java.util.Optional;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Wade Cao
@@ -77,8 +81,18 @@ public class LowLevelSearchOptionsPortletSharedSearchContributor
 			SearchStringUtil.splitAndUnquote(
 				lowLevelSearchOptionsPortletPreferences.getIndexesOptional())
 		).withSearchContext(
-			searchContext -> applyAttributes(
-				lowLevelSearchOptionsPortletPreferences, searchContext)
+			searchContext -> {
+				applyAttributes(
+					lowLevelSearchOptionsPortletPreferences, searchContext);
+
+				HttpServletRequest httpServletRequest =
+					_portal.getHttpServletRequest(
+						portletSharedSearchSettings.getRenderRequest());
+
+				searchContext.setAttribute(
+					"search.experiences.ipaddress",
+					httpServletRequest.getRemoteAddr());
+			}
 		);
 	}
 
@@ -98,5 +112,8 @@ public class LowLevelSearchOptionsPortletSharedSearchContributor
 				(Serializable)jsonObject.get("value"));
 		}
 	}
+
+	@Reference
+	private Portal _portal;
 
 }


### PR DESCRIPTION
This satisfies the need for now, but Blueprint options widget has to duplicate the logic. Maybe some others in the future, too.

In long term I'd thus like to consider a solution like https://liferay.slack.com/archives/C02E73PDR70/p1639433966277000?thread_ts=1639051538.269500&cid=C02E73PDR70:

-  Extend PortletSharedSearchRequestImpl to support multiple SharedSearchContributors per portlet
- Implement a single SXPSharedSearchRequestImpl wired to any number of widgets needed,  to contribute IP address now and possible any other SXP required attributes in the future

This will however require reorganizing and exposing OOTB search widget preferences classes and portlet name constants to sxp-web, so it's maybe better to postpone for now. @lipusz , @arboliveira if you are ok with this, maybe we could ticketize this for the future?