### PR TITLE
Revert "LPS-143549 Not needed because DataGuard will clean it up"

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/search/test/DepotEntrySearchTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/search/test/DepotEntrySearchTest.java
@@ -31,7 +31,7 @@ import com.liferay.portal.kernel.search.SearchResultUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
@@ -46,6 +46,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -59,7 +60,6 @@ import org.junit.runner.RunWith;
 /**
  * @author Alejandro Tardín
  */
-@DataGuard(scope = DataGuard.Scope.METHOD)
 @RunWith(Arquillian.class)
 @Sync
 public class DepotEntrySearchTest {
@@ -235,13 +235,20 @@ public class DepotEntrySearchTest {
 	public SearchTestRule searchTestRule = new SearchTestRule();
 
 	private DepotEntry _addDepotEntry(User user, String name) throws Exception {
-		return _depotEntryService.addDepotEntry(
+		DepotEntry depotEntry = _depotEntryService.addDepotEntry(
 			Collections.singletonMap(LocaleUtil.getDefault(), name),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			ServiceContextTestUtil.getServiceContext(
 				TestPropsValues.getGroupId(), user.getUserId()));
+
+		_depotEntries.add(depotEntry);
+
+		return depotEntry;
 	}
+
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
 
 	@Inject
 	private DepotEntryService _depotEntryService;


### PR DESCRIPTION
This reverts commit decef183a8f77f290bbedbcae827ff524ddaa15d.

DataGuard.Scope.METHOD makes the tests slow