### PR TITLE
LPS-131892: Management toolbar search keywords are in bold

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -1254,10 +1254,10 @@ public class ManagementToolbarTag extends BaseContainerTag {
 					new Object[] {getItemsTotal()}));
 
 			jspWriter.write("<strong>");
-			jspWriter.write(HtmlUtil.escape(StringPool.SPACE));
-			jspWriter.write(HtmlUtil.escape(StringPool.QUOTE));
-			jspWriter.write(HtmlUtil.escape(searchValue));
-			jspWriter.write(HtmlUtil.escape(StringPool.QUOTE));
+			jspWriter.write(StringPool.SPACE);
+			jspWriter.write(StringPool.QUOTE);
+			jspWriter.write(searchValue);
+			jspWriter.write(StringPool.QUOTE);
 
 			jspWriter.write("</strong>");
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -23,7 +23,6 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.ViewTypeItem;
 import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -1255,9 +1254,11 @@ public class ManagementToolbarTag extends BaseContainerTag {
 					new Object[] {getItemsTotal()}));
 
 			jspWriter.write("<strong>");
-			jspWriter.write(
-				HtmlUtil.escape(
-					StringBundler.concat(" ", '"', searchValue, '"')));
+			jspWriter.write(HtmlUtil.escape(StringPool.SPACE));
+			jspWriter.write(HtmlUtil.escape(StringPool.QUOTE));
+			jspWriter.write(HtmlUtil.escape(searchValue));
+			jspWriter.write(HtmlUtil.escape(StringPool.QUOTE));
+
 			jspWriter.write("</strong>");
 
 			jspWriter.write("</span></span></div></li>");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -23,6 +23,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.ViewTypeItem;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -1250,12 +1251,14 @@ public class ManagementToolbarTag extends BaseContainerTag {
 
 			jspWriter.write(
 				LanguageUtil.format(
-					resourceBundle, "x-results-for-x",
-					new Object[] {
-						getItemsTotal(),
-						(searchValue == null) ? StringPool.BLANK :
-							HtmlUtil.escape(searchValue)
-					}));
+					resourceBundle, "x-results-for",
+					new Object[] {getItemsTotal()}));
+
+			jspWriter.write("<strong>");
+			jspWriter.write(
+				HtmlUtil.escape(
+					StringBundler.concat(" ", '"', searchValue, '"')));
+			jspWriter.write("</strong>");
 
 			jspWriter.write("</span></span></div></li>");
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
@@ -31,10 +31,11 @@ const ResultsBar = ({
 					<span className="component-text text-truncate-inline">
 						<span className="text-truncate">
 							{Liferay.Util.sub(
-								Liferay.Language.get('x-results-for-x'),
-								itemsTotal,
-								searchValue || ''
+								Liferay.Language.get('x-results-for'),
+								itemsTotal
 							)}
+
+							<strong>{` "${searchValue}"`}</strong>
 						</span>
 					</span>
 				</ClayResultsBar.Item>

--- a/modules/apps/portal-language/portal-language-override-test/src/testFunctional/tests/LanguageOverride.testcase
+++ b/modules/apps/portal-language/portal-language-override-test/src/testFunctional/tests/LanguageOverride.testcase
@@ -182,7 +182,7 @@ definition {
 		task ("Then the language key can be viewed in the View page and there is results message") {
 			AssertTextEquals(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "1 Results for 2-synced-contact-data");
+				value1 = "1 Results for &quot;2-synced-contact-data&quot;");
 
 			AssertTextEquals(
 				key_languageKey = "2-synced-contact-data",
@@ -219,7 +219,7 @@ definition {
 		task ("Then the language key can be viewed in the View page and there is results message and search for translations") {
 			AssertTextEquals(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "1 Results for O texto contÃƒÂ©m erro");
+				value1 = "1 Results for &quot;O texto contÃƒÂ©m erro&quot;");
 
 			AssertTextEquals(
 				key_languageKey = "text-contains-error",
@@ -239,7 +239,7 @@ definition {
 
 			AssertTextEquals(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "1 Results for Le texte contient une erreur");
+				value1 = "1 Results for &quot;Le texte contient une erreur&quot;");
 
 			AssertTextEquals(
 				key_languageKey = "text-contains-error",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ItemSelector.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ItemSelector.macro
@@ -432,7 +432,7 @@ definition {
 
 		AssertTextEquals(
 			locator1 = "Search#SEARCH_INFO",
-			value1 = "1 Results for ${imageFileName}");
+			value1 = "1 Results for &quot;${imageFileName}&quot;");
 
 		LexiconCard.viewCardPresent(card = "${imageFileName}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagestree/PagesTree.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagestree/PagesTree.testcase
@@ -809,7 +809,7 @@ definition {
 
 			AssertTextEquals(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "11 Results for Test");
+				value1 = "11 Results for &quot;Test&quot;");
 		}
 	}
 


### PR DESCRIPTION
**Steps to reproduce:**
1. Go to **Site Builder** > **Pages**
2. Add some assets to component with **Management Toolbar**
3. Search for a keyword

**Expected Result.**
The keyword must be in bold and in inverted commas.


https://user-images.githubusercontent.com/44723449/158136153-feb6535d-7977-4da7-90a7-ca8b4d4f3ebc.mov

**JIRA TICKET:** https://issues.liferay.com/browse/LPS-131892
