### PR TITLE
LPS-144193: Invalid Parameter Errors

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/low/level/search/options/portlet/shared/search/LowLevelSearchOptionsPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/low/level/search/options/portlet/shared/search/LowLevelSearchOptionsPortletSharedSearchContributor.java
@@ -83,14 +83,11 @@ public class LowLevelSearchOptionsPortletSharedSearchContributor
 				lowLevelSearchOptionsPortletPreferences.getIndexesOptional())
 		).withSearchContext(
 			searchContext -> {
-				_applyAttributes(
-					lowLevelSearchOptionsPortletPreferences, searchContext);
-
 				ThemeDisplay themeDisplay =
 					portletSharedSearchSettings.getThemeDisplay();
 
 				searchContext.setAttribute(
-					"search.experiences.current.group.id",
+					"search.experiences.scope.group.id",
 					themeDisplay.getScopeGroupId());
 
 				HttpServletRequest httpServletRequest =
@@ -100,6 +97,9 @@ public class LowLevelSearchOptionsPortletSharedSearchContributor
 				searchContext.setAttribute(
 					"search.experiences.ip.address",
 					httpServletRequest.getRemoteAddr());
+
+				_applyAttributes(
+					lowLevelSearchOptionsPortletPreferences, searchContext);
 			}
 		);
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SearchResponseResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SearchResponseResourceImpl.java
@@ -107,10 +107,10 @@ public class SearchResponseResourceImpl extends BaseSearchResponseResourceImpl {
 			).withSearchContext(
 				searchContext -> {
 					searchContext.setAttribute(
-						"search.experiences.current.group.id", _getGroupId());
-					searchContext.setAttribute(
 						"search.experiences.ip.address",
 						contextHttpServletRequest.getRemoteAddr());
+					searchContext.setAttribute(
+						"search.experiences.scope.group.id", _getGroupId());
 					searchContext.setTimeZone(contextUser.getTimeZone());
 					searchContext.setUserId(contextUser.getUserId());
 				}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/contributor/ContextSXPParameterContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/contributor/ContextSXPParameterContributor.java
@@ -15,12 +15,14 @@
 package com.liferay.search.experiences.internal.blueprint.parameter.contributor;
 
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.search.experiences.blueprint.parameter.SXPParameter;
 import com.liferay.search.experiences.blueprint.parameter.contributor.SXPParameterContributorDefinition;
 import com.liferay.search.experiences.internal.blueprint.parameter.BooleanSXPParameter;
@@ -100,21 +102,24 @@ public class ContextSXPParameterContributor implements SXPParameterContributor {
 				new LongSXPParameter("plid", true, layout.getPlid()));
 		}
 
-		Long scopeGroupId = (Long)searchContext.getAttribute(
-			"search.experiences.current.group.id");
+		long scopeGroupId = GetterUtil.getLong(
+			searchContext.getAttribute("search.experiences.scope.group.id"));
 
-		if (scopeGroupId != null) {
+		if (scopeGroupId != 0) {
 			sxpParameters.add(
 				new LongSXPParameter(
 					"context.scope_group_id", true, scopeGroupId));
 
-			Group group = _groupLocalService.fetchGroup(scopeGroupId);
+			try {
+				Group group = _groupLocalService.getGroup(scopeGroupId);
 
-			if (group != null) {
 				sxpParameters.add(
 					new BooleanSXPParameter(
 						"context.is_staging_group", true,
 						group.isStagingGroup()));
+			}
+			catch (PortalException portalException) {
+				exceptionListener.exceptionThrown(portalException);
 			}
 		}
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/contributor/UserSXPParameterContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/contributor/UserSXPParameterContributor.java
@@ -163,33 +163,31 @@ public class UserSXPParameterContributor implements SXPParameterContributor {
 			return;
 		}
 
-		Long scopeGroupId = (Long)searchContext.getAttribute(
-			"search.experiences.current.group.id");
+		long[] segmentsEntryIds = new long[0];
 
-		if (scopeGroupId != null) {
-			long[] segmentsEntryIds =
-				_segmentsEntryRetriever.getSegmentsEntryIds(
-					scopeGroupId, user.getUserId(),
-					new Context() {
-						{
-							put(
-								Context.LANGUAGE_ID,
-								_language.getLanguageId(
-									searchContext.getLocale()));
-							put(Context.SIGNED_IN, !user.isDefaultUser());
-						}
-					});
+		long scopeGroupId = GetterUtil.getLong(
+			searchContext.getAttribute("search.experiences.scope.group.id"));
+
+		if (scopeGroupId != 0) {
+			segmentsEntryIds = _segmentsEntryRetriever.getSegmentsEntryIds(
+				scopeGroupId, user.getUserId(),
+				new Context() {
+					{
+						put(
+							Context.LANGUAGE_ID,
+							_language.getLanguageId(searchContext.getLocale()));
+						put(Context.SIGNED_IN, !user.isDefaultUser());
+					}
+				});
 
 			segmentsEntryIds = ArrayUtil.filter(
 				segmentsEntryIds, segmentsEntryId -> segmentsEntryId > 0);
-
-			if (segmentsEntryIds.length > 0) {
-				sxpParameters.add(
-					new LongArraySXPParameter(
-						"user.active_segment_entry_ids", true,
-						ArrayUtil.toLongArray(segmentsEntryIds)));
-			}
 		}
+
+		sxpParameters.add(
+			new LongArraySXPParameter(
+				"user.active_segment_entry_ids", true,
+				ArrayUtil.toLongArray(segmentsEntryIds)));
 
 		sxpParameters.add(
 			new IntegerSXPParameter(

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
@@ -757,7 +757,7 @@ public class SXPBlueprintSearchResultTest {
 							"search.experiences.blueprint.id",
 							String.valueOf(_sxpBlueprint.getSXPBlueprintId()));
 						_searchContext.setAttribute(
-							"search.experiences.current.group.id",
+							"search.experiences.scope.group.id",
 							_group.getGroupId());
 						_searchContext.setTimeZone(_user.getTimeZone());
 						_searchContext.setUserId(_serviceContext.getUserId());

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/options/portlet/shared/search/SXPBlueprintOptionsPortletSharedSearchContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/options/portlet/shared/search/SXPBlueprintOptionsPortletSharedSearchContributor.java
@@ -77,7 +77,7 @@ public class SXPBlueprintOptionsPortletSharedSearchContributor
 					portletSharedSearchSettings.getThemeDisplay();
 
 				searchContext.setAttribute(
-					"search.experiences.current.group.id",
+					"search.experiences.scope.group.id",
 					themeDisplay.getScopeGroupId());
 
 				HttpServletRequest httpServletRequest =


### PR DESCRIPTION
Contains commits for different issues but effectively fixes the LPS-144193.

Contains:

- Reverting search.experiences.current_group_id to search.experiences.scope_group_id because it's planned to be possibly passed within a Blueprint. "scope" describes it then better than "current". Also we are using getScopeGroup() to populate the value
- Change order of applying search context attributes in LLSO widget to allow setting search.experiences.ip.address manually for testing purposes
- Always populate user.active_segment_entry_ids to avoid errors and user confusion when trying to use the segments element in a Blueprint preview. In a future release, add a warning message / user advice later to set the desired group for segments testing in search context attributes
- Show an error if setting a non existing groupId in search context attributes in Blueprint preview