### PR TITLE
LPS-145874: IPStack and OWM Caching Fixes

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/web/cache/OpenWeatherMapWebCacheItem.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/web/cache/OpenWeatherMapWebCacheItem.java
@@ -38,6 +38,10 @@ public class OpenWeatherMapWebCacheItem implements WebCacheItem {
 		ExceptionListener exceptionListener, String latitude, String longitude,
 		OpenWeatherMapConfiguration openWeatherMapConfiguration) {
 
+		if (!openWeatherMapConfiguration.enabled()) {
+			return JSONFactoryUtil.createJSONObject();
+		}
+
 		return (JSONObject)WebCachePoolUtil.get(
 			StringBundler.concat(
 				OpenWeatherMapWebCacheItem.class.getName(), StringPool.POUND,
@@ -60,10 +64,6 @@ public class OpenWeatherMapWebCacheItem implements WebCacheItem {
 	@Override
 	public JSONObject convert(String key) {
 		try {
-			if (!_openWeatherMapConfiguration.enabled()) {
-				return JSONFactoryUtil.createJSONObject();
-			}
-
 			String url = StringBundler.concat(
 				_openWeatherMapConfiguration.apiURL(), "?APPID=",
 				_openWeatherMapConfiguration.apiKey(), "&format=json&lat=",
@@ -104,7 +104,7 @@ public class OpenWeatherMapWebCacheItem implements WebCacheItem {
 	private void _validateResponse(JSONObject jsonObject) {
 		String cod = jsonObject.getString("cod");
 
-		if (Validator.isNull(cod)) {
+		if (Validator.isNull(cod) || cod.startsWith("2")) {
 			return;
 		}
 


### PR DESCRIPTION
Resolves:
- Don't process / return cached objects if not enabled
- Don't cache data for non public IP addresses or if not enabled
- Show warnings on each preview request (previously once only because of caching)
- Pass OWM data validation with code 2xx (doesn't always appear in the response for some reason)