### PR TITLE
LPS-145950 search-experiences-service: Don't cache invalid responses

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/web/cache/IpstackWebCacheItem.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/web/cache/IpstackWebCacheItem.java
@@ -16,6 +16,7 @@ package com.liferay.search.experiences.internal.web.cache;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -29,8 +30,11 @@ import com.liferay.search.experiences.internal.configuration.IpstackConfiguratio
 
 import java.beans.ExceptionListener;
 
+import java.io.IOException;
+
 import java.net.Inet4Address;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 /**
  * @author Brian Wing Shun Chan
@@ -43,28 +47,30 @@ public class IpstackWebCacheItem implements WebCacheItem {
 
 		try {
 			if (!ipstackConfiguration.enabled() ||
-				_isPrivateIPAddress(exceptionListener, ipAddress)) {
+				_isPrivateIPAddress(ipAddress)) {
 
 				return JSONFactoryUtil.createJSONObject();
 			}
+
+			return (JSONObject)WebCachePoolUtil.get(
+				IpstackWebCacheItem.class.getName() + StringPool.POUND +
+					ipAddress,
+				new IpstackWebCacheItem(ipAddress, ipstackConfiguration));
 		}
 		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
+
 			exceptionListener.exceptionThrown(exception);
 
 			return JSONFactoryUtil.createJSONObject();
 		}
-
-		return (JSONObject)WebCachePoolUtil.get(
-			IpstackWebCacheItem.class.getName() + StringPool.POUND + ipAddress,
-			new IpstackWebCacheItem(
-				exceptionListener, ipAddress, ipstackConfiguration));
 	}
 
 	public IpstackWebCacheItem(
-		ExceptionListener exceptionListener, String ipAddress,
-		IpstackConfiguration ipstackConfiguration) {
+		String ipAddress, IpstackConfiguration ipstackConfiguration) {
 
-		_exceptionListener = exceptionListener;
 		_ipAddress = ipAddress;
 		_ipstackConfiguration = ipstackConfiguration;
 	}
@@ -93,14 +99,8 @@ public class IpstackWebCacheItem implements WebCacheItem {
 
 			return jsonObject;
 		}
-		catch (Exception exception) {
-			_exceptionListener.exceptionThrown(exception);
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception, exception);
-			}
-
-			return JSONFactoryUtil.createJSONObject();
+		catch (IOException | JSONException exception) {
+			throw new RuntimeException(exception);
 		}
 	}
 
@@ -113,9 +113,8 @@ public class IpstackWebCacheItem implements WebCacheItem {
 		return 0;
 	}
 
-	private static boolean _isPrivateIPAddress(
-			ExceptionListener exceptionListener, String ipAddress)
-		throws Exception {
+	private static boolean _isPrivateIPAddress(String ipAddress)
+		throws PrivateIPAddressException, UnknownHostException {
 
 		Inet4Address inet4Address = (Inet4Address)InetAddress.getByName(
 			ipAddress);
@@ -126,11 +125,8 @@ public class IpstackWebCacheItem implements WebCacheItem {
 			inet4Address.isMulticastAddress() ||
 			inet4Address.isSiteLocalAddress()) {
 
-			exceptionListener.exceptionThrown(
-				new PrivateIPAddressException(
-					"Unable to resolve private IP address " + ipAddress));
-
-			return true;
+			throw new PrivateIPAddressException(
+				"Unable to resolve private IP address " + ipAddress);
 		}
 
 		return false;
@@ -143,22 +139,20 @@ public class IpstackWebCacheItem implements WebCacheItem {
 			return;
 		}
 
-		_exceptionListener.exceptionThrown(
-			new RuntimeException(
-				StringBundler.concat(
-					"IPStack: ",
-					JSONUtil.getValueAsString(
-						jsonObject, "JSONObject/error", "Object/info"),
-					" (",
-					JSONUtil.getValueAsString(
-						jsonObject, "JSONObject/error", "Object/code"),
-					")")));
+		throw new RuntimeException(
+			StringBundler.concat(
+				"IPStack: ",
+				JSONUtil.getValueAsString(
+					jsonObject, "JSONObject/error", "Object/info"),
+				" (",
+				JSONUtil.getValueAsString(
+					jsonObject, "JSONObject/error", "Object/code"),
+				")"));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		IpstackWebCacheItem.class);
 
-	private final ExceptionListener _exceptionListener;
 	private final String _ipAddress;
 	private final IpstackConfiguration _ipstackConfiguration;
 

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/web/cache/OpenWeatherMapWebCacheItem.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/web/cache/OpenWeatherMapWebCacheItem.java
@@ -16,6 +16,7 @@ package com.liferay.search.experiences.internal.web.cache;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -28,6 +29,8 @@ import com.liferay.portal.kernel.webcache.WebCachePoolUtil;
 import com.liferay.search.experiences.internal.configuration.OpenWeatherMapConfiguration;
 
 import java.beans.ExceptionListener;
+
+import java.io.IOException;
 
 /**
  * @author Brian Wing Shun Chan
@@ -42,20 +45,29 @@ public class OpenWeatherMapWebCacheItem implements WebCacheItem {
 			return JSONFactoryUtil.createJSONObject();
 		}
 
-		return (JSONObject)WebCachePoolUtil.get(
-			StringBundler.concat(
-				OpenWeatherMapWebCacheItem.class.getName(), StringPool.POUND,
-				latitude, StringPool.POUND, longitude),
-			new OpenWeatherMapWebCacheItem(
-				exceptionListener, latitude, longitude,
-				openWeatherMapConfiguration));
+		try {
+			return (JSONObject)WebCachePoolUtil.get(
+				StringBundler.concat(
+					OpenWeatherMapWebCacheItem.class.getName(),
+					StringPool.POUND, latitude, StringPool.POUND, longitude),
+				new OpenWeatherMapWebCacheItem(
+					latitude, longitude, openWeatherMapConfiguration));
+		}
+		catch (Exception exception) {
+			exceptionListener.exceptionThrown(exception);
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
+
+			return JSONFactoryUtil.createJSONObject();
+		}
 	}
 
 	public OpenWeatherMapWebCacheItem(
-		ExceptionListener exceptionListener, String latitude, String longitude,
+		String latitude, String longitude,
 		OpenWeatherMapConfiguration openWeatherMapConfiguration) {
 
-		_exceptionListener = exceptionListener;
 		_latitude = latitude;
 		_longitude = longitude;
 		_openWeatherMapConfiguration = openWeatherMapConfiguration;
@@ -81,14 +93,8 @@ public class OpenWeatherMapWebCacheItem implements WebCacheItem {
 
 			return jsonObject;
 		}
-		catch (Exception exception) {
-			_exceptionListener.exceptionThrown(exception);
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception, exception);
-			}
-
-			return JSONFactoryUtil.createJSONObject();
+		catch (IOException | JSONException exception) {
+			throw new RuntimeException(exception);
 		}
 	}
 
@@ -108,18 +114,16 @@ public class OpenWeatherMapWebCacheItem implements WebCacheItem {
 			return;
 		}
 
-		_exceptionListener.exceptionThrown(
-			new RuntimeException(
-				StringBundler.concat(
-					"OpenWeatherMap: ",
-					JSONUtil.getValueAsString(jsonObject, "Object/message"),
-					" (", cod, ")")));
+		throw new RuntimeException(
+			StringBundler.concat(
+				"OpenWeatherMap: ",
+				JSONUtil.getValueAsString(jsonObject, "Object/message"), " (",
+				cod, ")"));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		OpenWeatherMapWebCacheItem.class);
 
-	private final ExceptionListener _exceptionListener;
 	private final String _latitude;
 	private final String _longitude;
 	private final OpenWeatherMapConfiguration _openWeatherMapConfiguration;


### PR DESCRIPTION
More enhancements to IPStack and OWM caching. Effectively: do not cache invalid response (as defined by the _validate() method). If API key or API url is wrong or there's a service error, responses are not cached.