### PR TITLE
LPS-148531 Double Entity Fields in REST Builder Filter and Sort autogenerated tests

### DIFF
--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseLogResourceTestCase.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseLogResourceTestCase.java
@@ -648,18 +648,21 @@ public abstract class BaseLogResourceTestCase {
 		}
 
 		if (entityFieldName.equals("size")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(log.getSize()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("status")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(log.getStatus()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("total")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(log.getTotal()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/bulk/bulk-rest-impl/rest-openapi.yaml
+++ b/modules/apps/bulk/bulk-rest-impl/rest-openapi.yaml
@@ -89,7 +89,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.bulk.rest.client', and version '3.0.11'."
+        'com.liferay.bulk.rest.client', and version '3.0.12'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.bulk.rest.client', and version '3.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.bulk.rest.client', and version '3.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/rest-openapi.yaml
@@ -488,7 +488,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Account API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.11'."
+        artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.12'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Account API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Account API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Account API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Account API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountAddressResourceTestCase.java
@@ -1457,13 +1457,15 @@ public abstract class BaseAccountAddressResourceTestCase {
 		}
 
 		if (entityFieldName.equals("latitude")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(accountAddress.getLatitude()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("longitude")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(accountAddress.getLongitude()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("name")) {
@@ -1515,8 +1517,9 @@ public abstract class BaseAccountAddressResourceTestCase {
 		}
 
 		if (entityFieldName.equals("type")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(accountAddress.getType()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("zip")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
@@ -253,6 +253,35 @@ public abstract class BaseAccountGroupResourceTestCase {
 	}
 
 	@Test
+	public void testGetAccountGroupsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		AccountGroup accountGroup1 = testGetAccountGroupsPage_addAccountGroup(
+			randomAccountGroup());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		AccountGroup accountGroup2 = testGetAccountGroupsPage_addAccountGroup(
+			randomAccountGroup());
+
+		for (EntityField entityField : entityFields) {
+			Page<AccountGroup> page = accountGroupResource.getAccountGroupsPage(
+				getFilterString(entityField, "eq", accountGroup1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(accountGroup1),
+				(List<AccountGroup>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetAccountGroupsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -333,6 +362,18 @@ public abstract class BaseAccountGroupResourceTestCase {
 				BeanUtils.setProperty(
 					accountGroup1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAccountGroupsPageWithSortDouble() throws Exception {
+		testGetAccountGroupsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, accountGroup1, accountGroup2) -> {
+				BeanUtils.setProperty(
+					accountGroup1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					accountGroup2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -283,6 +283,31 @@ public abstract class BaseAccountResourceTestCase {
 	}
 
 	@Test
+	public void testGetAccountsPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Account account1 = testGetAccountsPage_addAccount(randomAccount());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Account account2 = testGetAccountsPage_addAccount(randomAccount());
+
+		for (EntityField entityField : entityFields) {
+			Page<Account> page = accountResource.getAccountsPage(
+				null, getFilterString(entityField, "eq", account1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(account1),
+				(List<Account>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetAccountsPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -353,6 +378,16 @@ public abstract class BaseAccountResourceTestCase {
 				BeanUtils.setProperty(
 					account1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAccountsPageWithSortDouble() throws Exception {
+		testGetAccountsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, account1, account2) -> {
+				BeanUtils.setProperty(account1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(account2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1503,8 +1538,9 @@ public abstract class BaseAccountResourceTestCase {
 		}
 
 		if (entityFieldName.equals("type")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(account.getType()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
@@ -1537,7 +1537,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.16'."
+        artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.17'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.16'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Catalog API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.17'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Catalog API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
@@ -1564,8 +1564,9 @@ public abstract class BaseAttachmentResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(attachment.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("src")) {
@@ -1582,8 +1583,9 @@ public abstract class BaseAttachmentResourceTestCase {
 		}
 
 		if (entityFieldName.equals("type")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(attachment.getType()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
@@ -471,6 +471,31 @@ public abstract class BaseCatalogResourceTestCase {
 	}
 
 	@Test
+	public void testGetCatalogsPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Catalog catalog1 = testGetCatalogsPage_addCatalog(randomCatalog());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Catalog catalog2 = testGetCatalogsPage_addCatalog(randomCatalog());
+
+		for (EntityField entityField : entityFields) {
+			Page<Catalog> page = catalogResource.getCatalogsPage(
+				null, getFilterString(entityField, "eq", catalog1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(catalog1),
+				(List<Catalog>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetCatalogsPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -541,6 +566,16 @@ public abstract class BaseCatalogResourceTestCase {
 				BeanUtils.setProperty(
 					catalog1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetCatalogsPageWithSortDouble() throws Exception {
+		testGetCatalogsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, catalog1, catalog2) -> {
+				BeanUtils.setProperty(catalog1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(catalog2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseDiagramResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseDiagramResourceTestCase.java
@@ -839,8 +839,9 @@ public abstract class BaseDiagramResourceTestCase {
 		}
 
 		if (entityFieldName.equals("radius")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(diagram.getRadius()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("type")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
@@ -371,6 +371,20 @@ public abstract class BaseMappedProductResourceTestCase {
 	}
 
 	@Test
+	public void testGetProductByExternalReferenceCodeMappedProductsPageWithSortDouble()
+		throws Exception {
+
+		testGetProductByExternalReferenceCodeMappedProductsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, mappedProduct1, mappedProduct2) -> {
+				BeanUtils.setProperty(
+					mappedProduct1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					mappedProduct2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetProductByExternalReferenceCodeMappedProductsPageWithSortInteger()
 		throws Exception {
 
@@ -728,6 +742,20 @@ public abstract class BaseMappedProductResourceTestCase {
 				BeanUtils.setProperty(
 					mappedProduct1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetProductIdMappedProductsPageWithSortDouble()
+		throws Exception {
+
+		testGetProductIdMappedProductsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, mappedProduct1, mappedProduct2) -> {
+				BeanUtils.setProperty(
+					mappedProduct1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					mappedProduct2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1503,8 +1531,9 @@ public abstract class BaseMappedProductResourceTestCase {
 		}
 
 		if (entityFieldName.equals("quantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(mappedProduct.getQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("sequence")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionCategoryResourceTestCase.java
@@ -257,6 +257,38 @@ public abstract class BaseOptionCategoryResourceTestCase {
 	}
 
 	@Test
+	public void testGetOptionCategoriesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		OptionCategory optionCategory1 =
+			testGetOptionCategoriesPage_addOptionCategory(
+				randomOptionCategory());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		OptionCategory optionCategory2 =
+			testGetOptionCategoriesPage_addOptionCategory(
+				randomOptionCategory());
+
+		for (EntityField entityField : entityFields) {
+			Page<OptionCategory> page =
+				optionCategoryResource.getOptionCategoriesPage(
+					getFilterString(entityField, "eq", optionCategory1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(optionCategory1),
+				(List<OptionCategory>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetOptionCategoriesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -347,6 +379,18 @@ public abstract class BaseOptionCategoryResourceTestCase {
 				BeanUtils.setProperty(
 					optionCategory1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOptionCategoriesPageWithSortDouble() throws Exception {
+		testGetOptionCategoriesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, optionCategory1, optionCategory2) -> {
+				BeanUtils.setProperty(
+					optionCategory1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					optionCategory2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1042,8 +1086,9 @@ public abstract class BaseOptionCategoryResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(optionCategory.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("title")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
@@ -249,6 +249,31 @@ public abstract class BaseOptionResourceTestCase {
 	}
 
 	@Test
+	public void testGetOptionsPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Option option1 = testGetOptionsPage_addOption(randomOption());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Option option2 = testGetOptionsPage_addOption(randomOption());
+
+		for (EntityField entityField : entityFields) {
+			Page<Option> page = optionResource.getOptionsPage(
+				null, getFilterString(entityField, "eq", option1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(option1),
+				(List<Option>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetOptionsPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -319,6 +344,16 @@ public abstract class BaseOptionResourceTestCase {
 				BeanUtils.setProperty(
 					option1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOptionsPageWithSortDouble() throws Exception {
+		testGetOptionsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, option1, option2) -> {
+				BeanUtils.setProperty(option1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(option2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1250,8 +1285,9 @@ public abstract class BaseOptionResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(option.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("required")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionValueResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionValueResourceTestCase.java
@@ -557,6 +557,18 @@ public abstract class BaseOptionValueResourceTestCase {
 	}
 
 	@Test
+	public void testGetOptionByExternalReferenceCodeOptionValuesPageWithSortDouble()
+		throws Exception {
+
+		testGetOptionByExternalReferenceCodeOptionValuesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, optionValue1, optionValue2) -> {
+				BeanUtils.setProperty(optionValue1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(optionValue2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetOptionByExternalReferenceCodeOptionValuesPageWithSortInteger()
 		throws Exception {
 
@@ -826,6 +838,18 @@ public abstract class BaseOptionValueResourceTestCase {
 				BeanUtils.setProperty(
 					optionValue1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOptionIdOptionValuesPageWithSortDouble()
+		throws Exception {
+
+		testGetOptionIdOptionValuesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, optionValue1, optionValue2) -> {
+				BeanUtils.setProperty(optionValue1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(optionValue2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1394,8 +1418,9 @@ public abstract class BaseOptionValueResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(optionValue.getPriority()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BasePinResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BasePinResourceTestCase.java
@@ -333,6 +333,18 @@ public abstract class BasePinResourceTestCase {
 	}
 
 	@Test
+	public void testGetProductByExternalReferenceCodePinsPageWithSortDouble()
+		throws Exception {
+
+		testGetProductByExternalReferenceCodePinsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, pin1, pin2) -> {
+				BeanUtils.setProperty(pin1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(pin2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetProductByExternalReferenceCodePinsPageWithSortInteger()
 		throws Exception {
 
@@ -569,6 +581,16 @@ public abstract class BasePinResourceTestCase {
 				BeanUtils.setProperty(
 					pin1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetProductIdPinsPageWithSortDouble() throws Exception {
+		testGetProductIdPinsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, pin1, pin2) -> {
+				BeanUtils.setProperty(pin1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(pin2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1057,13 +1079,15 @@ public abstract class BasePinResourceTestCase {
 		}
 
 		if (entityFieldName.equals("positionX")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(pin.getPositionX()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("positionY")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(pin.getPositionY()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("sequence")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationResourceTestCase.java
@@ -772,23 +772,32 @@ public abstract class BaseProductConfigurationResourceTestCase {
 		}
 
 		if (entityFieldName.equals("maxOrderQuantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(productConfiguration.getMaxOrderQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("minOrderQuantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(productConfiguration.getMinOrderQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("minStockQuantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(productConfiguration.getMinStockQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("multipleOrderQuantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					productConfiguration.getMultipleOrderQuantity()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
@@ -251,6 +251,35 @@ public abstract class BaseProductGroupResourceTestCase {
 	}
 
 	@Test
+	public void testGetProductGroupsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		ProductGroup productGroup1 = testGetProductGroupsPage_addProductGroup(
+			randomProductGroup());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ProductGroup productGroup2 = testGetProductGroupsPage_addProductGroup(
+			randomProductGroup());
+
+		for (EntityField entityField : entityFields) {
+			Page<ProductGroup> page = productGroupResource.getProductGroupsPage(
+				null, getFilterString(entityField, "eq", productGroup1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(productGroup1),
+				(List<ProductGroup>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetProductGroupsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -331,6 +360,18 @@ public abstract class BaseProductGroupResourceTestCase {
 				BeanUtils.setProperty(
 					productGroup1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetProductGroupsPageWithSortDouble() throws Exception {
+		testGetProductGroupsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, productGroup1, productGroup2) -> {
+				BeanUtils.setProperty(
+					productGroup1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					productGroup2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1183,8 +1224,9 @@ public abstract class BaseProductGroupResourceTestCase {
 		}
 
 		if (entityFieldName.equals("productsCount")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(productGroup.getProductsCount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("title")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
@@ -452,6 +452,20 @@ public abstract class BaseProductOptionResourceTestCase {
 	}
 
 	@Test
+	public void testGetProductByExternalReferenceCodeProductOptionsPageWithSortDouble()
+		throws Exception {
+
+		testGetProductByExternalReferenceCodeProductOptionsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, productOption1, productOption2) -> {
+				BeanUtils.setProperty(
+					productOption1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					productOption2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetProductByExternalReferenceCodeProductOptionsPageWithSortInteger()
 		throws Exception {
 
@@ -713,6 +727,20 @@ public abstract class BaseProductOptionResourceTestCase {
 				BeanUtils.setProperty(
 					productOption1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetProductIdProductOptionsPageWithSortDouble()
+		throws Exception {
+
+		testGetProductIdProductOptionsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, productOption1, productOption2) -> {
+				BeanUtils.setProperty(
+					productOption1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					productOption2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1401,8 +1429,9 @@ public abstract class BaseProductOptionResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(productOption.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("productOptionValues")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionValueResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionValueResourceTestCase.java
@@ -317,6 +317,20 @@ public abstract class BaseProductOptionValueResourceTestCase {
 	}
 
 	@Test
+	public void testGetProductOptionIdProductOptionValuesPageWithSortDouble()
+		throws Exception {
+
+		testGetProductOptionIdProductOptionValuesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, productOptionValue1, productOptionValue2) -> {
+				BeanUtils.setProperty(
+					productOptionValue1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					productOptionValue2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetProductOptionIdProductOptionValuesPageWithSortInteger()
 		throws Exception {
 
@@ -862,8 +876,9 @@ public abstract class BaseProductOptionValueResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(productOptionValue.getPriority()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -257,6 +257,31 @@ public abstract class BaseProductResourceTestCase {
 	}
 
 	@Test
+	public void testGetProductsPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Product product1 = testGetProductsPage_addProduct(randomProduct());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Product product2 = testGetProductsPage_addProduct(randomProduct());
+
+		for (EntityField entityField : entityFields) {
+			Page<Product> page = productResource.getProductsPage(
+				null, getFilterString(entityField, "eq", product1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(product1),
+				(List<Product>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetProductsPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -327,6 +352,16 @@ public abstract class BaseProductResourceTestCase {
 				BeanUtils.setProperty(
 					product1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetProductsPageWithSortDouble() throws Exception {
+		testGetProductsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, product1, product2) -> {
+				BeanUtils.setProperty(product1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(product2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -2214,8 +2249,9 @@ public abstract class BaseProductResourceTestCase {
 		}
 
 		if (entityFieldName.equals("productStatus")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(product.getProductStatus()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("productType")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
@@ -796,8 +796,9 @@ public abstract class BaseProductSpecificationResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(productSpecification.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("productId")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSubscriptionConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSubscriptionConfigurationResourceTestCase.java
@@ -674,8 +674,10 @@ public abstract class BaseProductSubscriptionConfigurationResourceTestCase {
 		}
 
 		if (entityFieldName.equals("length")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(productSubscriptionConfiguration.getLength()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("numberOfLength")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
@@ -996,8 +996,9 @@ public abstract class BaseRelatedProductResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(relatedProduct.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("productExternalReferenceCode")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
@@ -490,6 +490,30 @@ public abstract class BaseSkuResourceTestCase {
 	}
 
 	@Test
+	public void testGetSkusPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Sku sku1 = testGetSkusPage_addSku(randomSku());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Sku sku2 = testGetSkusPage_addSku(randomSku());
+
+		for (EntityField entityField : entityFields) {
+			Page<Sku> page = skuResource.getSkusPage(
+				null, getFilterString(entityField, "eq", sku1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(sku1), (List<Sku>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSkusPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -557,6 +581,16 @@ public abstract class BaseSkuResourceTestCase {
 				BeanUtils.setProperty(
 					sku1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSkusPageWithSortDouble() throws Exception {
+		testGetSkusPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, sku1, sku2) -> {
+				BeanUtils.setProperty(sku1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(sku2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1640,8 +1674,9 @@ public abstract class BaseSkuResourceTestCase {
 		}
 
 		if (entityFieldName.equals("depth")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sku.getDepth()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("discontinued")) {
@@ -1759,8 +1794,9 @@ public abstract class BaseSkuResourceTestCase {
 		}
 
 		if (entityFieldName.equals("height")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sku.getHeight()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("id")) {
@@ -1769,8 +1805,9 @@ public abstract class BaseSkuResourceTestCase {
 		}
 
 		if (entityFieldName.equals("inventoryLevel")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sku.getInventoryLevel()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("manufacturerPartNumber")) {
@@ -1852,13 +1889,15 @@ public abstract class BaseSkuResourceTestCase {
 		}
 
 		if (entityFieldName.equals("weight")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sku.getWeight()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("width")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sku.getWidth()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
@@ -254,6 +254,36 @@ public abstract class BaseSpecificationResourceTestCase {
 	}
 
 	@Test
+	public void testGetSpecificationsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Specification specification1 =
+			testGetSpecificationsPage_addSpecification(randomSpecification());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Specification specification2 =
+			testGetSpecificationsPage_addSpecification(randomSpecification());
+
+		for (EntityField entityField : entityFields) {
+			Page<Specification> page =
+				specificationResource.getSpecificationsPage(
+					null, getFilterString(entityField, "eq", specification1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(specification1),
+				(List<Specification>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSpecificationsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -335,6 +365,18 @@ public abstract class BaseSpecificationResourceTestCase {
 				BeanUtils.setProperty(
 					specification1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSpecificationsPageWithSortDouble() throws Exception {
+		testGetSpecificationsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, specification1, specification2) -> {
+				BeanUtils.setProperty(
+					specification1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					specification2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-openapi.yaml
@@ -284,7 +284,7 @@ components:
 info:
     description:
         "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.13'."
+        artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.14'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.13'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Channel API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.14'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Channel API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -253,6 +253,31 @@ public abstract class BaseChannelResourceTestCase {
 	}
 
 	@Test
+	public void testGetChannelsPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Channel channel1 = testGetChannelsPage_addChannel(randomChannel());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Channel channel2 = testGetChannelsPage_addChannel(randomChannel());
+
+		for (EntityField entityField : entityFields) {
+			Page<Channel> page = channelResource.getChannelsPage(
+				null, getFilterString(entityField, "eq", channel1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(channel1),
+				(List<Channel>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetChannelsPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -323,6 +348,16 @@ public abstract class BaseChannelResourceTestCase {
 				BeanUtils.setProperty(
 					channel1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetChannelsPageWithSortDouble() throws Exception {
+		testGetChannelsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, channel1, channel2) -> {
+				BeanUtils.setProperty(channel1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(channel2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BasePaymentMethodGroupRelOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BasePaymentMethodGroupRelOrderTypeResourceTestCase.java
@@ -319,6 +319,44 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceTestCase {
 	}
 
 	@Test
+	public void testGetPaymentMethodGroupRelIdPaymentMethodGroupRelOrderTypesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id =
+			testGetPaymentMethodGroupRelIdPaymentMethodGroupRelOrderTypesPage_getId();
+
+		PaymentMethodGroupRelOrderType paymentMethodGroupRelOrderType1 =
+			testGetPaymentMethodGroupRelIdPaymentMethodGroupRelOrderTypesPage_addPaymentMethodGroupRelOrderType(
+				id, randomPaymentMethodGroupRelOrderType());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PaymentMethodGroupRelOrderType paymentMethodGroupRelOrderType2 =
+			testGetPaymentMethodGroupRelIdPaymentMethodGroupRelOrderTypesPage_addPaymentMethodGroupRelOrderType(
+				id, randomPaymentMethodGroupRelOrderType());
+
+		for (EntityField entityField : entityFields) {
+			Page<PaymentMethodGroupRelOrderType> page =
+				paymentMethodGroupRelOrderTypeResource.
+					getPaymentMethodGroupRelIdPaymentMethodGroupRelOrderTypesPage(
+						id, null,
+						getFilterString(
+							entityField, "eq", paymentMethodGroupRelOrderType1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(paymentMethodGroupRelOrderType1),
+				(List<PaymentMethodGroupRelOrderType>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetPaymentMethodGroupRelIdPaymentMethodGroupRelOrderTypesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -426,6 +464,24 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceTestCase {
 				BeanUtils.setProperty(
 					paymentMethodGroupRelOrderType1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetPaymentMethodGroupRelIdPaymentMethodGroupRelOrderTypesPageWithSortDouble()
+		throws Exception {
+
+		testGetPaymentMethodGroupRelIdPaymentMethodGroupRelOrderTypesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, paymentMethodGroupRelOrderType1,
+			 paymentMethodGroupRelOrderType2) -> {
+
+				BeanUtils.setProperty(
+					paymentMethodGroupRelOrderType1, entityField.getName(),
+					0.1);
+				BeanUtils.setProperty(
+					paymentMethodGroupRelOrderType2, entityField.getName(),
+					0.5);
 			});
 	}
 
@@ -1118,8 +1174,10 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(paymentMethodGroupRelOrderType.getPriority()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BasePaymentMethodGroupRelTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BasePaymentMethodGroupRelTermResourceTestCase.java
@@ -309,6 +309,44 @@ public abstract class BasePaymentMethodGroupRelTermResourceTestCase {
 	}
 
 	@Test
+	public void testGetPaymentMethodGroupRelIdPaymentMethodGroupRelTermsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id =
+			testGetPaymentMethodGroupRelIdPaymentMethodGroupRelTermsPage_getId();
+
+		PaymentMethodGroupRelTerm paymentMethodGroupRelTerm1 =
+			testGetPaymentMethodGroupRelIdPaymentMethodGroupRelTermsPage_addPaymentMethodGroupRelTerm(
+				id, randomPaymentMethodGroupRelTerm());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PaymentMethodGroupRelTerm paymentMethodGroupRelTerm2 =
+			testGetPaymentMethodGroupRelIdPaymentMethodGroupRelTermsPage_addPaymentMethodGroupRelTerm(
+				id, randomPaymentMethodGroupRelTerm());
+
+		for (EntityField entityField : entityFields) {
+			Page<PaymentMethodGroupRelTerm> page =
+				paymentMethodGroupRelTermResource.
+					getPaymentMethodGroupRelIdPaymentMethodGroupRelTermsPage(
+						id, null,
+						getFilterString(
+							entityField, "eq", paymentMethodGroupRelTerm1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(paymentMethodGroupRelTerm1),
+				(List<PaymentMethodGroupRelTerm>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetPaymentMethodGroupRelIdPaymentMethodGroupRelTermsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -415,6 +453,22 @@ public abstract class BasePaymentMethodGroupRelTermResourceTestCase {
 				BeanUtils.setProperty(
 					paymentMethodGroupRelTerm1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetPaymentMethodGroupRelIdPaymentMethodGroupRelTermsPageWithSortDouble()
+		throws Exception {
+
+		testGetPaymentMethodGroupRelIdPaymentMethodGroupRelTermsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, paymentMethodGroupRelTerm1,
+			 paymentMethodGroupRelTerm2) -> {
+
+				BeanUtils.setProperty(
+					paymentMethodGroupRelTerm1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					paymentMethodGroupRelTerm2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseShippingFixedOptionOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseShippingFixedOptionOrderTypeResourceTestCase.java
@@ -317,6 +317,44 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceTestCase {
 	}
 
 	@Test
+	public void testGetShippingFixedOptionIdShippingFixedOptionOrderTypesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id =
+			testGetShippingFixedOptionIdShippingFixedOptionOrderTypesPage_getId();
+
+		ShippingFixedOptionOrderType shippingFixedOptionOrderType1 =
+			testGetShippingFixedOptionIdShippingFixedOptionOrderTypesPage_addShippingFixedOptionOrderType(
+				id, randomShippingFixedOptionOrderType());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ShippingFixedOptionOrderType shippingFixedOptionOrderType2 =
+			testGetShippingFixedOptionIdShippingFixedOptionOrderTypesPage_addShippingFixedOptionOrderType(
+				id, randomShippingFixedOptionOrderType());
+
+		for (EntityField entityField : entityFields) {
+			Page<ShippingFixedOptionOrderType> page =
+				shippingFixedOptionOrderTypeResource.
+					getShippingFixedOptionIdShippingFixedOptionOrderTypesPage(
+						id, null,
+						getFilterString(
+							entityField, "eq", shippingFixedOptionOrderType1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(shippingFixedOptionOrderType1),
+				(List<ShippingFixedOptionOrderType>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetShippingFixedOptionIdShippingFixedOptionOrderTypesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -423,6 +461,22 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceTestCase {
 				BeanUtils.setProperty(
 					shippingFixedOptionOrderType1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetShippingFixedOptionIdShippingFixedOptionOrderTypesPageWithSortDouble()
+		throws Exception {
+
+		testGetShippingFixedOptionIdShippingFixedOptionOrderTypesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, shippingFixedOptionOrderType1,
+			 shippingFixedOptionOrderType2) -> {
+
+				BeanUtils.setProperty(
+					shippingFixedOptionOrderType1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					shippingFixedOptionOrderType2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1099,8 +1153,10 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(shippingFixedOptionOrderType.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("shippingFixedOptionId")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseShippingFixedOptionTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseShippingFixedOptionTermResourceTestCase.java
@@ -306,6 +306,44 @@ public abstract class BaseShippingFixedOptionTermResourceTestCase {
 	}
 
 	@Test
+	public void testGetShippingFixedOptionIdShippingFixedOptionTermsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id =
+			testGetShippingFixedOptionIdShippingFixedOptionTermsPage_getId();
+
+		ShippingFixedOptionTerm shippingFixedOptionTerm1 =
+			testGetShippingFixedOptionIdShippingFixedOptionTermsPage_addShippingFixedOptionTerm(
+				id, randomShippingFixedOptionTerm());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ShippingFixedOptionTerm shippingFixedOptionTerm2 =
+			testGetShippingFixedOptionIdShippingFixedOptionTermsPage_addShippingFixedOptionTerm(
+				id, randomShippingFixedOptionTerm());
+
+		for (EntityField entityField : entityFields) {
+			Page<ShippingFixedOptionTerm> page =
+				shippingFixedOptionTermResource.
+					getShippingFixedOptionIdShippingFixedOptionTermsPage(
+						id, null,
+						getFilterString(
+							entityField, "eq", shippingFixedOptionTerm1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(shippingFixedOptionTerm1),
+				(List<ShippingFixedOptionTerm>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetShippingFixedOptionIdShippingFixedOptionTermsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -410,6 +448,20 @@ public abstract class BaseShippingFixedOptionTermResourceTestCase {
 				BeanUtils.setProperty(
 					shippingFixedOptionTerm1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetShippingFixedOptionIdShippingFixedOptionTermsPageWithSortDouble()
+		throws Exception {
+
+		testGetShippingFixedOptionIdShippingFixedOptionTermsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, shippingFixedOptionTerm1, shippingFixedOptionTerm2) ->{
+				BeanUtils.setProperty(
+					shippingFixedOptionTerm1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					shippingFixedOptionTerm2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-openapi.yaml
@@ -144,7 +144,7 @@ info:
         name: "Commerce Team"
     description:
         "Liferay Commerce Admin Inventory API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.inventory.client', and version '4.0.11'."
+        artifact ID 'com.liferay.headless.commerce.admin.inventory.client', and version '4.0.12'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Inventory API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.inventory.client', and version '4.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Inventory API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Inventory API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.inventory.client', and version '4.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Inventory API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseItemResourceTestCase.java
@@ -1335,13 +1335,15 @@ public abstract class BaseWarehouseItemResourceTestCase {
 		}
 
 		if (entityFieldName.equals("quantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(warehouseItem.getQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("reservedQuantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(warehouseItem.getReservedQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("sku")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseResourceTestCase.java
@@ -459,6 +459,33 @@ public abstract class BaseWarehouseResourceTestCase {
 	}
 
 	@Test
+	public void testGetWarehousesPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Warehouse warehouse1 = testGetWarehousesPage_addWarehouse(
+			randomWarehouse());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Warehouse warehouse2 = testGetWarehousesPage_addWarehouse(
+			randomWarehouse());
+
+		for (EntityField entityField : entityFields) {
+			Page<Warehouse> page = warehouseResource.getWarehousesPage(
+				getFilterString(entityField, "eq", warehouse1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(warehouse1),
+				(List<Warehouse>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetWarehousesPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -534,6 +561,16 @@ public abstract class BaseWarehouseResourceTestCase {
 				BeanUtils.setProperty(
 					warehouse1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetWarehousesPageWithSortDouble() throws Exception {
+		testGetWarehousesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, warehouse1, warehouse2) -> {
+				BeanUtils.setProperty(warehouse1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(warehouse2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1326,13 +1363,15 @@ public abstract class BaseWarehouseResourceTestCase {
 		}
 
 		if (entityFieldName.equals("latitude")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(warehouse.getLatitude()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("longitude")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(warehouse.getLongitude()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("mvccVersion")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
@@ -1304,7 +1304,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.17'."
+        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.18'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.17'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.18'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -864,8 +864,9 @@ public abstract class BaseAccountResourceTestCase {
 		}
 
 		if (entityFieldName.equals("type")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(account.getType()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseBillingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseBillingAddressResourceTestCase.java
@@ -958,13 +958,15 @@ public abstract class BaseBillingAddressResourceTestCase {
 		}
 
 		if (entityFieldName.equals("latitude")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(billingAddress.getLatitude()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("longitude")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(billingAddress.getLongitude()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("name")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderItemResourceTestCase.java
@@ -1918,8 +1918,9 @@ public abstract class BaseOrderItemResourceTestCase {
 		}
 
 		if (entityFieldName.equals("quantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(orderItem.getQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("requestedDeliveryDate")) {
@@ -1957,8 +1958,9 @@ public abstract class BaseOrderItemResourceTestCase {
 		}
 
 		if (entityFieldName.equals("shippedQuantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(orderItem.getShippedQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("shippingAddress")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
@@ -308,6 +308,31 @@ public abstract class BaseOrderResourceTestCase {
 	}
 
 	@Test
+	public void testGetOrdersPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Order order1 = testGetOrdersPage_addOrder(randomOrder());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Order order2 = testGetOrdersPage_addOrder(randomOrder());
+
+		for (EntityField entityField : entityFields) {
+			Page<Order> page = orderResource.getOrdersPage(
+				null, getFilterString(entityField, "eq", order1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(order1),
+				(List<Order>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetOrdersPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -377,6 +402,16 @@ public abstract class BaseOrderResourceTestCase {
 				BeanUtils.setProperty(
 					order1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOrdersPageWithSortDouble() throws Exception {
+		testGetOrdersPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, order1, order2) -> {
+				BeanUtils.setProperty(order1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(order2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -3545,8 +3580,9 @@ public abstract class BaseOrderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("orderStatus")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getOrderStatus()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("orderStatusInfo")) {
@@ -3577,8 +3613,9 @@ public abstract class BaseOrderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("paymentStatus")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getPaymentStatus()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("paymentStatusInfo")) {
@@ -3680,8 +3717,9 @@ public abstract class BaseOrderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("shippingAmountValue")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getShippingAmountValue()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("shippingDiscountAmount")) {
@@ -3699,61 +3737,83 @@ public abstract class BaseOrderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("shippingDiscountAmountValue")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getShippingDiscountAmountValue()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("shippingDiscountPercentageLevel1")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(order.getShippingDiscountPercentageLevel1()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals(
 				"shippingDiscountPercentageLevel1WithTaxAmount")) {
 
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					order.getShippingDiscountPercentageLevel1WithTaxAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("shippingDiscountPercentageLevel2")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(order.getShippingDiscountPercentageLevel2()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals(
 				"shippingDiscountPercentageLevel2WithTaxAmount")) {
 
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					order.getShippingDiscountPercentageLevel2WithTaxAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("shippingDiscountPercentageLevel3")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(order.getShippingDiscountPercentageLevel3()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals(
 				"shippingDiscountPercentageLevel3WithTaxAmount")) {
 
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					order.getShippingDiscountPercentageLevel3WithTaxAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("shippingDiscountPercentageLevel4")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(order.getShippingDiscountPercentageLevel4()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals(
 				"shippingDiscountPercentageLevel4WithTaxAmount")) {
 
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					order.getShippingDiscountPercentageLevel4WithTaxAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("shippingDiscountWithTaxAmount")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getShippingDiscountWithTaxAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("shippingDiscountWithTaxAmountFormatted")) {
@@ -3797,8 +3857,9 @@ public abstract class BaseOrderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("shippingWithTaxAmountValue")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getShippingWithTaxAmountValue()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("subtotal")) {
@@ -3807,13 +3868,15 @@ public abstract class BaseOrderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("subtotalAmount")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getSubtotalAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("subtotalDiscountAmount")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getSubtotalDiscountAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("subtotalDiscountAmountFormatted")) {
@@ -3826,56 +3889,77 @@ public abstract class BaseOrderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("subtotalDiscountPercentageLevel1")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(order.getSubtotalDiscountPercentageLevel1()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals(
 				"subtotalDiscountPercentageLevel1WithTaxAmount")) {
 
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					order.getSubtotalDiscountPercentageLevel1WithTaxAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("subtotalDiscountPercentageLevel2")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(order.getSubtotalDiscountPercentageLevel2()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals(
 				"subtotalDiscountPercentageLevel2WithTaxAmount")) {
 
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					order.getSubtotalDiscountPercentageLevel2WithTaxAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("subtotalDiscountPercentageLevel3")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(order.getSubtotalDiscountPercentageLevel3()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals(
 				"subtotalDiscountPercentageLevel3WithTaxAmount")) {
 
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					order.getSubtotalDiscountPercentageLevel3WithTaxAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("subtotalDiscountPercentageLevel4")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(order.getSubtotalDiscountPercentageLevel4()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals(
 				"subtotalDiscountPercentageLevel4WithTaxAmount")) {
 
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					order.getSubtotalDiscountPercentageLevel4WithTaxAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("subtotalDiscountWithTaxAmount")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getSubtotalDiscountWithTaxAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("subtotalDiscountWithTaxAmountFormatted")) {
@@ -3911,8 +3995,9 @@ public abstract class BaseOrderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("subtotalWithTaxAmountValue")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getSubtotalWithTaxAmountValue()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("taxAmount")) {
@@ -3929,8 +4014,9 @@ public abstract class BaseOrderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("taxAmountValue")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getTaxAmountValue()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("total")) {
@@ -3939,8 +4025,9 @@ public abstract class BaseOrderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("totalAmount")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getTotalAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("totalDiscountAmount")) {
@@ -3957,56 +4044,73 @@ public abstract class BaseOrderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("totalDiscountAmountValue")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getTotalDiscountAmountValue()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("totalDiscountPercentageLevel1")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getTotalDiscountPercentageLevel1()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals(
 				"totalDiscountPercentageLevel1WithTaxAmount")) {
 
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					order.getTotalDiscountPercentageLevel1WithTaxAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("totalDiscountPercentageLevel2")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getTotalDiscountPercentageLevel2()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals(
 				"totalDiscountPercentageLevel2WithTaxAmount")) {
 
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					order.getTotalDiscountPercentageLevel2WithTaxAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("totalDiscountPercentageLevel3")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getTotalDiscountPercentageLevel3()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals(
 				"totalDiscountPercentageLevel3WithTaxAmount")) {
 
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					order.getTotalDiscountPercentageLevel3WithTaxAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("totalDiscountPercentageLevel4")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getTotalDiscountPercentageLevel4()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals(
 				"totalDiscountPercentageLevel4WithTaxAmount")) {
 
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					order.getTotalDiscountPercentageLevel4WithTaxAmount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("totalDiscountWithTaxAmount")) {
@@ -4024,8 +4128,10 @@ public abstract class BaseOrderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("totalDiscountWithTaxAmountValue")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(order.getTotalDiscountWithTaxAmountValue()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("totalFormatted")) {
@@ -4050,8 +4156,9 @@ public abstract class BaseOrderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("totalWithTaxAmountValue")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(order.getTotalWithTaxAmountValue()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("transactionId")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleAccountGroupResourceTestCase.java
@@ -469,6 +469,43 @@ public abstract class BaseOrderRuleAccountGroupResourceTestCase {
 	}
 
 	@Test
+	public void testGetOrderRuleIdOrderRuleAccountGroupsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetOrderRuleIdOrderRuleAccountGroupsPage_getId();
+
+		OrderRuleAccountGroup orderRuleAccountGroup1 =
+			testGetOrderRuleIdOrderRuleAccountGroupsPage_addOrderRuleAccountGroup(
+				id, randomOrderRuleAccountGroup());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		OrderRuleAccountGroup orderRuleAccountGroup2 =
+			testGetOrderRuleIdOrderRuleAccountGroupsPage_addOrderRuleAccountGroup(
+				id, randomOrderRuleAccountGroup());
+
+		for (EntityField entityField : entityFields) {
+			Page<OrderRuleAccountGroup> page =
+				orderRuleAccountGroupResource.
+					getOrderRuleIdOrderRuleAccountGroupsPage(
+						id, null,
+						getFilterString(
+							entityField, "eq", orderRuleAccountGroup1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(orderRuleAccountGroup1),
+				(List<OrderRuleAccountGroup>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetOrderRuleIdOrderRuleAccountGroupsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -571,6 +608,20 @@ public abstract class BaseOrderRuleAccountGroupResourceTestCase {
 				BeanUtils.setProperty(
 					orderRuleAccountGroup1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOrderRuleIdOrderRuleAccountGroupsPageWithSortDouble()
+		throws Exception {
+
+		testGetOrderRuleIdOrderRuleAccountGroupsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, orderRuleAccountGroup1, orderRuleAccountGroup2) -> {
+				BeanUtils.setProperty(
+					orderRuleAccountGroup1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					orderRuleAccountGroup2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleAccountResourceTestCase.java
@@ -447,6 +447,41 @@ public abstract class BaseOrderRuleAccountResourceTestCase {
 	}
 
 	@Test
+	public void testGetOrderRuleIdOrderRuleAccountsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetOrderRuleIdOrderRuleAccountsPage_getId();
+
+		OrderRuleAccount orderRuleAccount1 =
+			testGetOrderRuleIdOrderRuleAccountsPage_addOrderRuleAccount(
+				id, randomOrderRuleAccount());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		OrderRuleAccount orderRuleAccount2 =
+			testGetOrderRuleIdOrderRuleAccountsPage_addOrderRuleAccount(
+				id, randomOrderRuleAccount());
+
+		for (EntityField entityField : entityFields) {
+			Page<OrderRuleAccount> page =
+				orderRuleAccountResource.getOrderRuleIdOrderRuleAccountsPage(
+					id, null,
+					getFilterString(entityField, "eq", orderRuleAccount1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(orderRuleAccount1),
+				(List<OrderRuleAccount>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetOrderRuleIdOrderRuleAccountsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -541,6 +576,20 @@ public abstract class BaseOrderRuleAccountResourceTestCase {
 				BeanUtils.setProperty(
 					orderRuleAccount1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOrderRuleIdOrderRuleAccountsPageWithSortDouble()
+		throws Exception {
+
+		testGetOrderRuleIdOrderRuleAccountsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, orderRuleAccount1, orderRuleAccount2) -> {
+				BeanUtils.setProperty(
+					orderRuleAccount1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					orderRuleAccount2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleChannelResourceTestCase.java
@@ -447,6 +447,41 @@ public abstract class BaseOrderRuleChannelResourceTestCase {
 	}
 
 	@Test
+	public void testGetOrderRuleIdOrderRuleChannelsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetOrderRuleIdOrderRuleChannelsPage_getId();
+
+		OrderRuleChannel orderRuleChannel1 =
+			testGetOrderRuleIdOrderRuleChannelsPage_addOrderRuleChannel(
+				id, randomOrderRuleChannel());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		OrderRuleChannel orderRuleChannel2 =
+			testGetOrderRuleIdOrderRuleChannelsPage_addOrderRuleChannel(
+				id, randomOrderRuleChannel());
+
+		for (EntityField entityField : entityFields) {
+			Page<OrderRuleChannel> page =
+				orderRuleChannelResource.getOrderRuleIdOrderRuleChannelsPage(
+					id, null,
+					getFilterString(entityField, "eq", orderRuleChannel1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(orderRuleChannel1),
+				(List<OrderRuleChannel>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetOrderRuleIdOrderRuleChannelsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -541,6 +576,20 @@ public abstract class BaseOrderRuleChannelResourceTestCase {
 				BeanUtils.setProperty(
 					orderRuleChannel1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOrderRuleIdOrderRuleChannelsPageWithSortDouble()
+		throws Exception {
+
+		testGetOrderRuleIdOrderRuleChannelsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, orderRuleChannel1, orderRuleChannel2) -> {
+				BeanUtils.setProperty(
+					orderRuleChannel1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					orderRuleChannel2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleResourceTestCase.java
@@ -261,6 +261,33 @@ public abstract class BaseOrderRuleResourceTestCase {
 	}
 
 	@Test
+	public void testGetOrderRulesPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		OrderRule orderRule1 = testGetOrderRulesPage_addOrderRule(
+			randomOrderRule());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		OrderRule orderRule2 = testGetOrderRulesPage_addOrderRule(
+			randomOrderRule());
+
+		for (EntityField entityField : entityFields) {
+			Page<OrderRule> page = orderRuleResource.getOrderRulesPage(
+				null, getFilterString(entityField, "eq", orderRule1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(orderRule1),
+				(List<OrderRule>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetOrderRulesPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -336,6 +363,16 @@ public abstract class BaseOrderRuleResourceTestCase {
 				BeanUtils.setProperty(
 					orderRule1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOrderRulesPageWithSortDouble() throws Exception {
+		testGetOrderRulesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, orderRule1, orderRule2) -> {
+				BeanUtils.setProperty(orderRule1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(orderRule2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1583,8 +1620,9 @@ public abstract class BaseOrderRuleResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(orderRule.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("type")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeChannelResourceTestCase.java
@@ -477,6 +477,20 @@ public abstract class BaseOrderTypeChannelResourceTestCase {
 	}
 
 	@Test
+	public void testGetOrderTypeIdOrderTypeChannelsPageWithSortDouble()
+		throws Exception {
+
+		testGetOrderTypeIdOrderTypeChannelsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, orderTypeChannel1, orderTypeChannel2) -> {
+				BeanUtils.setProperty(
+					orderTypeChannel1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					orderTypeChannel2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetOrderTypeIdOrderTypeChannelsPageWithSortInteger()
 		throws Exception {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -316,6 +316,33 @@ public abstract class BaseOrderTypeResourceTestCase {
 	}
 
 	@Test
+	public void testGetOrderTypesPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		OrderType orderType1 = testGetOrderTypesPage_addOrderType(
+			randomOrderType());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		OrderType orderType2 = testGetOrderTypesPage_addOrderType(
+			randomOrderType());
+
+		for (EntityField entityField : entityFields) {
+			Page<OrderType> page = orderTypeResource.getOrderTypesPage(
+				null, getFilterString(entityField, "eq", orderType1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(orderType1),
+				(List<OrderType>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetOrderTypesPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -391,6 +418,16 @@ public abstract class BaseOrderTypeResourceTestCase {
 				BeanUtils.setProperty(
 					orderType1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOrderTypesPageWithSortDouble() throws Exception {
+		testGetOrderTypesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, orderType1, orderType2) -> {
+				BeanUtils.setProperty(orderType1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(orderType2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1470,8 +1507,9 @@ public abstract class BaseOrderTypeResourceTestCase {
 		}
 
 		if (entityFieldName.equals("displayOrder")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(orderType.getDisplayOrder()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("expirationDate")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
@@ -1014,13 +1014,15 @@ public abstract class BaseShippingAddressResourceTestCase {
 		}
 
 		if (entityFieldName.equals("latitude")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(shippingAddress.getLatitude()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("longitude")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(shippingAddress.getLongitude()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("name")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermResourceTestCase.java
@@ -254,6 +254,30 @@ public abstract class BaseTermResourceTestCase {
 	}
 
 	@Test
+	public void testGetTermsPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Term term1 = testGetTermsPage_addTerm(randomTerm());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Term term2 = testGetTermsPage_addTerm(randomTerm());
+
+		for (EntityField entityField : entityFields) {
+			Page<Term> page = termResource.getTermsPage(
+				null, getFilterString(entityField, "eq", term1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(term1), (List<Term>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetTermsPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -322,6 +346,16 @@ public abstract class BaseTermResourceTestCase {
 				BeanUtils.setProperty(
 					term1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetTermsPageWithSortDouble() throws Exception {
+		testGetTermsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, term1, term2) -> {
+				BeanUtils.setProperty(term1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(term2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1444,8 +1478,9 @@ public abstract class BaseTermResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(term.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("termOrderType")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/TermResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/TermResourceTest.java
@@ -91,6 +91,7 @@ public class TermResourceTest extends BaseTermResourceTestCase {
 					RandomTestUtil.randomLocaleStringMap());
 				name = FriendlyURLNormalizerUtil.normalize(
 					RandomTestUtil.randomString());
+				priority = RandomTestUtil.randomDouble();
 				type = StringUtil.toLowerCase(RandomTestUtil.randomString());
 			}
 		};
@@ -186,6 +187,7 @@ public class TermResourceTest extends BaseTermResourceTestCase {
 				id = commerceTermEntry.getCommerceTermEntryId();
 				label = commerceTermEntry.getLanguageIdToLabelMap();
 				name = commerceTermEntry.getName();
+				priority = commerceTermEntry.getPriority();
 				type = commerceTermEntry.getType();
 			}
 		};

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi-v2.0.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi-v2.0.yaml
@@ -1467,7 +1467,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.12'."
+        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.13'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi.yaml
@@ -484,7 +484,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.12'."
+        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.13'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.13'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v2.0")
+	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.13'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v2.0")
 )
 @Path("/v2.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountResourceTestCase.java
@@ -1383,8 +1383,9 @@ public abstract class BaseDiscountResourceTestCase {
 		}
 
 		if (entityFieldName.equals("limitationTimes")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(discount.getLimitationTimes()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("limitationType")) {
@@ -1406,8 +1407,9 @@ public abstract class BaseDiscountResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfUse")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(discount.getNumberOfUse()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("percentageLevel1")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListAccountGroupResourceTestCase.java
@@ -1014,8 +1014,9 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 		}
 
 		if (entityFieldName.equals("order")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(priceListAccountGroup.getOrder()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("priceListExternalReferenceCode")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListResourceTestCase.java
@@ -255,6 +255,33 @@ public abstract class BasePriceListResourceTestCase {
 	}
 
 	@Test
+	public void testGetPriceListsPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		PriceList priceList1 = testGetPriceListsPage_addPriceList(
+			randomPriceList());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PriceList priceList2 = testGetPriceListsPage_addPriceList(
+			randomPriceList());
+
+		for (EntityField entityField : entityFields) {
+			Page<PriceList> page = priceListResource.getPriceListsPage(
+				getFilterString(entityField, "eq", priceList1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(priceList1),
+				(List<PriceList>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetPriceListsPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -330,6 +357,16 @@ public abstract class BasePriceListResourceTestCase {
 				BeanUtils.setProperty(
 					priceList1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetPriceListsPageWithSortDouble() throws Exception {
+		testGetPriceListsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, priceList1, priceList2) -> {
+				BeanUtils.setProperty(priceList1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(priceList2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1361,8 +1398,9 @@ public abstract class BasePriceListResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(priceList.getPriority()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseTierPriceResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseTierPriceResourceTestCase.java
@@ -1136,8 +1136,9 @@ public abstract class BaseTierPriceResourceTestCase {
 		}
 
 		if (entityFieldName.equals("minimumQuantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(tierPrice.getMinimumQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("price")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountGroupResourceTestCase.java
@@ -462,6 +462,43 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 	}
 
 	@Test
+	public void testGetDiscountIdDiscountAccountGroupsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetDiscountIdDiscountAccountGroupsPage_getId();
+
+		DiscountAccountGroup discountAccountGroup1 =
+			testGetDiscountIdDiscountAccountGroupsPage_addDiscountAccountGroup(
+				id, randomDiscountAccountGroup());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		DiscountAccountGroup discountAccountGroup2 =
+			testGetDiscountIdDiscountAccountGroupsPage_addDiscountAccountGroup(
+				id, randomDiscountAccountGroup());
+
+		for (EntityField entityField : entityFields) {
+			Page<DiscountAccountGroup> page =
+				discountAccountGroupResource.
+					getDiscountIdDiscountAccountGroupsPage(
+						id, null,
+						getFilterString(
+							entityField, "eq", discountAccountGroup1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(discountAccountGroup1),
+				(List<DiscountAccountGroup>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetDiscountIdDiscountAccountGroupsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -561,6 +598,20 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 				BeanUtils.setProperty(
 					discountAccountGroup1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetDiscountIdDiscountAccountGroupsPageWithSortDouble()
+		throws Exception {
+
+		testGetDiscountIdDiscountAccountGroupsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, discountAccountGroup1, discountAccountGroup2) -> {
+				BeanUtils.setProperty(
+					discountAccountGroup1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					discountAccountGroup2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountResourceTestCase.java
@@ -446,6 +446,41 @@ public abstract class BaseDiscountAccountResourceTestCase {
 	}
 
 	@Test
+	public void testGetDiscountIdDiscountAccountsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetDiscountIdDiscountAccountsPage_getId();
+
+		DiscountAccount discountAccount1 =
+			testGetDiscountIdDiscountAccountsPage_addDiscountAccount(
+				id, randomDiscountAccount());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		DiscountAccount discountAccount2 =
+			testGetDiscountIdDiscountAccountsPage_addDiscountAccount(
+				id, randomDiscountAccount());
+
+		for (EntityField entityField : entityFields) {
+			Page<DiscountAccount> page =
+				discountAccountResource.getDiscountIdDiscountAccountsPage(
+					id, null,
+					getFilterString(entityField, "eq", discountAccount1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(discountAccount1),
+				(List<DiscountAccount>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetDiscountIdDiscountAccountsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -539,6 +574,20 @@ public abstract class BaseDiscountAccountResourceTestCase {
 				BeanUtils.setProperty(
 					discountAccount1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetDiscountIdDiscountAccountsPageWithSortDouble()
+		throws Exception {
+
+		testGetDiscountIdDiscountAccountsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, discountAccount1, discountAccount2) -> {
+				BeanUtils.setProperty(
+					discountAccount1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					discountAccount2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountCategoryResourceTestCase.java
@@ -447,6 +447,41 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 	}
 
 	@Test
+	public void testGetDiscountIdDiscountCategoriesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetDiscountIdDiscountCategoriesPage_getId();
+
+		DiscountCategory discountCategory1 =
+			testGetDiscountIdDiscountCategoriesPage_addDiscountCategory(
+				id, randomDiscountCategory());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		DiscountCategory discountCategory2 =
+			testGetDiscountIdDiscountCategoriesPage_addDiscountCategory(
+				id, randomDiscountCategory());
+
+		for (EntityField entityField : entityFields) {
+			Page<DiscountCategory> page =
+				discountCategoryResource.getDiscountIdDiscountCategoriesPage(
+					id, null,
+					getFilterString(entityField, "eq", discountCategory1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(discountCategory1),
+				(List<DiscountCategory>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetDiscountIdDiscountCategoriesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -541,6 +576,20 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 				BeanUtils.setProperty(
 					discountCategory1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetDiscountIdDiscountCategoriesPageWithSortDouble()
+		throws Exception {
+
+		testGetDiscountIdDiscountCategoriesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, discountCategory1, discountCategory2) -> {
+				BeanUtils.setProperty(
+					discountCategory1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					discountCategory2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountChannelResourceTestCase.java
@@ -446,6 +446,41 @@ public abstract class BaseDiscountChannelResourceTestCase {
 	}
 
 	@Test
+	public void testGetDiscountIdDiscountChannelsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetDiscountIdDiscountChannelsPage_getId();
+
+		DiscountChannel discountChannel1 =
+			testGetDiscountIdDiscountChannelsPage_addDiscountChannel(
+				id, randomDiscountChannel());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		DiscountChannel discountChannel2 =
+			testGetDiscountIdDiscountChannelsPage_addDiscountChannel(
+				id, randomDiscountChannel());
+
+		for (EntityField entityField : entityFields) {
+			Page<DiscountChannel> page =
+				discountChannelResource.getDiscountIdDiscountChannelsPage(
+					id, null,
+					getFilterString(entityField, "eq", discountChannel1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(discountChannel1),
+				(List<DiscountChannel>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetDiscountIdDiscountChannelsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -539,6 +574,20 @@ public abstract class BaseDiscountChannelResourceTestCase {
 				BeanUtils.setProperty(
 					discountChannel1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetDiscountIdDiscountChannelsPageWithSortDouble()
+		throws Exception {
+
+		testGetDiscountIdDiscountChannelsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, discountChannel1, discountChannel2) -> {
+				BeanUtils.setProperty(
+					discountChannel1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					discountChannel2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountOrderTypeResourceTestCase.java
@@ -450,6 +450,41 @@ public abstract class BaseDiscountOrderTypeResourceTestCase {
 	}
 
 	@Test
+	public void testGetDiscountIdDiscountOrderTypesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetDiscountIdDiscountOrderTypesPage_getId();
+
+		DiscountOrderType discountOrderType1 =
+			testGetDiscountIdDiscountOrderTypesPage_addDiscountOrderType(
+				id, randomDiscountOrderType());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		DiscountOrderType discountOrderType2 =
+			testGetDiscountIdDiscountOrderTypesPage_addDiscountOrderType(
+				id, randomDiscountOrderType());
+
+		for (EntityField entityField : entityFields) {
+			Page<DiscountOrderType> page =
+				discountOrderTypeResource.getDiscountIdDiscountOrderTypesPage(
+					id, null,
+					getFilterString(entityField, "eq", discountOrderType1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(discountOrderType1),
+				(List<DiscountOrderType>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetDiscountIdDiscountOrderTypesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -544,6 +579,20 @@ public abstract class BaseDiscountOrderTypeResourceTestCase {
 				BeanUtils.setProperty(
 					discountOrderType1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetDiscountIdDiscountOrderTypesPageWithSortDouble()
+		throws Exception {
+
+		testGetDiscountIdDiscountOrderTypesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, discountOrderType1, discountOrderType2) -> {
+				BeanUtils.setProperty(
+					discountOrderType1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					discountOrderType2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1208,8 +1257,9 @@ public abstract class BaseDiscountOrderTypeResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(discountOrderType.getPriority()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductGroupResourceTestCase.java
@@ -462,6 +462,43 @@ public abstract class BaseDiscountProductGroupResourceTestCase {
 	}
 
 	@Test
+	public void testGetDiscountIdDiscountProductGroupsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetDiscountIdDiscountProductGroupsPage_getId();
+
+		DiscountProductGroup discountProductGroup1 =
+			testGetDiscountIdDiscountProductGroupsPage_addDiscountProductGroup(
+				id, randomDiscountProductGroup());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		DiscountProductGroup discountProductGroup2 =
+			testGetDiscountIdDiscountProductGroupsPage_addDiscountProductGroup(
+				id, randomDiscountProductGroup());
+
+		for (EntityField entityField : entityFields) {
+			Page<DiscountProductGroup> page =
+				discountProductGroupResource.
+					getDiscountIdDiscountProductGroupsPage(
+						id, null,
+						getFilterString(
+							entityField, "eq", discountProductGroup1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(discountProductGroup1),
+				(List<DiscountProductGroup>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetDiscountIdDiscountProductGroupsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -561,6 +598,20 @@ public abstract class BaseDiscountProductGroupResourceTestCase {
 				BeanUtils.setProperty(
 					discountProductGroup1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetDiscountIdDiscountProductGroupsPageWithSortDouble()
+		throws Exception {
+
+		testGetDiscountIdDiscountProductGroupsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, discountProductGroup1, discountProductGroup2) -> {
+				BeanUtils.setProperty(
+					discountProductGroup1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					discountProductGroup2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductResourceTestCase.java
@@ -446,6 +446,41 @@ public abstract class BaseDiscountProductResourceTestCase {
 	}
 
 	@Test
+	public void testGetDiscountIdDiscountProductsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetDiscountIdDiscountProductsPage_getId();
+
+		DiscountProduct discountProduct1 =
+			testGetDiscountIdDiscountProductsPage_addDiscountProduct(
+				id, randomDiscountProduct());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		DiscountProduct discountProduct2 =
+			testGetDiscountIdDiscountProductsPage_addDiscountProduct(
+				id, randomDiscountProduct());
+
+		for (EntityField entityField : entityFields) {
+			Page<DiscountProduct> page =
+				discountProductResource.getDiscountIdDiscountProductsPage(
+					id, null,
+					getFilterString(entityField, "eq", discountProduct1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(discountProduct1),
+				(List<DiscountProduct>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetDiscountIdDiscountProductsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -539,6 +574,20 @@ public abstract class BaseDiscountProductResourceTestCase {
 				BeanUtils.setProperty(
 					discountProduct1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetDiscountIdDiscountProductsPageWithSortDouble()
+		throws Exception {
+
+		testGetDiscountIdDiscountProductsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, discountProduct1, discountProduct2) -> {
+				BeanUtils.setProperty(
+					discountProduct1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					discountProduct2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
@@ -261,6 +261,31 @@ public abstract class BaseDiscountResourceTestCase {
 	}
 
 	@Test
+	public void testGetDiscountsPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Discount discount1 = testGetDiscountsPage_addDiscount(randomDiscount());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Discount discount2 = testGetDiscountsPage_addDiscount(randomDiscount());
+
+		for (EntityField entityField : entityFields) {
+			Page<Discount> page = discountResource.getDiscountsPage(
+				null, getFilterString(entityField, "eq", discount1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(discount1),
+				(List<Discount>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetDiscountsPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -331,6 +356,16 @@ public abstract class BaseDiscountResourceTestCase {
 				BeanUtils.setProperty(
 					discount1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetDiscountsPageWithSortDouble() throws Exception {
+		testGetDiscountsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, discount1, discount2) -> {
+				BeanUtils.setProperty(discount1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(discount2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1834,13 +1869,15 @@ public abstract class BaseDiscountResourceTestCase {
 		}
 
 		if (entityFieldName.equals("limitationTimes")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(discount.getLimitationTimes()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("limitationTimesPerAccount")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(discount.getLimitationTimesPerAccount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("limitationType")) {
@@ -1862,8 +1899,9 @@ public abstract class BaseDiscountResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfUse")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(discount.getNumberOfUse()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("percentageLevel1")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountRuleResourceTestCase.java
@@ -590,6 +590,40 @@ public abstract class BaseDiscountRuleResourceTestCase {
 	}
 
 	@Test
+	public void testGetDiscountIdDiscountRulesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetDiscountIdDiscountRulesPage_getId();
+
+		DiscountRule discountRule1 =
+			testGetDiscountIdDiscountRulesPage_addDiscountRule(
+				id, randomDiscountRule());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		DiscountRule discountRule2 =
+			testGetDiscountIdDiscountRulesPage_addDiscountRule(
+				id, randomDiscountRule());
+
+		for (EntityField entityField : entityFields) {
+			Page<DiscountRule> page =
+				discountRuleResource.getDiscountIdDiscountRulesPage(
+					id, null, getFilterString(entityField, "eq", discountRule1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(discountRule1),
+				(List<DiscountRule>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetDiscountIdDiscountRulesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -682,6 +716,20 @@ public abstract class BaseDiscountRuleResourceTestCase {
 				BeanUtils.setProperty(
 					discountRule1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetDiscountIdDiscountRulesPageWithSortDouble()
+		throws Exception {
+
+		testGetDiscountIdDiscountRulesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, discountRule1, discountRule2) -> {
+				BeanUtils.setProperty(
+					discountRule1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					discountRule2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountSkuResourceTestCase.java
@@ -438,6 +438,40 @@ public abstract class BaseDiscountSkuResourceTestCase {
 	}
 
 	@Test
+	public void testGetDiscountIdDiscountSkusPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetDiscountIdDiscountSkusPage_getId();
+
+		DiscountSku discountSku1 =
+			testGetDiscountIdDiscountSkusPage_addDiscountSku(
+				id, randomDiscountSku());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		DiscountSku discountSku2 =
+			testGetDiscountIdDiscountSkusPage_addDiscountSku(
+				id, randomDiscountSku());
+
+		for (EntityField entityField : entityFields) {
+			Page<DiscountSku> page =
+				discountSkuResource.getDiscountIdDiscountSkusPage(
+					id, null, getFilterString(entityField, "eq", discountSku1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(discountSku1),
+				(List<DiscountSku>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetDiscountIdDiscountSkusPageWithFilterStringEquals()
 		throws Exception {
 
@@ -526,6 +560,18 @@ public abstract class BaseDiscountSkuResourceTestCase {
 				BeanUtils.setProperty(
 					discountSku1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetDiscountIdDiscountSkusPageWithSortDouble()
+		throws Exception {
+
+		testGetDiscountIdDiscountSkusPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, discountSku1, discountSku2) -> {
+				BeanUtils.setProperty(discountSku1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(discountSku2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceEntryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceEntryResourceTestCase.java
@@ -494,6 +494,40 @@ public abstract class BasePriceEntryResourceTestCase {
 	}
 
 	@Test
+	public void testGetPriceListIdPriceEntriesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetPriceListIdPriceEntriesPage_getId();
+
+		PriceEntry priceEntry1 =
+			testGetPriceListIdPriceEntriesPage_addPriceEntry(
+				id, randomPriceEntry());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PriceEntry priceEntry2 =
+			testGetPriceListIdPriceEntriesPage_addPriceEntry(
+				id, randomPriceEntry());
+
+		for (EntityField entityField : entityFields) {
+			Page<PriceEntry> page =
+				priceEntryResource.getPriceListIdPriceEntriesPage(
+					id, null, getFilterString(entityField, "eq", priceEntry1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(priceEntry1),
+				(List<PriceEntry>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetPriceListIdPriceEntriesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -582,6 +616,18 @@ public abstract class BasePriceEntryResourceTestCase {
 				BeanUtils.setProperty(
 					priceEntry1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetPriceListIdPriceEntriesPageWithSortDouble()
+		throws Exception {
+
+		testGetPriceListIdPriceEntriesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, priceEntry1, priceEntry2) -> {
+				BeanUtils.setProperty(priceEntry1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(priceEntry2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1628,8 +1674,9 @@ public abstract class BasePriceEntryResourceTestCase {
 		}
 
 		if (entityFieldName.equals("price")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(priceEntry.getPrice()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("priceEntryId")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountGroupResourceTestCase.java
@@ -469,6 +469,43 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 	}
 
 	@Test
+	public void testGetPriceListIdPriceListAccountGroupsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetPriceListIdPriceListAccountGroupsPage_getId();
+
+		PriceListAccountGroup priceListAccountGroup1 =
+			testGetPriceListIdPriceListAccountGroupsPage_addPriceListAccountGroup(
+				id, randomPriceListAccountGroup());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PriceListAccountGroup priceListAccountGroup2 =
+			testGetPriceListIdPriceListAccountGroupsPage_addPriceListAccountGroup(
+				id, randomPriceListAccountGroup());
+
+		for (EntityField entityField : entityFields) {
+			Page<PriceListAccountGroup> page =
+				priceListAccountGroupResource.
+					getPriceListIdPriceListAccountGroupsPage(
+						id, null,
+						getFilterString(
+							entityField, "eq", priceListAccountGroup1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(priceListAccountGroup1),
+				(List<PriceListAccountGroup>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetPriceListIdPriceListAccountGroupsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -571,6 +608,20 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 				BeanUtils.setProperty(
 					priceListAccountGroup1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetPriceListIdPriceListAccountGroupsPageWithSortDouble()
+		throws Exception {
+
+		testGetPriceListIdPriceListAccountGroupsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, priceListAccountGroup1, priceListAccountGroup2) -> {
+				BeanUtils.setProperty(
+					priceListAccountGroup1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					priceListAccountGroup2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1235,8 +1286,9 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 		}
 
 		if (entityFieldName.equals("order")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(priceListAccountGroup.getOrder()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("priceListAccountGroupId")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountResourceTestCase.java
@@ -447,6 +447,41 @@ public abstract class BasePriceListAccountResourceTestCase {
 	}
 
 	@Test
+	public void testGetPriceListIdPriceListAccountsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetPriceListIdPriceListAccountsPage_getId();
+
+		PriceListAccount priceListAccount1 =
+			testGetPriceListIdPriceListAccountsPage_addPriceListAccount(
+				id, randomPriceListAccount());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PriceListAccount priceListAccount2 =
+			testGetPriceListIdPriceListAccountsPage_addPriceListAccount(
+				id, randomPriceListAccount());
+
+		for (EntityField entityField : entityFields) {
+			Page<PriceListAccount> page =
+				priceListAccountResource.getPriceListIdPriceListAccountsPage(
+					id, null,
+					getFilterString(entityField, "eq", priceListAccount1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(priceListAccount1),
+				(List<PriceListAccount>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetPriceListIdPriceListAccountsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -541,6 +576,20 @@ public abstract class BasePriceListAccountResourceTestCase {
 				BeanUtils.setProperty(
 					priceListAccount1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetPriceListIdPriceListAccountsPageWithSortDouble()
+		throws Exception {
+
+		testGetPriceListIdPriceListAccountsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, priceListAccount1, priceListAccount2) -> {
+				BeanUtils.setProperty(
+					priceListAccount1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					priceListAccount2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1184,8 +1233,9 @@ public abstract class BasePriceListAccountResourceTestCase {
 		}
 
 		if (entityFieldName.equals("order")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(priceListAccount.getOrder()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("priceListAccountId")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListChannelResourceTestCase.java
@@ -447,6 +447,41 @@ public abstract class BasePriceListChannelResourceTestCase {
 	}
 
 	@Test
+	public void testGetPriceListIdPriceListChannelsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetPriceListIdPriceListChannelsPage_getId();
+
+		PriceListChannel priceListChannel1 =
+			testGetPriceListIdPriceListChannelsPage_addPriceListChannel(
+				id, randomPriceListChannel());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PriceListChannel priceListChannel2 =
+			testGetPriceListIdPriceListChannelsPage_addPriceListChannel(
+				id, randomPriceListChannel());
+
+		for (EntityField entityField : entityFields) {
+			Page<PriceListChannel> page =
+				priceListChannelResource.getPriceListIdPriceListChannelsPage(
+					id, null,
+					getFilterString(entityField, "eq", priceListChannel1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(priceListChannel1),
+				(List<PriceListChannel>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetPriceListIdPriceListChannelsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -541,6 +576,20 @@ public abstract class BasePriceListChannelResourceTestCase {
 				BeanUtils.setProperty(
 					priceListChannel1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetPriceListIdPriceListChannelsPageWithSortDouble()
+		throws Exception {
+
+		testGetPriceListIdPriceListChannelsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, priceListChannel1, priceListChannel2) -> {
+				BeanUtils.setProperty(
+					priceListChannel1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					priceListChannel2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1184,8 +1233,9 @@ public abstract class BasePriceListChannelResourceTestCase {
 		}
 
 		if (entityFieldName.equals("order")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(priceListChannel.getOrder()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("priceListChannelId")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListDiscountResourceTestCase.java
@@ -961,8 +961,9 @@ public abstract class BasePriceListDiscountResourceTestCase {
 		}
 
 		if (entityFieldName.equals("order")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(priceListDiscount.getOrder()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("priceListDiscountId")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListOrderTypeResourceTestCase.java
@@ -1008,8 +1008,9 @@ public abstract class BasePriceListOrderTypeResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(priceListOrderType.getPriority()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
@@ -259,6 +259,33 @@ public abstract class BasePriceListResourceTestCase {
 	}
 
 	@Test
+	public void testGetPriceListsPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		PriceList priceList1 = testGetPriceListsPage_addPriceList(
+			randomPriceList());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PriceList priceList2 = testGetPriceListsPage_addPriceList(
+			randomPriceList());
+
+		for (EntityField entityField : entityFields) {
+			Page<PriceList> page = priceListResource.getPriceListsPage(
+				null, getFilterString(entityField, "eq", priceList1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(priceList1),
+				(List<PriceList>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetPriceListsPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -334,6 +361,16 @@ public abstract class BasePriceListResourceTestCase {
 				BeanUtils.setProperty(
 					priceList1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetPriceListsPageWithSortDouble() throws Exception {
+		testGetPriceListsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, priceList1, priceList2) -> {
+				BeanUtils.setProperty(priceList1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(priceList2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1799,8 +1836,9 @@ public abstract class BasePriceListResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(priceList.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("type")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierCategoryResourceTestCase.java
@@ -469,6 +469,43 @@ public abstract class BasePriceModifierCategoryResourceTestCase {
 	}
 
 	@Test
+	public void testGetPriceModifierIdPriceModifierCategoriesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetPriceModifierIdPriceModifierCategoriesPage_getId();
+
+		PriceModifierCategory priceModifierCategory1 =
+			testGetPriceModifierIdPriceModifierCategoriesPage_addPriceModifierCategory(
+				id, randomPriceModifierCategory());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PriceModifierCategory priceModifierCategory2 =
+			testGetPriceModifierIdPriceModifierCategoriesPage_addPriceModifierCategory(
+				id, randomPriceModifierCategory());
+
+		for (EntityField entityField : entityFields) {
+			Page<PriceModifierCategory> page =
+				priceModifierCategoryResource.
+					getPriceModifierIdPriceModifierCategoriesPage(
+						id, null,
+						getFilterString(
+							entityField, "eq", priceModifierCategory1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(priceModifierCategory1),
+				(List<PriceModifierCategory>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetPriceModifierIdPriceModifierCategoriesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -571,6 +608,20 @@ public abstract class BasePriceModifierCategoryResourceTestCase {
 				BeanUtils.setProperty(
 					priceModifierCategory1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetPriceModifierIdPriceModifierCategoriesPageWithSortDouble()
+		throws Exception {
+
+		testGetPriceModifierIdPriceModifierCategoriesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, priceModifierCategory1, priceModifierCategory2) -> {
+				BeanUtils.setProperty(
+					priceModifierCategory1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					priceModifierCategory2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductGroupResourceTestCase.java
@@ -476,6 +476,43 @@ public abstract class BasePriceModifierProductGroupResourceTestCase {
 	}
 
 	@Test
+	public void testGetPriceModifierIdPriceModifierProductGroupsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetPriceModifierIdPriceModifierProductGroupsPage_getId();
+
+		PriceModifierProductGroup priceModifierProductGroup1 =
+			testGetPriceModifierIdPriceModifierProductGroupsPage_addPriceModifierProductGroup(
+				id, randomPriceModifierProductGroup());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PriceModifierProductGroup priceModifierProductGroup2 =
+			testGetPriceModifierIdPriceModifierProductGroupsPage_addPriceModifierProductGroup(
+				id, randomPriceModifierProductGroup());
+
+		for (EntityField entityField : entityFields) {
+			Page<PriceModifierProductGroup> page =
+				priceModifierProductGroupResource.
+					getPriceModifierIdPriceModifierProductGroupsPage(
+						id, null,
+						getFilterString(
+							entityField, "eq", priceModifierProductGroup1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(priceModifierProductGroup1),
+				(List<PriceModifierProductGroup>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetPriceModifierIdPriceModifierProductGroupsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -580,6 +617,22 @@ public abstract class BasePriceModifierProductGroupResourceTestCase {
 				BeanUtils.setProperty(
 					priceModifierProductGroup1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetPriceModifierIdPriceModifierProductGroupsPageWithSortDouble()
+		throws Exception {
+
+		testGetPriceModifierIdPriceModifierProductGroupsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, priceModifierProductGroup1,
+			 priceModifierProductGroup2) -> {
+
+				BeanUtils.setProperty(
+					priceModifierProductGroup1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					priceModifierProductGroup2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductResourceTestCase.java
@@ -467,6 +467,43 @@ public abstract class BasePriceModifierProductResourceTestCase {
 	}
 
 	@Test
+	public void testGetPriceModifierIdPriceModifierProductsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetPriceModifierIdPriceModifierProductsPage_getId();
+
+		PriceModifierProduct priceModifierProduct1 =
+			testGetPriceModifierIdPriceModifierProductsPage_addPriceModifierProduct(
+				id, randomPriceModifierProduct());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PriceModifierProduct priceModifierProduct2 =
+			testGetPriceModifierIdPriceModifierProductsPage_addPriceModifierProduct(
+				id, randomPriceModifierProduct());
+
+		for (EntityField entityField : entityFields) {
+			Page<PriceModifierProduct> page =
+				priceModifierProductResource.
+					getPriceModifierIdPriceModifierProductsPage(
+						id, null,
+						getFilterString(
+							entityField, "eq", priceModifierProduct1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(priceModifierProduct1),
+				(List<PriceModifierProduct>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetPriceModifierIdPriceModifierProductsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -569,6 +606,20 @@ public abstract class BasePriceModifierProductResourceTestCase {
 				BeanUtils.setProperty(
 					priceModifierProduct1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetPriceModifierIdPriceModifierProductsPageWithSortDouble()
+		throws Exception {
+
+		testGetPriceModifierIdPriceModifierProductsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, priceModifierProduct1, priceModifierProduct2) -> {
+				BeanUtils.setProperty(
+					priceModifierProduct1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					priceModifierProduct2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierResourceTestCase.java
@@ -448,6 +448,41 @@ public abstract class BasePriceModifierResourceTestCase {
 	}
 
 	@Test
+	public void testGetPriceListIdPriceModifiersPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long id = testGetPriceListIdPriceModifiersPage_getId();
+
+		PriceModifier priceModifier1 =
+			testGetPriceListIdPriceModifiersPage_addPriceModifier(
+				id, randomPriceModifier());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PriceModifier priceModifier2 =
+			testGetPriceListIdPriceModifiersPage_addPriceModifier(
+				id, randomPriceModifier());
+
+		for (EntityField entityField : entityFields) {
+			Page<PriceModifier> page =
+				priceModifierResource.getPriceListIdPriceModifiersPage(
+					id, null,
+					getFilterString(entityField, "eq", priceModifier1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(priceModifier1),
+				(List<PriceModifier>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetPriceListIdPriceModifiersPageWithFilterStringEquals()
 		throws Exception {
 
@@ -541,6 +576,20 @@ public abstract class BasePriceModifierResourceTestCase {
 				BeanUtils.setProperty(
 					priceModifier1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetPriceListIdPriceModifiersPageWithSortDouble()
+		throws Exception {
+
+		testGetPriceListIdPriceModifiersPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, priceModifier1, priceModifier2) -> {
+				BeanUtils.setProperty(
+					priceModifier1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					priceModifier2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1700,8 +1749,9 @@ public abstract class BasePriceModifierResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(priceModifier.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("target")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductGroupResourceTestCase.java
@@ -653,8 +653,9 @@ public abstract class BaseProductGroupResourceTestCase {
 		}
 
 		if (entityFieldName.equals("productsCount")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(productGroup.getProductsCount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("title")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseSkuResourceTestCase.java
@@ -669,8 +669,9 @@ public abstract class BaseSkuResourceTestCase {
 		sb.append(" ");
 
 		if (entityFieldName.equals("basePrice")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sku.getBasePrice()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("basePriceFormatted")) {
@@ -682,8 +683,9 @@ public abstract class BaseSkuResourceTestCase {
 		}
 
 		if (entityFieldName.equals("basePromoPrice")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sku.getBasePromoPrice()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("basePromoPriceFormatted")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseTierPriceResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseTierPriceResourceTestCase.java
@@ -1434,8 +1434,9 @@ public abstract class BaseTierPriceResourceTestCase {
 		}
 
 		if (entityFieldName.equals("minimumQuantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(tierPrice.getMinimumQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("neverExpire")) {
@@ -1444,8 +1445,9 @@ public abstract class BaseTierPriceResourceTestCase {
 		}
 
 		if (entityFieldName.equals("price")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(tierPrice.getPrice()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("priceEntryExternalReferenceCode")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/DiscountAccountGroupResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/DiscountAccountGroupResourceTest.java
@@ -177,6 +177,12 @@ public class DiscountAccountGroupResourceTest
 
 	@Override
 	@Test
+	public void testGetDiscountIdDiscountAccountGroupsPageWithFilterDoubleEquals()
+		throws Exception {
+	}
+
+	@Override
+	@Test
 	public void testGetDiscountIdDiscountAccountGroupsPageWithFilterStringEquals()
 		throws Exception {
 	}
@@ -184,6 +190,12 @@ public class DiscountAccountGroupResourceTest
 	@Override
 	@Test
 	public void testGetDiscountIdDiscountAccountGroupsPageWithSortDateTime()
+		throws Exception {
+	}
+
+	@Override
+	@Test
+	public void testGetDiscountIdDiscountAccountGroupsPageWithSortDouble()
 		throws Exception {
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-openapi.yaml
@@ -295,7 +295,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Admin Shipment API. A Java client JAR is available for use with the group ID
-        'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.11'."
+        'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.12'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Admin Shipment API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Admin Shipment API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Admin Shipment API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Admin Shipment API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentItemResourceTestCase.java
@@ -1350,8 +1350,9 @@ public abstract class BaseShipmentItemResourceTestCase {
 		}
 
 		if (entityFieldName.equals("quantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(shipmentItem.getQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("shipmentExternalReferenceCode")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
@@ -257,6 +257,31 @@ public abstract class BaseShipmentResourceTestCase {
 	}
 
 	@Test
+	public void testGetShipmentsPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Shipment shipment1 = testGetShipmentsPage_addShipment(randomShipment());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Shipment shipment2 = testGetShipmentsPage_addShipment(randomShipment());
+
+		for (EntityField entityField : entityFields) {
+			Page<Shipment> page = shipmentResource.getShipmentsPage(
+				null, getFilterString(entityField, "eq", shipment1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(shipment1),
+				(List<Shipment>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetShipmentsPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -327,6 +352,16 @@ public abstract class BaseShipmentResourceTestCase {
 				BeanUtils.setProperty(
 					shipment1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetShipmentsPageWithSortDouble() throws Exception {
+		testGetShipmentsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, shipment1, shipment2) -> {
+				BeanUtils.setProperty(shipment1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(shipment2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
@@ -1010,13 +1010,15 @@ public abstract class BaseShippingAddressResourceTestCase {
 		}
 
 		if (entityFieldName.equals("latitude")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(shippingAddress.getLatitude()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("longitude")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(shippingAddress.getLongitude()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("name")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/rest-openapi.yaml
@@ -315,7 +315,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Site Setting API. A Java client JAR is available for use with the group ID
-        'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.site.setting.client', and version '4.0.11'."
+        'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.site.setting.client', and version '4.0.12'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Site Setting API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.site.setting.client', and version '4.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Site Setting API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Site Setting API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.site.setting.client', and version '4.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Site Setting API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseAvailabilityEstimateResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseAvailabilityEstimateResourceTestCase.java
@@ -860,8 +860,9 @@ public abstract class BaseAvailabilityEstimateResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(availabilityEstimate.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("title")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseMeasurementUnitResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseMeasurementUnitResourceTestCase.java
@@ -932,18 +932,21 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(measurementUnit.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("rate")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(measurementUnit.getRate()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("type")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(measurementUnit.getType()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseWarehouseResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseWarehouseResourceTestCase.java
@@ -1062,13 +1062,15 @@ public abstract class BaseWarehouseResourceTestCase {
 		}
 
 		if (entityFieldName.equals("latitude")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(warehouse.getLatitude()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("longitude")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(warehouse.getLongitude()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("mvccVersion")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-openapi.yaml
@@ -502,7 +502,7 @@ components:
 info:
     description:
         "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.14'."
+        artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.15'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.14'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Cart API", version = "v1.0")
+	info = @Info(description = "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.15'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Cart API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
@@ -943,13 +943,15 @@ public abstract class BaseAddressResourceTestCase {
 		}
 
 		if (entityFieldName.equals("latitude")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(address.getLatitude()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("longitude")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(address.getLongitude()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("name")) {
@@ -1017,8 +1019,9 @@ public abstract class BaseAddressResourceTestCase {
 		}
 
 		if (entityFieldName.equals("typeId")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(address.getTypeId()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("vatNumber")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartItemResourceTestCase.java
@@ -1167,8 +1167,9 @@ public abstract class BaseCartItemResourceTestCase {
 		}
 
 		if (entityFieldName.equals("quantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(cartItem.getQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("settings")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartResourceTestCase.java
@@ -1688,8 +1688,9 @@ public abstract class BaseCartResourceTestCase {
 		}
 
 		if (entityFieldName.equals("paymentStatus")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(cart.getPaymentStatus()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("paymentStatusInfo")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-openapi.yaml
@@ -614,7 +614,7 @@ components:
 info:
     description:
         "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.17'."
+        artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.18'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.17'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Commerce Delivery Catalog API", version = "v1.0")
+	info = @Info(description = "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.18'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Commerce Delivery Catalog API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
@@ -986,8 +986,9 @@ public abstract class BaseAttachmentResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(attachment.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("src")) {
@@ -1007,8 +1008,9 @@ public abstract class BaseAttachmentResourceTestCase {
 		}
 
 		if (entityFieldName.equals("type")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(attachment.getType()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
@@ -321,6 +321,20 @@ public abstract class BaseMappedProductResourceTestCase {
 	}
 
 	@Test
+	public void testGetChannelProductMappedProductsPageWithSortDouble()
+		throws Exception {
+
+		testGetChannelProductMappedProductsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, mappedProduct1, mappedProduct2) -> {
+				BeanUtils.setProperty(
+					mappedProduct1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					mappedProduct2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetChannelProductMappedProductsPageWithSortInteger()
 		throws Exception {
 
@@ -1255,8 +1269,9 @@ public abstract class BaseMappedProductResourceTestCase {
 		}
 
 		if (entityFieldName.equals("quantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(mappedProduct.getQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("replacementMappedProduct")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BasePinResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BasePinResourceTestCase.java
@@ -291,6 +291,16 @@ public abstract class BasePinResourceTestCase {
 	}
 
 	@Test
+	public void testGetChannelProductPinsPageWithSortDouble() throws Exception {
+		testGetChannelProductPinsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, pin1, pin2) -> {
+				BeanUtils.setProperty(pin1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(pin2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetChannelProductPinsPageWithSortInteger()
 		throws Exception {
 
@@ -779,13 +789,15 @@ public abstract class BasePinResourceTestCase {
 		}
 
 		if (entityFieldName.equals("positionX")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(pin.getPositionX()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("positionY")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(pin.getPositionY()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("sequence")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
@@ -819,8 +819,9 @@ public abstract class BaseProductOptionResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(productOption.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("productOptionValues")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -283,6 +283,37 @@ public abstract class BaseProductResourceTestCase {
 	}
 
 	@Test
+	public void testGetChannelProductsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long channelId = testGetChannelProductsPage_getChannelId();
+
+		Product product1 = testGetChannelProductsPage_addProduct(
+			channelId, randomProduct());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Product product2 = testGetChannelProductsPage_addProduct(
+			channelId, randomProduct());
+
+		for (EntityField entityField : entityFields) {
+			Page<Product> page = productResource.getChannelProductsPage(
+				channelId, null, getFilterString(entityField, "eq", product1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(product1),
+				(List<Product>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetChannelProductsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -358,6 +389,16 @@ public abstract class BaseProductResourceTestCase {
 				BeanUtils.setProperty(
 					product1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetChannelProductsPageWithSortDouble() throws Exception {
+		testGetChannelProductsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, product1, product2) -> {
+				BeanUtils.setProperty(product1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(product2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1392,8 +1433,9 @@ public abstract class BaseProductResourceTestCase {
 		}
 
 		if (entityFieldName.equals("multipleOrderQuantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(product.getMultipleOrderQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("name")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
@@ -785,8 +785,9 @@ public abstract class BaseProductSpecificationResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(productSpecification.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("productId")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
@@ -684,8 +684,9 @@ public abstract class BaseRelatedProductResourceTestCase {
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(relatedProduct.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("productId")) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
@@ -908,8 +908,9 @@ public abstract class BaseSkuResourceTestCase {
 		}
 
 		if (entityFieldName.equals("depth")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sku.getDepth()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("displayDate")) {
@@ -983,8 +984,9 @@ public abstract class BaseSkuResourceTestCase {
 		}
 
 		if (entityFieldName.equals("height")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sku.getHeight()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("id")) {
@@ -1001,13 +1003,15 @@ public abstract class BaseSkuResourceTestCase {
 		}
 
 		if (entityFieldName.equals("maxOrderQuantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sku.getMaxOrderQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("minOrderQuantity")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sku.getMinOrderQuantity()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("neverExpire")) {
@@ -1044,13 +1048,15 @@ public abstract class BaseSkuResourceTestCase {
 		}
 
 		if (entityFieldName.equals("weight")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sku.getWeight()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("width")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sku.getWidth()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
+++ b/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
@@ -329,7 +329,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.data.engine.rest.client', and version '3.0.13'."
+        'com.liferay.data.engine.rest.client', and version '3.0.14'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/OpenAPIResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.data.engine.rest.client', and version '3.0.13'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Data Engine", version = "v2.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.data.engine.rest.client', and version '3.0.14'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Data Engine", version = "v2.0")
 )
 @Path("/v2.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
@@ -332,6 +332,20 @@ public abstract class BaseDataDefinitionResourceTestCase {
 	}
 
 	@Test
+	public void testGetDataDefinitionByContentTypeContentTypePageWithSortDouble()
+		throws Exception {
+
+		testGetDataDefinitionByContentTypeContentTypePageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, dataDefinition1, dataDefinition2) -> {
+				BeanUtils.setProperty(
+					dataDefinition1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					dataDefinition2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetDataDefinitionByContentTypeContentTypePageWithSortInteger()
 		throws Exception {
 
@@ -886,6 +900,20 @@ public abstract class BaseDataDefinitionResourceTestCase {
 				BeanUtils.setProperty(
 					dataDefinition1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteDataDefinitionByContentTypeContentTypePageWithSortDouble()
+		throws Exception {
+
+		testGetSiteDataDefinitionByContentTypeContentTypePageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, dataDefinition1, dataDefinition2) -> {
+				BeanUtils.setProperty(
+					dataDefinition1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					dataDefinition2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
@@ -331,6 +331,18 @@ public abstract class BaseDataLayoutResourceTestCase {
 	}
 
 	@Test
+	public void testGetDataDefinitionDataLayoutsPageWithSortDouble()
+		throws Exception {
+
+		testGetDataDefinitionDataLayoutsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, dataLayout1, dataLayout2) -> {
+				BeanUtils.setProperty(dataLayout1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(dataLayout2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetDataDefinitionDataLayoutsPageWithSortInteger()
 		throws Exception {
 

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
@@ -332,6 +332,20 @@ public abstract class BaseDataListViewResourceTestCase {
 	}
 
 	@Test
+	public void testGetDataDefinitionDataListViewsPageWithSortDouble()
+		throws Exception {
+
+		testGetDataDefinitionDataListViewsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, dataListView1, dataListView2) -> {
+				BeanUtils.setProperty(
+					dataListView1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					dataListView2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetDataDefinitionDataListViewsPageWithSortInteger()
 		throws Exception {
 

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
@@ -305,6 +305,18 @@ public abstract class BaseDataRecordResourceTestCase {
 	}
 
 	@Test
+	public void testGetDataDefinitionDataRecordsPageWithSortDouble()
+		throws Exception {
+
+		testGetDataDefinitionDataRecordsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, dataRecord1, dataRecord2) -> {
+				BeanUtils.setProperty(dataRecord1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(dataRecord2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetDataDefinitionDataRecordsPageWithSortInteger()
 		throws Exception {
 
@@ -571,6 +583,18 @@ public abstract class BaseDataRecordResourceTestCase {
 				BeanUtils.setProperty(
 					dataRecord1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetDataRecordCollectionDataRecordsPageWithSortDouble()
+		throws Exception {
+
+		testGetDataRecordCollectionDataRecordsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, dataRecord1, dataRecord2) -> {
+				BeanUtils.setProperty(dataRecord1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(dataRecord2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1257,8 +1281,9 @@ public abstract class BaseDataRecordResourceTestCase {
 		}
 
 		if (entityFieldName.equals("status")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(dataRecord.getStatus()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/digital-signature/digital-signature-rest-impl/rest-openapi.yaml
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/rest-openapi.yaml
@@ -61,7 +61,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.digital.signature.rest.client', and version '1.0.5'."
+        'com.liferay.digital.signature.rest.client', and version '1.0.6'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.digital.signature.rest.client', and version '1.0.5'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.digital.signature.rest.client', and version '1.0.6'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
@@ -186,7 +186,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.content.client', and version '2.0.13'."
+        'com.liferay.headless.admin.content.client', and version '2.0.14'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.13'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.14'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseDisplayPageTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseDisplayPageTemplateResourceTestCase.java
@@ -313,6 +313,20 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteDisplayPageTemplatesPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteDisplayPageTemplatesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, displayPageTemplate1, displayPageTemplate2) -> {
+				BeanUtils.setProperty(
+					displayPageTemplate1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					displayPageTemplate2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetSiteDisplayPageTemplatesPageWithSortInteger()
 		throws Exception {
 

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BasePageDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BasePageDefinitionResourceTestCase.java
@@ -524,8 +524,9 @@ public abstract class BasePageDefinitionResourceTestCase {
 		}
 
 		if (entityFieldName.equals("version")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(pageDefinition.getVersion()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -291,6 +291,41 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteStructuredContentsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteStructuredContentsPage_getSiteId();
+
+		StructuredContent structuredContent1 =
+			testGetSiteStructuredContentsPage_addStructuredContent(
+				siteId, randomStructuredContent());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		StructuredContent structuredContent2 =
+			testGetSiteStructuredContentsPage_addStructuredContent(
+				siteId, randomStructuredContent());
+
+		for (EntityField entityField : entityFields) {
+			Page<StructuredContent> page =
+				structuredContentResource.getSiteStructuredContentsPage(
+					siteId, null, null, null,
+					getFilterString(entityField, "eq", structuredContent1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(structuredContent1),
+				(List<StructuredContent>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteStructuredContentsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -385,6 +420,20 @@ public abstract class BaseStructuredContentResourceTestCase {
 				BeanUtils.setProperty(
 					structuredContent1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteStructuredContentsPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteStructuredContentsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, structuredContent1, structuredContent2) -> {
+				BeanUtils.setProperty(
+					structuredContent1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					structuredContent2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1833,13 +1882,15 @@ public abstract class BaseStructuredContentResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfComments")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(structuredContent.getNumberOfComments()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(structuredContent.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("relatedContents")) {

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
@@ -293,6 +293,7 @@ public class StructuredContentResourceTest
 					{
 						setContentStructureId(
 							structuredContent.getContentStructureId());
+						setPriority(structuredContent.getPriority());
 						setSiteId(structuredContent.getSiteId());
 						setTitle(structuredContent.getTitle());
 					}

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-openapi.yaml
@@ -68,7 +68,7 @@ info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
         'om.liferay.headless.admin.list.type.client', and version '1.0.0'.. A Java client JAR is available for use with
-        the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.7'."
+        the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.8'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'om.liferay.headless.admin.list.type.client', and version '1.0.0'.. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.7'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "List Type", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'om.liferay.headless.admin.list.type.client', and version '1.0.0'.. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.8'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "List Type", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
@@ -265,6 +265,39 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 	}
 
 	@Test
+	public void testGetListTypeDefinitionsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		ListTypeDefinition listTypeDefinition1 =
+			testGetListTypeDefinitionsPage_addListTypeDefinition(
+				randomListTypeDefinition());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ListTypeDefinition listTypeDefinition2 =
+			testGetListTypeDefinitionsPage_addListTypeDefinition(
+				randomListTypeDefinition());
+
+		for (EntityField entityField : entityFields) {
+			Page<ListTypeDefinition> page =
+				listTypeDefinitionResource.getListTypeDefinitionsPage(
+					null, null,
+					getFilterString(entityField, "eq", listTypeDefinition1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(listTypeDefinition1),
+				(List<ListTypeDefinition>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetListTypeDefinitionsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -364,6 +397,20 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 				BeanUtils.setProperty(
 					listTypeDefinition1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetListTypeDefinitionsPageWithSortDouble()
+		throws Exception {
+
+		testGetListTypeDefinitionsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, listTypeDefinition1, listTypeDefinition2) -> {
+				BeanUtils.setProperty(
+					listTypeDefinition1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					listTypeDefinition2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeEntryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeEntryResourceTestCase.java
@@ -292,6 +292,42 @@ public abstract class BaseListTypeEntryResourceTestCase {
 	}
 
 	@Test
+	public void testGetListTypeDefinitionListTypeEntriesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long listTypeDefinitionId =
+			testGetListTypeDefinitionListTypeEntriesPage_getListTypeDefinitionId();
+
+		ListTypeEntry listTypeEntry1 =
+			testGetListTypeDefinitionListTypeEntriesPage_addListTypeEntry(
+				listTypeDefinitionId, randomListTypeEntry());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ListTypeEntry listTypeEntry2 =
+			testGetListTypeDefinitionListTypeEntriesPage_addListTypeEntry(
+				listTypeDefinitionId, randomListTypeEntry());
+
+		for (EntityField entityField : entityFields) {
+			Page<ListTypeEntry> page =
+				listTypeEntryResource.getListTypeDefinitionListTypeEntriesPage(
+					listTypeDefinitionId, null, null,
+					getFilterString(entityField, "eq", listTypeEntry1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(listTypeEntry1),
+				(List<ListTypeEntry>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetListTypeDefinitionListTypeEntriesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -390,6 +426,20 @@ public abstract class BaseListTypeEntryResourceTestCase {
 				BeanUtils.setProperty(
 					listTypeEntry1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetListTypeDefinitionListTypeEntriesPageWithSortDouble()
+		throws Exception {
+
+		testGetListTypeDefinitionListTypeEntriesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, listTypeEntry1, listTypeEntry2) -> {
+				BeanUtils.setProperty(
+					listTypeEntry1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					listTypeEntry2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -363,7 +363,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.taxonomy.client', and version '4.0.13'."
+        'com.liferay.headless.admin.taxonomy.client', and version '4.0.14'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.taxonomy.client', and version '4.0.13'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Taxonomy", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.taxonomy.client', and version '4.0.14'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Taxonomy", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -299,6 +299,39 @@ public abstract class BaseKeywordResourceTestCase {
 	}
 
 	@Test
+	public void testGetAssetLibraryKeywordsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long assetLibraryId =
+			testGetAssetLibraryKeywordsPage_getAssetLibraryId();
+
+		Keyword keyword1 = testGetAssetLibraryKeywordsPage_addKeyword(
+			assetLibraryId, randomKeyword());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Keyword keyword2 = testGetAssetLibraryKeywordsPage_addKeyword(
+			assetLibraryId, randomKeyword());
+
+		for (EntityField entityField : entityFields) {
+			Page<Keyword> page = keywordResource.getAssetLibraryKeywordsPage(
+				assetLibraryId, null,
+				getFilterString(entityField, "eq", keyword1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(keyword1),
+				(List<Keyword>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetAssetLibraryKeywordsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -381,6 +414,18 @@ public abstract class BaseKeywordResourceTestCase {
 				BeanUtils.setProperty(
 					keyword1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAssetLibraryKeywordsPageWithSortDouble()
+		throws Exception {
+
+		testGetAssetLibraryKeywordsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, keyword1, keyword2) -> {
+				BeanUtils.setProperty(keyword1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(keyword2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -908,6 +953,37 @@ public abstract class BaseKeywordResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteKeywordsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteKeywordsPage_getSiteId();
+
+		Keyword keyword1 = testGetSiteKeywordsPage_addKeyword(
+			siteId, randomKeyword());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Keyword keyword2 = testGetSiteKeywordsPage_addKeyword(
+			siteId, randomKeyword());
+
+		for (EntityField entityField : entityFields) {
+			Page<Keyword> page = keywordResource.getSiteKeywordsPage(
+				siteId, null, getFilterString(entityField, "eq", keyword1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(keyword1),
+				(List<Keyword>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteKeywordsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -983,6 +1059,16 @@ public abstract class BaseKeywordResourceTestCase {
 				BeanUtils.setProperty(
 					keyword1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteKeywordsPageWithSortDouble() throws Exception {
+		testGetSiteKeywordsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, keyword1, keyword2) -> {
+				BeanUtils.setProperty(keyword1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(keyword2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1828,8 +1914,9 @@ public abstract class BaseKeywordResourceTestCase {
 		}
 
 		if (entityFieldName.equals("keywordUsageCount")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(keyword.getKeywordUsageCount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("name")) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -406,6 +406,43 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	}
 
 	@Test
+	public void testGetTaxonomyCategoryTaxonomyCategoriesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		String parentTaxonomyCategoryId =
+			testGetTaxonomyCategoryTaxonomyCategoriesPage_getParentTaxonomyCategoryId();
+
+		TaxonomyCategory taxonomyCategory1 =
+			testGetTaxonomyCategoryTaxonomyCategoriesPage_addTaxonomyCategory(
+				parentTaxonomyCategoryId, randomTaxonomyCategory());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		TaxonomyCategory taxonomyCategory2 =
+			testGetTaxonomyCategoryTaxonomyCategoriesPage_addTaxonomyCategory(
+				parentTaxonomyCategoryId, randomTaxonomyCategory());
+
+		for (EntityField entityField : entityFields) {
+			Page<TaxonomyCategory> page =
+				taxonomyCategoryResource.
+					getTaxonomyCategoryTaxonomyCategoriesPage(
+						parentTaxonomyCategoryId, null,
+						getFilterString(entityField, "eq", taxonomyCategory1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(taxonomyCategory1),
+				(List<TaxonomyCategory>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetTaxonomyCategoryTaxonomyCategoriesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -506,6 +543,20 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				BeanUtils.setProperty(
 					taxonomyCategory1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetTaxonomyCategoryTaxonomyCategoriesPageWithSortDouble()
+		throws Exception {
+
+		testGetTaxonomyCategoryTaxonomyCategoriesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, taxonomyCategory1, taxonomyCategory2) -> {
+				BeanUtils.setProperty(
+					taxonomyCategory1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					taxonomyCategory2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1040,6 +1091,43 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	}
 
 	@Test
+	public void testGetTaxonomyVocabularyTaxonomyCategoriesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long taxonomyVocabularyId =
+			testGetTaxonomyVocabularyTaxonomyCategoriesPage_getTaxonomyVocabularyId();
+
+		TaxonomyCategory taxonomyCategory1 =
+			testGetTaxonomyVocabularyTaxonomyCategoriesPage_addTaxonomyCategory(
+				taxonomyVocabularyId, randomTaxonomyCategory());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		TaxonomyCategory taxonomyCategory2 =
+			testGetTaxonomyVocabularyTaxonomyCategoriesPage_addTaxonomyCategory(
+				taxonomyVocabularyId, randomTaxonomyCategory());
+
+		for (EntityField entityField : entityFields) {
+			Page<TaxonomyCategory> page =
+				taxonomyCategoryResource.
+					getTaxonomyVocabularyTaxonomyCategoriesPage(
+						taxonomyVocabularyId, null,
+						getFilterString(entityField, "eq", taxonomyCategory1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(taxonomyCategory1),
+				(List<TaxonomyCategory>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetTaxonomyVocabularyTaxonomyCategoriesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1143,6 +1231,20 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				BeanUtils.setProperty(
 					taxonomyCategory1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetTaxonomyVocabularyTaxonomyCategoriesPageWithSortDouble()
+		throws Exception {
+
+		testGetTaxonomyVocabularyTaxonomyCategoriesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, taxonomyCategory1, taxonomyCategory2) -> {
+				BeanUtils.setProperty(
+					taxonomyCategory1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					taxonomyCategory2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -2297,8 +2399,11 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfTaxonomyCategories")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					taxonomyCategory.getNumberOfTaxonomyCategories()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("parentTaxonomyCategory")) {
@@ -2322,8 +2427,11 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		}
 
 		if (entityFieldName.equals("taxonomyCategoryUsageCount")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					taxonomyCategory.getTaxonomyCategoryUsageCount()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("taxonomyVocabularyId")) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -319,6 +319,43 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	}
 
 	@Test
+	public void testGetAssetLibraryTaxonomyVocabulariesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long assetLibraryId =
+			testGetAssetLibraryTaxonomyVocabulariesPage_getAssetLibraryId();
+
+		TaxonomyVocabulary taxonomyVocabulary1 =
+			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				assetLibraryId, randomTaxonomyVocabulary());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		TaxonomyVocabulary taxonomyVocabulary2 =
+			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				assetLibraryId, randomTaxonomyVocabulary());
+
+		for (EntityField entityField : entityFields) {
+			Page<TaxonomyVocabulary> page =
+				taxonomyVocabularyResource.
+					getAssetLibraryTaxonomyVocabulariesPage(
+						assetLibraryId, null,
+						getFilterString(entityField, "eq", taxonomyVocabulary1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(taxonomyVocabulary1),
+				(List<TaxonomyVocabulary>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetAssetLibraryTaxonomyVocabulariesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -416,6 +453,20 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 				BeanUtils.setProperty(
 					taxonomyVocabulary1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAssetLibraryTaxonomyVocabulariesPageWithSortDouble()
+		throws Exception {
+
+		testGetAssetLibraryTaxonomyVocabulariesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, taxonomyVocabulary1, taxonomyVocabulary2) -> {
+				BeanUtils.setProperty(
+					taxonomyVocabulary1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					taxonomyVocabulary2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -743,6 +794,41 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteTaxonomyVocabulariesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteTaxonomyVocabulariesPage_getSiteId();
+
+		TaxonomyVocabulary taxonomyVocabulary1 =
+			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				siteId, randomTaxonomyVocabulary());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		TaxonomyVocabulary taxonomyVocabulary2 =
+			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				siteId, randomTaxonomyVocabulary());
+
+		for (EntityField entityField : entityFields) {
+			Page<TaxonomyVocabulary> page =
+				taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
+					siteId, null,
+					getFilterString(entityField, "eq", taxonomyVocabulary1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(taxonomyVocabulary1),
+				(List<TaxonomyVocabulary>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteTaxonomyVocabulariesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -837,6 +923,20 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 				BeanUtils.setProperty(
 					taxonomyVocabulary1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteTaxonomyVocabulariesPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteTaxonomyVocabulariesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, taxonomyVocabulary1, taxonomyVocabulary2) -> {
+				BeanUtils.setProperty(
+					taxonomyVocabulary1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					taxonomyVocabulary2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -2405,8 +2505,11 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfTaxonomyCategories")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					taxonomyVocabulary.getNumberOfTaxonomyCategories()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("siteId")) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -1018,7 +1018,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.user.client', and version '4.0.22'."
+        'com.liferay.headless.admin.user.client', and version '4.0.23'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.22'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.23'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -251,6 +251,31 @@ public abstract class BaseAccountResourceTestCase {
 	}
 
 	@Test
+	public void testGetAccountsPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Account account1 = testGetAccountsPage_addAccount(randomAccount());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Account account2 = testGetAccountsPage_addAccount(randomAccount());
+
+		for (EntityField entityField : entityFields) {
+			Page<Account> page = accountResource.getAccountsPage(
+				null, getFilterString(entityField, "eq", account1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(account1),
+				(List<Account>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetAccountsPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -321,6 +346,16 @@ public abstract class BaseAccountResourceTestCase {
 				BeanUtils.setProperty(
 					account1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAccountsPageWithSortDouble() throws Exception {
+		testGetAccountsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, account1, account2) -> {
+				BeanUtils.setProperty(account1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(account2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -977,6 +1012,39 @@ public abstract class BaseAccountResourceTestCase {
 	}
 
 	@Test
+	public void testGetOrganizationAccountsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		String organizationId =
+			testGetOrganizationAccountsPage_getOrganizationId();
+
+		Account account1 = testGetOrganizationAccountsPage_addAccount(
+			organizationId, randomAccount());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Account account2 = testGetOrganizationAccountsPage_addAccount(
+			organizationId, randomAccount());
+
+		for (EntityField entityField : entityFields) {
+			Page<Account> page = accountResource.getOrganizationAccountsPage(
+				organizationId, null,
+				getFilterString(entityField, "eq", account1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(account1),
+				(List<Account>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetOrganizationAccountsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1059,6 +1127,18 @@ public abstract class BaseAccountResourceTestCase {
 				BeanUtils.setProperty(
 					account1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOrganizationAccountsPageWithSortDouble()
+		throws Exception {
+
+		testGetOrganizationAccountsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, account1, account2) -> {
+				BeanUtils.setProperty(account1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(account2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1802,8 +1882,9 @@ public abstract class BaseAccountResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfUsers")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(account.getNumberOfUsers()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("organizationIds")) {
@@ -1817,8 +1898,9 @@ public abstract class BaseAccountResourceTestCase {
 		}
 
 		if (entityFieldName.equals("status")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(account.getStatus()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("type")) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
@@ -480,6 +480,18 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
+	public void testGetAccountAccountRolesByExternalReferenceCodePageWithSortDouble()
+		throws Exception {
+
+		testGetAccountAccountRolesByExternalReferenceCodePageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, accountRole1, accountRole2) -> {
+				BeanUtils.setProperty(accountRole1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(accountRole2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetAccountAccountRolesByExternalReferenceCodePageWithSortInteger()
 		throws Exception {
 
@@ -903,6 +915,18 @@ public abstract class BaseAccountRoleResourceTestCase {
 				BeanUtils.setProperty(
 					accountRole1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAccountAccountRolesPageWithSortDouble()
+		throws Exception {
+
+		testGetAccountAccountRolesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, accountRole1, accountRole2) -> {
+				BeanUtils.setProperty(accountRole1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(accountRole2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -259,6 +259,35 @@ public abstract class BaseOrganizationResourceTestCase {
 	}
 
 	@Test
+	public void testGetOrganizationsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Organization organization1 = testGetOrganizationsPage_addOrganization(
+			randomOrganization());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Organization organization2 = testGetOrganizationsPage_addOrganization(
+			randomOrganization());
+
+		for (EntityField entityField : entityFields) {
+			Page<Organization> page = organizationResource.getOrganizationsPage(
+				null, null, getFilterString(entityField, "eq", organization1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(organization1),
+				(List<Organization>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetOrganizationsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -340,6 +369,18 @@ public abstract class BaseOrganizationResourceTestCase {
 				BeanUtils.setProperty(
 					organization1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOrganizationsPageWithSortDouble() throws Exception {
+		testGetOrganizationsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, organization1, organization2) -> {
+				BeanUtils.setProperty(
+					organization1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					organization2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -782,6 +823,42 @@ public abstract class BaseOrganizationResourceTestCase {
 	}
 
 	@Test
+	public void testGetOrganizationChildOrganizationsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		String organizationId =
+			testGetOrganizationChildOrganizationsPage_getOrganizationId();
+
+		Organization organization1 =
+			testGetOrganizationChildOrganizationsPage_addOrganization(
+				organizationId, randomOrganization());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Organization organization2 =
+			testGetOrganizationChildOrganizationsPage_addOrganization(
+				organizationId, randomOrganization());
+
+		for (EntityField entityField : entityFields) {
+			Page<Organization> page =
+				organizationResource.getOrganizationChildOrganizationsPage(
+					organizationId, null, null,
+					getFilterString(entityField, "eq", organization1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(organization1),
+				(List<Organization>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetOrganizationChildOrganizationsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -877,6 +954,20 @@ public abstract class BaseOrganizationResourceTestCase {
 				BeanUtils.setProperty(
 					organization1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOrganizationChildOrganizationsPageWithSortDouble()
+		throws Exception {
+
+		testGetOrganizationChildOrganizationsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, organization1, organization2) -> {
+				BeanUtils.setProperty(
+					organization1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					organization2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1153,6 +1244,42 @@ public abstract class BaseOrganizationResourceTestCase {
 	}
 
 	@Test
+	public void testGetOrganizationOrganizationsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		String parentOrganizationId =
+			testGetOrganizationOrganizationsPage_getParentOrganizationId();
+
+		Organization organization1 =
+			testGetOrganizationOrganizationsPage_addOrganization(
+				parentOrganizationId, randomOrganization());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Organization organization2 =
+			testGetOrganizationOrganizationsPage_addOrganization(
+				parentOrganizationId, randomOrganization());
+
+		for (EntityField entityField : entityFields) {
+			Page<Organization> page =
+				organizationResource.getOrganizationOrganizationsPage(
+					parentOrganizationId, null, null,
+					getFilterString(entityField, "eq", organization1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(organization1),
+				(List<Organization>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetOrganizationOrganizationsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1251,6 +1378,20 @@ public abstract class BaseOrganizationResourceTestCase {
 				BeanUtils.setProperty(
 					organization1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOrganizationOrganizationsPageWithSortDouble()
+		throws Exception {
+
+		testGetOrganizationOrganizationsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, organization1, organization2) -> {
+				BeanUtils.setProperty(
+					organization1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					organization2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -2718,18 +2859,21 @@ public abstract class BaseOrganizationResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfAccounts")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(organization.getNumberOfAccounts()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("numberOfOrganizations")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(organization.getNumberOfOrganizations()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("numberOfUsers")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(organization.getNumberOfUsers()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("organizationAccounts")) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -373,6 +373,43 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
+	public void testGetAccountUserAccountsByExternalReferenceCodePageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		String externalReferenceCode =
+			testGetAccountUserAccountsByExternalReferenceCodePage_getExternalReferenceCode();
+
+		UserAccount userAccount1 =
+			testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
+				externalReferenceCode, randomUserAccount());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		UserAccount userAccount2 =
+			testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
+				externalReferenceCode, randomUserAccount());
+
+		for (EntityField entityField : entityFields) {
+			Page<UserAccount> page =
+				userAccountResource.
+					getAccountUserAccountsByExternalReferenceCodePage(
+						externalReferenceCode, null,
+						getFilterString(entityField, "eq", userAccount1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(userAccount1),
+				(List<UserAccount>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetAccountUserAccountsByExternalReferenceCodePageWithFilterStringEquals()
 		throws Exception {
 
@@ -471,6 +508,18 @@ public abstract class BaseUserAccountResourceTestCase {
 				BeanUtils.setProperty(
 					userAccount1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAccountUserAccountsByExternalReferenceCodePageWithSortDouble()
+		throws Exception {
+
+		testGetAccountUserAccountsByExternalReferenceCodePageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, userAccount1, userAccount2) -> {
+				BeanUtils.setProperty(userAccount1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(userAccount2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -830,6 +879,41 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
+	public void testGetAccountUserAccountsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long accountId = testGetAccountUserAccountsPage_getAccountId();
+
+		UserAccount userAccount1 =
+			testGetAccountUserAccountsPage_addUserAccount(
+				accountId, randomUserAccount());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		UserAccount userAccount2 =
+			testGetAccountUserAccountsPage_addUserAccount(
+				accountId, randomUserAccount());
+
+		for (EntityField entityField : entityFields) {
+			Page<UserAccount> page =
+				userAccountResource.getAccountUserAccountsPage(
+					accountId, null,
+					getFilterString(entityField, "eq", userAccount1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(userAccount1),
+				(List<UserAccount>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetAccountUserAccountsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -919,6 +1003,18 @@ public abstract class BaseUserAccountResourceTestCase {
 				BeanUtils.setProperty(
 					userAccount1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAccountUserAccountsPageWithSortDouble()
+		throws Exception {
+
+		testGetAccountUserAccountsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, userAccount1, userAccount2) -> {
+				BeanUtils.setProperty(userAccount1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(userAccount2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1271,6 +1367,42 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
+	public void testGetOrganizationUserAccountsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		String organizationId =
+			testGetOrganizationUserAccountsPage_getOrganizationId();
+
+		UserAccount userAccount1 =
+			testGetOrganizationUserAccountsPage_addUserAccount(
+				organizationId, randomUserAccount());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		UserAccount userAccount2 =
+			testGetOrganizationUserAccountsPage_addUserAccount(
+				organizationId, randomUserAccount());
+
+		for (EntityField entityField : entityFields) {
+			Page<UserAccount> page =
+				userAccountResource.getOrganizationUserAccountsPage(
+					organizationId, null,
+					getFilterString(entityField, "eq", userAccount1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(userAccount1),
+				(List<UserAccount>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetOrganizationUserAccountsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1362,6 +1494,18 @@ public abstract class BaseUserAccountResourceTestCase {
 				BeanUtils.setProperty(
 					userAccount1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetOrganizationUserAccountsPageWithSortDouble()
+		throws Exception {
+
+		testGetOrganizationUserAccountsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, userAccount1, userAccount2) -> {
+				BeanUtils.setProperty(userAccount1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(userAccount2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1581,6 +1725,39 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteUserAccountsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteUserAccountsPage_getSiteId();
+
+		UserAccount userAccount1 = testGetSiteUserAccountsPage_addUserAccount(
+			siteId, randomUserAccount());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		UserAccount userAccount2 = testGetSiteUserAccountsPage_addUserAccount(
+			siteId, randomUserAccount());
+
+		for (EntityField entityField : entityFields) {
+			Page<UserAccount> page =
+				userAccountResource.getSiteUserAccountsPage(
+					siteId, null,
+					getFilterString(entityField, "eq", userAccount1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(userAccount1),
+				(List<UserAccount>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteUserAccountsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1658,6 +1835,16 @@ public abstract class BaseUserAccountResourceTestCase {
 				BeanUtils.setProperty(
 					userAccount1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteUserAccountsPageWithSortDouble() throws Exception {
+		testGetSiteUserAccountsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, userAccount1, userAccount2) -> {
+				BeanUtils.setProperty(userAccount1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(userAccount2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1842,6 +2029,35 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
+	public void testGetUserAccountsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		UserAccount userAccount1 = testGetUserAccountsPage_addUserAccount(
+			randomUserAccount());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		UserAccount userAccount2 = testGetUserAccountsPage_addUserAccount(
+			randomUserAccount());
+
+		for (EntityField entityField : entityFields) {
+			Page<UserAccount> page = userAccountResource.getUserAccountsPage(
+				null, getFilterString(entityField, "eq", userAccount1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(userAccount1),
+				(List<UserAccount>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetUserAccountsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1919,6 +2135,16 @@ public abstract class BaseUserAccountResourceTestCase {
 				BeanUtils.setProperty(
 					userAccount1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetUserAccountsPageWithSortDouble() throws Exception {
+		testGetUserAccountsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, userAccount1, userAccount2) -> {
+				BeanUtils.setProperty(userAccount1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(userAccount2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserGroupResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserGroupResourceTestCase.java
@@ -255,6 +255,33 @@ public abstract class BaseUserGroupResourceTestCase {
 	}
 
 	@Test
+	public void testGetUserGroupsPageWithFilterDoubleEquals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		UserGroup userGroup1 = testGetUserGroupsPage_addUserGroup(
+			randomUserGroup());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		UserGroup userGroup2 = testGetUserGroupsPage_addUserGroup(
+			randomUserGroup());
+
+		for (EntityField entityField : entityFields) {
+			Page<UserGroup> page = userGroupResource.getUserGroupsPage(
+				null, getFilterString(entityField, "eq", userGroup1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(userGroup1),
+				(List<UserGroup>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetUserGroupsPageWithFilterStringEquals() throws Exception {
 		List<EntityField> entityFields = getEntityFields(
 			EntityField.Type.STRING);
@@ -330,6 +357,16 @@ public abstract class BaseUserGroupResourceTestCase {
 				BeanUtils.setProperty(
 					userGroup1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetUserGroupsPageWithSortDouble() throws Exception {
+		testGetUserGroupsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, userGroup1, userGroup2) -> {
+				BeanUtils.setProperty(userGroup1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(userGroup2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1303,8 +1340,9 @@ public abstract class BaseUserGroupResourceTestCase {
 		}
 
 		if (entityFieldName.equals("usersCount")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(userGroup.getUsersCount()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
@@ -615,7 +615,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.workflow.client', and version '4.0.10'."
+        'com.liferay.headless.admin.workflow.client', and version '4.0.11'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.workflow.client', and version '4.0.10'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Workflow", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.workflow.client', and version '4.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Workflow", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionResourceTestCase.java
@@ -304,6 +304,20 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 	}
 
 	@Test
+	public void testGetWorkflowDefinitionsPageWithSortDouble()
+		throws Exception {
+
+		testGetWorkflowDefinitionsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, workflowDefinition1, workflowDefinition2) -> {
+				BeanUtils.setProperty(
+					workflowDefinition1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					workflowDefinition2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetWorkflowDefinitionsPageWithSortInteger()
 		throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -4842,7 +4842,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.21'."
+        'com.liferay.headless.delivery.client', and version '4.0.22'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.21'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.22'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -424,6 +424,41 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteBlogPostingImagesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteBlogPostingImagesPage_getSiteId();
+
+		BlogPostingImage blogPostingImage1 =
+			testGetSiteBlogPostingImagesPage_addBlogPostingImage(
+				siteId, randomBlogPostingImage());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		BlogPostingImage blogPostingImage2 =
+			testGetSiteBlogPostingImagesPage_addBlogPostingImage(
+				siteId, randomBlogPostingImage());
+
+		for (EntityField entityField : entityFields) {
+			Page<BlogPostingImage> page =
+				blogPostingImageResource.getSiteBlogPostingImagesPage(
+					siteId, null, null,
+					getFilterString(entityField, "eq", blogPostingImage1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(blogPostingImage1),
+				(List<BlogPostingImage>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteBlogPostingImagesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -518,6 +553,20 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 				BeanUtils.setProperty(
 					blogPostingImage1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteBlogPostingImagesPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteBlogPostingImagesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, blogPostingImage1, blogPostingImage2) -> {
+				BeanUtils.setProperty(
+					blogPostingImage1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					blogPostingImage2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -559,6 +559,39 @@ public abstract class BaseBlogPostingResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteBlogPostingsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteBlogPostingsPage_getSiteId();
+
+		BlogPosting blogPosting1 = testGetSiteBlogPostingsPage_addBlogPosting(
+			siteId, randomBlogPosting());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		BlogPosting blogPosting2 = testGetSiteBlogPostingsPage_addBlogPosting(
+			siteId, randomBlogPosting());
+
+		for (EntityField entityField : entityFields) {
+			Page<BlogPosting> page =
+				blogPostingResource.getSiteBlogPostingsPage(
+					siteId, null, null,
+					getFilterString(entityField, "eq", blogPosting1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(blogPosting1),
+				(List<BlogPosting>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteBlogPostingsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -636,6 +669,16 @@ public abstract class BaseBlogPostingResourceTestCase {
 				BeanUtils.setProperty(
 					blogPosting1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteBlogPostingsPageWithSortDouble() throws Exception {
+		testGetSiteBlogPostingsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, blogPosting1, blogPosting2) -> {
+				BeanUtils.setProperty(blogPosting1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(blogPosting2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -2356,8 +2399,9 @@ public abstract class BaseBlogPostingResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfComments")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(blogPosting.getNumberOfComments()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("relatedContents")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -276,6 +276,38 @@ public abstract class BaseCommentResourceTestCase {
 	}
 
 	@Test
+	public void testGetBlogPostingCommentsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long blogPostingId = testGetBlogPostingCommentsPage_getBlogPostingId();
+
+		Comment comment1 = testGetBlogPostingCommentsPage_addComment(
+			blogPostingId, randomComment());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Comment comment2 = testGetBlogPostingCommentsPage_addComment(
+			blogPostingId, randomComment());
+
+		for (EntityField entityField : entityFields) {
+			Page<Comment> page = commentResource.getBlogPostingCommentsPage(
+				blogPostingId, null, null,
+				getFilterString(entityField, "eq", comment1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(comment1),
+				(List<Comment>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetBlogPostingCommentsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -356,6 +388,18 @@ public abstract class BaseCommentResourceTestCase {
 				BeanUtils.setProperty(
 					comment1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetBlogPostingCommentsPageWithSortDouble()
+		throws Exception {
+
+		testGetBlogPostingCommentsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, comment1, comment2) -> {
+				BeanUtils.setProperty(comment1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(comment2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -716,6 +760,38 @@ public abstract class BaseCommentResourceTestCase {
 	}
 
 	@Test
+	public void testGetCommentCommentsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long parentCommentId = testGetCommentCommentsPage_getParentCommentId();
+
+		Comment comment1 = testGetCommentCommentsPage_addComment(
+			parentCommentId, randomComment());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Comment comment2 = testGetCommentCommentsPage_addComment(
+			parentCommentId, randomComment());
+
+		for (EntityField entityField : entityFields) {
+			Page<Comment> page = commentResource.getCommentCommentsPage(
+				parentCommentId, null, null,
+				getFilterString(entityField, "eq", comment1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(comment1),
+				(List<Comment>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetCommentCommentsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -792,6 +868,16 @@ public abstract class BaseCommentResourceTestCase {
 				BeanUtils.setProperty(
 					comment1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetCommentCommentsPageWithSortDouble() throws Exception {
+		testGetCommentCommentsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, comment1, comment2) -> {
+				BeanUtils.setProperty(comment1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(comment2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1016,6 +1102,38 @@ public abstract class BaseCommentResourceTestCase {
 	}
 
 	@Test
+	public void testGetDocumentCommentsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long documentId = testGetDocumentCommentsPage_getDocumentId();
+
+		Comment comment1 = testGetDocumentCommentsPage_addComment(
+			documentId, randomComment());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Comment comment2 = testGetDocumentCommentsPage_addComment(
+			documentId, randomComment());
+
+		for (EntityField entityField : entityFields) {
+			Page<Comment> page = commentResource.getDocumentCommentsPage(
+				documentId, null, null,
+				getFilterString(entityField, "eq", comment1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(comment1),
+				(List<Comment>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetDocumentCommentsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1092,6 +1210,16 @@ public abstract class BaseCommentResourceTestCase {
 				BeanUtils.setProperty(
 					comment1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetDocumentCommentsPageWithSortDouble() throws Exception {
+		testGetDocumentCommentsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, comment1, comment2) -> {
+				BeanUtils.setProperty(comment1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(comment2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1319,6 +1447,40 @@ public abstract class BaseCommentResourceTestCase {
 	}
 
 	@Test
+	public void testGetStructuredContentCommentsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long structuredContentId =
+			testGetStructuredContentCommentsPage_getStructuredContentId();
+
+		Comment comment1 = testGetStructuredContentCommentsPage_addComment(
+			structuredContentId, randomComment());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Comment comment2 = testGetStructuredContentCommentsPage_addComment(
+			structuredContentId, randomComment());
+
+		for (EntityField entityField : entityFields) {
+			Page<Comment> page =
+				commentResource.getStructuredContentCommentsPage(
+					structuredContentId, null, null,
+					getFilterString(entityField, "eq", comment1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(comment1),
+				(List<Comment>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetStructuredContentCommentsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1402,6 +1564,18 @@ public abstract class BaseCommentResourceTestCase {
 				BeanUtils.setProperty(
 					comment1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetStructuredContentCommentsPageWithSortDouble()
+		throws Exception {
+
+		testGetStructuredContentCommentsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, comment1, comment2) -> {
+				BeanUtils.setProperty(comment1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(comment2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -2036,8 +2210,9 @@ public abstract class BaseCommentResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfComments")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(comment.getNumberOfComments()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("parentCommentId")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
@@ -297,6 +297,42 @@ public abstract class BaseContentElementResourceTestCase {
 	}
 
 	@Test
+	public void testGetAssetLibraryContentElementsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long assetLibraryId =
+			testGetAssetLibraryContentElementsPage_getAssetLibraryId();
+
+		ContentElement contentElement1 =
+			testGetAssetLibraryContentElementsPage_addContentElement(
+				assetLibraryId, randomContentElement());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ContentElement contentElement2 =
+			testGetAssetLibraryContentElementsPage_addContentElement(
+				assetLibraryId, randomContentElement());
+
+		for (EntityField entityField : entityFields) {
+			Page<ContentElement> page =
+				contentElementResource.getAssetLibraryContentElementsPage(
+					assetLibraryId, null, null,
+					getFilterString(entityField, "eq", contentElement1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(contentElement1),
+				(List<ContentElement>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetAssetLibraryContentElementsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -392,6 +428,20 @@ public abstract class BaseContentElementResourceTestCase {
 				BeanUtils.setProperty(
 					contentElement1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAssetLibraryContentElementsPageWithSortDouble()
+		throws Exception {
+
+		testGetAssetLibraryContentElementsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, contentElement1, contentElement2) -> {
+				BeanUtils.setProperty(
+					contentElement1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					contentElement2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -616,6 +666,41 @@ public abstract class BaseContentElementResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteContentElementsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteContentElementsPage_getSiteId();
+
+		ContentElement contentElement1 =
+			testGetSiteContentElementsPage_addContentElement(
+				siteId, randomContentElement());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ContentElement contentElement2 =
+			testGetSiteContentElementsPage_addContentElement(
+				siteId, randomContentElement());
+
+		for (EntityField entityField : entityFields) {
+			Page<ContentElement> page =
+				contentElementResource.getSiteContentElementsPage(
+					siteId, null, null,
+					getFilterString(entityField, "eq", contentElement1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(contentElement1),
+				(List<ContentElement>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteContentElementsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -709,6 +794,20 @@ public abstract class BaseContentElementResourceTestCase {
 				BeanUtils.setProperty(
 					contentElement1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteContentElementsPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteContentElementsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, contentElement1, contentElement2) -> {
+				BeanUtils.setProperty(
+					contentElement1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					contentElement2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -304,6 +304,42 @@ public abstract class BaseContentStructureResourceTestCase {
 	}
 
 	@Test
+	public void testGetAssetLibraryContentStructuresPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long assetLibraryId =
+			testGetAssetLibraryContentStructuresPage_getAssetLibraryId();
+
+		ContentStructure contentStructure1 =
+			testGetAssetLibraryContentStructuresPage_addContentStructure(
+				assetLibraryId, randomContentStructure());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ContentStructure contentStructure2 =
+			testGetAssetLibraryContentStructuresPage_addContentStructure(
+				assetLibraryId, randomContentStructure());
+
+		for (EntityField entityField : entityFields) {
+			Page<ContentStructure> page =
+				contentStructureResource.getAssetLibraryContentStructuresPage(
+					assetLibraryId, null, null,
+					getFilterString(entityField, "eq", contentStructure1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(contentStructure1),
+				(List<ContentStructure>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetAssetLibraryContentStructuresPageWithFilterStringEquals()
 		throws Exception {
 
@@ -400,6 +436,20 @@ public abstract class BaseContentStructureResourceTestCase {
 				BeanUtils.setProperty(
 					contentStructure1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAssetLibraryContentStructuresPageWithSortDouble()
+		throws Exception {
+
+		testGetAssetLibraryContentStructuresPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, contentStructure1, contentStructure2) -> {
+				BeanUtils.setProperty(
+					contentStructure1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					contentStructure2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -827,6 +877,41 @@ public abstract class BaseContentStructureResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteContentStructuresPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteContentStructuresPage_getSiteId();
+
+		ContentStructure contentStructure1 =
+			testGetSiteContentStructuresPage_addContentStructure(
+				siteId, randomContentStructure());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ContentStructure contentStructure2 =
+			testGetSiteContentStructuresPage_addContentStructure(
+				siteId, randomContentStructure());
+
+		for (EntityField entityField : entityFields) {
+			Page<ContentStructure> page =
+				contentStructureResource.getSiteContentStructuresPage(
+					siteId, null, null,
+					getFilterString(entityField, "eq", contentStructure1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(contentStructure1),
+				(List<ContentStructure>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteContentStructuresPageWithFilterStringEquals()
 		throws Exception {
 
@@ -921,6 +1006,20 @@ public abstract class BaseContentStructureResourceTestCase {
 				BeanUtils.setProperty(
 					contentStructure1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteContentStructuresPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteContentStructuresPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, contentStructure1, contentStructure2) -> {
+				BeanUtils.setProperty(
+					contentStructure1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					contentStructure2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
@@ -306,6 +306,42 @@ public abstract class BaseContentTemplateResourceTestCase {
 	}
 
 	@Test
+	public void testGetAssetLibraryContentTemplatesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long assetLibraryId =
+			testGetAssetLibraryContentTemplatesPage_getAssetLibraryId();
+
+		ContentTemplate contentTemplate1 =
+			testGetAssetLibraryContentTemplatesPage_addContentTemplate(
+				assetLibraryId, randomContentTemplate());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ContentTemplate contentTemplate2 =
+			testGetAssetLibraryContentTemplatesPage_addContentTemplate(
+				assetLibraryId, randomContentTemplate());
+
+		for (EntityField entityField : entityFields) {
+			Page<ContentTemplate> page =
+				contentTemplateResource.getAssetLibraryContentTemplatesPage(
+					assetLibraryId, null, null,
+					getFilterString(entityField, "eq", contentTemplate1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(contentTemplate1),
+				(List<ContentTemplate>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetAssetLibraryContentTemplatesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -401,6 +437,20 @@ public abstract class BaseContentTemplateResourceTestCase {
 				BeanUtils.setProperty(
 					contentTemplate1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAssetLibraryContentTemplatesPageWithSortDouble()
+		throws Exception {
+
+		testGetAssetLibraryContentTemplatesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, contentTemplate1, contentTemplate2) -> {
+				BeanUtils.setProperty(
+					contentTemplate1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					contentTemplate2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -625,6 +675,41 @@ public abstract class BaseContentTemplateResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteContentTemplatesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteContentTemplatesPage_getSiteId();
+
+		ContentTemplate contentTemplate1 =
+			testGetSiteContentTemplatesPage_addContentTemplate(
+				siteId, randomContentTemplate());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ContentTemplate contentTemplate2 =
+			testGetSiteContentTemplatesPage_addContentTemplate(
+				siteId, randomContentTemplate());
+
+		for (EntityField entityField : entityFields) {
+			Page<ContentTemplate> page =
+				contentTemplateResource.getSiteContentTemplatesPage(
+					siteId, null, null,
+					getFilterString(entityField, "eq", contentTemplate1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(contentTemplate1),
+				(List<ContentTemplate>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteContentTemplatesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -718,6 +803,20 @@ public abstract class BaseContentTemplateResourceTestCase {
 				BeanUtils.setProperty(
 					contentTemplate1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteContentTemplatesPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteContentTemplatesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, contentTemplate1, contentTemplate2) -> {
+				BeanUtils.setProperty(
+					contentTemplate1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					contentTemplate2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -309,6 +309,42 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	}
 
 	@Test
+	public void testGetAssetLibraryDocumentFoldersPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long assetLibraryId =
+			testGetAssetLibraryDocumentFoldersPage_getAssetLibraryId();
+
+		DocumentFolder documentFolder1 =
+			testGetAssetLibraryDocumentFoldersPage_addDocumentFolder(
+				assetLibraryId, randomDocumentFolder());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		DocumentFolder documentFolder2 =
+			testGetAssetLibraryDocumentFoldersPage_addDocumentFolder(
+				assetLibraryId, randomDocumentFolder());
+
+		for (EntityField entityField : entityFields) {
+			Page<DocumentFolder> page =
+				documentFolderResource.getAssetLibraryDocumentFoldersPage(
+					assetLibraryId, null, null, null,
+					getFilterString(entityField, "eq", documentFolder1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(documentFolder1),
+				(List<DocumentFolder>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetAssetLibraryDocumentFoldersPageWithFilterStringEquals()
 		throws Exception {
 
@@ -407,6 +443,20 @@ public abstract class BaseDocumentFolderResourceTestCase {
 				BeanUtils.setProperty(
 					documentFolder1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAssetLibraryDocumentFoldersPageWithSortDouble()
+		throws Exception {
+
+		testGetAssetLibraryDocumentFoldersPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, documentFolder1, documentFolder2) -> {
+				BeanUtils.setProperty(
+					documentFolder1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					documentFolder2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1030,6 +1080,42 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	}
 
 	@Test
+	public void testGetDocumentFolderDocumentFoldersPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long parentDocumentFolderId =
+			testGetDocumentFolderDocumentFoldersPage_getParentDocumentFolderId();
+
+		DocumentFolder documentFolder1 =
+			testGetDocumentFolderDocumentFoldersPage_addDocumentFolder(
+				parentDocumentFolderId, randomDocumentFolder());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		DocumentFolder documentFolder2 =
+			testGetDocumentFolderDocumentFoldersPage_addDocumentFolder(
+				parentDocumentFolderId, randomDocumentFolder());
+
+		for (EntityField entityField : entityFields) {
+			Page<DocumentFolder> page =
+				documentFolderResource.getDocumentFolderDocumentFoldersPage(
+					parentDocumentFolderId, null, null, null,
+					getFilterString(entityField, "eq", documentFolder1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(documentFolder1),
+				(List<DocumentFolder>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetDocumentFolderDocumentFoldersPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1128,6 +1214,20 @@ public abstract class BaseDocumentFolderResourceTestCase {
 				BeanUtils.setProperty(
 					documentFolder1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetDocumentFolderDocumentFoldersPageWithSortDouble()
+		throws Exception {
+
+		testGetDocumentFolderDocumentFoldersPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, documentFolder1, documentFolder2) -> {
+				BeanUtils.setProperty(
+					documentFolder1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					documentFolder2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1381,6 +1481,41 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteDocumentFoldersPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteDocumentFoldersPage_getSiteId();
+
+		DocumentFolder documentFolder1 =
+			testGetSiteDocumentFoldersPage_addDocumentFolder(
+				siteId, randomDocumentFolder());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		DocumentFolder documentFolder2 =
+			testGetSiteDocumentFoldersPage_addDocumentFolder(
+				siteId, randomDocumentFolder());
+
+		for (EntityField entityField : entityFields) {
+			Page<DocumentFolder> page =
+				documentFolderResource.getSiteDocumentFoldersPage(
+					siteId, null, null, null,
+					getFilterString(entityField, "eq", documentFolder1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(documentFolder1),
+				(List<DocumentFolder>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteDocumentFoldersPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1474,6 +1609,20 @@ public abstract class BaseDocumentFolderResourceTestCase {
 				BeanUtils.setProperty(
 					documentFolder1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteDocumentFoldersPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteDocumentFoldersPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, documentFolder1, documentFolder2) -> {
+				BeanUtils.setProperty(
+					documentFolder1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					documentFolder2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -2496,13 +2645,16 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfDocumentFolders")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(documentFolder.getNumberOfDocumentFolders()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("numberOfDocuments")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(documentFolder.getNumberOfDocuments()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("parentDocumentFolderId")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -315,6 +315,39 @@ public abstract class BaseDocumentResourceTestCase {
 	}
 
 	@Test
+	public void testGetAssetLibraryDocumentsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long assetLibraryId =
+			testGetAssetLibraryDocumentsPage_getAssetLibraryId();
+
+		Document document1 = testGetAssetLibraryDocumentsPage_addDocument(
+			assetLibraryId, randomDocument());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Document document2 = testGetAssetLibraryDocumentsPage_addDocument(
+			assetLibraryId, randomDocument());
+
+		for (EntityField entityField : entityFields) {
+			Page<Document> page = documentResource.getAssetLibraryDocumentsPage(
+				assetLibraryId, null, null, null,
+				getFilterString(entityField, "eq", document1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(document1),
+				(List<Document>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetAssetLibraryDocumentsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -397,6 +430,18 @@ public abstract class BaseDocumentResourceTestCase {
 				BeanUtils.setProperty(
 					document1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAssetLibraryDocumentsPageWithSortDouble()
+		throws Exception {
+
+		testGetAssetLibraryDocumentsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, document1, document2) -> {
+				BeanUtils.setProperty(document1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(document2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -705,6 +750,40 @@ public abstract class BaseDocumentResourceTestCase {
 	}
 
 	@Test
+	public void testGetDocumentFolderDocumentsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long documentFolderId =
+			testGetDocumentFolderDocumentsPage_getDocumentFolderId();
+
+		Document document1 = testGetDocumentFolderDocumentsPage_addDocument(
+			documentFolderId, randomDocument());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Document document2 = testGetDocumentFolderDocumentsPage_addDocument(
+			documentFolderId, randomDocument());
+
+		for (EntityField entityField : entityFields) {
+			Page<Document> page =
+				documentResource.getDocumentFolderDocumentsPage(
+					documentFolderId, null, null, null,
+					getFilterString(entityField, "eq", document1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(document1),
+				(List<Document>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetDocumentFolderDocumentsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -791,6 +870,18 @@ public abstract class BaseDocumentResourceTestCase {
 				BeanUtils.setProperty(
 					document1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetDocumentFolderDocumentsPageWithSortDouble()
+		throws Exception {
+
+		testGetDocumentFolderDocumentsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, document1, document2) -> {
+				BeanUtils.setProperty(document1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(document2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1290,6 +1381,38 @@ public abstract class BaseDocumentResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteDocumentsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteDocumentsPage_getSiteId();
+
+		Document document1 = testGetSiteDocumentsPage_addDocument(
+			siteId, randomDocument());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Document document2 = testGetSiteDocumentsPage_addDocument(
+			siteId, randomDocument());
+
+		for (EntityField entityField : entityFields) {
+			Page<Document> page = documentResource.getSiteDocumentsPage(
+				siteId, null, null, null,
+				getFilterString(entityField, "eq", document1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(document1),
+				(List<Document>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteDocumentsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1366,6 +1489,16 @@ public abstract class BaseDocumentResourceTestCase {
 				BeanUtils.setProperty(
 					document1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteDocumentsPageWithSortDouble() throws Exception {
+		testGetSiteDocumentsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, document1, document2) -> {
+				BeanUtils.setProperty(document1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(document2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -3023,8 +3156,9 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfComments")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(document.getNumberOfComments()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("relatedContents")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -672,6 +672,44 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	}
 
 	@Test
+	public void testGetKnowledgeBaseArticleKnowledgeBaseArticlesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long parentKnowledgeBaseArticleId =
+			testGetKnowledgeBaseArticleKnowledgeBaseArticlesPage_getParentKnowledgeBaseArticleId();
+
+		KnowledgeBaseArticle knowledgeBaseArticle1 =
+			testGetKnowledgeBaseArticleKnowledgeBaseArticlesPage_addKnowledgeBaseArticle(
+				parentKnowledgeBaseArticleId, randomKnowledgeBaseArticle());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		KnowledgeBaseArticle knowledgeBaseArticle2 =
+			testGetKnowledgeBaseArticleKnowledgeBaseArticlesPage_addKnowledgeBaseArticle(
+				parentKnowledgeBaseArticleId, randomKnowledgeBaseArticle());
+
+		for (EntityField entityField : entityFields) {
+			Page<KnowledgeBaseArticle> page =
+				knowledgeBaseArticleResource.
+					getKnowledgeBaseArticleKnowledgeBaseArticlesPage(
+						parentKnowledgeBaseArticleId, null, null, null,
+						getFilterString(
+							entityField, "eq", knowledgeBaseArticle1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(knowledgeBaseArticle1),
+				(List<KnowledgeBaseArticle>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetKnowledgeBaseArticleKnowledgeBaseArticlesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -779,6 +817,20 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 				BeanUtils.setProperty(
 					knowledgeBaseArticle1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetKnowledgeBaseArticleKnowledgeBaseArticlesPageWithSortDouble()
+		throws Exception {
+
+		testGetKnowledgeBaseArticleKnowledgeBaseArticlesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, knowledgeBaseArticle1, knowledgeBaseArticle2) -> {
+				BeanUtils.setProperty(
+					knowledgeBaseArticle1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					knowledgeBaseArticle2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1060,6 +1112,44 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	}
 
 	@Test
+	public void testGetKnowledgeBaseFolderKnowledgeBaseArticlesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long knowledgeBaseFolderId =
+			testGetKnowledgeBaseFolderKnowledgeBaseArticlesPage_getKnowledgeBaseFolderId();
+
+		KnowledgeBaseArticle knowledgeBaseArticle1 =
+			testGetKnowledgeBaseFolderKnowledgeBaseArticlesPage_addKnowledgeBaseArticle(
+				knowledgeBaseFolderId, randomKnowledgeBaseArticle());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		KnowledgeBaseArticle knowledgeBaseArticle2 =
+			testGetKnowledgeBaseFolderKnowledgeBaseArticlesPage_addKnowledgeBaseArticle(
+				knowledgeBaseFolderId, randomKnowledgeBaseArticle());
+
+		for (EntityField entityField : entityFields) {
+			Page<KnowledgeBaseArticle> page =
+				knowledgeBaseArticleResource.
+					getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
+						knowledgeBaseFolderId, null, null, null,
+						getFilterString(
+							entityField, "eq", knowledgeBaseArticle1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(knowledgeBaseArticle1),
+				(List<KnowledgeBaseArticle>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetKnowledgeBaseFolderKnowledgeBaseArticlesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1167,6 +1257,20 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 				BeanUtils.setProperty(
 					knowledgeBaseArticle1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetKnowledgeBaseFolderKnowledgeBaseArticlesPageWithSortDouble()
+		throws Exception {
+
+		testGetKnowledgeBaseFolderKnowledgeBaseArticlesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, knowledgeBaseArticle1, knowledgeBaseArticle2) -> {
+				BeanUtils.setProperty(
+					knowledgeBaseArticle1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					knowledgeBaseArticle2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1436,6 +1540,41 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteKnowledgeBaseArticlesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteKnowledgeBaseArticlesPage_getSiteId();
+
+		KnowledgeBaseArticle knowledgeBaseArticle1 =
+			testGetSiteKnowledgeBaseArticlesPage_addKnowledgeBaseArticle(
+				siteId, randomKnowledgeBaseArticle());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		KnowledgeBaseArticle knowledgeBaseArticle2 =
+			testGetSiteKnowledgeBaseArticlesPage_addKnowledgeBaseArticle(
+				siteId, randomKnowledgeBaseArticle());
+
+		for (EntityField entityField : entityFields) {
+			Page<KnowledgeBaseArticle> page =
+				knowledgeBaseArticleResource.getSiteKnowledgeBaseArticlesPage(
+					siteId, null, null, null,
+					getFilterString(entityField, "eq", knowledgeBaseArticle1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(knowledgeBaseArticle1),
+				(List<KnowledgeBaseArticle>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteKnowledgeBaseArticlesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1533,6 +1672,20 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 				BeanUtils.setProperty(
 					knowledgeBaseArticle1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteKnowledgeBaseArticlesPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteKnowledgeBaseArticlesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, knowledgeBaseArticle1, knowledgeBaseArticle2) -> {
+				BeanUtils.setProperty(
+					knowledgeBaseArticle1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					knowledgeBaseArticle2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -3344,13 +3497,18 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfAttachments")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(knowledgeBaseArticle.getNumberOfAttachments()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("numberOfKnowledgeBaseArticles")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					knowledgeBaseArticle.getNumberOfKnowledgeBaseArticles()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("parentKnowledgeBaseArticleId")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -1916,13 +1916,19 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfKnowledgeBaseArticles")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					knowledgeBaseFolder.getNumberOfKnowledgeBaseArticles()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("numberOfKnowledgeBaseFolders")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					knowledgeBaseFolder.getNumberOfKnowledgeBaseFolders()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("parentKnowledgeBaseFolder")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -665,6 +665,44 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	}
 
 	@Test
+	public void testGetMessageBoardMessageMessageBoardMessagesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long parentMessageBoardMessageId =
+			testGetMessageBoardMessageMessageBoardMessagesPage_getParentMessageBoardMessageId();
+
+		MessageBoardMessage messageBoardMessage1 =
+			testGetMessageBoardMessageMessageBoardMessagesPage_addMessageBoardMessage(
+				parentMessageBoardMessageId, randomMessageBoardMessage());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		MessageBoardMessage messageBoardMessage2 =
+			testGetMessageBoardMessageMessageBoardMessagesPage_addMessageBoardMessage(
+				parentMessageBoardMessageId, randomMessageBoardMessage());
+
+		for (EntityField entityField : entityFields) {
+			Page<MessageBoardMessage> page =
+				messageBoardMessageResource.
+					getMessageBoardMessageMessageBoardMessagesPage(
+						parentMessageBoardMessageId, null, null, null,
+						getFilterString(
+							entityField, "eq", messageBoardMessage1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(messageBoardMessage1),
+				(List<MessageBoardMessage>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetMessageBoardMessageMessageBoardMessagesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -770,6 +808,20 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 				BeanUtils.setProperty(
 					messageBoardMessage1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetMessageBoardMessageMessageBoardMessagesPageWithSortDouble()
+		throws Exception {
+
+		testGetMessageBoardMessageMessageBoardMessagesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, messageBoardMessage1, messageBoardMessage2) -> {
+				BeanUtils.setProperty(
+					messageBoardMessage1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					messageBoardMessage2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1048,6 +1100,44 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	}
 
 	@Test
+	public void testGetMessageBoardThreadMessageBoardMessagesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long messageBoardThreadId =
+			testGetMessageBoardThreadMessageBoardMessagesPage_getMessageBoardThreadId();
+
+		MessageBoardMessage messageBoardMessage1 =
+			testGetMessageBoardThreadMessageBoardMessagesPage_addMessageBoardMessage(
+				messageBoardThreadId, randomMessageBoardMessage());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		MessageBoardMessage messageBoardMessage2 =
+			testGetMessageBoardThreadMessageBoardMessagesPage_addMessageBoardMessage(
+				messageBoardThreadId, randomMessageBoardMessage());
+
+		for (EntityField entityField : entityFields) {
+			Page<MessageBoardMessage> page =
+				messageBoardMessageResource.
+					getMessageBoardThreadMessageBoardMessagesPage(
+						messageBoardThreadId, null, null,
+						getFilterString(
+							entityField, "eq", messageBoardMessage1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(messageBoardMessage1),
+				(List<MessageBoardMessage>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetMessageBoardThreadMessageBoardMessagesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1153,6 +1243,20 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 				BeanUtils.setProperty(
 					messageBoardMessage1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetMessageBoardThreadMessageBoardMessagesPageWithSortDouble()
+		throws Exception {
+
+		testGetMessageBoardThreadMessageBoardMessagesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, messageBoardMessage1, messageBoardMessage2) -> {
+				BeanUtils.setProperty(
+					messageBoardMessage1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					messageBoardMessage2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1418,6 +1522,41 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteMessageBoardMessagesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteMessageBoardMessagesPage_getSiteId();
+
+		MessageBoardMessage messageBoardMessage1 =
+			testGetSiteMessageBoardMessagesPage_addMessageBoardMessage(
+				siteId, randomMessageBoardMessage());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		MessageBoardMessage messageBoardMessage2 =
+			testGetSiteMessageBoardMessagesPage_addMessageBoardMessage(
+				siteId, randomMessageBoardMessage());
+
+		for (EntityField entityField : entityFields) {
+			Page<MessageBoardMessage> page =
+				messageBoardMessageResource.getSiteMessageBoardMessagesPage(
+					siteId, null, null, null,
+					getFilterString(entityField, "eq", messageBoardMessage1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(messageBoardMessage1),
+				(List<MessageBoardMessage>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteMessageBoardMessagesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1513,6 +1652,20 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 				BeanUtils.setProperty(
 					messageBoardMessage1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteMessageBoardMessagesPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteMessageBoardMessagesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, messageBoardMessage1, messageBoardMessage2) -> {
+				BeanUtils.setProperty(
+					messageBoardMessage1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					messageBoardMessage2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -3249,13 +3402,19 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfMessageBoardAttachments")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					messageBoardMessage.getNumberOfMessageBoardAttachments()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("numberOfMessageBoardMessages")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					messageBoardMessage.getNumberOfMessageBoardMessages()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("parentMessageBoardMessageId")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -624,6 +624,44 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	}
 
 	@Test
+	public void testGetMessageBoardSectionMessageBoardSectionsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long parentMessageBoardSectionId =
+			testGetMessageBoardSectionMessageBoardSectionsPage_getParentMessageBoardSectionId();
+
+		MessageBoardSection messageBoardSection1 =
+			testGetMessageBoardSectionMessageBoardSectionsPage_addMessageBoardSection(
+				parentMessageBoardSectionId, randomMessageBoardSection());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		MessageBoardSection messageBoardSection2 =
+			testGetMessageBoardSectionMessageBoardSectionsPage_addMessageBoardSection(
+				parentMessageBoardSectionId, randomMessageBoardSection());
+
+		for (EntityField entityField : entityFields) {
+			Page<MessageBoardSection> page =
+				messageBoardSectionResource.
+					getMessageBoardSectionMessageBoardSectionsPage(
+						parentMessageBoardSectionId, null, null,
+						getFilterString(
+							entityField, "eq", messageBoardSection1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(messageBoardSection1),
+				(List<MessageBoardSection>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetMessageBoardSectionMessageBoardSectionsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -729,6 +767,20 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 				BeanUtils.setProperty(
 					messageBoardSection1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetMessageBoardSectionMessageBoardSectionsPageWithSortDouble()
+		throws Exception {
+
+		testGetMessageBoardSectionMessageBoardSectionsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, messageBoardSection1, messageBoardSection2) -> {
+				BeanUtils.setProperty(
+					messageBoardSection1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					messageBoardSection2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -994,6 +1046,41 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteMessageBoardSectionsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteMessageBoardSectionsPage_getSiteId();
+
+		MessageBoardSection messageBoardSection1 =
+			testGetSiteMessageBoardSectionsPage_addMessageBoardSection(
+				siteId, randomMessageBoardSection());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		MessageBoardSection messageBoardSection2 =
+			testGetSiteMessageBoardSectionsPage_addMessageBoardSection(
+				siteId, randomMessageBoardSection());
+
+		for (EntityField entityField : entityFields) {
+			Page<MessageBoardSection> page =
+				messageBoardSectionResource.getSiteMessageBoardSectionsPage(
+					siteId, null, null, null,
+					getFilterString(entityField, "eq", messageBoardSection1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(messageBoardSection1),
+				(List<MessageBoardSection>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteMessageBoardSectionsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1089,6 +1176,20 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 				BeanUtils.setProperty(
 					messageBoardSection1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteMessageBoardSectionsPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteMessageBoardSectionsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, messageBoardSection1, messageBoardSection2) -> {
+				BeanUtils.setProperty(
+					messageBoardSection1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					messageBoardSection2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -2141,13 +2242,19 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfMessageBoardSections")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					messageBoardSection.getNumberOfMessageBoardSections()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("numberOfMessageBoardThreads")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					messageBoardSection.getNumberOfMessageBoardThreads()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("parentMessageBoardSectionId")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -316,6 +316,43 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	}
 
 	@Test
+	public void testGetMessageBoardSectionMessageBoardThreadsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long messageBoardSectionId =
+			testGetMessageBoardSectionMessageBoardThreadsPage_getMessageBoardSectionId();
+
+		MessageBoardThread messageBoardThread1 =
+			testGetMessageBoardSectionMessageBoardThreadsPage_addMessageBoardThread(
+				messageBoardSectionId, randomMessageBoardThread());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		MessageBoardThread messageBoardThread2 =
+			testGetMessageBoardSectionMessageBoardThreadsPage_addMessageBoardThread(
+				messageBoardSectionId, randomMessageBoardThread());
+
+		for (EntityField entityField : entityFields) {
+			Page<MessageBoardThread> page =
+				messageBoardThreadResource.
+					getMessageBoardSectionMessageBoardThreadsPage(
+						messageBoardSectionId, null, null,
+						getFilterString(entityField, "eq", messageBoardThread1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(messageBoardThread1),
+				(List<MessageBoardThread>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetMessageBoardSectionMessageBoardThreadsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -419,6 +456,20 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 				BeanUtils.setProperty(
 					messageBoardThread1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetMessageBoardSectionMessageBoardThreadsPageWithSortDouble()
+		throws Exception {
+
+		testGetMessageBoardSectionMessageBoardThreadsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, messageBoardThread1, messageBoardThread2) -> {
+				BeanUtils.setProperty(
+					messageBoardThread1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					messageBoardThread2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -698,6 +749,20 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 				BeanUtils.setProperty(
 					messageBoardThread1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetMessageBoardThreadsRankedPageWithSortDouble()
+		throws Exception {
+
+		testGetMessageBoardThreadsRankedPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, messageBoardThread1, messageBoardThread2) -> {
+				BeanUtils.setProperty(
+					messageBoardThread1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					messageBoardThread2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1264,6 +1329,41 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteMessageBoardThreadsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteMessageBoardThreadsPage_getSiteId();
+
+		MessageBoardThread messageBoardThread1 =
+			testGetSiteMessageBoardThreadsPage_addMessageBoardThread(
+				siteId, randomMessageBoardThread());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		MessageBoardThread messageBoardThread2 =
+			testGetSiteMessageBoardThreadsPage_addMessageBoardThread(
+				siteId, randomMessageBoardThread());
+
+		for (EntityField entityField : entityFields) {
+			Page<MessageBoardThread> page =
+				messageBoardThreadResource.getSiteMessageBoardThreadsPage(
+					siteId, null, null, null,
+					getFilterString(entityField, "eq", messageBoardThread1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(messageBoardThread1),
+				(List<MessageBoardThread>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteMessageBoardThreadsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1358,6 +1458,20 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 				BeanUtils.setProperty(
 					messageBoardThread1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteMessageBoardThreadsPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteMessageBoardThreadsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, messageBoardThread1, messageBoardThread2) -> {
+				BeanUtils.setProperty(
+					messageBoardThread1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					messageBoardThread2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -3069,13 +3183,19 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfMessageBoardAttachments")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					messageBoardThread.getNumberOfMessageBoardAttachments()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("numberOfMessageBoardMessages")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					messageBoardThread.getNumberOfMessageBoardMessages()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("relatedContents")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
@@ -274,6 +274,38 @@ public abstract class BaseSitePageResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteSitePagesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteSitePagesPage_getSiteId();
+
+		SitePage sitePage1 = testGetSiteSitePagesPage_addSitePage(
+			siteId, randomSitePage());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		SitePage sitePage2 = testGetSiteSitePagesPage_addSitePage(
+			siteId, randomSitePage());
+
+		for (EntityField entityField : entityFields) {
+			Page<SitePage> page = sitePageResource.getSiteSitePagesPage(
+				siteId, null, null,
+				getFilterString(entityField, "eq", sitePage1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(sitePage1),
+				(List<SitePage>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteSitePagesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -350,6 +382,16 @@ public abstract class BaseSitePageResourceTestCase {
 				BeanUtils.setProperty(
 					sitePage1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteSitePagesPageWithSortDouble() throws Exception {
+		testGetSiteSitePagesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, sitePage1, sitePage2) -> {
+				BeanUtils.setProperty(sitePage1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(sitePage2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -331,6 +331,44 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	}
 
 	@Test
+	public void testGetAssetLibraryStructuredContentFoldersPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long assetLibraryId =
+			testGetAssetLibraryStructuredContentFoldersPage_getAssetLibraryId();
+
+		StructuredContentFolder structuredContentFolder1 =
+			testGetAssetLibraryStructuredContentFoldersPage_addStructuredContentFolder(
+				assetLibraryId, randomStructuredContentFolder());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		StructuredContentFolder structuredContentFolder2 =
+			testGetAssetLibraryStructuredContentFoldersPage_addStructuredContentFolder(
+				assetLibraryId, randomStructuredContentFolder());
+
+		for (EntityField entityField : entityFields) {
+			Page<StructuredContentFolder> page =
+				structuredContentFolderResource.
+					getAssetLibraryStructuredContentFoldersPage(
+						assetLibraryId, null, null, null,
+						getFilterString(
+							entityField, "eq", structuredContentFolder1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(structuredContentFolder1),
+				(List<StructuredContentFolder>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetAssetLibraryStructuredContentFoldersPageWithFilterStringEquals()
 		throws Exception {
 
@@ -438,6 +476,20 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 				BeanUtils.setProperty(
 					structuredContentFolder1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAssetLibraryStructuredContentFoldersPageWithSortDouble()
+		throws Exception {
+
+		testGetAssetLibraryStructuredContentFoldersPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, structuredContentFolder1, structuredContentFolder2) ->{
+				BeanUtils.setProperty(
+					structuredContentFolder1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					structuredContentFolder2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -783,6 +835,43 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteStructuredContentFoldersPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteStructuredContentFoldersPage_getSiteId();
+
+		StructuredContentFolder structuredContentFolder1 =
+			testGetSiteStructuredContentFoldersPage_addStructuredContentFolder(
+				siteId, randomStructuredContentFolder());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		StructuredContentFolder structuredContentFolder2 =
+			testGetSiteStructuredContentFoldersPage_addStructuredContentFolder(
+				siteId, randomStructuredContentFolder());
+
+		for (EntityField entityField : entityFields) {
+			Page<StructuredContentFolder> page =
+				structuredContentFolderResource.
+					getSiteStructuredContentFoldersPage(
+						siteId, null, null, null,
+						getFilterString(
+							entityField, "eq", structuredContentFolder1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(structuredContentFolder1),
+				(List<StructuredContentFolder>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteStructuredContentFoldersPageWithFilterStringEquals()
 		throws Exception {
 
@@ -882,6 +971,20 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 				BeanUtils.setProperty(
 					structuredContentFolder1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteStructuredContentFoldersPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteStructuredContentFoldersPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, structuredContentFolder1, structuredContentFolder2) ->{
+				BeanUtils.setProperty(
+					structuredContentFolder1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					structuredContentFolder2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1360,6 +1463,46 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	}
 
 	@Test
+	public void testGetStructuredContentFolderStructuredContentFoldersPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long parentStructuredContentFolderId =
+			testGetStructuredContentFolderStructuredContentFoldersPage_getParentStructuredContentFolderId();
+
+		StructuredContentFolder structuredContentFolder1 =
+			testGetStructuredContentFolderStructuredContentFoldersPage_addStructuredContentFolder(
+				parentStructuredContentFolderId,
+				randomStructuredContentFolder());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		StructuredContentFolder structuredContentFolder2 =
+			testGetStructuredContentFolderStructuredContentFoldersPage_addStructuredContentFolder(
+				parentStructuredContentFolderId,
+				randomStructuredContentFolder());
+
+		for (EntityField entityField : entityFields) {
+			Page<StructuredContentFolder> page =
+				structuredContentFolderResource.
+					getStructuredContentFolderStructuredContentFoldersPage(
+						parentStructuredContentFolderId, null, null,
+						getFilterString(
+							entityField, "eq", structuredContentFolder1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(structuredContentFolder1),
+				(List<StructuredContentFolder>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetStructuredContentFolderStructuredContentFoldersPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1472,6 +1615,20 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 				BeanUtils.setProperty(
 					structuredContentFolder1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetStructuredContentFolderStructuredContentFoldersPageWithSortDouble()
+		throws Exception {
+
+		testGetStructuredContentFolderStructuredContentFoldersPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, structuredContentFolder1, structuredContentFolder2) ->{
+				BeanUtils.setProperty(
+					structuredContentFolder1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					structuredContentFolder2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -2714,13 +2871,20 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfStructuredContentFolders")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					structuredContentFolder.
+						getNumberOfStructuredContentFolders()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("numberOfStructuredContents")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(
+					structuredContentFolder.getNumberOfStructuredContents()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("parentStructuredContentFolderId")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -324,6 +324,42 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	@Test
+	public void testGetAssetLibraryStructuredContentsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long assetLibraryId =
+			testGetAssetLibraryStructuredContentsPage_getAssetLibraryId();
+
+		StructuredContent structuredContent1 =
+			testGetAssetLibraryStructuredContentsPage_addStructuredContent(
+				assetLibraryId, randomStructuredContent());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		StructuredContent structuredContent2 =
+			testGetAssetLibraryStructuredContentsPage_addStructuredContent(
+				assetLibraryId, randomStructuredContent());
+
+		for (EntityField entityField : entityFields) {
+			Page<StructuredContent> page =
+				structuredContentResource.getAssetLibraryStructuredContentsPage(
+					assetLibraryId, null, null, null,
+					getFilterString(entityField, "eq", structuredContent1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(structuredContent1),
+				(List<StructuredContent>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetAssetLibraryStructuredContentsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -423,6 +459,20 @@ public abstract class BaseStructuredContentResourceTestCase {
 				BeanUtils.setProperty(
 					structuredContent1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetAssetLibraryStructuredContentsPageWithSortDouble()
+		throws Exception {
+
+		testGetAssetLibraryStructuredContentsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, structuredContent1, structuredContent2) -> {
+				BeanUtils.setProperty(
+					structuredContent1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					structuredContent2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -758,6 +808,43 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	@Test
+	public void testGetContentStructureStructuredContentsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long contentStructureId =
+			testGetContentStructureStructuredContentsPage_getContentStructureId();
+
+		StructuredContent structuredContent1 =
+			testGetContentStructureStructuredContentsPage_addStructuredContent(
+				contentStructureId, randomStructuredContent());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		StructuredContent structuredContent2 =
+			testGetContentStructureStructuredContentsPage_addStructuredContent(
+				contentStructureId, randomStructuredContent());
+
+		for (EntityField entityField : entityFields) {
+			Page<StructuredContent> page =
+				structuredContentResource.
+					getContentStructureStructuredContentsPage(
+						contentStructureId, null, null,
+						getFilterString(entityField, "eq", structuredContent1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(structuredContent1),
+				(List<StructuredContent>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetContentStructureStructuredContentsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -858,6 +945,20 @@ public abstract class BaseStructuredContentResourceTestCase {
 				BeanUtils.setProperty(
 					structuredContent1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetContentStructureStructuredContentsPageWithSortDouble()
+		throws Exception {
+
+		testGetContentStructureStructuredContentsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, structuredContent1, structuredContent2) -> {
+				BeanUtils.setProperty(
+					structuredContent1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					structuredContent2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1094,6 +1195,41 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteStructuredContentsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteStructuredContentsPage_getSiteId();
+
+		StructuredContent structuredContent1 =
+			testGetSiteStructuredContentsPage_addStructuredContent(
+				siteId, randomStructuredContent());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		StructuredContent structuredContent2 =
+			testGetSiteStructuredContentsPage_addStructuredContent(
+				siteId, randomStructuredContent());
+
+		for (EntityField entityField : entityFields) {
+			Page<StructuredContent> page =
+				structuredContentResource.getSiteStructuredContentsPage(
+					siteId, null, null, null,
+					getFilterString(entityField, "eq", structuredContent1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(structuredContent1),
+				(List<StructuredContent>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteStructuredContentsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -1188,6 +1324,20 @@ public abstract class BaseStructuredContentResourceTestCase {
 				BeanUtils.setProperty(
 					structuredContent1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteStructuredContentsPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteStructuredContentsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, structuredContent1, structuredContent2) -> {
+				BeanUtils.setProperty(
+					structuredContent1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					structuredContent2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1919,6 +2069,43 @@ public abstract class BaseStructuredContentResourceTestCase {
 	}
 
 	@Test
+	public void testGetStructuredContentFolderStructuredContentsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long structuredContentFolderId =
+			testGetStructuredContentFolderStructuredContentsPage_getStructuredContentFolderId();
+
+		StructuredContent structuredContent1 =
+			testGetStructuredContentFolderStructuredContentsPage_addStructuredContent(
+				structuredContentFolderId, randomStructuredContent());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		StructuredContent structuredContent2 =
+			testGetStructuredContentFolderStructuredContentsPage_addStructuredContent(
+				structuredContentFolderId, randomStructuredContent());
+
+		for (EntityField entityField : entityFields) {
+			Page<StructuredContent> page =
+				structuredContentResource.
+					getStructuredContentFolderStructuredContentsPage(
+						structuredContentFolderId, null, null, null,
+						getFilterString(entityField, "eq", structuredContent1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(structuredContent1),
+				(List<StructuredContent>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetStructuredContentFolderStructuredContentsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -2022,6 +2209,20 @@ public abstract class BaseStructuredContentResourceTestCase {
 				BeanUtils.setProperty(
 					structuredContent1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetStructuredContentFolderStructuredContentsPageWithSortDouble()
+		throws Exception {
+
+		testGetStructuredContentFolderStructuredContentsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, structuredContent1, structuredContent2) -> {
+				BeanUtils.setProperty(
+					structuredContent1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					structuredContent2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -3949,13 +4150,15 @@ public abstract class BaseStructuredContentResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfComments")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(structuredContent.getNumberOfComments()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("priority")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(structuredContent.getPriority()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("relatedContents")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
@@ -281,6 +281,38 @@ public abstract class BaseWikiNodeResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteWikiNodesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteWikiNodesPage_getSiteId();
+
+		WikiNode wikiNode1 = testGetSiteWikiNodesPage_addWikiNode(
+			siteId, randomWikiNode());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		WikiNode wikiNode2 = testGetSiteWikiNodesPage_addWikiNode(
+			siteId, randomWikiNode());
+
+		for (EntityField entityField : entityFields) {
+			Page<WikiNode> page = wikiNodeResource.getSiteWikiNodesPage(
+				siteId, null, null,
+				getFilterString(entityField, "eq", wikiNode1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(wikiNode1),
+				(List<WikiNode>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSiteWikiNodesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -357,6 +389,16 @@ public abstract class BaseWikiNodeResourceTestCase {
 				BeanUtils.setProperty(
 					wikiNode1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSiteWikiNodesPageWithSortDouble() throws Exception {
+		testGetSiteWikiNodesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, wikiNode1, wikiNode2) -> {
+				BeanUtils.setProperty(wikiNode1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(wikiNode2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1677,8 +1719,9 @@ public abstract class BaseWikiNodeResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfWikiPages")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(wikiNode.getNumberOfWikiPages()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("siteId")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
@@ -459,6 +459,38 @@ public abstract class BaseWikiPageResourceTestCase {
 	}
 
 	@Test
+	public void testGetWikiNodeWikiPagesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long wikiNodeId = testGetWikiNodeWikiPagesPage_getWikiNodeId();
+
+		WikiPage wikiPage1 = testGetWikiNodeWikiPagesPage_addWikiPage(
+			wikiNodeId, randomWikiPage());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		WikiPage wikiPage2 = testGetWikiNodeWikiPagesPage_addWikiPage(
+			wikiNodeId, randomWikiPage());
+
+		for (EntityField entityField : entityFields) {
+			Page<WikiPage> page = wikiPageResource.getWikiNodeWikiPagesPage(
+				wikiNodeId, null, null,
+				getFilterString(entityField, "eq", wikiPage1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(wikiPage1),
+				(List<WikiPage>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetWikiNodeWikiPagesPageWithFilterStringEquals()
 		throws Exception {
 
@@ -537,6 +569,16 @@ public abstract class BaseWikiPageResourceTestCase {
 				BeanUtils.setProperty(
 					wikiPage1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetWikiNodeWikiPagesPageWithSortDouble() throws Exception {
+		testGetWikiNodeWikiPagesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, wikiPage1, wikiPage2) -> {
+				BeanUtils.setProperty(wikiPage1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(wikiPage2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1826,13 +1868,15 @@ public abstract class BaseWikiPageResourceTestCase {
 		}
 
 		if (entityFieldName.equals("numberOfAttachments")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(wikiPage.getNumberOfAttachments()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("numberOfWikiPages")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(wikiPage.getNumberOfWikiPages()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("parentWikiPageId")) {

--- a/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
@@ -432,7 +432,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.form.client', and version '4.0.10'."
+        'com.liferay.headless.form.client', and version '4.0.11'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.form.client', and version '4.0.10'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Form", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.form.client', and version '4.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Form", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
@@ -58,7 +58,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.portal.instances.client', and version '1.0.6'."
+        'com.liferay.headless.portal.instances.client', and version '1.0.7'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.portal.instances.client', and version '1.0.6'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Portal Instances Headless API", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.portal.instances.client', and version '1.0.7'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Portal Instances Headless API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -378,7 +378,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.object.admin.rest.client', and version '1.0.15'."
+        'com.liferay.object.admin.rest.client', and version '1.0.17'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.15'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.17'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
@@ -268,6 +268,39 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 	}
 
 	@Test
+	public void testGetObjectDefinitionsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		ObjectDefinition objectDefinition1 =
+			testGetObjectDefinitionsPage_addObjectDefinition(
+				randomObjectDefinition());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ObjectDefinition objectDefinition2 =
+			testGetObjectDefinitionsPage_addObjectDefinition(
+				randomObjectDefinition());
+
+		for (EntityField entityField : entityFields) {
+			Page<ObjectDefinition> page =
+				objectDefinitionResource.getObjectDefinitionsPage(
+					null, null,
+					getFilterString(entityField, "eq", objectDefinition1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(objectDefinition1),
+				(List<ObjectDefinition>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetObjectDefinitionsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -365,6 +398,18 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 				BeanUtils.setProperty(
 					objectDefinition1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetObjectDefinitionsPageWithSortDouble() throws Exception {
+		testGetObjectDefinitionsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, objectDefinition1, objectDefinition2) -> {
+				BeanUtils.setProperty(
+					objectDefinition1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					objectDefinition2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
@@ -296,6 +296,43 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 	}
 
 	@Test
+	public void testGetObjectDefinitionObjectRelationshipsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long objectDefinitionId =
+			testGetObjectDefinitionObjectRelationshipsPage_getObjectDefinitionId();
+
+		ObjectRelationship objectRelationship1 =
+			testGetObjectDefinitionObjectRelationshipsPage_addObjectRelationship(
+				objectDefinitionId, randomObjectRelationship());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ObjectRelationship objectRelationship2 =
+			testGetObjectDefinitionObjectRelationshipsPage_addObjectRelationship(
+				objectDefinitionId, randomObjectRelationship());
+
+		for (EntityField entityField : entityFields) {
+			Page<ObjectRelationship> page =
+				objectRelationshipResource.
+					getObjectDefinitionObjectRelationshipsPage(
+						objectDefinitionId, null,
+						getFilterString(entityField, "eq", objectRelationship1),
+						Pagination.of(1, 2));
+
+			assertEquals(
+				Collections.singletonList(objectRelationship1),
+				(List<ObjectRelationship>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetObjectDefinitionObjectRelationshipsPageWithFilterStringEquals()
 		throws Exception {
 

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-openapi.yaml
@@ -319,7 +319,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Forecast API. A Java client JAR is available for use with the group ID 'com.liferay', artifact
-        ID 'com.liferay.headless.commerce.machine.learning.client', and version '1.0.4'."
+        ID 'com.liferay.headless.commerce.machine.learning.client', and version '1.0.5'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Forecast API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.machine.learning.client', and version '1.0.4'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Forecast API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Forecast API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.machine.learning.client', and version '1.0.5'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Forecast API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-openapi.yaml
@@ -570,7 +570,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.13'."
+        'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.14'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.13'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.14'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseHistogramMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseHistogramMetricResourceTestCase.java
@@ -541,8 +541,9 @@ public abstract class BaseHistogramMetricResourceTestCase {
 		}
 
 		if (entityFieldName.equals("value")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(histogramMetric.getValue()));
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
@@ -300,6 +300,16 @@ public abstract class BaseInstanceResourceTestCase {
 	}
 
 	@Test
+	public void testGetProcessInstancesPageWithSortDouble() throws Exception {
+		testGetProcessInstancesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, instance1, instance2) -> {
+				BeanUtils.setProperty(instance1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(instance2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetProcessInstancesPageWithSortInteger() throws Exception {
 		testGetProcessInstancesPageWithSort(
 			EntityField.Type.INTEGER,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeMetricResourceTestCase.java
@@ -289,6 +289,16 @@ public abstract class BaseNodeMetricResourceTestCase {
 	}
 
 	@Test
+	public void testGetProcessNodeMetricsPageWithSortDouble() throws Exception {
+		testGetProcessNodeMetricsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, nodeMetric1, nodeMetric2) -> {
+				BeanUtils.setProperty(nodeMetric1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(nodeMetric2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetProcessNodeMetricsPageWithSortInteger()
 		throws Exception {
 
@@ -835,8 +845,10 @@ public abstract class BaseNodeMetricResourceTestCase {
 		}
 
 		if (entityFieldName.equals("breachedInstancePercentage")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(
+				String.valueOf(nodeMetric.getBreachedInstancePercentage()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("durationAvg")) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessMetricResourceTestCase.java
@@ -270,6 +270,18 @@ public abstract class BaseProcessMetricResourceTestCase {
 	}
 
 	@Test
+	public void testGetProcessMetricsPageWithSortDouble() throws Exception {
+		testGetProcessMetricsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, processMetric1, processMetric2) -> {
+				BeanUtils.setProperty(
+					processMetric1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					processMetric2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
 	public void testGetProcessMetricsPageWithSortInteger() throws Exception {
 		testGetProcessMetricsPageWithSort(
 			EntityField.Type.INTEGER,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResourceTestCase.java
@@ -950,8 +950,9 @@ public abstract class BaseSLAResourceTestCase {
 		}
 
 		if (entityFieldName.equals("status")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sla.getStatus()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("stopNodeKeys")) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTimeRangeResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTimeRangeResourceTestCase.java
@@ -675,8 +675,9 @@ public abstract class BaseTimeRangeResourceTestCase {
 		}
 
 		if (entityFieldName.equals("id")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(timeRange.getId()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("name")) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
@@ -513,7 +513,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.search.experiences.rest.client', and version '1.0.4'."
+        'com.liferay.search.experiences.rest.client', and version '1.0.5'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '1.0.4'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '1.0.5'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseFieldMappingInfoResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseFieldMappingInfoResourceTestCase.java
@@ -570,8 +570,9 @@ public abstract class BaseFieldMappingInfoResourceTestCase {
 		sb.append(" ");
 
 		if (entityFieldName.equals("languageIdPosition")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(fieldMappingInfo.getLanguageIdPosition()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("name")) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
@@ -258,6 +258,35 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 	}
 
 	@Test
+	public void testGetSXPBlueprintsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		SXPBlueprint sxpBlueprint1 = testGetSXPBlueprintsPage_addSXPBlueprint(
+			randomSXPBlueprint());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		SXPBlueprint sxpBlueprint2 = testGetSXPBlueprintsPage_addSXPBlueprint(
+			randomSXPBlueprint());
+
+		for (EntityField entityField : entityFields) {
+			Page<SXPBlueprint> page = sxpBlueprintResource.getSXPBlueprintsPage(
+				null, getFilterString(entityField, "eq", sxpBlueprint1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(sxpBlueprint1),
+				(List<SXPBlueprint>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSXPBlueprintsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -338,6 +367,18 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 				BeanUtils.setProperty(
 					sxpBlueprint1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSXPBlueprintsPageWithSortDouble() throws Exception {
+		testGetSXPBlueprintsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, sxpBlueprint1, sxpBlueprint2) -> {
+				BeanUtils.setProperty(
+					sxpBlueprint1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(
+					sxpBlueprint2, entityField.getName(), 0.5);
 			});
 	}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPElementResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPElementResourceTestCase.java
@@ -258,6 +258,35 @@ public abstract class BaseSXPElementResourceTestCase {
 	}
 
 	@Test
+	public void testGetSXPElementsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DOUBLE);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		SXPElement sxpElement1 = testGetSXPElementsPage_addSXPElement(
+			randomSXPElement());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		SXPElement sxpElement2 = testGetSXPElementsPage_addSXPElement(
+			randomSXPElement());
+
+		for (EntityField entityField : entityFields) {
+			Page<SXPElement> page = sxpElementResource.getSXPElementsPage(
+				null, getFilterString(entityField, "eq", sxpElement1),
+				Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(sxpElement1),
+				(List<SXPElement>)page.getItems());
+		}
+	}
+
+	@Test
 	public void testGetSXPElementsPageWithFilterStringEquals()
 		throws Exception {
 
@@ -335,6 +364,16 @@ public abstract class BaseSXPElementResourceTestCase {
 				BeanUtils.setProperty(
 					sxpElement1, entityField.getName(),
 					DateUtils.addMinutes(new Date(), -2));
+			});
+	}
+
+	@Test
+	public void testGetSXPElementsPageWithSortDouble() throws Exception {
+		testGetSXPElementsPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, sxpElement1, sxpElement2) -> {
+				BeanUtils.setProperty(sxpElement1, entityField.getName(), 0.1);
+				BeanUtils.setProperty(sxpElement2, entityField.getName(), 0.5);
 			});
 	}
 
@@ -1302,8 +1341,9 @@ public abstract class BaseSXPElementResourceTestCase {
 		}
 
 		if (entityFieldName.equals("type")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(sxpElement.getType()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("userName")) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchResponseResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchResponseResourceTestCase.java
@@ -654,13 +654,15 @@ public abstract class BaseSearchResponseResourceTestCase {
 		}
 
 		if (entityFieldName.equals("page")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(searchResponse.getPage()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("pageSize")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(searchResponse.getPageSize()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("request")) {

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/rest-openapi.yaml
@@ -69,7 +69,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.segments.asah.rest.client', and version '3.0.11'."
+        'com.liferay.segments.asah.rest.client', and version '3.0.12'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.segments.asah.rest.client', and version '3.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Segments Asah", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.segments.asah.rest.client', and version '3.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Segments Asah", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentRunResourceTestCase.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentRunResourceTestCase.java
@@ -535,8 +535,9 @@ public abstract class BaseExperimentRunResourceTestCase {
 		sb.append(" ");
 
 		if (entityFieldName.equals("confidenceLevel")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			sb.append(String.valueOf(experimentRun.getConfidenceLevel()));
+
+			return sb.toString();
 		}
 
 		if (entityFieldName.equals("experimentVariants")) {

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -604,6 +604,60 @@ public abstract class Base${schemaName}ResourceTestCase {
 					}
 
 					@Test
+					public void test${javaMethodSignature.methodName?cap_first}WithFilterDoubleEquals() throws Exception {
+						List<EntityField> entityFields = getEntityFields(EntityField.Type.DOUBLE);
+
+						if (entityFields.isEmpty()) {
+							return;
+						}
+
+						<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
+							${javaMethodParameter.parameterType} ${javaMethodParameter.parameterName} = test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}();
+						</#list>
+
+						${schemaName} ${schemaVarName}1 = test${javaMethodSignature.methodName?cap_first}_add${schemaName}(
+
+						<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
+							${javaMethodParameter.parameterName},
+						</#list>
+
+						random${schemaName}());
+
+						@SuppressWarnings("PMD.UnusedLocalVariable")
+						${schemaName} ${schemaVarName}2 = test${javaMethodSignature.methodName?cap_first}_add${schemaName}(
+
+						<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
+							${javaMethodParameter.parameterName},
+						</#list>
+
+						random${schemaName}());
+
+						for (EntityField entityField : entityFields) {
+							Page<${schemaName}> page = ${schemaVarName}Resource.${javaMethodSignature.methodName}(
+
+							<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
+								<#if !javaMethodParameter?is_first>
+									,
+								</#if>
+
+								<#if stringUtil.equals(javaMethodParameter.parameterName, "filter")>
+									getFilterString(entityField, "eq", ${schemaVarName}1)
+								<#elseif stringUtil.equals(javaMethodParameter.parameterName, "pagination")>
+									Pagination.of(1, 2)
+								<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
+									${javaMethodParameter.parameterName}
+								<#else>
+									null
+								</#if>
+							</#list>
+
+							);
+
+							assertEquals(Collections.singletonList(${schemaVarName}1), (List<${schemaName}>)page.getItems());
+						}
+					}
+
+					@Test
 					public void test${javaMethodSignature.methodName?cap_first}WithFilterStringEquals() throws Exception {
 						List<EntityField> entityFields = getEntityFields(EntityField.Type.STRING);
 
@@ -790,6 +844,16 @@ public abstract class Base${schemaName}ResourceTestCase {
 							EntityField.Type.DATE_TIME,
 							(entityField, ${schemaVarName}1, ${schemaVarName}2) -> {
 								BeanUtils.setProperty(${schemaVarName}1, entityField.getName(), DateUtils.addMinutes(new Date(), -2));
+							});
+					}
+
+					@Test
+					public void test${javaMethodSignature.methodName?cap_first}WithSortDouble() throws Exception {
+						test${javaMethodSignature.methodName?cap_first}WithSort(
+							EntityField.Type.DOUBLE,
+							(entityField, ${schemaVarName}1, ${schemaVarName}2) -> {
+								BeanUtils.setProperty(${schemaVarName}1, entityField.getName(), 0.1);
+								BeanUtils.setProperty(${schemaVarName}2, entityField.getName(), 0.5);
 							});
 					}
 
@@ -2318,6 +2382,14 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 						sb.append(_dateFormat.format(${schemaVarName}.get${propertyName?cap_first}()));
 					}
+
+					return sb.toString();
+				<#elseif stringUtil.equals(properties[propertyName], "Double")>
+					sb.append(String.valueOf(${schemaVarName}.get${propertyName?cap_first}()));
+
+					return sb.toString();
+				<#elseif stringUtil.equals(properties[propertyName], "Integer")>
+					sb.append(String.valueOf(${schemaVarName}.get${propertyName?cap_first}()));
 
 					return sb.toString();
 				<#elseif stringUtil.equals(properties[propertyName], "String")>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -603,113 +603,15 @@ public abstract class Base${schemaName}ResourceTestCase {
 						}
 					}
 
-					@Test
-					public void test${javaMethodSignature.methodName?cap_first}WithFilterDoubleEquals() throws Exception {
-						List<EntityField> entityFields = getEntityFields(EntityField.Type.DOUBLE);
+					<@getFilterEqualsTest
+						fieldType="Double"
+						javaMethodSignature=javaMethodSignature
+					/>
 
-						if (entityFields.isEmpty()) {
-							return;
-						}
-
-						<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
-							${javaMethodParameter.parameterType} ${javaMethodParameter.parameterName} = test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}();
-						</#list>
-
-						${schemaName} ${schemaVarName}1 = test${javaMethodSignature.methodName?cap_first}_add${schemaName}(
-
-						<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
-							${javaMethodParameter.parameterName},
-						</#list>
-
-						random${schemaName}());
-
-						@SuppressWarnings("PMD.UnusedLocalVariable")
-						${schemaName} ${schemaVarName}2 = test${javaMethodSignature.methodName?cap_first}_add${schemaName}(
-
-						<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
-							${javaMethodParameter.parameterName},
-						</#list>
-
-						random${schemaName}());
-
-						for (EntityField entityField : entityFields) {
-							Page<${schemaName}> page = ${schemaVarName}Resource.${javaMethodSignature.methodName}(
-
-							<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
-								<#if !javaMethodParameter?is_first>
-									,
-								</#if>
-
-								<#if stringUtil.equals(javaMethodParameter.parameterName, "filter")>
-									getFilterString(entityField, "eq", ${schemaVarName}1)
-								<#elseif stringUtil.equals(javaMethodParameter.parameterName, "pagination")>
-									Pagination.of(1, 2)
-								<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
-									${javaMethodParameter.parameterName}
-								<#else>
-									null
-								</#if>
-							</#list>
-
-							);
-
-							assertEquals(Collections.singletonList(${schemaVarName}1), (List<${schemaName}>)page.getItems());
-						}
-					}
-
-					@Test
-					public void test${javaMethodSignature.methodName?cap_first}WithFilterStringEquals() throws Exception {
-						List<EntityField> entityFields = getEntityFields(EntityField.Type.STRING);
-
-						if (entityFields.isEmpty()) {
-							return;
-						}
-
-						<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
-							${javaMethodParameter.parameterType} ${javaMethodParameter.parameterName} = test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}();
-						</#list>
-
-						${schemaName} ${schemaVarName}1 = test${javaMethodSignature.methodName?cap_first}_add${schemaName}(
-
-						<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
-							${javaMethodParameter.parameterName},
-						</#list>
-
-						random${schemaName}());
-
-						@SuppressWarnings("PMD.UnusedLocalVariable")
-						${schemaName} ${schemaVarName}2 = test${javaMethodSignature.methodName?cap_first}_add${schemaName}(
-
-						<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
-							${javaMethodParameter.parameterName},
-						</#list>
-
-						random${schemaName}());
-
-						for (EntityField entityField : entityFields) {
-							Page<${schemaName}> page = ${schemaVarName}Resource.${javaMethodSignature.methodName}(
-
-							<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
-								<#if !javaMethodParameter?is_first>
-									,
-								</#if>
-
-								<#if stringUtil.equals(javaMethodParameter.parameterName, "filter")>
-									getFilterString(entityField, "eq", ${schemaVarName}1)
-								<#elseif stringUtil.equals(javaMethodParameter.parameterName, "pagination")>
-									Pagination.of(1, 2)
-								<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
-									${javaMethodParameter.parameterName}
-								<#else>
-									null
-								</#if>
-							</#list>
-
-							);
-
-							assertEquals(Collections.singletonList(${schemaVarName}1), (List<${schemaName}>)page.getItems());
-						}
-					}
+					<@getFilterEqualsTest
+						fieldType="String"
+						javaMethodSignature=javaMethodSignature
+					/>
 				</#if>
 
 				<#if parameters?contains("Pagination pagination")>
@@ -2606,6 +2508,65 @@ public abstract class Base${schemaName}ResourceTestCase {
 	<#else>
 		null
 	</#if>
+</#macro>
+
+<#macro getFilterEqualsTest
+	fieldType
+	javaMethodSignature
+>
+	@Test
+	public void test${javaMethodSignature.methodName?cap_first}WithFilter${fieldType?cap_first}Equals() throws Exception {
+		List<EntityField> entityFields = getEntityFields(EntityField.Type.${fieldType?upper_case});
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
+			${javaMethodParameter.parameterType} ${javaMethodParameter.parameterName} = test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}();
+		</#list>
+
+		${schemaName} ${schemaVarName}1 = test${javaMethodSignature.methodName?cap_first}_add${schemaName}(
+
+		<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
+			${javaMethodParameter.parameterName},
+		</#list>
+
+		random${schemaName}());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		${schemaName} ${schemaVarName}2 = test${javaMethodSignature.methodName?cap_first}_add${schemaName}(
+
+		<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
+			${javaMethodParameter.parameterName},
+		</#list>
+
+		random${schemaName}());
+
+		for (EntityField entityField : entityFields) {
+			Page<${schemaName}> page = ${schemaVarName}Resource.${javaMethodSignature.methodName}(
+
+			<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
+				<#if !javaMethodParameter?is_first>
+					,
+				</#if>
+
+				<#if stringUtil.equals(javaMethodParameter.parameterName, "filter")>
+					getFilterString(entityField, "eq", ${schemaVarName}1)
+				<#elseif stringUtil.equals(javaMethodParameter.parameterName, "pagination")>
+					Pagination.of(1, 2)
+				<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
+					${javaMethodParameter.parameterName}
+				<#else>
+					null
+				</#if>
+			</#list>
+
+			);
+
+			assertEquals(Collections.singletonList(${schemaVarName}1), (List<${schemaName}>)page.getItems());
+		}
+	}
 </#macro>
 
 <#macro getGetterParameters


### PR DESCRIPTION
Related ticket: [LPS-148531](https://issues.liferay.com/browse/LPS-148531)

Related PR (the CI was failing, verified that is not related to this PR): https://github.com/liferay-frontend/liferay-portal/pull/1971
Related PR (this PRs generates the test of this functionality): https://github.com/brianchandotcom/liferay-portal/pull/114074

This PR contains an updated Base*TestCase template in REST Builder to include Filter and Sort autogenerated tests for Double Entity Fields as part of the field types that are being tested (up to this point, String and DateTime fields in filter and String, DateTime and Integer in sort are the ones being tested).