### PR TITLE
LPS-150397 Avoid null value because it is resulting in a empty value,this is value='', in the html markup, this way checkbox preserves the default behaviour of the html entity input:checkbox

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/CheckboxTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/CheckboxTag.java
@@ -129,7 +129,10 @@ public class CheckboxTag extends BaseContainerTag {
 		}
 
 		props.put("name", _name);
-		props.put("value", _value);
+
+		if (Validator.isNotNull(getValue())) {
+			props.put("value", _value);
+		}
 
 		return super.prepareProps(props);
 	}


### PR DESCRIPTION
Manually forwarding because unrelated test failures on `ci:test:relevant`

Original PR https://github.com/liferay-frontend/liferay-portal/pull/2070

---

https://issues.liferay.com/browse/LPS-150397

According to this documentation https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#attr-value , a checkbox should send "on" by default if it is checked and it has not a value attribute

This is not happening with the current implementation of the clay:checkbox, that it is sending an empty value if the attribute is not added, just something like this code:

```
	<clay:checkbox
		label="clayCheckox"
		inline="<%= true %>"
		id="<%= liferayPortletResponse.getNamespace() + "clayCheckbox" %>"
		name="<%= liferayPortletResponse.getNamespace() + "clayCheckbox" %>"
	/>
```
Steps to reproduce:

1. Deploy [org.support.liferay.checkbox.jar](https://issues.liferay.com/secure/attachment/446569/446569_org.support.liferay.checkbox.jar)[](https://issues.liferay.com/secure/attachment/446442/446442_checkKO.png) , which has a aui:checkbox, a clay:checkbox and a html input:checkbox to compare differences.
2. Add the Checkbox portlet to a page, and select the three checboxes and click save.
3. Take a look to the values in the request (with the web developer tools of the browser) and also to the server log, in where parameters are written in the log file and previously loaded with the `com.liferay.portal.kernel.util.ParamUtil` class, just this code:
```
		boolean auiCheck = ParamUtil.getBoolean(renderRequest, "auiCheckbox");
		boolean clayCheck = ParamUtil.getBoolean(renderRequest, "clayCheckbox");

		String sAuiCheck = ParamUtil.getString(renderRequest, "auiCheckbox");
		String sClayCheck = ParamUtil.getString(renderRequest, "clayCheckbox");

		if (_log.isInfoEnabled()) {
			_log.info("auiCheckbox " + auiCheck + " string value: " + sAuiCheck);
			_log.info("clayCheckbox " + clayCheck + " string value: " + sClayCheck);
		}
```
	
 **Expected**: all sent values are the same, "on", when they are checked, and true if they are loaded with ParamUtil.getBoolean(...)
 
 **Observed**: Clay checkbox sends an empty value, this results in a false value when the checkbox is loaded from the request using our utils.