### PR TITLE
LPS 143536 Site Initializer

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/commerce-notification-templates/template-1/commerce-notification-template.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/commerce-notification-templates/template-1/commerce-notification-template.json
@@ -1,5 +1,4 @@
 {
-	"action": "create",
 	"description": "This is a description for Test Commerce Notification Template.",
 	"enabled": true,
 	"from": "test-integration@liferay.com",
@@ -7,9 +6,9 @@
 		"en-US": "Test Integration"
 	},
 	"name": "Test Commerce Notification Template",
-	"objectDefinitionName": "C_TestBundleSiteInitializer",
 	"subject": {
 		"en-US": "This is a subject for Test Commerce Notification Template"
 	},
-	"to": "test@liferay.com"
+	"to": "test@liferay.com",
+	"type": "com.liferay.object.model.ObjectDefinition#[$OBJECT_DEFINITION_ID:TestObjectDefinition1$]#create"
 }

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/object-definitions/test-object-definition-3.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/object-definitions/test-object-definition-3.json
@@ -1,0 +1,22 @@
+{
+	"label": {
+		"en_US": "Test Object Definition 3"
+	},
+	"name": "TestObjectDefinition3",
+	"objectFields": [
+		{
+			"indexed": false,
+			"indexedAsKeyword": false,
+			"label": {
+				"en_US": "Field 1"
+			},
+			"name": "field1",
+			"required": false,
+			"type": "String"
+		}
+	],
+	"pluralLabel": {
+		"en_US": "Test Object Definitions 3"
+	},
+	"scope": "company"
+}

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/object-definitions/test-object-definition-3.object-entries.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/object-definitions/test-object-definition-3.object-entries.json
@@ -1,17 +1,17 @@
 [
 	{
-		"field1": "Test Entry 1"
+		"field1": "Test Object Entry 1"
 	},
 	{
-		"field1": "Test Entry 2"
+		"field1": "Test Object Entry 2"
 	},
 	{
-		"field1": "Test Entry 3"
+		"field1": "Test Object Entry 3"
 	},
 	{
-		"field1": "Test Entry 4"
+		"field1": "Test Object Entry 4"
 	},
 	{
-		"field1": "Test Entry 5"
+		"field1": "Test Object Entry 5"
 	}
 ]

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/object-definitions/test-object-definition-3.object-entries.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/object-definitions/test-object-definition-3.object-entries.json
@@ -1,0 +1,17 @@
+[
+	{
+		"field1": "Test Entry 1"
+	},
+	{
+		"field1": "Test Entry 2"
+	},
+	{
+		"field1": "Test Entry 3"
+	},
+	{
+		"field1": "Test Entry 4"
+	},
+	{
+		"field1": "Test Entry 5"
+	}
+]

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/object-definitions/test-object-definition-4.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/object-definitions/test-object-definition-4.json
@@ -1,0 +1,22 @@
+{
+	"label": {
+		"en_US": "Test Object Definition 3"
+	},
+	"name": "TestObjectDefinition3",
+	"objectFields": [
+		{
+			"indexed": false,
+			"indexedAsKeyword": false,
+			"label": {
+				"en_US": "Field 1"
+			},
+			"name": "field1",
+			"required": false,
+			"type": "String"
+		}
+	],
+	"pluralLabel": {
+		"en_US": "Test Object Definitions 3"
+	},
+	"scope": "company"
+}

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/object-definitions/test-object-definition-4.object-entries.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/object-definitions/test-object-definition-4.object-entries.json
@@ -1,17 +1,17 @@
 [
 	{
-		"field1": "Test Entry 1"
+		"field1": "Test Object Entry 1"
 	},
 	{
-		"field1": "Test Entry 2"
+		"field1": "Test Object Entry 2"
 	},
 	{
-		"field1": "Test Entry 3"
+		"field1": "Test Object Entry 3"
 	},
 	{
-		"field1": "Test Entry 4"
+		"field1": "Test Object Entry 4"
 	},
 	{
-		"field1": "Test Entry 5"
+		"field1": "Test Object Entry 5"
 	}
 ]

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/object-definitions/test-object-definition-4.object-entries.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/object-definitions/test-object-definition-4.object-entries.json
@@ -1,0 +1,17 @@
+[
+	{
+		"field1": "Test Entry 1"
+	},
+	{
+		"field1": "Test Entry 2"
+	},
+	{
+		"field1": "Test Entry 3"
+	},
+	{
+		"field1": "Test Entry 4"
+	},
+	{
+		"field1": "Test Entry 5"
+	}
+]

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -333,11 +333,7 @@ public class BundleSiteInitializerTest {
 		Assert.assertEquals("Test Commerce Channel", commerceChannel.getName());
 		Assert.assertEquals("site", commerceChannel.getType());
 
-		// TODO Fix and enable test
-
-		if (false) {
-			_assertCommerceNotificationTemplate(commerceChannel, group);
-		}
+		_assertCommerceNotificationTemplate(commerceChannel, group);
 	}
 
 	private void _assertCommerceInventoryWarehouse(Group group) {
@@ -357,13 +353,17 @@ public class BundleSiteInitializerTest {
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinition(
-				group.getCompanyId(), "C_TestBundleSiteInitializer");
+				group.getCompanyId(), "C_TestObjectDefinition1");
+
+		Assert.assertNotNull(objectDefinition);
 
 		List<CommerceNotificationTemplate> commerceNotificationTemplates =
 			_commerceNotificationTemplateLocalService.
 				getCommerceNotificationTemplates(
 					commerceChannel.getGroupId(),
-					objectDefinition.getClassName() + "#create", true);
+					"com.liferay.object.model.ObjectDefinition#" +
+						objectDefinition.getObjectDefinitionId() + "#create",
+					true);
 
 		CommerceNotificationTemplate commerceNotificationTemplate =
 			commerceNotificationTemplates.get(0);

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -53,6 +53,7 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.object.admin.rest.dto.v1_0.ObjectRelationship;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectRelationshipResource;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
@@ -196,6 +197,15 @@ public class BundleSiteInitializerTest {
 			if (objectDefinition2 != null) {
 				_objectDefinitionLocalService.deleteObjectDefinition(
 					objectDefinition2.getObjectDefinitionId());
+			}
+
+			ObjectDefinition objectDefinition3 =
+				_objectDefinitionLocalService.fetchObjectDefinition(
+					serviceContext.getCompanyId(), "C_TestObjectDefinition3");
+
+			if (objectDefinition3 != null) {
+				_objectDefinitionLocalService.deleteObjectDefinition(
+					objectDefinition3.getObjectDefinitionId());
 			}
 
 			bundle.uninstall();
@@ -596,26 +606,41 @@ public class BundleSiteInitializerTest {
 		Assert.assertEquals(
 			objectDefinition1.getStatus(), WorkflowConstants.STATUS_APPROVED);
 
-		_assertObjectEntries(group, objectDefinition1);
+		_assertObjectEntries(0, group.getGroupId(), objectDefinition1);
 		_assertObjectRelationships(objectDefinition1, serviceContext);
 
 		ObjectDefinition objectDefinition2 =
 			_objectDefinitionLocalService.fetchObjectDefinition(
 				group.getCompanyId(), "C_TestObjectDefinition2");
 
+		Assert.assertEquals(objectDefinition2.isSystem(), false);
 		Assert.assertEquals(
 			objectDefinition2.getStatus(), WorkflowConstants.STATUS_APPROVED);
-		Assert.assertEquals(objectDefinition2.isSystem(), false);
+
+		_assertObjectEntries(0, group.getGroupId(), objectDefinition2);
+
+		ObjectDefinition objectDefinition3 =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				group.getCompanyId(), "C_TestObjectDefinition3");
+
+		Assert.assertEquals(objectDefinition3.isSystem(), false);
+		Assert.assertEquals(
+			objectDefinition3.getScope(),
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+		Assert.assertEquals(
+			objectDefinition3.getStatus(), WorkflowConstants.STATUS_APPROVED);
+
+		_assertObjectEntries(5, 0, objectDefinition3);
 	}
 
 	private void _assertObjectEntries(
-			Group group, ObjectDefinition objectDefinition)
+			int expected, long groupId, ObjectDefinition objectDefinition)
 		throws Exception {
 
 		Assert.assertEquals(
-			0,
+			expected,
 			_objectEntryLocalService.getObjectEntriesCount(
-				group.getGroupId(), objectDefinition.getObjectDefinitionId()));
+				groupId, objectDefinition.getObjectDefinitionId()));
 	}
 
 	private void _assertObjectRelationships(

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -165,7 +165,7 @@ public class BundleSiteInitializerTest {
 			_assertLayoutPageTemplateEntry(group);
 			_assertLayouts(group);
 			_assertLayoutSets(group);
-			_assertObjectDefinition(group, serviceContext);
+			_assertObjectDefinitions(group, serviceContext);
 			_assertPermissions(group);
 			_assertSiteNavigationMenu(group);
 			_assertStyleBookEntry(group);
@@ -594,7 +594,7 @@ public class BundleSiteInitializerTest {
 					"lfr-theme:regular:show-header")));
 	}
 
-	private void _assertObjectDefinition(
+	private void _assertObjectDefinitions(
 			Group group, ServiceContext serviceContext)
 		throws Exception {
 

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -347,10 +347,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 				() -> _addDocuments(serviceContext));
 
 			_invoke(
-				() -> _addCPDefinitions(
-					documentsStringUtilReplaceValues, serviceContext));
-
-			_invoke(
 				() -> _addDDMTemplates(
 					_ddmStructureLocalService, serviceContext));
 			_invoke(
@@ -370,6 +366,12 @@ public class BundleSiteInitializer implements SiteInitializer {
 					() -> _addObjectDefinitions(
 						listTypeDefinitionIdsStringUtilReplaceValues,
 						serviceContext));
+
+			_invoke(
+				() -> _addCPDefinitions(
+					documentsStringUtilReplaceValues,
+					objectDefinitionIdsStringUtilReplaceValues,
+					serviceContext));
 
 			_invoke(
 				() -> _addObjectRelationships(
@@ -665,6 +667,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 	private void _addCommerceNotificationTemplate(
 			long commerceChannelId,
 			Map<String, String> documentsStringUtilReplaceValues,
+			Map<String, String> objectDefinitionIdsStringUtilReplaceValues,
 			String resourcePath, ServiceContext serviceContext)
 		throws Exception {
 
@@ -677,16 +680,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 
 		JSONObject commerceNotificationTemplateJSONObject =
 			JSONFactoryUtil.createJSONObject(json);
-
-		com.liferay.object.model.ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.fetchObjectDefinition(
-				serviceContext.getCompanyId(),
-				commerceNotificationTemplateJSONObject.getString(
-					"objectDefinitionName"));
-
-		if (objectDefinition == null) {
-			return;
-		}
 
 		CommerceChannel commerceChannel =
 			_commerceReferencesHolder.commerceChannelLocalService.
@@ -722,9 +715,9 @@ public class BundleSiteInitializer implements SiteInitializer {
 				commerceNotificationTemplateJSONObject.getString("to"),
 				commerceNotificationTemplateJSONObject.getString("cc"),
 				commerceNotificationTemplateJSONObject.getString("bcc"),
-				StringBundler.concat(
-					objectDefinition.getClassName(), "#",
-					commerceNotificationTemplateJSONObject.getString("action")),
+				StringUtil.replace(
+					commerceNotificationTemplateJSONObject.getString("type"),
+					"[$", "$]", objectDefinitionIdsStringUtilReplaceValues),
 				commerceNotificationTemplateJSONObject.getBoolean("enabled"),
 				_toMap(
 					commerceNotificationTemplateJSONObject.getString(
@@ -735,6 +728,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 	private void _addCommerceNotificationTemplates(
 			long commerceChannelId,
 			Map<String, String> documentsStringUtilReplaceValues,
+			Map<String, String> objectDefinitionIdsStringUtilReplaceValues,
 			ServiceContext serviceContext)
 		throws Exception {
 
@@ -748,12 +742,14 @@ public class BundleSiteInitializer implements SiteInitializer {
 		for (String resourcePath : resourcePaths) {
 			_addCommerceNotificationTemplate(
 				commerceChannelId, documentsStringUtilReplaceValues,
-				resourcePath, serviceContext);
+				objectDefinitionIdsStringUtilReplaceValues, resourcePath,
+				serviceContext);
 		}
 	}
 
 	private void _addCPDefinitions(
 			Map<String, String> documentsStringUtilReplaceValues,
+			Map<String, String> objectDefinitionIdsStringUtilReplaceValues,
 			ServiceContext serviceContext)
 		throws Exception {
 
@@ -774,7 +770,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 			channel, _addCommerceInventoryWarehouses(serviceContext),
 			serviceContext);
 		_addCommerceNotificationTemplates(
-			channel.getId(), documentsStringUtilReplaceValues, serviceContext);
+			channel.getId(), documentsStringUtilReplaceValues,
+			objectDefinitionIdsStringUtilReplaceValues, serviceContext);
 	}
 
 	private void _addCPDefinitions(

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -65,6 +65,7 @@ import com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition;
 import com.liferay.object.admin.rest.dto.v1_0.ObjectRelationship;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectDefinitionResource;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectRelationshipResource;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.function.UnsafeRunnable;
@@ -1703,10 +1704,17 @@ public class BundleSiteInitializer implements SiteInitializer {
 				"OBJECT_DEFINITION_ID:" + objectDefinition.getName(),
 				String.valueOf(objectDefinition.getId()));
 
-			if (Objects.equals(objectDefinition.getScope(), "company") &&
-				(existingObjectDefinition != null)) {
+			long groupId = serviceContext.getScopeGroupId();
 
-				continue;
+			if (Objects.equals(
+					objectDefinition.getScope(),
+					ObjectDefinitionConstants.SCOPE_COMPANY)) {
+
+				groupId = 0;
+
+				if (existingObjectDefinition != null) {
+					continue;
+				}
 			}
 
 			String objectEntriesJSON = _read(
@@ -1722,8 +1730,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 
 			for (int i = 0; i < jsonArray.length(); i++) {
 				_objectEntryLocalService.addObjectEntry(
-					serviceContext.getUserId(),
-					serviceContext.getScopeGroupId(), objectDefinition.getId(),
+					serviceContext.getUserId(), groupId,
+					objectDefinition.getId(),
 					ObjectMapperUtil.readValue(
 						Serializable.class,
 						String.valueOf(jsonArray.getJSONObject(i))),

--- a/modules/apps/site-initializer/site-initializer-raylife/src/main/resources/site-initializer/commerce-notification-templates/template-1/commerce-notification-template.json
+++ b/modules/apps/site-initializer/site-initializer-raylife/src/main/resources/site-initializer/commerce-notification-templates/template-1/commerce-notification-template.json
@@ -1,5 +1,4 @@
 {
-	"action": "create",
 	"bcc": "",
 	"cc": "",
 	"description": "",
@@ -9,9 +8,9 @@
 		"en-US": "Raylife"
 	},
 	"name": "Quote retrieve notification template",
-	"objectDefinitionName": "C_QuoteRetrieve",
 	"subject": {
 		"en-US": "Continue your Raylife [%PRODUCTNAME%] quote"
 	},
-	"to": "[%RETRIEVEEMAIL%]"
+	"to": "[%RETRIEVEEMAIL%]",
+	"type": "com.liferay.object.model.ObjectDefinition#[$OBJECT_DEFINITION_ID:QuoteRetrieve$]#create"
 }


### PR DESCRIPTION
- LPS-143536 Fix to use correct groupId according scope (company or group)
- LPS-143536 _assertObjectDefinition to test unique insertion when scope is company
- LPS-143536 plural
- LPS-143536 add resources to test unique insertion when scope is company
- LPS-143536 add resources to test unique insertion when scope is company
- LPS-143536 Rename
- LPS-143536 Make _addCommerceNotificationTemplate generic to use any type
- LPS-143536 Use type to make it consistent and generic
- LPS-143536 Fix and enable _assertCommerceNotificationTemplate
