### PR TITLE
LPS-146762 Fix error in client module generated by REST Builder

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_resource.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_resource.ftl
@@ -202,7 +202,7 @@ public interface ${schemaName}Resource {
 				HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
 
 				<#if freeMarkerTool.hasHTTPMethod(javaMethodSignature, "delete", "patch", "post", "put")>
-					<#if freeMarkerTool.hasRequestBodyMediaType(javaMethodSignature, "multipart/form-data")>
+					<#if freeMarkerTool.hasRequestBodyMediaType(javaMethodSignature, "multipart/form-data") && freeMarkerTool.hasParameter(javaMethodSignature, "multipartBody")>
 						httpInvoker.multipart();
 
 						httpInvoker.part("${schemaVarName}", ${schemaName}SerDes.toJSON(${schemaVarName}));


### PR DESCRIPTION
We have a generation error when there is an endpoint that support multiple request content bodies including Multipart

Avoid compilation error checking if the current method is the one that has the multipartBody parameter and so is the one handling the Multipart request body type

Once the PR is merged I will send again the Headless Batch Engine client generation that was affected by this issue.

Sending directly to you to unblock Technical Writers with the client generation