### PR TITLE
LPS-145277 - Stop exposing authtoken for non-liferay domains

### DIFF
--- a/modules/apps/friendly-url/friendly-url-taglib/test/js/FriendlyURLHistory.js
+++ b/modules/apps/friendly-url/friendly-url-taglib/test/js/FriendlyURLHistory.js
@@ -23,7 +23,7 @@ const activeUrl = '/test';
 const defaultProps = {
 	defaultLanguageId: 'en_US',
 	elementId: 'elementId',
-	friendlyURLEntryURL: 'friendly_url_history',
+	friendlyURLEntryURL: '/o/friendly_url_history',
 	localizable: true,
 };
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/fetch.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/fetch.es.js
@@ -22,6 +22,10 @@
  */
 
 export default function defaultFetch(resource, init = {}) {
+	if (!resource) {
+		resource = '/o/';
+	}
+
 	let resourceLocation = resource.url ? resource.url : resource.toString();
 
 	if (resourceLocation.startsWith('/')) {

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/fetch.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/fetch.es.js
@@ -15,23 +15,73 @@
 import fetchWrapper from '../../../src/main/resources/META-INF/resources/liferay/util/fetch.es';
 
 describe('Liferay.Util.fetch', () => {
-	const sampleUrl = 'http://sampleurl.com';
+	const externalOriginUrl = 'http://externalOriginUrl.com';
+	const sameOriginUrl = window.location.origin + '/o/test';
 
 	beforeEach(() => {
 		fetch.mockResponse('');
 	});
 
 	it('applies default settings if none are given', () => {
-		fetchWrapper(sampleUrl);
+		fetchWrapper(externalOriginUrl);
 
 		const init = {
+			headers: new Headers(),
+		};
+
+		expect(fetch).toHaveBeenCalledWith(externalOriginUrl, init);
+	});
+
+	it('adds auth-token and credentials if origin is the same', () => {
+		fetchWrapper(sameOriginUrl);
+
+		const mergedInit = {
 			credentials: 'include',
 			headers: new Headers({
 				'x-csrf-token': 'default-mocked-auth-token',
 			}),
 		};
 
-		expect(fetch).toHaveBeenCalledWith(sampleUrl, init);
+		expect(fetch).toHaveBeenCalledWith(sameOriginUrl, mergedInit);
+	});
+
+	it('overrides default auth-token', () => {
+		fetchWrapper(sameOriginUrl, {
+			headers: new Headers({
+				'x-csrf-token': 'asdf',
+			}),
+		});
+
+		const mergedInit = {
+			credentials: 'include',
+			headers: new Headers({
+				'x-csrf-token': 'asdf',
+			}),
+		};
+
+		expect(fetch).toHaveBeenCalledWith(sameOriginUrl, mergedInit);
+	});
+
+	it('overrides default settings with given settings', () => {
+		const url = window.location.origin + '/o/test';
+
+		const init = {
+			credentials: 'omit',
+			headers: {
+				'x-csrf-token': 'efgh',
+			},
+		};
+
+		fetchWrapper(url, init);
+
+		const mergedInit = {
+			credentials: 'omit',
+			headers: new Headers({
+				'x-csrf-token': 'efgh',
+			}),
+		};
+
+		expect(fetch).toHaveBeenCalledWith(url, mergedInit);
 	});
 
 	it('overrides default settings with given settings', () => {
@@ -42,7 +92,7 @@ describe('Liferay.Util.fetch', () => {
 			},
 		};
 
-		fetchWrapper(sampleUrl, init);
+		fetchWrapper(externalOriginUrl, init);
 
 		const mergedInit = {
 			credentials: 'omit',
@@ -51,7 +101,7 @@ describe('Liferay.Util.fetch', () => {
 			}),
 		};
 
-		expect(fetch).toHaveBeenCalledWith(sampleUrl, mergedInit);
+		expect(fetch).toHaveBeenCalledWith(externalOriginUrl, mergedInit);
 	});
 
 	it('merges default settings with given different settings', () => {
@@ -62,18 +112,16 @@ describe('Liferay.Util.fetch', () => {
 			method: 'GET',
 		};
 
-		fetchWrapper(sampleUrl, init);
+		fetchWrapper(externalOriginUrl, init);
 
 		const mergedInit = {
-			credentials: 'include',
 			headers: new Headers({
 				'content-type': 'application/json',
-				'x-csrf-token': 'default-mocked-auth-token',
 			}),
 			method: 'GET',
 		};
 
-		expect(fetch).toHaveBeenCalledWith(sampleUrl, mergedInit);
+		expect(fetch).toHaveBeenCalledWith(externalOriginUrl, mergedInit);
 	});
 
 	it('sets given headers to lower-case before merging with defaults', () => {
@@ -84,17 +132,16 @@ describe('Liferay.Util.fetch', () => {
 			},
 		};
 
-		fetchWrapper(sampleUrl, init);
+		fetchWrapper(externalOriginUrl, init);
 
 		const mergedInit = {
-			credentials: 'include',
 			headers: new Headers({
 				'content-type': 'application/json',
 				'x-csrf-token': 'efgh',
 			}),
 		};
 
-		expect(fetch).toHaveBeenCalledWith(sampleUrl, mergedInit);
+		expect(fetch).toHaveBeenCalledWith(externalOriginUrl, mergedInit);
 	});
 
 	it('merges given multiple headers, setting name to lower-case', () => {
@@ -105,17 +152,15 @@ describe('Liferay.Util.fetch', () => {
 			},
 		};
 
-		fetchWrapper(sampleUrl, init);
+		fetchWrapper(externalOriginUrl, init);
 
 		const mergedInit = {
-			credentials: 'include',
 			headers: new Headers({
 				'content-type': 'application/json, multipart/form-data',
-				'x-csrf-token': 'default-mocked-auth-token',
 			}),
 		};
 
-		expect(fetch).toHaveBeenCalledWith(sampleUrl, mergedInit);
+		expect(fetch).toHaveBeenCalledWith(externalOriginUrl, mergedInit);
 	});
 
 	it('allows given headers to be an array of arrays', () => {
@@ -126,17 +171,16 @@ describe('Liferay.Util.fetch', () => {
 			],
 		};
 
-		fetchWrapper(sampleUrl, init);
+		fetchWrapper(externalOriginUrl, init);
 
 		const mergedInit = {
-			credentials: 'include',
 			headers: new Headers({
 				'content-type': 'application/json',
 				'x-csrf-token': 'efgh',
 			}),
 		};
 
-		expect(fetch).toHaveBeenCalledWith(sampleUrl, mergedInit);
+		expect(fetch).toHaveBeenCalledWith(externalOriginUrl, mergedInit);
 	});
 
 	it('allows given headers to be a Headers object', () => {
@@ -147,16 +191,15 @@ describe('Liferay.Util.fetch', () => {
 			}),
 		};
 
-		fetchWrapper(sampleUrl, init);
+		fetchWrapper(externalOriginUrl, init);
 
 		const mergedInit = {
-			credentials: 'include',
 			headers: new Headers({
 				'content-type': 'application/json',
 				'x-csrf-token': 'efgh',
 			}),
 		};
 
-		expect(fetch).toHaveBeenCalledWith(sampleUrl, mergedInit);
+		expect(fetch).toHaveBeenCalledWith(externalOriginUrl, mergedInit);
 	});
 });

--- a/modules/apps/remote-app/remote-app-web/src/main/resources/META-INF/resources/remote_protocol/bridge.js
+++ b/modules/apps/remote-app/remote-app-web/src/main/resources/META-INF/resources/remote_protocol/bridge.js
@@ -120,18 +120,22 @@ function receiveMessage(event) {
 
 					// TODO: more validation here
 
-					const resource = data.resource;
+					let resource = data.resource;
+
+					if (resource.startsWith('/o/')) {
+						resource = window.location.origin + resource;
+					}
+
+					const resourceUrl = new URL(resource);
 
 					// LPS-145277: Prevent requests to other origins
 
-					if (
-						!(
-							resource.startsWith(window.location.origin) ||
-							resource.startsWith('/o/')
-						)
-					) {
+					if (resourceUrl.origin !== window.location.origin) {
 						postMessage(source, {
 							appID,
+							error: new Error(
+								'Invalid resource: Resource must come from permitted origin.'
+							),
 							kind: 'fetch:reject',
 							requestID,
 						});

--- a/modules/apps/remote-app/remote-app-web/test/remote_protocol/bridge.js
+++ b/modules/apps/remote-app/remote-app-web/test/remote_protocol/bridge.js
@@ -278,6 +278,9 @@ describe('remote-app-web', () => {
 
 			expect(receiveMessage.mock.calls[0][0].data).toEqual({
 				appID: 'some UUID',
+				error: new Error(
+					'Invalid resource: Resource must come from permitted origin.'
+				),
 				kind: 'fetch:reject',
 				protocol: 'com.liferay.remote.app.protocol',
 				requestID: undefined,

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Navigation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/Navigation.js
@@ -20,11 +20,11 @@ import {StoreContextProvider} from '../../../src/main/resources/META-INF/resourc
 import '@testing-library/jest-dom/extend-expect';
 
 const mockEndpoints = {
-	analyticsReportsHistoricalReadsURL: 'analyticsReportsHistoricalReadsURL',
-	analyticsReportsHistoricalViewsURL: 'analyticsReportsHistoricalViewsURL',
-	analyticsReportsTotalReadsURL: 'analyticsReportsTotalReadsURL',
-	analyticsReportsTotalViewsURL: 'analyticsReportsTotalViewsURL',
-	analyticsReportsTrafficSourcesURL: 'analyticsReportsTrafficSourcesURL',
+	analyticsReportsHistoricalReadsURL: '/o/analyticsReportsHistoricalReadsURL',
+	analyticsReportsHistoricalViewsURL: '/o/analyticsReportsHistoricalViewsURL',
+	analyticsReportsTotalReadsURL: '/o/analyticsReportsTotalReadsURL',
+	analyticsReportsTotalViewsURL: '/o/analyticsReportsTotalViewsURL',
+	analyticsReportsTrafficSourcesURL: '/o/analyticsReportsTrafficSourcesURL',
 };
 
 const mockLanguageTag = 'en-US';

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -951,6 +951,24 @@
     classnames "^2.2.6"
     tinycolor2 "^1.4.2"
 
+"@clayui/core@3.44.1":
+  version "3.44.1"
+  resolved "https://registry.yarnpkg.com/@clayui/core/-/core-3.44.1.tgz#2bd479ad478f1ecfb2b189000e13ce404383c12c"
+  integrity sha512-mVrKc6BibhIaOmpqhnLZGQWDQqnuVG2JybMOJk3rkl0HAYlsjAt0qTemVyaBc3k+lQJ8WXDkBZu1KcfBNkMjiQ==
+  dependencies:
+    "@clayui/button" "^3.40.0"
+    "@clayui/drop-down" "^3.43.0"
+    "@clayui/icon" "^3.40.0"
+    "@clayui/layout" "^3.40.0"
+    "@clayui/loading-indicator" "^3.40.0"
+    "@clayui/modal" "^3.40.0"
+    "@clayui/provider" "^3.40.0"
+    "@clayui/shared" "^3.40.0"
+    classnames "^2.2.6"
+    react-dnd "^11.1.1"
+    react-dnd-html5-backend "^11.1.1"
+    react-transition-group "^4.4.1"
+
 "@clayui/css@3.44.2":
   version "3.44.2"
   resolved "https://registry.yarnpkg.com/@clayui/css/-/css-3.44.2.tgz#84d48d03675ff680a7a4bc442da3a11a2d644865"
@@ -1085,7 +1103,7 @@
     "@clayui/layout" "^3.40.0"
     classnames "^2.2.6"
 
-"@clayui/modal@3.40.0":
+"@clayui/modal@3.40.0", "@clayui/modal@^3.40.0":
   version "3.40.0"
   resolved "https://registry.yarnpkg.com/@clayui/modal/-/modal-3.40.0.tgz#0bc7edf13fb0b7b99af77b970896f0e5eaae811e"
   integrity sha512-Uk+ihZKDG5TmOMV05VwiZMs8SKRHv2BbtAS+vG8ymIktb/zNt2oBQlPGfVYO3jhU0mxxYzfVzdTVzDbgy31Tfg==
@@ -5762,7 +5780,7 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-dnd-core@^11.1.1:
+dnd-core@^11.1.1, dnd-core@^11.1.3:
   version "11.1.3"
   resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-11.1.3.tgz#f92099ba7245e49729d2433157031a6267afcc98"
   integrity sha512-QugF55dNW+h+vzxVJ/LSJeTeUw9MCJ2cllhmVThVPEtF16ooBkxj0WBE5RB+AceFxMFo1rO6bJKXtqKl+JNnyA==
@@ -12775,6 +12793,13 @@ react-dnd-html5-backend@11.1.1:
   dependencies:
     dnd-core "^11.1.1"
 
+react-dnd-html5-backend@^11.1.1:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-11.1.3.tgz#2749f04f416ec230ea193f5c1fbea2de7dffb8f7"
+  integrity sha512-/1FjNlJbW/ivkUxlxQd7o3trA5DE33QiRZgxent3zKme8DwF4Nbw3OFVhTRFGaYhHFNL1rZt6Rdj1D78BjnNLw==
+  dependencies:
+    dnd-core "^11.1.3"
+
 react-dnd-test-backend@11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/react-dnd-test-backend/-/react-dnd-test-backend-11.1.1.tgz#2aae20a15fc2f379cc96a45a276592c98fcefa58"
@@ -12795,6 +12820,16 @@ react-dnd@11.1.1:
     "@react-dnd/shallowequal" "^2.0.0"
     "@types/hoist-non-react-statics" "^3.3.1"
     dnd-core "^11.1.1"
+    hoist-non-react-statics "^3.3.0"
+
+react-dnd@^11.1.1:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-11.1.3.tgz#f9844f5699ccc55dfc81462c2c19f726e670c1af"
+  integrity sha512-8rtzzT8iwHgdSC89VktwhqdKKtfXaAyC4wiqp0SywpHG12TTLvfOoL6xNEIUWXwIEWu+CFfDn4GZJyynCEuHIQ==
+  dependencies:
+    "@react-dnd/shallowequal" "^2.0.0"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    dnd-core "^11.1.3"
     hoist-non-react-statics "^3.3.0"
 
 react-dom@*, react-dom@16.12.0, react-dom@^16.8.3:


### PR DESCRIPTION
Manual forward from: https://github.com/liferay-frontend/liferay-portal/pull/1840

QA approval and no CI failures for PR


I think the orignal failures seen that required a revert were just flukey CI failures.