### PR TITLE
LPS-149497 Generate methods to add objects with a default implementation and get non included fields in the API model

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountAddressResourceTestCase.java
@@ -274,7 +274,7 @@ public abstract class BaseAccountAddressResourceTestCase {
 		throws Exception {
 
 		AccountAddress accountAddress =
-			testGraphQLAccountAddress_addAccountAddress();
+			testGraphQLGetAccountAddressByExternalReferenceCode_addAccountAddress();
 
 		Assert.assertTrue(
 			equals(
@@ -324,6 +324,13 @@ public abstract class BaseAccountAddressResourceTestCase {
 				"Object/code"));
 	}
 
+	protected AccountAddress
+			testGraphQLGetAccountAddressByExternalReferenceCode_addAccountAddress()
+		throws Exception {
+
+		return testGraphQLAccountAddress_addAccountAddress();
+	}
+
 	@Test
 	public void testPatchAccountAddressByExternalReferenceCode()
 		throws Exception {
@@ -363,7 +370,7 @@ public abstract class BaseAccountAddressResourceTestCase {
 	@Test
 	public void testGraphQLDeleteAccountAddress() throws Exception {
 		AccountAddress accountAddress =
-			testGraphQLAccountAddress_addAccountAddress();
+			testGraphQLDeleteAccountAddress_addAccountAddress();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -392,6 +399,12 @@ public abstract class BaseAccountAddressResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected AccountAddress testGraphQLDeleteAccountAddress_addAccountAddress()
+		throws Exception {
+
+		return testGraphQLAccountAddress_addAccountAddress();
+	}
+
 	@Test
 	public void testGetAccountAddress() throws Exception {
 		AccountAddress postAccountAddress =
@@ -415,7 +428,7 @@ public abstract class BaseAccountAddressResourceTestCase {
 	@Test
 	public void testGraphQLGetAccountAddress() throws Exception {
 		AccountAddress accountAddress =
-			testGraphQLAccountAddress_addAccountAddress();
+			testGraphQLGetAccountAddress_addAccountAddress();
 
 		Assert.assertTrue(
 			equals(
@@ -452,6 +465,12 @@ public abstract class BaseAccountAddressResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected AccountAddress testGraphQLGetAccountAddress_addAccountAddress()
+		throws Exception {
+
+		return testGraphQLAccountAddress_addAccountAddress();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
@@ -508,8 +508,10 @@ public abstract class BaseAccountGroupResourceTestCase {
 
 		long totalCount = accountGroupsJSONObject.getLong("totalCount");
 
-		AccountGroup accountGroup1 = testGraphQLAccountGroup_addAccountGroup();
-		AccountGroup accountGroup2 = testGraphQLAccountGroup_addAccountGroup();
+		AccountGroup accountGroup1 =
+			testGraphQLGetAccountGroupsPage_addAccountGroup();
+		AccountGroup accountGroup2 =
+			testGraphQLGetAccountGroupsPage_addAccountGroup();
 
 		accountGroupsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -528,6 +530,12 @@ public abstract class BaseAccountGroupResourceTestCase {
 			Arrays.asList(
 				AccountGroupSerDes.toDTOs(
 					accountGroupsJSONObject.getString("items"))));
+	}
+
+	protected AccountGroup testGraphQLGetAccountGroupsPage_addAccountGroup()
+		throws Exception {
+
+		return testGraphQLAccountGroup_addAccountGroup();
 	}
 
 	@Test
@@ -609,7 +617,8 @@ public abstract class BaseAccountGroupResourceTestCase {
 	public void testGraphQLGetAccountGroupByExternalReferenceCode()
 		throws Exception {
 
-		AccountGroup accountGroup = testGraphQLAccountGroup_addAccountGroup();
+		AccountGroup accountGroup =
+			testGraphQLGetAccountGroupByExternalReferenceCode_addAccountGroup();
 
 		Assert.assertTrue(
 			equals(
@@ -659,6 +668,13 @@ public abstract class BaseAccountGroupResourceTestCase {
 				"Object/code"));
 	}
 
+	protected AccountGroup
+			testGraphQLGetAccountGroupByExternalReferenceCode_addAccountGroup()
+		throws Exception {
+
+		return testGraphQLAccountGroup_addAccountGroup();
+	}
+
 	@Test
 	public void testPatchAccountGroupByExternalReferenceCode()
 		throws Exception {
@@ -696,7 +712,8 @@ public abstract class BaseAccountGroupResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteAccountGroup() throws Exception {
-		AccountGroup accountGroup = testGraphQLAccountGroup_addAccountGroup();
+		AccountGroup accountGroup =
+			testGraphQLDeleteAccountGroup_addAccountGroup();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -725,6 +742,12 @@ public abstract class BaseAccountGroupResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected AccountGroup testGraphQLDeleteAccountGroup_addAccountGroup()
+		throws Exception {
+
+		return testGraphQLAccountGroup_addAccountGroup();
+	}
+
 	@Test
 	public void testGetAccountGroup() throws Exception {
 		AccountGroup postAccountGroup = testGetAccountGroup_addAccountGroup();
@@ -745,7 +768,8 @@ public abstract class BaseAccountGroupResourceTestCase {
 
 	@Test
 	public void testGraphQLGetAccountGroup() throws Exception {
-		AccountGroup accountGroup = testGraphQLAccountGroup_addAccountGroup();
+		AccountGroup accountGroup =
+			testGraphQLGetAccountGroup_addAccountGroup();
 
 		Assert.assertTrue(
 			equals(
@@ -782,6 +806,12 @@ public abstract class BaseAccountGroupResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected AccountGroup testGraphQLGetAccountGroup_addAccountGroup()
+		throws Exception {
+
+		return testGraphQLAccountGroup_addAccountGroup();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -222,7 +222,16 @@ public abstract class BaseAccountResourceTestCase {
 			204,
 			accountResource.
 				deleteAccountGroupByExternalReferenceCodeAccountHttpResponse(
-					null, account.getExternalReferenceCode()));
+					testDeleteAccountGroupByExternalReferenceCodeAccount_getAccountExternalReferenceCode(),
+					account.getExternalReferenceCode()));
+	}
+
+	protected String
+			testDeleteAccountGroupByExternalReferenceCodeAccount_getAccountExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Account

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -529,8 +529,8 @@ public abstract class BaseAccountResourceTestCase {
 
 		long totalCount = accountsJSONObject.getLong("totalCount");
 
-		Account account1 = testGraphQLAccount_addAccount();
-		Account account2 = testGraphQLAccount_addAccount();
+		Account account1 = testGraphQLGetAccountsPage_addAccount();
+		Account account2 = testGraphQLGetAccountsPage_addAccount();
 
 		accountsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -547,6 +547,10 @@ public abstract class BaseAccountResourceTestCase {
 			account2,
 			Arrays.asList(
 				AccountSerDes.toDTOs(accountsJSONObject.getString("items"))));
+	}
+
+	protected Account testGraphQLGetAccountsPage_addAccount() throws Exception {
+		return testGraphQLAccount_addAccount();
 	}
 
 	@Test
@@ -617,7 +621,8 @@ public abstract class BaseAccountResourceTestCase {
 	public void testGraphQLGetAccountByExternalReferenceCode()
 		throws Exception {
 
-		Account account = testGraphQLAccount_addAccount();
+		Account account =
+			testGraphQLGetAccountByExternalReferenceCode_addAccount();
 
 		Assert.assertTrue(
 			equals(
@@ -667,6 +672,12 @@ public abstract class BaseAccountResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Account testGraphQLGetAccountByExternalReferenceCode_addAccount()
+		throws Exception {
+
+		return testGraphQLAccount_addAccount();
+	}
+
 	@Test
 	public void testPatchAccountByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -699,7 +710,7 @@ public abstract class BaseAccountResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteAccount() throws Exception {
-		Account account = testGraphQLAccount_addAccount();
+		Account account = testGraphQLDeleteAccount_addAccount();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -728,6 +739,10 @@ public abstract class BaseAccountResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Account testGraphQLDeleteAccount_addAccount() throws Exception {
+		return testGraphQLAccount_addAccount();
+	}
+
 	@Test
 	public void testGetAccount() throws Exception {
 		Account postAccount = testGetAccount_addAccount();
@@ -745,7 +760,7 @@ public abstract class BaseAccountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetAccount() throws Exception {
-		Account account = testGraphQLAccount_addAccount();
+		Account account = testGraphQLGetAccount_addAccount();
 
 		Assert.assertTrue(
 			equals(
@@ -782,6 +797,10 @@ public abstract class BaseAccountResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Account testGraphQLGetAccount_addAccount() throws Exception {
+		return testGraphQLAccount_addAccount();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
@@ -254,7 +254,8 @@ public abstract class BaseCatalogResourceTestCase {
 	public void testGraphQLGetCatalogByExternalReferenceCode()
 		throws Exception {
 
-		Catalog catalog = testGraphQLCatalog_addCatalog();
+		Catalog catalog =
+			testGraphQLGetCatalogByExternalReferenceCode_addCatalog();
 
 		Assert.assertTrue(
 			equals(
@@ -304,6 +305,12 @@ public abstract class BaseCatalogResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Catalog testGraphQLGetCatalogByExternalReferenceCode_addCatalog()
+		throws Exception {
+
+		return testGraphQLCatalog_addCatalog();
+	}
+
 	@Test
 	public void testPatchCatalogByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -331,7 +338,7 @@ public abstract class BaseCatalogResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteCatalog() throws Exception {
-		Catalog catalog = testGraphQLCatalog_addCatalog();
+		Catalog catalog = testGraphQLDeleteCatalog_addCatalog();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -360,6 +367,10 @@ public abstract class BaseCatalogResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Catalog testGraphQLDeleteCatalog_addCatalog() throws Exception {
+		return testGraphQLCatalog_addCatalog();
+	}
+
 	@Test
 	public void testGetCatalog() throws Exception {
 		Catalog postCatalog = testGetCatalog_addCatalog();
@@ -377,7 +388,7 @@ public abstract class BaseCatalogResourceTestCase {
 
 	@Test
 	public void testGraphQLGetCatalog() throws Exception {
-		Catalog catalog = testGraphQLCatalog_addCatalog();
+		Catalog catalog = testGraphQLGetCatalog_addCatalog();
 
 		Assert.assertTrue(
 			equals(
@@ -414,6 +425,10 @@ public abstract class BaseCatalogResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Catalog testGraphQLGetCatalog_addCatalog() throws Exception {
+		return testGraphQLCatalog_addCatalog();
 	}
 
 	@Test
@@ -708,8 +723,8 @@ public abstract class BaseCatalogResourceTestCase {
 
 		long totalCount = catalogsJSONObject.getLong("totalCount");
 
-		Catalog catalog1 = testGraphQLCatalog_addCatalog();
-		Catalog catalog2 = testGraphQLCatalog_addCatalog();
+		Catalog catalog1 = testGraphQLGetCatalogsPage_addCatalog();
+		Catalog catalog2 = testGraphQLGetCatalogsPage_addCatalog();
 
 		catalogsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -726,6 +741,10 @@ public abstract class BaseCatalogResourceTestCase {
 			catalog2,
 			Arrays.asList(
 				CatalogSerDes.toDTOs(catalogsJSONObject.getString("items"))));
+	}
+
+	protected Catalog testGraphQLGetCatalogsPage_addCatalog() throws Exception {
+		return testGraphQLCatalog_addCatalog();
 	}
 
 	@Test
@@ -771,7 +790,8 @@ public abstract class BaseCatalogResourceTestCase {
 	public void testGraphQLGetProductByExternalReferenceCodeCatalog()
 		throws Exception {
 
-		Catalog catalog = testGraphQLCatalog_addCatalog();
+		Catalog catalog =
+			testGraphQLGetProductByExternalReferenceCodeCatalog_addCatalog();
 
 		Assert.assertTrue(
 			equals(
@@ -821,6 +841,13 @@ public abstract class BaseCatalogResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Catalog
+			testGraphQLGetProductByExternalReferenceCodeCatalog_addCatalog()
+		throws Exception {
+
+		return testGraphQLCatalog_addCatalog();
+	}
+
 	@Test
 	public void testGetProductIdCatalog() throws Exception {
 		Catalog postCatalog = testGetProductIdCatalog_addCatalog();
@@ -839,7 +866,7 @@ public abstract class BaseCatalogResourceTestCase {
 
 	@Test
 	public void testGraphQLGetProductIdCatalog() throws Exception {
-		Catalog catalog = testGraphQLCatalog_addCatalog();
+		Catalog catalog = testGraphQLGetProductIdCatalog_addCatalog();
 
 		Assert.assertTrue(
 			equals(
@@ -876,6 +903,12 @@ public abstract class BaseCatalogResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Catalog testGraphQLGetProductIdCatalog_addCatalog()
+		throws Exception {
+
+		return testGraphQLCatalog_addCatalog();
 	}
 
 	@Rule

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseDiagramResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseDiagramResourceTestCase.java
@@ -207,10 +207,19 @@ public abstract class BaseDiagramResourceTestCase {
 			testGetProductByExternalReferenceCodeDiagram_addDiagram();
 
 		Diagram getDiagram =
-			diagramResource.getProductByExternalReferenceCodeDiagram(null);
+			diagramResource.getProductByExternalReferenceCodeDiagram(
+				testGetProductByExternalReferenceCodeDiagram_getExternalReferenceCode());
 
 		assertEquals(postDiagram, getDiagram);
 		assertValid(getDiagram);
+	}
+
+	protected String
+			testGetProductByExternalReferenceCodeDiagram_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Diagram testGetProductByExternalReferenceCodeDiagram_addDiagram()
@@ -236,12 +245,24 @@ public abstract class BaseDiagramResourceTestCase {
 								"productByExternalReferenceCodeDiagram",
 								new HashMap<String, Object>() {
 									{
-										put("externalReferenceCode", null);
+										put(
+											"externalReferenceCode",
+											"\"" +
+												testGraphQLGetProductByExternalReferenceCodeDiagram_getExternalReferenceCode() +
+													"\"");
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/productByExternalReferenceCodeDiagram"))));
+	}
+
+	protected String
+			testGraphQLGetProductByExternalReferenceCodeDiagram_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseDiagramResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseDiagramResourceTestCase.java
@@ -233,7 +233,8 @@ public abstract class BaseDiagramResourceTestCase {
 	public void testGraphQLGetProductByExternalReferenceCodeDiagram()
 		throws Exception {
 
-		Diagram diagram = testGraphQLDiagram_addDiagram();
+		Diagram diagram =
+			testGraphQLGetProductByExternalReferenceCodeDiagram_addDiagram();
 
 		Assert.assertTrue(
 			equals(
@@ -290,6 +291,13 @@ public abstract class BaseDiagramResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Diagram
+			testGraphQLGetProductByExternalReferenceCodeDiagram_addDiagram()
+		throws Exception {
+
+		return testGraphQLDiagram_addDiagram();
+	}
+
 	@Test
 	public void testPostProductByExternalReferenceCodeDiagram()
 		throws Exception {
@@ -330,7 +338,7 @@ public abstract class BaseDiagramResourceTestCase {
 
 	@Test
 	public void testGraphQLGetProductIdDiagram() throws Exception {
-		Diagram diagram = testGraphQLDiagram_addDiagram();
+		Diagram diagram = testGraphQLGetProductIdDiagram_addDiagram();
 
 		Assert.assertTrue(
 			equals(
@@ -369,6 +377,12 @@ public abstract class BaseDiagramResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Diagram testGraphQLGetProductIdDiagram_addDiagram()
+		throws Exception {
+
+		return testGraphQLDiagram_addDiagram();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
@@ -562,10 +562,19 @@ public abstract class BaseMappedProductResourceTestCase {
 		MappedProduct getMappedProduct =
 			mappedProductResource.
 				getProductByExternalReferenceCodeMappedProductBySequence(
-					null, postMappedProduct.getSequence());
+					testGetProductByExternalReferenceCodeMappedProductBySequence_getExternalReferenceCode(),
+					postMappedProduct.getSequence());
 
 		assertEquals(postMappedProduct, getMappedProduct);
 		assertValid(getMappedProduct);
+	}
+
+	protected String
+			testGetProductByExternalReferenceCodeMappedProductBySequence_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected MappedProduct
@@ -593,7 +602,11 @@ public abstract class BaseMappedProductResourceTestCase {
 								"productByExternalReferenceCodeMappedProductBySequence",
 								new HashMap<String, Object>() {
 									{
-										put("externalReferenceCode", null);
+										put(
+											"externalReferenceCode",
+											"\"" +
+												testGraphQLGetProductByExternalReferenceCodeMappedProductBySequence_getExternalReferenceCode() +
+													"\"");
 										put(
 											"sequence",
 											"\"" + mappedProduct.getSequence() +
@@ -603,6 +616,14 @@ public abstract class BaseMappedProductResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/productByExternalReferenceCodeMappedProductBySequence"))));
+	}
+
+	protected String
+			testGraphQLGetProductByExternalReferenceCodeMappedProductBySequence_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
@@ -223,7 +223,7 @@ public abstract class BaseMappedProductResourceTestCase {
 	@Test
 	public void testGraphQLDeleteMappedProduct() throws Exception {
 		MappedProduct mappedProduct =
-			testGraphQLMappedProduct_addMappedProduct();
+			testGraphQLDeleteMappedProduct_addMappedProduct();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -236,6 +236,12 @@ public abstract class BaseMappedProductResourceTestCase {
 							}
 						})),
 				"JSONObject/data", "Object/deleteMappedProduct"));
+	}
+
+	protected MappedProduct testGraphQLDeleteMappedProduct_addMappedProduct()
+		throws Exception {
+
+		return testGraphQLMappedProduct_addMappedProduct();
 	}
 
 	@Test
@@ -590,7 +596,7 @@ public abstract class BaseMappedProductResourceTestCase {
 		throws Exception {
 
 		MappedProduct mappedProduct =
-			testGraphQLMappedProduct_addMappedProduct();
+			testGraphQLGetProductByExternalReferenceCodeMappedProductBySequence_addMappedProduct();
 
 		Assert.assertTrue(
 			equals(
@@ -651,6 +657,13 @@ public abstract class BaseMappedProductResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected MappedProduct
+			testGraphQLGetProductByExternalReferenceCodeMappedProductBySequence_addMappedProduct()
+		throws Exception {
+
+		return testGraphQLMappedProduct_addMappedProduct();
 	}
 
 	@Test
@@ -963,7 +976,7 @@ public abstract class BaseMappedProductResourceTestCase {
 		throws Exception {
 
 		MappedProduct mappedProduct =
-			testGraphQLMappedProduct_addMappedProduct();
+			testGraphQLGetProductMappedProductBySequence_addMappedProduct();
 
 		Assert.assertTrue(
 			equals(
@@ -1011,6 +1024,13 @@ public abstract class BaseMappedProductResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected MappedProduct
+			testGraphQLGetProductMappedProductBySequence_addMappedProduct()
+		throws Exception {
+
+		return testGraphQLMappedProduct_addMappedProduct();
 	}
 
 	protected MappedProduct testGraphQLMappedProduct_addMappedProduct()

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionCategoryResourceTestCase.java
@@ -531,9 +531,9 @@ public abstract class BaseOptionCategoryResourceTestCase {
 		long totalCount = optionCategoriesJSONObject.getLong("totalCount");
 
 		OptionCategory optionCategory1 =
-			testGraphQLOptionCategory_addOptionCategory();
+			testGraphQLGetOptionCategoriesPage_addOptionCategory();
 		OptionCategory optionCategory2 =
-			testGraphQLOptionCategory_addOptionCategory();
+			testGraphQLGetOptionCategoriesPage_addOptionCategory();
 
 		optionCategoriesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -552,6 +552,13 @@ public abstract class BaseOptionCategoryResourceTestCase {
 			Arrays.asList(
 				OptionCategorySerDes.toDTOs(
 					optionCategoriesJSONObject.getString("items"))));
+	}
+
+	protected OptionCategory
+			testGraphQLGetOptionCategoriesPage_addOptionCategory()
+		throws Exception {
+
+		return testGraphQLOptionCategory_addOptionCategory();
 	}
 
 	@Test
@@ -605,7 +612,7 @@ public abstract class BaseOptionCategoryResourceTestCase {
 	@Test
 	public void testGraphQLDeleteOptionCategory() throws Exception {
 		OptionCategory optionCategory =
-			testGraphQLOptionCategory_addOptionCategory();
+			testGraphQLDeleteOptionCategory_addOptionCategory();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -634,6 +641,12 @@ public abstract class BaseOptionCategoryResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected OptionCategory testGraphQLDeleteOptionCategory_addOptionCategory()
+		throws Exception {
+
+		return testGraphQLOptionCategory_addOptionCategory();
+	}
+
 	@Test
 	public void testGetOptionCategory() throws Exception {
 		OptionCategory postOptionCategory =
@@ -657,7 +670,7 @@ public abstract class BaseOptionCategoryResourceTestCase {
 	@Test
 	public void testGraphQLGetOptionCategory() throws Exception {
 		OptionCategory optionCategory =
-			testGraphQLOptionCategory_addOptionCategory();
+			testGraphQLGetOptionCategory_addOptionCategory();
 
 		Assert.assertTrue(
 			equals(
@@ -694,6 +707,12 @@ public abstract class BaseOptionCategoryResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected OptionCategory testGraphQLGetOptionCategory_addOptionCategory()
+		throws Exception {
+
+		return testGraphQLOptionCategory_addOptionCategory();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
@@ -486,8 +486,8 @@ public abstract class BaseOptionResourceTestCase {
 
 		long totalCount = optionsJSONObject.getLong("totalCount");
 
-		Option option1 = testGraphQLOption_addOption();
-		Option option2 = testGraphQLOption_addOption();
+		Option option1 = testGraphQLGetOptionsPage_addOption();
+		Option option2 = testGraphQLGetOptionsPage_addOption();
 
 		optionsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -504,6 +504,10 @@ public abstract class BaseOptionResourceTestCase {
 			option2,
 			Arrays.asList(
 				OptionSerDes.toDTOs(optionsJSONObject.getString("items"))));
+	}
+
+	protected Option testGraphQLGetOptionsPage_addOption() throws Exception {
+		return testGraphQLOption_addOption();
 	}
 
 	@Test
@@ -569,7 +573,7 @@ public abstract class BaseOptionResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOptionByExternalReferenceCode() throws Exception {
-		Option option = testGraphQLOption_addOption();
+		Option option = testGraphQLGetOptionByExternalReferenceCode_addOption();
 
 		Assert.assertTrue(
 			equals(
@@ -619,6 +623,12 @@ public abstract class BaseOptionResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Option testGraphQLGetOptionByExternalReferenceCode_addOption()
+		throws Exception {
+
+		return testGraphQLOption_addOption();
+	}
+
 	@Test
 	public void testPatchOptionByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -646,7 +656,7 @@ public abstract class BaseOptionResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteOption() throws Exception {
-		Option option = testGraphQLOption_addOption();
+		Option option = testGraphQLDeleteOption_addOption();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -675,6 +685,10 @@ public abstract class BaseOptionResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Option testGraphQLDeleteOption_addOption() throws Exception {
+		return testGraphQLOption_addOption();
+	}
+
 	@Test
 	public void testGetOption() throws Exception {
 		Option postOption = testGetOption_addOption();
@@ -692,7 +706,7 @@ public abstract class BaseOptionResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOption() throws Exception {
-		Option option = testGraphQLOption_addOption();
+		Option option = testGraphQLGetOption_addOption();
 
 		Assert.assertTrue(
 			equals(
@@ -729,6 +743,10 @@ public abstract class BaseOptionResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Option testGraphQLGetOption_addOption() throws Exception {
+		return testGraphQLOption_addOption();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionValueResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionValueResourceTestCase.java
@@ -257,7 +257,8 @@ public abstract class BaseOptionValueResourceTestCase {
 	public void testGraphQLGetOptionValueByExternalReferenceCode()
 		throws Exception {
 
-		OptionValue optionValue = testGraphQLOptionValue_addOptionValue();
+		OptionValue optionValue =
+			testGraphQLGetOptionValueByExternalReferenceCode_addOptionValue();
 
 		Assert.assertTrue(
 			equals(
@@ -307,6 +308,13 @@ public abstract class BaseOptionValueResourceTestCase {
 				"Object/code"));
 	}
 
+	protected OptionValue
+			testGraphQLGetOptionValueByExternalReferenceCode_addOptionValue()
+		throws Exception {
+
+		return testGraphQLOptionValue_addOptionValue();
+	}
+
 	@Test
 	public void testPatchOptionValueByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -342,7 +350,7 @@ public abstract class BaseOptionValueResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteOptionValue() throws Exception {
-		OptionValue optionValue = testGraphQLOptionValue_addOptionValue();
+		OptionValue optionValue = testGraphQLDeleteOptionValue_addOptionValue();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -371,6 +379,12 @@ public abstract class BaseOptionValueResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected OptionValue testGraphQLDeleteOptionValue_addOptionValue()
+		throws Exception {
+
+		return testGraphQLOptionValue_addOptionValue();
+	}
+
 	@Test
 	public void testGetOptionValue() throws Exception {
 		OptionValue postOptionValue = testGetOptionValue_addOptionValue();
@@ -389,7 +403,7 @@ public abstract class BaseOptionValueResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOptionValue() throws Exception {
-		OptionValue optionValue = testGraphQLOptionValue_addOptionValue();
+		OptionValue optionValue = testGraphQLGetOptionValue_addOptionValue();
 
 		Assert.assertTrue(
 			equals(
@@ -426,6 +440,12 @@ public abstract class BaseOptionValueResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected OptionValue testGraphQLGetOptionValue_addOptionValue()
+		throws Exception {
+
+		return testGraphQLOptionValue_addOptionValue();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BasePinResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BasePinResourceTestCase.java
@@ -210,7 +210,7 @@ public abstract class BasePinResourceTestCase {
 
 	@Test
 	public void testGraphQLDeletePin() throws Exception {
-		Pin pin = testGraphQLPin_addPin();
+		Pin pin = testGraphQLDeletePin_addPin();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -223,6 +223,10 @@ public abstract class BasePinResourceTestCase {
 							}
 						})),
 				"JSONObject/data", "Object/deletePin"));
+	}
+
+	protected Pin testGraphQLDeletePin_addPin() throws Exception {
+		return testGraphQLPin_addPin();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductAccountGroupResourceTestCase.java
@@ -228,7 +228,7 @@ public abstract class BaseProductAccountGroupResourceTestCase {
 	@Test
 	public void testGraphQLDeleteProductAccountGroup() throws Exception {
 		ProductAccountGroup productAccountGroup =
-			testGraphQLProductAccountGroup_addProductAccountGroup();
+			testGraphQLDeleteProductAccountGroup_addProductAccountGroup();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -257,6 +257,13 @@ public abstract class BaseProductAccountGroupResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected ProductAccountGroup
+			testGraphQLDeleteProductAccountGroup_addProductAccountGroup()
+		throws Exception {
+
+		return testGraphQLProductAccountGroup_addProductAccountGroup();
+	}
+
 	@Test
 	public void testGetProductAccountGroup() throws Exception {
 		ProductAccountGroup postProductAccountGroup =
@@ -281,7 +288,7 @@ public abstract class BaseProductAccountGroupResourceTestCase {
 	@Test
 	public void testGraphQLGetProductAccountGroup() throws Exception {
 		ProductAccountGroup productAccountGroup =
-			testGraphQLProductAccountGroup_addProductAccountGroup();
+			testGraphQLGetProductAccountGroup_addProductAccountGroup();
 
 		Assert.assertTrue(
 			equals(
@@ -318,6 +325,13 @@ public abstract class BaseProductAccountGroupResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ProductAccountGroup
+			testGraphQLGetProductAccountGroup_addProductAccountGroup()
+		throws Exception {
+
+		return testGraphQLProductAccountGroup_addProductAccountGroup();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductChannelResourceTestCase.java
@@ -229,7 +229,7 @@ public abstract class BaseProductChannelResourceTestCase {
 	@Test
 	public void testGraphQLDeleteProductChannel() throws Exception {
 		ProductChannel productChannel =
-			testGraphQLProductChannel_addProductChannel();
+			testGraphQLDeleteProductChannel_addProductChannel();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -258,6 +258,12 @@ public abstract class BaseProductChannelResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected ProductChannel testGraphQLDeleteProductChannel_addProductChannel()
+		throws Exception {
+
+		return testGraphQLProductChannel_addProductChannel();
+	}
+
 	@Test
 	public void testGetProductChannel() throws Exception {
 		ProductChannel postProductChannel =
@@ -281,7 +287,7 @@ public abstract class BaseProductChannelResourceTestCase {
 	@Test
 	public void testGraphQLGetProductChannel() throws Exception {
 		ProductChannel productChannel =
-			testGraphQLProductChannel_addProductChannel();
+			testGraphQLGetProductChannel_addProductChannel();
 
 		Assert.assertTrue(
 			equals(
@@ -318,6 +324,12 @@ public abstract class BaseProductChannelResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ProductChannel testGraphQLGetProductChannel_addProductChannel()
+		throws Exception {
+
+		return testGraphQLProductChannel_addProductChannel();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupProductResourceTestCase.java
@@ -222,7 +222,7 @@ public abstract class BaseProductGroupProductResourceTestCase {
 	@Test
 	public void testGraphQLDeleteProductGroupProduct() throws Exception {
 		ProductGroupProduct productGroupProduct =
-			testGraphQLProductGroupProduct_addProductGroupProduct();
+			testGraphQLDeleteProductGroupProduct_addProductGroupProduct();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -235,6 +235,13 @@ public abstract class BaseProductGroupProductResourceTestCase {
 							}
 						})),
 				"JSONObject/data", "Object/deleteProductGroupProduct"));
+	}
+
+	protected ProductGroupProduct
+			testGraphQLDeleteProductGroupProduct_addProductGroupProduct()
+		throws Exception {
+
+		return testGraphQLProductGroupProduct_addProductGroupProduct();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
@@ -508,8 +508,10 @@ public abstract class BaseProductGroupResourceTestCase {
 
 		long totalCount = productGroupsJSONObject.getLong("totalCount");
 
-		ProductGroup productGroup1 = testGraphQLProductGroup_addProductGroup();
-		ProductGroup productGroup2 = testGraphQLProductGroup_addProductGroup();
+		ProductGroup productGroup1 =
+			testGraphQLGetProductGroupsPage_addProductGroup();
+		ProductGroup productGroup2 =
+			testGraphQLGetProductGroupsPage_addProductGroup();
 
 		productGroupsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -528,6 +530,12 @@ public abstract class BaseProductGroupResourceTestCase {
 			Arrays.asList(
 				ProductGroupSerDes.toDTOs(
 					productGroupsJSONObject.getString("items"))));
+	}
+
+	protected ProductGroup testGraphQLGetProductGroupsPage_addProductGroup()
+		throws Exception {
+
+		return testGraphQLProductGroup_addProductGroup();
 	}
 
 	@Test
@@ -609,7 +617,8 @@ public abstract class BaseProductGroupResourceTestCase {
 	public void testGraphQLGetProductGroupByExternalReferenceCode()
 		throws Exception {
 
-		ProductGroup productGroup = testGraphQLProductGroup_addProductGroup();
+		ProductGroup productGroup =
+			testGraphQLGetProductGroupByExternalReferenceCode_addProductGroup();
 
 		Assert.assertTrue(
 			equals(
@@ -659,6 +668,13 @@ public abstract class BaseProductGroupResourceTestCase {
 				"Object/code"));
 	}
 
+	protected ProductGroup
+			testGraphQLGetProductGroupByExternalReferenceCode_addProductGroup()
+		throws Exception {
+
+		return testGraphQLProductGroup_addProductGroup();
+	}
+
 	@Test
 	public void testPatchProductGroupByExternalReferenceCode()
 		throws Exception {
@@ -696,7 +712,8 @@ public abstract class BaseProductGroupResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteProductGroup() throws Exception {
-		ProductGroup productGroup = testGraphQLProductGroup_addProductGroup();
+		ProductGroup productGroup =
+			testGraphQLDeleteProductGroup_addProductGroup();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -725,6 +742,12 @@ public abstract class BaseProductGroupResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected ProductGroup testGraphQLDeleteProductGroup_addProductGroup()
+		throws Exception {
+
+		return testGraphQLProductGroup_addProductGroup();
+	}
+
 	@Test
 	public void testGetProductGroup() throws Exception {
 		ProductGroup postProductGroup = testGetProductGroup_addProductGroup();
@@ -745,7 +768,8 @@ public abstract class BaseProductGroupResourceTestCase {
 
 	@Test
 	public void testGraphQLGetProductGroup() throws Exception {
-		ProductGroup productGroup = testGraphQLProductGroup_addProductGroup();
+		ProductGroup productGroup =
+			testGraphQLGetProductGroup_addProductGroup();
 
 		Assert.assertTrue(
 			equals(
@@ -782,6 +806,12 @@ public abstract class BaseProductGroupResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ProductGroup testGraphQLGetProductGroup_addProductGroup()
+		throws Exception {
+
+		return testGraphQLProductGroup_addProductGroup();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
@@ -229,7 +229,7 @@ public abstract class BaseProductOptionResourceTestCase {
 	@Test
 	public void testGraphQLDeleteProductOption() throws Exception {
 		ProductOption productOption =
-			testGraphQLProductOption_addProductOption();
+			testGraphQLDeleteProductOption_addProductOption();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -258,6 +258,12 @@ public abstract class BaseProductOptionResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected ProductOption testGraphQLDeleteProductOption_addProductOption()
+		throws Exception {
+
+		return testGraphQLProductOption_addProductOption();
+	}
+
 	@Test
 	public void testGetProductOption() throws Exception {
 		ProductOption postProductOption =
@@ -280,7 +286,7 @@ public abstract class BaseProductOptionResourceTestCase {
 	@Test
 	public void testGraphQLGetProductOption() throws Exception {
 		ProductOption productOption =
-			testGraphQLProductOption_addProductOption();
+			testGraphQLGetProductOption_addProductOption();
 
 		Assert.assertTrue(
 			equals(
@@ -317,6 +323,12 @@ public abstract class BaseProductOptionResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ProductOption testGraphQLGetProductOption_addProductOption()
+		throws Exception {
+
+		return testGraphQLProductOption_addProductOption();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -494,8 +494,8 @@ public abstract class BaseProductResourceTestCase {
 
 		long totalCount = productsJSONObject.getLong("totalCount");
 
-		Product product1 = testGraphQLProduct_addProduct();
-		Product product2 = testGraphQLProduct_addProduct();
+		Product product1 = testGraphQLGetProductsPage_addProduct();
+		Product product2 = testGraphQLGetProductsPage_addProduct();
 
 		productsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -512,6 +512,10 @@ public abstract class BaseProductResourceTestCase {
 			product2,
 			Arrays.asList(
 				ProductSerDes.toDTOs(productsJSONObject.getString("items"))));
+	}
+
+	protected Product testGraphQLGetProductsPage_addProduct() throws Exception {
+		return testGraphQLProduct_addProduct();
 	}
 
 	@Test
@@ -582,7 +586,8 @@ public abstract class BaseProductResourceTestCase {
 	public void testGraphQLGetProductByExternalReferenceCode()
 		throws Exception {
 
-		Product product = testGraphQLProduct_addProduct();
+		Product product =
+			testGraphQLGetProductByExternalReferenceCode_addProduct();
 
 		Assert.assertTrue(
 			equals(
@@ -632,6 +637,12 @@ public abstract class BaseProductResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Product testGraphQLGetProductByExternalReferenceCode_addProduct()
+		throws Exception {
+
+		return testGraphQLProduct_addProduct();
+	}
+
 	@Test
 	public void testPatchProductByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -679,7 +690,7 @@ public abstract class BaseProductResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteProduct() throws Exception {
-		Product product = testGraphQLProduct_addProduct();
+		Product product = testGraphQLDeleteProduct_addProduct();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -708,6 +719,10 @@ public abstract class BaseProductResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Product testGraphQLDeleteProduct_addProduct() throws Exception {
+		return testGraphQLProduct_addProduct();
+	}
+
 	@Test
 	public void testGetProduct() throws Exception {
 		Product postProduct = testGetProduct_addProduct();
@@ -725,7 +740,7 @@ public abstract class BaseProductResourceTestCase {
 
 	@Test
 	public void testGraphQLGetProduct() throws Exception {
-		Product product = testGraphQLProduct_addProduct();
+		Product product = testGraphQLGetProduct_addProduct();
 
 		Assert.assertTrue(
 			equals(
@@ -762,6 +777,10 @@ public abstract class BaseProductResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Product testGraphQLGetProduct_addProduct() throws Exception {
+		return testGraphQLProduct_addProduct();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductTaxConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductTaxConfigurationResourceTestCase.java
@@ -205,10 +205,19 @@ public abstract class BaseProductTaxConfigurationResourceTestCase {
 
 		ProductTaxConfiguration getProductTaxConfiguration =
 			productTaxConfigurationResource.
-				getProductByExternalReferenceCodeTaxConfiguration(null);
+				getProductByExternalReferenceCodeTaxConfiguration(
+					testGetProductByExternalReferenceCodeTaxConfiguration_getExternalReferenceCode());
 
 		assertEquals(postProductTaxConfiguration, getProductTaxConfiguration);
 		assertValid(getProductTaxConfiguration);
+	}
+
+	protected String
+			testGetProductByExternalReferenceCodeTaxConfiguration_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected ProductTaxConfiguration
@@ -236,12 +245,24 @@ public abstract class BaseProductTaxConfigurationResourceTestCase {
 								"productByExternalReferenceCodeTaxConfiguration",
 								new HashMap<String, Object>() {
 									{
-										put("externalReferenceCode", null);
+										put(
+											"externalReferenceCode",
+											"\"" +
+												testGraphQLGetProductByExternalReferenceCodeTaxConfiguration_getExternalReferenceCode() +
+													"\"");
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/productByExternalReferenceCodeTaxConfiguration"))));
+	}
+
+	protected String
+			testGraphQLGetProductByExternalReferenceCodeTaxConfiguration_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductTaxConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductTaxConfigurationResourceTestCase.java
@@ -233,7 +233,7 @@ public abstract class BaseProductTaxConfigurationResourceTestCase {
 		throws Exception {
 
 		ProductTaxConfiguration productTaxConfiguration =
-			testGraphQLProductTaxConfiguration_addProductTaxConfiguration();
+			testGraphQLGetProductByExternalReferenceCodeTaxConfiguration_addProductTaxConfiguration();
 
 		Assert.assertTrue(
 			equals(
@@ -290,6 +290,13 @@ public abstract class BaseProductTaxConfigurationResourceTestCase {
 				"Object/code"));
 	}
 
+	protected ProductTaxConfiguration
+			testGraphQLGetProductByExternalReferenceCodeTaxConfiguration_addProductTaxConfiguration()
+		throws Exception {
+
+		return testGraphQLProductTaxConfiguration_addProductTaxConfiguration();
+	}
+
 	@Test
 	public void testPatchProductByExternalReferenceCodeTaxConfiguration()
 		throws Exception {
@@ -321,7 +328,7 @@ public abstract class BaseProductTaxConfigurationResourceTestCase {
 	@Test
 	public void testGraphQLGetProductIdTaxConfiguration() throws Exception {
 		ProductTaxConfiguration productTaxConfiguration =
-			testGraphQLProductTaxConfiguration_addProductTaxConfiguration();
+			testGraphQLGetProductIdTaxConfiguration_addProductTaxConfiguration();
 
 		Assert.assertTrue(
 			equals(
@@ -363,6 +370,13 @@ public abstract class BaseProductTaxConfigurationResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ProductTaxConfiguration
+			testGraphQLGetProductIdTaxConfiguration_addProductTaxConfiguration()
+		throws Exception {
+
+		return testGraphQLProductTaxConfiguration_addProductTaxConfiguration();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
@@ -530,7 +530,7 @@ public abstract class BaseRelatedProductResourceTestCase {
 	@Test
 	public void testGraphQLDeleteRelatedProduct() throws Exception {
 		RelatedProduct relatedProduct =
-			testGraphQLRelatedProduct_addRelatedProduct();
+			testGraphQLDeleteRelatedProduct_addRelatedProduct();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -559,6 +559,12 @@ public abstract class BaseRelatedProductResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected RelatedProduct testGraphQLDeleteRelatedProduct_addRelatedProduct()
+		throws Exception {
+
+		return testGraphQLRelatedProduct_addRelatedProduct();
+	}
+
 	@Test
 	public void testGetRelatedProduct() throws Exception {
 		RelatedProduct postRelatedProduct =
@@ -582,7 +588,7 @@ public abstract class BaseRelatedProductResourceTestCase {
 	@Test
 	public void testGraphQLGetRelatedProduct() throws Exception {
 		RelatedProduct relatedProduct =
-			testGraphQLRelatedProduct_addRelatedProduct();
+			testGraphQLGetRelatedProduct_addRelatedProduct();
 
 		Assert.assertTrue(
 			equals(
@@ -619,6 +625,12 @@ public abstract class BaseRelatedProductResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected RelatedProduct testGraphQLGetRelatedProduct_addRelatedProduct()
+		throws Exception {
+
+		return testGraphQLRelatedProduct_addRelatedProduct();
 	}
 
 	protected RelatedProduct testGraphQLRelatedProduct_addRelatedProduct()

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
@@ -719,8 +719,8 @@ public abstract class BaseSkuResourceTestCase {
 
 		long totalCount = skusJSONObject.getLong("totalCount");
 
-		Sku sku1 = testGraphQLSku_addSku();
-		Sku sku2 = testGraphQLSku_addSku();
+		Sku sku1 = testGraphQLGetSkusPage_addSku();
+		Sku sku2 = testGraphQLGetSkusPage_addSku();
 
 		skusJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -735,6 +735,10 @@ public abstract class BaseSkuResourceTestCase {
 		assertContains(
 			sku2,
 			Arrays.asList(SkuSerDes.toDTOs(skusJSONObject.getString("items"))));
+	}
+
+	protected Sku testGraphQLGetSkusPage_addSku() throws Exception {
+		return testGraphQLSku_addSku();
 	}
 
 	@Test
@@ -783,7 +787,7 @@ public abstract class BaseSkuResourceTestCase {
 
 	@Test
 	public void testGraphQLGetSkuByExternalReferenceCode() throws Exception {
-		Sku sku = testGraphQLSku_addSku();
+		Sku sku = testGraphQLGetSkuByExternalReferenceCode_addSku();
 
 		Assert.assertTrue(
 			equals(
@@ -832,6 +836,12 @@ public abstract class BaseSkuResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Sku testGraphQLGetSkuByExternalReferenceCode_addSku()
+		throws Exception {
+
+		return testGraphQLSku_addSku();
+	}
+
 	@Test
 	public void testPatchSkuByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -859,7 +869,7 @@ public abstract class BaseSkuResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteSku() throws Exception {
-		Sku sku = testGraphQLSku_addSku();
+		Sku sku = testGraphQLDeleteSku_addSku();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -888,6 +898,10 @@ public abstract class BaseSkuResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Sku testGraphQLDeleteSku_addSku() throws Exception {
+		return testGraphQLSku_addSku();
+	}
+
 	@Test
 	public void testGetSku() throws Exception {
 		Sku postSku = testGetSku_addSku();
@@ -905,7 +919,7 @@ public abstract class BaseSkuResourceTestCase {
 
 	@Test
 	public void testGraphQLGetSku() throws Exception {
-		Sku sku = testGraphQLSku_addSku();
+		Sku sku = testGraphQLGetSku_addSku();
 
 		Assert.assertTrue(
 			equals(
@@ -942,6 +956,10 @@ public abstract class BaseSkuResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Sku testGraphQLGetSku_addSku() throws Exception {
+		return testGraphQLSku_addSku();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
@@ -517,9 +517,9 @@ public abstract class BaseSpecificationResourceTestCase {
 		long totalCount = specificationsJSONObject.getLong("totalCount");
 
 		Specification specification1 =
-			testGraphQLSpecification_addSpecification();
+			testGraphQLGetSpecificationsPage_addSpecification();
 		Specification specification2 =
-			testGraphQLSpecification_addSpecification();
+			testGraphQLGetSpecificationsPage_addSpecification();
 
 		specificationsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -538,6 +538,12 @@ public abstract class BaseSpecificationResourceTestCase {
 			Arrays.asList(
 				SpecificationSerDes.toDTOs(
 					specificationsJSONObject.getString("items"))));
+	}
+
+	protected Specification testGraphQLGetSpecificationsPage_addSpecification()
+		throws Exception {
+
+		return testGraphQLSpecification_addSpecification();
 	}
 
 	@Test
@@ -591,7 +597,7 @@ public abstract class BaseSpecificationResourceTestCase {
 	@Test
 	public void testGraphQLDeleteSpecification() throws Exception {
 		Specification specification =
-			testGraphQLSpecification_addSpecification();
+			testGraphQLDeleteSpecification_addSpecification();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -620,6 +626,12 @@ public abstract class BaseSpecificationResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Specification testGraphQLDeleteSpecification_addSpecification()
+		throws Exception {
+
+		return testGraphQLSpecification_addSpecification();
+	}
+
 	@Test
 	public void testGetSpecification() throws Exception {
 		Specification postSpecification =
@@ -642,7 +654,7 @@ public abstract class BaseSpecificationResourceTestCase {
 	@Test
 	public void testGraphQLGetSpecification() throws Exception {
 		Specification specification =
-			testGraphQLSpecification_addSpecification();
+			testGraphQLGetSpecification_addSpecification();
 
 		Assert.assertTrue(
 			equals(
@@ -679,6 +691,12 @@ public abstract class BaseSpecificationResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Specification testGraphQLGetSpecification_addSpecification()
+		throws Exception {
+
+		return testGraphQLSpecification_addSpecification();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -490,8 +490,8 @@ public abstract class BaseChannelResourceTestCase {
 
 		long totalCount = channelsJSONObject.getLong("totalCount");
 
-		Channel channel1 = testGraphQLChannel_addChannel();
-		Channel channel2 = testGraphQLChannel_addChannel();
+		Channel channel1 = testGraphQLGetChannelsPage_addChannel();
+		Channel channel2 = testGraphQLGetChannelsPage_addChannel();
 
 		channelsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -508,6 +508,10 @@ public abstract class BaseChannelResourceTestCase {
 			channel2,
 			Arrays.asList(
 				ChannelSerDes.toDTOs(channelsJSONObject.getString("items"))));
+	}
+
+	protected Channel testGraphQLGetChannelsPage_addChannel() throws Exception {
+		return testGraphQLChannel_addChannel();
 	}
 
 	@Test
@@ -578,7 +582,8 @@ public abstract class BaseChannelResourceTestCase {
 	public void testGraphQLGetChannelByExternalReferenceCode()
 		throws Exception {
 
-		Channel channel = testGraphQLChannel_addChannel();
+		Channel channel =
+			testGraphQLGetChannelByExternalReferenceCode_addChannel();
 
 		Assert.assertTrue(
 			equals(
@@ -626,6 +631,12 @@ public abstract class BaseChannelResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Channel testGraphQLGetChannelByExternalReferenceCode_addChannel()
+		throws Exception {
+
+		return testGraphQLChannel_addChannel();
 	}
 
 	@Test
@@ -731,7 +742,7 @@ public abstract class BaseChannelResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteChannel() throws Exception {
-		Channel channel = testGraphQLChannel_addChannel();
+		Channel channel = testGraphQLDeleteChannel_addChannel();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -760,6 +771,10 @@ public abstract class BaseChannelResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Channel testGraphQLDeleteChannel_addChannel() throws Exception {
+		return testGraphQLChannel_addChannel();
+	}
+
 	@Test
 	public void testGetChannel() throws Exception {
 		Channel postChannel = testGetChannel_addChannel();
@@ -777,7 +792,7 @@ public abstract class BaseChannelResourceTestCase {
 
 	@Test
 	public void testGraphQLGetChannel() throws Exception {
-		Channel channel = testGraphQLChannel_addChannel();
+		Channel channel = testGraphQLGetChannel_addChannel();
 
 		Assert.assertTrue(
 			equals(
@@ -814,6 +829,10 @@ public abstract class BaseChannelResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Channel testGraphQLGetChannel_addChannel() throws Exception {
+		return testGraphQLChannel_addChannel();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -191,10 +191,19 @@ public abstract class BaseOrderTypeResourceTestCase {
 			testGetPaymentMethodGroupRelOrderTypeOrderType_addOrderType();
 
 		OrderType getOrderType =
-			orderTypeResource.getPaymentMethodGroupRelOrderTypeOrderType(null);
+			orderTypeResource.getPaymentMethodGroupRelOrderTypeOrderType(
+				testGetPaymentMethodGroupRelOrderTypeOrderType_getPaymentMethodGroupRelOrderTypeId());
 
 		assertEquals(postOrderType, getOrderType);
 		assertValid(getOrderType);
+	}
+
+	protected Long
+			testGetPaymentMethodGroupRelOrderTypeOrderType_getPaymentMethodGroupRelOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected OrderType
@@ -223,12 +232,20 @@ public abstract class BaseOrderTypeResourceTestCase {
 									{
 										put(
 											"paymentMethodGroupRelOrderTypeId",
-											null);
+											testGraphQLGetPaymentMethodGroupRelOrderTypeOrderType_getPaymentMethodGroupRelOrderTypeId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/paymentMethodGroupRelOrderTypeOrderType"))));
+	}
+
+	protected Long
+			testGraphQLGetPaymentMethodGroupRelOrderTypeOrderType_getPaymentMethodGroupRelOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -264,10 +281,19 @@ public abstract class BaseOrderTypeResourceTestCase {
 			testGetShippingFixedOptionOrderTypeOrderType_addOrderType();
 
 		OrderType getOrderType =
-			orderTypeResource.getShippingFixedOptionOrderTypeOrderType(null);
+			orderTypeResource.getShippingFixedOptionOrderTypeOrderType(
+				testGetShippingFixedOptionOrderTypeOrderType_getShippingFixedOptionOrderTypeId());
 
 		assertEquals(postOrderType, getOrderType);
 		assertValid(getOrderType);
+	}
+
+	protected Long
+			testGetShippingFixedOptionOrderTypeOrderType_getShippingFixedOptionOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected OrderType
@@ -296,12 +322,20 @@ public abstract class BaseOrderTypeResourceTestCase {
 									{
 										put(
 											"shippingFixedOptionOrderTypeId",
-											null);
+											testGraphQLGetShippingFixedOptionOrderTypeOrderType_getShippingFixedOptionOrderTypeId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/shippingFixedOptionOrderTypeOrderType"))));
+	}
+
+	protected Long
+			testGraphQLGetShippingFixedOptionOrderTypeOrderType_getShippingFixedOptionOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -218,7 +218,8 @@ public abstract class BaseOrderTypeResourceTestCase {
 	public void testGraphQLGetPaymentMethodGroupRelOrderTypeOrderType()
 		throws Exception {
 
-		OrderType orderType = testGraphQLOrderType_addOrderType();
+		OrderType orderType =
+			testGraphQLGetPaymentMethodGroupRelOrderTypeOrderType_addOrderType();
 
 		Assert.assertTrue(
 			equals(
@@ -273,6 +274,13 @@ public abstract class BaseOrderTypeResourceTestCase {
 				"Object/code"));
 	}
 
+	protected OrderType
+			testGraphQLGetPaymentMethodGroupRelOrderTypeOrderType_addOrderType()
+		throws Exception {
+
+		return testGraphQLOrderType_addOrderType();
+	}
+
 	@Test
 	public void testGetShippingFixedOptionOrderTypeOrderType()
 		throws Exception {
@@ -308,7 +316,8 @@ public abstract class BaseOrderTypeResourceTestCase {
 	public void testGraphQLGetShippingFixedOptionOrderTypeOrderType()
 		throws Exception {
 
-		OrderType orderType = testGraphQLOrderType_addOrderType();
+		OrderType orderType =
+			testGraphQLGetShippingFixedOptionOrderTypeOrderType_addOrderType();
 
 		Assert.assertTrue(
 			equals(
@@ -361,6 +370,13 @@ public abstract class BaseOrderTypeResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected OrderType
+			testGraphQLGetShippingFixedOptionOrderTypeOrderType_addOrderType()
+		throws Exception {
+
+		return testGraphQLOrderType_addOrderType();
 	}
 
 	protected OrderType testGraphQLOrderType_addOrderType() throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
@@ -277,8 +277,10 @@ public abstract class BaseTaxCategoryResourceTestCase {
 
 		long totalCount = taxCategoriesJSONObject.getLong("totalCount");
 
-		TaxCategory taxCategory1 = testGraphQLTaxCategory_addTaxCategory();
-		TaxCategory taxCategory2 = testGraphQLTaxCategory_addTaxCategory();
+		TaxCategory taxCategory1 =
+			testGraphQLGetTaxCategoriesPage_addTaxCategory();
+		TaxCategory taxCategory2 =
+			testGraphQLGetTaxCategoriesPage_addTaxCategory();
 
 		taxCategoriesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -299,6 +301,12 @@ public abstract class BaseTaxCategoryResourceTestCase {
 					taxCategoriesJSONObject.getString("items"))));
 	}
 
+	protected TaxCategory testGraphQLGetTaxCategoriesPage_addTaxCategory()
+		throws Exception {
+
+		return testGraphQLTaxCategory_addTaxCategory();
+	}
+
 	@Test
 	public void testGetTaxCategory() throws Exception {
 		TaxCategory postTaxCategory = testGetTaxCategory_addTaxCategory();
@@ -317,7 +325,7 @@ public abstract class BaseTaxCategoryResourceTestCase {
 
 	@Test
 	public void testGraphQLGetTaxCategory() throws Exception {
-		TaxCategory taxCategory = testGraphQLTaxCategory_addTaxCategory();
+		TaxCategory taxCategory = testGraphQLGetTaxCategory_addTaxCategory();
 
 		Assert.assertTrue(
 			equals(
@@ -354,6 +362,12 @@ public abstract class BaseTaxCategoryResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected TaxCategory testGraphQLGetTaxCategory_addTaxCategory()
+		throws Exception {
+
+		return testGraphQLTaxCategory_addTaxCategory();
 	}
 
 	protected TaxCategory testGraphQLTaxCategory_addTaxCategory()

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTermResourceTestCase.java
@@ -192,10 +192,19 @@ public abstract class BaseTermResourceTestCase {
 	public void testGetPaymentMethodGroupRelTermTerm() throws Exception {
 		Term postTerm = testGetPaymentMethodGroupRelTermTerm_addTerm();
 
-		Term getTerm = termResource.getPaymentMethodGroupRelTermTerm(null);
+		Term getTerm = termResource.getPaymentMethodGroupRelTermTerm(
+			testGetPaymentMethodGroupRelTermTerm_getPaymentMethodGroupRelTermId());
 
 		assertEquals(postTerm, getTerm);
 		assertValid(getTerm);
+	}
+
+	protected Long
+			testGetPaymentMethodGroupRelTermTerm_getPaymentMethodGroupRelTermId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Term testGetPaymentMethodGroupRelTermTerm_addTerm()
@@ -221,12 +230,20 @@ public abstract class BaseTermResourceTestCase {
 									{
 										put(
 											"paymentMethodGroupRelTermId",
-											null);
+											testGraphQLGetPaymentMethodGroupRelTermTerm_getPaymentMethodGroupRelTermId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/paymentMethodGroupRelTermTerm"))));
+	}
+
+	protected Long
+			testGraphQLGetPaymentMethodGroupRelTermTerm_getPaymentMethodGroupRelTermId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -258,10 +275,19 @@ public abstract class BaseTermResourceTestCase {
 	public void testGetShippingFixedOptionTermTerm() throws Exception {
 		Term postTerm = testGetShippingFixedOptionTermTerm_addTerm();
 
-		Term getTerm = termResource.getShippingFixedOptionTermTerm(null);
+		Term getTerm = termResource.getShippingFixedOptionTermTerm(
+			testGetShippingFixedOptionTermTerm_getShippingFixedOptionTermId());
 
 		assertEquals(postTerm, getTerm);
 		assertValid(getTerm);
+	}
+
+	protected Long
+			testGetShippingFixedOptionTermTerm_getShippingFixedOptionTermId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Term testGetShippingFixedOptionTermTerm_addTerm()
@@ -285,12 +311,22 @@ public abstract class BaseTermResourceTestCase {
 								"shippingFixedOptionTermTerm",
 								new HashMap<String, Object>() {
 									{
-										put("shippingFixedOptionTermId", null);
+										put(
+											"shippingFixedOptionTermId",
+											testGraphQLGetShippingFixedOptionTermTerm_getShippingFixedOptionTermId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/shippingFixedOptionTermTerm"))));
+	}
+
+	protected Long
+			testGraphQLGetShippingFixedOptionTermTerm_getShippingFixedOptionTermId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTermResourceTestCase.java
@@ -216,7 +216,7 @@ public abstract class BaseTermResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPaymentMethodGroupRelTermTerm() throws Exception {
-		Term term = testGraphQLTerm_addTerm();
+		Term term = testGraphQLGetPaymentMethodGroupRelTermTerm_addTerm();
 
 		Assert.assertTrue(
 			equals(
@@ -271,6 +271,12 @@ public abstract class BaseTermResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Term testGraphQLGetPaymentMethodGroupRelTermTerm_addTerm()
+		throws Exception {
+
+		return testGraphQLTerm_addTerm();
+	}
+
 	@Test
 	public void testGetShippingFixedOptionTermTerm() throws Exception {
 		Term postTerm = testGetShippingFixedOptionTermTerm_addTerm();
@@ -299,7 +305,7 @@ public abstract class BaseTermResourceTestCase {
 
 	@Test
 	public void testGraphQLGetShippingFixedOptionTermTerm() throws Exception {
-		Term term = testGraphQLTerm_addTerm();
+		Term term = testGraphQLGetShippingFixedOptionTermTerm_addTerm();
 
 		Assert.assertTrue(
 			equals(
@@ -351,6 +357,12 @@ public abstract class BaseTermResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Term testGraphQLGetShippingFixedOptionTermTerm_addTerm()
+		throws Exception {
+
+		return testGraphQLTerm_addTerm();
 	}
 
 	protected Term testGraphQLTerm_addTerm() throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseItemResourceTestCase.java
@@ -258,7 +258,7 @@ public abstract class BaseWarehouseItemResourceTestCase {
 		throws Exception {
 
 		WarehouseItem warehouseItem =
-			testGraphQLWarehouseItem_addWarehouseItem();
+			testGraphQLGetWarehouseItemByExternalReferenceCode_addWarehouseItem();
 
 		Assert.assertTrue(
 			equals(
@@ -306,6 +306,13 @@ public abstract class BaseWarehouseItemResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected WarehouseItem
+			testGraphQLGetWarehouseItemByExternalReferenceCode_addWarehouseItem()
+		throws Exception {
+
+		return testGraphQLWarehouseItem_addWarehouseItem();
 	}
 
 	@Test
@@ -370,7 +377,7 @@ public abstract class BaseWarehouseItemResourceTestCase {
 	@Test
 	public void testGraphQLDeleteWarehouseItem() throws Exception {
 		WarehouseItem warehouseItem =
-			testGraphQLWarehouseItem_addWarehouseItem();
+			testGraphQLDeleteWarehouseItem_addWarehouseItem();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -399,6 +406,12 @@ public abstract class BaseWarehouseItemResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected WarehouseItem testGraphQLDeleteWarehouseItem_addWarehouseItem()
+		throws Exception {
+
+		return testGraphQLWarehouseItem_addWarehouseItem();
+	}
+
 	@Test
 	public void testGetWarehouseItem() throws Exception {
 		WarehouseItem postWarehouseItem =
@@ -421,7 +434,7 @@ public abstract class BaseWarehouseItemResourceTestCase {
 	@Test
 	public void testGraphQLGetWarehouseItem() throws Exception {
 		WarehouseItem warehouseItem =
-			testGraphQLWarehouseItem_addWarehouseItem();
+			testGraphQLGetWarehouseItem_addWarehouseItem();
 
 		Assert.assertTrue(
 			equals(
@@ -458,6 +471,12 @@ public abstract class BaseWarehouseItemResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected WarehouseItem testGraphQLGetWarehouseItem_addWarehouseItem()
+		throws Exception {
+
+		return testGraphQLWarehouseItem_addWarehouseItem();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseResourceTestCase.java
@@ -269,7 +269,8 @@ public abstract class BaseWarehouseResourceTestCase {
 	public void testGraphQLGetWarehousByExternalReferenceCode()
 		throws Exception {
 
-		Warehouse warehouse = testGraphQLWarehouse_addWarehouse();
+		Warehouse warehouse =
+			testGraphQLGetWarehousByExternalReferenceCode_addWarehouse();
 
 		Assert.assertTrue(
 			equals(
@@ -319,6 +320,13 @@ public abstract class BaseWarehouseResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Warehouse
+			testGraphQLGetWarehousByExternalReferenceCode_addWarehouse()
+		throws Exception {
+
+		return testGraphQLWarehouse_addWarehouse();
+	}
+
 	@Test
 	public void testPatchWarehousByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -365,7 +373,7 @@ public abstract class BaseWarehouseResourceTestCase {
 
 	@Test
 	public void testGraphQLGetWarehousId() throws Exception {
-		Warehouse warehouse = testGraphQLWarehouse_addWarehouse();
+		Warehouse warehouse = testGraphQLGetWarehousId_addWarehouse();
 
 		Assert.assertTrue(
 			equals(
@@ -402,6 +410,12 @@ public abstract class BaseWarehouseResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Warehouse testGraphQLGetWarehousId_addWarehouse()
+		throws Exception {
+
+		return testGraphQLWarehouse_addWarehouse();
 	}
 
 	@Test
@@ -701,8 +715,8 @@ public abstract class BaseWarehouseResourceTestCase {
 
 		long totalCount = warehousesJSONObject.getLong("totalCount");
 
-		Warehouse warehouse1 = testGraphQLWarehouse_addWarehouse();
-		Warehouse warehouse2 = testGraphQLWarehouse_addWarehouse();
+		Warehouse warehouse1 = testGraphQLGetWarehousesPage_addWarehouse();
+		Warehouse warehouse2 = testGraphQLGetWarehousesPage_addWarehouse();
 
 		warehousesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -721,6 +735,12 @@ public abstract class BaseWarehouseResourceTestCase {
 			Arrays.asList(
 				WarehouseSerDes.toDTOs(
 					warehousesJSONObject.getString("items"))));
+	}
+
+	protected Warehouse testGraphQLGetWarehousesPage_addWarehouse()
+		throws Exception {
+
+		return testGraphQLWarehouse_addWarehouse();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
@@ -1304,7 +1304,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.18'."
+        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.19'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.18'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.19'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
@@ -194,10 +194,19 @@ public abstract class BaseAccountGroupResourceTestCase {
 			testGetOrderRuleAccountGroupAccountGroup_addAccountGroup();
 
 		AccountGroup getAccountGroup =
-			accountGroupResource.getOrderRuleAccountGroupAccountGroup(null);
+			accountGroupResource.getOrderRuleAccountGroupAccountGroup(
+				testGetOrderRuleAccountGroupAccountGroup_getOrderRuleAccountGroupId());
 
 		assertEquals(postAccountGroup, getAccountGroup);
 		assertValid(getAccountGroup);
+	}
+
+	protected Long
+			testGetOrderRuleAccountGroupAccountGroup_getOrderRuleAccountGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected AccountGroup
@@ -224,12 +233,22 @@ public abstract class BaseAccountGroupResourceTestCase {
 								"orderRuleAccountGroupAccountGroup",
 								new HashMap<String, Object>() {
 									{
-										put("orderRuleAccountGroupId", null);
+										put(
+											"orderRuleAccountGroupId",
+											testGraphQLGetOrderRuleAccountGroupAccountGroup_getOrderRuleAccountGroupId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/orderRuleAccountGroupAccountGroup"))));
+	}
+
+	protected Long
+			testGraphQLGetOrderRuleAccountGroupAccountGroup_getOrderRuleAccountGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
@@ -221,7 +221,8 @@ public abstract class BaseAccountGroupResourceTestCase {
 	public void testGraphQLGetOrderRuleAccountGroupAccountGroup()
 		throws Exception {
 
-		AccountGroup accountGroup = testGraphQLAccountGroup_addAccountGroup();
+		AccountGroup accountGroup =
+			testGraphQLGetOrderRuleAccountGroupAccountGroup_addAccountGroup();
 
 		Assert.assertTrue(
 			equals(
@@ -273,6 +274,13 @@ public abstract class BaseAccountGroupResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected AccountGroup
+			testGraphQLGetOrderRuleAccountGroupAccountGroup_addAccountGroup()
+		throws Exception {
+
+		return testGraphQLAccountGroup_addAccountGroup();
 	}
 
 	protected AccountGroup testGraphQLAccountGroup_addAccountGroup()

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -198,10 +198,18 @@ public abstract class BaseAccountResourceTestCase {
 	public void testGetOrderRuleAccountAccount() throws Exception {
 		Account postAccount = testGetOrderRuleAccountAccount_addAccount();
 
-		Account getAccount = accountResource.getOrderRuleAccountAccount(null);
+		Account getAccount = accountResource.getOrderRuleAccountAccount(
+			testGetOrderRuleAccountAccount_getOrderRuleAccountId());
 
 		assertEquals(postAccount, getAccount);
 		assertValid(getAccount);
+	}
+
+	protected Long testGetOrderRuleAccountAccount_getOrderRuleAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Account testGetOrderRuleAccountAccount_addAccount()
@@ -225,11 +233,20 @@ public abstract class BaseAccountResourceTestCase {
 								"orderRuleAccountAccount",
 								new HashMap<String, Object>() {
 									{
-										put("orderRuleAccountId", null);
+										put(
+											"orderRuleAccountId",
+											testGraphQLGetOrderRuleAccountAccount_getOrderRuleAccountId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/orderRuleAccountAccount"))));
+	}
+
+	protected Long testGraphQLGetOrderRuleAccountAccount_getOrderRuleAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -221,7 +221,7 @@ public abstract class BaseAccountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrderRuleAccountAccount() throws Exception {
-		Account account = testGraphQLAccount_addAccount();
+		Account account = testGraphQLGetOrderRuleAccountAccount_addAccount();
 
 		Assert.assertTrue(
 			equals(
@@ -273,6 +273,12 @@ public abstract class BaseAccountResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Account testGraphQLGetOrderRuleAccountAccount_addAccount()
+		throws Exception {
+
+		return testGraphQLAccount_addAccount();
+	}
+
 	@Test
 	public void testGetOrderByExternalReferenceCodeAccount() throws Exception {
 		Account postAccount =
@@ -297,7 +303,8 @@ public abstract class BaseAccountResourceTestCase {
 	public void testGraphQLGetOrderByExternalReferenceCodeAccount()
 		throws Exception {
 
-		Account account = testGraphQLAccount_addAccount();
+		Account account =
+			testGraphQLGetOrderByExternalReferenceCodeAccount_addAccount();
 
 		Assert.assertTrue(
 			equals(
@@ -347,6 +354,13 @@ public abstract class BaseAccountResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Account
+			testGraphQLGetOrderByExternalReferenceCodeAccount_addAccount()
+		throws Exception {
+
+		return testGraphQLAccount_addAccount();
+	}
+
 	@Test
 	public void testGetOrderIdAccount() throws Exception {
 		Account postAccount = testGetOrderIdAccount_addAccount();
@@ -365,7 +379,7 @@ public abstract class BaseAccountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrderIdAccount() throws Exception {
-		Account account = testGraphQLAccount_addAccount();
+		Account account = testGraphQLGetOrderIdAccount_addAccount();
 
 		Assert.assertTrue(
 			equals(
@@ -402,6 +416,12 @@ public abstract class BaseAccountResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Account testGraphQLGetOrderIdAccount_addAccount()
+		throws Exception {
+
+		return testGraphQLAccount_addAccount();
 	}
 
 	protected Account testGraphQLAccount_addAccount() throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseBillingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseBillingAddressResourceTestCase.java
@@ -240,7 +240,7 @@ public abstract class BaseBillingAddressResourceTestCase {
 		throws Exception {
 
 		BillingAddress billingAddress =
-			testGraphQLBillingAddress_addBillingAddress();
+			testGraphQLGetOrderByExternalReferenceCodeBillingAddress_addBillingAddress();
 
 		Assert.assertTrue(
 			equals(
@@ -290,6 +290,13 @@ public abstract class BaseBillingAddressResourceTestCase {
 				"Object/code"));
 	}
 
+	protected BillingAddress
+			testGraphQLGetOrderByExternalReferenceCodeBillingAddress_addBillingAddress()
+		throws Exception {
+
+		return testGraphQLBillingAddress_addBillingAddress();
+	}
+
 	@Test
 	public void testPatchOrderByExternalReferenceCodeBillingAddress()
 		throws Exception {
@@ -320,7 +327,7 @@ public abstract class BaseBillingAddressResourceTestCase {
 	@Test
 	public void testGraphQLGetOrderIdBillingAddress() throws Exception {
 		BillingAddress billingAddress =
-			testGraphQLBillingAddress_addBillingAddress();
+			testGraphQLGetOrderIdBillingAddress_addBillingAddress();
 
 		Assert.assertTrue(
 			equals(
@@ -357,6 +364,13 @@ public abstract class BaseBillingAddressResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected BillingAddress
+			testGraphQLGetOrderIdBillingAddress_addBillingAddress()
+		throws Exception {
+
+		return testGraphQLBillingAddress_addBillingAddress();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -198,10 +198,18 @@ public abstract class BaseChannelResourceTestCase {
 	public void testGetOrderRuleChannelChannel() throws Exception {
 		Channel postChannel = testGetOrderRuleChannelChannel_addChannel();
 
-		Channel getChannel = channelResource.getOrderRuleChannelChannel(null);
+		Channel getChannel = channelResource.getOrderRuleChannelChannel(
+			testGetOrderRuleChannelChannel_getOrderRuleChannelId());
 
 		assertEquals(postChannel, getChannel);
 		assertValid(getChannel);
+	}
+
+	protected Long testGetOrderRuleChannelChannel_getOrderRuleChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Channel testGetOrderRuleChannelChannel_addChannel()
@@ -225,11 +233,20 @@ public abstract class BaseChannelResourceTestCase {
 								"orderRuleChannelChannel",
 								new HashMap<String, Object>() {
 									{
-										put("orderRuleChannelId", null);
+										put(
+											"orderRuleChannelId",
+											testGraphQLGetOrderRuleChannelChannel_getOrderRuleChannelId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/orderRuleChannelChannel"))));
+	}
+
+	protected Long testGraphQLGetOrderRuleChannelChannel_getOrderRuleChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -260,10 +277,18 @@ public abstract class BaseChannelResourceTestCase {
 	public void testGetOrderTypeChannelChannel() throws Exception {
 		Channel postChannel = testGetOrderTypeChannelChannel_addChannel();
 
-		Channel getChannel = channelResource.getOrderTypeChannelChannel(null);
+		Channel getChannel = channelResource.getOrderTypeChannelChannel(
+			testGetOrderTypeChannelChannel_getOrderTypeChannelId());
 
 		assertEquals(postChannel, getChannel);
 		assertValid(getChannel);
+	}
+
+	protected Long testGetOrderTypeChannelChannel_getOrderTypeChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Channel testGetOrderTypeChannelChannel_addChannel()
@@ -287,11 +312,20 @@ public abstract class BaseChannelResourceTestCase {
 								"orderTypeChannelChannel",
 								new HashMap<String, Object>() {
 									{
-										put("orderTypeChannelId", null);
+										put(
+											"orderTypeChannelId",
+											testGraphQLGetOrderTypeChannelChannel_getOrderTypeChannelId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/orderTypeChannelChannel"))));
+	}
+
+	protected Long testGraphQLGetOrderTypeChannelChannel_getOrderTypeChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -221,7 +221,7 @@ public abstract class BaseChannelResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrderRuleChannelChannel() throws Exception {
-		Channel channel = testGraphQLChannel_addChannel();
+		Channel channel = testGraphQLGetOrderRuleChannelChannel_addChannel();
 
 		Assert.assertTrue(
 			equals(
@@ -273,6 +273,12 @@ public abstract class BaseChannelResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Channel testGraphQLGetOrderRuleChannelChannel_addChannel()
+		throws Exception {
+
+		return testGraphQLChannel_addChannel();
+	}
+
 	@Test
 	public void testGetOrderTypeChannelChannel() throws Exception {
 		Channel postChannel = testGetOrderTypeChannelChannel_addChannel();
@@ -300,7 +306,7 @@ public abstract class BaseChannelResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrderTypeChannelChannel() throws Exception {
-		Channel channel = testGraphQLChannel_addChannel();
+		Channel channel = testGraphQLGetOrderTypeChannelChannel_addChannel();
 
 		Assert.assertTrue(
 			equals(
@@ -352,6 +358,12 @@ public abstract class BaseChannelResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Channel testGraphQLGetOrderTypeChannelChannel_addChannel()
+		throws Exception {
+
+		return testGraphQLChannel_addChannel();
+	}
+
 	@Test
 	public void testGetOrderByExternalReferenceCodeChannel() throws Exception {
 		Channel postChannel =
@@ -376,7 +388,8 @@ public abstract class BaseChannelResourceTestCase {
 	public void testGraphQLGetOrderByExternalReferenceCodeChannel()
 		throws Exception {
 
-		Channel channel = testGraphQLChannel_addChannel();
+		Channel channel =
+			testGraphQLGetOrderByExternalReferenceCodeChannel_addChannel();
 
 		Assert.assertTrue(
 			equals(
@@ -426,6 +439,13 @@ public abstract class BaseChannelResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Channel
+			testGraphQLGetOrderByExternalReferenceCodeChannel_addChannel()
+		throws Exception {
+
+		return testGraphQLChannel_addChannel();
+	}
+
 	@Test
 	public void testGetOrderIdChannel() throws Exception {
 		Channel postChannel = testGetOrderIdChannel_addChannel();
@@ -444,7 +464,7 @@ public abstract class BaseChannelResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrderIdChannel() throws Exception {
-		Channel channel = testGraphQLChannel_addChannel();
+		Channel channel = testGraphQLGetOrderIdChannel_addChannel();
 
 		Assert.assertTrue(
 			equals(
@@ -481,6 +501,12 @@ public abstract class BaseChannelResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Channel testGraphQLGetOrderIdChannel_addChannel()
+		throws Exception {
+
+		return testGraphQLChannel_addChannel();
 	}
 
 	protected Channel testGraphQLChannel_addChannel() throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderItemResourceTestCase.java
@@ -262,7 +262,8 @@ public abstract class BaseOrderItemResourceTestCase {
 	public void testGraphQLGetOrderItemByExternalReferenceCode()
 		throws Exception {
 
-		OrderItem orderItem = testGraphQLOrderItem_addOrderItem();
+		OrderItem orderItem =
+			testGraphQLGetOrderItemByExternalReferenceCode_addOrderItem();
 
 		Assert.assertTrue(
 			equals(
@@ -312,6 +313,13 @@ public abstract class BaseOrderItemResourceTestCase {
 				"Object/code"));
 	}
 
+	protected OrderItem
+			testGraphQLGetOrderItemByExternalReferenceCode_addOrderItem()
+		throws Exception {
+
+		return testGraphQLOrderItem_addOrderItem();
+	}
+
 	@Test
 	public void testPatchOrderItemByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -340,7 +348,7 @@ public abstract class BaseOrderItemResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteOrderItem() throws Exception {
-		OrderItem orderItem = testGraphQLOrderItem_addOrderItem();
+		OrderItem orderItem = testGraphQLDeleteOrderItem_addOrderItem();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -369,6 +377,12 @@ public abstract class BaseOrderItemResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected OrderItem testGraphQLDeleteOrderItem_addOrderItem()
+		throws Exception {
+
+		return testGraphQLOrderItem_addOrderItem();
+	}
+
 	@Test
 	public void testGetOrderItem() throws Exception {
 		OrderItem postOrderItem = testGetOrderItem_addOrderItem();
@@ -387,7 +401,7 @@ public abstract class BaseOrderItemResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrderItem() throws Exception {
-		OrderItem orderItem = testGraphQLOrderItem_addOrderItem();
+		OrderItem orderItem = testGraphQLGetOrderItem_addOrderItem();
 
 		Assert.assertTrue(
 			equals(
@@ -424,6 +438,12 @@ public abstract class BaseOrderItemResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected OrderItem testGraphQLGetOrderItem_addOrderItem()
+		throws Exception {
+
+		return testGraphQLOrderItem_addOrderItem();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderNoteResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderNoteResourceTestCase.java
@@ -251,7 +251,8 @@ public abstract class BaseOrderNoteResourceTestCase {
 	public void testGraphQLGetOrderNoteByExternalReferenceCode()
 		throws Exception {
 
-		OrderNote orderNote = testGraphQLOrderNote_addOrderNote();
+		OrderNote orderNote =
+			testGraphQLGetOrderNoteByExternalReferenceCode_addOrderNote();
 
 		Assert.assertTrue(
 			equals(
@@ -301,6 +302,13 @@ public abstract class BaseOrderNoteResourceTestCase {
 				"Object/code"));
 	}
 
+	protected OrderNote
+			testGraphQLGetOrderNoteByExternalReferenceCode_addOrderNote()
+		throws Exception {
+
+		return testGraphQLOrderNote_addOrderNote();
+	}
+
 	@Test
 	public void testPatchOrderNoteByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -329,7 +337,7 @@ public abstract class BaseOrderNoteResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteOrderNote() throws Exception {
-		OrderNote orderNote = testGraphQLOrderNote_addOrderNote();
+		OrderNote orderNote = testGraphQLDeleteOrderNote_addOrderNote();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -358,6 +366,12 @@ public abstract class BaseOrderNoteResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected OrderNote testGraphQLDeleteOrderNote_addOrderNote()
+		throws Exception {
+
+		return testGraphQLOrderNote_addOrderNote();
+	}
+
 	@Test
 	public void testGetOrderNote() throws Exception {
 		OrderNote postOrderNote = testGetOrderNote_addOrderNote();
@@ -376,7 +390,7 @@ public abstract class BaseOrderNoteResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrderNote() throws Exception {
-		OrderNote orderNote = testGraphQLOrderNote_addOrderNote();
+		OrderNote orderNote = testGraphQLGetOrderNote_addOrderNote();
 
 		Assert.assertTrue(
 			equals(
@@ -413,6 +427,12 @@ public abstract class BaseOrderNoteResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected OrderNote testGraphQLGetOrderNote_addOrderNote()
+		throws Exception {
+
+		return testGraphQLOrderNote_addOrderNote();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
@@ -541,8 +541,8 @@ public abstract class BaseOrderResourceTestCase {
 
 		long totalCount = ordersJSONObject.getLong("totalCount");
 
-		Order order1 = testGraphQLOrder_addOrder();
-		Order order2 = testGraphQLOrder_addOrder();
+		Order order1 = testGraphQLGetOrdersPage_addOrder();
+		Order order2 = testGraphQLGetOrdersPage_addOrder();
 
 		ordersJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -559,6 +559,10 @@ public abstract class BaseOrderResourceTestCase {
 			order2,
 			Arrays.asList(
 				OrderSerDes.toDTOs(ordersJSONObject.getString("items"))));
+	}
+
+	protected Order testGraphQLGetOrdersPage_addOrder() throws Exception {
+		return testGraphQLOrder_addOrder();
 	}
 
 	@Test
@@ -624,7 +628,7 @@ public abstract class BaseOrderResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrderByExternalReferenceCode() throws Exception {
-		Order order = testGraphQLOrder_addOrder();
+		Order order = testGraphQLGetOrderByExternalReferenceCode_addOrder();
 
 		Assert.assertTrue(
 			equals(
@@ -674,6 +678,12 @@ public abstract class BaseOrderResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Order testGraphQLGetOrderByExternalReferenceCode_addOrder()
+		throws Exception {
+
+		return testGraphQLOrder_addOrder();
+	}
+
 	@Test
 	public void testPatchOrderByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -701,7 +711,7 @@ public abstract class BaseOrderResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteOrder() throws Exception {
-		Order order = testGraphQLOrder_addOrder();
+		Order order = testGraphQLDeleteOrder_addOrder();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -730,6 +740,10 @@ public abstract class BaseOrderResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Order testGraphQLDeleteOrder_addOrder() throws Exception {
+		return testGraphQLOrder_addOrder();
+	}
+
 	@Test
 	public void testGetOrder() throws Exception {
 		Order postOrder = testGetOrder_addOrder();
@@ -747,7 +761,7 @@ public abstract class BaseOrderResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrder() throws Exception {
-		Order order = testGraphQLOrder_addOrder();
+		Order order = testGraphQLGetOrder_addOrder();
 
 		Assert.assertTrue(
 			equals(
@@ -784,6 +798,10 @@ public abstract class BaseOrderResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Order testGraphQLGetOrder_addOrder() throws Exception {
+		return testGraphQLOrder_addOrder();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleResourceTestCase.java
@@ -505,8 +505,8 @@ public abstract class BaseOrderRuleResourceTestCase {
 
 		long totalCount = orderRulesJSONObject.getLong("totalCount");
 
-		OrderRule orderRule1 = testGraphQLOrderRule_addOrderRule();
-		OrderRule orderRule2 = testGraphQLOrderRule_addOrderRule();
+		OrderRule orderRule1 = testGraphQLGetOrderRulesPage_addOrderRule();
+		OrderRule orderRule2 = testGraphQLGetOrderRulesPage_addOrderRule();
 
 		orderRulesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -525,6 +525,12 @@ public abstract class BaseOrderRuleResourceTestCase {
 			Arrays.asList(
 				OrderRuleSerDes.toDTOs(
 					orderRulesJSONObject.getString("items"))));
+	}
+
+	protected OrderRule testGraphQLGetOrderRulesPage_addOrderRule()
+		throws Exception {
+
+		return testGraphQLOrderRule_addOrderRule();
 	}
 
 	@Test
@@ -600,7 +606,8 @@ public abstract class BaseOrderRuleResourceTestCase {
 	public void testGraphQLGetOrderRuleByExternalReferenceCode()
 		throws Exception {
 
-		OrderRule orderRule = testGraphQLOrderRule_addOrderRule();
+		OrderRule orderRule =
+			testGraphQLGetOrderRuleByExternalReferenceCode_addOrderRule();
 
 		Assert.assertTrue(
 			equals(
@@ -648,6 +655,13 @@ public abstract class BaseOrderRuleResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected OrderRule
+			testGraphQLGetOrderRuleByExternalReferenceCode_addOrderRule()
+		throws Exception {
+
+		return testGraphQLOrderRule_addOrderRule();
 	}
 
 	@Test
@@ -705,7 +719,7 @@ public abstract class BaseOrderRuleResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteOrderRule() throws Exception {
-		OrderRule orderRule = testGraphQLOrderRule_addOrderRule();
+		OrderRule orderRule = testGraphQLDeleteOrderRule_addOrderRule();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -734,6 +748,12 @@ public abstract class BaseOrderRuleResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected OrderRule testGraphQLDeleteOrderRule_addOrderRule()
+		throws Exception {
+
+		return testGraphQLOrderRule_addOrderRule();
+	}
+
 	@Test
 	public void testGetOrderRule() throws Exception {
 		OrderRule postOrderRule = testGetOrderRule_addOrderRule();
@@ -752,7 +772,7 @@ public abstract class BaseOrderRuleResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrderRule() throws Exception {
-		OrderRule orderRule = testGraphQLOrderRule_addOrderRule();
+		OrderRule orderRule = testGraphQLGetOrderRule_addOrderRule();
 
 		Assert.assertTrue(
 			equals(
@@ -789,6 +809,12 @@ public abstract class BaseOrderRuleResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected OrderRule testGraphQLGetOrderRule_addOrderRule()
+		throws Exception {
+
+		return testGraphQLOrderRule_addOrderRule();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -203,10 +203,18 @@ public abstract class BaseOrderTypeResourceTestCase {
 			testGetOrderRuleOrderTypeOrderType_addOrderType();
 
 		OrderType getOrderType =
-			orderTypeResource.getOrderRuleOrderTypeOrderType(null);
+			orderTypeResource.getOrderRuleOrderTypeOrderType(
+				testGetOrderRuleOrderTypeOrderType_getOrderRuleOrderTypeId());
 
 		assertEquals(postOrderType, getOrderType);
 		assertValid(getOrderType);
+	}
+
+	protected Long testGetOrderRuleOrderTypeOrderType_getOrderRuleOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected OrderType testGetOrderRuleOrderTypeOrderType_addOrderType()
@@ -230,12 +238,22 @@ public abstract class BaseOrderTypeResourceTestCase {
 								"orderRuleOrderTypeOrderType",
 								new HashMap<String, Object>() {
 									{
-										put("orderRuleOrderTypeId", null);
+										put(
+											"orderRuleOrderTypeId",
+											testGraphQLGetOrderRuleOrderTypeOrderType_getOrderRuleOrderTypeId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/orderRuleOrderTypeOrderType"))));
+	}
+
+	protected Long
+			testGraphQLGetOrderRuleOrderTypeOrderType_getOrderRuleOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -878,10 +896,17 @@ public abstract class BaseOrderTypeResourceTestCase {
 		OrderType postOrderType = testGetTermOrderTypeOrderType_addOrderType();
 
 		OrderType getOrderType = orderTypeResource.getTermOrderTypeOrderType(
-			null);
+			testGetTermOrderTypeOrderType_getTermOrderTypeId());
 
 		assertEquals(postOrderType, getOrderType);
 		assertValid(getOrderType);
+	}
+
+	protected Long testGetTermOrderTypeOrderType_getTermOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected OrderType testGetTermOrderTypeOrderType_addOrderType()
@@ -905,11 +930,20 @@ public abstract class BaseOrderTypeResourceTestCase {
 								"termOrderTypeOrderType",
 								new HashMap<String, Object>() {
 									{
-										put("termOrderTypeId", null);
+										put(
+											"termOrderTypeId",
+											testGraphQLGetTermOrderTypeOrderType_getTermOrderTypeId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/termOrderTypeOrderType"))));
+	}
+
+	protected Long testGraphQLGetTermOrderTypeOrderType_getTermOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -226,7 +226,8 @@ public abstract class BaseOrderTypeResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrderRuleOrderTypeOrderType() throws Exception {
-		OrderType orderType = testGraphQLOrderType_addOrderType();
+		OrderType orderType =
+			testGraphQLGetOrderRuleOrderTypeOrderType_addOrderType();
 
 		Assert.assertTrue(
 			equals(
@@ -278,6 +279,12 @@ public abstract class BaseOrderTypeResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected OrderType testGraphQLGetOrderRuleOrderTypeOrderType_addOrderType()
+		throws Exception {
+
+		return testGraphQLOrderType_addOrderType();
 	}
 
 	@Test
@@ -578,8 +585,8 @@ public abstract class BaseOrderTypeResourceTestCase {
 
 		long totalCount = orderTypesJSONObject.getLong("totalCount");
 
-		OrderType orderType1 = testGraphQLOrderType_addOrderType();
-		OrderType orderType2 = testGraphQLOrderType_addOrderType();
+		OrderType orderType1 = testGraphQLGetOrderTypesPage_addOrderType();
+		OrderType orderType2 = testGraphQLGetOrderTypesPage_addOrderType();
 
 		orderTypesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -598,6 +605,12 @@ public abstract class BaseOrderTypeResourceTestCase {
 			Arrays.asList(
 				OrderTypeSerDes.toDTOs(
 					orderTypesJSONObject.getString("items"))));
+	}
+
+	protected OrderType testGraphQLGetOrderTypesPage_addOrderType()
+		throws Exception {
+
+		return testGraphQLOrderType_addOrderType();
 	}
 
 	@Test
@@ -673,7 +686,8 @@ public abstract class BaseOrderTypeResourceTestCase {
 	public void testGraphQLGetOrderTypeByExternalReferenceCode()
 		throws Exception {
 
-		OrderType orderType = testGraphQLOrderType_addOrderType();
+		OrderType orderType =
+			testGraphQLGetOrderTypeByExternalReferenceCode_addOrderType();
 
 		Assert.assertTrue(
 			equals(
@@ -721,6 +735,13 @@ public abstract class BaseOrderTypeResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected OrderType
+			testGraphQLGetOrderTypeByExternalReferenceCode_addOrderType()
+		throws Exception {
+
+		return testGraphQLOrderType_addOrderType();
 	}
 
 	@Test
@@ -778,7 +799,7 @@ public abstract class BaseOrderTypeResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteOrderType() throws Exception {
-		OrderType orderType = testGraphQLOrderType_addOrderType();
+		OrderType orderType = testGraphQLDeleteOrderType_addOrderType();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -807,6 +828,12 @@ public abstract class BaseOrderTypeResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected OrderType testGraphQLDeleteOrderType_addOrderType()
+		throws Exception {
+
+		return testGraphQLOrderType_addOrderType();
+	}
+
 	@Test
 	public void testGetOrderType() throws Exception {
 		OrderType postOrderType = testGetOrderType_addOrderType();
@@ -825,7 +852,7 @@ public abstract class BaseOrderTypeResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrderType() throws Exception {
-		OrderType orderType = testGraphQLOrderType_addOrderType();
+		OrderType orderType = testGraphQLGetOrderType_addOrderType();
 
 		Assert.assertTrue(
 			equals(
@@ -862,6 +889,12 @@ public abstract class BaseOrderTypeResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected OrderType testGraphQLGetOrderType_addOrderType()
+		throws Exception {
+
+		return testGraphQLOrderType_addOrderType();
 	}
 
 	@Test
@@ -918,7 +951,8 @@ public abstract class BaseOrderTypeResourceTestCase {
 
 	@Test
 	public void testGraphQLGetTermOrderTypeOrderType() throws Exception {
-		OrderType orderType = testGraphQLOrderType_addOrderType();
+		OrderType orderType =
+			testGraphQLGetTermOrderTypeOrderType_addOrderType();
 
 		Assert.assertTrue(
 			equals(
@@ -968,6 +1002,12 @@ public abstract class BaseOrderTypeResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected OrderType testGraphQLGetTermOrderTypeOrderType_addOrderType()
+		throws Exception {
+
+		return testGraphQLOrderType_addOrderType();
 	}
 
 	@Rule

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
@@ -233,7 +233,7 @@ public abstract class BaseShippingAddressResourceTestCase {
 	@Test
 	public void testGraphQLGetOrderItemShippingAddress() throws Exception {
 		ShippingAddress shippingAddress =
-			testGraphQLShippingAddress_addShippingAddress();
+			testGraphQLGetOrderItemShippingAddress_addShippingAddress();
 
 		Assert.assertTrue(
 			equals(
@@ -275,6 +275,13 @@ public abstract class BaseShippingAddressResourceTestCase {
 				"Object/code"));
 	}
 
+	protected ShippingAddress
+			testGraphQLGetOrderItemShippingAddress_addShippingAddress()
+		throws Exception {
+
+		return testGraphQLShippingAddress_addShippingAddress();
+	}
+
 	@Test
 	public void testGetOrderByExternalReferenceCodeShippingAddress()
 		throws Exception {
@@ -304,7 +311,7 @@ public abstract class BaseShippingAddressResourceTestCase {
 		throws Exception {
 
 		ShippingAddress shippingAddress =
-			testGraphQLShippingAddress_addShippingAddress();
+			testGraphQLGetOrderByExternalReferenceCodeShippingAddress_addShippingAddress();
 
 		Assert.assertTrue(
 			equals(
@@ -354,6 +361,13 @@ public abstract class BaseShippingAddressResourceTestCase {
 				"Object/code"));
 	}
 
+	protected ShippingAddress
+			testGraphQLGetOrderByExternalReferenceCodeShippingAddress_addShippingAddress()
+		throws Exception {
+
+		return testGraphQLShippingAddress_addShippingAddress();
+	}
+
 	@Test
 	public void testPatchOrderByExternalReferenceCodeShippingAddress()
 		throws Exception {
@@ -384,7 +398,7 @@ public abstract class BaseShippingAddressResourceTestCase {
 	@Test
 	public void testGraphQLGetOrderIdShippingAddress() throws Exception {
 		ShippingAddress shippingAddress =
-			testGraphQLShippingAddress_addShippingAddress();
+			testGraphQLGetOrderIdShippingAddress_addShippingAddress();
 
 		Assert.assertTrue(
 			equals(
@@ -423,6 +437,13 @@ public abstract class BaseShippingAddressResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ShippingAddress
+			testGraphQLGetOrderIdShippingAddress_addShippingAddress()
+		throws Exception {
+
+		return testGraphQLShippingAddress_addShippingAddress();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermResourceTestCase.java
@@ -484,8 +484,8 @@ public abstract class BaseTermResourceTestCase {
 
 		long totalCount = termsJSONObject.getLong("totalCount");
 
-		Term term1 = testGraphQLTerm_addTerm();
-		Term term2 = testGraphQLTerm_addTerm();
+		Term term1 = testGraphQLGetTermsPage_addTerm();
+		Term term2 = testGraphQLGetTermsPage_addTerm();
 
 		termsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -502,6 +502,10 @@ public abstract class BaseTermResourceTestCase {
 			term2,
 			Arrays.asList(
 				TermSerDes.toDTOs(termsJSONObject.getString("items"))));
+	}
+
+	protected Term testGraphQLGetTermsPage_addTerm() throws Exception {
+		return testGraphQLTerm_addTerm();
 	}
 
 	@Test
@@ -567,7 +571,7 @@ public abstract class BaseTermResourceTestCase {
 
 	@Test
 	public void testGraphQLGetTermByExternalReferenceCode() throws Exception {
-		Term term = testGraphQLTerm_addTerm();
+		Term term = testGraphQLGetTermByExternalReferenceCode_addTerm();
 
 		Assert.assertTrue(
 			equals(
@@ -615,6 +619,12 @@ public abstract class BaseTermResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Term testGraphQLGetTermByExternalReferenceCode_addTerm()
+		throws Exception {
+
+		return testGraphQLTerm_addTerm();
 	}
 
 	@Test
@@ -667,7 +677,7 @@ public abstract class BaseTermResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteTerm() throws Exception {
-		Term term = testGraphQLTerm_addTerm();
+		Term term = testGraphQLDeleteTerm_addTerm();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -696,6 +706,10 @@ public abstract class BaseTermResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Term testGraphQLDeleteTerm_addTerm() throws Exception {
+		return testGraphQLTerm_addTerm();
+	}
+
 	@Test
 	public void testGetTerm() throws Exception {
 		Term postTerm = testGetTerm_addTerm();
@@ -713,7 +727,7 @@ public abstract class BaseTermResourceTestCase {
 
 	@Test
 	public void testGraphQLGetTerm() throws Exception {
-		Term term = testGraphQLTerm_addTerm();
+		Term term = testGraphQLGetTerm_addTerm();
 
 		Assert.assertTrue(
 			equals(
@@ -750,6 +764,10 @@ public abstract class BaseTermResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Term testGraphQLGetTerm_addTerm() throws Exception {
+		return testGraphQLTerm_addTerm();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/OrderTypeResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/OrderTypeResourceTest.java
@@ -26,18 +26,15 @@ import com.liferay.commerce.term.model.CommerceTermEntryRel;
 import com.liferay.commerce.term.service.CommerceTermEntryLocalService;
 import com.liferay.commerce.term.service.CommerceTermEntryRelLocalService;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderType;
-import com.liferay.headless.commerce.admin.order.client.serdes.v1_0.OrderTypeSerDes;
 import com.liferay.headless.commerce.core.util.DateConfig;
 import com.liferay.headless.commerce.core.util.LanguageUtils;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.ArrayList;
@@ -45,7 +42,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -93,21 +89,6 @@ public class OrderTypeResourceTest extends BaseOrderTypeResourceTestCase {
 
 	@Override
 	@Test
-	public void testGetOrderRuleOrderTypeOrderType() throws Exception {
-		OrderType postOrderType = _addOrderType(randomOrderType());
-
-		COREntryRel corEntryRel = _getCOREntryRel(postOrderType);
-
-		OrderType getOrderType =
-			orderTypeResource.getOrderRuleOrderTypeOrderType(
-				corEntryRel.getCOREntryRelId());
-
-		assertEquals(postOrderType, getOrderType);
-		assertValid(getOrderType);
-	}
-
-	@Override
-	@Test
 	public void testGetTermOrderTypeOrderType() throws Exception {
 		OrderType postOrderType = _addOrderType(randomOrderType());
 
@@ -123,56 +104,7 @@ public class OrderTypeResourceTest extends BaseOrderTypeResourceTestCase {
 
 	@Override
 	@Test
-	public void testGraphQLGetOrderRuleOrderTypeOrderType() throws Exception {
-		OrderType orderType = testGraphQLOrderType_addOrderType();
-
-		COREntryRel corEntryRel = _getCOREntryRel(orderType);
-
-		Assert.assertTrue(
-			equals(
-				orderType,
-				OrderTypeSerDes.toDTO(
-					JSONUtil.getValueAsString(
-						invokeGraphQLQuery(
-							new GraphQLField(
-								"orderRuleOrderTypeOrderType",
-								HashMapBuilder.<String, Object>put(
-									"orderRuleOrderTypeId",
-									corEntryRel.getCOREntryRelId()
-								).build(),
-								getGraphQLFields())),
-						"JSONObject/data",
-						"Object/orderRuleOrderTypeOrderType"))));
-	}
-
-	@Override
-	@Test
 	public void testGraphQLGetOrderTypeNotFound() throws Exception {
-	}
-
-	@Override
-	@Test
-	public void testGraphQLGetTermOrderTypeOrderType() throws Exception {
-		OrderType orderType = testGraphQLOrderType_addOrderType();
-
-		CommerceTermEntryRel commerceTermEntryRel = _getCommerceTermEntryRel(
-			orderType);
-
-		Assert.assertTrue(
-			equals(
-				orderType,
-				OrderTypeSerDes.toDTO(
-					JSONUtil.getValueAsString(
-						invokeGraphQLQuery(
-							new GraphQLField(
-								"termOrderTypeOrderType",
-								HashMapBuilder.<String, Object>put(
-									"termOrderTypeId",
-									commerceTermEntryRel.
-										getCommerceTermEntryRelId()
-								).build(),
-								getGraphQLFields())),
-						"JSONObject/data", "Object/termOrderTypeOrderType"))));
 	}
 
 	@Override
@@ -217,6 +149,24 @@ public class OrderTypeResourceTest extends BaseOrderTypeResourceTestCase {
 	}
 
 	@Override
+	protected OrderType testGetOrderRuleOrderTypeOrderType_addOrderType()
+		throws Exception {
+
+		OrderType orderType = _addOrderType(randomOrderType());
+
+		_corEntryRel = _getCOREntryRel(orderType);
+
+		return orderType;
+	}
+
+	@Override
+	protected Long testGetOrderRuleOrderTypeOrderType_getOrderRuleOrderTypeId()
+		throws Exception {
+
+		return _corEntryRel.getCOREntryRelId();
+	}
+
+	@Override
 	protected OrderType testGetOrderType_addOrderType() throws Exception {
 		return _addOrderType(randomOrderType());
 	}
@@ -236,8 +186,28 @@ public class OrderTypeResourceTest extends BaseOrderTypeResourceTestCase {
 	}
 
 	@Override
+	protected Long
+			testGraphQLGetOrderRuleOrderTypeOrderType_getOrderRuleOrderTypeId()
+		throws Exception {
+
+		return _corEntryRel.getCOREntryRelId();
+	}
+
+	@Override
+	protected Long testGraphQLGetTermOrderTypeOrderType_getTermOrderTypeId()
+		throws Exception {
+
+		return _commerceTermEntryRel.getCommerceTermEntryRelId();
+	}
+
+	@Override
 	protected OrderType testGraphQLOrderType_addOrderType() throws Exception {
-		return _addOrderType(randomOrderType());
+		OrderType orderType = _addOrderType(randomOrderType());
+
+		_commerceTermEntryRel = _getCommerceTermEntryRel(orderType);
+		_corEntryRel = _getCOREntryRel(orderType);
+
+		return orderType;
 	}
 
 	@Override
@@ -364,11 +334,15 @@ public class OrderTypeResourceTest extends BaseOrderTypeResourceTestCase {
 	@Inject
 	private CommerceTermEntryLocalService _commerceTermEntryLocalService;
 
+	private CommerceTermEntryRel _commerceTermEntryRel;
+
 	@Inject
 	private CommerceTermEntryRelLocalService _commerceTermEntryRelLocalService;
 
 	@Inject
 	private COREntryLocalService _corEntryLocalService;
+
+	private COREntryRel _corEntryRel;
 
 	@Inject
 	private COREntryRelLocalService _corEntryRelLocalService;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountAccountGroupResourceTestCase.java
@@ -221,7 +221,7 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 	@Test
 	public void testGraphQLDeleteDiscountAccountGroup() throws Exception {
 		DiscountAccountGroup discountAccountGroup =
-			testGraphQLDiscountAccountGroup_addDiscountAccountGroup();
+			testGraphQLDeleteDiscountAccountGroup_addDiscountAccountGroup();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -234,6 +234,13 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 							}
 						})),
 				"JSONObject/data", "Object/deleteDiscountAccountGroup"));
+	}
+
+	protected DiscountAccountGroup
+			testGraphQLDeleteDiscountAccountGroup_addDiscountAccountGroup()
+		throws Exception {
+
+		return testGraphQLDiscountAccountGroup_addDiscountAccountGroup();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountCategoryResourceTestCase.java
@@ -216,7 +216,7 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 	@Test
 	public void testGraphQLDeleteDiscountCategory() throws Exception {
 		DiscountCategory discountCategory =
-			testGraphQLDiscountCategory_addDiscountCategory();
+			testGraphQLDeleteDiscountCategory_addDiscountCategory();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -229,6 +229,13 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 							}
 						})),
 				"JSONObject/data", "Object/deleteDiscountCategory"));
+	}
+
+	protected DiscountCategory
+			testGraphQLDeleteDiscountCategory_addDiscountCategory()
+		throws Exception {
+
+		return testGraphQLDiscountCategory_addDiscountCategory();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountProductResourceTestCase.java
@@ -216,7 +216,7 @@ public abstract class BaseDiscountProductResourceTestCase {
 	@Test
 	public void testGraphQLDeleteDiscountProduct() throws Exception {
 		DiscountProduct discountProduct =
-			testGraphQLDiscountProduct_addDiscountProduct();
+			testGraphQLDeleteDiscountProduct_addDiscountProduct();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -229,6 +229,13 @@ public abstract class BaseDiscountProductResourceTestCase {
 							}
 						})),
 				"JSONObject/data", "Object/deleteDiscountProduct"));
+	}
+
+	protected DiscountProduct
+			testGraphQLDeleteDiscountProduct_addDiscountProduct()
+		throws Exception {
+
+		return testGraphQLDiscountProduct_addDiscountProduct();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountResourceTestCase.java
@@ -287,8 +287,8 @@ public abstract class BaseDiscountResourceTestCase {
 
 		long totalCount = discountsJSONObject.getLong("totalCount");
 
-		Discount discount1 = testGraphQLDiscount_addDiscount();
-		Discount discount2 = testGraphQLDiscount_addDiscount();
+		Discount discount1 = testGraphQLGetDiscountsPage_addDiscount();
+		Discount discount2 = testGraphQLGetDiscountsPage_addDiscount();
 
 		discountsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -305,6 +305,12 @@ public abstract class BaseDiscountResourceTestCase {
 			discount2,
 			Arrays.asList(
 				DiscountSerDes.toDTOs(discountsJSONObject.getString("items"))));
+	}
+
+	protected Discount testGraphQLGetDiscountsPage_addDiscount()
+		throws Exception {
+
+		return testGraphQLDiscount_addDiscount();
 	}
 
 	@Test
@@ -377,7 +383,8 @@ public abstract class BaseDiscountResourceTestCase {
 	public void testGraphQLGetDiscountByExternalReferenceCode()
 		throws Exception {
 
-		Discount discount = testGraphQLDiscount_addDiscount();
+		Discount discount =
+			testGraphQLGetDiscountByExternalReferenceCode_addDiscount();
 
 		Assert.assertTrue(
 			equals(
@@ -427,6 +434,13 @@ public abstract class BaseDiscountResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Discount
+			testGraphQLGetDiscountByExternalReferenceCode_addDiscount()
+		throws Exception {
+
+		return testGraphQLDiscount_addDiscount();
+	}
+
 	@Test
 	public void testPatchDiscountByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -454,7 +468,7 @@ public abstract class BaseDiscountResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteDiscount() throws Exception {
-		Discount discount = testGraphQLDiscount_addDiscount();
+		Discount discount = testGraphQLDeleteDiscount_addDiscount();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -483,6 +497,12 @@ public abstract class BaseDiscountResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Discount testGraphQLDeleteDiscount_addDiscount()
+		throws Exception {
+
+		return testGraphQLDiscount_addDiscount();
+	}
+
 	@Test
 	public void testGetDiscount() throws Exception {
 		Discount postDiscount = testGetDiscount_addDiscount();
@@ -501,7 +521,7 @@ public abstract class BaseDiscountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDiscount() throws Exception {
-		Discount discount = testGraphQLDiscount_addDiscount();
+		Discount discount = testGraphQLGetDiscount_addDiscount();
 
 		Assert.assertTrue(
 			equals(
@@ -538,6 +558,10 @@ public abstract class BaseDiscountResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Discount testGraphQLGetDiscount_addDiscount() throws Exception {
+		return testGraphQLDiscount_addDiscount();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountRuleResourceTestCase.java
@@ -382,7 +382,8 @@ public abstract class BaseDiscountRuleResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteDiscountRule() throws Exception {
-		DiscountRule discountRule = testGraphQLDiscountRule_addDiscountRule();
+		DiscountRule discountRule =
+			testGraphQLDeleteDiscountRule_addDiscountRule();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -411,6 +412,12 @@ public abstract class BaseDiscountRuleResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected DiscountRule testGraphQLDeleteDiscountRule_addDiscountRule()
+		throws Exception {
+
+		return testGraphQLDiscountRule_addDiscountRule();
+	}
+
 	@Test
 	public void testGetDiscountRule() throws Exception {
 		DiscountRule postDiscountRule = testGetDiscountRule_addDiscountRule();
@@ -431,7 +438,8 @@ public abstract class BaseDiscountRuleResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDiscountRule() throws Exception {
-		DiscountRule discountRule = testGraphQLDiscountRule_addDiscountRule();
+		DiscountRule discountRule =
+			testGraphQLGetDiscountRule_addDiscountRule();
 
 		Assert.assertTrue(
 			equals(
@@ -468,6 +476,12 @@ public abstract class BaseDiscountRuleResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected DiscountRule testGraphQLGetDiscountRule_addDiscountRule()
+		throws Exception {
+
+		return testGraphQLDiscountRule_addDiscountRule();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceEntryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceEntryResourceTestCase.java
@@ -253,7 +253,8 @@ public abstract class BasePriceEntryResourceTestCase {
 	public void testGraphQLGetPriceEntryByExternalReferenceCode()
 		throws Exception {
 
-		PriceEntry priceEntry = testGraphQLPriceEntry_addPriceEntry();
+		PriceEntry priceEntry =
+			testGraphQLGetPriceEntryByExternalReferenceCode_addPriceEntry();
 
 		Assert.assertTrue(
 			equals(
@@ -303,6 +304,13 @@ public abstract class BasePriceEntryResourceTestCase {
 				"Object/code"));
 	}
 
+	protected PriceEntry
+			testGraphQLGetPriceEntryByExternalReferenceCode_addPriceEntry()
+		throws Exception {
+
+		return testGraphQLPriceEntry_addPriceEntry();
+	}
+
 	@Test
 	public void testPatchPriceEntryByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -334,7 +342,7 @@ public abstract class BasePriceEntryResourceTestCase {
 
 	@Test
 	public void testGraphQLDeletePriceEntry() throws Exception {
-		PriceEntry priceEntry = testGraphQLPriceEntry_addPriceEntry();
+		PriceEntry priceEntry = testGraphQLDeletePriceEntry_addPriceEntry();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -363,6 +371,12 @@ public abstract class BasePriceEntryResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected PriceEntry testGraphQLDeletePriceEntry_addPriceEntry()
+		throws Exception {
+
+		return testGraphQLPriceEntry_addPriceEntry();
+	}
+
 	@Test
 	public void testGetPriceEntry() throws Exception {
 		PriceEntry postPriceEntry = testGetPriceEntry_addPriceEntry();
@@ -381,7 +395,7 @@ public abstract class BasePriceEntryResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPriceEntry() throws Exception {
-		PriceEntry priceEntry = testGraphQLPriceEntry_addPriceEntry();
+		PriceEntry priceEntry = testGraphQLGetPriceEntry_addPriceEntry();
 
 		Assert.assertTrue(
 			equals(
@@ -418,6 +432,12 @@ public abstract class BasePriceEntryResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected PriceEntry testGraphQLGetPriceEntry_addPriceEntry()
+		throws Exception {
+
+		return testGraphQLPriceEntry_addPriceEntry();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListAccountGroupResourceTestCase.java
@@ -225,7 +225,7 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 	@Test
 	public void testGraphQLDeletePriceListAccountGroup() throws Exception {
 		PriceListAccountGroup priceListAccountGroup =
-			testGraphQLPriceListAccountGroup_addPriceListAccountGroup();
+			testGraphQLDeletePriceListAccountGroup_addPriceListAccountGroup();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -238,6 +238,13 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 							}
 						})),
 				"JSONObject/data", "Object/deletePriceListAccountGroup"));
+	}
+
+	protected PriceListAccountGroup
+			testGraphQLDeletePriceListAccountGroup_addPriceListAccountGroup()
+		throws Exception {
+
+		return testGraphQLPriceListAccountGroup_addPriceListAccountGroup();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListResourceTestCase.java
@@ -497,8 +497,8 @@ public abstract class BasePriceListResourceTestCase {
 
 		long totalCount = priceListsJSONObject.getLong("totalCount");
 
-		PriceList priceList1 = testGraphQLPriceList_addPriceList();
-		PriceList priceList2 = testGraphQLPriceList_addPriceList();
+		PriceList priceList1 = testGraphQLGetPriceListsPage_addPriceList();
+		PriceList priceList2 = testGraphQLGetPriceListsPage_addPriceList();
 
 		priceListsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -517,6 +517,12 @@ public abstract class BasePriceListResourceTestCase {
 			Arrays.asList(
 				PriceListSerDes.toDTOs(
 					priceListsJSONObject.getString("items"))));
+	}
+
+	protected PriceList testGraphQLGetPriceListsPage_addPriceList()
+		throws Exception {
+
+		return testGraphQLPriceList_addPriceList();
 	}
 
 	@Test
@@ -592,7 +598,8 @@ public abstract class BasePriceListResourceTestCase {
 	public void testGraphQLGetPriceListByExternalReferenceCode()
 		throws Exception {
 
-		PriceList priceList = testGraphQLPriceList_addPriceList();
+		PriceList priceList =
+			testGraphQLGetPriceListByExternalReferenceCode_addPriceList();
 
 		Assert.assertTrue(
 			equals(
@@ -642,6 +649,13 @@ public abstract class BasePriceListResourceTestCase {
 				"Object/code"));
 	}
 
+	protected PriceList
+			testGraphQLGetPriceListByExternalReferenceCode_addPriceList()
+		throws Exception {
+
+		return testGraphQLPriceList_addPriceList();
+	}
+
 	@Test
 	public void testPatchPriceListByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -670,7 +684,7 @@ public abstract class BasePriceListResourceTestCase {
 
 	@Test
 	public void testGraphQLDeletePriceList() throws Exception {
-		PriceList priceList = testGraphQLPriceList_addPriceList();
+		PriceList priceList = testGraphQLDeletePriceList_addPriceList();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -699,6 +713,12 @@ public abstract class BasePriceListResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected PriceList testGraphQLDeletePriceList_addPriceList()
+		throws Exception {
+
+		return testGraphQLPriceList_addPriceList();
+	}
+
 	@Test
 	public void testGetPriceList() throws Exception {
 		PriceList postPriceList = testGetPriceList_addPriceList();
@@ -717,7 +737,7 @@ public abstract class BasePriceListResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPriceList() throws Exception {
-		PriceList priceList = testGraphQLPriceList_addPriceList();
+		PriceList priceList = testGraphQLGetPriceList_addPriceList();
 
 		Assert.assertTrue(
 			equals(
@@ -754,6 +774,12 @@ public abstract class BasePriceListResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected PriceList testGraphQLGetPriceList_addPriceList()
+		throws Exception {
+
+		return testGraphQLPriceList_addPriceList();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseTierPriceResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseTierPriceResourceTestCase.java
@@ -528,7 +528,8 @@ public abstract class BaseTierPriceResourceTestCase {
 	public void testGraphQLGetTierPriceByExternalReferenceCode()
 		throws Exception {
 
-		TierPrice tierPrice = testGraphQLTierPrice_addTierPrice();
+		TierPrice tierPrice =
+			testGraphQLGetTierPriceByExternalReferenceCode_addTierPrice();
 
 		Assert.assertTrue(
 			equals(
@@ -578,6 +579,13 @@ public abstract class BaseTierPriceResourceTestCase {
 				"Object/code"));
 	}
 
+	protected TierPrice
+			testGraphQLGetTierPriceByExternalReferenceCode_addTierPrice()
+		throws Exception {
+
+		return testGraphQLTierPrice_addTierPrice();
+	}
+
 	@Test
 	public void testPatchTierPriceByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -606,7 +614,7 @@ public abstract class BaseTierPriceResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteTierPrice() throws Exception {
-		TierPrice tierPrice = testGraphQLTierPrice_addTierPrice();
+		TierPrice tierPrice = testGraphQLDeleteTierPrice_addTierPrice();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -635,6 +643,12 @@ public abstract class BaseTierPriceResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected TierPrice testGraphQLDeleteTierPrice_addTierPrice()
+		throws Exception {
+
+		return testGraphQLTierPrice_addTierPrice();
+	}
+
 	@Test
 	public void testGetTierPrice() throws Exception {
 		TierPrice postTierPrice = testGetTierPrice_addTierPrice();
@@ -653,7 +667,7 @@ public abstract class BaseTierPriceResourceTestCase {
 
 	@Test
 	public void testGraphQLGetTierPrice() throws Exception {
-		TierPrice tierPrice = testGraphQLTierPrice_addTierPrice();
+		TierPrice tierPrice = testGraphQLGetTierPrice_addTierPrice();
 
 		Assert.assertTrue(
 			equals(
@@ -690,6 +704,12 @@ public abstract class BaseTierPriceResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected TierPrice testGraphQLGetTierPrice_addTierPrice()
+		throws Exception {
+
+		return testGraphQLTierPrice_addTierPrice();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountGroupResourceTestCase.java
@@ -194,10 +194,19 @@ public abstract class BaseAccountGroupResourceTestCase {
 			testGetDiscountAccountGroupAccountGroup_addAccountGroup();
 
 		AccountGroup getAccountGroup =
-			accountGroupResource.getDiscountAccountGroupAccountGroup(null);
+			accountGroupResource.getDiscountAccountGroupAccountGroup(
+				testGetDiscountAccountGroupAccountGroup_getDiscountAccountGroupId());
 
 		assertEquals(postAccountGroup, getAccountGroup);
 		assertValid(getAccountGroup);
+	}
+
+	protected Long
+			testGetDiscountAccountGroupAccountGroup_getDiscountAccountGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected AccountGroup
@@ -224,12 +233,22 @@ public abstract class BaseAccountGroupResourceTestCase {
 								"discountAccountGroupAccountGroup",
 								new HashMap<String, Object>() {
 									{
-										put("discountAccountGroupId", null);
+										put(
+											"discountAccountGroupId",
+											testGraphQLGetDiscountAccountGroupAccountGroup_getDiscountAccountGroupId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/discountAccountGroupAccountGroup"))));
+	}
+
+	protected Long
+			testGraphQLGetDiscountAccountGroupAccountGroup_getDiscountAccountGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -262,10 +281,19 @@ public abstract class BaseAccountGroupResourceTestCase {
 			testGetPriceListAccountGroupAccountGroup_addAccountGroup();
 
 		AccountGroup getAccountGroup =
-			accountGroupResource.getPriceListAccountGroupAccountGroup(null);
+			accountGroupResource.getPriceListAccountGroupAccountGroup(
+				testGetPriceListAccountGroupAccountGroup_getPriceListAccountGroupId());
 
 		assertEquals(postAccountGroup, getAccountGroup);
 		assertValid(getAccountGroup);
+	}
+
+	protected Long
+			testGetPriceListAccountGroupAccountGroup_getPriceListAccountGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected AccountGroup
@@ -292,12 +320,22 @@ public abstract class BaseAccountGroupResourceTestCase {
 								"priceListAccountGroupAccountGroup",
 								new HashMap<String, Object>() {
 									{
-										put("priceListAccountGroupId", null);
+										put(
+											"priceListAccountGroupId",
+											testGraphQLGetPriceListAccountGroupAccountGroup_getPriceListAccountGroupId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/priceListAccountGroupAccountGroup"))));
+	}
+
+	protected Long
+			testGraphQLGetPriceListAccountGroupAccountGroup_getPriceListAccountGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountGroupResourceTestCase.java
@@ -221,7 +221,8 @@ public abstract class BaseAccountGroupResourceTestCase {
 	public void testGraphQLGetDiscountAccountGroupAccountGroup()
 		throws Exception {
 
-		AccountGroup accountGroup = testGraphQLAccountGroup_addAccountGroup();
+		AccountGroup accountGroup =
+			testGraphQLGetDiscountAccountGroupAccountGroup_addAccountGroup();
 
 		Assert.assertTrue(
 			equals(
@@ -275,6 +276,13 @@ public abstract class BaseAccountGroupResourceTestCase {
 				"Object/code"));
 	}
 
+	protected AccountGroup
+			testGraphQLGetDiscountAccountGroupAccountGroup_addAccountGroup()
+		throws Exception {
+
+		return testGraphQLAccountGroup_addAccountGroup();
+	}
+
 	@Test
 	public void testGetPriceListAccountGroupAccountGroup() throws Exception {
 		AccountGroup postAccountGroup =
@@ -308,7 +316,8 @@ public abstract class BaseAccountGroupResourceTestCase {
 	public void testGraphQLGetPriceListAccountGroupAccountGroup()
 		throws Exception {
 
-		AccountGroup accountGroup = testGraphQLAccountGroup_addAccountGroup();
+		AccountGroup accountGroup =
+			testGraphQLGetPriceListAccountGroupAccountGroup_addAccountGroup();
 
 		Assert.assertTrue(
 			equals(
@@ -360,6 +369,13 @@ public abstract class BaseAccountGroupResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected AccountGroup
+			testGraphQLGetPriceListAccountGroupAccountGroup_addAccountGroup()
+		throws Exception {
+
+		return testGraphQLAccountGroup_addAccountGroup();
 	}
 
 	protected AccountGroup testGraphQLAccountGroup_addAccountGroup()

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountResourceTestCase.java
@@ -192,10 +192,18 @@ public abstract class BaseAccountResourceTestCase {
 	public void testGetDiscountAccountAccount() throws Exception {
 		Account postAccount = testGetDiscountAccountAccount_addAccount();
 
-		Account getAccount = accountResource.getDiscountAccountAccount(null);
+		Account getAccount = accountResource.getDiscountAccountAccount(
+			testGetDiscountAccountAccount_getDiscountAccountId());
 
 		assertEquals(postAccount, getAccount);
 		assertValid(getAccount);
+	}
+
+	protected Long testGetDiscountAccountAccount_getDiscountAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Account testGetDiscountAccountAccount_addAccount()
@@ -219,11 +227,20 @@ public abstract class BaseAccountResourceTestCase {
 								"discountAccountAccount",
 								new HashMap<String, Object>() {
 									{
-										put("discountAccountId", null);
+										put(
+											"discountAccountId",
+											testGraphQLGetDiscountAccountAccount_getDiscountAccountId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/discountAccountAccount"))));
+	}
+
+	protected Long testGraphQLGetDiscountAccountAccount_getDiscountAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -254,10 +271,18 @@ public abstract class BaseAccountResourceTestCase {
 	public void testGetPriceListAccountAccount() throws Exception {
 		Account postAccount = testGetPriceListAccountAccount_addAccount();
 
-		Account getAccount = accountResource.getPriceListAccountAccount(null);
+		Account getAccount = accountResource.getPriceListAccountAccount(
+			testGetPriceListAccountAccount_getPriceListAccountId());
 
 		assertEquals(postAccount, getAccount);
 		assertValid(getAccount);
+	}
+
+	protected Long testGetPriceListAccountAccount_getPriceListAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Account testGetPriceListAccountAccount_addAccount()
@@ -281,11 +306,20 @@ public abstract class BaseAccountResourceTestCase {
 								"priceListAccountAccount",
 								new HashMap<String, Object>() {
 									{
-										put("priceListAccountId", null);
+										put(
+											"priceListAccountId",
+											testGraphQLGetPriceListAccountAccount_getPriceListAccountId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/priceListAccountAccount"))));
+	}
+
+	protected Long testGraphQLGetPriceListAccountAccount_getPriceListAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountResourceTestCase.java
@@ -215,7 +215,7 @@ public abstract class BaseAccountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDiscountAccountAccount() throws Exception {
-		Account account = testGraphQLAccount_addAccount();
+		Account account = testGraphQLGetDiscountAccountAccount_addAccount();
 
 		Assert.assertTrue(
 			equals(
@@ -267,6 +267,12 @@ public abstract class BaseAccountResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Account testGraphQLGetDiscountAccountAccount_addAccount()
+		throws Exception {
+
+		return testGraphQLAccount_addAccount();
+	}
+
 	@Test
 	public void testGetPriceListAccountAccount() throws Exception {
 		Account postAccount = testGetPriceListAccountAccount_addAccount();
@@ -294,7 +300,7 @@ public abstract class BaseAccountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPriceListAccountAccount() throws Exception {
-		Account account = testGraphQLAccount_addAccount();
+		Account account = testGraphQLGetPriceListAccountAccount_addAccount();
 
 		Assert.assertTrue(
 			equals(
@@ -344,6 +350,12 @@ public abstract class BaseAccountResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Account testGraphQLGetPriceListAccountAccount_addAccount()
+		throws Exception {
+
+		return testGraphQLAccount_addAccount();
 	}
 
 	protected Account testGraphQLAccount_addAccount() throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseCategoryResourceTestCase.java
@@ -197,10 +197,17 @@ public abstract class BaseCategoryResourceTestCase {
 		Category postCategory = testGetDiscountCategoryCategory_addCategory();
 
 		Category getCategory = categoryResource.getDiscountCategoryCategory(
-			null);
+			testGetDiscountCategoryCategory_getDiscountCategoryId());
 
 		assertEquals(postCategory, getCategory);
 		assertValid(getCategory);
+	}
+
+	protected Long testGetDiscountCategoryCategory_getDiscountCategoryId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Category testGetDiscountCategoryCategory_addCategory()
@@ -224,12 +231,22 @@ public abstract class BaseCategoryResourceTestCase {
 								"discountCategoryCategory",
 								new HashMap<String, Object>() {
 									{
-										put("discountCategoryId", null);
+										put(
+											"discountCategoryId",
+											testGraphQLGetDiscountCategoryCategory_getDiscountCategoryId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/discountCategoryCategory"))));
+	}
+
+	protected Long
+			testGraphQLGetDiscountCategoryCategory_getDiscountCategoryId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -262,10 +279,19 @@ public abstract class BaseCategoryResourceTestCase {
 			testGetPriceModifierCategoryCategory_addCategory();
 
 		Category getCategory =
-			categoryResource.getPriceModifierCategoryCategory(null);
+			categoryResource.getPriceModifierCategoryCategory(
+				testGetPriceModifierCategoryCategory_getPriceModifierCategoryId());
 
 		assertEquals(postCategory, getCategory);
 		assertValid(getCategory);
+	}
+
+	protected Long
+			testGetPriceModifierCategoryCategory_getPriceModifierCategoryId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Category testGetPriceModifierCategoryCategory_addCategory()
@@ -289,12 +315,22 @@ public abstract class BaseCategoryResourceTestCase {
 								"priceModifierCategoryCategory",
 								new HashMap<String, Object>() {
 									{
-										put("priceModifierCategoryId", null);
+										put(
+											"priceModifierCategoryId",
+											testGraphQLGetPriceModifierCategoryCategory_getPriceModifierCategoryId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/priceModifierCategoryCategory"))));
+	}
+
+	protected Long
+			testGraphQLGetPriceModifierCategoryCategory_getPriceModifierCategoryId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseCategoryResourceTestCase.java
@@ -219,7 +219,8 @@ public abstract class BaseCategoryResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDiscountCategoryCategory() throws Exception {
-		Category category = testGraphQLCategory_addCategory();
+		Category category =
+			testGraphQLGetDiscountCategoryCategory_addCategory();
 
 		Assert.assertTrue(
 			equals(
@@ -273,6 +274,12 @@ public abstract class BaseCategoryResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Category testGraphQLGetDiscountCategoryCategory_addCategory()
+		throws Exception {
+
+		return testGraphQLCategory_addCategory();
+	}
+
 	@Test
 	public void testGetPriceModifierCategoryCategory() throws Exception {
 		Category postCategory =
@@ -303,7 +310,8 @@ public abstract class BaseCategoryResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPriceModifierCategoryCategory() throws Exception {
-		Category category = testGraphQLCategory_addCategory();
+		Category category =
+			testGraphQLGetPriceModifierCategoryCategory_addCategory();
 
 		Assert.assertTrue(
 			equals(
@@ -355,6 +363,12 @@ public abstract class BaseCategoryResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Category testGraphQLGetPriceModifierCategoryCategory_addCategory()
+		throws Exception {
+
+		return testGraphQLCategory_addCategory();
 	}
 
 	protected Category testGraphQLCategory_addCategory() throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseChannelResourceTestCase.java
@@ -198,10 +198,18 @@ public abstract class BaseChannelResourceTestCase {
 	public void testGetDiscountChannelChannel() throws Exception {
 		Channel postChannel = testGetDiscountChannelChannel_addChannel();
 
-		Channel getChannel = channelResource.getDiscountChannelChannel(null);
+		Channel getChannel = channelResource.getDiscountChannelChannel(
+			testGetDiscountChannelChannel_getDiscountChannelId());
 
 		assertEquals(postChannel, getChannel);
 		assertValid(getChannel);
+	}
+
+	protected Long testGetDiscountChannelChannel_getDiscountChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Channel testGetDiscountChannelChannel_addChannel()
@@ -225,11 +233,20 @@ public abstract class BaseChannelResourceTestCase {
 								"discountChannelChannel",
 								new HashMap<String, Object>() {
 									{
-										put("discountChannelId", null);
+										put(
+											"discountChannelId",
+											testGraphQLGetDiscountChannelChannel_getDiscountChannelId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/discountChannelChannel"))));
+	}
+
+	protected Long testGraphQLGetDiscountChannelChannel_getDiscountChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -260,10 +277,18 @@ public abstract class BaseChannelResourceTestCase {
 	public void testGetPriceListChannelChannel() throws Exception {
 		Channel postChannel = testGetPriceListChannelChannel_addChannel();
 
-		Channel getChannel = channelResource.getPriceListChannelChannel(null);
+		Channel getChannel = channelResource.getPriceListChannelChannel(
+			testGetPriceListChannelChannel_getPriceListChannelId());
 
 		assertEquals(postChannel, getChannel);
 		assertValid(getChannel);
+	}
+
+	protected Long testGetPriceListChannelChannel_getPriceListChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Channel testGetPriceListChannelChannel_addChannel()
@@ -287,11 +312,20 @@ public abstract class BaseChannelResourceTestCase {
 								"priceListChannelChannel",
 								new HashMap<String, Object>() {
 									{
-										put("priceListChannelId", null);
+										put(
+											"priceListChannelId",
+											testGraphQLGetPriceListChannelChannel_getPriceListChannelId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/priceListChannelChannel"))));
+	}
+
+	protected Long testGraphQLGetPriceListChannelChannel_getPriceListChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseChannelResourceTestCase.java
@@ -221,7 +221,7 @@ public abstract class BaseChannelResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDiscountChannelChannel() throws Exception {
-		Channel channel = testGraphQLChannel_addChannel();
+		Channel channel = testGraphQLGetDiscountChannelChannel_addChannel();
 
 		Assert.assertTrue(
 			equals(
@@ -273,6 +273,12 @@ public abstract class BaseChannelResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Channel testGraphQLGetDiscountChannelChannel_addChannel()
+		throws Exception {
+
+		return testGraphQLChannel_addChannel();
+	}
+
 	@Test
 	public void testGetPriceListChannelChannel() throws Exception {
 		Channel postChannel = testGetPriceListChannelChannel_addChannel();
@@ -300,7 +306,7 @@ public abstract class BaseChannelResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPriceListChannelChannel() throws Exception {
-		Channel channel = testGraphQLChannel_addChannel();
+		Channel channel = testGraphQLGetPriceListChannelChannel_addChannel();
 
 		Assert.assertTrue(
 			equals(
@@ -350,6 +356,12 @@ public abstract class BaseChannelResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Channel testGraphQLGetPriceListChannelChannel_addChannel()
+		throws Exception {
+
+		return testGraphQLChannel_addChannel();
 	}
 
 	protected Channel testGraphQLChannel_addChannel() throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
@@ -498,8 +498,8 @@ public abstract class BaseDiscountResourceTestCase {
 
 		long totalCount = discountsJSONObject.getLong("totalCount");
 
-		Discount discount1 = testGraphQLDiscount_addDiscount();
-		Discount discount2 = testGraphQLDiscount_addDiscount();
+		Discount discount1 = testGraphQLGetDiscountsPage_addDiscount();
+		Discount discount2 = testGraphQLGetDiscountsPage_addDiscount();
 
 		discountsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -516,6 +516,12 @@ public abstract class BaseDiscountResourceTestCase {
 			discount2,
 			Arrays.asList(
 				DiscountSerDes.toDTOs(discountsJSONObject.getString("items"))));
+	}
+
+	protected Discount testGraphQLGetDiscountsPage_addDiscount()
+		throws Exception {
+
+		return testGraphQLDiscount_addDiscount();
 	}
 
 	@Test
@@ -588,7 +594,8 @@ public abstract class BaseDiscountResourceTestCase {
 	public void testGraphQLGetDiscountByExternalReferenceCode()
 		throws Exception {
 
-		Discount discount = testGraphQLDiscount_addDiscount();
+		Discount discount =
+			testGraphQLGetDiscountByExternalReferenceCode_addDiscount();
 
 		Assert.assertTrue(
 			equals(
@@ -636,6 +643,13 @@ public abstract class BaseDiscountResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Discount
+			testGraphQLGetDiscountByExternalReferenceCode_addDiscount()
+		throws Exception {
+
+		return testGraphQLDiscount_addDiscount();
 	}
 
 	@Test
@@ -692,7 +706,7 @@ public abstract class BaseDiscountResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteDiscount() throws Exception {
-		Discount discount = testGraphQLDiscount_addDiscount();
+		Discount discount = testGraphQLDeleteDiscount_addDiscount();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -721,6 +735,12 @@ public abstract class BaseDiscountResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Discount testGraphQLDeleteDiscount_addDiscount()
+		throws Exception {
+
+		return testGraphQLDiscount_addDiscount();
+	}
+
 	@Test
 	public void testGetDiscount() throws Exception {
 		Discount postDiscount = testGetDiscount_addDiscount();
@@ -739,7 +759,7 @@ public abstract class BaseDiscountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDiscount() throws Exception {
-		Discount discount = testGraphQLDiscount_addDiscount();
+		Discount discount = testGraphQLGetDiscount_addDiscount();
 
 		Assert.assertTrue(
 			equals(
@@ -776,6 +796,10 @@ public abstract class BaseDiscountResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Discount testGraphQLGetDiscount_addDiscount() throws Exception {
+		return testGraphQLDiscount_addDiscount();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountRuleResourceTestCase.java
@@ -230,7 +230,8 @@ public abstract class BaseDiscountRuleResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteDiscountRule() throws Exception {
-		DiscountRule discountRule = testGraphQLDiscountRule_addDiscountRule();
+		DiscountRule discountRule =
+			testGraphQLDeleteDiscountRule_addDiscountRule();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -259,6 +260,12 @@ public abstract class BaseDiscountRuleResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected DiscountRule testGraphQLDeleteDiscountRule_addDiscountRule()
+		throws Exception {
+
+		return testGraphQLDiscountRule_addDiscountRule();
+	}
+
 	@Test
 	public void testGetDiscountRule() throws Exception {
 		DiscountRule postDiscountRule = testGetDiscountRule_addDiscountRule();
@@ -279,7 +286,8 @@ public abstract class BaseDiscountRuleResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDiscountRule() throws Exception {
-		DiscountRule discountRule = testGraphQLDiscountRule_addDiscountRule();
+		DiscountRule discountRule =
+			testGraphQLGetDiscountRule_addDiscountRule();
 
 		Assert.assertTrue(
 			equals(
@@ -316,6 +324,12 @@ public abstract class BaseDiscountRuleResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected DiscountRule testGraphQLGetDiscountRule_addDiscountRule()
+		throws Exception {
+
+		return testGraphQLDiscountRule_addDiscountRule();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseOrderTypeResourceTestCase.java
@@ -189,10 +189,18 @@ public abstract class BaseOrderTypeResourceTestCase {
 			testGetDiscountOrderTypeOrderType_addOrderType();
 
 		OrderType getOrderType =
-			orderTypeResource.getDiscountOrderTypeOrderType(null);
+			orderTypeResource.getDiscountOrderTypeOrderType(
+				testGetDiscountOrderTypeOrderType_getDiscountOrderTypeId());
 
 		assertEquals(postOrderType, getOrderType);
 		assertValid(getOrderType);
+	}
+
+	protected Long testGetDiscountOrderTypeOrderType_getDiscountOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected OrderType testGetDiscountOrderTypeOrderType_addOrderType()
@@ -216,12 +224,22 @@ public abstract class BaseOrderTypeResourceTestCase {
 								"discountOrderTypeOrderType",
 								new HashMap<String, Object>() {
 									{
-										put("discountOrderTypeId", null);
+										put(
+											"discountOrderTypeId",
+											testGraphQLGetDiscountOrderTypeOrderType_getDiscountOrderTypeId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/discountOrderTypeOrderType"))));
+	}
+
+	protected Long
+			testGraphQLGetDiscountOrderTypeOrderType_getDiscountOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -254,10 +272,18 @@ public abstract class BaseOrderTypeResourceTestCase {
 			testGetPriceListOrderTypeOrderType_addOrderType();
 
 		OrderType getOrderType =
-			orderTypeResource.getPriceListOrderTypeOrderType(null);
+			orderTypeResource.getPriceListOrderTypeOrderType(
+				testGetPriceListOrderTypeOrderType_getPriceListOrderTypeId());
 
 		assertEquals(postOrderType, getOrderType);
 		assertValid(getOrderType);
+	}
+
+	protected Long testGetPriceListOrderTypeOrderType_getPriceListOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected OrderType testGetPriceListOrderTypeOrderType_addOrderType()
@@ -281,12 +307,22 @@ public abstract class BaseOrderTypeResourceTestCase {
 								"priceListOrderTypeOrderType",
 								new HashMap<String, Object>() {
 									{
-										put("priceListOrderTypeId", null);
+										put(
+											"priceListOrderTypeId",
+											testGraphQLGetPriceListOrderTypeOrderType_getPriceListOrderTypeId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/priceListOrderTypeOrderType"))));
+	}
+
+	protected Long
+			testGraphQLGetPriceListOrderTypeOrderType_getPriceListOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseOrderTypeResourceTestCase.java
@@ -212,7 +212,8 @@ public abstract class BaseOrderTypeResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDiscountOrderTypeOrderType() throws Exception {
-		OrderType orderType = testGraphQLOrderType_addOrderType();
+		OrderType orderType =
+			testGraphQLGetDiscountOrderTypeOrderType_addOrderType();
 
 		Assert.assertTrue(
 			equals(
@@ -266,6 +267,12 @@ public abstract class BaseOrderTypeResourceTestCase {
 				"Object/code"));
 	}
 
+	protected OrderType testGraphQLGetDiscountOrderTypeOrderType_addOrderType()
+		throws Exception {
+
+		return testGraphQLOrderType_addOrderType();
+	}
+
 	@Test
 	public void testGetPriceListOrderTypeOrderType() throws Exception {
 		OrderType postOrderType =
@@ -295,7 +302,8 @@ public abstract class BaseOrderTypeResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPriceListOrderTypeOrderType() throws Exception {
-		OrderType orderType = testGraphQLOrderType_addOrderType();
+		OrderType orderType =
+			testGraphQLGetPriceListOrderTypeOrderType_addOrderType();
 
 		Assert.assertTrue(
 			equals(
@@ -347,6 +355,12 @@ public abstract class BaseOrderTypeResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected OrderType testGraphQLGetPriceListOrderTypeOrderType_addOrderType()
+		throws Exception {
+
+		return testGraphQLOrderType_addOrderType();
 	}
 
 	protected OrderType testGraphQLOrderType_addOrderType() throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
@@ -503,8 +503,8 @@ public abstract class BasePriceListResourceTestCase {
 
 		long totalCount = priceListsJSONObject.getLong("totalCount");
 
-		PriceList priceList1 = testGraphQLPriceList_addPriceList();
-		PriceList priceList2 = testGraphQLPriceList_addPriceList();
+		PriceList priceList1 = testGraphQLGetPriceListsPage_addPriceList();
+		PriceList priceList2 = testGraphQLGetPriceListsPage_addPriceList();
 
 		priceListsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -523,6 +523,12 @@ public abstract class BasePriceListResourceTestCase {
 			Arrays.asList(
 				PriceListSerDes.toDTOs(
 					priceListsJSONObject.getString("items"))));
+	}
+
+	protected PriceList testGraphQLGetPriceListsPage_addPriceList()
+		throws Exception {
+
+		return testGraphQLPriceList_addPriceList();
 	}
 
 	@Test
@@ -598,7 +604,8 @@ public abstract class BasePriceListResourceTestCase {
 	public void testGraphQLGetPriceListByExternalReferenceCode()
 		throws Exception {
 
-		PriceList priceList = testGraphQLPriceList_addPriceList();
+		PriceList priceList =
+			testGraphQLGetPriceListByExternalReferenceCode_addPriceList();
 
 		Assert.assertTrue(
 			equals(
@@ -646,6 +653,13 @@ public abstract class BasePriceListResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected PriceList
+			testGraphQLGetPriceListByExternalReferenceCode_addPriceList()
+		throws Exception {
+
+		return testGraphQLPriceList_addPriceList();
 	}
 
 	@Test
@@ -703,7 +717,7 @@ public abstract class BasePriceListResourceTestCase {
 
 	@Test
 	public void testGraphQLDeletePriceList() throws Exception {
-		PriceList priceList = testGraphQLPriceList_addPriceList();
+		PriceList priceList = testGraphQLDeletePriceList_addPriceList();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -732,6 +746,12 @@ public abstract class BasePriceListResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected PriceList testGraphQLDeletePriceList_addPriceList()
+		throws Exception {
+
+		return testGraphQLPriceList_addPriceList();
+	}
+
 	@Test
 	public void testGetPriceList() throws Exception {
 		PriceList postPriceList = testGetPriceList_addPriceList();
@@ -750,7 +770,7 @@ public abstract class BasePriceListResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPriceList() throws Exception {
-		PriceList priceList = testGraphQLPriceList_addPriceList();
+		PriceList priceList = testGraphQLGetPriceList_addPriceList();
 
 		Assert.assertTrue(
 			equals(
@@ -787,6 +807,12 @@ public abstract class BasePriceListResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected PriceList testGraphQLGetPriceList_addPriceList()
+		throws Exception {
+
+		return testGraphQLPriceList_addPriceList();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierResourceTestCase.java
@@ -811,7 +811,7 @@ public abstract class BasePriceModifierResourceTestCase {
 		throws Exception {
 
 		PriceModifier priceModifier =
-			testGraphQLPriceModifier_addPriceModifier();
+			testGraphQLGetPriceModifierByExternalReferenceCode_addPriceModifier();
 
 		Assert.assertTrue(
 			equals(
@@ -861,6 +861,13 @@ public abstract class BasePriceModifierResourceTestCase {
 				"Object/code"));
 	}
 
+	protected PriceModifier
+			testGraphQLGetPriceModifierByExternalReferenceCode_addPriceModifier()
+		throws Exception {
+
+		return testGraphQLPriceModifier_addPriceModifier();
+	}
+
 	@Test
 	public void testPatchPriceModifierByExternalReferenceCode()
 		throws Exception {
@@ -900,7 +907,7 @@ public abstract class BasePriceModifierResourceTestCase {
 	@Test
 	public void testGraphQLDeletePriceModifier() throws Exception {
 		PriceModifier priceModifier =
-			testGraphQLPriceModifier_addPriceModifier();
+			testGraphQLDeletePriceModifier_addPriceModifier();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -929,6 +936,12 @@ public abstract class BasePriceModifierResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected PriceModifier testGraphQLDeletePriceModifier_addPriceModifier()
+		throws Exception {
+
+		return testGraphQLPriceModifier_addPriceModifier();
+	}
+
 	@Test
 	public void testGetPriceModifier() throws Exception {
 		PriceModifier postPriceModifier =
@@ -951,7 +964,7 @@ public abstract class BasePriceModifierResourceTestCase {
 	@Test
 	public void testGraphQLGetPriceModifier() throws Exception {
 		PriceModifier priceModifier =
-			testGraphQLPriceModifier_addPriceModifier();
+			testGraphQLGetPriceModifier_addPriceModifier();
 
 		Assert.assertTrue(
 			equals(
@@ -988,6 +1001,12 @@ public abstract class BasePriceModifierResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected PriceModifier testGraphQLGetPriceModifier_addPriceModifier()
+		throws Exception {
+
+		return testGraphQLPriceModifier_addPriceModifier();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductGroupResourceTestCase.java
@@ -189,10 +189,19 @@ public abstract class BaseProductGroupResourceTestCase {
 			testGetDiscountProductGroupProductGroup_addProductGroup();
 
 		ProductGroup getProductGroup =
-			productGroupResource.getDiscountProductGroupProductGroup(null);
+			productGroupResource.getDiscountProductGroupProductGroup(
+				testGetDiscountProductGroupProductGroup_getDiscountProductGroupId());
 
 		assertEquals(postProductGroup, getProductGroup);
 		assertValid(getProductGroup);
+	}
+
+	protected Long
+			testGetDiscountProductGroupProductGroup_getDiscountProductGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected ProductGroup
@@ -219,12 +228,22 @@ public abstract class BaseProductGroupResourceTestCase {
 								"discountProductGroupProductGroup",
 								new HashMap<String, Object>() {
 									{
-										put("discountProductGroupId", null);
+										put(
+											"discountProductGroupId",
+											testGraphQLGetDiscountProductGroupProductGroup_getDiscountProductGroupId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/discountProductGroupProductGroup"))));
+	}
+
+	protected Long
+			testGraphQLGetDiscountProductGroupProductGroup_getDiscountProductGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -259,10 +278,19 @@ public abstract class BaseProductGroupResourceTestCase {
 			testGetPriceModifierProductGroupProductGroup_addProductGroup();
 
 		ProductGroup getProductGroup =
-			productGroupResource.getPriceModifierProductGroupProductGroup(null);
+			productGroupResource.getPriceModifierProductGroupProductGroup(
+				testGetPriceModifierProductGroupProductGroup_getPriceModifierProductGroupId());
 
 		assertEquals(postProductGroup, getProductGroup);
 		assertValid(getProductGroup);
+	}
+
+	protected Long
+			testGetPriceModifierProductGroupProductGroup_getPriceModifierProductGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected ProductGroup
@@ -291,12 +319,20 @@ public abstract class BaseProductGroupResourceTestCase {
 									{
 										put(
 											"priceModifierProductGroupId",
-											null);
+											testGraphQLGetPriceModifierProductGroupProductGroup_getPriceModifierProductGroupId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/priceModifierProductGroupProductGroup"))));
+	}
+
+	protected Long
+			testGraphQLGetPriceModifierProductGroupProductGroup_getPriceModifierProductGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductGroupResourceTestCase.java
@@ -216,7 +216,8 @@ public abstract class BaseProductGroupResourceTestCase {
 	public void testGraphQLGetDiscountProductGroupProductGroup()
 		throws Exception {
 
-		ProductGroup productGroup = testGraphQLProductGroup_addProductGroup();
+		ProductGroup productGroup =
+			testGraphQLGetDiscountProductGroupProductGroup_addProductGroup();
 
 		Assert.assertTrue(
 			equals(
@@ -270,6 +271,13 @@ public abstract class BaseProductGroupResourceTestCase {
 				"Object/code"));
 	}
 
+	protected ProductGroup
+			testGraphQLGetDiscountProductGroupProductGroup_addProductGroup()
+		throws Exception {
+
+		return testGraphQLProductGroup_addProductGroup();
+	}
+
 	@Test
 	public void testGetPriceModifierProductGroupProductGroup()
 		throws Exception {
@@ -305,7 +313,8 @@ public abstract class BaseProductGroupResourceTestCase {
 	public void testGraphQLGetPriceModifierProductGroupProductGroup()
 		throws Exception {
 
-		ProductGroup productGroup = testGraphQLProductGroup_addProductGroup();
+		ProductGroup productGroup =
+			testGraphQLGetPriceModifierProductGroupProductGroup_addProductGroup();
 
 		Assert.assertTrue(
 			equals(
@@ -358,6 +367,13 @@ public abstract class BaseProductGroupResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ProductGroup
+			testGraphQLGetPriceModifierProductGroupProductGroup_addProductGroup()
+		throws Exception {
+
+		return testGraphQLProductGroup_addProductGroup();
 	}
 
 	protected ProductGroup testGraphQLProductGroup_addProductGroup()

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductResourceTestCase.java
@@ -194,10 +194,18 @@ public abstract class BaseProductResourceTestCase {
 	public void testGetDiscountProductProduct() throws Exception {
 		Product postProduct = testGetDiscountProductProduct_addProduct();
 
-		Product getProduct = productResource.getDiscountProductProduct(null);
+		Product getProduct = productResource.getDiscountProductProduct(
+			testGetDiscountProductProduct_getDiscountProductId());
 
 		assertEquals(postProduct, getProduct);
 		assertValid(getProduct);
+	}
+
+	protected Long testGetDiscountProductProduct_getDiscountProductId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Product testGetDiscountProductProduct_addProduct()
@@ -221,11 +229,20 @@ public abstract class BaseProductResourceTestCase {
 								"discountProductProduct",
 								new HashMap<String, Object>() {
 									{
-										put("discountProductId", null);
+										put(
+											"discountProductId",
+											testGraphQLGetDiscountProductProduct_getDiscountProductId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/discountProductProduct"))));
+	}
+
+	protected Long testGraphQLGetDiscountProductProduct_getDiscountProductId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -256,10 +273,18 @@ public abstract class BaseProductResourceTestCase {
 	public void testGetPriceEntryIdProduct() throws Exception {
 		Product postProduct = testGetPriceEntryIdProduct_addProduct();
 
-		Product getProduct = productResource.getPriceEntryIdProduct(null);
+		Product getProduct = productResource.getPriceEntryIdProduct(
+			testGetPriceEntryIdProduct_getPriceEntryId());
 
 		assertEquals(postProduct, getProduct);
 		assertValid(getProduct);
+	}
+
+	protected Long testGetPriceEntryIdProduct_getPriceEntryId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Product testGetPriceEntryIdProduct_addProduct() throws Exception {
@@ -281,11 +306,20 @@ public abstract class BaseProductResourceTestCase {
 								"priceEntryIdProduct",
 								new HashMap<String, Object>() {
 									{
-										put("priceEntryId", null);
+										put(
+											"priceEntryId",
+											testGraphQLGetPriceEntryIdProduct_getPriceEntryId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/priceEntryIdProduct"))));
+	}
+
+	protected Long testGraphQLGetPriceEntryIdProduct_getPriceEntryId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -313,10 +347,18 @@ public abstract class BaseProductResourceTestCase {
 		Product postProduct = testGetPriceModifierProductProduct_addProduct();
 
 		Product getProduct = productResource.getPriceModifierProductProduct(
-			null);
+			testGetPriceModifierProductProduct_getPriceModifierProductId());
 
 		assertEquals(postProduct, getProduct);
 		assertValid(getProduct);
+	}
+
+	protected Long
+			testGetPriceModifierProductProduct_getPriceModifierProductId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Product testGetPriceModifierProductProduct_addProduct()
@@ -340,12 +382,22 @@ public abstract class BaseProductResourceTestCase {
 								"priceModifierProductProduct",
 								new HashMap<String, Object>() {
 									{
-										put("priceModifierProductId", null);
+										put(
+											"priceModifierProductId",
+											testGraphQLGetPriceModifierProductProduct_getPriceModifierProductId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/priceModifierProductProduct"))));
+	}
+
+	protected Long
+			testGraphQLGetPriceModifierProductProduct_getPriceModifierProductId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductResourceTestCase.java
@@ -217,7 +217,7 @@ public abstract class BaseProductResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDiscountProductProduct() throws Exception {
-		Product product = testGraphQLProduct_addProduct();
+		Product product = testGraphQLGetDiscountProductProduct_addProduct();
 
 		Assert.assertTrue(
 			equals(
@@ -269,6 +269,12 @@ public abstract class BaseProductResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Product testGraphQLGetDiscountProductProduct_addProduct()
+		throws Exception {
+
+		return testGraphQLProduct_addProduct();
+	}
+
 	@Test
 	public void testGetPriceEntryIdProduct() throws Exception {
 		Product postProduct = testGetPriceEntryIdProduct_addProduct();
@@ -294,7 +300,7 @@ public abstract class BaseProductResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPriceEntryIdProduct() throws Exception {
-		Product product = testGraphQLProduct_addProduct();
+		Product product = testGraphQLGetPriceEntryIdProduct_addProduct();
 
 		Assert.assertTrue(
 			equals(
@@ -342,6 +348,12 @@ public abstract class BaseProductResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Product testGraphQLGetPriceEntryIdProduct_addProduct()
+		throws Exception {
+
+		return testGraphQLProduct_addProduct();
+	}
+
 	@Test
 	public void testGetPriceModifierProductProduct() throws Exception {
 		Product postProduct = testGetPriceModifierProductProduct_addProduct();
@@ -370,7 +382,8 @@ public abstract class BaseProductResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPriceModifierProductProduct() throws Exception {
-		Product product = testGraphQLProduct_addProduct();
+		Product product =
+			testGraphQLGetPriceModifierProductProduct_addProduct();
 
 		Assert.assertTrue(
 			equals(
@@ -422,6 +435,12 @@ public abstract class BaseProductResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Product testGraphQLGetPriceModifierProductProduct_addProduct()
+		throws Exception {
+
+		return testGraphQLProduct_addProduct();
 	}
 
 	protected Product testGraphQLProduct_addProduct() throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseSkuResourceTestCase.java
@@ -196,10 +196,16 @@ public abstract class BaseSkuResourceTestCase {
 	public void testGetDiscountSkuSku() throws Exception {
 		Sku postSku = testGetDiscountSkuSku_addSku();
 
-		Sku getSku = skuResource.getDiscountSkuSku(null);
+		Sku getSku = skuResource.getDiscountSkuSku(
+			testGetDiscountSkuSku_getDiscountSkuId());
 
 		assertEquals(postSku, getSku);
 		assertValid(getSku);
+	}
+
+	protected Long testGetDiscountSkuSku_getDiscountSkuId() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Sku testGetDiscountSkuSku_addSku() throws Exception {
@@ -221,11 +227,20 @@ public abstract class BaseSkuResourceTestCase {
 								"discountSkuSku",
 								new HashMap<String, Object>() {
 									{
-										put("discountSkuId", null);
+										put(
+											"discountSkuId",
+											testGraphQLGetDiscountSkuSku_getDiscountSkuId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/discountSkuSku"))));
+	}
+
+	protected Long testGraphQLGetDiscountSkuSku_getDiscountSkuId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -252,10 +267,16 @@ public abstract class BaseSkuResourceTestCase {
 	public void testGetPriceEntryIdSku() throws Exception {
 		Sku postSku = testGetPriceEntryIdSku_addSku();
 
-		Sku getSku = skuResource.getPriceEntryIdSku(null);
+		Sku getSku = skuResource.getPriceEntryIdSku(
+			testGetPriceEntryIdSku_getPriceEntryId());
 
 		assertEquals(postSku, getSku);
 		assertValid(getSku);
+	}
+
+	protected Long testGetPriceEntryIdSku_getPriceEntryId() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Sku testGetPriceEntryIdSku_addSku() throws Exception {
@@ -277,11 +298,20 @@ public abstract class BaseSkuResourceTestCase {
 								"priceEntryIdSku",
 								new HashMap<String, Object>() {
 									{
-										put("priceEntryId", null);
+										put(
+											"priceEntryId",
+											testGraphQLGetPriceEntryIdSku_getPriceEntryId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/priceEntryIdSku"))));
+	}
+
+	protected Long testGraphQLGetPriceEntryIdSku_getPriceEntryId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseSkuResourceTestCase.java
@@ -215,7 +215,7 @@ public abstract class BaseSkuResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDiscountSkuSku() throws Exception {
-		Sku sku = testGraphQLSku_addSku();
+		Sku sku = testGraphQLGetDiscountSkuSku_addSku();
 
 		Assert.assertTrue(
 			equals(
@@ -263,6 +263,10 @@ public abstract class BaseSkuResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Sku testGraphQLGetDiscountSkuSku_addSku() throws Exception {
+		return testGraphQLSku_addSku();
+	}
+
 	@Test
 	public void testGetPriceEntryIdSku() throws Exception {
 		Sku postSku = testGetPriceEntryIdSku_addSku();
@@ -286,7 +290,7 @@ public abstract class BaseSkuResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPriceEntryIdSku() throws Exception {
-		Sku sku = testGraphQLSku_addSku();
+		Sku sku = testGraphQLGetPriceEntryIdSku_addSku();
 
 		Assert.assertTrue(
 			equals(
@@ -332,6 +336,10 @@ public abstract class BaseSkuResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Sku testGraphQLGetPriceEntryIdSku_addSku() throws Exception {
+		return testGraphQLSku_addSku();
 	}
 
 	protected Sku testGraphQLSku_addSku() throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseTierPriceResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseTierPriceResourceTestCase.java
@@ -534,7 +534,8 @@ public abstract class BaseTierPriceResourceTestCase {
 	public void testGraphQLGetTierPriceByExternalReferenceCode()
 		throws Exception {
 
-		TierPrice tierPrice = testGraphQLTierPrice_addTierPrice();
+		TierPrice tierPrice =
+			testGraphQLGetTierPriceByExternalReferenceCode_addTierPrice();
 
 		Assert.assertTrue(
 			equals(
@@ -584,6 +585,13 @@ public abstract class BaseTierPriceResourceTestCase {
 				"Object/code"));
 	}
 
+	protected TierPrice
+			testGraphQLGetTierPriceByExternalReferenceCode_addTierPrice()
+		throws Exception {
+
+		return testGraphQLTierPrice_addTierPrice();
+	}
+
 	@Test
 	public void testPatchTierPriceByExternalReferenceCode() throws Exception {
 		Assert.assertTrue(false);
@@ -612,7 +620,7 @@ public abstract class BaseTierPriceResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteTierPrice() throws Exception {
-		TierPrice tierPrice = testGraphQLTierPrice_addTierPrice();
+		TierPrice tierPrice = testGraphQLDeleteTierPrice_addTierPrice();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -641,6 +649,12 @@ public abstract class BaseTierPriceResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected TierPrice testGraphQLDeleteTierPrice_addTierPrice()
+		throws Exception {
+
+		return testGraphQLTierPrice_addTierPrice();
+	}
+
 	@Test
 	public void testGetTierPrice() throws Exception {
 		TierPrice postTierPrice = testGetTierPrice_addTierPrice();
@@ -659,7 +673,7 @@ public abstract class BaseTierPriceResourceTestCase {
 
 	@Test
 	public void testGraphQLGetTierPrice() throws Exception {
-		TierPrice tierPrice = testGraphQLTierPrice_addTierPrice();
+		TierPrice tierPrice = testGraphQLGetTierPrice_addTierPrice();
 
 		Assert.assertTrue(
 			equals(
@@ -696,6 +710,12 @@ public abstract class BaseTierPriceResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected TierPrice testGraphQLGetTierPrice_addTierPrice()
+		throws Exception {
+
+		return testGraphQLTierPrice_addTierPrice();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentItemResourceTestCase.java
@@ -244,7 +244,8 @@ public abstract class BaseShipmentItemResourceTestCase {
 	public void testGraphQLGetShipmentByExternalReferenceCodeItem()
 		throws Exception {
 
-		ShipmentItem shipmentItem = testGraphQLShipmentItem_addShipmentItem();
+		ShipmentItem shipmentItem =
+			testGraphQLGetShipmentByExternalReferenceCodeItem_addShipmentItem();
 
 		Assert.assertTrue(
 			equals(
@@ -294,6 +295,13 @@ public abstract class BaseShipmentItemResourceTestCase {
 				"Object/code"));
 	}
 
+	protected ShipmentItem
+			testGraphQLGetShipmentByExternalReferenceCodeItem_addShipmentItem()
+		throws Exception {
+
+		return testGraphQLShipmentItem_addShipmentItem();
+	}
+
 	@Test
 	public void testPatchShipmentItemByExternalReferenceCode()
 		throws Exception {
@@ -329,7 +337,8 @@ public abstract class BaseShipmentItemResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteShipmentItem() throws Exception {
-		ShipmentItem shipmentItem = testGraphQLShipmentItem_addShipmentItem();
+		ShipmentItem shipmentItem =
+			testGraphQLDeleteShipmentItem_addShipmentItem();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -358,6 +367,12 @@ public abstract class BaseShipmentItemResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected ShipmentItem testGraphQLDeleteShipmentItem_addShipmentItem()
+		throws Exception {
+
+		return testGraphQLShipmentItem_addShipmentItem();
+	}
+
 	@Test
 	public void testGetShipmentItem() throws Exception {
 		ShipmentItem postShipmentItem = testGetShipmentItem_addShipmentItem();
@@ -378,7 +393,8 @@ public abstract class BaseShipmentItemResourceTestCase {
 
 	@Test
 	public void testGraphQLGetShipmentItem() throws Exception {
-		ShipmentItem shipmentItem = testGraphQLShipmentItem_addShipmentItem();
+		ShipmentItem shipmentItem =
+			testGraphQLGetShipmentItem_addShipmentItem();
 
 		Assert.assertTrue(
 			equals(
@@ -417,6 +433,12 @@ public abstract class BaseShipmentItemResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ShipmentItem testGraphQLGetShipmentItem_addShipmentItem()
+		throws Exception {
+
+		return testGraphQLShipmentItem_addShipmentItem();
 	}
 
 	@Test
@@ -741,8 +763,10 @@ public abstract class BaseShipmentItemResourceTestCase {
 
 		Assert.assertEquals(0, shipmentItemsJSONObject.get("totalCount"));
 
-		ShipmentItem shipmentItem1 = testGraphQLShipmentItem_addShipmentItem();
-		ShipmentItem shipmentItem2 = testGraphQLShipmentItem_addShipmentItem();
+		ShipmentItem shipmentItem1 =
+			testGraphQLGetShipmentItemsPage_addShipmentItem();
+		ShipmentItem shipmentItem2 =
+			testGraphQLGetShipmentItemsPage_addShipmentItem();
 
 		shipmentItemsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -755,6 +779,12 @@ public abstract class BaseShipmentItemResourceTestCase {
 			Arrays.asList(
 				ShipmentItemSerDes.toDTOs(
 					shipmentItemsJSONObject.getString("items"))));
+	}
+
+	protected ShipmentItem testGraphQLGetShipmentItemsPage_addShipmentItem()
+		throws Exception {
+
+		return testGraphQLShipmentItem_addShipmentItem();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
@@ -494,8 +494,8 @@ public abstract class BaseShipmentResourceTestCase {
 
 		long totalCount = shipmentsJSONObject.getLong("totalCount");
 
-		Shipment shipment1 = testGraphQLShipment_addShipment();
-		Shipment shipment2 = testGraphQLShipment_addShipment();
+		Shipment shipment1 = testGraphQLGetShipmentsPage_addShipment();
+		Shipment shipment2 = testGraphQLGetShipmentsPage_addShipment();
 
 		shipmentsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -512,6 +512,12 @@ public abstract class BaseShipmentResourceTestCase {
 			shipment2,
 			Arrays.asList(
 				ShipmentSerDes.toDTOs(shipmentsJSONObject.getString("items"))));
+	}
+
+	protected Shipment testGraphQLGetShipmentsPage_addShipment()
+		throws Exception {
+
+		return testGraphQLShipment_addShipment();
 	}
 
 	@Test
@@ -584,7 +590,8 @@ public abstract class BaseShipmentResourceTestCase {
 	public void testGraphQLGetShipmentByExternalReferenceCode()
 		throws Exception {
 
-		Shipment shipment = testGraphQLShipment_addShipment();
+		Shipment shipment =
+			testGraphQLGetShipmentByExternalReferenceCode_addShipment();
 
 		Assert.assertTrue(
 			equals(
@@ -632,6 +639,13 @@ public abstract class BaseShipmentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Shipment
+			testGraphQLGetShipmentByExternalReferenceCode_addShipment()
+		throws Exception {
+
+		return testGraphQLShipment_addShipment();
 	}
 
 	@Test
@@ -810,7 +824,7 @@ public abstract class BaseShipmentResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteShipment() throws Exception {
-		Shipment shipment = testGraphQLShipment_addShipment();
+		Shipment shipment = testGraphQLDeleteShipment_addShipment();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -839,6 +853,12 @@ public abstract class BaseShipmentResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Shipment testGraphQLDeleteShipment_addShipment()
+		throws Exception {
+
+		return testGraphQLShipment_addShipment();
+	}
+
 	@Test
 	public void testGetShipment() throws Exception {
 		Shipment postShipment = testGetShipment_addShipment();
@@ -857,7 +877,7 @@ public abstract class BaseShipmentResourceTestCase {
 
 	@Test
 	public void testGraphQLGetShipment() throws Exception {
-		Shipment shipment = testGraphQLShipment_addShipment();
+		Shipment shipment = testGraphQLGetShipment_addShipment();
 
 		Assert.assertTrue(
 			equals(
@@ -894,6 +914,10 @@ public abstract class BaseShipmentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Shipment testGraphQLGetShipment_addShipment() throws Exception {
+		return testGraphQLShipment_addShipment();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
@@ -334,10 +334,18 @@ public abstract class BaseShippingAddressResourceTestCase {
 			testGetShipmentShippingAddress_addShippingAddress();
 
 		ShippingAddress getShippingAddress =
-			shippingAddressResource.getShipmentShippingAddress(null);
+			shippingAddressResource.getShipmentShippingAddress(
+				testGetShipmentShippingAddress_getShipmentId());
 
 		assertEquals(postShippingAddress, getShippingAddress);
 		assertValid(getShippingAddress);
+	}
+
+	protected Long testGetShipmentShippingAddress_getShipmentId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected ShippingAddress
@@ -363,11 +371,20 @@ public abstract class BaseShippingAddressResourceTestCase {
 								"shipmentShippingAddress",
 								new HashMap<String, Object>() {
 									{
-										put("shipmentId", null);
+										put(
+											"shipmentId",
+											testGraphQLGetShipmentShippingAddress_getShipmentId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/shipmentShippingAddress"))));
+	}
+
+	protected Long testGraphQLGetShipmentShippingAddress_getShipmentId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
@@ -238,7 +238,7 @@ public abstract class BaseShippingAddressResourceTestCase {
 		throws Exception {
 
 		ShippingAddress shippingAddress =
-			testGraphQLShippingAddress_addShippingAddress();
+			testGraphQLGetShipmentByExternalReferenceCodeShippingAddress_addShippingAddress();
 
 		Assert.assertTrue(
 			equals(
@@ -286,6 +286,13 @@ public abstract class BaseShippingAddressResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ShippingAddress
+			testGraphQLGetShipmentByExternalReferenceCodeShippingAddress_addShippingAddress()
+		throws Exception {
+
+		return testGraphQLShippingAddress_addShippingAddress();
 	}
 
 	@Test
@@ -359,7 +366,7 @@ public abstract class BaseShippingAddressResourceTestCase {
 	@Test
 	public void testGraphQLGetShipmentShippingAddress() throws Exception {
 		ShippingAddress shippingAddress =
-			testGraphQLShippingAddress_addShippingAddress();
+			testGraphQLGetShipmentShippingAddress_addShippingAddress();
 
 		Assert.assertTrue(
 			equals(
@@ -407,6 +414,13 @@ public abstract class BaseShippingAddressResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ShippingAddress
+			testGraphQLGetShipmentShippingAddress_addShippingAddress()
+		throws Exception {
+
+		return testGraphQLShippingAddress_addShippingAddress();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/ShippingAddressResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/ShippingAddressResourceTest.java
@@ -25,10 +25,8 @@ import com.liferay.commerce.service.CommerceShipmentLocalServiceUtil;
 import com.liferay.commerce.test.util.CommerceInventoryTestUtil;
 import com.liferay.commerce.test.util.CommerceTestUtil;
 import com.liferay.headless.commerce.admin.shipment.client.dto.v1_0.ShippingAddress;
-import com.liferay.headless.commerce.admin.shipment.client.serdes.v1_0.ShippingAddressSerDes;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.Region;
 import com.liferay.portal.kernel.model.User;
@@ -40,12 +38,10 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.math.BigDecimal;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -118,66 +114,6 @@ public class ShippingAddressResourceTest
 
 		assertEquals(shippingAddress, getShippingAddress);
 		assertValid(getShippingAddress);
-	}
-
-	@Override
-	@Test
-	public void testGetShipmentShippingAddress() throws Exception {
-		ShippingAddress shippingAddress = _toShippingAddress(
-			_commerceShipment.fetchCommerceAddress());
-
-		ShippingAddress getShippingAddress =
-			shippingAddressResource.getShipmentShippingAddress(
-				_commerceShipment.getCommerceShipmentId());
-
-		assertEquals(shippingAddress, getShippingAddress);
-		assertValid(getShippingAddress);
-	}
-
-	@Override
-	@Test
-	public void testGraphQLGetShipmentByExternalReferenceCodeShippingAddress()
-		throws Exception {
-
-		ShippingAddress shippingAddress = _toShippingAddress(
-			_commerceShipment.fetchCommerceAddress());
-
-		Assert.assertTrue(
-			equals(
-				shippingAddress,
-				ShippingAddressSerDes.toDTO(
-					JSONUtil.getValueAsString(
-						invokeGraphQLQuery(
-							new GraphQLField(
-								"shipmentShippingAddress",
-								HashMapBuilder.<String, Object>put(
-									"shipmentId",
-									_commerceShipment.getCommerceShipmentId()
-								).build(),
-								getGraphQLFields())),
-						"JSONObject/data", "Object/shipmentShippingAddress"))));
-	}
-
-	@Override
-	@Test
-	public void testGraphQLGetShipmentShippingAddress() throws Exception {
-		ShippingAddress shippingAddress = _toShippingAddress(
-			_commerceShipment.fetchCommerceAddress());
-
-		Assert.assertTrue(
-			equals(
-				shippingAddress,
-				ShippingAddressSerDes.toDTO(
-					JSONUtil.getValueAsString(
-						invokeGraphQLQuery(
-							new GraphQLField(
-								"shipmentShippingAddress",
-								HashMapBuilder.<String, Object>put(
-									"shipmentId",
-									_commerceShipment.getCommerceShipmentId()
-								).build(),
-								getGraphQLFields())),
-						"JSONObject/data", "Object/shipmentShippingAddress"))));
 	}
 
 	@Override
@@ -258,6 +194,35 @@ public class ShippingAddressResourceTest
 				zip = StringUtil.toLowerCase(RandomTestUtil.randomString());
 			}
 		};
+	}
+
+	@Override
+	protected ShippingAddress
+			testGetShipmentShippingAddress_addShippingAddress()
+		throws Exception {
+
+		return _toShippingAddress(_commerceShipment.fetchCommerceAddress());
+	}
+
+	@Override
+	protected Long testGetShipmentShippingAddress_getShipmentId()
+		throws Exception {
+
+		return _commerceShipment.getCommerceShipmentId();
+	}
+
+	@Override
+	protected Long testGraphQLGetShipmentShippingAddress_getShipmentId()
+		throws Exception {
+
+		return _commerceShipment.getCommerceShipmentId();
+	}
+
+	@Override
+	protected ShippingAddress testGraphQLShippingAddress_addShippingAddress()
+		throws Exception {
+
+		return _toShippingAddress(_commerceShipment.fetchCommerceAddress());
 	}
 
 	private String _getRegionISOCode(CommerceAddress commerceAddress)

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseAvailabilityEstimateResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseAvailabilityEstimateResourceTestCase.java
@@ -223,7 +223,7 @@ public abstract class BaseAvailabilityEstimateResourceTestCase {
 	@Test
 	public void testGraphQLDeleteAvailabilityEstimate() throws Exception {
 		AvailabilityEstimate availabilityEstimate =
-			testGraphQLAvailabilityEstimate_addAvailabilityEstimate();
+			testGraphQLDeleteAvailabilityEstimate_addAvailabilityEstimate();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -252,6 +252,13 @@ public abstract class BaseAvailabilityEstimateResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected AvailabilityEstimate
+			testGraphQLDeleteAvailabilityEstimate_addAvailabilityEstimate()
+		throws Exception {
+
+		return testGraphQLAvailabilityEstimate_addAvailabilityEstimate();
+	}
+
 	@Test
 	public void testGetAvailabilityEstimate() throws Exception {
 		AvailabilityEstimate postAvailabilityEstimate =
@@ -276,7 +283,7 @@ public abstract class BaseAvailabilityEstimateResourceTestCase {
 	@Test
 	public void testGraphQLGetAvailabilityEstimate() throws Exception {
 		AvailabilityEstimate availabilityEstimate =
-			testGraphQLAvailabilityEstimate_addAvailabilityEstimate();
+			testGraphQLGetAvailabilityEstimate_addAvailabilityEstimate();
 
 		Assert.assertTrue(
 			equals(
@@ -313,6 +320,13 @@ public abstract class BaseAvailabilityEstimateResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected AvailabilityEstimate
+			testGraphQLGetAvailabilityEstimate_addAvailabilityEstimate()
+		throws Exception {
+
+		return testGraphQLAvailabilityEstimate_addAvailabilityEstimate();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseMeasurementUnitResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseMeasurementUnitResourceTestCase.java
@@ -382,7 +382,7 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 	@Test
 	public void testGraphQLDeleteMeasurementUnit() throws Exception {
 		MeasurementUnit measurementUnit =
-			testGraphQLMeasurementUnit_addMeasurementUnit();
+			testGraphQLDeleteMeasurementUnit_addMeasurementUnit();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -411,6 +411,13 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected MeasurementUnit
+			testGraphQLDeleteMeasurementUnit_addMeasurementUnit()
+		throws Exception {
+
+		return testGraphQLMeasurementUnit_addMeasurementUnit();
+	}
+
 	@Test
 	public void testGetMeasurementUnit() throws Exception {
 		MeasurementUnit postMeasurementUnit =
@@ -434,7 +441,7 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 	@Test
 	public void testGraphQLGetMeasurementUnit() throws Exception {
 		MeasurementUnit measurementUnit =
-			testGraphQLMeasurementUnit_addMeasurementUnit();
+			testGraphQLGetMeasurementUnit_addMeasurementUnit();
 
 		Assert.assertTrue(
 			equals(
@@ -471,6 +478,12 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected MeasurementUnit testGraphQLGetMeasurementUnit_addMeasurementUnit()
+		throws Exception {
+
+		return testGraphQLMeasurementUnit_addMeasurementUnit();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
@@ -367,7 +367,7 @@ public abstract class BaseTaxCategoryResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteTaxCategory() throws Exception {
-		TaxCategory taxCategory = testGraphQLTaxCategory_addTaxCategory();
+		TaxCategory taxCategory = testGraphQLDeleteTaxCategory_addTaxCategory();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -396,6 +396,12 @@ public abstract class BaseTaxCategoryResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected TaxCategory testGraphQLDeleteTaxCategory_addTaxCategory()
+		throws Exception {
+
+		return testGraphQLTaxCategory_addTaxCategory();
+	}
+
 	@Test
 	public void testGetTaxCategory() throws Exception {
 		TaxCategory postTaxCategory = testGetTaxCategory_addTaxCategory();
@@ -414,7 +420,7 @@ public abstract class BaseTaxCategoryResourceTestCase {
 
 	@Test
 	public void testGraphQLGetTaxCategory() throws Exception {
-		TaxCategory taxCategory = testGraphQLTaxCategory_addTaxCategory();
+		TaxCategory taxCategory = testGraphQLGetTaxCategory_addTaxCategory();
 
 		Assert.assertTrue(
 			equals(
@@ -451,6 +457,12 @@ public abstract class BaseTaxCategoryResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected TaxCategory testGraphQLGetTaxCategory_addTaxCategory()
+		throws Exception {
+
+		return testGraphQLTaxCategory_addTaxCategory();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseWarehouseResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseWarehouseResourceTestCase.java
@@ -373,7 +373,7 @@ public abstract class BaseWarehouseResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteWarehouse() throws Exception {
-		Warehouse warehouse = testGraphQLWarehouse_addWarehouse();
+		Warehouse warehouse = testGraphQLDeleteWarehouse_addWarehouse();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -402,6 +402,12 @@ public abstract class BaseWarehouseResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Warehouse testGraphQLDeleteWarehouse_addWarehouse()
+		throws Exception {
+
+		return testGraphQLWarehouse_addWarehouse();
+	}
+
 	@Test
 	public void testGetWarehouse() throws Exception {
 		Warehouse postWarehouse = testGetWarehouse_addWarehouse();
@@ -420,7 +426,7 @@ public abstract class BaseWarehouseResourceTestCase {
 
 	@Test
 	public void testGraphQLGetWarehouse() throws Exception {
-		Warehouse warehouse = testGraphQLWarehouse_addWarehouse();
+		Warehouse warehouse = testGraphQLGetWarehouse_addWarehouse();
 
 		Assert.assertTrue(
 			equals(
@@ -457,6 +463,12 @@ public abstract class BaseWarehouseResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Warehouse testGraphQLGetWarehouse_addWarehouse()
+		throws Exception {
+
+		return testGraphQLWarehouse_addWarehouse();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
@@ -218,10 +218,16 @@ public abstract class BaseAddressResourceTestCase {
 	public void testGetCartBillingAddres() throws Exception {
 		Address postAddress = testGetCartBillingAddres_addAddress();
 
-		Address getAddress = addressResource.getCartBillingAddres(null);
+		Address getAddress = addressResource.getCartBillingAddres(
+			testGetCartBillingAddres_getCartId());
 
 		assertEquals(postAddress, getAddress);
 		assertValid(getAddress);
+	}
+
+	protected Long testGetCartBillingAddres_getCartId() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Address testGetCartBillingAddres_addAddress() throws Exception {
@@ -243,11 +249,20 @@ public abstract class BaseAddressResourceTestCase {
 								"cartBillingAddres",
 								new HashMap<String, Object>() {
 									{
-										put("cartId", null);
+										put(
+											"cartId",
+											testGraphQLGetCartBillingAddres_getCartId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/cartBillingAddres"))));
+	}
+
+	protected Long testGraphQLGetCartBillingAddres_getCartId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -274,10 +289,16 @@ public abstract class BaseAddressResourceTestCase {
 	public void testGetCartShippingAddres() throws Exception {
 		Address postAddress = testGetCartShippingAddres_addAddress();
 
-		Address getAddress = addressResource.getCartShippingAddres(null);
+		Address getAddress = addressResource.getCartShippingAddres(
+			testGetCartShippingAddres_getCartId());
 
 		assertEquals(postAddress, getAddress);
 		assertValid(getAddress);
+	}
+
+	protected Long testGetCartShippingAddres_getCartId() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Address testGetCartShippingAddres_addAddress() throws Exception {
@@ -299,11 +320,20 @@ public abstract class BaseAddressResourceTestCase {
 								"cartShippingAddres",
 								new HashMap<String, Object>() {
 									{
-										put("cartId", null);
+										put(
+											"cartId",
+											testGraphQLGetCartShippingAddres_getCartId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/cartShippingAddres"))));
+	}
+
+	protected Long testGraphQLGetCartShippingAddres_getCartId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
@@ -237,7 +237,7 @@ public abstract class BaseAddressResourceTestCase {
 
 	@Test
 	public void testGraphQLGetCartBillingAddres() throws Exception {
-		Address address = testGraphQLAddress_addAddress();
+		Address address = testGraphQLGetCartBillingAddres_addAddress();
 
 		Assert.assertTrue(
 			equals(
@@ -285,6 +285,12 @@ public abstract class BaseAddressResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Address testGraphQLGetCartBillingAddres_addAddress()
+		throws Exception {
+
+		return testGraphQLAddress_addAddress();
+	}
+
 	@Test
 	public void testGetCartShippingAddres() throws Exception {
 		Address postAddress = testGetCartShippingAddres_addAddress();
@@ -308,7 +314,7 @@ public abstract class BaseAddressResourceTestCase {
 
 	@Test
 	public void testGraphQLGetCartShippingAddres() throws Exception {
-		Address address = testGraphQLAddress_addAddress();
+		Address address = testGraphQLGetCartShippingAddres_addAddress();
 
 		Assert.assertTrue(
 			equals(
@@ -354,6 +360,12 @@ public abstract class BaseAddressResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Address testGraphQLGetCartShippingAddres_addAddress()
+		throws Exception {
+
+		return testGraphQLAddress_addAddress();
 	}
 
 	protected Address testGraphQLAddress_addAddress() throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartCommentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartCommentResourceTestCase.java
@@ -220,7 +220,7 @@ public abstract class BaseCartCommentResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteCartComment() throws Exception {
-		CartComment cartComment = testGraphQLCartComment_addCartComment();
+		CartComment cartComment = testGraphQLDeleteCartComment_addCartComment();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -249,6 +249,12 @@ public abstract class BaseCartCommentResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected CartComment testGraphQLDeleteCartComment_addCartComment()
+		throws Exception {
+
+		return testGraphQLCartComment_addCartComment();
+	}
+
 	@Test
 	public void testGetCartComment() throws Exception {
 		CartComment postCartComment = testGetCartComment_addCartComment();
@@ -267,7 +273,7 @@ public abstract class BaseCartCommentResourceTestCase {
 
 	@Test
 	public void testGraphQLGetCartComment() throws Exception {
-		CartComment cartComment = testGraphQLCartComment_addCartComment();
+		CartComment cartComment = testGraphQLGetCartComment_addCartComment();
 
 		Assert.assertTrue(
 			equals(
@@ -306,6 +312,12 @@ public abstract class BaseCartCommentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected CartComment testGraphQLGetCartComment_addCartComment()
+		throws Exception {
+
+		return testGraphQLCartComment_addCartComment();
 	}
 
 	@Test
@@ -487,8 +499,10 @@ public abstract class BaseCartCommentResourceTestCase {
 
 		Assert.assertEquals(0, cartCommentsJSONObject.get("totalCount"));
 
-		CartComment cartComment1 = testGraphQLCartComment_addCartComment();
-		CartComment cartComment2 = testGraphQLCartComment_addCartComment();
+		CartComment cartComment1 =
+			testGraphQLGetCartCommentsPage_addCartComment();
+		CartComment cartComment2 =
+			testGraphQLGetCartCommentsPage_addCartComment();
 
 		cartCommentsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -501,6 +515,12 @@ public abstract class BaseCartCommentResourceTestCase {
 			Arrays.asList(
 				CartCommentSerDes.toDTOs(
 					cartCommentsJSONObject.getString("items"))));
+	}
+
+	protected CartComment testGraphQLGetCartCommentsPage_addCartComment()
+		throws Exception {
+
+		return testGraphQLCartComment_addCartComment();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartItemResourceTestCase.java
@@ -220,7 +220,7 @@ public abstract class BaseCartItemResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteCartItem() throws Exception {
-		CartItem cartItem = testGraphQLCartItem_addCartItem();
+		CartItem cartItem = testGraphQLDeleteCartItem_addCartItem();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -249,6 +249,12 @@ public abstract class BaseCartItemResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected CartItem testGraphQLDeleteCartItem_addCartItem()
+		throws Exception {
+
+		return testGraphQLCartItem_addCartItem();
+	}
+
 	@Test
 	public void testGetCartItem() throws Exception {
 		CartItem postCartItem = testGetCartItem_addCartItem();
@@ -267,7 +273,7 @@ public abstract class BaseCartItemResourceTestCase {
 
 	@Test
 	public void testGraphQLGetCartItem() throws Exception {
-		CartItem cartItem = testGraphQLCartItem_addCartItem();
+		CartItem cartItem = testGraphQLGetCartItem_addCartItem();
 
 		Assert.assertTrue(
 			equals(
@@ -304,6 +310,10 @@ public abstract class BaseCartItemResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected CartItem testGraphQLGetCartItem_addCartItem() throws Exception {
+		return testGraphQLCartItem_addCartItem();
 	}
 
 	@Test
@@ -480,8 +490,8 @@ public abstract class BaseCartItemResourceTestCase {
 
 		Assert.assertEquals(0, cartItemsJSONObject.get("totalCount"));
 
-		CartItem cartItem1 = testGraphQLCartItem_addCartItem();
-		CartItem cartItem2 = testGraphQLCartItem_addCartItem();
+		CartItem cartItem1 = testGraphQLGetCartItemsPage_addCartItem();
+		CartItem cartItem2 = testGraphQLGetCartItemsPage_addCartItem();
 
 		cartItemsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -493,6 +503,12 @@ public abstract class BaseCartItemResourceTestCase {
 			Arrays.asList(cartItem1, cartItem2),
 			Arrays.asList(
 				CartItemSerDes.toDTOs(cartItemsJSONObject.getString("items"))));
+	}
+
+	protected CartItem testGraphQLGetCartItemsPage_addCartItem()
+		throws Exception {
+
+		return testGraphQLCartItem_addCartItem();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartResourceTestCase.java
@@ -238,7 +238,7 @@ public abstract class BaseCartResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteCart() throws Exception {
-		Cart cart = testGraphQLCart_addCart();
+		Cart cart = testGraphQLDeleteCart_addCart();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -267,6 +267,10 @@ public abstract class BaseCartResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Cart testGraphQLDeleteCart_addCart() throws Exception {
+		return testGraphQLCart_addCart();
+	}
+
 	@Test
 	public void testGetCart() throws Exception {
 		Cart postCart = testGetCart_addCart();
@@ -284,7 +288,7 @@ public abstract class BaseCartResourceTestCase {
 
 	@Test
 	public void testGraphQLGetCart() throws Exception {
-		Cart cart = testGraphQLCart_addCart();
+		Cart cart = testGraphQLGetCart_addCart();
 
 		Assert.assertTrue(
 			equals(
@@ -321,6 +325,10 @@ public abstract class BaseCartResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Cart testGraphQLGetCart_addCart() throws Exception {
+		return testGraphQLCart_addCart();
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -531,10 +531,15 @@ public abstract class BaseProductResourceTestCase {
 		Product postProduct = testGetChannelProduct_addProduct();
 
 		Product getProduct = productResource.getChannelProduct(
-			null, postProduct.getId(), null);
+			testGetChannelProduct_getChannelId(), postProduct.getId(), null);
 
 		assertEquals(postProduct, getProduct);
 		assertValid(getProduct);
+	}
+
+	protected Long testGetChannelProduct_getChannelId() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Product testGetChannelProduct_addProduct() throws Exception {
@@ -556,12 +561,21 @@ public abstract class BaseProductResourceTestCase {
 								"channelProduct",
 								new HashMap<String, Object>() {
 									{
-										put("channelId", null);
+										put(
+											"channelId",
+											testGraphQLGetChannelProduct_getChannelId());
 										put("productId", product.getId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/channelProduct"))));
+	}
+
+	protected Long testGraphQLGetChannelProduct_getChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -549,7 +549,7 @@ public abstract class BaseProductResourceTestCase {
 
 	@Test
 	public void testGraphQLGetChannelProduct() throws Exception {
-		Product product = testGraphQLProduct_addProduct();
+		Product product = testGraphQLGetChannelProduct_addProduct();
 
 		Assert.assertTrue(
 			equals(
@@ -598,6 +598,12 @@ public abstract class BaseProductResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Product testGraphQLGetChannelProduct_addProduct()
+		throws Exception {
+
+		return testGraphQLProduct_addProduct();
 	}
 
 	@Rule

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
@@ -549,7 +549,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 	@Test
 	public void testGraphQLDeleteDataDefinition() throws Exception {
 		DataDefinition dataDefinition =
-			testGraphQLDataDefinition_addDataDefinition();
+			testGraphQLDeleteDataDefinition_addDataDefinition();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -578,6 +578,12 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected DataDefinition testGraphQLDeleteDataDefinition_addDataDefinition()
+		throws Exception {
+
+		return testGraphQLDataDefinition_addDataDefinition();
+	}
+
 	@Test
 	public void testGetDataDefinition() throws Exception {
 		DataDefinition postDataDefinition =
@@ -601,7 +607,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 	@Test
 	public void testGraphQLGetDataDefinition() throws Exception {
 		DataDefinition dataDefinition =
-			testGraphQLDataDefinition_addDataDefinition();
+			testGraphQLGetDataDefinition_addDataDefinition();
 
 		Assert.assertTrue(
 			equals(
@@ -642,6 +648,12 @@ public abstract class BaseDataDefinitionResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected DataDefinition testGraphQLGetDataDefinition_addDataDefinition()
+		throws Exception {
+
+		return testGraphQLDataDefinition_addDataDefinition();
 	}
 
 	@Test
@@ -1132,7 +1144,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		throws Exception {
 
 		DataDefinition dataDefinition =
-			testGraphQLDataDefinition_addDataDefinition();
+			testGraphQLGetSiteDataDefinitionByContentTypeByDataDefinitionKey_addDataDefinition();
 
 		Assert.assertTrue(
 			equals(
@@ -1195,6 +1207,13 @@ public abstract class BaseDataDefinitionResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected DataDefinition
+			testGraphQLGetSiteDataDefinitionByContentTypeByDataDefinitionKey_addDataDefinition()
+		throws Exception {
+
+		return testGraphQLDataDefinition_addDataDefinition();
 	}
 
 	protected DataDefinition testGraphQLDataDefinition_addDataDefinition()

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
@@ -523,7 +523,7 @@ public abstract class BaseDataLayoutResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteDataLayout() throws Exception {
-		DataLayout dataLayout = testGraphQLDataLayout_addDataLayout();
+		DataLayout dataLayout = testGraphQLDeleteDataLayout_addDataLayout();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -552,6 +552,12 @@ public abstract class BaseDataLayoutResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected DataLayout testGraphQLDeleteDataLayout_addDataLayout()
+		throws Exception {
+
+		return testGraphQLDataLayout_addDataLayout();
+	}
+
 	@Test
 	public void testGetDataLayout() throws Exception {
 		DataLayout postDataLayout = testGetDataLayout_addDataLayout();
@@ -570,7 +576,7 @@ public abstract class BaseDataLayoutResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDataLayout() throws Exception {
-		DataLayout dataLayout = testGraphQLDataLayout_addDataLayout();
+		DataLayout dataLayout = testGraphQLGetDataLayout_addDataLayout();
 
 		Assert.assertTrue(
 			equals(
@@ -607,6 +613,12 @@ public abstract class BaseDataLayoutResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected DataLayout testGraphQLGetDataLayout_addDataLayout()
+		throws Exception {
+
+		return testGraphQLDataLayout_addDataLayout();
 	}
 
 	@Test
@@ -666,7 +678,8 @@ public abstract class BaseDataLayoutResourceTestCase {
 	public void testGraphQLGetSiteDataLayoutByContentTypeByDataLayoutKey()
 		throws Exception {
 
-		DataLayout dataLayout = testGraphQLDataLayout_addDataLayout();
+		DataLayout dataLayout =
+			testGraphQLGetSiteDataLayoutByContentTypeByDataLayoutKey_addDataLayout();
 
 		Assert.assertTrue(
 			equals(
@@ -725,6 +738,13 @@ public abstract class BaseDataLayoutResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected DataLayout
+			testGraphQLGetSiteDataLayoutByContentTypeByDataLayoutKey_addDataLayout()
+		throws Exception {
+
+		return testGraphQLDataLayout_addDataLayout();
 	}
 
 	protected DataLayout testGraphQLDataLayout_addDataLayout()

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
@@ -532,7 +532,8 @@ public abstract class BaseDataListViewResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteDataListView() throws Exception {
-		DataListView dataListView = testGraphQLDataListView_addDataListView();
+		DataListView dataListView =
+			testGraphQLDeleteDataListView_addDataListView();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -561,6 +562,12 @@ public abstract class BaseDataListViewResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected DataListView testGraphQLDeleteDataListView_addDataListView()
+		throws Exception {
+
+		return testGraphQLDataListView_addDataListView();
+	}
+
 	@Test
 	public void testGetDataListView() throws Exception {
 		DataListView postDataListView = testGetDataListView_addDataListView();
@@ -581,7 +588,8 @@ public abstract class BaseDataListViewResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDataListView() throws Exception {
-		DataListView dataListView = testGraphQLDataListView_addDataListView();
+		DataListView dataListView =
+			testGraphQLGetDataListView_addDataListView();
 
 		Assert.assertTrue(
 			equals(
@@ -620,6 +628,12 @@ public abstract class BaseDataListViewResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected DataListView testGraphQLGetDataListView_addDataListView()
+		throws Exception {
+
+		return testGraphQLDataListView_addDataListView();
 	}
 
 	@Test

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
@@ -225,7 +225,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		throws Exception {
 
 		DataRecordCollection dataRecordCollection =
-			testGraphQLDataRecordCollection_addDataRecordCollection();
+			testGraphQLGetDataDefinitionDataRecordCollection_addDataRecordCollection();
 
 		Assert.assertTrue(
 			equals(
@@ -270,6 +270,13 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected DataRecordCollection
+			testGraphQLGetDataDefinitionDataRecordCollection_addDataRecordCollection()
+		throws Exception {
+
+		return testGraphQLDataRecordCollection_addDataRecordCollection();
 	}
 
 	@Test
@@ -475,7 +482,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 	@Test
 	public void testGraphQLDeleteDataRecordCollection() throws Exception {
 		DataRecordCollection dataRecordCollection =
-			testGraphQLDataRecordCollection_addDataRecordCollection();
+			testGraphQLDeleteDataRecordCollection_addDataRecordCollection();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -508,6 +515,13 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected DataRecordCollection
+			testGraphQLDeleteDataRecordCollection_addDataRecordCollection()
+		throws Exception {
+
+		return testGraphQLDataRecordCollection_addDataRecordCollection();
+	}
+
 	@Test
 	public void testGetDataRecordCollection() throws Exception {
 		DataRecordCollection postDataRecordCollection =
@@ -532,7 +546,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 	@Test
 	public void testGraphQLGetDataRecordCollection() throws Exception {
 		DataRecordCollection dataRecordCollection =
-			testGraphQLDataRecordCollection_addDataRecordCollection();
+			testGraphQLGetDataRecordCollection_addDataRecordCollection();
 
 		Assert.assertTrue(
 			equals(
@@ -573,6 +587,13 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected DataRecordCollection
+			testGraphQLGetDataRecordCollection_addDataRecordCollection()
+		throws Exception {
+
+		return testGraphQLDataRecordCollection_addDataRecordCollection();
 	}
 
 	@Test
@@ -710,7 +731,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		throws Exception {
 
 		DataRecordCollection dataRecordCollection =
-			testGraphQLDataRecordCollection_addDataRecordCollection();
+			testGraphQLGetSiteDataRecordCollectionByDataRecordCollectionKey_addDataRecordCollection();
 
 		Assert.assertTrue(
 			equals(
@@ -766,6 +787,13 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected DataRecordCollection
+			testGraphQLGetSiteDataRecordCollectionByDataRecordCollectionKey_addDataRecordCollection()
+		throws Exception {
+
+		return testGraphQLDataRecordCollection_addDataRecordCollection();
 	}
 
 	protected DataRecordCollection

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
@@ -787,7 +787,7 @@ public abstract class BaseDataRecordResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteDataRecord() throws Exception {
-		DataRecord dataRecord = testGraphQLDataRecord_addDataRecord();
+		DataRecord dataRecord = testGraphQLDeleteDataRecord_addDataRecord();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -816,6 +816,12 @@ public abstract class BaseDataRecordResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected DataRecord testGraphQLDeleteDataRecord_addDataRecord()
+		throws Exception {
+
+		return testGraphQLDataRecord_addDataRecord();
+	}
+
 	@Test
 	public void testGetDataRecord() throws Exception {
 		DataRecord postDataRecord = testGetDataRecord_addDataRecord();
@@ -834,7 +840,7 @@ public abstract class BaseDataRecordResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDataRecord() throws Exception {
-		DataRecord dataRecord = testGraphQLDataRecord_addDataRecord();
+		DataRecord dataRecord = testGraphQLGetDataRecord_addDataRecord();
 
 		Assert.assertTrue(
 			equals(
@@ -871,6 +877,12 @@ public abstract class BaseDataRecordResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected DataRecord testGraphQLGetDataRecord_addDataRecord()
+		throws Exception {
+
+		return testGraphQLDataRecord_addDataRecord();
 	}
 
 	@Test

--- a/modules/apps/digital-signature/digital-signature-rest-test/src/testIntegration/java/com/liferay/digital/signature/rest/resource/v1_0/test/BaseDSEnvelopeResourceTestCase.java
+++ b/modules/apps/digital-signature/digital-signature-rest-test/src/testIntegration/java/com/liferay/digital/signature/rest/resource/v1_0/test/BaseDSEnvelopeResourceTestCase.java
@@ -348,7 +348,7 @@ public abstract class BaseDSEnvelopeResourceTestCase {
 
 	@Test
 	public void testGraphQLGetSiteDSEnvelope() throws Exception {
-		DSEnvelope dsEnvelope = testGraphQLDSEnvelope_addDSEnvelope();
+		DSEnvelope dsEnvelope = testGraphQLGetSiteDSEnvelope_addDSEnvelope();
 
 		Assert.assertTrue(
 			equals(
@@ -395,6 +395,12 @@ public abstract class BaseDSEnvelopeResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected DSEnvelope testGraphQLGetSiteDSEnvelope_addDSEnvelope()
+		throws Exception {
+
+		return testGraphQLDSEnvelope_addDSEnvelope();
 	}
 
 	protected void appendGraphQLFieldValue(StringBuilder sb, Object value)

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -650,17 +650,26 @@ public abstract class BaseStructuredContentResourceTestCase {
 			204,
 			structuredContentResource.
 				deleteStructuredContentByVersionHttpResponse(
-					structuredContent.getId(), null));
+					structuredContent.getId(),
+					testDeleteStructuredContentByVersion_getVersion()));
 
 		assertHttpResponseStatusCode(
 			404,
 			structuredContentResource.getStructuredContentByVersionHttpResponse(
-				structuredContent.getId(), null));
+				structuredContent.getId(),
+				testDeleteStructuredContentByVersion_getVersion()));
 
 		assertHttpResponseStatusCode(
 			404,
 			structuredContentResource.getStructuredContentByVersionHttpResponse(
-				0L, null));
+				0L, testDeleteStructuredContentByVersion_getVersion()));
+	}
+
+	protected Double testDeleteStructuredContentByVersion_getVersion()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected StructuredContent
@@ -678,10 +687,18 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 		StructuredContent getStructuredContent =
 			structuredContentResource.getStructuredContentByVersion(
-				postStructuredContent.getId(), null);
+				postStructuredContent.getId(),
+				testGetStructuredContentByVersion_getVersion());
 
 		assertEquals(postStructuredContent, getStructuredContent);
 		assertValid(getStructuredContent);
+	}
+
+	protected Double testGetStructuredContentByVersion_getVersion()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected StructuredContent
@@ -710,12 +727,21 @@ public abstract class BaseStructuredContentResourceTestCase {
 										put(
 											"structuredContentId",
 											structuredContent.getId());
-										put("version", null);
+										put(
+											"version",
+											testGraphQLGetStructuredContentByVersion_getVersion());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/structuredContentByVersion"))));
+	}
+
+	protected Double testGraphQLGetStructuredContentByVersion_getVersion()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -601,9 +601,9 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Assert.assertEquals(0, structuredContentsJSONObject.get("totalCount"));
 
 		StructuredContent structuredContent1 =
-			testGraphQLStructuredContent_addStructuredContent();
+			testGraphQLGetSiteStructuredContentsPage_addStructuredContent();
 		StructuredContent structuredContent2 =
-			testGraphQLStructuredContent_addStructuredContent();
+			testGraphQLGetSiteStructuredContentsPage_addStructuredContent();
 
 		structuredContentsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -617,6 +617,13 @@ public abstract class BaseStructuredContentResourceTestCase {
 			Arrays.asList(
 				StructuredContentSerDes.toDTOs(
 					structuredContentsJSONObject.getString("items"))));
+	}
+
+	protected StructuredContent
+			testGraphQLGetSiteStructuredContentsPage_addStructuredContent()
+		throws Exception {
+
+		return testGraphQLStructuredContent_addStructuredContent();
 	}
 
 	@Test
@@ -712,7 +719,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 	@Test
 	public void testGraphQLGetStructuredContentByVersion() throws Exception {
 		StructuredContent structuredContent =
-			testGraphQLStructuredContent_addStructuredContent();
+			testGraphQLGetStructuredContentByVersion_addStructuredContent();
 
 		Assert.assertTrue(
 			equals(
@@ -768,6 +775,13 @@ public abstract class BaseStructuredContentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected StructuredContent
+			testGraphQLGetStructuredContentByVersion_addStructuredContent()
+		throws Exception {
+
+		return testGraphQLStructuredContent_addStructuredContent();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
@@ -77,40 +77,6 @@ public class StructuredContentResourceTest
 
 	@Override
 	@Test
-	public void testDeleteStructuredContentByVersion() throws Exception {
-		StructuredContent structuredContent = _postSiteStructuredContent(
-			testGroup.getGroupId(), randomStructuredContent());
-
-		Page<StructuredContent> structuredContentsVersionsPage =
-			structuredContentResource.getStructuredContentsVersionsPage(
-				structuredContent.getId());
-
-		Assert.assertEquals(1L, structuredContentsVersionsPage.getTotalCount());
-
-		structuredContentResource.deleteStructuredContentByVersion(
-			structuredContent.getId(), 1.0D);
-
-		assertHttpResponseStatusCode(
-			404,
-			structuredContentResource.getStructuredContentByVersionHttpResponse(
-				structuredContent.getId(), 1.0D));
-	}
-
-	@Override
-	@Test
-	public void testGetStructuredContentByVersion() throws Exception {
-		StructuredContent structuredContent = _postSiteStructuredContent(
-			testGroup.getGroupId(), randomStructuredContent());
-
-		StructuredContent structuredContentVersion =
-			structuredContentResource.getStructuredContentByVersion(
-				structuredContent.getId(), 1.0D);
-
-		assertEquals(structuredContent, structuredContentVersion);
-	}
-
-	@Override
-	@Test
 	public void testGetStructuredContentsVersionsPage() throws Exception {
 		StructuredContent structuredContent = _postSiteStructuredContent(
 			testGroup.getGroupId(), randomStructuredContent());
@@ -219,11 +185,43 @@ public class StructuredContentResourceTest
 
 	@Override
 	protected StructuredContent
+			testDeleteStructuredContentByVersion_addStructuredContent()
+		throws Exception {
+
+		return _postSiteStructuredContent(
+			testGroup.getGroupId(), randomStructuredContent());
+	}
+
+	@Override
+	protected Double testDeleteStructuredContentByVersion_getVersion()
+		throws Exception {
+
+		return 1.0D;
+	}
+
+	@Override
+	protected StructuredContent
 			testGetSiteStructuredContentsPage_addStructuredContent(
 				Long siteId, StructuredContent structuredContent)
 		throws Exception {
 
 		return _postSiteStructuredContent(siteId, structuredContent);
+	}
+
+	@Override
+	protected StructuredContent
+			testGetStructuredContentByVersion_addStructuredContent()
+		throws Exception {
+
+		return _postSiteStructuredContent(
+			testGroup.getGroupId(), randomStructuredContent());
+	}
+
+	@Override
+	protected Double testGetStructuredContentByVersion_getVersion()
+		throws Exception {
+
+		return 1.0D;
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
@@ -561,9 +561,9 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 		long totalCount = listTypeDefinitionsJSONObject.getLong("totalCount");
 
 		ListTypeDefinition listTypeDefinition1 =
-			testGraphQLListTypeDefinition_addListTypeDefinition();
+			testGraphQLGetListTypeDefinitionsPage_addListTypeDefinition();
 		ListTypeDefinition listTypeDefinition2 =
-			testGraphQLListTypeDefinition_addListTypeDefinition();
+			testGraphQLGetListTypeDefinitionsPage_addListTypeDefinition();
 
 		listTypeDefinitionsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -583,6 +583,13 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 			Arrays.asList(
 				ListTypeDefinitionSerDes.toDTOs(
 					listTypeDefinitionsJSONObject.getString("items"))));
+	}
+
+	protected ListTypeDefinition
+			testGraphQLGetListTypeDefinitionsPage_addListTypeDefinition()
+		throws Exception {
+
+		return testGraphQLListTypeDefinition_addListTypeDefinition();
 	}
 
 	@Test
@@ -639,7 +646,7 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 	@Test
 	public void testGraphQLDeleteListTypeDefinition() throws Exception {
 		ListTypeDefinition listTypeDefinition =
-			testGraphQLListTypeDefinition_addListTypeDefinition();
+			testGraphQLDeleteListTypeDefinition_addListTypeDefinition();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -672,6 +679,13 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected ListTypeDefinition
+			testGraphQLDeleteListTypeDefinition_addListTypeDefinition()
+		throws Exception {
+
+		return testGraphQLListTypeDefinition_addListTypeDefinition();
+	}
+
 	@Test
 	public void testGetListTypeDefinition() throws Exception {
 		ListTypeDefinition postListTypeDefinition =
@@ -696,7 +710,7 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 	@Test
 	public void testGraphQLGetListTypeDefinition() throws Exception {
 		ListTypeDefinition listTypeDefinition =
-			testGraphQLListTypeDefinition_addListTypeDefinition();
+			testGraphQLGetListTypeDefinition_addListTypeDefinition();
 
 		Assert.assertTrue(
 			equals(
@@ -737,6 +751,13 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ListTypeDefinition
+			testGraphQLGetListTypeDefinition_addListTypeDefinition()
+		throws Exception {
+
+		return testGraphQLListTypeDefinition_addListTypeDefinition();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeEntryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeEntryResourceTestCase.java
@@ -637,7 +637,7 @@ public abstract class BaseListTypeEntryResourceTestCase {
 	@Test
 	public void testGraphQLDeleteListTypeEntry() throws Exception {
 		ListTypeEntry listTypeEntry =
-			testGraphQLListTypeEntry_addListTypeEntry();
+			testGraphQLDeleteListTypeEntry_addListTypeEntry();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -666,6 +666,12 @@ public abstract class BaseListTypeEntryResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected ListTypeEntry testGraphQLDeleteListTypeEntry_addListTypeEntry()
+		throws Exception {
+
+		return testGraphQLListTypeEntry_addListTypeEntry();
+	}
+
 	@Test
 	public void testGetListTypeEntry() throws Exception {
 		ListTypeEntry postListTypeEntry =
@@ -688,7 +694,7 @@ public abstract class BaseListTypeEntryResourceTestCase {
 	@Test
 	public void testGraphQLGetListTypeEntry() throws Exception {
 		ListTypeEntry listTypeEntry =
-			testGraphQLListTypeEntry_addListTypeEntry();
+			testGraphQLGetListTypeEntry_addListTypeEntry();
 
 		Assert.assertTrue(
 			equals(
@@ -729,6 +735,12 @@ public abstract class BaseListTypeEntryResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ListTypeEntry testGraphQLGetListTypeEntry_addListTypeEntry()
+		throws Exception {
+
+		return testGraphQLListTypeEntry_addListTypeEntry();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -735,7 +735,7 @@ public abstract class BaseKeywordResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteKeyword() throws Exception {
-		Keyword keyword = testGraphQLKeyword_addKeyword();
+		Keyword keyword = testGraphQLDeleteKeyword_addKeyword();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -764,6 +764,10 @@ public abstract class BaseKeywordResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Keyword testGraphQLDeleteKeyword_addKeyword() throws Exception {
+		return testGraphQLKeyword_addKeyword();
+	}
+
 	@Test
 	public void testGetKeyword() throws Exception {
 		Keyword postKeyword = testGetKeyword_addKeyword();
@@ -781,7 +785,7 @@ public abstract class BaseKeywordResourceTestCase {
 
 	@Test
 	public void testGraphQLGetKeyword() throws Exception {
-		Keyword keyword = testGraphQLKeyword_addKeyword();
+		Keyword keyword = testGraphQLGetKeyword_addKeyword();
 
 		Assert.assertTrue(
 			equals(
@@ -818,6 +822,10 @@ public abstract class BaseKeywordResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Keyword testGraphQLGetKeyword_addKeyword() throws Exception {
+		return testGraphQLKeyword_addKeyword();
 	}
 
 	@Test
@@ -1217,8 +1225,8 @@ public abstract class BaseKeywordResourceTestCase {
 
 		Assert.assertEquals(0, keywordsJSONObject.get("totalCount"));
 
-		Keyword keyword1 = testGraphQLKeyword_addKeyword();
-		Keyword keyword2 = testGraphQLKeyword_addKeyword();
+		Keyword keyword1 = testGraphQLGetSiteKeywordsPage_addKeyword();
+		Keyword keyword2 = testGraphQLGetSiteKeywordsPage_addKeyword();
 
 		keywordsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -1230,6 +1238,12 @@ public abstract class BaseKeywordResourceTestCase {
 			Arrays.asList(keyword1, keyword2),
 			Arrays.asList(
 				KeywordSerDes.toDTOs(keywordsJSONObject.getString("items"))));
+	}
+
+	protected Keyword testGraphQLGetSiteKeywordsPage_addKeyword()
+		throws Exception {
+
+		return testGraphQLKeyword_addKeyword();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -759,7 +759,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	@Test
 	public void testGraphQLDeleteTaxonomyCategory() throws Exception {
 		TaxonomyCategory taxonomyCategory =
-			testGraphQLTaxonomyCategory_addTaxonomyCategory();
+			testGraphQLDeleteTaxonomyCategory_addTaxonomyCategory();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -792,6 +792,13 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected TaxonomyCategory
+			testGraphQLDeleteTaxonomyCategory_addTaxonomyCategory()
+		throws Exception {
+
+		return testGraphQLTaxonomyCategory_addTaxonomyCategory();
+	}
+
 	@Test
 	public void testGetTaxonomyCategory() throws Exception {
 		TaxonomyCategory postTaxonomyCategory =
@@ -815,7 +822,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	@Test
 	public void testGraphQLGetTaxonomyCategory() throws Exception {
 		TaxonomyCategory taxonomyCategory =
-			testGraphQLTaxonomyCategory_addTaxonomyCategory();
+			testGraphQLGetTaxonomyCategory_addTaxonomyCategory();
 
 		Assert.assertTrue(
 			equals(
@@ -858,6 +865,13 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected TaxonomyCategory
+			testGraphQLGetTaxonomyCategory_addTaxonomyCategory()
+		throws Exception {
+
+		return testGraphQLTaxonomyCategory_addTaxonomyCategory();
 	}
 
 	@Test
@@ -1484,7 +1498,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		throws Exception {
 
 		TaxonomyCategory taxonomyCategory =
-			testGraphQLTaxonomyCategory_addTaxonomyCategory();
+			testGraphQLGetTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_addTaxonomyCategory();
 
 		Assert.assertTrue(
 			equals(
@@ -1540,6 +1554,13 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected TaxonomyCategory
+			testGraphQLGetTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode_addTaxonomyCategory()
+		throws Exception {
+
+		return testGraphQLTaxonomyCategory_addTaxonomyCategory();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -1106,9 +1106,9 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			0, taxonomyVocabulariesJSONObject.get("totalCount"));
 
 		TaxonomyVocabulary taxonomyVocabulary1 =
-			testGraphQLTaxonomyVocabulary_addTaxonomyVocabulary();
+			testGraphQLGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary();
 		TaxonomyVocabulary taxonomyVocabulary2 =
-			testGraphQLTaxonomyVocabulary_addTaxonomyVocabulary();
+			testGraphQLGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary();
 
 		taxonomyVocabulariesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -1122,6 +1122,13 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			Arrays.asList(
 				TaxonomyVocabularySerDes.toDTOs(
 					taxonomyVocabulariesJSONObject.getString("items"))));
+	}
+
+	protected TaxonomyVocabulary
+			testGraphQLGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary()
+		throws Exception {
+
+		return testGraphQLTaxonomyVocabulary_addTaxonomyVocabulary();
 	}
 
 	@Test
@@ -1227,7 +1234,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		throws Exception {
 
 		TaxonomyVocabulary taxonomyVocabulary =
-			testGraphQLTaxonomyVocabulary_addTaxonomyVocabulary();
+			testGraphQLGetSiteTaxonomyVocabularyByExternalReferenceCode_addTaxonomyVocabulary();
 
 		Assert.assertTrue(
 			equals(
@@ -1283,6 +1290,13 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected TaxonomyVocabulary
+			testGraphQLGetSiteTaxonomyVocabularyByExternalReferenceCode_addTaxonomyVocabulary()
+		throws Exception {
+
+		return testGraphQLTaxonomyVocabulary_addTaxonomyVocabulary();
 	}
 
 	@Test
@@ -1455,7 +1469,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	@Test
 	public void testGraphQLDeleteTaxonomyVocabulary() throws Exception {
 		TaxonomyVocabulary taxonomyVocabulary =
-			testGraphQLTaxonomyVocabulary_addTaxonomyVocabulary();
+			testGraphQLDeleteTaxonomyVocabulary_addTaxonomyVocabulary();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -1488,6 +1502,13 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected TaxonomyVocabulary
+			testGraphQLDeleteTaxonomyVocabulary_addTaxonomyVocabulary()
+		throws Exception {
+
+		return testGraphQLTaxonomyVocabulary_addTaxonomyVocabulary();
+	}
+
 	@Test
 	public void testGetTaxonomyVocabulary() throws Exception {
 		TaxonomyVocabulary postTaxonomyVocabulary =
@@ -1512,7 +1533,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	@Test
 	public void testGraphQLGetTaxonomyVocabulary() throws Exception {
 		TaxonomyVocabulary taxonomyVocabulary =
-			testGraphQLTaxonomyVocabulary_addTaxonomyVocabulary();
+			testGraphQLGetTaxonomyVocabulary_addTaxonomyVocabulary();
 
 		Assert.assertTrue(
 			equals(
@@ -1553,6 +1574,13 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected TaxonomyVocabulary
+			testGraphQLGetTaxonomyVocabulary_addTaxonomyVocabulary()
+		throws Exception {
+
+		return testGraphQLTaxonomyVocabulary_addTaxonomyVocabulary();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
@@ -516,6 +516,22 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 	}
 
 	@Override
+	protected String
+			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getEmailAddress()
+		throws Exception {
+
+		return null;
+	}
+
+	@Override
+	protected String
+			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getExternalReferenceCode()
+		throws Exception {
+
+		return null;
+	}
+
+	@Override
 	protected AccountRole
 			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_addAccountRole()
 		throws Exception {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -921,7 +921,15 @@ public abstract class BaseAccountResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			204,
-			accountResource.deleteOrganizationAccountsHttpResponse(null, null));
+			accountResource.deleteOrganizationAccountsHttpResponse(
+				testDeleteOrganizationAccounts_getOrganizationId(), null));
+	}
+
+	protected Long testDeleteOrganizationAccounts_getOrganizationId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Account testDeleteOrganizationAccounts_addAccount()
@@ -1310,7 +1318,16 @@ public abstract class BaseAccountResourceTestCase {
 			204,
 			accountResource.
 				deleteOrganizationAccountsByExternalReferenceCodeHttpResponse(
-					null, null));
+					testDeleteOrganizationAccountsByExternalReferenceCode_getOrganizationId(),
+					null));
+	}
+
+	protected Long
+			testDeleteOrganizationAccountsByExternalReferenceCode_getOrganizationId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Account

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -488,8 +488,8 @@ public abstract class BaseAccountResourceTestCase {
 
 		long totalCount = accountsJSONObject.getLong("totalCount");
 
-		Account account1 = testGraphQLAccount_addAccount();
-		Account account2 = testGraphQLAccount_addAccount();
+		Account account1 = testGraphQLGetAccountsPage_addAccount();
+		Account account2 = testGraphQLGetAccountsPage_addAccount();
 
 		accountsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -506,6 +506,10 @@ public abstract class BaseAccountResourceTestCase {
 			account2,
 			Arrays.asList(
 				AccountSerDes.toDTOs(accountsJSONObject.getString("items"))));
+	}
+
+	protected Account testGraphQLGetAccountsPage_addAccount() throws Exception {
+		return testGraphQLAccount_addAccount();
 	}
 
 	@Test
@@ -576,7 +580,8 @@ public abstract class BaseAccountResourceTestCase {
 	public void testGraphQLGetAccountByExternalReferenceCode()
 		throws Exception {
 
-		Account account = testGraphQLAccount_addAccount();
+		Account account =
+			testGraphQLGetAccountByExternalReferenceCode_addAccount();
 
 		Assert.assertTrue(
 			equals(
@@ -624,6 +629,12 @@ public abstract class BaseAccountResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Account testGraphQLGetAccountByExternalReferenceCode_addAccount()
+		throws Exception {
+
+		return testGraphQLAccount_addAccount();
 	}
 
 	@Test
@@ -729,7 +740,7 @@ public abstract class BaseAccountResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteAccount() throws Exception {
-		Account account = testGraphQLAccount_addAccount();
+		Account account = testGraphQLDeleteAccount_addAccount();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -758,6 +769,10 @@ public abstract class BaseAccountResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Account testGraphQLDeleteAccount_addAccount() throws Exception {
+		return testGraphQLAccount_addAccount();
+	}
+
 	@Test
 	public void testGetAccount() throws Exception {
 		Account postAccount = testGetAccount_addAccount();
@@ -775,7 +790,7 @@ public abstract class BaseAccountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetAccount() throws Exception {
-		Account account = testGraphQLAccount_addAccount();
+		Account account = testGraphQLGetAccount_addAccount();
 
 		Assert.assertTrue(
 			equals(
@@ -812,6 +827,10 @@ public abstract class BaseAccountResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Account testGraphQLGetAccount_addAccount() throws Exception {
+		return testGraphQLAccount_addAccount();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
@@ -211,7 +211,25 @@ public abstract class BaseAccountRoleResourceTestCase {
 			204,
 			accountRoleResource.
 				deleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCodeHttpResponse(
-					null, accountRole.getId(), null));
+					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getAccountExternalReferenceCode(),
+					accountRole.getId(),
+					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getUserAccountExternalReferenceCode()));
+	}
+
+	protected String
+			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getAccountExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getUserAccountExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected AccountRole
@@ -783,7 +801,25 @@ public abstract class BaseAccountRoleResourceTestCase {
 			204,
 			accountRoleResource.
 				deleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddressHttpResponse(
-					null, accountRole.getId(), null));
+					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getExternalReferenceCode(),
+					accountRole.getId(),
+					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getEmailAddress()));
+	}
+
+	protected String
+			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getEmailAddress()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected AccountRole
@@ -1309,7 +1345,16 @@ public abstract class BaseAccountRoleResourceTestCase {
 			204,
 			accountRoleResource.
 				deleteAccountAccountRoleUserAccountAssociationHttpResponse(
-					accountRole.getAccountId(), accountRole.getId(), null));
+					accountRole.getAccountId(), accountRole.getId(),
+					testDeleteAccountAccountRoleUserAccountAssociation_getUserAccountId()));
+	}
+
+	protected Long
+			testDeleteAccountAccountRoleUserAccountAssociation_getUserAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected AccountRole

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailAddressResourceTestCase.java
@@ -210,7 +210,8 @@ public abstract class BaseEmailAddressResourceTestCase {
 
 	@Test
 	public void testGraphQLGetEmailAddress() throws Exception {
-		EmailAddress emailAddress = testGraphQLEmailAddress_addEmailAddress();
+		EmailAddress emailAddress =
+			testGraphQLGetEmailAddress_addEmailAddress();
 
 		Assert.assertTrue(
 			equals(
@@ -249,6 +250,12 @@ public abstract class BaseEmailAddressResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected EmailAddress testGraphQLGetEmailAddress_addEmailAddress()
+		throws Exception {
+
+		return testGraphQLEmailAddress_addEmailAddress();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -1030,7 +1030,15 @@ public abstract class BaseOrganizationResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			organizationResource.deleteAccountOrganizationHttpResponse(
-				null, organization.getId()));
+				testDeleteAccountOrganization_getAccountId(),
+				organization.getId()));
+	}
+
+	protected Long testDeleteAccountOrganization_getAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Organization testDeleteAccountOrganization_addOrganization()
@@ -2210,7 +2218,15 @@ public abstract class BaseOrganizationResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			organizationResource.deleteUserAccountByEmailAddressHttpResponse(
-				organization.getId(), null));
+				organization.getId(),
+				testDeleteUserAccountByEmailAddress_getEmailAddress()));
+	}
+
+	protected String testDeleteUserAccountByEmailAddress_getEmailAddress()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Organization testDeleteUserAccountByEmailAddress_addOrganization()

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -1385,8 +1385,10 @@ public abstract class BaseOrganizationResourceTestCase {
 
 		long totalCount = organizationsJSONObject.getLong("totalCount");
 
-		Organization organization1 = testGraphQLOrganization_addOrganization();
-		Organization organization2 = testGraphQLOrganization_addOrganization();
+		Organization organization1 =
+			testGraphQLGetOrganizationsPage_addOrganization();
+		Organization organization2 =
+			testGraphQLGetOrganizationsPage_addOrganization();
 
 		organizationsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -1405,6 +1407,12 @@ public abstract class BaseOrganizationResourceTestCase {
 			Arrays.asList(
 				OrganizationSerDes.toDTOs(
 					organizationsJSONObject.getString("items"))));
+	}
+
+	protected Organization testGraphQLGetOrganizationsPage_addOrganization()
+		throws Exception {
+
+		return testGraphQLOrganization_addOrganization();
 	}
 
 	@Test
@@ -1486,7 +1494,8 @@ public abstract class BaseOrganizationResourceTestCase {
 	public void testGraphQLGetOrganizationByExternalReferenceCode()
 		throws Exception {
 
-		Organization organization = testGraphQLOrganization_addOrganization();
+		Organization organization =
+			testGraphQLGetOrganizationByExternalReferenceCode_addOrganization();
 
 		Assert.assertTrue(
 			equals(
@@ -1534,6 +1543,13 @@ public abstract class BaseOrganizationResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Organization
+			testGraphQLGetOrganizationByExternalReferenceCode_addOrganization()
+		throws Exception {
+
+		return testGraphQLOrganization_addOrganization();
 	}
 
 	@Test
@@ -1658,7 +1674,8 @@ public abstract class BaseOrganizationResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteOrganization() throws Exception {
-		Organization organization = testGraphQLOrganization_addOrganization();
+		Organization organization =
+			testGraphQLDeleteOrganization_addOrganization();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -1691,6 +1708,12 @@ public abstract class BaseOrganizationResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Organization testGraphQLDeleteOrganization_addOrganization()
+		throws Exception {
+
+		return testGraphQLOrganization_addOrganization();
+	}
+
 	@Test
 	public void testGetOrganization() throws Exception {
 		Organization postOrganization = testGetOrganization_addOrganization();
@@ -1711,7 +1734,8 @@ public abstract class BaseOrganizationResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrganization() throws Exception {
-		Organization organization = testGraphQLOrganization_addOrganization();
+		Organization organization =
+			testGraphQLGetOrganization_addOrganization();
 
 		Assert.assertTrue(
 			equals(
@@ -1751,6 +1775,12 @@ public abstract class BaseOrganizationResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Organization testGraphQLGetOrganization_addOrganization()
+		throws Exception {
+
+		return testGraphQLOrganization_addOrganization();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
@@ -271,7 +271,7 @@ public abstract class BasePhoneResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPhone() throws Exception {
-		Phone phone = testGraphQLPhone_addPhone();
+		Phone phone = testGraphQLGetPhone_addPhone();
 
 		Assert.assertTrue(
 			equals(
@@ -308,6 +308,10 @@ public abstract class BasePhoneResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Phone testGraphQLGetPhone_addPhone() throws Exception {
+		return testGraphQLPhone_addPhone();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
@@ -295,7 +295,7 @@ public abstract class BasePostalAddressResourceTestCase {
 	@Test
 	public void testGraphQLGetPostalAddress() throws Exception {
 		PostalAddress postalAddress =
-			testGraphQLPostalAddress_addPostalAddress();
+			testGraphQLGetPostalAddress_addPostalAddress();
 
 		Assert.assertTrue(
 			equals(
@@ -336,6 +336,12 @@ public abstract class BasePostalAddressResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected PostalAddress testGraphQLGetPostalAddress_addPostalAddress()
+		throws Exception {
+
+		return testGraphQLPostalAddress_addPostalAddress();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -358,7 +358,15 @@ public abstract class BaseRoleResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			roleResource.deleteRoleUserAccountAssociationHttpResponse(
-				role.getId(), null));
+				role.getId(),
+				testDeleteRoleUserAccountAssociation_getUserAccountId()));
+	}
+
+	protected Long testDeleteRoleUserAccountAssociation_getUserAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Role testDeleteRoleUserAccountAssociation_addRole()
@@ -401,7 +409,25 @@ public abstract class BaseRoleResourceTestCase {
 			204,
 			roleResource.
 				deleteOrganizationRoleUserAccountAssociationHttpResponse(
-					role.getId(), null, null));
+					role.getId(),
+					testDeleteOrganizationRoleUserAccountAssociation_getUserAccountId(),
+					testDeleteOrganizationRoleUserAccountAssociation_getOrganizationId()));
+	}
+
+	protected Long
+			testDeleteOrganizationRoleUserAccountAssociation_getUserAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Long
+			testDeleteOrganizationRoleUserAccountAssociation_getOrganizationId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Role testDeleteOrganizationRoleUserAccountAssociation_addRole()
@@ -444,7 +470,23 @@ public abstract class BaseRoleResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			roleResource.deleteSiteRoleUserAccountAssociationHttpResponse(
-				role.getId(), null, null));
+				role.getId(),
+				testDeleteSiteRoleUserAccountAssociation_getUserAccountId(),
+				testDeleteSiteRoleUserAccountAssociation_getSiteId()));
+	}
+
+	protected Long testDeleteSiteRoleUserAccountAssociation_getUserAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Long testDeleteSiteRoleUserAccountAssociation_getSiteId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Role testDeleteSiteRoleUserAccountAssociation_addRole()

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -274,8 +274,8 @@ public abstract class BaseRoleResourceTestCase {
 
 		long totalCount = rolesJSONObject.getLong("totalCount");
 
-		Role role1 = testGraphQLRole_addRole();
-		Role role2 = testGraphQLRole_addRole();
+		Role role1 = testGraphQLGetRolesPage_addRole();
+		Role role2 = testGraphQLGetRolesPage_addRole();
 
 		rolesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -292,6 +292,10 @@ public abstract class BaseRoleResourceTestCase {
 			role2,
 			Arrays.asList(
 				RoleSerDes.toDTOs(rolesJSONObject.getString("items"))));
+	}
+
+	protected Role testGraphQLGetRolesPage_addRole() throws Exception {
+		return testGraphQLRole_addRole();
 	}
 
 	@Test
@@ -311,7 +315,7 @@ public abstract class BaseRoleResourceTestCase {
 
 	@Test
 	public void testGraphQLGetRole() throws Exception {
-		Role role = testGraphQLRole_addRole();
+		Role role = testGraphQLGetRole_addRole();
 
 		Assert.assertTrue(
 			equals(
@@ -348,6 +352,10 @@ public abstract class BaseRoleResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Role testGraphQLGetRole_addRole() throws Exception {
+		return testGraphQLRole_addRole();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
@@ -313,8 +313,8 @@ public abstract class BaseSegmentResourceTestCase {
 
 		Assert.assertEquals(0, segmentsJSONObject.get("totalCount"));
 
-		Segment segment1 = testGraphQLSegment_addSegment();
-		Segment segment2 = testGraphQLSegment_addSegment();
+		Segment segment1 = testGraphQLGetSiteSegmentsPage_addSegment();
+		Segment segment2 = testGraphQLGetSiteSegmentsPage_addSegment();
 
 		segmentsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -326,6 +326,12 @@ public abstract class BaseSegmentResourceTestCase {
 			Arrays.asList(segment1, segment2),
 			Arrays.asList(
 				SegmentSerDes.toDTOs(segmentsJSONObject.getString("items"))));
+	}
+
+	protected Segment testGraphQLGetSiteSegmentsPage_addSegment()
+		throws Exception {
+
+		return testGraphQLSegment_addSegment();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSiteResourceTestCase.java
@@ -279,7 +279,7 @@ public abstract class BaseSiteResourceTestCase {
 
 	@Test
 	public void testGraphQLGetSiteByFriendlyUrlPath() throws Exception {
-		Site site = testGraphQLSite_addSite();
+		Site site = testGraphQLGetSiteByFriendlyUrlPath_addSite();
 
 		Assert.assertTrue(
 			equals(
@@ -324,6 +324,12 @@ public abstract class BaseSiteResourceTestCase {
 				"Object/code"));
 	}
 
+	protected Site testGraphQLGetSiteByFriendlyUrlPath_addSite()
+		throws Exception {
+
+		return testGraphQLSite_addSite();
+	}
+
 	@Test
 	public void testGetSite() throws Exception {
 		Site postSite = testGetSite_addSite();
@@ -341,7 +347,7 @@ public abstract class BaseSiteResourceTestCase {
 
 	@Test
 	public void testGraphQLGetSite() throws Exception {
-		Site site = testGraphQLSite_addSite();
+		Site site = testGraphQLGetSite_addSite();
 
 		Assert.assertTrue(
 			equals(
@@ -378,6 +384,10 @@ public abstract class BaseSiteResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Site testGraphQLGetSite_addSite() throws Exception {
+		return testGraphQLSite_addSite();
 	}
 
 	protected Site testGraphQLSite_addSite() throws Exception {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSubscriptionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSubscriptionResourceTestCase.java
@@ -330,7 +330,8 @@ public abstract class BaseSubscriptionResourceTestCase {
 
 	@Test
 	public void testGraphQLGetMyUserAccountSubscription() throws Exception {
-		Subscription subscription = testGraphQLSubscription_addSubscription();
+		Subscription subscription =
+			testGraphQLGetMyUserAccountSubscription_addSubscription();
 
 		Assert.assertTrue(
 			equals(
@@ -372,6 +373,13 @@ public abstract class BaseSubscriptionResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Subscription
+			testGraphQLGetMyUserAccountSubscription_addSubscription()
+		throws Exception {
+
+		return testGraphQLSubscription_addSubscription();
 	}
 
 	protected Subscription testGraphQLSubscription_addSubscription()

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -235,7 +235,24 @@ public abstract class BaseUserAccountResourceTestCase {
 			204,
 			userAccountResource.
 				deleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeHttpResponse(
-					null, null));
+					testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_getAccountExternalReferenceCode(),
+					testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_getUserAccountExternalReferenceCode()));
+	}
+
+	protected String
+			testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_getAccountExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_getUserAccountExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected UserAccount
@@ -1181,7 +1198,15 @@ public abstract class BaseUserAccountResourceTestCase {
 			204,
 			userAccountResource.
 				deleteAccountUserAccountsByEmailAddressHttpResponse(
-					null, null));
+					testDeleteAccountUserAccountsByEmailAddress_getAccountId(),
+					null));
+	}
+
+	protected Long testDeleteAccountUserAccountsByEmailAddress_getAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected UserAccount
@@ -1207,7 +1232,15 @@ public abstract class BaseUserAccountResourceTestCase {
 			204,
 			userAccountResource.
 				deleteAccountUserAccountByEmailAddressHttpResponse(
-					null, userAccount.getEmailAddress()));
+					testDeleteAccountUserAccountByEmailAddress_getAccountId(),
+					userAccount.getEmailAddress()));
+	}
+
+	protected Long testDeleteAccountUserAccountByEmailAddress_getAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected UserAccount

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -1291,7 +1291,7 @@ public abstract class BaseUserAccountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetMyUserAccount() throws Exception {
-		UserAccount userAccount = testGraphQLUserAccount_addUserAccount();
+		UserAccount userAccount = testGraphQLGetMyUserAccount_addUserAccount();
 
 		Assert.assertTrue(
 			equals(
@@ -1312,6 +1312,12 @@ public abstract class BaseUserAccountResourceTestCase {
 	@Test
 	public void testGraphQLGetMyUserAccountNotFound() throws Exception {
 		Assert.assertTrue(true);
+	}
+
+	protected UserAccount testGraphQLGetMyUserAccount_addUserAccount()
+		throws Exception {
+
+		return testGraphQLUserAccount_addUserAccount();
 	}
 
 	@Test
@@ -2312,8 +2318,10 @@ public abstract class BaseUserAccountResourceTestCase {
 
 		long totalCount = userAccountsJSONObject.getLong("totalCount");
 
-		UserAccount userAccount1 = testGraphQLUserAccount_addUserAccount();
-		UserAccount userAccount2 = testGraphQLUserAccount_addUserAccount();
+		UserAccount userAccount1 =
+			testGraphQLGetUserAccountsPage_addUserAccount();
+		UserAccount userAccount2 =
+			testGraphQLGetUserAccountsPage_addUserAccount();
 
 		userAccountsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -2332,6 +2340,12 @@ public abstract class BaseUserAccountResourceTestCase {
 			Arrays.asList(
 				UserAccountSerDes.toDTOs(
 					userAccountsJSONObject.getString("items"))));
+	}
+
+	protected UserAccount testGraphQLGetUserAccountsPage_addUserAccount()
+		throws Exception {
+
+		return testGraphQLUserAccount_addUserAccount();
 	}
 
 	@Test
@@ -2413,7 +2427,8 @@ public abstract class BaseUserAccountResourceTestCase {
 	public void testGraphQLGetUserAccountByExternalReferenceCode()
 		throws Exception {
 
-		UserAccount userAccount = testGraphQLUserAccount_addUserAccount();
+		UserAccount userAccount =
+			testGraphQLGetUserAccountByExternalReferenceCode_addUserAccount();
 
 		Assert.assertTrue(
 			equals(
@@ -2461,6 +2476,13 @@ public abstract class BaseUserAccountResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected UserAccount
+			testGraphQLGetUserAccountByExternalReferenceCode_addUserAccount()
+		throws Exception {
+
+		return testGraphQLUserAccount_addUserAccount();
 	}
 
 	@Test
@@ -2548,7 +2570,7 @@ public abstract class BaseUserAccountResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteUserAccount() throws Exception {
-		UserAccount userAccount = testGraphQLUserAccount_addUserAccount();
+		UserAccount userAccount = testGraphQLDeleteUserAccount_addUserAccount();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -2577,6 +2599,12 @@ public abstract class BaseUserAccountResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected UserAccount testGraphQLDeleteUserAccount_addUserAccount()
+		throws Exception {
+
+		return testGraphQLUserAccount_addUserAccount();
+	}
+
 	@Test
 	public void testGetUserAccount() throws Exception {
 		UserAccount postUserAccount = testGetUserAccount_addUserAccount();
@@ -2595,7 +2623,7 @@ public abstract class BaseUserAccountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetUserAccount() throws Exception {
-		UserAccount userAccount = testGraphQLUserAccount_addUserAccount();
+		UserAccount userAccount = testGraphQLGetUserAccount_addUserAccount();
 
 		Assert.assertTrue(
 			equals(
@@ -2634,6 +2662,12 @@ public abstract class BaseUserAccountResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected UserAccount testGraphQLGetUserAccount_addUserAccount()
+		throws Exception {
+
+		return testGraphQLUserAccount_addUserAccount();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserGroupResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserGroupResourceTestCase.java
@@ -499,8 +499,8 @@ public abstract class BaseUserGroupResourceTestCase {
 
 		long totalCount = userGroupsJSONObject.getLong("totalCount");
 
-		UserGroup userGroup1 = testGraphQLUserGroup_addUserGroup();
-		UserGroup userGroup2 = testGraphQLUserGroup_addUserGroup();
+		UserGroup userGroup1 = testGraphQLGetUserGroupsPage_addUserGroup();
+		UserGroup userGroup2 = testGraphQLGetUserGroupsPage_addUserGroup();
 
 		userGroupsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -519,6 +519,12 @@ public abstract class BaseUserGroupResourceTestCase {
 			Arrays.asList(
 				UserGroupSerDes.toDTOs(
 					userGroupsJSONObject.getString("items"))));
+	}
+
+	protected UserGroup testGraphQLGetUserGroupsPage_addUserGroup()
+		throws Exception {
+
+		return testGraphQLUserGroup_addUserGroup();
 	}
 
 	@Test
@@ -594,7 +600,8 @@ public abstract class BaseUserGroupResourceTestCase {
 	public void testGraphQLGetUserGroupByExternalReferenceCode()
 		throws Exception {
 
-		UserGroup userGroup = testGraphQLUserGroup_addUserGroup();
+		UserGroup userGroup =
+			testGraphQLGetUserGroupByExternalReferenceCode_addUserGroup();
 
 		Assert.assertTrue(
 			equals(
@@ -642,6 +649,13 @@ public abstract class BaseUserGroupResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected UserGroup
+			testGraphQLGetUserGroupByExternalReferenceCode_addUserGroup()
+		throws Exception {
+
+		return testGraphQLUserGroup_addUserGroup();
 	}
 
 	@Test
@@ -753,7 +767,7 @@ public abstract class BaseUserGroupResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteUserGroup() throws Exception {
-		UserGroup userGroup = testGraphQLUserGroup_addUserGroup();
+		UserGroup userGroup = testGraphQLDeleteUserGroup_addUserGroup();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -782,6 +796,12 @@ public abstract class BaseUserGroupResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected UserGroup testGraphQLDeleteUserGroup_addUserGroup()
+		throws Exception {
+
+		return testGraphQLUserGroup_addUserGroup();
+	}
+
 	@Test
 	public void testGetUserGroup() throws Exception {
 		UserGroup postUserGroup = testGetUserGroup_addUserGroup();
@@ -800,7 +820,7 @@ public abstract class BaseUserGroupResourceTestCase {
 
 	@Test
 	public void testGraphQLGetUserGroup() throws Exception {
-		UserGroup userGroup = testGraphQLUserGroup_addUserGroup();
+		UserGroup userGroup = testGraphQLGetUserGroup_addUserGroup();
 
 		Assert.assertTrue(
 			equals(
@@ -837,6 +857,12 @@ public abstract class BaseUserGroupResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected UserGroup testGraphQLGetUserGroup_addUserGroup()
+		throws Exception {
+
+		return testGraphQLUserGroup_addUserGroup();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
@@ -331,7 +331,7 @@ public abstract class BaseWebUrlResourceTestCase {
 
 	@Test
 	public void testGraphQLGetWebUrl() throws Exception {
-		WebUrl webUrl = testGraphQLWebUrl_addWebUrl();
+		WebUrl webUrl = testGraphQLGetWebUrl_addWebUrl();
 
 		Assert.assertTrue(
 			equals(
@@ -368,6 +368,10 @@ public abstract class BaseWebUrlResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected WebUrl testGraphQLGetWebUrl_addWebUrl() throws Exception {
+		return testGraphQLWebUrl_addWebUrl();
 	}
 
 	protected WebUrl testGraphQLWebUrl_addWebUrl() throws Exception {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/OrganizationResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/OrganizationResourceTest.java
@@ -77,18 +77,6 @@ public class OrganizationResourceTest extends BaseOrganizationResourceTestCase {
 
 	@Override
 	@Test
-	public void testDeleteAccountOrganization() throws Exception {
-		Organization organization =
-			testDeleteAccountOrganization_addOrganization();
-
-		assertHttpResponseStatusCode(
-			204,
-			organizationResource.deleteAccountOrganizationHttpResponse(
-				_accountEntry.getAccountEntryId(), organization.getId()));
-	}
-
-	@Override
-	@Test
 	public void testDeleteUserAccountByEmailAddress() throws Exception {
 		Organization organization = _toOrganization(
 			_addOrganization(randomOrganization(), "0"));
@@ -292,6 +280,13 @@ public class OrganizationResourceTest extends BaseOrganizationResourceTestCase {
 		return organizationResource.putOrganizationByExternalReferenceCode(
 			StringUtil.toLowerCase(RandomTestUtil.randomString()),
 			randomOrganization());
+	}
+
+	@Override
+	protected Long testDeleteAccountOrganization_getAccountId()
+		throws Exception {
+
+		return _accountEntry.getAccountEntryId();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/RoleResourceTest.java
@@ -67,44 +67,6 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 
 	@Override
 	@Test
-	public void testDeleteOrganizationRoleUserAccountAssociation()
-		throws Exception {
-
-		Role role = testDeleteOrganizationRoleUserAccountAssociation_addRole();
-		Organization organization = OrganizationTestUtil.addOrganization();
-
-		assertHttpResponseStatusCode(
-			204,
-			roleResource.
-				deleteOrganizationRoleUserAccountAssociationHttpResponse(
-					role.getId(), _user.getUserId(),
-					organization.getOrganizationId()));
-	}
-
-	@Override
-	@Test
-	public void testDeleteRoleUserAccountAssociation() throws Exception {
-		Role role = testDeleteRoleUserAccountAssociation_addRole();
-
-		assertHttpResponseStatusCode(
-			204,
-			roleResource.deleteRoleUserAccountAssociationHttpResponse(
-				role.getId(), _user.getUserId()));
-	}
-
-	@Override
-	@Test
-	public void testDeleteSiteRoleUserAccountAssociation() throws Exception {
-		Role role = testDeleteSiteRoleUserAccountAssociation_addRole();
-
-		assertHttpResponseStatusCode(
-			204,
-			roleResource.deleteSiteRoleUserAccountAssociationHttpResponse(
-				role.getId(), _user.getUserId(), testGroup.getGroupId()));
-	}
-
-	@Override
-	@Test
 	public void testGetRolesPage() throws Exception {
 		Page<Role> page = roleResource.getRolesPage(
 			null, Pagination.of(1, 100));
@@ -292,6 +254,24 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 	}
 
 	@Override
+	protected Long
+			testDeleteOrganizationRoleUserAccountAssociation_getOrganizationId()
+		throws Exception {
+
+		Organization organization = OrganizationTestUtil.addOrganization();
+
+		return organization.getOrganizationId();
+	}
+
+	@Override
+	protected Long
+			testDeleteOrganizationRoleUserAccountAssociation_getUserAccountId()
+		throws Exception {
+
+		return _user.getUserId();
+	}
+
+	@Override
 	protected Role testDeleteRoleUserAccountAssociation_addRole()
 		throws Exception {
 
@@ -299,10 +279,31 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 	}
 
 	@Override
+	protected Long testDeleteRoleUserAccountAssociation_getUserAccountId()
+		throws Exception {
+
+		return _user.getUserId();
+	}
+
+	@Override
 	protected Role testDeleteSiteRoleUserAccountAssociation_addRole()
 		throws Exception {
 
 		return _addRole(RoleConstants.TYPE_SITE);
+	}
+
+	@Override
+	protected Long testDeleteSiteRoleUserAccountAssociation_getSiteId()
+		throws Exception {
+
+		return testGroup.getGroupId();
+	}
+
+	@Override
+	protected Long testDeleteSiteRoleUserAccountAssociation_getUserAccountId()
+		throws Exception {
+
+		return _user.getUserId();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowInstanceResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowInstanceResourceTestCase.java
@@ -315,9 +315,9 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 		long totalCount = workflowInstancesJSONObject.getLong("totalCount");
 
 		WorkflowInstance workflowInstance1 =
-			testGraphQLWorkflowInstance_addWorkflowInstance();
+			testGraphQLGetWorkflowInstancesPage_addWorkflowInstance();
 		WorkflowInstance workflowInstance2 =
-			testGraphQLWorkflowInstance_addWorkflowInstance();
+			testGraphQLGetWorkflowInstancesPage_addWorkflowInstance();
 
 		workflowInstancesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -336,6 +336,13 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 			Arrays.asList(
 				WorkflowInstanceSerDes.toDTOs(
 					workflowInstancesJSONObject.getString("items"))));
+	}
+
+	protected WorkflowInstance
+			testGraphQLGetWorkflowInstancesPage_addWorkflowInstance()
+		throws Exception {
+
+		return testGraphQLWorkflowInstance_addWorkflowInstance();
 	}
 
 	@Test
@@ -389,7 +396,7 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 	@Test
 	public void testGraphQLDeleteWorkflowInstance() throws Exception {
 		WorkflowInstance workflowInstance =
-			testGraphQLWorkflowInstance_addWorkflowInstance();
+			testGraphQLDeleteWorkflowInstance_addWorkflowInstance();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -420,6 +427,13 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected WorkflowInstance
+			testGraphQLDeleteWorkflowInstance_addWorkflowInstance()
+		throws Exception {
+
+		return testGraphQLWorkflowInstance_addWorkflowInstance();
+	}
+
 	@Test
 	public void testGetWorkflowInstance() throws Exception {
 		WorkflowInstance postWorkflowInstance =
@@ -443,7 +457,7 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 	@Test
 	public void testGraphQLGetWorkflowInstance() throws Exception {
 		WorkflowInstance workflowInstance =
-			testGraphQLWorkflowInstance_addWorkflowInstance();
+			testGraphQLGetWorkflowInstance_addWorkflowInstance();
 
 		Assert.assertTrue(
 			equals(
@@ -484,6 +498,13 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected WorkflowInstance
+			testGraphQLGetWorkflowInstance_addWorkflowInstance()
+		throws Exception {
+
+		return testGraphQLWorkflowInstance_addWorkflowInstance();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
@@ -333,7 +333,7 @@ public abstract class BaseWorkflowLogResourceTestCase {
 
 	@Test
 	public void testGraphQLGetWorkflowLog() throws Exception {
-		WorkflowLog workflowLog = testGraphQLWorkflowLog_addWorkflowLog();
+		WorkflowLog workflowLog = testGraphQLGetWorkflowLog_addWorkflowLog();
 
 		Assert.assertTrue(
 			equals(
@@ -372,6 +372,12 @@ public abstract class BaseWorkflowLogResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected WorkflowLog testGraphQLGetWorkflowLog_addWorkflowLog()
+		throws Exception {
+
+		return testGraphQLWorkflowLog_addWorkflowLog();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
@@ -1210,7 +1210,8 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 	@Test
 	public void testGraphQLGetWorkflowTask() throws Exception {
-		WorkflowTask workflowTask = testGraphQLWorkflowTask_addWorkflowTask();
+		WorkflowTask workflowTask =
+			testGraphQLGetWorkflowTask_addWorkflowTask();
 
 		Assert.assertTrue(
 			equals(
@@ -1249,6 +1250,12 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected WorkflowTask testGraphQLGetWorkflowTask_addWorkflowTask()
+		throws Exception {
+
+		return testGraphQLWorkflowTask_addWorkflowTask();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -240,7 +240,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 	@Test
 	public void testGraphQLDeleteBlogPostingImage() throws Exception {
 		BlogPostingImage blogPostingImage =
-			testGraphQLBlogPostingImage_addBlogPostingImage();
+			testGraphQLDeleteBlogPostingImage_addBlogPostingImage();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -271,6 +271,13 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected BlogPostingImage
+			testGraphQLDeleteBlogPostingImage_addBlogPostingImage()
+		throws Exception {
+
+		return testGraphQLBlogPostingImage_addBlogPostingImage();
+	}
+
 	@Test
 	public void testGetBlogPostingImage() throws Exception {
 		BlogPostingImage postBlogPostingImage =
@@ -295,7 +302,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 	@Test
 	public void testGraphQLGetBlogPostingImage() throws Exception {
 		BlogPostingImage blogPostingImage =
-			testGraphQLBlogPostingImage_addBlogPostingImage();
+			testGraphQLGetBlogPostingImage_addBlogPostingImage();
 
 		Assert.assertTrue(
 			equals(
@@ -336,6 +343,13 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected BlogPostingImage
+			testGraphQLGetBlogPostingImage_addBlogPostingImage()
+		throws Exception {
+
+		return testGraphQLBlogPostingImage_addBlogPostingImage();
 	}
 
 	@Test
@@ -734,9 +748,9 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		Assert.assertEquals(0, blogPostingImagesJSONObject.get("totalCount"));
 
 		BlogPostingImage blogPostingImage1 =
-			testGraphQLBlogPostingImage_addBlogPostingImage();
+			testGraphQLGetSiteBlogPostingImagesPage_addBlogPostingImage();
 		BlogPostingImage blogPostingImage2 =
-			testGraphQLBlogPostingImage_addBlogPostingImage();
+			testGraphQLGetSiteBlogPostingImagesPage_addBlogPostingImage();
 
 		blogPostingImagesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -750,6 +764,13 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 			Arrays.asList(
 				BlogPostingImageSerDes.toDTOs(
 					blogPostingImagesJSONObject.getString("items"))));
+	}
+
+	protected BlogPostingImage
+			testGraphQLGetSiteBlogPostingImagesPage_addBlogPostingImage()
+		throws Exception {
+
+		return testGraphQLBlogPostingImage_addBlogPostingImage();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -242,7 +242,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteBlogPosting() throws Exception {
-		BlogPosting blogPosting = testGraphQLBlogPosting_addBlogPosting();
+		BlogPosting blogPosting = testGraphQLDeleteBlogPosting_addBlogPosting();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -271,6 +271,12 @@ public abstract class BaseBlogPostingResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected BlogPosting testGraphQLDeleteBlogPosting_addBlogPosting()
+		throws Exception {
+
+		return testGraphQLBlogPosting_addBlogPosting();
+	}
+
 	@Test
 	public void testGetBlogPosting() throws Exception {
 		BlogPosting postBlogPosting = testGetBlogPosting_addBlogPosting();
@@ -289,7 +295,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 	@Test
 	public void testGraphQLGetBlogPosting() throws Exception {
-		BlogPosting blogPosting = testGraphQLBlogPosting_addBlogPosting();
+		BlogPosting blogPosting = testGraphQLGetBlogPosting_addBlogPosting();
 
 		Assert.assertTrue(
 			equals(
@@ -328,6 +334,12 @@ public abstract class BaseBlogPostingResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected BlogPosting testGraphQLGetBlogPosting_addBlogPosting()
+		throws Exception {
+
+		return testGraphQLBlogPosting_addBlogPosting();
 	}
 
 	@Test
@@ -831,8 +843,10 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 		Assert.assertEquals(0, blogPostingsJSONObject.get("totalCount"));
 
-		BlogPosting blogPosting1 = testGraphQLBlogPosting_addBlogPosting();
-		BlogPosting blogPosting2 = testGraphQLBlogPosting_addBlogPosting();
+		BlogPosting blogPosting1 =
+			testGraphQLGetSiteBlogPostingsPage_addBlogPosting();
+		BlogPosting blogPosting2 =
+			testGraphQLGetSiteBlogPostingsPage_addBlogPosting();
 
 		blogPostingsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -845,6 +859,12 @@ public abstract class BaseBlogPostingResourceTestCase {
 			Arrays.asList(
 				BlogPostingSerDes.toDTOs(
 					blogPostingsJSONObject.getString("items"))));
+	}
+
+	protected BlogPosting testGraphQLGetSiteBlogPostingsPage_addBlogPosting()
+		throws Exception {
+
+		return testGraphQLBlogPosting_addBlogPosting();
 	}
 
 	@Test
@@ -942,7 +962,8 @@ public abstract class BaseBlogPostingResourceTestCase {
 	public void testGraphQLGetSiteBlogPostingByExternalReferenceCode()
 		throws Exception {
 
-		BlogPosting blogPosting = testGraphQLBlogPosting_addBlogPosting();
+		BlogPosting blogPosting =
+			testGraphQLGetSiteBlogPostingByExternalReferenceCode_addBlogPosting();
 
 		Assert.assertTrue(
 			equals(
@@ -997,6 +1018,13 @@ public abstract class BaseBlogPostingResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected BlogPosting
+			testGraphQLGetSiteBlogPostingByExternalReferenceCode_addBlogPosting()
+		throws Exception {
+
+		return testGraphQLBlogPosting_addBlogPosting();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -574,7 +574,7 @@ public abstract class BaseCommentResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteComment() throws Exception {
-		Comment comment = testGraphQLComment_addComment();
+		Comment comment = testGraphQLDeleteComment_addComment();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -603,6 +603,10 @@ public abstract class BaseCommentResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Comment testGraphQLDeleteComment_addComment() throws Exception {
+		return testGraphQLComment_addComment();
+	}
+
 	@Test
 	public void testGetComment() throws Exception {
 		Comment postComment = testGetComment_addComment();
@@ -620,7 +624,7 @@ public abstract class BaseCommentResourceTestCase {
 
 	@Test
 	public void testGraphQLGetComment() throws Exception {
-		Comment comment = testGraphQLComment_addComment();
+		Comment comment = testGraphQLGetComment_addComment();
 
 		Assert.assertTrue(
 			equals(
@@ -657,6 +661,10 @@ public abstract class BaseCommentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Comment testGraphQLGetComment_addComment() throws Exception {
+		return testGraphQLComment_addComment();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
@@ -970,9 +970,9 @@ public abstract class BaseContentElementResourceTestCase {
 		Assert.assertEquals(0, contentElementsJSONObject.get("totalCount"));
 
 		ContentElement contentElement1 =
-			testGraphQLContentElement_addContentElement();
+			testGraphQLGetSiteContentElementsPage_addContentElement();
 		ContentElement contentElement2 =
-			testGraphQLContentElement_addContentElement();
+			testGraphQLGetSiteContentElementsPage_addContentElement();
 
 		contentElementsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -985,6 +985,13 @@ public abstract class BaseContentElementResourceTestCase {
 			Arrays.asList(
 				ContentElementSerDes.toDTOs(
 					contentElementsJSONObject.getString("items"))));
+	}
+
+	protected ContentElement
+			testGraphQLGetSiteContentElementsPage_addContentElement()
+		throws Exception {
+
+		return testGraphQLContentElement_addContentElement();
 	}
 
 	@Rule

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -687,7 +687,7 @@ public abstract class BaseContentStructureResourceTestCase {
 	@Test
 	public void testGraphQLGetContentStructure() throws Exception {
 		ContentStructure contentStructure =
-			testGraphQLContentStructure_addContentStructure();
+			testGraphQLGetContentStructure_addContentStructure();
 
 		Assert.assertTrue(
 			equals(
@@ -728,6 +728,13 @@ public abstract class BaseContentStructureResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ContentStructure
+			testGraphQLGetContentStructure_addContentStructure()
+		throws Exception {
+
+		return testGraphQLContentStructure_addContentStructure();
 	}
 
 	@Test
@@ -1187,9 +1194,9 @@ public abstract class BaseContentStructureResourceTestCase {
 		Assert.assertEquals(0, contentStructuresJSONObject.get("totalCount"));
 
 		ContentStructure contentStructure1 =
-			testGraphQLContentStructure_addContentStructure();
+			testGraphQLGetSiteContentStructuresPage_addContentStructure();
 		ContentStructure contentStructure2 =
-			testGraphQLContentStructure_addContentStructure();
+			testGraphQLGetSiteContentStructuresPage_addContentStructure();
 
 		contentStructuresJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -1203,6 +1210,13 @@ public abstract class BaseContentStructureResourceTestCase {
 			Arrays.asList(
 				ContentStructureSerDes.toDTOs(
 					contentStructuresJSONObject.getString("items"))));
+	}
+
+	protected ContentStructure
+			testGraphQLGetSiteContentStructuresPage_addContentStructure()
+		throws Exception {
+
+		return testGraphQLContentStructure_addContentStructure();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
@@ -982,9 +982,9 @@ public abstract class BaseContentTemplateResourceTestCase {
 		Assert.assertEquals(0, contentTemplatesJSONObject.get("totalCount"));
 
 		ContentTemplate contentTemplate1 =
-			testGraphQLContentTemplate_addContentTemplate();
+			testGraphQLGetSiteContentTemplatesPage_addContentTemplate();
 		ContentTemplate contentTemplate2 =
-			testGraphQLContentTemplate_addContentTemplate();
+			testGraphQLGetSiteContentTemplatesPage_addContentTemplate();
 
 		contentTemplatesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -998,6 +998,13 @@ public abstract class BaseContentTemplateResourceTestCase {
 			Arrays.asList(
 				ContentTemplateSerDes.toDTOs(
 					contentTemplatesJSONObject.getString("items"))));
+	}
+
+	protected ContentTemplate
+			testGraphQLGetSiteContentTemplatesPage_addContentTemplate()
+		throws Exception {
+
+		return testGraphQLContentTemplate_addContentTemplate();
 	}
 
 	@Test
@@ -1023,7 +1030,7 @@ public abstract class BaseContentTemplateResourceTestCase {
 	@Test
 	public void testGraphQLGetSiteContentTemplate() throws Exception {
 		ContentTemplate contentTemplate =
-			testGraphQLContentTemplate_addContentTemplate();
+			testGraphQLGetSiteContentTemplate_addContentTemplate();
 
 		Assert.assertTrue(
 			equals(
@@ -1073,6 +1080,13 @@ public abstract class BaseContentTemplateResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ContentTemplate
+			testGraphQLGetSiteContentTemplate_addContentTemplate()
+		throws Exception {
+
+		return testGraphQLContentTemplate_addContentTemplate();
 	}
 
 	@Rule

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -722,7 +722,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	@Test
 	public void testGraphQLDeleteDocumentFolder() throws Exception {
 		DocumentFolder documentFolder =
-			testGraphQLDocumentFolder_addDocumentFolder();
+			testGraphQLDeleteDocumentFolder_addDocumentFolder();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -751,6 +751,12 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected DocumentFolder testGraphQLDeleteDocumentFolder_addDocumentFolder()
+		throws Exception {
+
+		return testGraphQLDocumentFolder_addDocumentFolder();
+	}
+
 	@Test
 	public void testGetDocumentFolder() throws Exception {
 		DocumentFolder postDocumentFolder =
@@ -774,7 +780,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	@Test
 	public void testGraphQLGetDocumentFolder() throws Exception {
 		DocumentFolder documentFolder =
-			testGraphQLDocumentFolder_addDocumentFolder();
+			testGraphQLGetDocumentFolder_addDocumentFolder();
 
 		Assert.assertTrue(
 			equals(
@@ -815,6 +821,12 @@ public abstract class BaseDocumentFolderResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected DocumentFolder testGraphQLGetDocumentFolder_addDocumentFolder()
+		throws Exception {
+
+		return testGraphQLDocumentFolder_addDocumentFolder();
 	}
 
 	@Test
@@ -1785,9 +1797,9 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Assert.assertEquals(0, documentFoldersJSONObject.get("totalCount"));
 
 		DocumentFolder documentFolder1 =
-			testGraphQLDocumentFolder_addDocumentFolder();
+			testGraphQLGetSiteDocumentFoldersPage_addDocumentFolder();
 		DocumentFolder documentFolder2 =
-			testGraphQLDocumentFolder_addDocumentFolder();
+			testGraphQLGetSiteDocumentFoldersPage_addDocumentFolder();
 
 		documentFoldersJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -1800,6 +1812,13 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			Arrays.asList(
 				DocumentFolderSerDes.toDTOs(
 					documentFoldersJSONObject.getString("items"))));
+	}
+
+	protected DocumentFolder
+			testGraphQLGetSiteDocumentFoldersPage_addDocumentFolder()
+		throws Exception {
+
+		return testGraphQLDocumentFolder_addDocumentFolder();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -1067,7 +1067,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteDocument() throws Exception {
-		Document document = testGraphQLDocument_addDocument();
+		Document document = testGraphQLDeleteDocument_addDocument();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -1096,6 +1096,12 @@ public abstract class BaseDocumentResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Document testGraphQLDeleteDocument_addDocument()
+		throws Exception {
+
+		return testGraphQLDocument_addDocument();
+	}
+
 	@Test
 	public void testGetDocument() throws Exception {
 		Document postDocument = testGetDocument_addDocument();
@@ -1114,7 +1120,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDocument() throws Exception {
-		Document document = testGraphQLDocument_addDocument();
+		Document document = testGraphQLGetDocument_addDocument();
 
 		Assert.assertTrue(
 			equals(
@@ -1151,6 +1157,10 @@ public abstract class BaseDocumentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Document testGraphQLGetDocument_addDocument() throws Exception {
+		return testGraphQLDocument_addDocument();
 	}
 
 	@Test
@@ -1648,8 +1658,8 @@ public abstract class BaseDocumentResourceTestCase {
 
 		Assert.assertEquals(0, documentsJSONObject.get("totalCount"));
 
-		Document document1 = testGraphQLDocument_addDocument();
-		Document document2 = testGraphQLDocument_addDocument();
+		Document document1 = testGraphQLGetSiteDocumentsPage_addDocument();
+		Document document2 = testGraphQLGetSiteDocumentsPage_addDocument();
 
 		documentsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -1661,6 +1671,12 @@ public abstract class BaseDocumentResourceTestCase {
 			Arrays.asList(document1, document2),
 			Arrays.asList(
 				DocumentSerDes.toDTOs(documentsJSONObject.getString("items"))));
+	}
+
+	protected Document testGraphQLGetSiteDocumentsPage_addDocument()
+		throws Exception {
+
+		return testGraphQLDocument_addDocument();
 	}
 
 	@Test
@@ -1744,7 +1760,8 @@ public abstract class BaseDocumentResourceTestCase {
 	public void testGraphQLGetSiteDocumentByExternalReferenceCode()
 		throws Exception {
 
-		Document document = testGraphQLDocument_addDocument();
+		Document document =
+			testGraphQLGetSiteDocumentByExternalReferenceCode_addDocument();
 
 		Assert.assertTrue(
 			equals(
@@ -1798,6 +1815,13 @@ public abstract class BaseDocumentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Document
+			testGraphQLGetSiteDocumentByExternalReferenceCode_addDocument()
+		throws Exception {
+
+		return testGraphQLDocument_addDocument();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -251,7 +251,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	@Test
 	public void testGraphQLDeleteKnowledgeBaseArticle() throws Exception {
 		KnowledgeBaseArticle knowledgeBaseArticle =
-			testGraphQLKnowledgeBaseArticle_addKnowledgeBaseArticle();
+			testGraphQLDeleteKnowledgeBaseArticle_addKnowledgeBaseArticle();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -284,6 +284,13 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected KnowledgeBaseArticle
+			testGraphQLDeleteKnowledgeBaseArticle_addKnowledgeBaseArticle()
+		throws Exception {
+
+		return testGraphQLKnowledgeBaseArticle_addKnowledgeBaseArticle();
+	}
+
 	@Test
 	public void testGetKnowledgeBaseArticle() throws Exception {
 		KnowledgeBaseArticle postKnowledgeBaseArticle =
@@ -308,7 +315,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	@Test
 	public void testGraphQLGetKnowledgeBaseArticle() throws Exception {
 		KnowledgeBaseArticle knowledgeBaseArticle =
-			testGraphQLKnowledgeBaseArticle_addKnowledgeBaseArticle();
+			testGraphQLGetKnowledgeBaseArticle_addKnowledgeBaseArticle();
 
 		Assert.assertTrue(
 			equals(
@@ -349,6 +356,13 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected KnowledgeBaseArticle
+			testGraphQLGetKnowledgeBaseArticle_addKnowledgeBaseArticle()
+		throws Exception {
+
+		return testGraphQLKnowledgeBaseArticle_addKnowledgeBaseArticle();
 	}
 
 	@Test
@@ -1857,9 +1871,9 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			0, knowledgeBaseArticlesJSONObject.get("totalCount"));
 
 		KnowledgeBaseArticle knowledgeBaseArticle1 =
-			testGraphQLKnowledgeBaseArticle_addKnowledgeBaseArticle();
+			testGraphQLGetSiteKnowledgeBaseArticlesPage_addKnowledgeBaseArticle();
 		KnowledgeBaseArticle knowledgeBaseArticle2 =
-			testGraphQLKnowledgeBaseArticle_addKnowledgeBaseArticle();
+			testGraphQLGetSiteKnowledgeBaseArticlesPage_addKnowledgeBaseArticle();
 
 		knowledgeBaseArticlesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -1873,6 +1887,13 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			Arrays.asList(
 				KnowledgeBaseArticleSerDes.toDTOs(
 					knowledgeBaseArticlesJSONObject.getString("items"))));
+	}
+
+	protected KnowledgeBaseArticle
+			testGraphQLGetSiteKnowledgeBaseArticlesPage_addKnowledgeBaseArticle()
+		throws Exception {
+
+		return testGraphQLKnowledgeBaseArticle_addKnowledgeBaseArticle();
 	}
 
 	@Test
@@ -1979,7 +2000,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		throws Exception {
 
 		KnowledgeBaseArticle knowledgeBaseArticle =
-			testGraphQLKnowledgeBaseArticle_addKnowledgeBaseArticle();
+			testGraphQLGetSiteKnowledgeBaseArticleByExternalReferenceCode_addKnowledgeBaseArticle();
 
 		Assert.assertTrue(
 			equals(
@@ -2035,6 +2056,13 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected KnowledgeBaseArticle
+			testGraphQLGetSiteKnowledgeBaseArticleByExternalReferenceCode_addKnowledgeBaseArticle()
+		throws Exception {
+
+		return testGraphQLKnowledgeBaseArticle_addKnowledgeBaseArticle();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
@@ -364,7 +364,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 	@Test
 	public void testGraphQLDeleteKnowledgeBaseAttachment() throws Exception {
 		KnowledgeBaseAttachment knowledgeBaseAttachment =
-			testGraphQLKnowledgeBaseAttachment_addKnowledgeBaseAttachment();
+			testGraphQLDeleteKnowledgeBaseAttachment_addKnowledgeBaseAttachment();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -397,6 +397,13 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected KnowledgeBaseAttachment
+			testGraphQLDeleteKnowledgeBaseAttachment_addKnowledgeBaseAttachment()
+		throws Exception {
+
+		return testGraphQLKnowledgeBaseAttachment_addKnowledgeBaseAttachment();
+	}
+
 	@Test
 	public void testGetKnowledgeBaseAttachment() throws Exception {
 		KnowledgeBaseAttachment postKnowledgeBaseAttachment =
@@ -421,7 +428,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 	@Test
 	public void testGraphQLGetKnowledgeBaseAttachment() throws Exception {
 		KnowledgeBaseAttachment knowledgeBaseAttachment =
-			testGraphQLKnowledgeBaseAttachment_addKnowledgeBaseAttachment();
+			testGraphQLGetKnowledgeBaseAttachment_addKnowledgeBaseAttachment();
 
 		Assert.assertTrue(
 			equals(
@@ -464,6 +471,13 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected KnowledgeBaseAttachment
+			testGraphQLGetKnowledgeBaseAttachment_addKnowledgeBaseAttachment()
+		throws Exception {
+
+		return testGraphQLKnowledgeBaseAttachment_addKnowledgeBaseAttachment();
 	}
 
 	protected KnowledgeBaseAttachment

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -235,7 +235,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	@Test
 	public void testGraphQLDeleteKnowledgeBaseFolder() throws Exception {
 		KnowledgeBaseFolder knowledgeBaseFolder =
-			testGraphQLKnowledgeBaseFolder_addKnowledgeBaseFolder();
+			testGraphQLDeleteKnowledgeBaseFolder_addKnowledgeBaseFolder();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -268,6 +268,13 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected KnowledgeBaseFolder
+			testGraphQLDeleteKnowledgeBaseFolder_addKnowledgeBaseFolder()
+		throws Exception {
+
+		return testGraphQLKnowledgeBaseFolder_addKnowledgeBaseFolder();
+	}
+
 	@Test
 	public void testGetKnowledgeBaseFolder() throws Exception {
 		KnowledgeBaseFolder postKnowledgeBaseFolder =
@@ -292,7 +299,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	@Test
 	public void testGraphQLGetKnowledgeBaseFolder() throws Exception {
 		KnowledgeBaseFolder knowledgeBaseFolder =
-			testGraphQLKnowledgeBaseFolder_addKnowledgeBaseFolder();
+			testGraphQLGetKnowledgeBaseFolder_addKnowledgeBaseFolder();
 
 		Assert.assertTrue(
 			equals(
@@ -333,6 +340,13 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected KnowledgeBaseFolder
+			testGraphQLGetKnowledgeBaseFolder_addKnowledgeBaseFolder()
+		throws Exception {
+
+		return testGraphQLKnowledgeBaseFolder_addKnowledgeBaseFolder();
 	}
 
 	@Test
@@ -790,9 +804,9 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			0, knowledgeBaseFoldersJSONObject.get("totalCount"));
 
 		KnowledgeBaseFolder knowledgeBaseFolder1 =
-			testGraphQLKnowledgeBaseFolder_addKnowledgeBaseFolder();
+			testGraphQLGetSiteKnowledgeBaseFoldersPage_addKnowledgeBaseFolder();
 		KnowledgeBaseFolder knowledgeBaseFolder2 =
-			testGraphQLKnowledgeBaseFolder_addKnowledgeBaseFolder();
+			testGraphQLGetSiteKnowledgeBaseFoldersPage_addKnowledgeBaseFolder();
 
 		knowledgeBaseFoldersJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -806,6 +820,13 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			Arrays.asList(
 				KnowledgeBaseFolderSerDes.toDTOs(
 					knowledgeBaseFoldersJSONObject.getString("items"))));
+	}
+
+	protected KnowledgeBaseFolder
+			testGraphQLGetSiteKnowledgeBaseFoldersPage_addKnowledgeBaseFolder()
+		throws Exception {
+
+		return testGraphQLKnowledgeBaseFolder_addKnowledgeBaseFolder();
 	}
 
 	@Test
@@ -912,7 +933,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		throws Exception {
 
 		KnowledgeBaseFolder knowledgeBaseFolder =
-			testGraphQLKnowledgeBaseFolder_addKnowledgeBaseFolder();
+			testGraphQLGetSiteKnowledgeBaseFolderByExternalReferenceCode_addKnowledgeBaseFolder();
 
 		Assert.assertTrue(
 			equals(
@@ -968,6 +989,13 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected KnowledgeBaseFolder
+			testGraphQLGetSiteKnowledgeBaseFolderByExternalReferenceCode_addKnowledgeBaseFolder()
+		throws Exception {
+
+		return testGraphQLKnowledgeBaseFolder_addKnowledgeBaseFolder();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
@@ -351,8 +351,8 @@ public abstract class BaseLanguageResourceTestCase {
 
 		Assert.assertEquals(0, languagesJSONObject.get("totalCount"));
 
-		Language language1 = testGraphQLLanguage_addLanguage();
-		Language language2 = testGraphQLLanguage_addLanguage();
+		Language language1 = testGraphQLGetSiteLanguagesPage_addLanguage();
+		Language language2 = testGraphQLGetSiteLanguagesPage_addLanguage();
 
 		languagesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -364,6 +364,12 @@ public abstract class BaseLanguageResourceTestCase {
 			Arrays.asList(language1, language2),
 			Arrays.asList(
 				LanguageSerDes.toDTOs(languagesJSONObject.getString("items"))));
+	}
+
+	protected Language testGraphQLGetSiteLanguagesPage_addLanguage()
+		throws Exception {
+
+		return testGraphQLLanguage_addLanguage();
 	}
 
 	protected Language testGraphQLLanguage_addLanguage() throws Exception {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -243,7 +243,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 	@Test
 	public void testGraphQLDeleteMessageBoardAttachment() throws Exception {
 		MessageBoardAttachment messageBoardAttachment =
-			testGraphQLMessageBoardAttachment_addMessageBoardAttachment();
+			testGraphQLDeleteMessageBoardAttachment_addMessageBoardAttachment();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -276,6 +276,13 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected MessageBoardAttachment
+			testGraphQLDeleteMessageBoardAttachment_addMessageBoardAttachment()
+		throws Exception {
+
+		return testGraphQLMessageBoardAttachment_addMessageBoardAttachment();
+	}
+
 	@Test
 	public void testGetMessageBoardAttachment() throws Exception {
 		MessageBoardAttachment postMessageBoardAttachment =
@@ -300,7 +307,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 	@Test
 	public void testGraphQLGetMessageBoardAttachment() throws Exception {
 		MessageBoardAttachment messageBoardAttachment =
-			testGraphQLMessageBoardAttachment_addMessageBoardAttachment();
+			testGraphQLGetMessageBoardAttachment_addMessageBoardAttachment();
 
 		Assert.assertTrue(
 			equals(
@@ -343,6 +350,13 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected MessageBoardAttachment
+			testGraphQLGetMessageBoardAttachment_addMessageBoardAttachment()
+		throws Exception {
+
+		return testGraphQLMessageBoardAttachment_addMessageBoardAttachment();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -246,7 +246,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	@Test
 	public void testGraphQLDeleteMessageBoardMessage() throws Exception {
 		MessageBoardMessage messageBoardMessage =
-			testGraphQLMessageBoardMessage_addMessageBoardMessage();
+			testGraphQLDeleteMessageBoardMessage_addMessageBoardMessage();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -279,6 +279,13 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected MessageBoardMessage
+			testGraphQLDeleteMessageBoardMessage_addMessageBoardMessage()
+		throws Exception {
+
+		return testGraphQLMessageBoardMessage_addMessageBoardMessage();
+	}
+
 	@Test
 	public void testGetMessageBoardMessage() throws Exception {
 		MessageBoardMessage postMessageBoardMessage =
@@ -303,7 +310,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	@Test
 	public void testGraphQLGetMessageBoardMessage() throws Exception {
 		MessageBoardMessage messageBoardMessage =
-			testGraphQLMessageBoardMessage_addMessageBoardMessage();
+			testGraphQLGetMessageBoardMessage_addMessageBoardMessage();
 
 		Assert.assertTrue(
 			equals(
@@ -344,6 +351,13 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected MessageBoardMessage
+			testGraphQLGetMessageBoardMessage_addMessageBoardMessage()
+		throws Exception {
+
+		return testGraphQLMessageBoardMessage_addMessageBoardMessage();
 	}
 
 	@Test
@@ -1835,9 +1849,9 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			0, messageBoardMessagesJSONObject.get("totalCount"));
 
 		MessageBoardMessage messageBoardMessage1 =
-			testGraphQLMessageBoardMessage_addMessageBoardMessage();
+			testGraphQLGetSiteMessageBoardMessagesPage_addMessageBoardMessage();
 		MessageBoardMessage messageBoardMessage2 =
-			testGraphQLMessageBoardMessage_addMessageBoardMessage();
+			testGraphQLGetSiteMessageBoardMessagesPage_addMessageBoardMessage();
 
 		messageBoardMessagesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -1851,6 +1865,13 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			Arrays.asList(
 				MessageBoardMessageSerDes.toDTOs(
 					messageBoardMessagesJSONObject.getString("items"))));
+	}
+
+	protected MessageBoardMessage
+			testGraphQLGetSiteMessageBoardMessagesPage_addMessageBoardMessage()
+		throws Exception {
+
+		return testGraphQLMessageBoardMessage_addMessageBoardMessage();
 	}
 
 	@Test
@@ -1921,7 +1942,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		throws Exception {
 
 		MessageBoardMessage messageBoardMessage =
-			testGraphQLMessageBoardMessage_addMessageBoardMessage();
+			testGraphQLGetSiteMessageBoardMessageByExternalReferenceCode_addMessageBoardMessage();
 
 		Assert.assertTrue(
 			equals(
@@ -1977,6 +1998,13 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected MessageBoardMessage
+			testGraphQLGetSiteMessageBoardMessageByExternalReferenceCode_addMessageBoardMessage()
+		throws Exception {
+
+		return testGraphQLMessageBoardMessage_addMessageBoardMessage();
 	}
 
 	@Test
@@ -2079,7 +2107,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		throws Exception {
 
 		MessageBoardMessage messageBoardMessage =
-			testGraphQLMessageBoardMessage_addMessageBoardMessage();
+			testGraphQLGetSiteMessageBoardMessageByFriendlyUrlPath_addMessageBoardMessage();
 
 		Assert.assertTrue(
 			equals(
@@ -2135,6 +2163,13 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected MessageBoardMessage
+			testGraphQLGetSiteMessageBoardMessageByFriendlyUrlPath_addMessageBoardMessage()
+		throws Exception {
+
+		return testGraphQLMessageBoardMessage_addMessageBoardMessage();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -237,7 +237,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	@Test
 	public void testGraphQLDeleteMessageBoardSection() throws Exception {
 		MessageBoardSection messageBoardSection =
-			testGraphQLMessageBoardSection_addMessageBoardSection();
+			testGraphQLDeleteMessageBoardSection_addMessageBoardSection();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -270,6 +270,13 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected MessageBoardSection
+			testGraphQLDeleteMessageBoardSection_addMessageBoardSection()
+		throws Exception {
+
+		return testGraphQLMessageBoardSection_addMessageBoardSection();
+	}
+
 	@Test
 	public void testGetMessageBoardSection() throws Exception {
 		MessageBoardSection postMessageBoardSection =
@@ -294,7 +301,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	@Test
 	public void testGraphQLGetMessageBoardSection() throws Exception {
 		MessageBoardSection messageBoardSection =
-			testGraphQLMessageBoardSection_addMessageBoardSection();
+			testGraphQLGetMessageBoardSection_addMessageBoardSection();
 
 		Assert.assertTrue(
 			equals(
@@ -335,6 +342,13 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected MessageBoardSection
+			testGraphQLGetMessageBoardSection_addMessageBoardSection()
+		throws Exception {
+
+		return testGraphQLMessageBoardSection_addMessageBoardSection();
 	}
 
 	@Test
@@ -1359,9 +1373,9 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 			0, messageBoardSectionsJSONObject.get("totalCount"));
 
 		MessageBoardSection messageBoardSection1 =
-			testGraphQLMessageBoardSection_addMessageBoardSection();
+			testGraphQLGetSiteMessageBoardSectionsPage_addMessageBoardSection();
 		MessageBoardSection messageBoardSection2 =
-			testGraphQLMessageBoardSection_addMessageBoardSection();
+			testGraphQLGetSiteMessageBoardSectionsPage_addMessageBoardSection();
 
 		messageBoardSectionsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -1375,6 +1389,13 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 			Arrays.asList(
 				MessageBoardSectionSerDes.toDTOs(
 					messageBoardSectionsJSONObject.getString("items"))));
+	}
+
+	protected MessageBoardSection
+			testGraphQLGetSiteMessageBoardSectionsPage_addMessageBoardSection()
+		throws Exception {
+
+		return testGraphQLMessageBoardSection_addMessageBoardSection();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -924,7 +924,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	@Test
 	public void testGraphQLDeleteMessageBoardThread() throws Exception {
 		MessageBoardThread messageBoardThread =
-			testGraphQLMessageBoardThread_addMessageBoardThread();
+			testGraphQLDeleteMessageBoardThread_addMessageBoardThread();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -957,6 +957,13 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected MessageBoardThread
+			testGraphQLDeleteMessageBoardThread_addMessageBoardThread()
+		throws Exception {
+
+		return testGraphQLMessageBoardThread_addMessageBoardThread();
+	}
+
 	@Test
 	public void testGetMessageBoardThread() throws Exception {
 		MessageBoardThread postMessageBoardThread =
@@ -981,7 +988,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	@Test
 	public void testGraphQLGetMessageBoardThread() throws Exception {
 		MessageBoardThread messageBoardThread =
-			testGraphQLMessageBoardThread_addMessageBoardThread();
+			testGraphQLGetMessageBoardThread_addMessageBoardThread();
 
 		Assert.assertTrue(
 			equals(
@@ -1022,6 +1029,13 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected MessageBoardThread
+			testGraphQLGetMessageBoardThread_addMessageBoardThread()
+		throws Exception {
+
+		return testGraphQLMessageBoardThread_addMessageBoardThread();
 	}
 
 	@Test
@@ -1640,9 +1654,9 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Assert.assertEquals(0, messageBoardThreadsJSONObject.get("totalCount"));
 
 		MessageBoardThread messageBoardThread1 =
-			testGraphQLMessageBoardThread_addMessageBoardThread();
+			testGraphQLGetSiteMessageBoardThreadsPage_addMessageBoardThread();
 		MessageBoardThread messageBoardThread2 =
-			testGraphQLMessageBoardThread_addMessageBoardThread();
+			testGraphQLGetSiteMessageBoardThreadsPage_addMessageBoardThread();
 
 		messageBoardThreadsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -1656,6 +1670,13 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 			Arrays.asList(
 				MessageBoardThreadSerDes.toDTOs(
 					messageBoardThreadsJSONObject.getString("items"))));
+	}
+
+	protected MessageBoardThread
+			testGraphQLGetSiteMessageBoardThreadsPage_addMessageBoardThread()
+		throws Exception {
+
+		return testGraphQLMessageBoardThread_addMessageBoardThread();
 	}
 
 	@Test
@@ -1722,7 +1743,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		throws Exception {
 
 		MessageBoardThread messageBoardThread =
-			testGraphQLMessageBoardThread_addMessageBoardThread();
+			testGraphQLGetSiteMessageBoardThreadByFriendlyUrlPath_addMessageBoardThread();
 
 		Assert.assertTrue(
 			equals(
@@ -1778,6 +1799,13 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected MessageBoardThread
+			testGraphQLGetSiteMessageBoardThreadByFriendlyUrlPath_addMessageBoardThread()
+		throws Exception {
+
+		return testGraphQLMessageBoardThread_addMessageBoardThread();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
@@ -227,7 +227,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 	@Test
 	public void testGraphQLDeleteNavigationMenu() throws Exception {
 		NavigationMenu navigationMenu =
-			testGraphQLNavigationMenu_addNavigationMenu();
+			testGraphQLDeleteNavigationMenu_addNavigationMenu();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -256,6 +256,12 @@ public abstract class BaseNavigationMenuResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected NavigationMenu testGraphQLDeleteNavigationMenu_addNavigationMenu()
+		throws Exception {
+
+		return testGraphQLNavigationMenu_addNavigationMenu();
+	}
+
 	@Test
 	public void testGetNavigationMenu() throws Exception {
 		NavigationMenu postNavigationMenu =
@@ -279,7 +285,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 	@Test
 	public void testGraphQLGetNavigationMenu() throws Exception {
 		NavigationMenu navigationMenu =
-			testGraphQLNavigationMenu_addNavigationMenu();
+			testGraphQLGetNavigationMenu_addNavigationMenu();
 
 		Assert.assertTrue(
 			equals(
@@ -320,6 +326,12 @@ public abstract class BaseNavigationMenuResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected NavigationMenu testGraphQLGetNavigationMenu_addNavigationMenu()
+		throws Exception {
+
+		return testGraphQLNavigationMenu_addNavigationMenu();
 	}
 
 	@Test
@@ -557,9 +569,9 @@ public abstract class BaseNavigationMenuResourceTestCase {
 		Assert.assertEquals(0, navigationMenusJSONObject.get("totalCount"));
 
 		NavigationMenu navigationMenu1 =
-			testGraphQLNavigationMenu_addNavigationMenu();
+			testGraphQLGetSiteNavigationMenusPage_addNavigationMenu();
 		NavigationMenu navigationMenu2 =
-			testGraphQLNavigationMenu_addNavigationMenu();
+			testGraphQLGetSiteNavigationMenusPage_addNavigationMenu();
 
 		navigationMenusJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -572,6 +584,13 @@ public abstract class BaseNavigationMenuResourceTestCase {
 			Arrays.asList(
 				NavigationMenuSerDes.toDTOs(
 					navigationMenusJSONObject.getString("items"))));
+	}
+
+	protected NavigationMenu
+			testGraphQLGetSiteNavigationMenusPage_addNavigationMenu()
+		throws Exception {
+
+		return testGraphQLNavigationMenu_addNavigationMenu();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -1163,9 +1163,9 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			0, structuredContentFoldersJSONObject.get("totalCount"));
 
 		StructuredContentFolder structuredContentFolder1 =
-			testGraphQLStructuredContentFolder_addStructuredContentFolder();
+			testGraphQLGetSiteStructuredContentFoldersPage_addStructuredContentFolder();
 		StructuredContentFolder structuredContentFolder2 =
-			testGraphQLStructuredContentFolder_addStructuredContentFolder();
+			testGraphQLGetSiteStructuredContentFoldersPage_addStructuredContentFolder();
 
 		structuredContentFoldersJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -1179,6 +1179,13 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			Arrays.asList(
 				StructuredContentFolderSerDes.toDTOs(
 					structuredContentFoldersJSONObject.getString("items"))));
+	}
+
+	protected StructuredContentFolder
+			testGraphQLGetSiteStructuredContentFoldersPage_addStructuredContentFolder()
+		throws Exception {
+
+		return testGraphQLStructuredContentFolder_addStructuredContentFolder();
 	}
 
 	@Test
@@ -1848,7 +1855,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	@Test
 	public void testGraphQLDeleteStructuredContentFolder() throws Exception {
 		StructuredContentFolder structuredContentFolder =
-			testGraphQLStructuredContentFolder_addStructuredContentFolder();
+			testGraphQLDeleteStructuredContentFolder_addStructuredContentFolder();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -1881,6 +1888,13 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected StructuredContentFolder
+			testGraphQLDeleteStructuredContentFolder_addStructuredContentFolder()
+		throws Exception {
+
+		return testGraphQLStructuredContentFolder_addStructuredContentFolder();
+	}
+
 	@Test
 	public void testGetStructuredContentFolder() throws Exception {
 		StructuredContentFolder postStructuredContentFolder =
@@ -1905,7 +1919,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	@Test
 	public void testGraphQLGetStructuredContentFolder() throws Exception {
 		StructuredContentFolder structuredContentFolder =
-			testGraphQLStructuredContentFolder_addStructuredContentFolder();
+			testGraphQLGetStructuredContentFolder_addStructuredContentFolder();
 
 		Assert.assertTrue(
 			equals(
@@ -1948,6 +1962,13 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected StructuredContentFolder
+			testGraphQLGetStructuredContentFolder_addStructuredContentFolder()
+		throws Exception {
+
+		return testGraphQLStructuredContentFolder_addStructuredContentFolder();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -1505,9 +1505,9 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Assert.assertEquals(0, structuredContentsJSONObject.get("totalCount"));
 
 		StructuredContent structuredContent1 =
-			testGraphQLStructuredContent_addStructuredContent();
+			testGraphQLGetSiteStructuredContentsPage_addStructuredContent();
 		StructuredContent structuredContent2 =
-			testGraphQLStructuredContent_addStructuredContent();
+			testGraphQLGetSiteStructuredContentsPage_addStructuredContent();
 
 		structuredContentsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -1521,6 +1521,13 @@ public abstract class BaseStructuredContentResourceTestCase {
 			Arrays.asList(
 				StructuredContentSerDes.toDTOs(
 					structuredContentsJSONObject.getString("items"))));
+	}
+
+	protected StructuredContent
+			testGraphQLGetSiteStructuredContentsPage_addStructuredContent()
+		throws Exception {
+
+		return testGraphQLStructuredContent_addStructuredContent();
 	}
 
 	@Test
@@ -1623,7 +1630,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		throws Exception {
 
 		StructuredContent structuredContent =
-			testGraphQLStructuredContent_addStructuredContent();
+			testGraphQLGetSiteStructuredContentByExternalReferenceCode_addStructuredContent();
 
 		Assert.assertTrue(
 			equals(
@@ -1679,6 +1686,13 @@ public abstract class BaseStructuredContentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected StructuredContent
+			testGraphQLGetSiteStructuredContentByExternalReferenceCode_addStructuredContent()
+		throws Exception {
+
+		return testGraphQLStructuredContent_addStructuredContent();
 	}
 
 	@Test
@@ -1775,7 +1789,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 	@Test
 	public void testGraphQLGetSiteStructuredContentByKey() throws Exception {
 		StructuredContent structuredContent =
-			testGraphQLStructuredContent_addStructuredContent();
+			testGraphQLGetSiteStructuredContentByKey_addStructuredContent();
 
 		Assert.assertTrue(
 			equals(
@@ -1827,6 +1841,13 @@ public abstract class BaseStructuredContentResourceTestCase {
 				"Object/code"));
 	}
 
+	protected StructuredContent
+			testGraphQLGetSiteStructuredContentByKey_addStructuredContent()
+		throws Exception {
+
+		return testGraphQLStructuredContent_addStructuredContent();
+	}
+
 	@Test
 	public void testGetSiteStructuredContentByUuid() throws Exception {
 		StructuredContent postStructuredContent =
@@ -1852,7 +1873,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 	@Test
 	public void testGraphQLGetSiteStructuredContentByUuid() throws Exception {
 		StructuredContent structuredContent =
-			testGraphQLStructuredContent_addStructuredContent();
+			testGraphQLGetSiteStructuredContentByUuid_addStructuredContent();
 
 		Assert.assertTrue(
 			equals(
@@ -1902,6 +1923,13 @@ public abstract class BaseStructuredContentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected StructuredContent
+			testGraphQLGetSiteStructuredContentByUuid_addStructuredContent()
+		throws Exception {
+
+		return testGraphQLStructuredContent_addStructuredContent();
 	}
 
 	@Test
@@ -2431,7 +2459,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 	@Test
 	public void testGraphQLDeleteStructuredContent() throws Exception {
 		StructuredContent structuredContent =
-			testGraphQLStructuredContent_addStructuredContent();
+			testGraphQLDeleteStructuredContent_addStructuredContent();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -2464,6 +2492,13 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected StructuredContent
+			testGraphQLDeleteStructuredContent_addStructuredContent()
+		throws Exception {
+
+		return testGraphQLStructuredContent_addStructuredContent();
+	}
+
 	@Test
 	public void testGetStructuredContent() throws Exception {
 		StructuredContent postStructuredContent =
@@ -2487,7 +2522,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 	@Test
 	public void testGraphQLGetStructuredContent() throws Exception {
 		StructuredContent structuredContent =
-			testGraphQLStructuredContent_addStructuredContent();
+			testGraphQLGetStructuredContent_addStructuredContent();
 
 		Assert.assertTrue(
 			equals(
@@ -2528,6 +2563,13 @@ public abstract class BaseStructuredContentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected StructuredContent
+			testGraphQLGetStructuredContent_addStructuredContent()
+		throws Exception {
+
+		return testGraphQLStructuredContent_addStructuredContent();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
@@ -547,8 +547,8 @@ public abstract class BaseWikiNodeResourceTestCase {
 
 		Assert.assertEquals(0, wikiNodesJSONObject.get("totalCount"));
 
-		WikiNode wikiNode1 = testGraphQLWikiNode_addWikiNode();
-		WikiNode wikiNode2 = testGraphQLWikiNode_addWikiNode();
+		WikiNode wikiNode1 = testGraphQLGetSiteWikiNodesPage_addWikiNode();
+		WikiNode wikiNode2 = testGraphQLGetSiteWikiNodesPage_addWikiNode();
 
 		wikiNodesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -560,6 +560,12 @@ public abstract class BaseWikiNodeResourceTestCase {
 			Arrays.asList(wikiNode1, wikiNode2),
 			Arrays.asList(
 				WikiNodeSerDes.toDTOs(wikiNodesJSONObject.getString("items"))));
+	}
+
+	protected WikiNode testGraphQLGetSiteWikiNodesPage_addWikiNode()
+		throws Exception {
+
+		return testGraphQLWikiNode_addWikiNode();
 	}
 
 	@Test
@@ -647,7 +653,8 @@ public abstract class BaseWikiNodeResourceTestCase {
 	public void testGraphQLGetSiteWikiNodeByExternalReferenceCode()
 		throws Exception {
 
-		WikiNode wikiNode = testGraphQLWikiNode_addWikiNode();
+		WikiNode wikiNode =
+			testGraphQLGetSiteWikiNodeByExternalReferenceCode_addWikiNode();
 
 		Assert.assertTrue(
 			equals(
@@ -701,6 +708,13 @@ public abstract class BaseWikiNodeResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected WikiNode
+			testGraphQLGetSiteWikiNodeByExternalReferenceCode_addWikiNode()
+		throws Exception {
+
+		return testGraphQLWikiNode_addWikiNode();
 	}
 
 	@Test
@@ -839,7 +853,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteWikiNode() throws Exception {
-		WikiNode wikiNode = testGraphQLWikiNode_addWikiNode();
+		WikiNode wikiNode = testGraphQLDeleteWikiNode_addWikiNode();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -868,6 +882,12 @@ public abstract class BaseWikiNodeResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected WikiNode testGraphQLDeleteWikiNode_addWikiNode()
+		throws Exception {
+
+		return testGraphQLWikiNode_addWikiNode();
+	}
+
 	@Test
 	public void testGetWikiNode() throws Exception {
 		WikiNode postWikiNode = testGetWikiNode_addWikiNode();
@@ -886,7 +906,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 
 	@Test
 	public void testGraphQLGetWikiNode() throws Exception {
-		WikiNode wikiNode = testGraphQLWikiNode_addWikiNode();
+		WikiNode wikiNode = testGraphQLGetWikiNode_addWikiNode();
 
 		Assert.assertTrue(
 			equals(
@@ -923,6 +943,10 @@ public abstract class BaseWikiNodeResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected WikiNode testGraphQLGetWikiNode_addWikiNode() throws Exception {
+		return testGraphQLWikiNode_addWikiNode();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
@@ -234,7 +234,7 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 	@Test
 	public void testGraphQLDeleteWikiPageAttachment() throws Exception {
 		WikiPageAttachment wikiPageAttachment =
-			testGraphQLWikiPageAttachment_addWikiPageAttachment();
+			testGraphQLDeleteWikiPageAttachment_addWikiPageAttachment();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -267,6 +267,13 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected WikiPageAttachment
+			testGraphQLDeleteWikiPageAttachment_addWikiPageAttachment()
+		throws Exception {
+
+		return testGraphQLWikiPageAttachment_addWikiPageAttachment();
+	}
+
 	@Test
 	public void testGetWikiPageAttachment() throws Exception {
 		WikiPageAttachment postWikiPageAttachment =
@@ -291,7 +298,7 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 	@Test
 	public void testGraphQLGetWikiPageAttachment() throws Exception {
 		WikiPageAttachment wikiPageAttachment =
-			testGraphQLWikiPageAttachment_addWikiPageAttachment();
+			testGraphQLGetWikiPageAttachment_addWikiPageAttachment();
 
 		Assert.assertTrue(
 			equals(
@@ -332,6 +339,13 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected WikiPageAttachment
+			testGraphQLGetWikiPageAttachment_addWikiPageAttachment()
+		throws Exception {
+
+		return testGraphQLWikiPageAttachment_addWikiPageAttachment();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
@@ -266,7 +266,8 @@ public abstract class BaseWikiPageResourceTestCase {
 	public void testGraphQLGetSiteWikiPageByExternalReferenceCode()
 		throws Exception {
 
-		WikiPage wikiPage = testGraphQLWikiPage_addWikiPage();
+		WikiPage wikiPage =
+			testGraphQLGetSiteWikiPageByExternalReferenceCode_addWikiPage();
 
 		Assert.assertTrue(
 			equals(
@@ -320,6 +321,13 @@ public abstract class BaseWikiPageResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected WikiPage
+			testGraphQLGetSiteWikiPageByExternalReferenceCode_addWikiPage()
+		throws Exception {
+
+		return testGraphQLWikiPage_addWikiPage();
 	}
 
 	@Test
@@ -836,7 +844,7 @@ public abstract class BaseWikiPageResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteWikiPage() throws Exception {
-		WikiPage wikiPage = testGraphQLWikiPage_addWikiPage();
+		WikiPage wikiPage = testGraphQLDeleteWikiPage_addWikiPage();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -865,6 +873,12 @@ public abstract class BaseWikiPageResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected WikiPage testGraphQLDeleteWikiPage_addWikiPage()
+		throws Exception {
+
+		return testGraphQLWikiPage_addWikiPage();
+	}
+
 	@Test
 	public void testGetWikiPage() throws Exception {
 		WikiPage postWikiPage = testGetWikiPage_addWikiPage();
@@ -883,7 +897,7 @@ public abstract class BaseWikiPageResourceTestCase {
 
 	@Test
 	public void testGraphQLGetWikiPage() throws Exception {
-		WikiPage wikiPage = testGraphQLWikiPage_addWikiPage();
+		WikiPage wikiPage = testGraphQLGetWikiPage_addWikiPage();
 
 		Assert.assertTrue(
 			equals(
@@ -920,6 +934,10 @@ public abstract class BaseWikiPageResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected WikiPage testGraphQLGetWikiPage_addWikiPage() throws Exception {
+		return testGraphQLWikiPage_addWikiPage();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
@@ -225,7 +225,8 @@ public abstract class BaseFormDocumentResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteFormDocument() throws Exception {
-		FormDocument formDocument = testGraphQLFormDocument_addFormDocument();
+		FormDocument formDocument =
+			testGraphQLDeleteFormDocument_addFormDocument();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -254,6 +255,12 @@ public abstract class BaseFormDocumentResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected FormDocument testGraphQLDeleteFormDocument_addFormDocument()
+		throws Exception {
+
+		return testGraphQLFormDocument_addFormDocument();
+	}
+
 	@Test
 	public void testGetFormDocument() throws Exception {
 		FormDocument postFormDocument = testGetFormDocument_addFormDocument();
@@ -274,7 +281,8 @@ public abstract class BaseFormDocumentResourceTestCase {
 
 	@Test
 	public void testGraphQLGetFormDocument() throws Exception {
-		FormDocument formDocument = testGraphQLFormDocument_addFormDocument();
+		FormDocument formDocument =
+			testGraphQLGetFormDocument_addFormDocument();
 
 		Assert.assertTrue(
 			equals(
@@ -313,6 +321,12 @@ public abstract class BaseFormDocumentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected FormDocument testGraphQLGetFormDocument_addFormDocument()
+		throws Exception {
+
+		return testGraphQLFormDocument_addFormDocument();
 	}
 
 	protected FormDocument testGraphQLFormDocument_addFormDocument()

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
@@ -203,7 +203,7 @@ public abstract class BaseFormRecordResourceTestCase {
 
 	@Test
 	public void testGraphQLGetFormRecord() throws Exception {
-		FormRecord formRecord = testGraphQLFormRecord_addFormRecord();
+		FormRecord formRecord = testGraphQLGetFormRecord_addFormRecord();
 
 		Assert.assertTrue(
 			equals(
@@ -240,6 +240,12 @@ public abstract class BaseFormRecordResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected FormRecord testGraphQLGetFormRecord_addFormRecord()
+		throws Exception {
+
+		return testGraphQLFormRecord_addFormRecord();
 	}
 
 	@Test
@@ -406,7 +412,8 @@ public abstract class BaseFormRecordResourceTestCase {
 
 	@Test
 	public void testGraphQLGetFormFormRecordByLatestDraft() throws Exception {
-		FormRecord formRecord = testGraphQLFormRecord_addFormRecord();
+		FormRecord formRecord =
+			testGraphQLGetFormFormRecordByLatestDraft_addFormRecord();
 
 		Assert.assertTrue(
 			equals(
@@ -446,6 +453,13 @@ public abstract class BaseFormRecordResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected FormRecord
+			testGraphQLGetFormFormRecordByLatestDraft_addFormRecord()
+		throws Exception {
+
+		return testGraphQLFormRecord_addFormRecord();
 	}
 
 	protected FormRecord testGraphQLFormRecord_addFormRecord()

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
@@ -213,7 +213,7 @@ public abstract class BaseFormResourceTestCase {
 
 	@Test
 	public void testGraphQLGetForm() throws Exception {
-		Form form = testGraphQLForm_addForm();
+		Form form = testGraphQLGetForm_addForm();
 
 		Assert.assertTrue(
 			equals(
@@ -250,6 +250,10 @@ public abstract class BaseFormResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Form testGraphQLGetForm_addForm() throws Exception {
+		return testGraphQLForm_addForm();
 	}
 
 	@Test
@@ -360,8 +364,8 @@ public abstract class BaseFormResourceTestCase {
 
 		Assert.assertEquals(0, formsJSONObject.get("totalCount"));
 
-		Form form1 = testGraphQLForm_addForm();
-		Form form2 = testGraphQLForm_addForm();
+		Form form1 = testGraphQLGetSiteFormsPage_addForm();
+		Form form2 = testGraphQLGetSiteFormsPage_addForm();
 
 		formsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -373,6 +377,10 @@ public abstract class BaseFormResourceTestCase {
 			Arrays.asList(form1, form2),
 			Arrays.asList(
 				FormSerDes.toDTOs(formsJSONObject.getString("items"))));
+	}
+
+	protected Form testGraphQLGetSiteFormsPage_addForm() throws Exception {
+		return testGraphQLForm_addForm();
 	}
 
 	@Test

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
@@ -214,7 +214,7 @@ public abstract class BaseFormStructureResourceTestCase {
 	@Test
 	public void testGraphQLGetFormStructure() throws Exception {
 		FormStructure formStructure =
-			testGraphQLFormStructure_addFormStructure();
+			testGraphQLGetFormStructure_addFormStructure();
 
 		Assert.assertTrue(
 			equals(
@@ -255,6 +255,12 @@ public abstract class BaseFormStructureResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected FormStructure testGraphQLGetFormStructure_addFormStructure()
+		throws Exception {
+
+		return testGraphQLFormStructure_addFormStructure();
 	}
 
 	@Test
@@ -393,9 +399,9 @@ public abstract class BaseFormStructureResourceTestCase {
 		Assert.assertEquals(0, formStructuresJSONObject.get("totalCount"));
 
 		FormStructure formStructure1 =
-			testGraphQLFormStructure_addFormStructure();
+			testGraphQLGetSiteFormStructuresPage_addFormStructure();
 		FormStructure formStructure2 =
-			testGraphQLFormStructure_addFormStructure();
+			testGraphQLGetSiteFormStructuresPage_addFormStructure();
 
 		formStructuresJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -408,6 +414,13 @@ public abstract class BaseFormStructureResourceTestCase {
 			Arrays.asList(
 				FormStructureSerDes.toDTOs(
 					formStructuresJSONObject.getString("items"))));
+	}
+
+	protected FormStructure
+			testGraphQLGetSiteFormStructuresPage_addFormStructure()
+		throws Exception {
+
+		return testGraphQLFormStructure_addFormStructure();
 	}
 
 	protected FormStructure testGraphQLFormStructure_addFormStructure()

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -376,7 +376,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.object.admin.rest.client', and version '1.0.17'."
+        'com.liferay.object.admin.rest.client', and version '1.0.18'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.17'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.18'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectActionResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectActionResourceTestCase.java
@@ -223,7 +223,8 @@ public abstract class BaseObjectActionResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteObjectAction() throws Exception {
-		ObjectAction objectAction = testGraphQLObjectAction_addObjectAction();
+		ObjectAction objectAction =
+			testGraphQLDeleteObjectAction_addObjectAction();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -252,6 +253,12 @@ public abstract class BaseObjectActionResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected ObjectAction testGraphQLDeleteObjectAction_addObjectAction()
+		throws Exception {
+
+		return testGraphQLObjectAction_addObjectAction();
+	}
+
 	@Test
 	public void testGetObjectAction() throws Exception {
 		ObjectAction postObjectAction = testGetObjectAction_addObjectAction();
@@ -272,7 +279,8 @@ public abstract class BaseObjectActionResourceTestCase {
 
 	@Test
 	public void testGraphQLGetObjectAction() throws Exception {
-		ObjectAction objectAction = testGraphQLObjectAction_addObjectAction();
+		ObjectAction objectAction =
+			testGraphQLGetObjectAction_addObjectAction();
 
 		Assert.assertTrue(
 			equals(
@@ -311,6 +319,12 @@ public abstract class BaseObjectActionResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ObjectAction testGraphQLGetObjectAction_addObjectAction()
+		throws Exception {
+
+		return testGraphQLObjectAction_addObjectAction();
 	}
 
 	@Test

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
@@ -552,9 +552,9 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 		long totalCount = objectDefinitionsJSONObject.getLong("totalCount");
 
 		ObjectDefinition objectDefinition1 =
-			testGraphQLObjectDefinition_addObjectDefinition();
+			testGraphQLGetObjectDefinitionsPage_addObjectDefinition();
 		ObjectDefinition objectDefinition2 =
-			testGraphQLObjectDefinition_addObjectDefinition();
+			testGraphQLGetObjectDefinitionsPage_addObjectDefinition();
 
 		objectDefinitionsJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -573,6 +573,13 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 			Arrays.asList(
 				ObjectDefinitionSerDes.toDTOs(
 					objectDefinitionsJSONObject.getString("items"))));
+	}
+
+	protected ObjectDefinition
+			testGraphQLGetObjectDefinitionsPage_addObjectDefinition()
+		throws Exception {
+
+		return testGraphQLObjectDefinition_addObjectDefinition();
 	}
 
 	@Test
@@ -625,7 +632,7 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 	@Test
 	public void testGraphQLDeleteObjectDefinition() throws Exception {
 		ObjectDefinition objectDefinition =
-			testGraphQLObjectDefinition_addObjectDefinition();
+			testGraphQLDeleteObjectDefinition_addObjectDefinition();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -656,6 +663,13 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected ObjectDefinition
+			testGraphQLDeleteObjectDefinition_addObjectDefinition()
+		throws Exception {
+
+		return testGraphQLObjectDefinition_addObjectDefinition();
+	}
+
 	@Test
 	public void testGetObjectDefinition() throws Exception {
 		ObjectDefinition postObjectDefinition =
@@ -679,7 +693,7 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 	@Test
 	public void testGraphQLGetObjectDefinition() throws Exception {
 		ObjectDefinition objectDefinition =
-			testGraphQLObjectDefinition_addObjectDefinition();
+			testGraphQLGetObjectDefinition_addObjectDefinition();
 
 		Assert.assertTrue(
 			equals(
@@ -720,6 +734,13 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ObjectDefinition
+			testGraphQLGetObjectDefinition_addObjectDefinition()
+		throws Exception {
+
+		return testGraphQLObjectDefinition_addObjectDefinition();
 	}
 
 	@Test

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
@@ -364,7 +364,7 @@ public abstract class BaseObjectFieldResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteObjectField() throws Exception {
-		ObjectField objectField = testGraphQLObjectField_addObjectField();
+		ObjectField objectField = testGraphQLDeleteObjectField_addObjectField();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -393,6 +393,12 @@ public abstract class BaseObjectFieldResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected ObjectField testGraphQLDeleteObjectField_addObjectField()
+		throws Exception {
+
+		return testGraphQLObjectField_addObjectField();
+	}
+
 	@Test
 	public void testGetObjectField() throws Exception {
 		ObjectField postObjectField = testGetObjectField_addObjectField();
@@ -411,7 +417,7 @@ public abstract class BaseObjectFieldResourceTestCase {
 
 	@Test
 	public void testGraphQLGetObjectField() throws Exception {
-		ObjectField objectField = testGraphQLObjectField_addObjectField();
+		ObjectField objectField = testGraphQLGetObjectField_addObjectField();
 
 		Assert.assertTrue(
 			equals(
@@ -450,6 +456,12 @@ public abstract class BaseObjectFieldResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ObjectField testGraphQLGetObjectField_addObjectField()
+		throws Exception {
+
+		return testGraphQLObjectField_addObjectField();
 	}
 
 	@Test

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectLayoutResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectLayoutResourceTestCase.java
@@ -362,7 +362,8 @@ public abstract class BaseObjectLayoutResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteObjectLayout() throws Exception {
-		ObjectLayout objectLayout = testGraphQLObjectLayout_addObjectLayout();
+		ObjectLayout objectLayout =
+			testGraphQLDeleteObjectLayout_addObjectLayout();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -391,6 +392,12 @@ public abstract class BaseObjectLayoutResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected ObjectLayout testGraphQLDeleteObjectLayout_addObjectLayout()
+		throws Exception {
+
+		return testGraphQLObjectLayout_addObjectLayout();
+	}
+
 	@Test
 	public void testGetObjectLayout() throws Exception {
 		ObjectLayout postObjectLayout = testGetObjectLayout_addObjectLayout();
@@ -411,7 +418,8 @@ public abstract class BaseObjectLayoutResourceTestCase {
 
 	@Test
 	public void testGraphQLGetObjectLayout() throws Exception {
-		ObjectLayout objectLayout = testGraphQLObjectLayout_addObjectLayout();
+		ObjectLayout objectLayout =
+			testGraphQLGetObjectLayout_addObjectLayout();
 
 		Assert.assertTrue(
 			equals(
@@ -450,6 +458,12 @@ public abstract class BaseObjectLayoutResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ObjectLayout testGraphQLGetObjectLayout_addObjectLayout()
+		throws Exception {
+
+		return testGraphQLObjectLayout_addObjectLayout();
 	}
 
 	@Test

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
@@ -504,7 +504,7 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 	@Test
 	public void testGraphQLDeleteObjectRelationship() throws Exception {
 		ObjectRelationship objectRelationship =
-			testGraphQLObjectRelationship_addObjectRelationship();
+			testGraphQLDeleteObjectRelationship_addObjectRelationship();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -537,6 +537,13 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected ObjectRelationship
+			testGraphQLDeleteObjectRelationship_addObjectRelationship()
+		throws Exception {
+
+		return testGraphQLObjectRelationship_addObjectRelationship();
+	}
+
 	@Test
 	public void testGetObjectRelationship() throws Exception {
 		ObjectRelationship postObjectRelationship =
@@ -561,7 +568,7 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 	@Test
 	public void testGraphQLGetObjectRelationship() throws Exception {
 		ObjectRelationship objectRelationship =
-			testGraphQLObjectRelationship_addObjectRelationship();
+			testGraphQLGetObjectRelationship_addObjectRelationship();
 
 		Assert.assertTrue(
 			equals(
@@ -602,6 +609,13 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ObjectRelationship
+			testGraphQLGetObjectRelationship_addObjectRelationship()
+		throws Exception {
+
+		return testGraphQLObjectRelationship_addObjectRelationship();
 	}
 
 	@Test

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectViewResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectViewResourceTestCase.java
@@ -352,7 +352,7 @@ public abstract class BaseObjectViewResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteObjectView() throws Exception {
-		ObjectView objectView = testGraphQLObjectView_addObjectView();
+		ObjectView objectView = testGraphQLDeleteObjectView_addObjectView();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -381,6 +381,12 @@ public abstract class BaseObjectViewResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected ObjectView testGraphQLDeleteObjectView_addObjectView()
+		throws Exception {
+
+		return testGraphQLObjectView_addObjectView();
+	}
+
 	@Test
 	public void testGetObjectView() throws Exception {
 		ObjectView postObjectView = testGetObjectView_addObjectView();
@@ -399,7 +405,7 @@ public abstract class BaseObjectViewResourceTestCase {
 
 	@Test
 	public void testGraphQLGetObjectView() throws Exception {
-		ObjectView objectView = testGraphQLObjectView_addObjectView();
+		ObjectView objectView = testGraphQLGetObjectView_addObjectView();
 
 		Assert.assertTrue(
 			equals(
@@ -436,6 +442,12 @@ public abstract class BaseObjectViewResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected ObjectView testGraphQLGetObjectView_addObjectView()
+		throws Exception {
+
+		return testGraphQLObjectView_addObjectView();
 	}
 
 	@Test

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-openapi.yaml
@@ -570,7 +570,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.14'."
+        'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.15'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.14'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.15'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
@@ -498,7 +498,7 @@ public abstract class BaseInstanceResourceTestCase {
 
 	@Test
 	public void testGraphQLGetProcessInstance() throws Exception {
-		Instance instance = testGraphQLInstance_addInstance();
+		Instance instance = testGraphQLGetProcessInstance_addInstance();
 
 		Assert.assertTrue(
 			equals(
@@ -540,6 +540,12 @@ public abstract class BaseInstanceResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Instance testGraphQLGetProcessInstance_addInstance()
+		throws Exception {
+
+		return testGraphQLInstance_addInstance();
 	}
 
 	@Test

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessResourceTestCase.java
@@ -235,7 +235,7 @@ public abstract class BaseProcessResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteProcess() throws Exception {
-		Process process = testGraphQLProcess_addProcess();
+		Process process = testGraphQLDeleteProcess_addProcess();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -264,6 +264,10 @@ public abstract class BaseProcessResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Process testGraphQLDeleteProcess_addProcess() throws Exception {
+		return testGraphQLProcess_addProcess();
+	}
+
 	@Test
 	public void testGetProcess() throws Exception {
 		Process postProcess = testGetProcess_addProcess();
@@ -281,7 +285,7 @@ public abstract class BaseProcessResourceTestCase {
 
 	@Test
 	public void testGraphQLGetProcess() throws Exception {
-		Process process = testGraphQLProcess_addProcess();
+		Process process = testGraphQLGetProcess_addProcess();
 
 		Assert.assertTrue(
 			equals(
@@ -318,6 +322,10 @@ public abstract class BaseProcessResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Process testGraphQLGetProcess_addProcess() throws Exception {
+		return testGraphQLProcess_addProcess();
 	}
 
 	@Test

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResourceTestCase.java
@@ -324,7 +324,7 @@ public abstract class BaseSLAResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteSLA() throws Exception {
-		SLA sla = testGraphQLSLA_addSLA();
+		SLA sla = testGraphQLDeleteSLA_addSLA();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -353,6 +353,10 @@ public abstract class BaseSLAResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected SLA testGraphQLDeleteSLA_addSLA() throws Exception {
+		return testGraphQLSLA_addSLA();
+	}
+
 	@Test
 	public void testGetSLA() throws Exception {
 		SLA postSLA = testGetSLA_addSLA();
@@ -370,7 +374,7 @@ public abstract class BaseSLAResourceTestCase {
 
 	@Test
 	public void testGraphQLGetSLA() throws Exception {
-		SLA sla = testGraphQLSLA_addSLA();
+		SLA sla = testGraphQLGetSLA_addSLA();
 
 		Assert.assertTrue(
 			equals(
@@ -407,6 +411,10 @@ public abstract class BaseSLAResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected SLA testGraphQLGetSLA_addSLA() throws Exception {
+		return testGraphQLSLA_addSLA();
 	}
 
 	@Test

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResultResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResultResourceTestCase.java
@@ -194,10 +194,15 @@ public abstract class BaseSLAResultResourceTestCase {
 		SLAResult postSLAResult = testGetProcessLastSLAResult_addSLAResult();
 
 		SLAResult getSLAResult = slaResultResource.getProcessLastSLAResult(
-			null);
+			testGetProcessLastSLAResult_getProcessId());
 
 		assertEquals(postSLAResult, getSLAResult);
 		assertValid(getSLAResult);
+	}
+
+	protected Long testGetProcessLastSLAResult_getProcessId() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected SLAResult testGetProcessLastSLAResult_addSLAResult()
@@ -221,11 +226,20 @@ public abstract class BaseSLAResultResourceTestCase {
 								"processLastSLAResult",
 								new HashMap<String, Object>() {
 									{
-										put("processId", null);
+										put(
+											"processId",
+											testGraphQLGetProcessLastSLAResult_getProcessId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/processLastSLAResult"))));
+	}
+
+	protected Long testGraphQLGetProcessLastSLAResult_getProcessId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResultResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResultResourceTestCase.java
@@ -214,7 +214,7 @@ public abstract class BaseSLAResultResourceTestCase {
 
 	@Test
 	public void testGraphQLGetProcessLastSLAResult() throws Exception {
-		SLAResult slaResult = testGraphQLSLAResult_addSLAResult();
+		SLAResult slaResult = testGraphQLGetProcessLastSLAResult_addSLAResult();
 
 		Assert.assertTrue(
 			equals(
@@ -260,6 +260,12 @@ public abstract class BaseSLAResultResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected SLAResult testGraphQLGetProcessLastSLAResult_addSLAResult()
+		throws Exception {
+
+		return testGraphQLSLAResult_addSLAResult();
 	}
 
 	protected SLAResult testGraphQLSLAResult_addSLAResult() throws Exception {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTaskResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTaskResourceTestCase.java
@@ -310,7 +310,7 @@ public abstract class BaseTaskResourceTestCase {
 
 	@Test
 	public void testGraphQLGetProcessTask() throws Exception {
-		Task task = testGraphQLTask_addTask();
+		Task task = testGraphQLGetProcessTask_addTask();
 
 		Assert.assertTrue(
 			equals(
@@ -350,6 +350,10 @@ public abstract class BaseTaskResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Task testGraphQLGetProcessTask_addTask() throws Exception {
+		return testGraphQLTask_addTask();
 	}
 
 	@Test

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTimeRangeResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTimeRangeResourceTestCase.java
@@ -234,8 +234,8 @@ public abstract class BaseTimeRangeResourceTestCase {
 
 		long totalCount = timeRangesJSONObject.getLong("totalCount");
 
-		TimeRange timeRange1 = testGraphQLTimeRange_addTimeRange();
-		TimeRange timeRange2 = testGraphQLTimeRange_addTimeRange();
+		TimeRange timeRange1 = testGraphQLGetTimeRangesPage_addTimeRange();
+		TimeRange timeRange2 = testGraphQLGetTimeRangesPage_addTimeRange();
 
 		timeRangesJSONObject = JSONUtil.getValueAsJSONObject(
 			invokeGraphQLQuery(graphQLField), "JSONObject/data",
@@ -254,6 +254,12 @@ public abstract class BaseTimeRangeResourceTestCase {
 			Arrays.asList(
 				TimeRangeSerDes.toDTOs(
 					timeRangesJSONObject.getString("items"))));
+	}
+
+	protected TimeRange testGraphQLGetTimeRangesPage_addTimeRange()
+		throws Exception {
+
+		return testGraphQLTimeRange_addTimeRange();
 	}
 
 	protected TimeRange testGraphQLTimeRange_addTimeRange() throws Exception {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
@@ -562,7 +562,8 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteSXPBlueprint() throws Exception {
-		SXPBlueprint sxpBlueprint = testGraphQLSXPBlueprint_addSXPBlueprint();
+		SXPBlueprint sxpBlueprint =
+			testGraphQLDeleteSXPBlueprint_addSXPBlueprint();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -591,6 +592,12 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected SXPBlueprint testGraphQLDeleteSXPBlueprint_addSXPBlueprint()
+		throws Exception {
+
+		return testGraphQLSXPBlueprint_addSXPBlueprint();
+	}
+
 	@Test
 	public void testGetSXPBlueprint() throws Exception {
 		SXPBlueprint postSXPBlueprint = testGetSXPBlueprint_addSXPBlueprint();
@@ -611,7 +618,8 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 
 	@Test
 	public void testGraphQLGetSXPBlueprint() throws Exception {
-		SXPBlueprint sxpBlueprint = testGraphQLSXPBlueprint_addSXPBlueprint();
+		SXPBlueprint sxpBlueprint =
+			testGraphQLGetSXPBlueprint_addSXPBlueprint();
 
 		Assert.assertTrue(
 			equals(
@@ -650,6 +658,12 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected SXPBlueprint testGraphQLGetSXPBlueprint_addSXPBlueprint()
+		throws Exception {
+
+		return testGraphQLSXPBlueprint_addSXPBlueprint();
 	}
 
 	@Test

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPElementResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPElementResourceTestCase.java
@@ -550,7 +550,7 @@ public abstract class BaseSXPElementResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteSXPElement() throws Exception {
-		SXPElement sxpElement = testGraphQLSXPElement_addSXPElement();
+		SXPElement sxpElement = testGraphQLDeleteSXPElement_addSXPElement();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -579,6 +579,12 @@ public abstract class BaseSXPElementResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected SXPElement testGraphQLDeleteSXPElement_addSXPElement()
+		throws Exception {
+
+		return testGraphQLSXPElement_addSXPElement();
+	}
+
 	@Test
 	public void testGetSXPElement() throws Exception {
 		SXPElement postSXPElement = testGetSXPElement_addSXPElement();
@@ -597,7 +603,7 @@ public abstract class BaseSXPElementResourceTestCase {
 
 	@Test
 	public void testGraphQLGetSXPElement() throws Exception {
-		SXPElement sxpElement = testGraphQLSXPElement_addSXPElement();
+		SXPElement sxpElement = testGraphQLGetSXPElement_addSXPElement();
 
 		Assert.assertTrue(
 			equals(
@@ -634,6 +640,12 @@ public abstract class BaseSXPElementResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected SXPElement testGraphQLGetSXPElement_addSXPElement()
+		throws Exception {
+
+		return testGraphQLSXPElement_addSXPElement();
 	}
 
 	@Test

--- a/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentResourceTestCase.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentResourceTestCase.java
@@ -221,7 +221,7 @@ public abstract class BaseExperimentResourceTestCase {
 
 	@Test
 	public void testGraphQLDeleteExperiment() throws Exception {
-		Experiment experiment = testGraphQLExperiment_addExperiment();
+		Experiment experiment = testGraphQLDeleteExperiment_addExperiment();
 
 		Assert.assertTrue(
 			JSONUtil.getValueAsBoolean(
@@ -254,6 +254,12 @@ public abstract class BaseExperimentResourceTestCase {
 		Assert.assertTrue(errorsJSONArray.length() > 0);
 	}
 
+	protected Experiment testGraphQLDeleteExperiment_addExperiment()
+		throws Exception {
+
+		return testGraphQLExperiment_addExperiment();
+	}
+
 	@Test
 	public void testGetExperiment() throws Exception {
 		Experiment postExperiment = testGetExperiment_addExperiment();
@@ -272,7 +278,7 @@ public abstract class BaseExperimentResourceTestCase {
 
 	@Test
 	public void testGraphQLGetExperiment() throws Exception {
-		Experiment experiment = testGraphQLExperiment_addExperiment();
+		Experiment experiment = testGraphQLGetExperiment_addExperiment();
 
 		Assert.assertTrue(
 			equals(
@@ -312,6 +318,12 @@ public abstract class BaseExperimentResourceTestCase {
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
+
+	protected Experiment testGraphQLGetExperiment_addExperiment()
+		throws Exception {
+
+		return testGraphQLExperiment_addExperiment();
 	}
 
 	protected Experiment testGraphQLExperiment_addExperiment()

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -250,6 +250,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 		</#if>
 
 		<#if freeMarkerTool.hasHTTPMethod(javaMethodSignature, "delete")>
+			<#assign missingGetterJavaMethodParametersMap = {} />
+
 			@Test
 			public void test${javaMethodSignature.methodName?cap_first}() throws Exception {
 				<#if properties?keys?seq_contains("id")>
@@ -269,7 +271,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
 								${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
 							<#else>
-								null
+								<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
 							</#if>
 						<#else>
 							null
@@ -291,7 +294,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
 								${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
 							<#else>
-								null
+								<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
 							</#if>
 
 							<#sep>, </#sep>
@@ -307,7 +311,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
 								${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
 							<#else>
-								null
+								<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
 							</#if>
 
 							<#sep>, </#sep>
@@ -319,6 +324,12 @@ public abstract class Base${schemaName}ResourceTestCase {
 					Assert.assertTrue(false);
 				</#if>
 			}
+
+			<@getGetterParameterMethods
+				javaMethodSignature=javaMethodSignature
+				missingGetterJavaMethodParametersMap=missingGetterJavaMethodParametersMap
+				testNamePrefix="test"
+			/>
 
 			<#if properties?keys?seq_contains("id")>
 				protected ${schemaName} test${javaMethodSignature.methodName?cap_first}_add${schemaName}() throws Exception {
@@ -1030,6 +1041,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 				</#list>
 			</#if>
 		<#elseif freeMarkerTool.hasHTTPMethod(javaMethodSignature, "get") && javaMethodSignature.returnType?ends_with(schemaName)>
+			<#assign missingGetterJavaMethodParametersMap = {} />
+
 			@Test
 			public void test${javaMethodSignature.methodName?cap_first}() throws Exception {
 				<#if properties?keys?seq_contains("id")>
@@ -1050,7 +1063,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
 								post${schemaName}.get${javaMethodParameter.parameterName?cap_first}()
 							<#else>
-								null
+								<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
 							</#if>
 						<#else>
 							null
@@ -1065,6 +1079,12 @@ public abstract class Base${schemaName}ResourceTestCase {
 					Assert.assertTrue(false);
 				</#if>
 			}
+
+			<@getGetterParameterMethods
+				javaMethodSignature=javaMethodSignature
+				missingGetterJavaMethodParametersMap=missingGetterJavaMethodParametersMap
+				testNamePrefix="test"
+			/>
 
 			<#if properties?keys?seq_contains("id")>
 				protected ${schemaName} test${javaMethodSignature.methodName?cap_first}_add${schemaName}() throws Exception {
@@ -1307,6 +1327,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 				</#if>
 			}
 		<#elseif freeMarkerTool.hasHTTPMethod(javaMethodSignature, "put") && javaMethodSignature.returnType?ends_with(schemaName)>
+			<#assign missingGetterJavaMethodParametersMap = {} />
+
 			@Test
 			public void test${javaMethodSignature.methodName?cap_first}() throws Exception {
 				<#if !properties?keys?seq_contains("id")>
@@ -1376,6 +1398,12 @@ public abstract class Base${schemaName}ResourceTestCase {
 						put${schemaName}.getExternalReferenceCode());
 				</#if>
 			}
+
+			<@getGetterParameterMethods
+				javaMethodSignature=javaMethodSignature
+				missingGetterJavaMethodParametersMap=missingGetterJavaMethodParametersMap
+				testNamePrefix="test"
+			/>
 
 			<#if javaMethodSignature.methodName?cap_first?ends_with("ByExternalReferenceCode")>
 				protected ${schemaName} test${javaMethodSignature.methodName?cap_first}_create${schemaName}() throws Exception {
@@ -1626,6 +1654,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 				</#if>
 			}
 		<#elseif configYAML.generateGraphQL && freeMarkerTool.hasHTTPMethod(javaMethodSignature, "get") && javaMethodSignature.returnType?ends_with(schemaName)>
+			<#assign missingGetterJavaMethodParametersMap = {} />
+
 			@Test
 			public void testGraphQL${javaMethodSignature.methodName?cap_first}() throws Exception {
 				<#if properties?keys?seq_contains("id")>
@@ -1650,18 +1680,31 @@ public abstract class Base${schemaName}ResourceTestCase {
 																	${schemaVarName}.getId()
 																</#if>
 															);
-														<#elseif stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
-															put("siteKey", "\"" + ${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}() + "\"");
 														<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
-															put("${javaMethodParameter.parameterName}",
-																<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
-																	"\"" + ${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}() + "\""
-																<#else>
-																	${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
-																</#if>
-															);
+															<#if stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
+																put("siteKey", "\"" + ${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}() + "\"");
+															<#else>
+																put("${javaMethodParameter.parameterName}",
+																	<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
+																		"\"" + ${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}() + "\""
+																	<#else>
+																		${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+																	</#if>
+																);
+															</#if>
 														<#else>
-															put("${javaMethodParameter.parameterName}", null);
+															<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+															<#if stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
+																put("siteKey", "\"" + testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}() + "\"");
+															<#else>
+																put("${javaMethodParameter.parameterName}",
+																<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
+																	"\"" + testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}() + "\""
+																<#else>
+																	testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
+																</#if>
+																);
+															</#if>
 														</#if>
 													</#if>
 												</#list>
@@ -1674,6 +1717,12 @@ public abstract class Base${schemaName}ResourceTestCase {
 					Assert.assertTrue(true);
 				</#if>
 			}
+
+			<@getGetterParameterMethods
+				javaMethodSignature=javaMethodSignature
+				missingGetterJavaMethodParametersMap=missingGetterJavaMethodParametersMap
+				testNamePrefix="testGraphQL"
+			/>
 
 			@Test
 			public void testGraphQL${javaMethodSignature.methodName?cap_first}NotFound() throws Exception {
@@ -2616,9 +2665,36 @@ public abstract class Base${schemaName}ResourceTestCase {
 			put${schemaName}.getId()
 		<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
 			put${schemaName}.get${javaMethodParameter.parameterName?cap_first}()
+		<#else>
+			<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+			test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
 		</#if>
 
 		<#sep>, </#sep>
+	</#list>
+</#macro>
+
+<#macro getGetterParameterMethod
+	javaMethodParameter
+	javaMethodSignature
+	testNamePrefix
+>
+	protected ${javaMethodParameter.parameterType} ${testNamePrefix}${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}() throws Exception {
+		throw new UnsupportedOperationException("This method needs to be implemented");
+	}
+</#macro>
+
+<#macro getGetterParameterMethods
+	javaMethodSignature
+	missingGetterJavaMethodParametersMap
+	testNamePrefix
+>
+	<#list missingGetterJavaMethodParametersMap?values as javaMethodParameter>
+		<@getGetterParameterMethod
+			javaMethodParameter=javaMethodParameter
+			javaMethodSignature=javaMethodSignature
+			testNamePrefix=testNamePrefix
+		/>
 	</#list>
 </#macro>
 
@@ -2671,7 +2747,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 		<#elseif stringUtil.equals(javaMethodParameter.parameterName, "multipartBody") || stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
 			${newSchemaVarNamePrefix}${schemaName}
 		<#else>
-			null
+			<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+			test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
 		</#if>
 		<#sep>, </#sep>
 	</#list>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -1542,7 +1542,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 													<#if stringUtil.equals(javaMethodParameter.parameterName, "id") || stringUtil.equals(javaMethodParameter.parameterName, "${schemaVarName}Id")>
 														"${javaMethodParameter.parameterName}",
 														<#if stringUtil.equals(properties.id, "String")>
-															"\"" + ${schemaVarName}.getId() + "\""
+															<@getQuotedString unquotedString="${schemaVarName}.getId()" />
 														<#else>
 															${schemaVarName}.getId()
 														</#if>
@@ -1566,7 +1566,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 													<#if stringUtil.equals(javaMethodParameter.parameterName, "id") || stringUtil.equals(javaMethodParameter.parameterName, "${schemaVarName}Id")>
 														"${javaMethodParameter.parameterName}",
 														<#if stringUtil.equals(properties.id, "String")>
-															"\"" + ${schemaVarName}.getId() + "\""
+															<@getQuotedString unquotedString="${schemaVarName}.getId()" />
 														<#else>
 															${schemaVarName}.getId()
 														</#if>
@@ -1607,11 +1607,11 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 								<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
 									<#if stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
-										put("siteKey", "\"" + ${javaMethodParameter.parameterName} + "\"");
+										put("siteKey", <@getQuotedString unquotedString="${javaMethodParameter.parameterName}" />);
 									<#else>
 										put("${javaMethodParameter.parameterName}",
 											<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
-												"\"" + ${javaMethodParameter.parameterName} + "\""
+												<@getQuotedString unquotedString="${javaMethodParameter.parameterName}" />
 											<#else>
 												${javaMethodParameter.parameterName}
 											</#if>
@@ -1675,18 +1675,18 @@ public abstract class Base${schemaName}ResourceTestCase {
 														<#if stringUtil.equals(javaMethodParameter.parameterName, schemaVarName + "Id")>
 															put("${javaMethodParameter.parameterName}",
 																<#if stringUtil.equals(properties.id, "String")>
-																	"\"" + ${schemaVarName}.getId() + "\""
+																	<@getQuotedString unquotedString="${schemaVarName}.getId()" />
 																<#else>
 																	${schemaVarName}.getId()
 																</#if>
 															);
 														<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
 															<#if stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
-																put("siteKey", "\"" + ${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}() + "\"");
+																put("siteKey", <@getQuotedString unquotedString="${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()" />);
 															<#else>
 																put("${javaMethodParameter.parameterName}",
 																	<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
-																		"\"" + ${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}() + "\""
+																		<@getQuotedString unquotedString="${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()" />
 																	<#else>
 																		${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
 																	</#if>
@@ -1695,11 +1695,11 @@ public abstract class Base${schemaName}ResourceTestCase {
 														<#else>
 															<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
 															<#if stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
-																put("siteKey", "\"" + testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}() + "\"");
+																put("siteKey", <@getQuotedString unquotedString="testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()" />);
 															<#else>
 																put("${javaMethodParameter.parameterName}",
 																<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
-																	"\"" + testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}() + "\""
+																	<@getQuotedString unquotedString="testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()" />
 																<#else>
 																	testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
 																</#if>
@@ -1739,7 +1739,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.Double")>
 								RandomTestUtil.randomDouble();
 							<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
-								"\"" + RandomTestUtil.randomString() + "\"";
+								<@getQuotedString unquotedString="RandomTestUtil.randomString()" />;
 							<#else>
 								null;
 							</#if>
@@ -1757,7 +1757,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 											<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
 												<#if freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
 													<#if stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
-														put("siteKey", "\"" + irrelevantGroup.getGroupId() + "\"");
+														put("siteKey", <@getQuotedString unquotedString="irrelevantGroup.getGroupId()" />);
 													<#else>
 														put("${javaMethodParameter.parameterName}", irrelevant${javaMethodParameter.parameterName?cap_first});
 													</#if>
@@ -1978,7 +1978,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 								"createSite${schemaName}",
 								new HashMap<String, Object>() {
 									{
-										put("siteKey", "\"" + testGroup.getGroupId() + "\"");
+										put("siteKey", <@getQuotedString unquotedString="testGroup.getGroupId()" />);
 										put("${schemaVarName}", sb.toString());
 									}
 								},
@@ -2729,6 +2729,11 @@ public abstract class Base${schemaName}ResourceTestCase {
 	<#else>
 		null
 	</#if>
+</#macro>
+
+<#macro getQuotedString
+	unquotedString>
+	"\"" + ${unquotedString} + "\""
 </#macro>
 
 <#macro getPutParameters

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -1522,13 +1522,17 @@ public abstract class Base${schemaName}ResourceTestCase {
 			}
 		</#if>
 
+		<#assign generateTestGraphQLAddMethod = false />
+
 		<#if configYAML.generateGraphQL && freeMarkerTool.hasHTTPMethod(javaMethodSignature, "delete") && stringUtil.equals(freeMarkerTool.getGraphQLPropertyName(javaMethodSignature, javaMethodSignatures), "delete" + schemaName)>
+
 			@Test
 			public void testGraphQL${javaMethodSignature.methodName?cap_first}() throws Exception {
 				<#if !properties?keys?seq_contains("id")>
 					Assert.assertTrue(false);
 				<#else>
-					${schemaName} ${schemaVarName} = testGraphQL${schemaName}_add${schemaName}();
+					<#assign generateTestGraphQLAddMethod = true />
+					${schemaName} ${schemaVarName} = testGraphQL${javaMethodSignature.methodName?cap_first}_add${schemaName}();
 
 					Assert.assertTrue(
 						JSONUtil.getValueAsBoolean(
@@ -1582,6 +1586,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 					</#if>
 				</#if>
 			}
+
 		<#elseif configYAML.generateGraphQL && freeMarkerTool.hasHTTPMethod(javaMethodSignature, "get") && javaMethodSignature.returnType?contains("Page<") && stringUtil.equals(freeMarkerTool.getGraphQLPropertyName(javaMethodSignature, javaMethodSignatures), schemaVarNames)>
 			@Test
 			public void testGraphQL${javaMethodSignature.methodName?cap_first}() throws Exception {
@@ -1635,8 +1640,9 @@ public abstract class Base${schemaName}ResourceTestCase {
 						Assert.assertEquals(0, ${schemaVarNames}JSONObject.get("totalCount"));
 					</#if>
 
-					${schemaName} ${schemaVarName}1 = testGraphQL${schemaName}_add${schemaName}();
-					${schemaName} ${schemaVarName}2 = testGraphQL${schemaName}_add${schemaName}();
+					<#assign generateTestGraphQLAddMethod = true />
+					${schemaName} ${schemaVarName}1 = testGraphQL${javaMethodSignature.methodName?cap_first}_add${schemaName}();
+					${schemaName} ${schemaVarName}2 = testGraphQL${javaMethodSignature.methodName?cap_first}_add${schemaName}();
 
 					${schemaVarNames}JSONObject = JSONUtil.getValueAsJSONObject(
 						invokeGraphQLQuery(graphQLField),
@@ -1659,7 +1665,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 			@Test
 			public void testGraphQL${javaMethodSignature.methodName?cap_first}() throws Exception {
 				<#if properties?keys?seq_contains("id")>
-					${schemaName} ${schemaVarName} = testGraphQL${schemaName}_add${schemaName}();
+					<#assign generateTestGraphQLAddMethod = true />
+					${schemaName} ${schemaVarName} = testGraphQL${javaMethodSignature.methodName?cap_first}_add${schemaName}();
 
 					Assert.assertTrue(
 						equals(${schemaVarName},
@@ -1779,6 +1786,12 @@ public abstract class Base${schemaName}ResourceTestCase {
 				${schemaName} ${schemaVarName} = testGraphQL${schemaName}_add${schemaName}(random${schemaName});
 
 				Assert.assertTrue(equals(random${schemaName}, ${schemaVarName}));
+			}
+		</#if>
+
+		<#if generateTestGraphQLAddMethod>
+			protected ${schemaName} testGraphQL${javaMethodSignature.methodName?cap_first}_add${schemaName}() throws Exception {
+				return testGraphQL${schemaName}_add${schemaName}();
 			}
 		</#if>
 	</#list>


### PR DESCRIPTION
Related PR (the CI was failing, verified that is not related to this PR): https://github.com/liferay-frontend/liferay-portal/pull/2068

Related ticket: [LPS-149497](https://issues.liferay.com/browse/LPS-149497)

This PR contains an updated template for the `Base*ResourceTestCase` that includes the following:

- Auto-generation of new protected methods to allow, from any extended Test, to modify the value of the attributes that are not included in the API model.
- Auto-generation of new protected methods to customize the creation of API model objects for GraphQL tests.

**Before the PR:**

The test should be completely overriden without calling the test from the parent because it was not possible to customize the value of any parameter included in the path of the URL but not in the requested API model either the creation of objects from different GraphQL.

```
@Test
public void testGetTermOrderTypeOrderType() throws Exception {
        OrderType postOrderType = testGetTermOrderTypeOrderType_addOrderType();
        
        OrderType getOrderType = orderTypeResource.getTermOrderTypeOrderType(null);
        
        assertEquals(postOrderType, getOrderType);
        assertValid(getOrderType);
}
```

The test should be completely overriden without calling the test from the parent because it was not possible to customize in some cases the way of creating objects from different tests as it was always the same way.

```
@Test
public void testGraphQLGetSiteDocumentCommentByExternalReferenceCode()
	throws Exception {

	Comment comment = testGraphQLComment_addComment();
...

```
```
@Test
public void testGraphQLGetSiteStructuredContentCommentByExternalReferenceCode()
	throws Exception {

	Comment comment = testGraphQLComment_addComment();
...

```

The method creates only one type of element, in this case a Comment associated to a BlogPosting (internally StructuredContent), not associated to a Document.

```
@Override
protected Comment testGraphQLComment_addComment() throws Exception {
	return _addBlogPostingComment();
}
```
So it would be necessary to override the whole tests to customize the created object.


**After the PR:**

It is possible to use the test from the Base class by implementing/overriding the required methods.

```
@Test
public void testGetTermOrderTypeOrderType() throws Exception {
	OrderType postOrderType = testGetTermOrderTypeOrderType_addOrderType();

	OrderType getOrderType = orderTypeResource.getTermOrderTypeOrderType(
		testGetTermOrderTypeOrderType_getTermOrderTypeId());

	assertEquals(postOrderType, getOrderType);
	assertValid(getOrderType);
}
```

```
protected Long testGetTermOrderTypeOrderType_getTermOrderTypeId()
	throws Exception {

	throw new UnsupportedOperationException(
		"This method needs to be implemented");
}
```

It is possible to customize the created object:


```
@Test
public void testGraphQLGetSiteDocumentCommentByExternalReferenceCode()
	throws Exception {

	Comment comment = testGraphQLGetSiteDocumentCommentByExternalReferenceCode_addComment();
...

```
```
@Test
public void testGraphQLGetSiteStructuredContentCommentByExternalReferenceCode()
	throws Exception {

	Comment comment = testGraphQLGetSiteStructuredContentCommentByExternalReferenceCode_addComment();
...

```
```
@Override
public void testGraphQLGetSiteDocumentCommentByExternalReferenceCode_addComment()
	throws Exception {

	Comment comment = _addFileEntryComment();
...

```
```
@Override
public void testGraphQLGetSiteStructuredContentCommentByExternalReferenceCode_addComment()
	throws Exception {

	Comment comment = _addBlogEntryComment();
...

```

The default implementation invokes the previous method:
```
protected Comment testGraphQLGetSiteDocumentCommentByExternalReferenceCode_addComment() throws Exception {
	return testGraphQLComment_addComment();
}
```