### PR TITLE
LPS-147280 LPS-147278 Change way of validating PathParam annotation values for matching with Java 8 and Java 11

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/param/converter/provider/SiteParamConverterProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/param/converter/provider/SiteParamConverterProvider.java
@@ -24,12 +24,16 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.cxf.jaxrs.utils.AnnotationUtils;
 
 /**
  * @author Javier Gamarra
@@ -120,12 +124,10 @@ public class SiteParamConverterProvider
 
 	private boolean _hasSiteIdAnnotation(Annotation[] annotations) {
 		for (Annotation annotation : annotations) {
-			String annotationString = annotation.toString();
-
-			if (annotationString.equals(
-					"@javax.ws.rs.PathParam(value=assetLibraryId)") ||
-				annotationString.equals(
-					"@javax.ws.rs.PathParam(value=siteId)")) {
+			if ((annotation.annotationType() == PathParam.class) &&
+				StringUtils.equalsAny(
+					AnnotationUtils.getAnnotationValue(annotation),
+					"assetLibraryId", "siteId")) {
 
 				return true;
 			}


### PR DESCRIPTION
Related tickets:

[LPS-147278](https://issues.liferay.com/browse/LPS-147278)
[LPS-147280](https://issues.liferay.com/browse/LPS-147280)

Related PR (the CI was failing, verified that is not related to this PR): https://github.com/liferay-frontend/liferay-portal/pull/2009

This PR contains a change on the way of validating if an Annotation is related to a desired one with a specified value. In Java 8 it was working perfectly but in Java 11 the toString() method returned a different String.

It can be tested by launching the Integration Test **StructuredContentResourceTest.testGetAssetLibraryStructuredContentPermissionsPage**

Before the PR:

In Java 8 this method:
```
annotation.toString()
```
returned the text `@javax.ws.rs.PathParam(value=assetLibraryId)`

In Java 11 this method:
```
annotation.toString()
```
returned the text `@javax.ws.rs.PathParam(value="assetLibraryId")`

After the PR: It is independent of the toString implementation
