### PR TITLE
LPS-147149 - Prevent render of closing tag if opening not rendered

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownMenuTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownMenuTag.java
@@ -29,7 +29,7 @@ public class DropdownMenuTag extends ButtonTag {
 
 	@Override
 	public int doEndTag() throws JspException {
-		if (DropdownItemListUtil.isEmpty(_dropdownItems)) {
+		if (_isEmpty) {
 			return EVAL_PAGE;
 		}
 
@@ -40,7 +40,9 @@ public class DropdownMenuTag extends ButtonTag {
 	public int doStartTag() throws JspException {
 		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
 
-		if (DropdownItemListUtil.isEmpty(_dropdownItems)) {
+		_isEmpty = DropdownItemListUtil.isEmpty(_dropdownItems);
+
+		if (_isEmpty) {
 			return SKIP_BODY;
 		}
 
@@ -83,5 +85,6 @@ public class DropdownMenuTag extends ButtonTag {
 
 	private String _buttonType;
 	private List<DropdownItem> _dropdownItems;
+	private Boolean _isEmpty;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownMenuTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownMenuTag.java
@@ -28,6 +28,15 @@ import javax.servlet.jsp.JspException;
 public class DropdownMenuTag extends ButtonTag {
 
 	@Override
+	public int doEndTag() throws JspException {
+		if (DropdownItemListUtil.isEmpty(_dropdownItems)) {
+			return EVAL_PAGE;
+		}
+
+		return super.doEndTag();
+	}
+
+	@Override
 	public int doStartTag() throws JspException {
 		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownMenuTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownMenuTag.java
@@ -29,7 +29,7 @@ public class DropdownMenuTag extends ButtonTag {
 
 	@Override
 	public int doEndTag() throws JspException {
-		if (_isEmpty) {
+		if (_empty) {
 			return EVAL_PAGE;
 		}
 
@@ -40,9 +40,9 @@ public class DropdownMenuTag extends ButtonTag {
 	public int doStartTag() throws JspException {
 		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
 
-		_isEmpty = DropdownItemListUtil.isEmpty(_dropdownItems);
+		_empty = DropdownItemListUtil.isEmpty(_dropdownItems);
 
-		if (_isEmpty) {
+		if (_empty) {
 			return SKIP_BODY;
 		}
 
@@ -63,6 +63,7 @@ public class DropdownMenuTag extends ButtonTag {
 
 		_buttonType = null;
 		_dropdownItems = null;
+		_empty = null;
 	}
 
 	@Override
@@ -85,6 +86,6 @@ public class DropdownMenuTag extends ButtonTag {
 
 	private String _buttonType;
 	private List<DropdownItem> _dropdownItems;
-	private Boolean _isEmpty;
+	private Boolean _empty;
 
 }


### PR DESCRIPTION
Manually forwarding since multiple ci:forward attempts ran into unrelated test failures in https://github.com/liferay-frontend/liferay-portal/pull/1936#issuecomment-1050394976

cc/ @tinycarol

----

### References

- [LPS-147149](https://issues.liferay.com/browse/LPS-147149)

### What is the goal?
* Prevent rendering closing tag if opening tag hasn't been rendered.

### What is going on here?

I took a deeper look at the linked issue, where rendering a widget with a SearchContainer with ClayCards returned an error, marking the widget as unavailable.

This happened when the items we were passing to the `ClayCard` for the action dropdown were made up of item groups with no items inside. This was patched by @victorg1991 in #1904 by not rendering the dropdown when such conditions happened, but as he noted the cause is a different one, so I did some digging.

The dropdown actions are rendered by [`VerticalCardTag`](https://github.com/liferay-frontend/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java#L632):
```java
	DropdownActionsTag dropdownActionsTag = new DropdownActionsTag();
	dropdownActionsTag.setDropdownItems(actionDropdownItems);
	
	dropdownActionsTag.doTag(pageContext);
```
This `doTag` method comes from the `DirectTag` component, which *always* runs [these two methods, `doStartTag` and `doEndTag`](https://github.com/liferay-frontend/liferay-portal/blob/master/util-taglib/src/com/liferay/taglib/DirectTag.java#L127-L128).  
```java
[...]
	public default void doTag(PageContext pageContext) throws JspException {
		setPageContext(pageContext);

		doStartTag();
		doEndTag();
	}
[...]
```
That ends up running the following code in `DropdownMenuTag`:
```java
public class DropdownMenuTag extends ButtonTag {

	@Override
	public int doStartTag() throws JspException {
		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);

		if (DropdownItemListUtil.isEmpty(_dropdownItems)) {
			return SKIP_BODY;
		}

		return super.doStartTag();
	}
[...]
```
With the fix to this bug, the condition in the if statement is true, so for this tag `super.doStartTag()` doesn't run, **so the opening tag isn't rendered** (\*). But that doesn't stop `doEndTag` from executing, which through inheritance [runs this code](https://github.com/liferay-frontend/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java#L54), which [ends up executing this](https://github.com/liferay-frontend/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java#L329-L334):
```java
 protected int processEndTag() throws Exception {
		JspWriter jspWriter = pageContext.getOut();

		jspWriter.write("</");
		jspWriter.write(_containerElement);
		jspWriter.write(">");
		// ...
}
```
So while the opening tag doesn't render, **the closing tag is being rendered**. That's why, as Victor noted in the ticket, "the next cards are rendered outside the search container", because we are closing a tag without opening it. I'm guessing he added the fixed empty dropdown check to this component, it caused this "closing unopened tag" bug, and added it again to simply not render the entire component.

I have fixed this by also overriding `doEndTag` and running the same check to skip the closing tag being rendered.

My issue with this is that I've found this pattern in multiple places. If you look for `return SKIP_BODY;` it's used all over DXP in the same way as here (returning it in `doStartTag` without overriding `doEndTag`), and I don't understand why it hasn't broken this way before. Also, I think that [by definition SKIP_BODY](https://docs.oracle.com/javaee/6/api/javax/servlet/jsp/tagext/Tag.html#SKIP_BODY) should be used to prevent the **contents** of a tag from being rendered, not the tag itself, so it seems like we're not using it right?


(*) There's another bug caused by this, and it's that in the `doStartTag` method we call `processStartTag`, which is where [the `containerElement` attribute gets its default value](https://github.com/liferay-frontend/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java#L399-L401). If this method doesn't run before the `doEndTag` method, [the line with `jspWriter.write(_containerElement)`](https://github.com/liferay-frontend/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java#L333) throws a NullPointerException.

### How to replicate
* Check out this commit https://github.com/tinycarol/liferay-portal/commit/23897626261d2f2fae9d65240882e38631d62dbc
* `> ant -f build-dist.xml unzip-wildfly`
* `> ant all`
* Navigate to `liferay-portal/modules/apps/frontend-taglib/frontend-taglib-clay`
* `> gradlew deploy -a`
* Navigate to `bundles/wildfly/bin`
* `> ./standalone.sh`
* Create a widget page
* Add the portlet `Clay Sample` to the page
* See that it doesn't break