### PR TITLE
LPS-139343 Use Service instead of LocalService from the Portal Instance APIs

### DIFF
--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
@@ -20,7 +20,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.instances.service.PortalInstancesLocalService;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.CompanyService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.vulcan.pagination.Page;
 
@@ -44,10 +44,9 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 
 	@Override
 	public void deletePortalInstance(String portalInstanceId) throws Exception {
-		Company company = _companyLocalService.getCompanyByWebId(
-			portalInstanceId);
+		Company company = _companyService.getCompanyByWebId(portalInstanceId);
 
-		_companyLocalService.deleteCompany(company.getCompanyId());
+		_companyService.deleteCompany(company.getCompanyId());
 
 		_portalInstancesLocalService.synchronizePortalInstances();
 	}
@@ -57,7 +56,7 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 		throws Exception {
 
 		return _toPortalInstance(
-			_companyLocalService.getCompanyByWebId(portalInstanceId));
+			_companyService.getCompanyByWebId(portalInstanceId));
 	}
 
 	@Override
@@ -68,7 +67,7 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 
 		List<PortalInstance> portalInstances = new ArrayList<>();
 
-		_companyLocalService.forEachCompany(
+		_companyService.forEachCompany(
 			company -> {
 				if (!finalSkipDefault ||
 					(_portalInstancesLocalService.getDefaultCompanyId() !=
@@ -86,8 +85,7 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 			String portalInstanceId, PortalInstance portalInstance)
 		throws Exception {
 
-		Company company = _companyLocalService.getCompanyByWebId(
-			portalInstanceId);
+		Company company = _companyService.getCompanyByWebId(portalInstanceId);
 
 		String virtualHostname = GetterUtil.getString(
 			portalInstance.getVirtualHost(), company.getVirtualHostname());
@@ -95,7 +93,7 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 			portalInstance.getDomain(), company.getMx());
 
 		return _toPortalInstance(
-			_companyLocalService.updateCompany(
+			_companyService.updateCompany(
 				company.getCompanyId(), virtualHostname, domain,
 				company.getMaxUsers(), company.isActive()));
 	}
@@ -104,7 +102,7 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 	public PortalInstance postPortalInstance(PortalInstance portalInstance)
 		throws Exception {
 
-		Company company = _companyLocalService.addCompany(
+		Company company = _companyService.addCompany(
 			portalInstance.getCompanyId(), portalInstance.getPortalInstanceId(),
 			portalInstance.getVirtualHost(), portalInstance.getDomain(), false,
 			0, true);
@@ -127,10 +125,9 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 	public void putPortalInstanceActivate(String portalInstanceId)
 		throws Exception {
 
-		Company company = _companyLocalService.getCompanyByWebId(
-			portalInstanceId);
+		Company company = _companyService.getCompanyByWebId(portalInstanceId);
 
-		_companyLocalService.updateCompany(
+		_companyService.updateCompany(
 			company.getCompanyId(), company.getVirtualHostname(),
 			company.getMx(), company.getMaxUsers(), true);
 	}
@@ -139,10 +136,9 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 	public void putPortalInstanceDeactivate(String portalInstanceId)
 		throws Exception {
 
-		Company company = _companyLocalService.getCompanyByWebId(
-			portalInstanceId);
+		Company company = _companyService.getCompanyByWebId(portalInstanceId);
 
-		_companyLocalService.updateCompany(
+		_companyService.updateCompany(
 			company.getCompanyId(), company.getVirtualHostname(),
 			company.getMx(), company.getMaxUsers(), false);
 	}
@@ -160,7 +156,7 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 	}
 
 	@Reference
-	private CompanyLocalService _companyLocalService;
+	private CompanyService _companyService;
 
 	@Reference
 	private PortalInstancesLocalService _portalInstancesLocalService;

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 14.1.1
+Bundle-Version: 14.2.0
 Export-Package:\
 	com.liferay.portal.asm,\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portal/service/http/CompanyServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/CompanyServiceHttp.java
@@ -52,6 +52,49 @@ import com.liferay.portal.kernel.util.MethodKey;
 public class CompanyServiceHttp {
 
 	public static com.liferay.portal.kernel.model.Company addCompany(
+			HttpPrincipal httpPrincipal, long companyId, String webId,
+			String virtualHost, String mx, boolean system, int maxUsers,
+			boolean active)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				CompanyServiceUtil.class, "addCompany",
+				_addCompanyParameterTypes0);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, webId, virtualHost, mx, system, maxUsers,
+				active);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.model.Company)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.portal.kernel.model.Company addCompany(
 			HttpPrincipal httpPrincipal, String webId, String virtualHost,
 			String mx, boolean system, int maxUsers, boolean active)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -59,7 +102,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "addCompany",
-				_addCompanyParameterTypes0);
+				_addCompanyParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, webId, virtualHost, mx, system, maxUsers, active);
@@ -99,7 +142,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "deleteCompany",
-				_deleteCompanyParameterTypes1);
+				_deleteCompanyParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId);
@@ -138,7 +181,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "deleteLogo",
-				_deleteLogoParameterTypes2);
+				_deleteLogoParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId);
@@ -167,13 +210,49 @@ public class CompanyServiceHttp {
 		}
 	}
 
+	public static void forEachCompany(
+			HttpPrincipal httpPrincipal,
+			com.liferay.petra.function.UnsafeConsumer
+				<com.liferay.portal.kernel.model.Company, Exception>
+					unsafeConsumer)
+		throws Exception {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				CompanyServiceUtil.class, "forEachCompany",
+				_forEachCompanyParameterTypes4);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, unsafeConsumer);
+
+			try {
+				TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof Exception) {
+					throw (Exception)exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static java.util.List<com.liferay.portal.kernel.model.Company>
 		getCompanies(HttpPrincipal httpPrincipal) {
 
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "getCompanies",
-				_getCompaniesParameterTypes3);
+				_getCompaniesParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey);
 
@@ -206,7 +285,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "getCompanyById",
-				_getCompanyByIdParameterTypes4);
+				_getCompanyByIdParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId);
@@ -246,7 +325,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "getCompanyByLogoId",
-				_getCompanyByLogoIdParameterTypes5);
+				_getCompanyByLogoIdParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, logoId);
 
@@ -285,7 +364,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "getCompanyByMx",
-				_getCompanyByMxParameterTypes6);
+				_getCompanyByMxParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, mx);
 
@@ -325,7 +404,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "getCompanyByVirtualHost",
-				_getCompanyByVirtualHostParameterTypes7);
+				_getCompanyByVirtualHostParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, virtualHost);
@@ -365,7 +444,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "getCompanyByWebId",
-				_getCompanyByWebIdParameterTypes8);
+				_getCompanyByWebIdParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, webId);
 
@@ -404,7 +483,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "removePreferences",
-				_removePreferencesParameterTypes9);
+				_removePreferencesParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, keys);
@@ -441,7 +520,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updateCompany",
-				_updateCompanyParameterTypes10);
+				_updateCompanyParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, virtualHost, mx, maxUsers, active);
@@ -485,7 +564,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updateCompany",
-				_updateCompanyParameterTypes11);
+				_updateCompanyParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, virtualHost, mx, homeURL, hasLogo,
@@ -537,7 +616,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updateCompany",
-				_updateCompanyParameterTypes12);
+				_updateCompanyParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, virtualHost, mx, homeURL, hasLogo,
@@ -581,7 +660,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updateDisplay",
-				_updateDisplayParameterTypes13);
+				_updateDisplayParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, languageId, timeZoneId);
@@ -617,7 +696,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updateLogo",
-				_updateLogoParameterTypes14);
+				_updateLogoParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, bytes);
@@ -658,7 +737,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updateLogo",
-				_updateLogoParameterTypes15);
+				_updateLogoParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, inputStream);
@@ -699,7 +778,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updatePreferences",
-				_updatePreferencesParameterTypes16);
+				_updatePreferencesParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, unicodeProperties);
@@ -737,7 +816,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updateSecurity",
-				_updateSecurityParameterTypes17);
+				_updateSecurityParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, authType, autoLogin, sendPassword,
@@ -770,40 +849,46 @@ public class CompanyServiceHttp {
 	private static Log _log = LogFactoryUtil.getLog(CompanyServiceHttp.class);
 
 	private static final Class<?>[] _addCompanyParameterTypes0 = new Class[] {
+		long.class, String.class, String.class, String.class, boolean.class,
+		int.class, boolean.class
+	};
+	private static final Class<?>[] _addCompanyParameterTypes1 = new Class[] {
 		String.class, String.class, String.class, boolean.class, int.class,
 		boolean.class
 	};
-	private static final Class<?>[] _deleteCompanyParameterTypes1 =
+	private static final Class<?>[] _deleteCompanyParameterTypes2 =
 		new Class[] {long.class};
-	private static final Class<?>[] _deleteLogoParameterTypes2 = new Class[] {
+	private static final Class<?>[] _deleteLogoParameterTypes3 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getCompaniesParameterTypes3 =
+	private static final Class<?>[] _forEachCompanyParameterTypes4 =
+		new Class[] {com.liferay.petra.function.UnsafeConsumer.class};
+	private static final Class<?>[] _getCompaniesParameterTypes5 =
 		new Class[] {};
-	private static final Class<?>[] _getCompanyByIdParameterTypes4 =
+	private static final Class<?>[] _getCompanyByIdParameterTypes6 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getCompanyByLogoIdParameterTypes5 =
+	private static final Class<?>[] _getCompanyByLogoIdParameterTypes7 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getCompanyByMxParameterTypes6 =
+	private static final Class<?>[] _getCompanyByMxParameterTypes8 =
 		new Class[] {String.class};
-	private static final Class<?>[] _getCompanyByVirtualHostParameterTypes7 =
+	private static final Class<?>[] _getCompanyByVirtualHostParameterTypes9 =
 		new Class[] {String.class};
-	private static final Class<?>[] _getCompanyByWebIdParameterTypes8 =
+	private static final Class<?>[] _getCompanyByWebIdParameterTypes10 =
 		new Class[] {String.class};
-	private static final Class<?>[] _removePreferencesParameterTypes9 =
+	private static final Class<?>[] _removePreferencesParameterTypes11 =
 		new Class[] {long.class, String[].class};
-	private static final Class<?>[] _updateCompanyParameterTypes10 =
+	private static final Class<?>[] _updateCompanyParameterTypes12 =
 		new Class[] {
 			long.class, String.class, String.class, int.class, boolean.class
 		};
-	private static final Class<?>[] _updateCompanyParameterTypes11 =
+	private static final Class<?>[] _updateCompanyParameterTypes13 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, boolean.class,
 			byte[].class, String.class, String.class, String.class,
 			String.class, String.class, String.class, String.class,
 			String.class, String.class
 		};
-	private static final Class<?>[] _updateCompanyParameterTypes12 =
+	private static final Class<?>[] _updateCompanyParameterTypes14 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, boolean.class,
 			byte[].class, String.class, String.class, String.class,
@@ -813,19 +898,19 @@ public class CompanyServiceHttp {
 			java.util.List.class,
 			com.liferay.portal.kernel.util.UnicodeProperties.class
 		};
-	private static final Class<?>[] _updateDisplayParameterTypes13 =
+	private static final Class<?>[] _updateDisplayParameterTypes15 =
 		new Class[] {long.class, String.class, String.class};
-	private static final Class<?>[] _updateLogoParameterTypes14 = new Class[] {
+	private static final Class<?>[] _updateLogoParameterTypes16 = new Class[] {
 		long.class, byte[].class
 	};
-	private static final Class<?>[] _updateLogoParameterTypes15 = new Class[] {
+	private static final Class<?>[] _updateLogoParameterTypes17 = new Class[] {
 		long.class, java.io.InputStream.class
 	};
-	private static final Class<?>[] _updatePreferencesParameterTypes16 =
+	private static final Class<?>[] _updatePreferencesParameterTypes18 =
 		new Class[] {
 			long.class, com.liferay.portal.kernel.util.UnicodeProperties.class
 		};
-	private static final Class<?>[] _updateSecurityParameterTypes17 =
+	private static final Class<?>[] _updateSecurityParameterTypes19 =
 		new Class[] {
 			long.class, String.class, boolean.class, boolean.class,
 			boolean.class, boolean.class, boolean.class, boolean.class

--- a/portal-impl/src/com/liferay/portal/service/http/CompanyServiceSoap.java
+++ b/portal-impl/src/com/liferay/portal/service/http/CompanyServiceSoap.java
@@ -66,6 +66,41 @@ public class CompanyServiceSoap {
 	/**
 	 * Adds a company.
 	 *
+	 * @param companyId the primary key of the company (optionally <code>null</code> or
+	 *         <code>0</code> to generate a key automatically)
+	 * @param webId the company's web domain
+	 * @param virtualHost the company's virtual host name
+	 * @param mx the company's mail domain
+	 * @param system whether the company is the very first company (i.e., the
+	 * @param maxUsers the max number of company users (optionally
+	 <code>0</code>)
+	 * @param active whether the company is active
+	 * @return the company
+	 */
+	public static com.liferay.portal.kernel.model.CompanySoap addCompany(
+			long companyId, String webId, String virtualHost, String mx,
+			boolean system, int maxUsers, boolean active)
+		throws RemoteException {
+
+		try {
+			com.liferay.portal.kernel.model.Company returnValue =
+				CompanyServiceUtil.addCompany(
+					companyId, webId, virtualHost, mx, system, maxUsers,
+					active);
+
+			return com.liferay.portal.kernel.model.CompanySoap.toSoapModel(
+				returnValue);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			throw new RemoteException(exception.getMessage());
+		}
+	}
+
+	/**
+	 * Adds a company.
+	 *
 	 * @param webId the company's web domain
 	 * @param virtualHost the company's virtual host name
 	 * @param mx the company's mail domain
@@ -121,6 +156,22 @@ public class CompanyServiceSoap {
 	public static void deleteLogo(long companyId) throws RemoteException {
 		try {
 			CompanyServiceUtil.deleteLogo(companyId);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			throw new RemoteException(exception.getMessage());
+		}
+	}
+
+	public static void forEachCompany(
+			com.liferay.petra.function.UnsafeConsumer
+				<com.liferay.portal.kernel.model.Company, Exception>
+					unsafeConsumer)
+		throws RemoteException {
+
+		try {
+			CompanyServiceUtil.forEachCompany(unsafeConsumer);
 		}
 		catch (Exception exception) {
 			_log.error(exception, exception);

--- a/portal-impl/src/com/liferay/portal/service/http/packageinfo
+++ b/portal-impl/src/com/liferay/portal/service/http/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyServiceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.service.impl;
 
+import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
@@ -49,6 +50,37 @@ import javax.portlet.PortletPreferences;
  */
 @JSONWebService
 public class CompanyServiceImpl extends CompanyServiceBaseImpl {
+
+	/**
+	 * Adds a company.
+	 *
+	 * @param	companyId the primary key of the company (optionally <code>null</code> or
+	 * 	 *         <code>0</code> to generate a key automatically)
+	 * @param  webId the company's web domain
+	 * @param  virtualHost the company's virtual host name
+	 * @param  mx the company's mail domain
+	 * @param  system whether the company is the very first company (i.e., the
+	 * @param  maxUsers the max number of company users (optionally
+	 *         <code>0</code>)
+	 * @param  active whether the company is active
+	 * @return the company
+	 */
+	@JSONWebService(mode = JSONWebServiceMode.IGNORE)
+	@Override
+	public Company addCompany(
+			long companyId, String webId, String virtualHost, String mx,
+			boolean system, int maxUsers, boolean active)
+		throws PortalException {
+
+		PermissionChecker permissionChecker = getPermissionChecker();
+
+		if (!permissionChecker.isOmniadmin()) {
+			throw new PrincipalException.MustBeOmniadmin(permissionChecker);
+		}
+
+		return companyLocalService.addCompany(
+			companyId, webId, virtualHost, mx, system, maxUsers, active);
+	}
 
 	/**
 	 * Adds a company.
@@ -105,6 +137,20 @@ public class CompanyServiceImpl extends CompanyServiceBaseImpl {
 		}
 
 		companyLocalService.deleteLogo(companyId);
+	}
+
+	@Override
+	public void forEachCompany(
+			UnsafeConsumer<Company, Exception> unsafeConsumer)
+		throws Exception {
+
+		PermissionChecker permissionChecker = getPermissionChecker();
+
+		if (!permissionChecker.isOmniadmin()) {
+			throw new PrincipalException.MustBeOmniadmin(permissionChecker);
+		}
+
+		companyLocalService.forEachCompany(unsafeConsumer);
 	}
 
 	/**

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 24.0.1
+Bundle-Version: 24.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CompanyService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CompanyService.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.service;
 
+import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
@@ -62,6 +63,26 @@ public interface CompanyService extends BaseService {
 	/**
 	 * Adds a company.
 	 *
+	 * @param companyId the primary key of the company (optionally <code>null</code> or
+	 *         <code>0</code> to generate a key automatically)
+	 * @param webId the company's web domain
+	 * @param virtualHost the company's virtual host name
+	 * @param mx the company's mail domain
+	 * @param system whether the company is the very first company (i.e., the
+	 * @param maxUsers the max number of company users (optionally
+	 <code>0</code>)
+	 * @param active whether the company is active
+	 * @return the company
+	 */
+	@JSONWebService(mode = JSONWebServiceMode.IGNORE)
+	public Company addCompany(
+			long companyId, String webId, String virtualHost, String mx,
+			boolean system, int maxUsers, boolean active)
+		throws PortalException;
+
+	/**
+	 * Adds a company.
+	 *
 	 * @param webId the company's web domain
 	 * @param virtualHost the company's virtual host name
 	 * @param mx the company's mail domain
@@ -86,6 +107,10 @@ public interface CompanyService extends BaseService {
 	 * @param companyId the primary key of the company
 	 */
 	public void deleteLogo(long companyId) throws PortalException;
+
+	public void forEachCompany(
+			UnsafeConsumer<Company, Exception> unsafeConsumer)
+		throws Exception;
 
 	/**
 	 * Returns all the companies.

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CompanyServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CompanyServiceUtil.java
@@ -44,6 +44,29 @@ public class CompanyServiceUtil {
 	/**
 	 * Adds a company.
 	 *
+	 * @param companyId the primary key of the company (optionally <code>null</code> or
+	 <code>0</code> to generate a key automatically)
+	 * @param webId the company's web domain
+	 * @param virtualHost the company's virtual host name
+	 * @param mx the company's mail domain
+	 * @param system whether the company is the very first company (i.e., the
+	 * @param maxUsers the max number of company users (optionally
+	 <code>0</code>)
+	 * @param active whether the company is active
+	 * @return the company
+	 */
+	public static Company addCompany(
+			long companyId, String webId, String virtualHost, String mx,
+			boolean system, int maxUsers, boolean active)
+		throws PortalException {
+
+		return getService().addCompany(
+			companyId, webId, virtualHost, mx, system, maxUsers, active);
+	}
+
+	/**
+	 * Adds a company.
+	 *
 	 * @param webId the company's web domain
 	 * @param virtualHost the company's virtual host name
 	 * @param mx the company's mail domain
@@ -73,6 +96,14 @@ public class CompanyServiceUtil {
 	 */
 	public static void deleteLogo(long companyId) throws PortalException {
 		getService().deleteLogo(companyId);
+	}
+
+	public static void forEachCompany(
+			com.liferay.petra.function.UnsafeConsumer<Company, Exception>
+				unsafeConsumer)
+		throws Exception {
+
+		getService().forEachCompany(unsafeConsumer);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CompanyServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CompanyServiceWrapper.java
@@ -35,6 +35,31 @@ public class CompanyServiceWrapper
 	/**
 	 * Adds a company.
 	 *
+	 * @param companyId the primary key of the company (optionally <code>null</code> or
+	 <code>0</code> to generate a key automatically)
+	 * @param webId the company's web domain
+	 * @param virtualHost the company's virtual host name
+	 * @param mx the company's mail domain
+	 * @param system whether the company is the very first company (i.e., the
+	 * @param maxUsers the max number of company users (optionally
+	 <code>0</code>)
+	 * @param active whether the company is active
+	 * @return the company
+	 */
+	@Override
+	public com.liferay.portal.kernel.model.Company addCompany(
+			long companyId, java.lang.String webId,
+			java.lang.String virtualHost, java.lang.String mx, boolean system,
+			int maxUsers, boolean active)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _companyService.addCompany(
+			companyId, webId, virtualHost, mx, system, maxUsers, active);
+	}
+
+	/**
+	 * Adds a company.
+	 *
 	 * @param webId the company's web domain
 	 * @param virtualHost the company's virtual host name
 	 * @param mx the company's mail domain
@@ -71,6 +96,16 @@ public class CompanyServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_companyService.deleteLogo(companyId);
+	}
+
+	@Override
+	public void forEachCompany(
+			com.liferay.petra.function.UnsafeConsumer
+				<com.liferay.portal.kernel.model.Company, java.lang.Exception>
+					unsafeConsumer)
+		throws java.lang.Exception {
+
+		_companyService.forEachCompany(unsafeConsumer);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 8.2.0
+version 8.3.0


### PR DESCRIPTION
Sending directly as it has been stuck several times on the CI for unrelated errors

Original description:
---

Replace the use of LocalService to Service to check permissions from the Portal Instance APIs. Just resending from here after rebase

Original PR from @SamZiemer at liferay-headless#712:

https://issues.liferay.com/browse/LPS-139343

This pull changes PortalInstanceResourceImpl to no longer use CompanyLocalService and instead use CompanyService for permission checking.