### PR TITLE
LPS-147617 Always use log for exception

### DIFF
--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/portlet/action/ImportCommerceOrderItemsMVCActionCommand.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/portlet/action/ImportCommerceOrderItemsMVCActionCommand.java
@@ -122,6 +122,10 @@ public class ImportCommerceOrderItemsMVCActionCommand
 					catch (NoSuchCPInstanceException
 								noSuchCPInstanceException) {
 
+						if (_log.isDebugEnabled()) {
+							_log.debug(exception);
+						}
+
 						notImportedRowsCount++;
 					}
 				}
@@ -183,6 +187,9 @@ public class ImportCommerceOrderItemsMVCActionCommand
 			"commerceOrderId", commerceOrderId
 		).buildString();
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ImportCommerceOrderItemsMVCActionCommand.class);
 
 	@Reference
 	private CommerceOrderImporterTypeRegistry

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
@@ -180,6 +180,10 @@ public class DLFolderItemSelectorView
 			return _dlAppService.getFolder(folderId);
 		}
 		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
 			return null;
 		}
 	}
@@ -189,6 +193,10 @@ public class DLFolderItemSelectorView
 			return _groupService.getGroup(groupId);
 		}
 		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
 			return null;
 		}
 	}
@@ -204,6 +212,10 @@ public class DLFolderItemSelectorView
 				DepotEntry::getGroupId);
 		}
 		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
 			return Collections.emptyList();
 		}
 	}
@@ -228,6 +240,9 @@ public class DLFolderItemSelectorView
 
 		return itemSelectorCriterion.isShowGroupSelector();
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DLFolderItemSelectorView.class);
 
 	private static final List<String> _portletIds = Arrays.asList(
 		DLPortletKeys.DOCUMENT_LIBRARY_ADMIN, DLPortletKeys.DOCUMENT_LIBRARY);


### PR DESCRIPTION
Hi brian, I am Simon. I am doing this source format issue (https://github.com/liferay/liferay-portal/commit/f7aca1692bbf10c9f67909e9fdff16a7764bc450)
Before I commit all codes about adding log for those unprocessed exception. I found those unprocessed exceptions have serveal different scenarios and want to confirm with you.

1)Catch block defined exception variable and don't contain any code, this type we should to add log. Portal source codes has 72 this type SF issue.

2)Catch block defined exception variable and contain codes but not use this exception variable, these type classes are usually util class and most of them diretly return default value in catch block. Portal source code has 193 this type SF issue. For this type, I am not sure what's solution is better
