### PR TITLE
LPS-145554: IPStack Local Address

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/exception/NonPublicIPAddressException.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-api/src/main/java/com/liferay/search/experiences/exception/NonPublicIPAddressException.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.search.experiences.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class NonPublicIPAddressException extends PortalException {
+
+	public NonPublicIPAddressException() {
+	}
+
+	public NonPublicIPAddressException(String msg) {
+		super(msg);
+	}
+
+	public NonPublicIPAddressException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public NonPublicIPAddressException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SearchResponseResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/SearchResponseResourceImpl.java
@@ -38,6 +38,7 @@ import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.search.experiences.blueprint.exception.InvalidElementInstanceException;
 import com.liferay.search.experiences.blueprint.search.request.enhancer.SXPBlueprintSearchRequestEnhancer;
+import com.liferay.search.experiences.exception.NonPublicIPAddressException;
 import com.liferay.search.experiences.exception.SXPExceptionUtil;
 import com.liferay.search.experiences.rest.dto.v1_0.DocumentField;
 import com.liferay.search.experiences.rest.dto.v1_0.Hit;
@@ -212,6 +213,9 @@ public class SearchResponseResourceImpl extends BaseSearchResponseResourceImpl {
 				errorMap.put("sxpElementId", sxpElementId);
 
 				inheritMap.put("sxpElementId", sxpElementId);
+			}
+			else if (throwable1 instanceof NonPublicIPAddressException) {
+				errorMap.put("severity", "WARN");
 			}
 			else {
 				errorMap.put("localizedMessage", "Error");


### PR DESCRIPTION
This fix prevents making calls to IPStack service for nothing, if user is not having a public IP address. This can also substantially save user's IPStack quota and make it possible to work with a free subscription longer.

A user warning and advice how to test with a public IP is also set.