### PR TITLE
LPS-149317 Fix tag closing syntax error

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/stickers.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/stickers.jsp
@@ -96,8 +96,8 @@
 				label="PDF"
 				position="bottom-left"
 			/>
-		</clay:col>
-	</div>
+		</div>
+	</clay:col>
 
 	<clay:col
 		md="2"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ProgressBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ProgressBarTag.java
@@ -120,7 +120,7 @@ public class ProgressBarTag extends BaseContainerTag {
 
 			iconTag.doTag(pageContext);
 
-			jspWriter.write("</div");
+			jspWriter.write("</div>");
 		}
 		else {
 			jspWriter.write(String.valueOf(_value));


### PR DESCRIPTION
Manually forwarding because unrelated test failures on `ci:test:relevant`

Original PR https://github.com/liferay-frontend/liferay-portal/pull/2011

---

Basically, these are the fixes that we fixed in PR https://github.com/liferay-frontend/liferay-portal/pull/1986, but the error of the problem was happening because the SSR of the taglib progress bar was not closing the tag correctly.

You can reproduce this behavior by editing the DXP main page, adding a new Clay Sample widget, and trying to navigate the Stickers tab, without this PR it will not render anything with this fix it will show the stickers examples.

Basically, the stickers examples were being rendered but the incorrect tag closing caused the stickers tab to be rendered inside the progress bar example.