### PR TITLE
POSHI-315 POSHI-321 POSHI-323 Update documentation and improve poshi release process

### DIFF
--- a/modules/sdk/gradle-plugins-poshi-runner/README.markdown
+++ b/modules/sdk/gradle-plugins-poshi-runner/README.markdown
@@ -60,3 +60,62 @@ Name | Depends On | Type | Description
 `runPoshi` | \- | [`Test`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html) | Executes a Poshi test.
 `validatePoshi` | \- | [`JavaExec`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.JavaExec.html) | Invokes the Poshi class: [`com.liferay.poshi.core.PoshiValidation`](https://github.com/liferay/liferay-portal/blob/master/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiValidation.java). Validates the Poshi file syntax
 `writePoshiProperties` | \- | [`JavaExec`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.JavaExec.html) | Generates properties using meta data from Poshi files in the project.
+
+# Poshi Runner Resources Gradle Plugin
+The Poshi Runner Resources Gradle plugin lets you use Poshi resource jars in your Poshi project or publish them.
+
+## Usage
+
+To use the plugin, include it in your build script:
+
+```gradle
+buildscript {
+	dependencies {
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.poshi.runner", version: "3.0.35"
+	}
+
+	repositories {
+		maven {
+			url "https://repository-cdn.liferay.com/nexus/content/groups/public"
+		}
+	}
+}
+
+apply plugin: "com.liferay.poshi.runner.resources.defaults"
+```
+
+To use a specific Poshi Resource JAR, add the following applying the plugin (where `GROUP`, `NAME` and `VERSION` refer to a maven dependency):
+```gradle
+dependencies {
+	poshiRunnerResources group: "GROUP", name: "NAME", version: "VERSION"
+}
+```
+
+For example (this resource is already configured in the plugin by default):
+```gradle
+dependencies {
+	poshiRunnerResources group: "com.liferay", name: "com.liferay.poshi.runner.resources", version: "latest.release"
+}
+```
+
+## Project Extension
+
+The Poshi Runner Gradle plugin exposes the following properties through the
+extension named `poshiRunnerResources`:
+
+Property Name | Type | Default Value | Description
+------------- | ---- | ------------- | -----------
+`artifactAppendix` | `String` |  | For creating a Poshi resource jar. The appendix for the generated Poshi resource jar (used for the group ID)
+`artifactVersion` | `String` |  | For creating a Poshi resource jar. The version for the generated Poshi resource jar (used for the artifact ID)
+`baseName` | `String` | `default` | For creating a Poshi resource jar. The base directory name for the Poshi files in the Poshi resource jar.
+`dirs` | Set<String> | | For creating a Poshi resource jar. The directories to include as subdirectories of `baseName` in teh Poshi resource jar.
+`version` | `String` | `latest.release` | For using a Poshi resource jar. The version of a Poshi resource jar to be used.
+
+## Tasks
+
+The plugin adds a series of tasks to your project:
+
+Name | Depends On | Type | Description
+---- | ---------- | ---- | -----------
+`jarPoshiRunnerResources` | \- | [`Jar`](https://docs.gradle.org/6.6/dsl/org.gradle.api.tasks.bundling.Jar.html) | Creates a Poshi resource jar.
+`uploadPoshiRunnerResources` | \- | [`Upload`](https://docs.gradle.org/6.6/javadoc/org/gradle/api/tasks/Upload.html) | Uploads all Poshi resource artifacts.

--- a/modules/sdk/gradle-plugins-poshi-runner/README.markdown
+++ b/modules/sdk/gradle-plugins-poshi-runner/README.markdown
@@ -105,8 +105,8 @@ extension named `poshiRunnerResources`:
 
 Property Name | Type | Default Value | Description
 ------------- | ---- | ------------- | -----------
-`artifactAppendix` | `String` |  | For creating a Poshi resource jar. The appendix for the generated Poshi resource jar (used for the group ID)
-`artifactVersion` | `String` |  | For creating a Poshi resource jar. The version for the generated Poshi resource jar (used for the artifact ID)
+`artifactAppendix` | `String` | | For creating a Poshi resource jar. The appendix for the generated Poshi resource jar (used for the group ID)
+`artifactVersion` | `String` | | For creating a Poshi resource jar. The version for the generated Poshi resource jar (used for the artifact ID)
 `baseName` | `String` | `default` | For creating a Poshi resource jar. The base directory name for the Poshi files in the Poshi resource jar.
 `dirs` | Set<String> | | For creating a Poshi resource jar. The directories to include as subdirectories of `baseName` in teh Poshi resource jar.
 `version` | `String` | `latest.release` | For using a Poshi resource jar. The version of a Poshi resource jar to be used.

--- a/modules/sdk/gradle-plugins-poshi-runner/README.markdown
+++ b/modules/sdk/gradle-plugins-poshi-runner/README.markdown
@@ -34,12 +34,20 @@ Property Name | Type | Default Value | Description
 `openCVVersion` | `String` | `2.4.9-0.9` | The version of OpenCV to use (Sikuli dependency).
 `poshiPropertiesFile` | `File` | `poshi.properties` | The properties file that will override and update test configurations.
 `testNames` | Set<String> | | The test names to be passed along to Poshi. The plugin will set `test.name` to `testNames` in system properties.
-`version` | `String` | `"1.0.311"` | The version of [`com.liferay.poshi.runner`](https://github.com/liferay/liferay-portal/tree/master/modules/test/poshi/poshi-runner) to use.
+`version` | `String` | `1.0.311` | The version of [`com.liferay.poshi.runner`](https://github.com/liferay/liferay-portal/tree/master/modules/test/poshi/poshi-runner) to use.
 
 The properties of type `File` support any type that can be resolved by
 [`project.file`](https://docs.gradle.org/current/dsl/org.gradle.api.Project.html#org.gradle.api.Project:file(java.css.Object)).
 Moreover, it is possible to use Closures and Callables as values for `String`,
 to defer evaluation until execution.
+
+### Setting a specific version of Poshi Runner
+In your `build.gradle`, after applying the plugin:
+```gradle
+poshiRunner {
+	version = "1.0.311"
+}
+```
 
 ## Tasks
 

--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 	compile group: "com.amazonaws", name: "aws-java-sdk-rds", version: "1.11.220"
 	compile group: "com.google.cloud", name: "google-cloud-storage", version: "1.113.16"
 	compile group: "com.google.guava", name: "guava", version: "30.1.1-jre"
-	compile group: "com.liferay", name: "com.liferay.poshi.core", version: "1.0.58"
+	compile group: "com.liferay", name: "com.liferay.poshi.core", version: "1.0.59"
 	compile group: "com.sun.mail", name: "jakarta.mail", version: "1.6.6"
 	compile group: "commons-codec", name: "commons-codec", version: "1.9"
 	compile group: "commons-io", name: "commons-io", version: "2.8.0"

--- a/modules/test/poshi/poshi-runner/build.gradle
+++ b/modules/test/poshi/poshi-runner/build.gradle
@@ -1,3 +1,4 @@
+import com.liferay.gradle.plugins.defaults.tasks.ReplaceRegexTask
 import com.liferay.gradle.util.copy.RenameDependencyClosure
 
 buildCSS {
@@ -31,6 +32,8 @@ dependencies {
 	compileOnly project(":test:data-guard-connector")
 }
 
+task release(type: ReplaceRegexTask)
+
 deploy {
 	from configurations.runtime
 	rename new RenameDependencyClosure(project, configurations.runtime.name)
@@ -42,4 +45,16 @@ liferay {
 
 liferayOSGi {
 	expandCompileInclude = true
+}
+
+release {
+	String releaseVersion = project.getVersion()
+
+	if (project.hasProperty("releaseVersion")) {
+		releaseVersion = getProperty("releaseVersion")
+	}
+
+	setReplacement(releaseVersion)
+
+	match(/private Object _version = "(\d.+)";/, "../../../sdk/gradle-plugins-poshi-runner/src/main/java/com/liferay/gradle/plugins/poshi/runner/PoshiRunnerExtension.java")
 }

--- a/modules/util/source-formatter-standalone/build.gradle
+++ b/modules/util/source-formatter-standalone/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 	compileInclude group: "com.liferay", name: "com.liferay.petra.lang", version: "1.0.0"
 	compileInclude group: "com.liferay", name: "com.liferay.petra.nio", version: "1.0.0"
 	compileInclude group: "com.liferay", name: "com.liferay.petra.string", version: "2.0.0"
-	compileInclude group: "com.liferay", name: "com.liferay.poshi.core", version: "1.0.56"
+	compileInclude group: "com.liferay", name: "com.liferay.poshi.core", version: "1.0.59"
 
 	compileInclude group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	compileInclude group: "com.liferay", name: "com.liferay.petra.concurrent", version: "1.1.0"

--- a/modules/util/source-formatter/build.gradle
+++ b/modules/util/source-formatter/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	compileInclude group: "com.liferay", name: "com.liferay.petra.lang", version: "1.0.0"
 	compileInclude group: "com.liferay", name: "com.liferay.petra.nio", version: "1.0.0"
 	compileInclude group: "com.liferay", name: "com.liferay.petra.string", version: "2.0.0"
-	compileInclude group: "com.liferay", name: "com.liferay.poshi.core", version: "1.0.56"
+	compileInclude group: "com.liferay", name: "com.liferay.poshi.core", version: "1.0.59"
 
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.concurrent", version: "1.1.0"

--- a/portal-web/build-test.gradle
+++ b/portal-web/build-test.gradle
@@ -1,7 +1,10 @@
+import com.liferay.gradle.plugins.defaults.tasks.ReplaceRegexTask
 import com.liferay.gradle.util.GradleUtil
 
 import java.util.regex.Matcher
 
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.util.GUtil
 
 buildscript {
@@ -50,6 +53,7 @@ poshiRunner {
 }
 
 task updateGradleCache
+task updatePoshiCore(type: ReplaceRegexTask)
 
 configurations {
 	sikuliComplete
@@ -141,4 +145,16 @@ updateGradleCache {
 		configurations.poshiRunner.resolve()
 		configurations.sikuliComplete.resolve()
 	}
+}
+
+updatePoshiCore {
+	Configuration compileConfiguration = project.configurations.getByName("poshiRunner")
+
+	ResolvedArtifact resolvedArtifact = compileConfiguration.resolvedConfiguration.resolvedArtifacts.find {
+		it.name.contains('com.liferay.poshi.core')
+	}
+
+	setReplacement(resolvedArtifact.moduleVersion.id.version)
+
+	match(/group: "com\.liferay", name: "com\.liferay\.poshi\.core", version: "(\d.+)"/, "../modules/test/jenkins-results-parser/build.gradle", "../modules/util/source-formatter/build.gradle", "../modules/util/source-formatter-standalone/build.gradle")
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/POSHI-323
https://issues.liferay.com/browse/POSHI-315
https://issues.liferay.com/browse/POSHI-321

Manually forwarding due to unrelated SF errors and only contains documentation and build.gradle changes. https://github.com/kenjiheigel/liferay-portal/pull/1011#issuecomment-1085297157 

The gradle tasks are to make it easier for us to do poshi releases. Once we're ready for release, we'll bump the poshi core versions in Jenkins & SF to match poshi runner to avoid some of the issues that have happened due to mismatched poshi-core jars (results in inconsistent Poshi parsing). 

Please publish SF, and jenkins-results-parser after merging. Thanks!