### PR TITLE
LPS-148862 search-experiences-web: Remove browser errors in blueprint query settings

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/QuerySettings.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/QuerySettings.js
@@ -136,14 +136,11 @@ function QuerySettings({
 								</span>
 
 								<ClaySticker
-									borderless
 									displayType="secondary"
-									monospaced
 									onClick={(event) => {
 										event.stopPropagation();
 										onChangeIndexerClausesVisibility();
 									}}
-									size="md"
 								>
 									<ClayIcon symbol="question-circle" />
 								</ClaySticker>


### PR DESCRIPTION
Forwarded from https://github.com/liferay-search/liferay-portal/pull/346

Test failures look unrelated!

---
https://issues.liferay.com/browse/LPS-148862 - Browser console errors when navigating to Blueprints Query Settings

Small change! This was the error I saw. 

```
Warning: Received `true` for a non-boolean attribute `borderless`.

If you want to write it to the DOM, pass a string instead: borderless="true" or borderless={value.toString()}
```