### PR TITLE
LPS-138329 Patch the module-info.class file out of

### DIFF
--- a/modules/third-party/com-fasterxml-jackson-core-jackson-annotations/bnd.bnd
+++ b/modules/third-party/com-fasterxml-jackson-core-jackson-annotations/bnd.bnd
@@ -1,0 +1,2 @@
+Bundle-SymbolicName: com.fasterxml.jackson.core.jackson-annotations
+Bundle-Version: 2.10.3.LIFERAY-PATCHED-1

--- a/modules/third-party/com-fasterxml-jackson-core-jackson-annotations/build.gradle
+++ b/modules/third-party/com-fasterxml-jackson-core-jackson-annotations/build.gradle
@@ -1,0 +1,25 @@
+task jarPatched(type: Zip)
+
+dependencies {
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", transitive: false, version: "2.10.3"
+}
+
+jar {
+	setActions([])
+
+	dependsOn jarPatched
+}
+
+jarPatched {
+	archiveName = jar.archiveName
+	destinationDir = jar.destinationDir
+	duplicatesStrategy = "exclude"
+
+	exclude "module-info.class"
+
+	from sourceSets.main.output
+
+	from {
+		zipTree(configurations.compileOnly.singleFile)
+	}
+}

--- a/modules/third-party/com-fasterxml-jackson-core-jackson-core/bnd.bnd
+++ b/modules/third-party/com-fasterxml-jackson-core-jackson-core/bnd.bnd
@@ -1,0 +1,2 @@
+Bundle-SymbolicName: com.fasterxml.jackson.core.jackson-core
+Bundle-Version: 2.10.3.LIFERAY-PATCHED-1

--- a/modules/third-party/com-fasterxml-jackson-core-jackson-core/build.gradle
+++ b/modules/third-party/com-fasterxml-jackson-core-jackson-core/build.gradle
@@ -1,0 +1,25 @@
+task jarPatched(type: Zip)
+
+dependencies {
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", transitive: false, version: "2.10.3"
+}
+
+jar {
+	setActions([])
+
+	dependsOn jarPatched
+}
+
+jarPatched {
+	archiveName = jar.archiveName
+	destinationDir = jar.destinationDir
+	duplicatesStrategy = "exclude"
+
+	exclude "module-info.class"
+
+	from sourceSets.main.output
+
+	from {
+		zipTree(configurations.compileOnly.singleFile)
+	}
+}


### PR DESCRIPTION
jackson-annotations.jar and jackson-core.jar to avoid failed startups on
older (but supported) versions of JBoss/Wildfly that can't handle .jars
with module-info.class files in them.