### PR TITLE
LPS-145187 Search context attribute values should always be applied to blueprint parameters of same name, even global parameters

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/SXPParameterData.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/SXPParameterData.java
@@ -16,15 +16,16 @@ package com.liferay.search.experiences.internal.blueprint.parameter;
 
 import com.liferay.search.experiences.blueprint.parameter.SXPParameter;
 
-import java.util.Objects;
-import java.util.Set;
+import java.util.Map;
 
 /**
  * @author Petteri Karttunen
  */
 public class SXPParameterData {
 
-	public SXPParameterData(String keywords, Set<SXPParameter> sxpParameters) {
+	public SXPParameterData(
+		String keywords, Map<String, SXPParameter> sxpParameters) {
+
 		_keywords = keywords;
 		_sxpParameters = sxpParameters;
 	}
@@ -34,24 +35,14 @@ public class SXPParameterData {
 	}
 
 	public SXPParameter getSXPParameterByName(String name) {
-		if (name == null) {
-			return null;
-		}
-
-		for (SXPParameter sxpParameter : _sxpParameters) {
-			if (Objects.equals(sxpParameter.getName(), name)) {
-				return sxpParameter;
-			}
-		}
-
-		return null;
+		return _sxpParameters.get(name);
 	}
 
-	public Set<SXPParameter> getSXPParameters() {
+	public Map<String, SXPParameter> getSXPParameters() {
 		return _sxpParameters;
 	}
 
 	private final String _keywords;
-	private final Set<SXPParameter> _sxpParameters;
+	private final Map<String, SXPParameter> _sxpParameters;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/SXPParameterDataCreator.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/SXPParameterDataCreator.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.search.experiences.blueprint.parameter.SXPParameter;
@@ -53,10 +54,14 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+
+import org.apache.commons.lang.StringUtils;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -78,7 +83,7 @@ public class SXPParameterDataCreator
 	public SXPParameterData create(
 		SearchContext searchContext, SXPBlueprint sxpBlueprint) {
 
-		Set<SXPParameter> sxpParameters = new LinkedHashSet<>();
+		Map<String, SXPParameter> sxpParameters = new LinkedHashMap<>();
 
 		String keywords = _addKeywordsSXPParameters(
 			searchContext, sxpParameters);
@@ -132,13 +137,20 @@ public class SXPParameterDataCreator
 		};
 	}
 
+	private void _add(
+		SXPParameter sxpParameter, Map<String, SXPParameter> sxpParameters) {
+
+		sxpParameters.put(sxpParameter.getName(), sxpParameter);
+	}
+
 	private String _addKeywordsSXPParameters(
-		SearchContext searchContext, Set<SXPParameter> sxpParameters) {
+		SearchContext searchContext, Map<String, SXPParameter> sxpParameters) {
 
 		String keywords = GetterUtil.getString(searchContext.getKeywords());
 
-		sxpParameters.add(
-			new StringSXPParameter("keywords.raw", true, keywords));
+		_add(
+			new StringSXPParameter("keywords.raw", true, keywords),
+			sxpParameters);
 
 		if ((StringUtil.count(keywords, CharPool.QUOTE) % 2) != 0) {
 			keywords = StringUtil.replace(
@@ -151,14 +163,20 @@ public class SXPParameterDataCreator
 		keywords = keywords.replaceAll("\\\\", "&#92;");
 		keywords = keywords.replaceAll("\\]", "&#93;");
 
-		sxpParameters.add(new StringSXPParameter("keywords", true, keywords));
+		_add(new StringSXPParameter("keywords", true, keywords), sxpParameters);
 
 		return keywords;
 	}
 
 	private void _addSXPParameter(
-		String name, Parameter parameter, SearchContext searchContext,
-		Set<SXPParameter> sxpParameters) {
+		SearchContext searchContext,
+		SXPParameterContributorDefinition sxpParameterContributorDefinition,
+		Map<String, SXPParameter> sxpParameters) {
+
+		String name = StringUtils.substringBetween(
+			sxpParameterContributorDefinition.getTemplateVariable(),
+			StringPool.DOLLAR_AND_OPEN_CURLY_BRACE,
+			StringPool.CLOSE_CURLY_BRACE);
 
 		Object object = searchContext.getAttribute(name);
 
@@ -167,18 +185,39 @@ public class SXPParameterDataCreator
 		}
 
 		SXPParameter sxpParameter = _getSXPParameter(
-			name, object, parameter, searchContext);
+			name, object, new Parameter(), searchContext,
+			_getType(sxpParameterContributorDefinition));
 
 		if (sxpParameter == null) {
 			return;
 		}
 
-		sxpParameters.add(sxpParameter);
+		_add(sxpParameter, sxpParameters);
+	}
+
+	private void _addSXPParameter(
+		String name, Parameter parameter, SearchContext searchContext,
+		Map<String, SXPParameter> sxpParameters) {
+
+		Object object = searchContext.getAttribute(name);
+
+		if (object == null) {
+			return;
+		}
+
+		SXPParameter sxpParameter = _getSXPParameter(
+			name, object, parameter, searchContext, parameter.getType());
+
+		if (sxpParameter == null) {
+			return;
+		}
+
+		_add(sxpParameter, sxpParameters);
 	}
 
 	private void _addSXPParameters(
 		ParameterConfiguration parameterConfiguration,
-		SearchContext searchContext, Set<SXPParameter> sxpParameters) {
+		SearchContext searchContext, Map<String, SXPParameter> sxpParameters) {
 
 		if (parameterConfiguration == null) {
 			return;
@@ -192,7 +231,7 @@ public class SXPParameterDataCreator
 
 	private void _contribute(
 		SearchContext searchContext, SXPBlueprint sxpBlueprint,
-		Set<SXPParameter> sxpParameters) {
+		Map<String, SXPParameter> sxpParameters) {
 
 		if (ArrayUtil.isEmpty(_sxpParameterContributors)) {
 			return;
@@ -201,8 +240,31 @@ public class SXPParameterDataCreator
 		for (SXPParameterContributor sxpParameterContributor :
 				_sxpParameterContributors) {
 
+			Set<SXPParameter> set = new LinkedHashSet<>();
+
 			sxpParameterContributor.contribute(
-				searchContext, sxpBlueprint, sxpParameters);
+				searchContext, sxpBlueprint, set);
+
+			for (SXPParameter sxpParameter : set) {
+				_add(sxpParameter, sxpParameters);
+			}
+
+			List<SXPParameterContributorDefinition>
+				sxpParameterContributorDefinitions =
+					sxpParameterContributor.
+						getSXPParameterContributorDefinitions(
+							searchContext.getCompanyId());
+
+			if (ListUtil.isNotEmpty(sxpParameterContributorDefinitions)) {
+				for (SXPParameterContributorDefinition
+						sxpParameterContributorDefinition :
+							sxpParameterContributorDefinitions) {
+
+					_addSXPParameter(
+						searchContext, sxpParameterContributorDefinition,
+						sxpParameters);
+				}
+			}
 		}
 	}
 
@@ -369,6 +431,11 @@ public class SXPParameterDataCreator
 	}
 
 	private Integer[] _getIntegerArray(Integer[] defaultValue, Object object) {
+		if (object instanceof String) {
+			return ArrayUtil.toArray(
+				GetterUtil.getIntegerValues(StringUtil.split((String)object)));
+		}
+
 		if (object != null) {
 			return ArrayUtil.toArray(GetterUtil.getIntegerValues(object));
 		}
@@ -423,6 +490,11 @@ public class SXPParameterDataCreator
 	}
 
 	private Long[] _getLongArray(Long[] defaultValue, Object object) {
+		if (object instanceof String) {
+			return ArrayUtil.toArray(
+				GetterUtil.getLongValues(StringUtil.split((String)object)));
+		}
+
 		if (object != null) {
 			return ArrayUtil.toArray(GetterUtil.getLongValues(object));
 		}
@@ -512,9 +584,7 @@ public class SXPParameterDataCreator
 
 	private SXPParameter _getSXPParameter(
 		String name, Object object, Parameter parameter,
-		SearchContext searchContext) {
-
-		Parameter.Type type = parameter.getType();
+		SearchContext searchContext, Parameter.Type type) {
 
 		if (type.equals(Parameter.Type.BOOLEAN)) {
 			return _getBooleanSXPParameter(name, object, parameter);
@@ -580,6 +650,45 @@ public class SXPParameterDataCreator
 		}
 
 		return new DateSXPParameter(name, true, calendar.getTime());
+	}
+
+	private Parameter.Type _getType(
+		SXPParameterContributorDefinition sxpParameterContributorDefinition) {
+
+		String className = sxpParameterContributorDefinition.getClassName();
+
+		if (className.equals(BooleanSXPParameter.class.getName())) {
+			return Parameter.Type.BOOLEAN;
+		}
+		else if (className.equals(DateSXPParameter.class.getName())) {
+			return Parameter.Type.DATE;
+		}
+		else if (className.equals(DoubleSXPParameter.class.getName())) {
+			return Parameter.Type.DOUBLE;
+		}
+		else if (className.equals(FloatSXPParameter.class.getName())) {
+			return Parameter.Type.FLOAT;
+		}
+		else if (className.equals(IntegerSXPParameter.class.getName())) {
+			return Parameter.Type.INTEGER;
+		}
+		else if (className.equals(IntegerArraySXPParameter.class.getName())) {
+			return Parameter.Type.INTEGER_ARRAY;
+		}
+		else if (className.equals(LongSXPParameter.class.getName())) {
+			return Parameter.Type.LONG;
+		}
+		else if (className.equals(LongArraySXPParameter.class.getName())) {
+			return Parameter.Type.LONG_ARRAY;
+		}
+		else if (className.equals(StringSXPParameter.class.getName())) {
+			return Parameter.Type.STRING;
+		}
+		else if (className.equals(StringArraySXPParameter.class.getName())) {
+			return Parameter.Type.STRING_ARRAY;
+		}
+
+		throw new IllegalArgumentException();
 	}
 
 	@Reference

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/test/java/com/liferay/search/experiences/internal/blueprint/condition/SXPConditionEvaluatorTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/test/java/com/liferay/search/experiences/internal/blueprint/condition/SXPConditionEvaluatorTest.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.search.experiences.blueprint.parameter.SXPParameter;
 import com.liferay.search.experiences.internal.blueprint.parameter.BooleanSXPParameter;
@@ -38,6 +37,8 @@ import com.liferay.search.experiences.rest.dto.v1_0.Exists;
 import java.time.ZonedDateTime;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.function.Consumer;
 
@@ -693,14 +694,23 @@ public class SXPConditionEvaluatorTest {
 	}
 
 	private void _setSXPParameters(SXPParameter... sxpParameters) {
-		_sxpParameterData = new SXPParameterData(
-			null, SetUtil.fromArray(sxpParameters));
+		_sxpParameterData = new SXPParameterData(null, _toMap(sxpParameters));
+	}
+
+	private Map<String, SXPParameter> _toMap(SXPParameter... sxpParameters) {
+		Map<String, SXPParameter> map = new HashMap<>();
+
+		for (SXPParameter sxpParameter : sxpParameters) {
+			map.put(sxpParameter.getName(), sxpParameter);
+		}
+
+		return map;
 	}
 
 	private Condition _condition = new Condition();
 	private SXPParameterData _sxpParameterData = new SXPParameterData(
 		"test",
-		SetUtil.fromArray(
+		_toMap(
 			new BooleanSXPParameter("boolean", true, true),
 			new DoubleSXPParameter("double", true, 1.0D),
 			new FloatSXPParameter("float", true, 1.0F),


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-145187