### PR TITLE
SXP | LPS-144910, LPS-144951 Fix invalid parameter names in OOTB elements' JSON

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/com/liferay/search/experiences/internal/model/listener/dependencies/boost_contents_in_a_category_for_new_user_accounts.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/com/liferay/search/experiences/internal/model/listener/dependencies/boost_contents_in_a_category_for_new_user_accounts.json
@@ -26,7 +26,7 @@
 							"range": {
 								"format": "yyyyMMdd",
 								"gte": "${time.current_date|modifier=-${configuration.time_range},date_format=yyyyMMdd}",
-								"lte": "${time.current_date|modifier=+1d,dateFormat=yyyyMMdd}",
+								"lte": "${time.current_date|modifier=+1d,date_format=yyyyMMdd}",
 								"parameterName": "user.create_date"
 							}
 						}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/com/liferay/search/experiences/internal/model/listener/dependencies/scheduling_aware.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/com/liferay/search/experiences/internal/model/listener/dependencies/scheduling_aware.json
@@ -35,7 +35,7 @@
 																	"from": "-9223372036854775808",
 																	"include_lower": true,
 																	"include_upper": true,
-																	"to": "${time.current_date|dateFormat=timestamp}"
+																	"to": "${time.current_date|date_format=timestamp}"
 																}
 															}
 														}
@@ -58,14 +58,14 @@
 																	"from": "-9223372036854775808",
 																	"include_lower": true,
 																	"include_upper": true,
-																	"to": "${time.current_date|dateFormat=timestamp}"
+																	"to": "${time.current_date|date_format=timestamp}"
 																}
 															}
 														},
 														{
 															"range": {
 																"expirationDate_sortable": {
-																	"from": "${time.current_date|dateFormat=timestamp}",
+																	"from": "${time.current_date|date_format=timestamp}",
 																	"include_lower": true,
 																	"include_upper": true,
 																	"to": "9223372036854775807"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-144910
https://issues.liferay.com/browse/LPS-144951

:heavy_check_mark: `ci:test:sf` passed locally.

Thanks,
Tibor