### PR TITLE
LPS-143724 Notify unsaved changes when navigating away from edit blueprint form | master

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -31,6 +31,7 @@ import {fetchData, fetchPreviewSearch} from '../utils/fetch';
 import {INPUT_TYPES} from '../utils/inputTypes';
 import {TEST_IDS} from '../utils/testIds';
 import {openErrorToast, openSuccessToast} from '../utils/toasts';
+import useShouldConfirmBeforeNavigate from '../utils/useShouldConfirmBeforeNavigate';
 import {
 	cleanUIConfiguration,
 	filterAndSortClassNames,
@@ -845,6 +846,8 @@ function EditSXPBlueprintForm({
 				);
 		}
 	};
+
+	useShouldConfirmBeforeNavigate(formik.dirty && !formik.isSubmitting);
 
 	if (
 		!indexFields ||

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -365,6 +365,8 @@ function EditSXPBlueprintForm({
 		validate: _handleFormikValidate,
 	});
 
+	useShouldConfirmBeforeNavigate(formik.dirty && !formik.isSubmitting);
+
 	useEffect(() => {
 		fetchData(
 			`/o/search-experiences-rest/v1.0/searchable-asset-names/${locale}`,
@@ -847,8 +849,6 @@ function EditSXPBlueprintForm({
 				);
 		}
 	};
-
-	useShouldConfirmBeforeNavigate(formik.dirty && !formik.isSubmitting);
 
 	if (
 		!indexFields ||

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
@@ -154,6 +154,11 @@ function EditSXPElementForm({
 
 	const [variables, setVariables] = useState(filteredCategories);
 
+	useShouldConfirmBeforeNavigate(
+		initialElementJSONEditorValueString !== elementJSONEditorValue &&
+			!isSubmitting
+	);
+
 	/**
 	 * Workaround to force a re-render so `elementJSONEditorRef` will be
 	 * defined when calling `_handleVariableClick`
@@ -352,11 +357,6 @@ function EditSXPElementForm({
 			</div>
 		);
 	}
-
-	useShouldConfirmBeforeNavigate(
-		initialElementJSONEditorValueString !== elementJSONEditorValue &&
-			!isSubmitting
-	);
 
 	return (
 		<>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
@@ -39,6 +39,7 @@ import SXPElement from '../shared/sxp_element/index';
 import {CONFIG_PREFIX, DEFAULT_ERROR} from '../utils/constants';
 import {sub} from '../utils/language';
 import {openErrorToast} from '../utils/toasts';
+import useShouldConfirmBeforeNavigate from '../utils/useShouldConfirmBeforeNavigate';
 import {getUIConfigurationValues} from '../utils/utils';
 import SidebarPanel from './SidebarPanel';
 
@@ -125,13 +126,19 @@ function EditSXPElementForm({
 	const formRef = useRef();
 	const elementJSONEditorRef = useRef();
 
+	const initialElementJSONEditorValueString = JSON.stringify(
+		initialElementJSONEditorValue,
+		null,
+		'\t'
+	);
+
 	const [errors, setErrors] = useState([]);
 	const [expandAllVariables, setExpandAllVariables] = useState(false);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [showSidebar, setShowSidebar] = useState(false);
 	const [showSubmitWarningModal, setShowSubmitWarningModal] = useState(false);
 	const [elementJSONEditorValue, setElementJSONEditorValue] = useState(
-		JSON.stringify(initialElementJSONEditorValue, null, '\t')
+		initialElementJSONEditorValueString
 	);
 
 	const filteredCategories = {};
@@ -345,6 +352,11 @@ function EditSXPElementForm({
 			</div>
 		);
 	}
+
+	useShouldConfirmBeforeNavigate(
+		initialElementJSONEditorValueString !== elementJSONEditorValue &&
+			!isSubmitting
+	);
 
 	return (
 		<>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/useShouldConfirmBeforeNavigate.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/useShouldConfirmBeforeNavigate.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ */
+
+import {useEffect} from 'react';
+
+/**
+ * This ensures that a confirmation appears upon navigating away if there are
+ * warnings such as unsaved changes. It adds a listener to the window to
+ * detect when the user closes the window or refreshes the page. There is also
+ * an SPA lifecycle event used to detect when the user cancels or navigates to
+ * a new page within Liferay.
+ *
+ *
+ * @param {boolean} requiresConfirmation True if the user should be prompted
+ * @param {string} message Message to display in prompt
+ */
+export default function useShouldConfirmBeforeNavigate(
+	requiresConfirmation,
+	message = Liferay.Language.get(
+		'you-have-unsaved-changes-do-you-want-to-proceed-without-saving'
+	)
+) {
+	useEffect(() => {
+
+		// The beforeunload event occurs when user reloads or closes the window. The
+		// confirmation is specific to the browser. Using preventDefault() will
+		// signal the browser to show the default confirmation.
+
+		const handleBeforeUnload = (event) => {
+			event.preventDefault();
+			event.returnValue = '';
+		};
+
+		// The beforeNavigate event occurs when the user navigates to a new page on
+		// Liferay. Using preventDefault() prevents the browser from navigating to
+		// the new page.
+		// https://help.liferay.com/hc/en-us/articles/360030709511-Available-SPA-Lifecycle-Events
+
+		const handleBeforeNavigate = (event) => {
+			if (!confirm(message)) {
+				event.originalEvent.preventDefault();
+			}
+		};
+
+		if (requiresConfirmation) {
+			window.addEventListener('beforeunload', handleBeforeUnload);
+			Liferay.on('beforeNavigate', handleBeforeNavigate);
+
+			return () => {
+				window.removeEventListener('beforeunload', handleBeforeUnload);
+				Liferay.detach('beforeNavigate', handleBeforeNavigate);
+			};
+		}
+	}, [requiresConfirmation, message]);
+}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/useShouldConfirmBeforeNavigate.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/useShouldConfirmBeforeNavigate.js
@@ -18,7 +18,6 @@ import {useEffect} from 'react';
  * an SPA lifecycle event used to detect when the user cancels or navigates to
  * a new page within Liferay.
  *
- *
  * @param {boolean} requiresConfirmation True if the user should be prompted
  * @param {string} message Message to display in prompt
  */
@@ -36,6 +35,12 @@ export default function useShouldConfirmBeforeNavigate(
 
 		const handleBeforeUnload = (event) => {
 			event.preventDefault();
+
+			// Setting returnValue is required for activation in certain browsers like Chrome.
+			// Its string message was once used to customize the confirmation message, but now
+			// for security purposes, each browser is in control of its own message.
+			// https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload
+
 			event.returnValue = '';
 		};
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/shared/PageToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/shared/PageToolbar.js
@@ -19,21 +19,23 @@ import '@testing-library/jest-dom/extend-expect';
 jest.useFakeTimers();
 
 const onSubmit = jest.fn();
+const onChangeTitleAndDescription = jest.fn();
 
 Liferay.ThemeDisplay.getDefaultLanguageId = () => 'en_US';
 
 function renderPageToolbar(props) {
 	return render(
 		<PageToolbar
-			initialDescription={{}}
-			initialTitle={{}}
+			description=""
 			onCancel="/link"
 			onChangeTab={jest.fn()}
+			onChangeTitleAndDescription={onChangeTitleAndDescription}
 			onSubmit={onSubmit}
 			tab="query-builder"
 			tabs={{
 				'query-builder': 'query-builder',
 			}}
+			title=""
 			{...props}
 		/>
 	);
@@ -47,27 +49,21 @@ describe('PageToolbar', () => {
 	});
 
 	it('renders the title', () => {
-		const initialTitle = {
-			'en-US': 'Apple',
-		};
+		const title = 'Apple';
 
-		const {getByText} = renderPageToolbar({
-			initialTitle,
-		});
+		const {getByText} = renderPageToolbar({title});
 
-		getByText(initialTitle['en-US']);
+		getByText(title);
 	});
 
-	it('updates the title', () => {
-		const initialTitle = {
-			'en-US': 'Apple',
-		};
+	it('calls onChangeTitle when updating title', () => {
+		const title = 'Apple';
 
-		const {getByLabelText, getByText, queryByText} = renderPageToolbar({
-			initialTitle,
+		const {getByLabelText, getByText} = renderPageToolbar({
+			title,
 		});
 
-		getByText('Apple');
+		getByText(title);
 
 		fireEvent.click(getByLabelText('edit-title'));
 
@@ -81,22 +77,17 @@ describe('PageToolbar', () => {
 
 		act(() => jest.runAllTimers());
 
-		expect(queryByText('Apple')).toBeNull();
-		getByText('Banana');
+		expect(onChangeTitleAndDescription).toHaveBeenCalled();
 	});
 
-	it('updates the description', () => {
-		const initialTitle = {
-			'en-US': 'Apple',
-		};
+	it('calls onChangeTitle when updating description', () => {
+		const title = 'Apple';
 
-		const initialDescription = {
-			'en-US': 'A fruit',
-		};
+		const description = 'A fruit';
 
-		const {getByLabelText, getByText, queryByText} = renderPageToolbar({
-			initialDescription,
-			initialTitle,
+		const {getByLabelText, getByText} = renderPageToolbar({
+			description,
+			title,
 		});
 
 		getByText('A fruit');
@@ -113,8 +104,7 @@ describe('PageToolbar', () => {
 
 		act(() => jest.runAllTimers());
 
-		expect(queryByText('A fruit')).toBeNull();
-		getByText('A red fruit');
+		expect(onChangeTitleAndDescription).toHaveBeenCalled();
 	});
 
 	it('offers link to cancel', () => {
@@ -138,12 +128,10 @@ describe('PageToolbar', () => {
 	});
 
 	it('focuses on the title input when clicked on', () => {
-		const initialTitle = {
-			'en-US': 'Apple',
-		};
+		const title = 'Apple';
 
 		const {getByLabelText} = renderPageToolbar({
-			initialTitle,
+			title,
 		});
 
 		fireEvent.click(getByLabelText('edit-title'));
@@ -154,12 +142,10 @@ describe('PageToolbar', () => {
 	});
 
 	it('focuses on the description input when clicked on', () => {
-		const initialTitle = {
-			'en-US': 'Apple',
-		};
+		const title = 'Apple';
 
 		const {getByLabelText} = renderPageToolbar({
-			initialTitle,
+			title,
 		});
 
 		fireEvent.click(getByLabelText('edit-description'));

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
@@ -545,9 +545,11 @@ definition {
 			locator1 = "Blueprints#BLUEPRINTS_CONFIGURATION_EDITOR",
 			value1 = "${aggregationConfigurationJson}");
 
-		Click(
+		ClickNoError(
 			key_text = "Cancel",
 			locator1 = "Link#ANY");
+
+		AssertConfirm(value1 = "You have unsaved changes. Do you want to proceed without saving?");
 
 		Blueprints.editBlueprint(title = "Test Blueprint");
 
@@ -577,9 +579,11 @@ definition {
 
 		Blueprints.addElement(element = "Limit Search to My Contents");
 
-		Click(
+		ClickNoError(
 			key_text = "Cancel",
 			locator1 = "Link#ANY");
+
+		AssertConfirm(value1 = "You have unsaved changes. Do you want to proceed without saving?");
 
 		Blueprints.editBlueprint(title = "Test Blueprint");
 
@@ -633,6 +637,10 @@ definition {
 		SelectFrameTop();
 
 		Click.javaScriptClick(locator1 = "Button#COPY");
+
+		Click(locator1 = "Modal#CLOSE_BUTTON");
+
+		PortletEntry.save();
 
 		Blueprints.viewCopiedContent(text = "clauses");
 	}
@@ -2179,9 +2187,11 @@ definition {
 			configurationField = "Advanced Configuration",
 			locator1 = "Blueprints#BLUEPRINTS_CONFIGURATION_INVALID_JSON_ERROR");
 
-		Click(
+		ClickNoError(
 			key_text = "Cancel",
 			locator1 = "Link#ANY");
+
+		AssertConfirm(value1 = "You have unsaved changes. Do you want to proceed without saving?");
 
 		Blueprints.editBlueprint(title = "Test Blueprint");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/DefaultElements.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/DefaultElements.testcase
@@ -1,3 +1,4 @@
+@ignore = "true"
 @component-name = "portal-search"
 definition {
 


### PR DESCRIPTION
From @oliv-yu:

https://issues.liferay.com/browse/LPS-143724 - When editing a Blueprint, I want to be notified when there are unsaved changes before closing

- Hook `useShouldConfirmBeforeNavigate` was created in order to add into any form that needs confirmation upon navigating away
- Added to edit element too! It is based on whether the initial and final string values differ.
- It seemed like blueprint title and description would actually not trigger the prompt if they were edited, so I tucked them into values of formik. It seemed a bit confusing the way it originally worked, assigning the title/description into a new object with defaultValue and then using form inputs that get read and added to the submission object. So hopefully this update makes it easier to follow.

Closing browser (not customizable, depends on browser):
<img width="1621" alt="Screen Shot 2022-02-28 at 3 13 40 PM" src="https://user-images.githubusercontent.com/14063502/156075048-f1da21b9-a2d2-4a5f-80b6-3ba4a483d015.png">

Clicking cancel / back button:
<img width="1629" alt="Screen Shot 2022-02-28 at 3 13 16 PM" src="https://user-images.githubusercontent.com/14063502/156075101-0a1176c7-2f38-4fb9-853c-d6b20330c05f.png">

Test fixes: https://issues.liferay.com/browse/LRQA-73572

Tested on: https://github.com/liferay-search/liferay-portal/pull/314#issuecomment-1057527921
The only unique failure was caused by a CI network fluke.