### PR TITLE
LPS-143467 LPS-143469 LPS-143455 Add Util class to get metadata information from OpenAPI to help batch framework

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
@@ -729,6 +729,10 @@ public abstract class BaseAccountAddressResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<AccountAddress> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
@@ -547,6 +547,10 @@ public abstract class BaseAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<AccountGroup> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountMemberResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountMemberResourceImpl.java
@@ -561,6 +561,10 @@ public abstract class BaseAccountMemberResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<AccountMember> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountOrganizationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountOrganizationResourceImpl.java
@@ -492,6 +492,10 @@ public abstract class BaseAccountOrganizationResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<AccountOrganization> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -619,6 +619,10 @@ public abstract class BaseAccountResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Account> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseUserResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseUserResourceImpl.java
@@ -131,6 +131,10 @@ public abstract class BaseUserResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<User> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-address.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-address.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.account.dto.v1_0.AccountAddress
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Account)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-group.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.account.dto.v1_0.AccountGroup
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Account)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-member.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-member.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.account.dto.v1_0.AccountMember
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Account)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-organization.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-organization.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.account.dto.v1_0.AccountOrganization
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Account)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.account.dto.v1_0.Account
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Account)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/user.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/user.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.account.dto.v1_0.User
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Account)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
@@ -700,6 +700,10 @@ public abstract class BaseAttachmentResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Attachment> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
@@ -549,6 +549,10 @@ public abstract class BaseCatalogResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Catalog> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
@@ -247,6 +247,10 @@ public abstract class BaseCategoryResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Category> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseDiagramResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseDiagramResourceImpl.java
@@ -257,6 +257,10 @@ public abstract class BaseDiagramResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Diagram> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
@@ -477,6 +477,10 @@ public abstract class BaseMappedProductResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<MappedProduct> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
@@ -378,6 +378,10 @@ public abstract class BaseOptionCategoryResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<OptionCategory> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionResourceImpl.java
@@ -470,6 +470,10 @@ public abstract class BaseOptionResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Option> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
@@ -568,6 +568,10 @@ public abstract class BaseOptionValueResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<OptionValue> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
@@ -377,6 +377,10 @@ public abstract class BasePinResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Pin> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductAccountGroupResourceImpl.java
@@ -310,6 +310,10 @@ public abstract class BaseProductAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProductAccountGroup> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductChannelResourceImpl.java
@@ -300,6 +300,10 @@ public abstract class BaseProductChannelResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProductChannel> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductConfigurationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductConfigurationResourceImpl.java
@@ -244,6 +244,10 @@ public abstract class BaseProductConfigurationResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProductConfiguration> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupProductResourceImpl.java
@@ -406,6 +406,10 @@ public abstract class BaseProductGroupProductResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProductGroupProduct> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupResourceImpl.java
@@ -465,6 +465,10 @@ public abstract class BaseProductGroupResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProductGroup> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
@@ -433,6 +433,10 @@ public abstract class BaseProductOptionResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProductOption> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionValueResourceImpl.java
@@ -237,6 +237,10 @@ public abstract class BaseProductOptionValueResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProductOptionValue> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
@@ -546,6 +546,10 @@ public abstract class BaseProductResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Product> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductShippingConfigurationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductShippingConfigurationResourceImpl.java
@@ -247,6 +247,10 @@ public abstract class BaseProductShippingConfigurationResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProductShippingConfiguration> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
@@ -231,6 +231,10 @@ public abstract class BaseProductSpecificationResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProductSpecification> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSubscriptionConfigurationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSubscriptionConfigurationResourceImpl.java
@@ -252,6 +252,10 @@ public abstract class BaseProductSubscriptionConfigurationResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProductSubscriptionConfiguration> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductTaxConfigurationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductTaxConfigurationResourceImpl.java
@@ -247,6 +247,10 @@ public abstract class BaseProductTaxConfigurationResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProductTaxConfiguration> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
@@ -440,6 +440,10 @@ public abstract class BaseRelatedProductResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<RelatedProduct> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
@@ -586,6 +586,10 @@ public abstract class BaseSkuResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Sku> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSpecificationResourceImpl.java
@@ -385,6 +385,10 @@ public abstract class BaseSpecificationResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Specification> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/attachment.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/attachment.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Attachment
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/catalog.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/catalog.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Catalog
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/category.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Category
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/diagram.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/diagram.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Diagram
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/mapped-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/mapped-product.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.MappedProduct
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/option-category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/option-category.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.OptionCategory
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/option-value.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/option-value.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.OptionValue
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/option.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/option.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Option
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/pin.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/pin.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Pin
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-account-group.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductAccountGroup
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-channel.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-channel.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductChannel
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-configuration.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-configuration.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductConfiguration
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-group-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-group-product.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductGroupProduct
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-group.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductGroup
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-option-value.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-option-value.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductOptionValue
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-option.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-option.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductOption
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-shipping-configuration.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-shipping-configuration.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductShippingConfiguration
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-specification.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-specification.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductSpecification
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-subscription-configuration.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-subscription-configuration.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductSubscriptionConfiguration
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-tax-configuration.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-tax-configuration.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductTaxConfiguration
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Product
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/related-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/related-product.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.RelatedProduct
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sku.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sku.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Sku
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/specification.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/specification.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.catalog.dto.v1_0.Specification
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -625,6 +625,10 @@ public abstract class BaseChannelResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Channel> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
@@ -161,6 +161,10 @@ public abstract class BaseOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<OrderType> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelOrderTypeResourceImpl.java
@@ -295,6 +295,10 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<PaymentMethodGroupRelOrderType> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelTermResourceImpl.java
@@ -292,6 +292,10 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<PaymentMethodGroupRelTerm> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionOrderTypeResourceImpl.java
@@ -294,6 +294,10 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ShippingFixedOptionOrderType> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionTermResourceImpl.java
@@ -292,6 +292,10 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ShippingFixedOptionTerm> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -142,6 +142,10 @@ public abstract class BaseShippingMethodResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ShippingMethod> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -165,6 +165,10 @@ public abstract class BaseTaxCategoryResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<TaxCategory> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTermResourceImpl.java
@@ -161,6 +161,10 @@ public abstract class BaseTermResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Term> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/channel.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/channel.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.Channel
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-type.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.OrderType
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/payment-method-group-rel-order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/payment-method-group-rel-order-type.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.PaymentMethodGroupRelOrderType
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/payment-method-group-rel-term.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/payment-method-group-rel-term.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.PaymentMethodGroupRelTerm
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-fixed-option-order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-fixed-option-order-type.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.ShippingFixedOptionOrderType
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-fixed-option-term.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-fixed-option-term.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.ShippingFixedOptionTerm
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-method.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-method.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.ShippingMethod
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/tax-category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/tax-category.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.TaxCategory
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/term.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/term.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.channel.dto.v1_0.Term
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Channel)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
@@ -600,6 +600,10 @@ public abstract class BaseWarehouseItemResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<WarehouseItem> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -352,6 +352,10 @@ public abstract class BaseWarehouseResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Warehouse> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/warehouse-item.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/warehouse-item.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.inventory.dto.v1_0.WarehouseItem
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Inventory)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/warehouse.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/warehouse.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.inventory.dto.v1_0.Warehouse
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Inventory)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
@@ -129,6 +129,10 @@ public abstract class BaseAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<AccountGroup> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -188,6 +188,10 @@ public abstract class BaseAccountResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Account> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseBillingAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseBillingAddressResourceImpl.java
@@ -236,6 +236,10 @@ public abstract class BaseBillingAddressResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<BillingAddress> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -218,6 +218,10 @@ public abstract class BaseChannelResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Channel> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderItemResourceImpl.java
@@ -544,6 +544,10 @@ public abstract class BaseOrderItemResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<OrderItem> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
@@ -544,6 +544,10 @@ public abstract class BaseOrderNoteResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<OrderNote> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderResourceImpl.java
@@ -470,6 +470,10 @@ public abstract class BaseOrderResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Order> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountGroupResourceImpl.java
@@ -409,6 +409,10 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<OrderRuleAccountGroup> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountResourceImpl.java
@@ -395,6 +395,10 @@ public abstract class BaseOrderRuleAccountResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<OrderRuleAccount> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleChannelResourceImpl.java
@@ -403,6 +403,10 @@ public abstract class BaseOrderRuleChannelResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<OrderRuleChannel> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleOrderTypeResourceImpl.java
@@ -394,6 +394,10 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<OrderRuleOrderType> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleResourceImpl.java
@@ -459,6 +459,10 @@ public abstract class BaseOrderRuleResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<OrderRule> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeChannelResourceImpl.java
@@ -398,6 +398,10 @@ public abstract class BaseOrderTypeChannelResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<OrderTypeChannel> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
@@ -521,6 +521,10 @@ public abstract class BaseOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<OrderType> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseShippingAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseShippingAddressResourceImpl.java
@@ -267,6 +267,10 @@ public abstract class BaseShippingAddressResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ShippingAddress> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermOrderTypeResourceImpl.java
@@ -391,6 +391,10 @@ public abstract class BaseTermOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<TermOrderType> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermResourceImpl.java
@@ -452,6 +452,10 @@ public abstract class BaseTermResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Term> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-group.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.AccountGroup
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.Account
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/billing-address.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/billing-address.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.BillingAddress
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/channel.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/channel.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.Channel
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-item.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-item.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderItem
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-note.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-note.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderNote
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-account-group.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRuleAccountGroup
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-account.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-account.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRuleAccount
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-channel.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-channel.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRuleChannel
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule-order-type.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRuleOrderType
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-rule.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRule
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-type-channel.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-type-channel.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderTypeChannel
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order-type.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.OrderType
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/order.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.Order
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-address.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-address.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.ShippingAddress
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/term-order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/term-order-type.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.TermOrderType
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/term.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/term.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.order.dto.v1_0.Term
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountAccountGroupResourceImpl.java
@@ -412,6 +412,10 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<DiscountAccountGroup> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountCategoryResourceImpl.java
@@ -395,6 +395,10 @@ public abstract class BaseDiscountCategoryResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<DiscountCategory> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountProductResourceImpl.java
@@ -395,6 +395,10 @@ public abstract class BaseDiscountProductResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<DiscountProduct> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountResourceImpl.java
@@ -454,6 +454,10 @@ public abstract class BaseDiscountResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Discount> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
@@ -443,6 +443,10 @@ public abstract class BaseDiscountRuleResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<DiscountRule> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
@@ -544,6 +544,10 @@ public abstract class BasePriceEntryResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<PriceEntry> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListAccountGroupResourceImpl.java
@@ -413,6 +413,10 @@ public abstract class BasePriceListAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<PriceListAccountGroup> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListResourceImpl.java
@@ -464,6 +464,10 @@ public abstract class BasePriceListResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<PriceList> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
@@ -544,6 +544,10 @@ public abstract class BaseTierPriceResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<TierPrice> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseAccountGroupResourceImpl.java
@@ -161,6 +161,10 @@ public abstract class BaseAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<AccountGroup> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseAccountResourceImpl.java
@@ -157,6 +157,10 @@ public abstract class BaseAccountResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<Account> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseCategoryResourceImpl.java
@@ -159,6 +159,10 @@ public abstract class BaseCategoryResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<Category> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseChannelResourceImpl.java
@@ -157,6 +157,10 @@ public abstract class BaseChannelResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<Channel> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountGroupResourceImpl.java
@@ -420,6 +420,10 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DiscountAccountGroup> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountResourceImpl.java
@@ -402,6 +402,10 @@ public abstract class BaseDiscountAccountResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DiscountAccount> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountCategoryResourceImpl.java
@@ -402,6 +402,10 @@ public abstract class BaseDiscountCategoryResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DiscountCategory> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountChannelResourceImpl.java
@@ -402,6 +402,10 @@ public abstract class BaseDiscountChannelResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DiscountChannel> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountOrderTypeResourceImpl.java
@@ -403,6 +403,10 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DiscountOrderType> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductGroupResourceImpl.java
@@ -420,6 +420,10 @@ public abstract class BaseDiscountProductGroupResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DiscountProductGroup> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductResourceImpl.java
@@ -402,6 +402,10 @@ public abstract class BaseDiscountProductResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DiscountProduct> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountResourceImpl.java
@@ -459,6 +459,10 @@ public abstract class BaseDiscountResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<Discount> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
@@ -454,6 +454,10 @@ public abstract class BaseDiscountRuleResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DiscountRule> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountSkuResourceImpl.java
@@ -387,6 +387,10 @@ public abstract class BaseDiscountSkuResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DiscountSku> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseOrderTypeResourceImpl.java
@@ -159,6 +159,10 @@ public abstract class BaseOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<OrderType> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
@@ -545,6 +545,10 @@ public abstract class BasePriceEntryResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<PriceEntry> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountGroupResourceImpl.java
@@ -409,6 +409,10 @@ public abstract class BasePriceListAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<PriceListAccountGroup> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountResourceImpl.java
@@ -395,6 +395,10 @@ public abstract class BasePriceListAccountResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<PriceListAccount> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListChannelResourceImpl.java
@@ -403,6 +403,10 @@ public abstract class BasePriceListChannelResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<PriceListChannel> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListDiscountResourceImpl.java
@@ -386,6 +386,10 @@ public abstract class BasePriceListDiscountResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<PriceListDiscount> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListOrderTypeResourceImpl.java
@@ -386,6 +386,10 @@ public abstract class BasePriceListOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<PriceListOrderType> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListResourceImpl.java
@@ -459,6 +459,10 @@ public abstract class BasePriceListResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<PriceList> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierCategoryResourceImpl.java
@@ -423,6 +423,10 @@ public abstract class BasePriceModifierCategoryResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<PriceModifierCategory> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductGroupResourceImpl.java
@@ -429,6 +429,10 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<PriceModifierProductGroup> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductResourceImpl.java
@@ -422,6 +422,10 @@ public abstract class BasePriceModifierProductResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<PriceModifierProduct> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
@@ -578,6 +578,10 @@ public abstract class BasePriceModifierResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<PriceModifier> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseProductGroupResourceImpl.java
@@ -161,6 +161,10 @@ public abstract class BaseProductGroupResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<ProductGroup> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseProductResourceImpl.java
@@ -189,6 +189,10 @@ public abstract class BaseProductResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<Product> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseSkuResourceImpl.java
@@ -157,6 +157,10 @@ public abstract class BaseSkuResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<Sku> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
@@ -539,6 +539,10 @@ public abstract class BaseTierPriceResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<TierPrice> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-account-group.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.DiscountAccountGroup
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-category.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.DiscountCategory
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-product.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.DiscountProduct
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-rule.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount-rule.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.DiscountRule
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/discount.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.Discount
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/price-entry.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/price-entry.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.PriceEntry
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/price-list-account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/price-list-account-group.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.PriceListAccountGroup
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/price-list.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/price-list.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.PriceList
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/tier-price.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/tier-price.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v1_0.TierPrice
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/account-group.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.AccountGroup
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/account.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/account.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.Account
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/category.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.Category
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/channel.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/channel.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.Channel
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-account-group.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountAccountGroup
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-account.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-account.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountAccount
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-category.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountCategory
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-channel.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-channel.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountChannel
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-order-type.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountOrderType
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-product-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-product-group.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountProductGroup
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-product.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountProduct
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-rule.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-rule.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountRule
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-sku.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount-sku.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountSku
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/discount.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.Discount
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/order-type.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.OrderType
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-entry.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-entry.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceEntry
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-account-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-account-group.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListAccountGroup
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-account.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-account.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListAccount
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-channel.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-channel.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListChannel
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-discount.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-discount.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListDiscount
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-order-type.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list-order-type.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListOrderType
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-list.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceList
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier-category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier-category.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceModifierCategory
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier-product-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier-product-group.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceModifierProductGroup
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier-product.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceModifierProduct
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/price-modifier.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceModifier
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/product-group.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/product-group.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.ProductGroup
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/product.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.Product
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/sku.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/sku.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.Sku
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/tier-price.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/tier-price.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.pricing.dto.v2_0.TierPrice
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Pricing)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
@@ -479,6 +479,10 @@ public abstract class BaseShipmentItemResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ShipmentItem> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
@@ -744,6 +744,10 @@ public abstract class BaseShipmentResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Shipment> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShippingAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShippingAddressResourceImpl.java
@@ -233,6 +233,10 @@ public abstract class BaseShippingAddressResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ShippingAddress> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipment-item.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipment-item.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.shipment.dto.v1_0.ShipmentItem
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Shipment)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipment.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipment.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.shipment.dto.v1_0.Shipment
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Shipment)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-address.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-address.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.shipment.dto.v1_0.ShippingAddress
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Shipment)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
@@ -405,6 +405,10 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<AvailabilityEstimate> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
@@ -391,6 +391,10 @@ public abstract class BaseMeasurementUnitResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<MeasurementUnit> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -369,6 +369,10 @@ public abstract class BaseTaxCategoryResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<TaxCategory> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -376,6 +376,10 @@ public abstract class BaseWarehouseResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Warehouse> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/availability-estimate.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/availability-estimate.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.site.setting.dto.v1_0.AvailabilityEstimate
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Site.Setting)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/measurement-unit.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/measurement-unit.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.site.setting.dto.v1_0.MeasurementUnit
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Site.Setting)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/tax-category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/tax-category.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.site.setting.dto.v1_0.TaxCategory
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Site.Setting)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/warehouse.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/warehouse.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.admin.site.setting.dto.v1_0.Warehouse
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Site.Setting)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseAddressResourceImpl.java
@@ -163,6 +163,10 @@ public abstract class BaseAddressResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Address> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
@@ -408,6 +408,10 @@ public abstract class BaseCartCommentResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<CartComment> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
@@ -475,6 +475,10 @@ public abstract class BaseCartItemResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<CartItem> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
@@ -619,6 +619,10 @@ public abstract class BaseCartResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Cart> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
@@ -133,6 +133,10 @@ public abstract class BasePaymentMethodResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<PaymentMethod> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -133,6 +133,10 @@ public abstract class BaseShippingMethodResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ShippingMethod> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/address.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/address.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.Address
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Cart)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cart-comment.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cart-comment.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.CartComment
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Cart)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cart-item.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cart-item.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.CartItem
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Cart)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cart.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cart.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.Cart
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Cart)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/payment-method.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/payment-method.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.PaymentMethod
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Cart)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-method.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shipping-method.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.cart.dto.v1_0.ShippingMethod
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Cart)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
@@ -206,6 +206,10 @@ public abstract class BaseAttachmentResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Attachment> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
@@ -148,6 +148,10 @@ public abstract class BaseCategoryResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Category> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
@@ -168,6 +168,10 @@ public abstract class BaseMappedProductResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<MappedProduct> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BasePinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BasePinResourceImpl.java
@@ -164,6 +164,10 @@ public abstract class BasePinResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Pin> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
@@ -149,6 +149,10 @@ public abstract class BaseProductOptionResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProductOption> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
@@ -205,6 +205,10 @@ public abstract class BaseProductResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Product> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
@@ -152,6 +152,10 @@ public abstract class BaseProductSpecificationResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProductSpecification> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
@@ -159,6 +159,10 @@ public abstract class BaseRelatedProductResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<RelatedProduct> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
@@ -155,6 +155,10 @@ public abstract class BaseSkuResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Sku> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/attachment.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/attachment.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Attachment
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/category.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/category.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Category
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/mapped-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/mapped-product.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.MappedProduct
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/pin.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/pin.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Pin
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-option.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-option.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.ProductOption
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-specification.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product-specification.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.ProductSpecification
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/product.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Product
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/related-product.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/related-product.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.RelatedProduct
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sku.properties
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sku.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Sku
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Catalog)
 osgi.jaxrs.resource=true

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
@@ -144,6 +144,10 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DataDefinitionFieldLink> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
@@ -779,6 +779,10 @@ public abstract class BaseDataDefinitionResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DataDefinition> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
@@ -542,6 +542,10 @@ public abstract class BaseDataLayoutResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DataLayout> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
@@ -461,6 +461,10 @@ public abstract class BaseDataListViewResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DataListView> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
@@ -733,6 +733,10 @@ public abstract class BaseDataRecordCollectionResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DataRecordCollection> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
@@ -678,6 +678,10 @@ public abstract class BaseDataRecordResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v2.0";
+	}
+
 	@Override
 	public Page<DataRecord> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-definition-field-link.properties
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-definition-field-link.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.data.engine.rest.dto.v2_0.DataDefinitionFieldLink
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Data.Engine.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-definition.properties
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-definition.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.data.engine.rest.dto.v2_0.DataDefinition
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Data.Engine.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-layout.properties
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-layout.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.data.engine.rest.dto.v2_0.DataLayout
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Data.Engine.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-list-view.properties
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-list-view.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.data.engine.rest.dto.v2_0.DataListView
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Data.Engine.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-record-collection.properties
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-record-collection.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.data.engine.rest.dto.v2_0.DataRecordCollection
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Data.Engine.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-record.properties
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v2_0/data-record.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v2.0
+batch.engine.entity.class.name=com.liferay.data.engine.rest.dto.v2_0.DataRecord
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Data.Engine.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
@@ -280,6 +280,10 @@ public abstract class BaseDSEnvelopeResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<DSEnvelope> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/ds-envelope.properties
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/ds-envelope.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.digital.signature.rest.dto.v1_0.DSEnvelope
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Digital.Signature.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
@@ -490,6 +490,10 @@ public abstract class BaseListTypeDefinitionResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ListTypeDefinition> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
@@ -460,6 +460,10 @@ public abstract class BaseListTypeEntryResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ListTypeEntry> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/list-type-definition.properties
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/list-type-definition.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.list.type.dto.v1_0.ListTypeDefinition
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.List.Type)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/list-type-entry.properties
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/list-type-entry.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.list.type.dto.v1_0.ListTypeEntry
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.List.Type)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -938,6 +938,10 @@ public abstract class BaseKeywordResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Keyword> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -999,6 +999,10 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<TaxonomyCategory> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -1254,6 +1254,10 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<TaxonomyVocabulary> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/keyword.properties
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/keyword.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.taxonomy.dto.v1_0.Keyword
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Taxonomy)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/taxonomy-category.properties
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/taxonomy-category.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyCategory
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Taxonomy)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/taxonomy-vocabulary.properties
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/taxonomy-vocabulary.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyVocabulary
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Taxonomy)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -943,6 +943,10 @@ public abstract class BaseAccountResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Account> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
@@ -744,6 +744,10 @@ public abstract class BaseAccountRoleResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<AccountRole> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
@@ -197,6 +197,10 @@ public abstract class BaseEmailAddressResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<EmailAddress> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -1274,6 +1274,10 @@ public abstract class BaseOrganizationResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Organization> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
@@ -197,6 +197,10 @@ public abstract class BasePhoneResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Phone> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
@@ -203,6 +203,10 @@ public abstract class BasePostalAddressResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<PostalAddress> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -450,6 +450,10 @@ public abstract class BaseRoleResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Role> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
@@ -181,6 +181,10 @@ public abstract class BaseSegmentResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Segment> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
@@ -140,6 +140,10 @@ public abstract class BaseSegmentUserResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<SegmentUser> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSiteResourceImpl.java
@@ -183,6 +183,10 @@ public abstract class BaseSiteResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Site> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSubscriptionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSubscriptionResourceImpl.java
@@ -194,6 +194,10 @@ public abstract class BaseSubscriptionResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Subscription> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -1419,6 +1419,10 @@ public abstract class BaseUserAccountResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<UserAccount> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
@@ -677,6 +677,10 @@ public abstract class BaseUserGroupResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<UserGroup> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
@@ -197,6 +197,10 @@ public abstract class BaseWebUrlResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<WebUrl> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-role.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-role.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.AccountRole
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.Account
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/email-address.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/email-address.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.EmailAddress
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/organization.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/organization.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.Organization
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/phone.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/phone.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.Phone
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/postal-address.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/postal-address.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.PostalAddress
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/role.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/role.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.Role
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/segment-user.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/segment-user.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.SegmentUser
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/segment.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/segment.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.Segment
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/site.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/site.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.Site
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/subscription.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/subscription.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.Subscription
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/user-account.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/user-account.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.UserAccount
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/user-group.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/user-group.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.UserGroup
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/web-url.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/web-url.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.WebUrl
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -4903,7 +4903,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.24'."
+        'com.liferay.headless.delivery.client', and version '4.0.25'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -394,6 +394,10 @@ public abstract class BaseBlogPostingImageResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<BlogPostingImage> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -1170,6 +1170,10 @@ public abstract class BaseBlogPostingResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<BlogPosting> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -846,6 +846,10 @@ public abstract class BaseCommentResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Comment> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
@@ -218,6 +218,10 @@ public abstract class BaseContentElementResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ContentElement> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
@@ -354,6 +354,10 @@ public abstract class BaseContentSetElementResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ContentSetElement> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -639,6 +639,10 @@ public abstract class BaseContentStructureResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ContentStructure> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
@@ -258,6 +258,10 @@ public abstract class BaseContentTemplateResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ContentTemplate> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -1288,6 +1288,10 @@ public abstract class BaseDocumentFolderResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<DocumentFolder> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -1480,6 +1480,10 @@ public abstract class BaseDocumentResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Document> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -1637,6 +1637,10 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<KnowledgeBaseArticle> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
@@ -391,6 +391,10 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<KnowledgeBaseAttachment> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -1074,6 +1074,10 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<KnowledgeBaseFolder> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
@@ -164,6 +164,10 @@ public abstract class BaseLanguageResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Language> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -530,6 +530,10 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<MessageBoardAttachment> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -1515,6 +1515,10 @@ public abstract class BaseMessageBoardMessageResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<MessageBoardMessage> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -1046,6 +1046,10 @@ public abstract class BaseMessageBoardSectionResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<MessageBoardSection> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -1365,6 +1365,10 @@ public abstract class BaseMessageBoardThreadResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<MessageBoardThread> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -698,6 +698,10 @@ public abstract class BaseNavigationMenuResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<NavigationMenu> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -389,6 +389,10 @@ public abstract class BaseSitePageResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<SitePage> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -1372,6 +1372,10 @@ public abstract class BaseStructuredContentFolderResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<StructuredContentFolder> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -1933,6 +1933,10 @@ public abstract class BaseStructuredContentResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<StructuredContent> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -881,6 +881,10 @@ public abstract class BaseWikiNodeResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<WikiNode> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
@@ -362,6 +362,10 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<WikiPageAttachment> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -830,6 +830,10 @@ public abstract class BaseWikiPageResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<WikiPage> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.24'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.25'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/blog-posting-image.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/blog-posting-image.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.BlogPostingImage
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/blog-posting.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/blog-posting.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.BlogPosting
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/comment.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/comment.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.Comment
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-element.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-element.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.ContentElement
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-set-element.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-set-element.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.ContentSetElement
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-structure.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-structure.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.ContentStructure
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-template.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-template.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.ContentTemplate
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/document-folder.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/document-folder.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.DocumentFolder
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/document.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/document.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.Document
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/knowledge-base-article.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/knowledge-base-article.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseArticle
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/knowledge-base-attachment.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/knowledge-base-attachment.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseAttachment
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/knowledge-base-folder.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/knowledge-base-folder.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseFolder
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/language.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/language.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.Language
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-attachment.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-attachment.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.MessageBoardAttachment
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-message.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-message.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.MessageBoardMessage
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-section.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-section.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.MessageBoardSection
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-thread.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message-board-thread.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.MessageBoardThread
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/navigation-menu.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/navigation-menu.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.NavigationMenu
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/site-page.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/site-page.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.SitePage
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/structured-content-folder.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/structured-content-folder.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.StructuredContentFolder
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/structured-content.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/structured-content.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.StructuredContent
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/wiki-node.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/wiki-node.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.WikiNode
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/wiki-page-attachment.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/wiki-page-attachment.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.WikiPageAttachment
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/wiki-page.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/wiki-page.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.WikiPage
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
@@ -208,6 +208,10 @@ public abstract class BaseFormDocumentResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<FormDocument> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
@@ -382,6 +382,10 @@ public abstract class BaseFormRecordResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<FormRecord> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
@@ -242,6 +242,10 @@ public abstract class BaseFormResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Form> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
@@ -175,6 +175,10 @@ public abstract class BaseFormStructureResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<FormStructure> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form-document.properties
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form-document.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.form.dto.v1_0.FormDocument
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Form)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form-record.properties
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form-record.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.form.dto.v1_0.FormRecord
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Form)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form-structure.properties
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form-structure.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.form.dto.v1_0.FormStructure
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Form)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form.properties
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/form.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.form.dto.v1_0.Form
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Form)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
@@ -499,6 +499,10 @@ public abstract class BaseObjectActionResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ObjectAction> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
@@ -553,6 +553,10 @@ public abstract class BaseObjectDefinitionResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ObjectDefinition> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
@@ -516,6 +516,10 @@ public abstract class BaseObjectFieldResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ObjectField> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
@@ -428,6 +428,10 @@ public abstract class BaseObjectLayoutResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ObjectLayout> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
@@ -455,6 +455,10 @@ public abstract class BaseObjectRelationshipResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ObjectRelationship> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
@@ -559,6 +559,10 @@ public abstract class BaseObjectValidationRuleResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ObjectValidationRule> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
@@ -458,6 +458,10 @@ public abstract class BaseObjectViewResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ObjectView> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-action.properties
+++ b/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-action.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.object.admin.rest.dto.v1_0.ObjectAction
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-definition.properties
+++ b/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-definition.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-field.properties
+++ b/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-field.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.object.admin.rest.dto.v1_0.ObjectField
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-layout.properties
+++ b/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-layout.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.object.admin.rest.dto.v1_0.ObjectLayout
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-relationship.properties
+++ b/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-relationship.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.object.admin.rest.dto.v1_0.ObjectRelationship
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-validation-rule.properties
+++ b/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-validation-rule.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.object.admin.rest.dto.v1_0.ObjectValidationRule
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-view.properties
+++ b/modules/apps/object/object-admin-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-view.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.object.admin.rest.dto.v1_0.ObjectView
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -694,6 +694,10 @@ public abstract class BaseObjectEntryResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ObjectEntry> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/apps/object/object-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-entry.properties
+++ b/modules/apps/object/object-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-entry.properties
@@ -3,5 +3,6 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.object.rest.dto.v1_0.ObjectEntry
 batch.engine.task.item.delegate=true
 osgi.jaxrs.resource=true

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 9.7.2
+Bundle-Version: 9.8.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/Field.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/Field.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.batch.engine;
+
+/**
+ * @author Javier de Arcos
+ */
+public class Field {
+
+	public static Field of(
+		String description, String name, boolean readOnly, boolean required,
+		String type, boolean writeOnly) {
+
+		return new Field(
+			_toAccessType(readOnly, writeOnly), description, name, required,
+			type);
+	}
+
+	public AccessType getAccessType() {
+		return _accessType;
+	}
+
+	public String getDescription() {
+		return _description;
+	}
+
+	public String getName() {
+		return _name;
+	}
+
+	public String getType() {
+		return _type;
+	}
+
+	public boolean isRequired() {
+		return _required;
+	}
+
+	public enum AccessType {
+
+		READ, READWRITE, WRITE
+
+	}
+
+	private static AccessType _toAccessType(
+		boolean readOnly, boolean writeOnly) {
+
+		if (readOnly) {
+			return AccessType.READ;
+		}
+		else if (writeOnly) {
+			return AccessType.WRITE;
+		}
+
+		return AccessType.READWRITE;
+	}
+
+	private Field(
+		AccessType accessType, String description, String name,
+		boolean required, String type) {
+
+		_accessType = accessType;
+		_description = description;
+		_name = name;
+		_required = required;
+		_type = type;
+	}
+
+	private final AccessType _accessType;
+	private final String _description;
+	private final String _name;
+	private final boolean _required;
+	private final String _type;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegate.java
@@ -49,6 +49,14 @@ public interface VulcanBatchEngineTaskItemDelegate<T> {
 	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
 		throws Exception;
 
+	public default Class<?> getResourceClass() {
+		return getClass();
+	}
+
+	public default String getVersion() {
+		return "v1.0";
+	}
+
 	public Page<T> read(
 			Filter filter, Pagination pagination, Sort[] sorts,
 			Map<String, Serializable> parameters, String search)

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegateRegistry.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegateRegistry.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.batch.engine;
+
+import java.util.Set;
+
+/**
+ * @author Javier de Arcos
+ */
+public interface VulcanBatchEngineTaskItemDelegateRegistry {
+
+	public Set<String> getEntityClassNames();
+
+	public VulcanBatchEngineTaskItemDelegate
+		getVulcanBatchEngineTaskItemDelegate(String entityClassName);
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/OpenAPIUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/OpenAPIUtil.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.util;
+
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.batch.engine.Field;
+import com.liferay.portal.vulcan.yaml.openapi.Components;
+import com.liferay.portal.vulcan.yaml.openapi.Get;
+import com.liferay.portal.vulcan.yaml.openapi.OpenAPIYAML;
+import com.liferay.portal.vulcan.yaml.openapi.Operation;
+import com.liferay.portal.vulcan.yaml.openapi.Parameter;
+import com.liferay.portal.vulcan.yaml.openapi.PathItem;
+import com.liferay.portal.vulcan.yaml.openapi.Post;
+import com.liferay.portal.vulcan.yaml.openapi.Response;
+import com.liferay.portal.vulcan.yaml.openapi.ResponseCode;
+import com.liferay.portal.vulcan.yaml.openapi.Schema;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author Javier de Arcos
+ */
+public class OpenAPIUtil {
+
+	public static List<String> getCreateEntityScopes(
+		String entityName, OpenAPIYAML openAPIYAML) {
+
+		Map<String, PathItem> pathItemsMap = openAPIYAML.getPathItems();
+
+		List<String> scopes = new ArrayList<>();
+
+		for (PathItem pathItem : pathItemsMap.values()) {
+			Post post = pathItem.getPost();
+
+			if ((post == null) ||
+				!_hasOKResponseContentSchemaReferenceLike(entityName, post)) {
+
+				continue;
+			}
+
+			scopes.add(_getOperationScope(post));
+		}
+
+		return scopes;
+	}
+
+	public static Map<String, Field> getDTOEntityFields(
+		String entityName, OpenAPIYAML openAPIYAML) {
+
+		Components components = openAPIYAML.getComponents();
+
+		Map<String, Schema> schemas = components.getSchemas();
+
+		Schema schema = schemas.get(entityName);
+
+		if (schema == null) {
+			return Collections.emptyMap();
+		}
+
+		List<String> requiredPropertySchemaNames =
+			schema.getRequiredPropertySchemaNames();
+
+		Map<String, Schema> propertySchemas = schema.getPropertySchemas();
+
+		Map<String, Field> fields = new HashMap<>();
+
+		for (Map.Entry<String, Schema> schemaEntry :
+				propertySchemas.entrySet()) {
+
+			String propertyName = schemaEntry.getKey();
+			Schema propertySchema = schemaEntry.getValue();
+
+			fields.put(
+				propertyName,
+				Field.of(
+					propertySchema.getDescription(), propertyName,
+					propertySchema.isReadOnly(),
+					requiredPropertySchemaNames.contains(propertyName),
+					propertySchema.getType(), propertySchema.isWriteOnly()));
+		}
+
+		return fields;
+	}
+
+	public static List<String> getReadEntityScopes(
+		String entityName, OpenAPIYAML openAPIYAML) {
+
+		Map<String, PathItem> pathItemsMap = openAPIYAML.getPathItems();
+
+		List<String> scopes = new ArrayList<>();
+
+		for (PathItem pathItem : pathItemsMap.values()) {
+			Get get = pathItem.getGet();
+
+			if ((get == null) ||
+				!_hasOKResponseContentSchemaReferenceLike(
+					"Page" + entityName, get)) {
+
+				continue;
+			}
+
+			scopes.add(_getOperationScope(get));
+		}
+
+		return scopes;
+	}
+
+	private static String _getOperationScope(Operation operation) {
+		List<Parameter> parameters = operation.getParameters();
+
+		Stream<Parameter> parametersStream = parameters.stream();
+
+		return parametersStream.filter(
+			parameter -> StringUtil.equals(parameter.getIn(), "path")
+		).map(
+			parameter -> {
+				String name = parameter.getName();
+
+				if (name.endsWith("Id")) {
+					name = StringUtil.removeLast(name, "Id");
+				}
+
+				return name;
+			}
+		).collect(
+			Collectors.joining(",")
+		);
+	}
+
+	private static boolean _hasOKResponseContentSchemaReferenceLike(
+		String name, Operation operation) {
+
+		Map<ResponseCode, Response> responses = operation.getResponses();
+
+		if (responses == null) {
+			return false;
+		}
+
+		Set<Map.Entry<ResponseCode, Response>> entries = responses.entrySet();
+
+		Stream<Map.Entry<ResponseCode, Response>> stream = entries.stream();
+
+		return stream.filter(
+			entry -> _isOKResponseCode(entry.getKey())
+		).map(
+			Map.Entry::getValue
+		).map(
+			Response::getContent
+		).map(
+			Map::entrySet
+		).flatMap(
+			Set::stream
+		).map(
+			Map.Entry::getValue
+		).anyMatch(
+			content -> Optional.ofNullable(
+				content.getSchema()
+			).map(
+				Schema::getReference
+			).map(
+				reference -> StringUtil.equals(
+					name, reference.substring(reference.lastIndexOf('/') + 1))
+			).orElse(
+				false
+			)
+		);
+	}
+
+	private static boolean _isOKResponseCode(ResponseCode responseCode) {
+		if (responseCode.isDefaultResponse() ||
+			((responseCode.getHttpCode() / 100) == 2)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/YAMLUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/YAMLUtil.java
@@ -37,9 +37,7 @@ import org.yaml.snakeyaml.representer.Representer;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class YAMLUtil {
 
 	public static ConfigYAML loadConfigYAML(String yamlString) {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Components.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Components.java
@@ -18,9 +18,7 @@ import java.util.Map;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Components {
 
 	public Map<String, Parameter> getParameters() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Content.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Content.java
@@ -16,9 +16,7 @@ package com.liferay.portal.vulcan.yaml.openapi;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Content {
 
 	public Schema getSchema() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Delete.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Delete.java
@@ -16,8 +16,6 @@ package com.liferay.portal.vulcan.yaml.openapi;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Delete extends Operation {
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Get.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Get.java
@@ -16,8 +16,6 @@ package com.liferay.portal.vulcan.yaml.openapi;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Get extends Operation {
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Head.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Head.java
@@ -16,8 +16,6 @@ package com.liferay.portal.vulcan.yaml.openapi;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Head extends Operation {
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Info.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Info.java
@@ -16,9 +16,7 @@ package com.liferay.portal.vulcan.yaml.openapi;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Info {
 
 	public String getDescription() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Items.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Items.java
@@ -18,9 +18,7 @@ import java.util.Map;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Items {
 
 	public Schema getAdditionalPropertySchema() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/License.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/License.java
@@ -16,9 +16,7 @@ package com.liferay.portal.vulcan.yaml.openapi;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class License {
 
 	public String getName() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/OpenAPIYAML.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/OpenAPIYAML.java
@@ -18,9 +18,7 @@ import java.util.Map;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class OpenAPIYAML {
 
 	public Components getComponents() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Operation.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Operation.java
@@ -20,9 +20,7 @@ import java.util.Map;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Operation {
 
 	public String getDescription() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Options.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Options.java
@@ -16,8 +16,6 @@ package com.liferay.portal.vulcan.yaml.openapi;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Options extends Operation {
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Parameter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Parameter.java
@@ -16,9 +16,7 @@ package com.liferay.portal.vulcan.yaml.openapi;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Parameter {
 
 	public String getExample() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Patch.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Patch.java
@@ -16,8 +16,6 @@ package com.liferay.portal.vulcan.yaml.openapi;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Patch extends Operation {
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/PathItem.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/PathItem.java
@@ -16,9 +16,7 @@ package com.liferay.portal.vulcan.yaml.openapi;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class PathItem {
 
 	public Delete getDelete() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Post.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Post.java
@@ -16,8 +16,6 @@ package com.liferay.portal.vulcan.yaml.openapi;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Post extends Operation {
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Put.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Put.java
@@ -16,8 +16,6 @@ package com.liferay.portal.vulcan.yaml.openapi;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Put extends Operation {
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/RequestBody.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/RequestBody.java
@@ -18,9 +18,7 @@ import java.util.Map;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class RequestBody {
 
 	public Map<String, Content> getContent() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Response.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Response.java
@@ -18,9 +18,7 @@ import java.util.Map;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Response {
 
 	public Map<String, Content> getContent() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/ResponseCode.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/ResponseCode.java
@@ -19,9 +19,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 
 /**
  * @author     Javier de Arcos
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class ResponseCode {
 
 	public ResponseCode(String code) {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Schema.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Schema.java
@@ -21,9 +21,7 @@ import java.util.Map;
 
 /**
  * @author     Peter Shin
- * @deprecated As of Athanasius (7.3.x)
  */
-@Deprecated
 public class Schema {
 
 	public Schema() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/batch/engine/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/batch/engine/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/util/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/OpenAPIUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/OpenAPIUtilTest.java
@@ -1,0 +1,282 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.util;
+
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.vulcan.batch.engine.Field;
+import com.liferay.portal.vulcan.yaml.openapi.Components;
+import com.liferay.portal.vulcan.yaml.openapi.Content;
+import com.liferay.portal.vulcan.yaml.openapi.Get;
+import com.liferay.portal.vulcan.yaml.openapi.OpenAPIYAML;
+import com.liferay.portal.vulcan.yaml.openapi.Parameter;
+import com.liferay.portal.vulcan.yaml.openapi.PathItem;
+import com.liferay.portal.vulcan.yaml.openapi.Post;
+import com.liferay.portal.vulcan.yaml.openapi.Response;
+import com.liferay.portal.vulcan.yaml.openapi.ResponseCode;
+import com.liferay.portal.vulcan.yaml.openapi.Schema;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Javier de Arcos
+ */
+public class OpenAPIUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_openAPIYAML = new OpenAPIYAML();
+
+		Schema readOnlyPropertySchema = new Schema() {
+			{
+				setDescription("Read only property");
+				setReadOnly(true);
+				setType("string");
+			}
+		};
+
+		Schema requiredPropertySchema = new Schema() {
+			{
+				setDescription("Required property");
+				setType("string");
+			}
+		};
+
+		Schema writeOnlyPropertySchema = new Schema() {
+			{
+				setDescription("Write only property");
+				setType("integer");
+				setWriteOnly(true);
+			}
+		};
+
+		Schema schema = new Schema() {
+			{
+				setPropertySchemas(
+					HashMapBuilder.put(
+						"readOnlyPropertySchema", readOnlyPropertySchema
+					).put(
+						"requiredPropertySchema", requiredPropertySchema
+					).put(
+						"writeOnlyPropertySchema", writeOnlyPropertySchema
+					).build());
+				setRequiredPropertySchemaNames(
+					Collections.singletonList("requiredPropertySchema"));
+			}
+		};
+
+		Components components = new Components();
+
+		components.setSchemas(Collections.singletonMap("Test", schema));
+
+		_openAPIYAML.setComponents(components);
+
+		Parameter ignoredParameter = new Parameter() {
+			{
+				setIn("path");
+				setName("ignoredId");
+			}
+		};
+
+		Content ignoredContent = new Content();
+
+		ignoredContent.setSchema(new Schema());
+
+		Response ignoredResponse = new Response();
+
+		ignoredResponse.setContent(
+			Collections.singletonMap("application/json", ignoredContent));
+
+		Schema getSchema = new Schema();
+
+		getSchema.setReference("#/components/schema/PageTest");
+
+		Content getContent = new Content();
+
+		getContent.setSchema(getSchema);
+
+		Response getResponse = new Response();
+
+		getResponse.setContent(
+			Collections.singletonMap("application/json", getContent));
+
+		Schema postSchema = new Schema();
+
+		postSchema.setReference("#/components/schema/Test");
+
+		Content postContent = new Content();
+
+		postContent.setSchema(postSchema);
+
+		Response postResponse = new Response();
+
+		postResponse.setContent(
+			Collections.singletonMap("application/json", postContent));
+
+		_openAPIYAML.setPathItems(
+			HashMapBuilder.<String, PathItem>put(
+				"/{ignoredId}/tests",
+				() -> new PathItem() {
+					{
+						setGet(
+							new Get() {
+								{
+									setParameters(
+										Collections.singletonList(
+											ignoredParameter));
+									setResponses(
+										Collections.singletonMap(
+											new ResponseCode("200"),
+											ignoredResponse));
+								}
+							});
+						setPost(
+							new Post() {
+								{
+									setParameters(
+										Collections.singletonList(
+											ignoredParameter));
+								}
+							});
+					}
+				}
+			).put(
+				"/{scopeId}/tests",
+				() -> new PathItem() {
+					{
+						setGet(
+							new Get() {
+								{
+									setParameters(
+										Collections.singletonList(
+											new Parameter() {
+												{
+													setIn("path");
+													setName("scopeId");
+												}
+											}));
+									setResponses(
+										Collections.singletonMap(
+											new ResponseCode("200"),
+											getResponse));
+								}
+							});
+						setPost(
+							new Post() {
+								{
+									setParameters(
+										Arrays.asList(
+											new Parameter() {
+												{
+													setIn("query");
+													setName("query");
+												}
+											},
+											new Parameter() {
+												{
+													setIn("path");
+													setName("scopeId");
+												}
+											}));
+									setResponses(
+										Collections.singletonMap(
+											new ResponseCode("default"),
+											postResponse));
+								}
+							});
+					}
+				}
+			).build());
+	}
+
+	@Test
+	public void testGetCreateEntityScopes() {
+		List<String> createEntityScopes = OpenAPIUtil.getCreateEntityScopes(
+			"NonExistent", _openAPIYAML);
+
+		Assert.assertTrue(createEntityScopes.isEmpty());
+
+		createEntityScopes = OpenAPIUtil.getCreateEntityScopes(
+			"Test", _openAPIYAML);
+
+		Assert.assertEquals(
+			Collections.singletonList("scope"), createEntityScopes);
+	}
+
+	@Test
+	public void testGetDTOFields() {
+		Map<String, Field> fields = OpenAPIUtil.getDTOEntityFields(
+			"NonExistent", _openAPIYAML);
+
+		Assert.assertTrue(fields.isEmpty());
+
+		fields = OpenAPIUtil.getDTOEntityFields("Test", _openAPIYAML);
+
+		Assert.assertEquals(fields.toString(), 3, fields.size());
+
+		_assertField(
+			fields.get("readOnlyPropertySchema"), Field.AccessType.READ,
+			"Read only property", "readOnlyPropertySchema", "string", false);
+		_assertField(
+			fields.get("requiredPropertySchema"), Field.AccessType.READWRITE,
+			"Required property", "requiredPropertySchema", "string", true);
+		_assertField(
+			fields.get("writeOnlyPropertySchema"), Field.AccessType.WRITE,
+			"Write only property", "writeOnlyPropertySchema", "integer", false);
+	}
+
+	@Test
+	public void testGetReadEntityScopes() {
+		List<String> readEntityScopes = OpenAPIUtil.getReadEntityScopes(
+			"NonExistent", _openAPIYAML);
+
+		Assert.assertTrue(readEntityScopes.isEmpty());
+
+		readEntityScopes = OpenAPIUtil.getReadEntityScopes(
+			"Test", _openAPIYAML);
+
+		Assert.assertEquals(
+			Collections.singletonList("scope"), readEntityScopes);
+	}
+
+	private void _assertField(
+		Field readOnlyPropertySchema, Field.AccessType accessType,
+		String description, String name, String type, boolean required) {
+
+		Assert.assertEquals(accessType, readOnlyPropertySchema.getAccessType());
+		Assert.assertEquals(
+			description, readOnlyPropertySchema.getDescription());
+		Assert.assertEquals(name, readOnlyPropertySchema.getName());
+		Assert.assertEquals(type, readOnlyPropertySchema.getType());
+		Assert.assertEquals(required, readOnlyPropertySchema.isRequired());
+	}
+
+	private OpenAPIYAML _openAPIYAML;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.batch.engine;
+
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegateRegistry;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Filter;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(
+	immediate = true, service = VulcanBatchEngineTaskItemDelegateRegistry.class
+)
+public class VulcanBatchEngineTaskItemDelegateRegistryImpl
+	implements VulcanBatchEngineTaskItemDelegateRegistry {
+
+	@Override
+	public Set<String> getEntityClassNames() {
+		return _vulcanBatchEngineTaskItemDelegateMap.keySet();
+	}
+
+	@Override
+	public VulcanBatchEngineTaskItemDelegate<?>
+		getVulcanBatchEngineTaskItemDelegate(String entityClassName) {
+
+		return _vulcanBatchEngineTaskItemDelegateMap.get(entityClassName);
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext)
+		throws InvalidSyntaxException {
+
+		Filter filter = bundleContext.createFilter(
+			"(batch.engine.task.item.delegate=true)");
+
+		_serviceTracker = new ServiceTracker<>(
+			bundleContext, filter,
+			new VulcanBatchEngineTaskItemDelegateServiceTrackerCustomizer(
+				bundleContext));
+
+		_serviceTracker.open();
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceTracker.close();
+	}
+
+	private ServiceTracker<?, ?> _serviceTracker;
+	private final Map<String, VulcanBatchEngineTaskItemDelegate<?>>
+		_vulcanBatchEngineTaskItemDelegateMap = new HashMap<>();
+
+	private class VulcanBatchEngineTaskItemDelegateServiceTrackerCustomizer
+		implements ServiceTrackerCustomizer
+			<VulcanBatchEngineTaskItemDelegate<?>,
+			 VulcanBatchEngineTaskItemDelegate<?>> {
+
+		@Override
+		public VulcanBatchEngineTaskItemDelegate<?> addingService(
+			ServiceReference<VulcanBatchEngineTaskItemDelegate<?>>
+				serviceReference) {
+
+			VulcanBatchEngineTaskItemDelegate<?>
+				vulcanBatchEngineTaskItemDelegate = _bundleContext.getService(
+					serviceReference);
+
+			_vulcanBatchEngineTaskItemDelegateMap.put(
+				(String)serviceReference.getProperty(
+					"batch.engine.entity.class.name"),
+				vulcanBatchEngineTaskItemDelegate);
+
+			return vulcanBatchEngineTaskItemDelegate;
+		}
+
+		@Override
+		public void modifiedService(
+			ServiceReference<VulcanBatchEngineTaskItemDelegate<?>>
+				serviceReference,
+			VulcanBatchEngineTaskItemDelegate<?>
+				vulcanBatchEngineTaskItemDelegate) {
+		}
+
+		@Override
+		public void removedService(
+			ServiceReference<VulcanBatchEngineTaskItemDelegate<?>>
+				serviceReference,
+			VulcanBatchEngineTaskItemDelegate<?>
+				vulcanBatchEngineTaskItemDelegate) {
+
+			_vulcanBatchEngineTaskItemDelegateMap.remove(
+				(String)serviceReference.getProperty(
+					"batch.engine.entity.class.name"));
+		}
+
+		private VulcanBatchEngineTaskItemDelegateServiceTrackerCustomizer(
+			BundleContext bundleContext) {
+
+			_bundleContext = bundleContext;
+		}
+
+		private final BundleContext _bundleContext;
+
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/batch/engine/test/VulcanBatchEngineTaskItemDelegateRegistryTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/batch/engine/test/VulcanBatchEngineTaskItemDelegateRegistryTest.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.batch.engine.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.batch.engine.Field;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegateRegistry;
+import com.liferay.portal.vulcan.resource.OpenAPIResource;
+import com.liferay.portal.vulcan.util.OpenAPIUtil;
+import com.liferay.portal.vulcan.yaml.YAMLUtil;
+import com.liferay.portal.vulcan.yaml.openapi.OpenAPIYAML;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.core.Response;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Javier de Arcos
+ */
+@RunWith(Arquillian.class)
+public class VulcanBatchEngineTaskItemDelegateRegistryTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testGetEntityClassNames() {
+		Set<String> entityClassNames =
+			_vulcanBatchEngineTaskItemDelegateRegistry.getEntityClassNames();
+
+		Assert.assertFalse(entityClassNames.isEmpty());
+
+		Assert.assertTrue(
+			entityClassNames.contains(
+				"com.liferay.headless.delivery.dto.v1_0.StructuredContent"));
+	}
+
+	@Test
+	public void testGetVulcanBatchEngineTaskItemDelegate() {
+		VulcanBatchEngineTaskItemDelegate<?> vulcanBatchEngineTaskItemDelegate =
+			_vulcanBatchEngineTaskItemDelegateRegistry.
+				getVulcanBatchEngineTaskItemDelegate(
+					"com.liferay.headless.delivery.dto.v1_0.StructuredContent");
+
+		Assert.assertNotNull(vulcanBatchEngineTaskItemDelegate);
+
+		Class<?> resourceClass =
+			vulcanBatchEngineTaskItemDelegate.getResourceClass();
+
+		Assert.assertEquals(
+			"com.liferay.headless.delivery.internal.resource.v1_0." +
+				"StructuredContentResourceImpl",
+			resourceClass.getName());
+	}
+
+	@Test
+	public void testRegistryAndOpenAPIUtilToGetEntityMetadata()
+		throws Exception {
+
+		Set<String> entityClassNames =
+			_vulcanBatchEngineTaskItemDelegateRegistry.getEntityClassNames();
+
+		Assert.assertTrue(
+			entityClassNames.contains(
+				"com.liferay.headless.delivery.dto.v1_0.StructuredContent"));
+
+		VulcanBatchEngineTaskItemDelegate<?> vulcanBatchEngineTaskItemDelegate =
+			_vulcanBatchEngineTaskItemDelegateRegistry.
+				getVulcanBatchEngineTaskItemDelegate(
+					"com.liferay.headless.delivery.dto.v1_0.StructuredContent");
+
+		Assert.assertNotNull(vulcanBatchEngineTaskItemDelegate);
+
+		Class<?> resourceClass =
+			vulcanBatchEngineTaskItemDelegate.getResourceClass();
+
+		Assert.assertEquals(
+			"com.liferay.headless.delivery.internal.resource.v1_0." +
+				"StructuredContentResourceImpl",
+			resourceClass.getName());
+
+		Assert.assertEquals(
+			"v1.0", vulcanBatchEngineTaskItemDelegate.getVersion());
+
+		Response response = _openAPIResource.getOpenAPI(
+			Collections.singleton(resourceClass), "yaml");
+
+		Assert.assertEquals(200, response.getStatus());
+
+		OpenAPIYAML openAPIYAML = YAMLUtil.loadOpenAPIYAML(
+			(String)response.getEntity());
+
+		Assert.assertNotNull(openAPIYAML);
+
+		List<String> createEntityScopes = OpenAPIUtil.getCreateEntityScopes(
+			"StructuredContent", openAPIYAML);
+
+		Assert.assertEquals(
+			createEntityScopes.toString(), 3, createEntityScopes.size());
+		AssertUtils.assertEquals(
+			Arrays.asList("assetLibrary", "site", "structuredContentFolder"),
+			createEntityScopes);
+
+		List<String> readEntityScopes = OpenAPIUtil.getReadEntityScopes(
+			"StructuredContent", openAPIYAML);
+
+		Assert.assertEquals(
+			readEntityScopes.toString(), 4, readEntityScopes.size());
+		AssertUtils.assertEquals(
+			Arrays.asList(
+				"assetLibrary", "contentStructure", "site",
+				"structuredContentFolder"),
+			readEntityScopes);
+
+		Map<String, Field> dtoEntityFields = OpenAPIUtil.getDTOEntityFields(
+			"StructuredContent", openAPIYAML);
+
+		_assertContainsAll(
+			dtoEntityFields.keySet(), "contentFields", "description", "id",
+			"title");
+	}
+
+	private void _assertContainsAll(
+		Collection<String> collection, String... keys) {
+
+		for (String key : keys) {
+			Assert.assertTrue(collection.contains(key));
+		}
+	}
+
+	@Inject
+	private OpenAPIResource _openAPIResource;
+
+	@Inject
+	private VulcanBatchEngineTaskItemDelegateRegistry
+		_vulcanBatchEngineTaskItemDelegateRegistry;
+
+}

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/src/main/java/com/liferay/headless/commerce/punchout/internal/resource/v1_0/BasePunchOutSessionResourceImpl.java
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/src/main/java/com/liferay/headless/commerce/punchout/internal/resource/v1_0/BasePunchOutSessionResourceImpl.java
@@ -123,6 +123,10 @@ public abstract class BasePunchOutSessionResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<PunchOutSession> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/punch-out-session.properties
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/punch-out-session.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.punchout.dto.v1_0.PunchOutSession
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.PunchOut)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-openapi.yaml
@@ -720,7 +720,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce ML API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.commerce.machine.learning.client', and version '1.0.5'."
+        'com.liferay.headless.commerce.machine.learning.client', and version '1.0.6'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountCategoryForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountCategoryForecastResourceImpl.java
@@ -174,6 +174,10 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<AccountCategoryForecast> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountForecastResourceImpl.java
@@ -162,6 +162,10 @@ public abstract class BaseAccountForecastResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<AccountForecast> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseSkuForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseSkuForecastResourceImpl.java
@@ -160,6 +160,10 @@ public abstract class BaseSkuForecastResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<SkuForecast> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce ML API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.machine.learning.client', and version '1.0.5'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce ML API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce ML API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.machine.learning.client', and version '1.0.6'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce ML API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-category-forecast.properties
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-category-forecast.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.machine.learning.dto.v1_0.AccountCategoryForecast
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Machine.Learning)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-forecast.properties
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/account-forecast.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.machine.learning.dto.v1_0.AccountForecast
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Machine.Learning)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sku-forecast.properties
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sku-forecast.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.commerce.machine.learning.dto.v1_0.SkuForecast
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Machine.Learning)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeMetricResourceImpl.java
@@ -147,6 +147,10 @@ public abstract class BaseAssigneeMetricResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<AssigneeMetric> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeResourceImpl.java
@@ -131,6 +131,10 @@ public abstract class BaseAssigneeResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Assignee> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseCalendarResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseCalendarResourceImpl.java
@@ -114,6 +114,10 @@ public abstract class BaseCalendarResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Calendar> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseHistogramMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseHistogramMetricResourceImpl.java
@@ -151,6 +151,10 @@ public abstract class BaseHistogramMetricResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<HistogramMetric> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseIndexResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseIndexResourceImpl.java
@@ -146,6 +146,10 @@ public abstract class BaseIndexResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Index> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
@@ -440,6 +440,10 @@ public abstract class BaseInstanceResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Instance> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeMetricResourceImpl.java
@@ -177,6 +177,10 @@ public abstract class BaseNodeMetricResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<NodeMetric> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
@@ -262,6 +262,10 @@ public abstract class BaseNodeResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Node> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessMetricResourceImpl.java
@@ -196,6 +196,10 @@ public abstract class BaseProcessMetricResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProcessMetric> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
@@ -382,6 +382,10 @@ public abstract class BaseProcessResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Process> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
@@ -130,6 +130,10 @@ public abstract class BaseProcessVersionResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ProcessVersion> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseReindexStatusResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseReindexStatusResourceImpl.java
@@ -116,6 +116,10 @@ public abstract class BaseReindexStatusResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ReindexStatus> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -135,6 +135,10 @@ public abstract class BaseRoleResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Role> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
@@ -442,6 +442,10 @@ public abstract class BaseSLAResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<SLA> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResultResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResultResourceImpl.java
@@ -127,6 +127,10 @@ public abstract class BaseSLAResultResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<SLAResult> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
@@ -410,6 +410,10 @@ public abstract class BaseTaskResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Task> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTimeRangeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTimeRangeResourceImpl.java
@@ -114,6 +114,10 @@ public abstract class BaseTimeRangeResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<TimeRange> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/assignee-metric.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/assignee-metric.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.AssigneeMetric
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/assignee.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/assignee.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Assignee
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/calendar.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/calendar.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Calendar
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/histogram-metric.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/histogram-metric.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.HistogramMetric
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/index.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/index.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Index
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/instance.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/instance.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Instance
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/node-metric.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/node-metric.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.NodeMetric
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/node.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/node.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Node
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/process-metric.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/process-metric.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.ProcessMetric
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/process-version.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/process-version.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.ProcessVersion
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/process.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/process.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Process
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/reindex-status.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/reindex-status.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.ReindexStatus
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/role.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/role.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sla-result.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sla-result.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.SLAResult
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sla.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sla.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.SLA
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/task.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/task.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.Task
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/time-range.properties
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/time-range.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.workflow.metrics.rest.dto.v1_0.TimeRange
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Workflow.Metrics.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseFieldMappingInfoResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseFieldMappingInfoResourceImpl.java
@@ -130,6 +130,10 @@ public abstract class BaseFieldMappingInfoResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<FieldMappingInfo> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseKeywordQueryContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseKeywordQueryContributorResourceImpl.java
@@ -122,6 +122,10 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<KeywordQueryContributor> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseModelPrefilterContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseModelPrefilterContributorResourceImpl.java
@@ -122,6 +122,10 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ModelPrefilterContributor> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseQueryPrefilterContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseQueryPrefilterContributorResourceImpl.java
@@ -122,6 +122,10 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<QueryPrefilterContributor> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
@@ -452,6 +452,10 @@ public abstract class BaseSXPBlueprintResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<SXPBlueprint> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
@@ -448,6 +448,10 @@ public abstract class BaseSXPElementResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<SXPElement> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPParameterContributorDefinitionResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPParameterContributorDefinitionResourceImpl.java
@@ -124,6 +124,10 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<SXPParameterContributorDefinition> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchResponseResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchResponseResourceImpl.java
@@ -141,6 +141,10 @@ public abstract class BaseSearchResponseResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<SearchResponse> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameDisplayResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameDisplayResourceImpl.java
@@ -135,6 +135,10 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<SearchableAssetNameDisplay> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameResourceImpl.java
@@ -120,6 +120,10 @@ public abstract class BaseSearchableAssetNameResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<SearchableAssetName> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/field-mapping-info.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/field-mapping-info.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.FieldMappingInfo
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/keyword-query-contributor.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/keyword-query-contributor.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.KeywordQueryContributor
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/model-prefilter-contributor.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/model-prefilter-contributor.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.ModelPrefilterContributor
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/query-prefilter-contributor.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/query-prefilter-contributor.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.QueryPrefilterContributor
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/search-response.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/search-response.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.SearchResponse
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/searchable-asset-name-display.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/searchable-asset-name-display.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.SearchableAssetNameDisplay
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/searchable-asset-name.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/searchable-asset-name.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.SearchableAssetName
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sxp-blueprint.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sxp-blueprint.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.SXPBlueprint
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sxp-element.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sxp-element.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.SXPElement
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sxp-parameter-contributor-definition.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/sxp-parameter-contributor-definition.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.search.experiences.rest.dto.v1_0.SXPParameterContributorDefinition
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Search.Experiences.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentResourceImpl.java
@@ -204,6 +204,10 @@ public abstract class BaseExperimentResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Experiment> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentRunResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentRunResourceImpl.java
@@ -131,6 +131,10 @@ public abstract class BaseExperimentRunResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<ExperimentRun> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
@@ -196,6 +196,10 @@ public abstract class BaseStatusResourceImpl
 		return null;
 	}
 
+	public String getVersion() {
+		return "v1.0";
+	}
+
 	@Override
 	public Page<Status> read(
 			Filter filter, Pagination pagination, Sort[] sorts,

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/experiment-run.properties
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/experiment-run.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.segments.asah.rest.dto.v1_0.ExperimentRun
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Segments.Asah.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/experiment.properties
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/experiment.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.segments.asah.rest.dto.v1_0.Experiment
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Segments.Asah.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/status.properties
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/status.properties
@@ -3,6 +3,7 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.segments.asah.rest.dto.v1_0.Status
 batch.engine.task.item.delegate=true
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Segments.Asah.REST)
 osgi.jaxrs.resource=true

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -751,6 +751,10 @@ public class FreeMarkerTool {
 		return OpenAPIParserUtil.getSchemaVarName(schemaName);
 	}
 
+	public String getVersion(OpenAPIYAML openAPIYAML) {
+		return OpenAPIParserUtil.getVersion(openAPIYAML);
+	}
+
 	public boolean hasHTTPMethod(
 		JavaMethodSignature javaMethodSignature, String... httpMethods) {
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
@@ -26,6 +26,7 @@ import com.liferay.portal.tools.rest.builder.internal.yaml.YAMLUtil;
 import com.liferay.portal.tools.rest.builder.internal.yaml.config.ConfigYAML;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Components;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Content;
+import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Info;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Items;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.OpenAPIYAML;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Operation;
@@ -486,6 +487,12 @@ public class OpenAPIParserUtil {
 
 	public static String getSchemaVarName(String schemaName) {
 		return TextFormatter.format(schemaName, TextFormatter.I);
+	}
+
+	public static String getVersion(OpenAPIYAML openAPIYAML) {
+		Info info = openAPIYAML.getInfo();
+
+		return info.getVersion();
 	}
 
 	public static boolean hasHTTPMethod(

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -404,6 +404,10 @@ public abstract class Base${schemaName}ResourceImpl
 			return null;
 		}
 
+		public String getVersion() {
+			return "${freeMarkerTool.getVersion(openAPIYAML)}";
+		}
+
 		@Override
 		public Page<${javaDataType}> read(Filter filter, Pagination pagination, Sort[] sorts, Map<String, Serializable> parameters, String search) throws Exception {
 			<#if getAssetLibraryBatchJavaMethodSignature?? || getBatchJavaMethodSignature?? || getSiteBatchJavaMethodSignature??>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/properties.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/properties.ftl
@@ -9,6 +9,7 @@ api.version=${openAPIYAML.info.version}
 	generateBatch = configYAML.generateBatch && javaDataType?has_content
 />
 <#if !stringUtil.equals(schemaName, "openapi") && generateBatch>
+batch.engine.entity.class.name=${javaDataType}
 batch.engine.task.item.delegate=true
 </#if>
 <#if configYAML.resourceApplicationSelect??>


### PR DESCRIPTION
Related PR: https://github.com/liferay-frontend/liferay-portal/pull/2050

I've created a new class OpenAPIUtil to get the OpenAPI entity metadata for the batch framework.

The available methods are:
- getCreateEntityScopes: get a list of strings with the available scopes to create an entity. There could be composite scopes formed by more than one property and are represented as a string with the properties separated by commas.
- getDTOEntityFields: The list of entity fields with information about name, description, type of access, required or not...
- getReadEntityScopes: get a list of strings with the available scopes to read the entity.

This class is meant to be used with the OpenAPIResource interface to get the correspondent OpenAPI YAML file and then call the OpenAPIUtil methods.

I've created a registry to ease getting the VulcanBatchEngineTaskItemDelegates by the DTO entity name.

I've also modified the REST Builder templates to add the DTO entity name as property and to add the information about the version that is needed to retrieve this information

I've created a test inside VulcanBatchEngineTaskItemDelegateRegistryTest named testRegistryAndOpenAPIUtilToGetEntityMetadata to illustrate the usage of this classes together to get the Entity Metadata