### PR TITLE
LPS-144684 SearchResponseResourceImplTest unit tests fails due to NoClassDefFoundError

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/build.gradle
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	compileOnly project(":dxp:apps:search-experiences:search-experiences-api")
 	compileOnly project(":dxp:apps:search-experiences:search-experiences-rest-api")
 
+	testCompile group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.12.4"
 	testCompile project(":apps:portal-search:portal-search")
 	testCompile project(":dxp:apps:search-experiences:search-experiences-service")
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-144684