### PR TITLE
LPS-150044 Remove ModularTrashEntryServiceWrapper getEntries() functi…

### DIFF
--- a/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/service/ModularTrashEntryServiceWrapper.java
+++ b/modules/apps/trash/trash-service/src/main/java/com/liferay/trash/internal/service/ModularTrashEntryServiceWrapper.java
@@ -71,8 +71,8 @@ public class ModularTrashEntryServiceWrapper extends TrashEntryServiceWrapper {
 
 	@Override
 	public TrashEntryList getEntries(long groupId) throws PrincipalException {
-		return ModelAdapterUtil.adapt(
-			TrashEntryList.class, _trashEntryService.getEntries(groupId));
+		throw new UnsupportedOperationException(
+			getClass() + " does not support getEntries() method.");
 	}
 
 	@Override
@@ -81,11 +81,8 @@ public class ModularTrashEntryServiceWrapper extends TrashEntryServiceWrapper {
 			OrderByComparator<TrashEntry> orderByComparator)
 		throws PrincipalException {
 
-		return ModelAdapterUtil.adapt(
-			TrashEntryList.class,
-			_trashEntryService.getEntries(
-				groupId, start, end,
-				new TrashEntryOrderByComparatorAdapter(orderByComparator)));
+		throw new UnsupportedOperationException(
+			getClass() + " does not support getEntries() method.");
 	}
 
 	@Override


### PR DESCRIPTION
…onality

See also LPS-149460.
When we are moving petra-model-adapt into core/petra, we found that getEntries methods in ModularTrashEntryServiceWrapper incorrectly use ModelAdapterUtil.adapt() by passing in a concrete class instead of an interface.
This causes the method to throw IllegalArgumentException. Java Proxy API requires the use of an interface.
Since the original TrashEntryList class in kernel has been deprecated and no other classes use these methods, we decide to throw the exception to note that this operation is not supported. Other solutions may require additional time to implement either a wrapper class for TrashEntryList or extend ASMWrapperUtil's createWrapper method to support both interface and class.