### PR TITLE
POSHI-264 Update chromedriver versions for Chrome 98, 99

### DIFF
--- a/modules/sdk/gradle-plugins-poshi-runner/src/main/java/com/liferay/gradle/plugins/poshi/runner/PoshiRunnerPlugin.java
+++ b/modules/sdk/gradle-plugins-poshi-runner/src/main/java/com/liferay/gradle/plugins/poshi/runner/PoshiRunnerPlugin.java
@@ -828,8 +828,8 @@ public class PoshiRunnerPlugin implements Plugin<Project> {
 				put("95", "95.0.4638.17");
 				put("96", "96.0.4664.45");
 				put("97", "97.0.4692.71");
-				put("98", "98.0.4758.80");
-				put("99", "99.0.4844.17");
+				put("98", "98.0.4758.102");
+				put("99", "99.0.4844.51");
 			}
 		};
 	private static final Pattern _chromeVersionPattern = Pattern.compile(


### PR DESCRIPTION
https://issues.liferay.com/browse/POSHI-264

Please publish `gradle-plugins-poshi-runner` and `gradle-plugins-defaults` after merging, thanks! Bypassing forward due to the change only affecting local versions and high CI load