### PR TITLE
Readonly.config

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/model/ConfigurationModel.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/model/ConfigurationModel.java
@@ -354,6 +354,23 @@ public class ConfigurationModel implements ExtendedObjectClassDefinition {
 		return _isScope(Scope.PORTLET_INSTANCE);
 	}
 
+	public boolean isReadOnly() {
+		if (_configuration == null) {
+			return false;
+		}
+
+		Set<Configuration.ConfigurationAttribute> configurationAttributes =
+			_configuration.getAttributes();
+
+		if (configurationAttributes.contains(
+				Configuration.ConfigurationAttribute.READ_ONLY)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	public boolean isStrictScope() {
 		Map<String, String> extensionAttributes =
 			_extendedObjectClassDefinition.getExtensionAttributes(

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/action/ExportConfigurationMVCResourceCommand.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/action/ExportConfigurationMVCResourceCommand.java
@@ -319,11 +319,17 @@ public class ExportConfigurationMVCResourceCommand
 		if (Validator.isNotNull(factoryPid) && !factoryPid.equals(pid)) {
 			String factoryInstanceId = pid.substring(factoryPid.length() + 1);
 
-			if (factoryInstanceId.startsWith("scoped")) {
+			if (factoryInstanceId.startsWith("scoped.")) {
 				factoryPid = factoryPid + ".scoped";
 
 				factoryInstanceId = StringUtil.removeSubstring(
 					factoryInstanceId, "scoped.");
+			}
+			else if (factoryInstanceId.startsWith("scoped~")) {
+				factoryPid = factoryPid + ".scoped";
+
+				factoryInstanceId = StringUtil.removeSubstring(
+					factoryInstanceId, "scoped~");
 			}
 
 			fileName = factoryPid + StringPool.TILDE + factoryInstanceId;

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelToDDMFormConverter.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelToDDMFormConverter.java
@@ -76,6 +76,12 @@ public class ConfigurationModelToDDMFormConverter {
 		_addRequiredDDMFormFields(ddmForm);
 		_addOptionalDDMFormFields(ddmForm);
 
+		if (_configurationModel.isReadOnly()) {
+			for (DDMFormField ddmFormField : ddmForm.getDDMFormFields()) {
+				ddmFormField.setReadOnly(true);
+			}
+		}
+
 		return ddmForm;
 	}
 

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
@@ -209,6 +209,12 @@ renderResponse.setTitle(categoryDisplayName);
 						</c:if>
 					</h2>
 
+					<c:if test="<%= configurationModel.hasScopeConfiguration(configurationScopeDisplayContext.getScope()) && configurationModel.isReadOnly() %>">
+						<aui:alert closeable="<%= false %>" id="readonlyAlert" type="info">
+							<liferay-ui:message key="this-configuration-is-read-only" />
+						</aui:alert>
+					</c:if>
+
 					<c:if test="<%= !configurationModel.hasScopeConfiguration(configurationScopeDisplayContext.getScope()) %>">
 						<aui:alert closeable="<%= false %>" id="errorAlert" type="info">
 							<liferay-ui:message key="this-configuration-is-not-saved-yet.-the-values-shown-are-the-default" />
@@ -235,27 +241,29 @@ renderResponse.setTitle(categoryDisplayName);
 
 					<liferay-util:dynamic-include key='<%= "com.liferay.configuration.admin.web#/edit_configuration.jsp#" + configurationModel.getFactoryPid() + "#post" %>' />
 
-					<aui:button-row>
-						<c:choose>
-							<c:when test="<%= configurationModel.hasScopeConfiguration(configurationScopeDisplayContext.getScope()) %>">
-								<aui:button name="update" type="submit" value="update" />
-							</c:when>
-							<c:otherwise>
-								<aui:button name="save" type="submit" value="save" />
-							</c:otherwise>
-						</c:choose>
+					<c:if test="<%= !configurationModel.isReadOnly() %>">
+						<aui:button-row>
+							<c:choose>
+								<c:when test="<%= configurationModel.hasScopeConfiguration(configurationScopeDisplayContext.getScope()) %>">
+									<aui:button name="update" type="submit" value="update" />
+								</c:when>
+								<c:otherwise>
+									<aui:button name="save" type="submit" value="save" />
+								</c:otherwise>
+							</c:choose>
 
-						<aui:button href="<%= redirect %>" name="cancel" type="cancel" />
+							<aui:button href="<%= redirect %>" name="cancel" type="cancel" />
 
-						<c:if test="<%= Validator.isNotNull(configurationModel.getLiferayLearnMessageKey()) && Validator.isNotNull(configurationModel.getLiferayLearnMessageResource()) %>">
-							<div class="btn float-right">
-								<liferay-learn:message
-									key="<%= configurationModel.getLiferayLearnMessageKey() %>"
-									resource="<%= configurationModel.getLiferayLearnMessageResource() %>"
-								/>
-							</div>
-						</c:if>
-					</aui:button-row>
+							<c:if test="<%= Validator.isNotNull(configurationModel.getLiferayLearnMessageKey()) && Validator.isNotNull(configurationModel.getLiferayLearnMessageResource()) %>">
+								<div class="btn float-right">
+									<liferay-learn:message
+										key="<%= configurationModel.getLiferayLearnMessageKey() %>"
+										resource="<%= configurationModel.getLiferayLearnMessageResource() %>"
+									/>
+								</div>
+							</c:if>
+						</aui:button-row>
+					</c:if>
 				</aui:form>
 			</clay:sheet>
 		</clay:col>

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -15839,6 +15839,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=This change will only 
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration.
 this-configuration-is-not-saved-yet=This configuration is not saved yet.
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=This configuration is not saved yet. The values shown are the default.
+this-configuration-is-read-only=This configuartion is read-only.
 this-content-has-a-display-page=This content has a display page.
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=This content has expired or you do not have the required permissions to access it.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=This coupon only applies to items that are children of this comma delimited list of categories.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=هذا التغيير 
 this-collection-has-no-items=هذا التحصيل ليس به عناصر. يلزمك على الأقل عنصر واحد لاستخدام هذا التكوين.
 this-configuration-is-not-saved-yet=لم يتم حفظ هذا التكوين بعد.
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=لم يتم حفظ هذا التكوين بعد. القيم المعروضة هي قيم افتراضية.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=محتوى الويب هذا يتضمن صفحة عرض.
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=هذا المحتوى انتهت صلاحيته أو أنه ليس لديك صلاحية للوصول إليه.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=هذا الكوبون صالح فقط للأصناف الموجودة في تصنيفات هذه القائمة.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Тази промян�
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Тази конфигурация още не е записана. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Тази конфигурация още не е записана. Показаните стойности са по подразбиране. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Това съдържание има страница за показване. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Това съдържание е с изтекъл срок или нямате необходимите разрешения за достъп до него. (Automatic Translation)
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Този купон се прилага само към елементи, които са деца на този списък от категории, разделен със запетаи.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -15835,6 +15835,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Aquest canvi només es
 this-collection-has-no-items=Aquesta col·lecció no té elements. Necessiteu com a mínim un element per utilitzar aquesta configuració.
 this-configuration-is-not-saved-yet=Aquesta configuració encara no està desada.
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Aquesta configuració encara no s'ha guardat. Els valors mostrats són els valors per defecte.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Aquest contingut web té una pàgina de visualització.
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=O bé aquest contingut ha caducat, o bé no teniu els permisos necessaris per accedir-hi.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Aquest cupó només s'aplica als elements que són d'un nivell inferior en aquesta llista de categories delimitada per una coma.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Změny budou patrné a
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Tato konfigurace ještě není uložena. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Tato konfigurace ještě není uložena. Zobrazené hodnoty jsou výchozí. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Tento obsah má zobrazovanou stránku. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Tomuto obsahu vypršela platnost nebo nemáte potřebná oprávnění.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Tento kupón může být použit jen na položky v těchto kategoriích.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=This change will only 
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Denne konfiguration er ikke gemt endnu. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Denne konfiguration er ikke gemt endnu. De viste værdier er standardværdierne. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Dette indhold har en visningsside. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Dette indhold er udløbet, eller du har ikke de nødvendige tilladelser til at få adgang til det. (Automatic Translation)
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=This coupon only applies to items that are children of this comma delimited list of categories. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -15835,6 +15835,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Diese Änderung wird e
 this-collection-has-no-items=Diese Sammlung enthält keine Artikel. Sie benötigen mindestens einen Artikel, um diese Konfiguration zu verwenden.
 this-configuration-is-not-saved-yet=Diese Konfiguration wurde noch nicht gespeichert.
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Diese Konfiguration wurde noch nicht gespeichert. Die angezeigten Werte werden standardmäßig erstellt.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Dieser Web-Inhalt hat eine Anzeigeseite.
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Entweder ist dieser Inhalt abgehlaufen oder Ihnen fehlt die Berechtigung um darauf zuzugreifen.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Dieser Gutschein ist nur für Artikel gültig, welche den - in der Liste mit Kommas getrennten - Einträgen untergeordnet sind.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Αυτή η αλλαγ
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Αυτή η ρύθμιση παραμέτρων δεν έχει αποθηκευτεί ακόμα. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Αυτή η ρύθμιση παραμέτρων δεν έχει αποθηκευτεί ακόμα. Οι τιμές που εμφανίζονται είναι οι προεπιλεγμένες. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Αυτό το περιεχόμενο έχει μια σελίδα εμφάνισης. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Αυτό το περιεχόμενο έχει λήξει ή δεν έχετε τα απαραίτητα δικαιώματα πρόσβασης σε αυτό.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Αυτό το κουπόνι ισχύει μόνο για τα είδη που είναι παιδιά αυτού του καταλόγου κατηγοριών που χωρίζονται με κόμμα.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -15839,6 +15839,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=This change will only 
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration.
 this-configuration-is-not-saved-yet=This configuration is not saved yet.
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=This configuration is not saved yet. The values shown are the default.
+this-configuration-is-read-only=This configuartion is read-only.
 this-content-has-a-display-page=This content has a display page.
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=This content has expired or you do not have the required permissions to access it.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=This coupon only applies to items that are children of this comma delimited list of categories.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=This change will only 
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=This configuration is not saved yet. (Automatic Copy)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=This configuration is not saved yet. The values shown are the default. (Automatic Copy)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=This content has a display page. (Automatic Copy)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=This content has expired or you do not have the required permissions to access it. (Automatic Copy)
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=This coupon only applies to items that are children of this comma delimited list of categories. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=This change will only 
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=This configuration is not saved yet. (Automatic Copy)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=This configuration is not saved yet. The values shown are the default. (Automatic Copy)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=This content has a display page. (Automatic Copy)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=This content has expired or you do not have the required permissions to access it. (Automatic Copy)
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=This coupon only applies to items that are children of this comma delimited list of categories. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -15835,6 +15835,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Este cambio será apli
 this-collection-has-no-items=Esta colección no tiene elementos. Necesita como mínimo un elemento para usar esta configuración.
 this-configuration-is-not-saved-yet=Esta configuración aún no se ha guardado.
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Esta configuración todavía no ha sido guardada. Los valores que se muestran son los valores por defecto.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Este contenido web tiene una página de visualización.
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Este contenido ha expirado o usted no tiene los permisos requeridos para acceder.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Este cupón se aplica solamente a los artículos que pertenecen a alguna de las siguientes categorías:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=See muudatus on nähta
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Seda konfiguratsiooni pole veel salvestatud. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Seda konfiguratsiooni pole veel salvestatud. Kuvatavad väärtused on vaikeväärtused. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Sellel sisul on kuvaleht. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=See sisu on aegunud või teil pole sellele juurdepääsuks vajalikke õigusi. (Automatic Translation)
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=See kupong kehtib ainult elementide puhul, mis on alamad antud komadega eraldatud kategooriate loendile.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Aldaketa hau orria ber
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=This configuration is not saved yet. (Automatic Copy)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=This configuration is not saved yet. The values shown are the default. (Automatic Copy)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=This content has a display page. (Automatic Copy)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Eduki hau iraungita dago edo ez duzu baimenik sartzeko.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Kupoi hau komaz bereizitako zerrenda honetako umeak diren elementuei aplikatzen zaie soilik.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=این تغییر فق
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=این پیکربندی هنوز ذخیره نشده است. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=تنظیمات هنوز ذخیره نشده است. مقادیر نشان داده شده پیش‌فرض هستند.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=این محتوا یک صفحه نمایش دارد.
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=این محتوا منقضی شده است و یا شما مجوز لازم برای دسترسی به آن را ندارید.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=این کوپن فقط مربوط به محصولات این طبقه‌بندی‌ها می‌شود، طبقه‌بندی‌ها توسط کاما از یکدیگر جدا می شوند

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -15831,6 +15831,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Tämä muutos näkyy v
 this-collection-has-no-items=Tässä kokoelmassa ei ole kohteita. Tarvitset ainakin yhden kohteen käyttääksesi tätä kokoonpanoa.
 this-configuration-is-not-saved-yet=Näitä asetuksia ei ole vielä tallennettu.
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Tätä asetusta ei ole vielä tallennettu. Näytetyt arvot ovat vakiot.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Tällä web-sisällöllä on näyttösivu.
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Sisältö on joko vanhentunut tai sinulla ei ole riittäviä käyttöoikeuksia sen tarkastelemiseen.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Tämä kuponki käy vain tuotteille jotka ovat seuraavan kategorialistan alaisia.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -15835,6 +15835,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Ce changement sera aff
 this-collection-has-no-items=Cette collection n'a pas d'articles. Vous avez besoin d'au moins un élément pour utiliser cette configuration.
 this-configuration-is-not-saved-yet=Cette configuration n'est pas encore enregistrée.
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Cette configuration n'a pas été sauvegardée encore. Les valeurs affichées sont celles par défaut.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Ce contenu web a une page d'affichage.
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Ce contenu a expiré ou vous n'avez pas les permissions requises pour y accéder.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Ce bon s'applique seulement aux articles qui sont des enfants de cette liste délimitée par virgule de catégories.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Ce changement sera aff
 this-collection-has-no-items=Cette collection n'a pas d'articles. Vous avez besoin d'au moins un élément pour utiliser cette configuration.
 this-configuration-is-not-saved-yet=Cette configuration n'est pas encore enregistrée.
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Cette configuration n'a pas été sauvegardée encore. Les valeurs affichées sont celles par défaut.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Ce contenu web a une page d'affichage.
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Ce contenu a expiré ou vous n'avez pas les permissions requises pour y accéder.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Ce bon s'applique seulement aux articles qui sont des enfants de cette liste délimitée par virgule de catégories.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Este cambio será apli
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=This configuration is not saved yet. (Automatic Copy)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=This configuration is not saved yet. The values shown are the default. (Automatic Copy)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=This content has a display page. (Automatic Copy)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Este contido caducou ou non tes os permisos requiridos para acceder a el.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Este cupón aplícase soamente aos artigos que pertencen a algunha das seguintes categorías (separadas por comas).

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=तुम्हार�
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=यह विन्यास अभी तक सहेजा नहीं गया है। (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=यह विन्यास अभी तक सहेजा नहीं गया है। दिखाए गए मूल्य डिफ़ॉल्ट हैं। (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=इस कंटेंट में डिस्प्ले पेज है। (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=यह सामग्री समाप्त हो गई है या आपके पास इसे एक्सेस करने के लिए आवश्यक अनुमतियां नहीं हैं। (Automatic Translation)
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=यह कूपन केवल उन वस्तुओं पर लागू होता है जो श्रेणियों की इस अल्पविराम सीमित सूची के बच्चे हैं। (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Promjene će biti vidl
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=This configuration is not saved yet. (Automatic Copy)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=This configuration is not saved yet. The values shown are the default. (Automatic Copy)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=This content has a display page. (Automatic Copy)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Ovaj sadržaj je istekla ili nemate potrebne dozvole za pristup.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Ovaj se kupon primjenjuje samo na stavke koji su podmape ovog popisa kategorija odvojenih zarezima.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -15836,6 +15836,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=A változtatás csak a
 this-collection-has-no-items=A gyűjteménynek nincsenek elemei. A konfiguráció használatához legalább egy elemre van szükség.
 this-configuration-is-not-saved-yet=Ez a konfiguráció még nincs elmentve.
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Ez a konfiguráció még nem lett elmentve. A megjelenített értékek, az alap értékek.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=A webes tartalomhoz megjelenítő oldal tartozik.
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Ez a tartalom lejárt, vagy nincs megfelelő hozzáférési jogosultság.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Ez a kupon csak azokra a tételekre vonatkozik, amelyek a vesszővel elválasztott kategórialista alá tartoznak.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Perubahan ini hanya ak
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Konfigurasi ini belum disimpan. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Konfigurasi ini belum disimpan. Nilai yang ditampilkan adalah default. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Konten ini memiliki halaman tampilan. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Konten ini telah kedaluwarsa atau Anda tidak memiliki izin yang diperlukan untuk mengaksesnya.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Kupon ini hanya berlaku untuk item yang merupakan sub dari daftar kategori yang dibatasi koma..

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -15834,6 +15834,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Questa modifica sarà 
 this-collection-has-no-items=Questa raccolta non ha elementi. Hai bisogno di almeno un elemento per usare questa configurazione.
 this-configuration-is-not-saved-yet=Questa configurazione non è ancora stata salvata. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Questa configurazione non è ancora stata salvata. I valori visualizzati sono quelli predefiniti.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Questo contenuto ha una pagina di visualizzazione. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Il contenuto è scaduto o non hai i requisiti per accedervi.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Questo buono si applica soltanto agli elementi che sono figli di questa lista di categorie delimitate da virgola.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=ניתן לראות א
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=תצורה זו עדיין לא נשמרה. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=תצורה זו לא נשמרה עדיין. הערכים המוצגים הם ערכי ברירת המחדל.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=תוכן זה כולל דף תצוגה. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=פג תוקף תוכן זה, או שאין לך את ההרשאות המתאימות לגשת אליו.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=תלוש זה תקף לפריטים שהם בנים של רשימת הקטגוריות המופרדת על ידי פסיקים.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -15835,6 +15835,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=現在のページを�
 this-collection-has-no-items=このコレクションには項目がありません。この設定を使用するには、1 件以上の項目が必要です。
 this-configuration-is-not-saved-yet=この設定はまだ保存されていません。
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=この設定はまだ保存されていません。現在デフォルトの設定値が表示されています。
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=このWebコンテンツには表示ページがありません。
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=このコンテンツは期限が切れているか、アクセスに必要な権限を割り当てられていません
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=このクーポンはカンマ区切りのカテゴリに含まれる商品のみに適用できます。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=This change will only 
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=This configuration is not saved yet. (Automatic Copy)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=This configuration is not saved yet. The values shown are the default. (Automatic Copy)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=This content has a display page. (Automatic Copy)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=This content has expired or you do not have the required permissions to access it. (Automatic Copy)
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=This coupon only applies to items that are children of this comma delimited list of categories. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -15832,6 +15832,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=너가 현재 페이�
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=이 구성은 아직 저장되지 않았습니다. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=이 구성은 아직 저장되지 않았습니다. 표시된 값은 기본값입니다. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=이 콘텐츠에는 디스플레이 페이지가 있습니다. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=이 콘텐츠가 만료되었거나 액세스할 수 있는 필수 권한이 없습니다. (Automatic Translation)
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=이 쿠폰은 종류의 이 쉼표에 의하여 한계를 정하는 명부의 아이들 이는 품목에 단 적용한다.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=ການປ່ຽນ�
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=This configuration is not saved yet. (Automatic Copy)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=This configuration is not saved yet. The values shown are the default. (Automatic Copy)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=This content has a display page. (Automatic Copy)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=ເນື້ອໃນນີ້ໝົດອາຍຸ ຫຼື ທ່ານບໍ່ມີສິດໃນການເຂົ້າຫາພາກສ່ວນນີ້
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=ຄູປ໋ອງນີ້ແມ່ນແອັບພລາຍຫົວຂໍ້ເຫຼົ່ານີ້ເພື່ອເປັນລູກຂອງລາຍການຄອມມາດີລີມິດຂອງໝວດຕ່າງໆ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Šis pakeitimas bus ro
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Ši konfigūracija dar neįrašyta. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Ši konfigūracija dar neįrašyta. Rodomos reikšmės yra numatytosios. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Šiame turinyje yra rodomas puslapis. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Šio turinio galiojimo laikas baigėsi arba neturite reikiamų teisių jį pasiekti. (Automatic Translation)
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Šis kuponas taikomas tik elementams, kurie yra šio kablelio atskirto kategorijų sąrašo vaikai. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Perubahan ini hanya ak
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Konfigurasi ini belum disimpan lagi. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Konfigurasi ini belum disimpan lagi. Nilai yang ditunjukkan adalah lalai. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Kandungan ini mempunyai halaman paparan. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Kandungan ini telah luput atau anda tidak mempunyai keizinan yang diperlukan untuk mengaksesnya. (Automatic Translation)
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Kupon ini hanya terpakai kepada item yang meriah adalah kanak-kanak senarai kategori yang disengajakan koma ini. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Endringen vil ikke vis
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Denne konfigurasjonen er ikke lagret ennå. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Denne konfigurasjonen er ikke lagret enda. Verdiene som vises er standardverdiene.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Dette innholdet har en visningsside. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Dette innholdet er utgått eller du har ikke rettigheter til det.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Denne kupongen kan brukes til varer som finnes i følgende kategorier.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -15836,6 +15836,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Deze wijziging wordt p
 this-collection-has-no-items=Deze collectie bevat geen items. U heeft minstens één item nodig om deze configuratie te gebruiken.
 this-configuration-is-not-saved-yet=Deze configuratie is nog niet opgeslagen.
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=De configuratie is nog niet opgeslagen. De getoonde waarden zijn de standaardwaarden.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Deze webinhoud heeft een weergavepagina.
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Deze content is verlopen of u hebt niet de vereiste rechten voor toegang.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Deze kortingsbon is alleen geldig voor artikelen die behoren tot een van de volgende categorieën.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -15836,6 +15836,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Deze wijziging zal pas
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=This configuration is not saved yet. (Automatic Copy)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=This configuration is not saved yet. The values shown are the default. (Automatic Copy)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=This content has a display page. (Automatic Copy)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Deze inhoud is vervallen of je beschikt niet over nodige permissies om hem te bekijken.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Deze kortingsbon is slechts van toepassing op artikelen die kinderen zijn van deze kommagescheiden lijst van categorieën.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Ta zmiana będzie wido
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Ta konfiguracja nie została jeszcze zapisana. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Ta konfiguracja nie została jeszcze zapisana. Wyświetlane wartości są wartościami domyślnymi. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Ta zawartość ma stronę wyświetlania. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Treść wygasła albo nie masz uprawnień do dostępu.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Ten kupon ma zastosowanie tylko do przedmiotów, które należą do jednej z podanych na liście kategorii oddzielonych przecinkami.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Esta modificação ser
 this-collection-has-no-items=Esta coleção não possui nenhum item. Você precisa de pelo menos um item para usar esta configuração.
 this-configuration-is-not-saved-yet=Esta configuração ainda não foi salva.
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Esta configuração ainda não foi salva. Os valores mostrados são os valores padrão.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Este conteúdo web possui uma página de exibição.
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Este conteúdo expirou ou você não tem as permissões exigidas para acessá-lo.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Este cupom aplica-se somente aos itens que são filhos desta lista de categorias delimitada por vírgula.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -15835,6 +15835,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Esta alteração apena
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Esta configuração ainda não está salva. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Esta configuração ainda não foi salva. Os valores apresentados são os por omissão.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Este conteúdo tem uma página de exibição. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Este conteúdo expirou ou não tem as permissões necessárias para aceder-lhe.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Este cupão aplica-se apenas aos itens que são filhos desta lista de categorias, delimitada por vírgula.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Aceasta schimbare va f
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Această configurație nu este salvată încă. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Această configurație nu este salvată încă. Valorile afișate sunt implicite. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Acest conținut are o pagină de afișare. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Acest continut a expirat sau nu aveti permisiunile necesare pentru a il accesa.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Acest cupon apare numai la elementele care sunt copii a listei de categorii delimitate de virgula.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Эти изменен�
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Эта конфигурация еще не сохранена. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Эта конфигурация еще не сохранена. Показанные значения являются значением по умолчанию. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Это содержимое имеет страницу отображения. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Истек срок действия этого содержимого или у вас недостаточно прав доступа к этому.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Купон применим только к товарам, которые содержаться в этих категориях. Категории разделяются запятыми.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Táto zmena bude vidit
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Táto konfigurácia ešte nie je uložená. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Táto konfigurácia ešte nie je uložená. Zobrazené hodnoty sú predvolené. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Tento obsah má zobrazenú stránku. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Tomuto obsahu vypršala platnosť alebo nemáte potrebné oprávnenia.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Kupón je aplikovateľný len na položky, ktoré su potomkami tohto čiarkami oddeleného zoznamu kategórií.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Ta sprememba bo vidna,
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Ta konfiguracija še ni shranjena. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Ta konfiguracija še ni shranjena. Prikazane vrednosti so privzete. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Ta vsebina ima prikazno stran. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Ta vsebina je potekla ali pa nimate zahtevanih dovoljenj za dostop do tega. (Automatic Translation)
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Ta kupon velja le za izdelke, ki so podrejeni seznamu kategorij (zapisi ločeni z vejico).

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Ова промена 
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=This configuration is not saved yet. (Automatic Copy)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=This configuration is not saved yet. The values shown are the default. (Automatic Copy)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=This content has a display page. (Automatic Copy)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Овај садржај је истекао или немате потребне дозволе да му приступите.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Овај купон важи само за ставке које су деца ове разграничене зарезом листе категорија.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Ova promena će se pri
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=This configuration is not saved yet. (Automatic Copy)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=This configuration is not saved yet. The values shown are the default. (Automatic Copy)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=This content has a display page. (Automatic Copy)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Ovaj sadržaj je istekao ili nemate potrebne dozvole da mu pristupite.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Ovaj kupon važi samo za stavke koje su deca ove razgraničene zarezom liste kategorija.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Ändringarna syns inte
 this-collection-has-no-items=Den här samlingen har inga objekt. Du behöver minst ett objekt för att använda den här konfigurationen.
 this-configuration-is-not-saved-yet=Den här konfigurationen har inte sparats än.
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Konfigurationen har inte sparats ännu. De värden som visas är standardvärden.
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Webbinnehållet har en visningssida.
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Innehållet har slutat gälla eller du saknar behörighet att få tillgång till det.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Denna kupong kan användas till varor som finns i följande kategorier.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=தற்போதை�
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=This configuration is not saved yet. (Automatic Copy)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=This configuration is not saved yet. The values shown are the default. (Automatic Copy)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=This content has a display page. (Automatic Copy)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=இந்த content காலாவதியானது அல்லது அதை அணுகுவதற்கு தேவையான அனுமதிகள் உங்களிடம் இல்லை.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=This coupon only applies to items that are children of this comma delimited list of categories. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=การเปลี�
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=การกําหนดค่านี้ยังไม่ถูกบันทึก (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=การกำหนดค่านี้ยังไม่ถูกบันทึก ค่าที่แสดงเป็นค่าเริ่มต้น
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=เนื้อหานี้มีหน้าจอแสดงผล (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=เนื้อหานี้หมดอายุหรือคุณไม่มีสิทธิ์ที่จำเป็นในการเข้าถึง
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=คูปองนี้ใช้เฉพาะกับรายการที่เป็นรายการย่อยของรายการประเภทที่คั่นด้วยเครื่องหมายจุลภาคนี้เท่านั้น (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Bu değişiklik sayfan
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Bu yapılandırma henüz kaydedilmedi. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Bu yapılandırma henüz kaydedilmedi. Gösterilen değerler varsayılan değerdir. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Bu içeriğin bir görüntü sayfası vardır. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Bu içeriğin süresi doldu veya bu içeriğe erişmek için gerekli izinlere sahip değilsiniz. (Automatic Translation)
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Bu kupon kategorilerin vigülle ayrılmış listesinin altındaki maddelere uygulannır.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Ці зміни буд
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Цю конфігурацію ще не збережено. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Цю конфігурацію ще не збережено. Показані значення є типовими. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Цей вміст має Медійну сторінку. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Термін дії цього вмісту минув, або ви не маєте необхідних дозволів на доступ до нього. (Automatic Translation)
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Купон використовується тільки до товару, який міститьсяя у цих категоріях. Категорії розділяються комами.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -15833,6 +15833,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=Sự thay đổi chỉ
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=Cấu hình này chưa được lưu. (Automatic Translation)
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=Cấu hình này chưa được lưu. Các giá trị được hiển thị là mặc định. (Automatic Translation)
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=Nội dung này có một trang hiển thị. (Automatic Translation)
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=Nội dung đã hết hạn hoặc bạn không có đủ quyền truy nhập vào nội dung này.
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=Phiếu này chỉ sử dụng cho Hàng hóa của Danh sách phân loại (phân cách bởi dấu phẩy) .

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -15835,6 +15835,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=这些改动只在您�
 this-collection-has-no-items=此集合没有条目。您至少需要一个条目才能使用此配置。
 this-configuration-is-not-saved-yet=尚未保存此设置。
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=此配置尚未保存。当前显示为默认值。
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=此 Web 内容具有显示页。
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=此内容已过期或您没有访问权限。
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=这张优惠券只适用于以逗号分隔的类别列表的下级项目。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -15834,6 +15834,7 @@ this-change-will-only-be-shown-after-you-refresh-the-page=這變動只將被顯�
 this-collection-has-no-items=This collection has no items. You need at least one item to use this configuration. (Automatic Copy)
 this-configuration-is-not-saved-yet=尚未儲存此配置。
 this-configuration-is-not-saved-yet.-the-values-shown-are-the-default=此配置尚未儲存，目前顯示為預設值。
+this-configuration-is-read-only=This configuartion is read-only. (Automatic Copy)
 this-content-has-a-display-page=此內容有顯示頁。
 this-content-has-expired-or-you-do-not-have-the-required-permissions-to-access-it=這個內容已經到期或是您沒有必須的權限存取它。
 this-coupon-only-applies-to-items-that-are-children-of-this-comma-delimited-list-of-categories=這張優惠券只適用於類別的逗號區隔列表子項目的項目。

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/Scanner.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/Scanner.java
@@ -116,6 +116,7 @@ public class Scanner {
 		if (file.isFile()) {
 			_checksum(file.lastModified(), crc32);
 			_checksum(file.length(), crc32);
+			_checksum(file.canWrite() ? 1000L : -1000L, crc32);
 		}
 		else if (file.isDirectory()) {
 			File[] children = file.listFiles();

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
@@ -35,6 +35,7 @@ import java.net.URL;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.Objects;
+import java.util.Set;
 
 import org.osgi.framework.Constants;
 import org.osgi.service.cm.Configuration;
@@ -90,6 +91,16 @@ public class ConfigurationFileInstaller implements FileInstaller {
 		Configuration configuration = _getConfiguration(
 			_toConfigKey(file), pid[0], pid[1]);
 
+		Set<Configuration.ConfigurationAttribute> configurationAttributes =
+			configuration.getAttributes();
+
+		if (configurationAttributes.contains(
+				Configuration.ConfigurationAttribute.READ_ONLY)) {
+
+			configuration.removeAttributes(
+				Configuration.ConfigurationAttribute.READ_ONLY);
+		}
+
 		Dictionary<String, Object> properties = configuration.getProperties();
 
 		Dictionary<String, Object> old = null;
@@ -128,7 +139,10 @@ public class ConfigurationFileInstaller implements FileInstaller {
 		String currentFileName = _toConfigKey(file);
 
 		if (!_equals(dictionary, old) ||
-			!Objects.equals(oldFileName, currentFileName)) {
+			!Objects.equals(oldFileName, currentFileName) ||
+			configurationAttributes.contains(
+				Configuration.ConfigurationAttribute.READ_ONLY) ||
+			!file.canWrite()) {
 
 			dictionary.put(
 				FileInstallConstants.FELIX_FILE_INSTALL_FILENAME,
@@ -157,7 +171,17 @@ public class ConfigurationFileInstaller implements FileInstaller {
 				}
 			}
 
-			configuration.update(dictionary);
+			configuration.updateIfDifferent(dictionary);
+
+			if (!file.canWrite()) {
+				try {
+					configuration.addAttributes(
+						Configuration.ConfigurationAttribute.READ_ONLY);
+				}
+				catch (Throwable throwable) {
+					_log.error("ERROR ", throwable);
+				}
+			}
 		}
 
 		return null;

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/FileSyncConfigurationListener.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/FileSyncConfigurationListener.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.file.install.internal.configuration;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.file.install.constants.FileInstallConstants;
 import com.liferay.portal.file.install.internal.activator.FileInstallImplBundleActivator;
@@ -115,6 +116,20 @@ public class FileSyncConfigurationListener implements ConfigurationListener {
 				}
 
 				if ((file != null) && file.isFile()) {
+					if (!file.canWrite()) {
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								StringBundler.concat(
+									"Unable to save configuration because the ",
+									"file ", file.getAbsolutePath(),
+									" is not writable"));
+						}
+
+						_pidToFile.remove(configuration.getPid(), fileName);
+
+						return;
+					}
+
 					_pidToFile.put(configuration.getPid(), fileName);
 
 					ConfigurationProperties configurationProperties =


### PR DESCRIPTION
There are many cases where one may wish for OSGi configuration to be read-only. For example any scenario where we don't want end users to be able to alter the configuration from the portal UI for any number of reasons.

The OSGi Configuration Admin supports this. We just need to manifest this ability through infrastructure.

The primary usage will be where a file visible to Liferay File Install is marked as not writable (e.g. `chmod -x file.config`) then the configuration will appear in the Admin UI as read-only (i.e. not editable). Configuration Admin itself will protect updates to the configuration and throw an error if this is attempted (though the UI would not make this option available.)
