### PR TITLE
LPS-143997 search-experiences: Add permissions to view table actions

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/SXPBlueprint.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/SXPBlueprint.java
@@ -64,6 +64,36 @@ public class SXPBlueprint implements Serializable {
 
 	@Schema
 	@Valid
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	@JsonIgnore
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Map<String, Map<String, String>> actions;
+
+	@Schema
+	@Valid
 	public Configuration getConfiguration() {
 		return configuration;
 	}
@@ -404,6 +434,16 @@ public class SXPBlueprint implements Serializable {
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		if (actions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(actions));
+		}
 
 		if (configuration != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/SXPElement.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/SXPElement.java
@@ -63,6 +63,36 @@ public class SXPElement implements Serializable {
 	}
 
 	@Schema
+	@Valid
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	@JsonIgnore
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Map<String, Map<String, String>> actions;
+
+	@Schema
 	public Date getCreateDate() {
 		return createDate;
 	}
@@ -457,6 +487,16 @@ public class SXPElement implements Serializable {
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		if (actions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(actions));
+		}
 
 		if (createDate != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/dto/v1_0/SXPBlueprint.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/dto/v1_0/SXPBlueprint.java
@@ -36,6 +36,28 @@ public class SXPBlueprint implements Cloneable, Serializable {
 		return SXPBlueprintSerDes.toDTO(json);
 	}
 
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Map<String, String>> actions;
+
 	public Configuration getConfiguration() {
 		return configuration;
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/dto/v1_0/SXPElement.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/dto/v1_0/SXPElement.java
@@ -36,6 +36,28 @@ public class SXPElement implements Cloneable, Serializable {
 		return SXPElementSerDes.toDTO(json);
 	}
 
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Map<String, String>> actions;
+
 	public Date getCreateDate() {
 		return createDate;
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/serdes/v1_0/SXPBlueprintSerDes.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/serdes/v1_0/SXPBlueprintSerDes.java
@@ -63,6 +63,16 @@ public class SXPBlueprintSerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		if (sxpBlueprint.getActions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(sxpBlueprint.getActions()));
+		}
+
 		if (sxpBlueprint.getConfiguration() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -234,6 +244,13 @@ public class SXPBlueprintSerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		if (sxpBlueprint.getActions() == null) {
+			map.put("actions", null);
+		}
+		else {
+			map.put("actions", String.valueOf(sxpBlueprint.getActions()));
+		}
+
 		if (sxpBlueprint.getConfiguration() == null) {
 			map.put("configuration", null);
 		}
@@ -345,7 +362,14 @@ public class SXPBlueprintSerDes {
 			SXPBlueprint sxpBlueprint, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "configuration")) {
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					sxpBlueprint.setActions(
+						(Map)SXPBlueprintSerDes.toMap(
+							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "configuration")) {
 				if (jsonParserFieldValue != null) {
 					sxpBlueprint.setConfiguration(
 						ConfigurationSerDes.toDTO(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/serdes/v1_0/SXPElementSerDes.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/serdes/v1_0/SXPElementSerDes.java
@@ -59,6 +59,16 @@ public class SXPElementSerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		if (sxpElement.getActions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(sxpElement.getActions()));
+		}
+
 		if (sxpElement.getCreateDate() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -236,6 +246,13 @@ public class SXPElementSerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		if (sxpElement.getActions() == null) {
+			map.put("actions", null);
+		}
+		else {
+			map.put("actions", String.valueOf(sxpElement.getActions()));
+		}
+
 		if (sxpElement.getCreateDate() == null) {
 			map.put("createDate", null);
 		}
@@ -357,7 +374,14 @@ public class SXPElementSerDes {
 			SXPElement sxpElement, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "createDate")) {
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					sxpElement.setActions(
+						(Map)SXPElementSerDes.toMap(
+							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "createDate")) {
 				if (jsonParserFieldValue != null) {
 					sxpElement.setCreateDate(
 						toDate((String)jsonParserFieldValue));

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
@@ -351,6 +351,13 @@ components:
                     type: string
         SXPBlueprint:
             properties:
+                actions:
+                    additionalProperties:
+                        additionalProperties:
+                            type: string
+                        type: object
+                    readOnly: true
+                    type: object
                 configuration:
                     $ref: "#/components/schemas/Configuration"
                 createDate:
@@ -385,6 +392,13 @@ components:
             type: object
         SXPElement:
             properties:
+                actions:
+                    additionalProperties:
+                        additionalProperties:
+                            type: string
+                        type: object
+                    readOnly: true
+                    type: object
                 createDate:
                     format: date
                     type: string

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/graphql/query/v1_0/Query.java
@@ -242,7 +242,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sXPBlueprint(sxpBlueprintId: ___){configuration, createDate, description, description_i18n, elementInstances, id, modifiedDate, schemaVersion, title, title_i18n, userName}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sXPBlueprint(sxpBlueprintId: ___){actions, configuration, createDate, description, description_i18n, elementInstances, id, modifiedDate, schemaVersion, title, title_i18n, userName}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public SXPBlueprint sXPBlueprint(
@@ -301,7 +301,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sXPElement(sxpElementId: ___){createDate, description, description_i18n, elementDefinition, hidden, id, modifiedDate, readOnly, schemaVersion, title, title_i18n, type, userName}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sXPElement(sxpElementId: ___){actions, createDate, description, description_i18n, elementDefinition, hidden, id, modifiedDate, readOnly, schemaVersion, title, title_i18n, type, userName}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public SXPElement sXPElement(@GraphQLName("sxpElementId") Long sxpElementId)

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPBlueprintResourceImpl.java
@@ -114,10 +114,7 @@ public class SXPBlueprintResourceImpl
 				_jsonFactory.createJSONArray(
 					sxpBlueprint.getElementInstancesJSON())
 			).put(
-				"schemaVersion",
-				_jsonFactory.createJSONObject(
-					_jsonFactory.looseSerialize(
-						sxpBlueprint.getSchemaVersion()))
+				"schemaVersion", sxpBlueprint.getSchemaVersion()
 			).put(
 				"title_i18n",
 				_jsonFactory.createJSONObject(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPElementResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SXPElementResourceImpl.java
@@ -105,9 +105,7 @@ public class SXPElementResourceImpl
 				_jsonFactory.createJSONObject(
 					sxpElement.getElementDefinitionJSON())
 			).put(
-				"schemaVersion",
-				_jsonFactory.createJSONObject(
-					_jsonFactory.looseSerialize(sxpElement.getSchemaVersion()))
+				"schemaVersion", sxpElement.getSchemaVersion()
 			).put(
 				"title_i18n",
 				_jsonFactory.createJSONObject(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
@@ -752,6 +752,14 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (sxpBlueprint.getActions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("configuration", additionalAssertFieldName)) {
 				if (sxpBlueprint.getConfiguration() == null) {
 					valid = false;
@@ -924,6 +932,17 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (!equals(
+						(Map)sxpBlueprint1.getActions(),
+						(Map)sxpBlueprint2.getActions())) {
+
+					return false;
+				}
+
+				continue;
+			}
 
 			if (Objects.equals("configuration", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
@@ -1140,6 +1159,11 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 		sb.append(" ");
 		sb.append(operator);
 		sb.append(" ");
+
+		if (entityFieldName.equals("actions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
 
 		if (entityFieldName.equals("configuration")) {
 			throw new IllegalArgumentException(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPElementResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPElementResourceTestCase.java
@@ -735,6 +735,14 @@ public abstract class BaseSXPElementResourceTestCase {
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (sxpElement.getActions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("createDate", additionalAssertFieldName)) {
 				if (sxpElement.getCreateDate() == null) {
 					valid = false;
@@ -923,6 +931,17 @@ public abstract class BaseSXPElementResourceTestCase {
 
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (!equals(
+						(Map)sxpElement1.getActions(),
+						(Map)sxpElement2.getActions())) {
+
+					return false;
+				}
+
+				continue;
+			}
 
 			if (Objects.equals("createDate", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
@@ -1159,6 +1178,11 @@ public abstract class BaseSXPElementResourceTestCase {
 		sb.append(" ");
 		sb.append(operator);
 		sb.append(" ");
+
+		if (entityFieldName.equals("actions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
 
 		if (entityFieldName.equals("createDate")) {
 			if (operator.equals("between")) {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPBlueprintsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPBlueprintsDisplayContext.java
@@ -86,7 +86,7 @@ public class ViewSXPBlueprintsDisplayContext {
 				).buildString(),
 				"pencil", "edit",
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "edit"), "get",
-				null, null),
+				"view", null),
 			new FDSActionDropdownItem(
 				getAPIURL() + "/{id}/export", "download", "export",
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "export"),
@@ -97,7 +97,7 @@ public class ViewSXPBlueprintsDisplayContext {
 					"are-you-sure-you-want-to-delete-this-entry"),
 				getAPIURL() + "/{id}", "trash", "delete",
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "delete"),
-				"delete", null, "async"));
+				"delete", "delete", "async"));
 	}
 
 	public PortletURL getPortletURL() throws PortletException {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPBlueprintsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPBlueprintsDisplayContext.java
@@ -90,7 +90,7 @@ public class ViewSXPBlueprintsDisplayContext {
 			new FDSActionDropdownItem(
 				getAPIURL() + "/{id}/export", "download", "export",
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "export"),
-				"get", null, "blank"),
+				"get", null, null),
 			new FDSActionDropdownItem(
 				LanguageUtil.get(
 					_sxpRequestHelper.getRequest(),

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPElementsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPElementsDisplayContext.java
@@ -84,7 +84,7 @@ public class ViewSXPElementsDisplayContext {
 				).buildString(),
 				"pencil", "edit",
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "edit"), "get",
-				null, null),
+				"view", null),
 			new FDSActionDropdownItem(
 				getAPIURL() + "/{id}/export", "download", "export",
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "export"),
@@ -95,7 +95,7 @@ public class ViewSXPElementsDisplayContext {
 					"are-you-sure-you-want-to-delete-this-entry"),
 				getAPIURL() + "/{id}", "trash", "delete",
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "delete"),
-				"delete", null, "async"));
+				"delete", "delete", "async"));
 	}
 
 	public PortletURL getPortletURL() throws PortletException {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPElementsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPElementsDisplayContext.java
@@ -82,8 +82,8 @@ public class ViewSXPElementsDisplayContext {
 				).setParameter(
 					"sxpElementId", "{id}"
 				).buildString(),
-				"pencil", "edit",
-				LanguageUtil.get(_sxpRequestHelper.getRequest(), "edit"), "get",
+				"view", "view",
+				LanguageUtil.get(_sxpRequestHelper.getRequest(), "view"), "get",
 				"view", null),
 			new FDSActionDropdownItem(
 				getAPIURL() + "/{id}/export", "download", "export",

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPElementsDisplayContext.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/display/context/ViewSXPElementsDisplayContext.java
@@ -88,7 +88,7 @@ public class ViewSXPElementsDisplayContext {
 			new FDSActionDropdownItem(
 				getAPIURL() + "/{id}/export", "download", "export",
 				LanguageUtil.get(_sxpRequestHelper.getRequest(), "export"),
-				"get", null, "blank"),
+				"get", null, null),
 			new FDSActionDropdownItem(
 				LanguageUtil.get(
 					_sxpRequestHelper.getRequest(),

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/edit_sxp_element.jsp
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/edit_sxp_element.jsp
@@ -32,7 +32,7 @@ if (Validator.isNull(redirect)) {
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(redirect);
 
-renderResponse.setTitle(LanguageUtil.get(request, "edit-element"));
+renderResponse.setTitle(LanguageUtil.get(request, "view-element"));
 %>
 
 <div>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-143997

- Applies permissions to table actions (view/delete)
- Hides "delete" only read only elements
- Changes elements table "edit" action label to "view" (to not confuse read only elements with an edit action)

- Includes a temporary workaround for export which will navigate to a new page with the JSON so at least the user can save the JSON payload (currently errors or improperly formats data when attempting to export). Pending changes from https://github.com/liferay-frontend/liferay-portal/pull/1777 to allow a proper fix.

cc @oliv-yu