### PR TITLE
LPS-148632 Unescape Structure names in Web Content list showed after click on Plus button

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -114,7 +114,7 @@ const CreationMenu = ({
 				symbolLeft={item.icon}
 				{...getDataAttributes(item.data)}
 			>
-				{item.label}
+				{Liferay.Util.unescapeHTML(item.label)}
 			</ClayDropDown.Item>
 		);
 	};


### PR DESCRIPTION
Manually forwarded from: https://github.com/liferay-frontend/liferay-portal/pull/2054

PR Description:

https://issues.liferay.com/browse/LPS-148632

/cc @hongvo2308 @sontruongces

CreationMenu (used by features like web content when adding a new web content of a specific web content structure) in the management toolbar double-escapes the label.

## Steps to reproduce

1. Go to Content & Data > Web Content > Structure
1. Add a Structure;
1. Add any field to the Structure;
1. Add a title using some or all of these symbols:
    * &apos;
    * &quot;
    * &amp;
    * &gt;
    * &lt;
1. Save the structure;
1. Go to the Web Content tab;
1. Click on the Add button (the plus top right) to expand the CreationMenu

Expected behavior is that the menu shows the proper structure titles.

Actual behavior is that the menu shows an escaped version of the structure titles.

## Solution notes

From @sontruongces
> The Structure name already escape in JournalManagementToolbarDisplayContext.java line 588. And browser will unescape it to show the correct value. But In React, React DOM escapes one more time the value embedded in JSX before rendering them.