### PR TITLE
 LPS-147713 - Migrate ClayManagementToolbar usages to DXP MT

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingChangesView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingChangesView.js
@@ -26,7 +26,7 @@ import ClaySticker from '@clayui/sticker';
 import ClayTable from '@clayui/table';
 import ClayToolbar from '@clayui/toolbar';
 import classNames from 'classnames';
-import {ManagementToolbar, ResultsBar} from 'frontend-js-components-web';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {CSSTransition} from 'react-transition-group';
 
@@ -2356,7 +2356,7 @@ export default function ChangeTrackingChangesView({
 		const items = [];
 
 		items.push(
-			<ResultsBar.Item>
+			<ManagementToolbar.ResultsBarItem>
 				<span className="component-text text-truncate-inline">
 					<span className="text-truncate">
 						{Liferay.Util.sub(
@@ -2370,12 +2370,12 @@ export default function ChangeTrackingChangesView({
 						)}
 					</span>
 				</span>
-			</ResultsBar.Item>
+			</ManagementToolbar.ResultsBarItem>
 		);
 
 		if (resultsKeywords) {
 			items.push(
-				<ResultsBar.Item>
+				<ManagementToolbar.ResultsBarItem>
 					<ClayLabel
 						className="component-label tbar-label"
 						closeButtonProps={{
@@ -2391,13 +2391,13 @@ export default function ChangeTrackingChangesView({
 							': ' +
 							resultsKeywords}
 					</ClayLabel>
-				</ResultsBar.Item>
+				</ManagementToolbar.ResultsBarItem>
 			);
 		}
 
 		for (let i = 0; i < labels.length; i++) {
 			items.push(
-				<ResultsBar.Item>
+				<ManagementToolbar.ResultsBarItem>
 					<ClayLabel
 						className="component-label tbar-label"
 						closeButtonProps={{
@@ -2408,13 +2408,13 @@ export default function ChangeTrackingChangesView({
 					>
 						{labels[i].label}
 					</ClayLabel>
-				</ResultsBar.Item>
+				</ManagementToolbar.ResultsBarItem>
 			);
 		}
 
-		items.push(<ResultsBar.Item expand />);
+		items.push(<ManagementToolbar.ResultsBarItem expand />);
 		items.push(
-			<ResultsBar.Item>
+			<ManagementToolbar.ResultsBarItem>
 				<ClayButton
 					className="component-link tbar-link"
 					displayType="unstyled"
@@ -2428,10 +2428,10 @@ export default function ChangeTrackingChangesView({
 				>
 					{Liferay.Language.get('clear')}
 				</ClayButton>
-			</ResultsBar.Item>
+			</ManagementToolbar.ResultsBarItem>
 		);
 
-		return <ResultsBar>{items}</ResultsBar>;
+		return <ManagementToolbar.ResultsBar>{items}</ManagementToolbar.ResultsBar>;
 	};
 
 	const renderTableBody = () => {

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingChangesView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingChangesView.js
@@ -20,15 +20,13 @@ import {ClayCheckbox, ClayInput, ClayToggle} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import ClayLink from '@clayui/link';
-import ClayManagementToolbar, {
-	ClayResultsBar,
-} from '@clayui/management-toolbar';
 import ClayNavigationBar from '@clayui/navigation-bar';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import ClaySticker from '@clayui/sticker';
 import ClayTable from '@clayui/table';
 import ClayToolbar from '@clayui/toolbar';
 import classNames from 'classnames';
+import {ManagementToolbar, ResultsBar} from 'frontend-js-components-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {CSSTransition} from 'react-transition-group';
 
@@ -1883,8 +1881,8 @@ export default function ChangeTrackingChangesView({
 		}
 
 		return (
-			<ClayManagementToolbar.ItemList>
-				<ClayManagementToolbar.Item>
+			<ManagementToolbar.ItemList>
+				<ManagementToolbar.Item>
 					<ClayDropDown
 						active={dropdownActive}
 						menuElementAttrs={{
@@ -1989,8 +1987,8 @@ export default function ChangeTrackingChangesView({
 							</div>
 						</form>
 					</ClayDropDown>
-				</ClayManagementToolbar.Item>
-			</ClayManagementToolbar.ItemList>
+				</ManagementToolbar.Item>
+			</ManagementToolbar.ItemList>
 		);
 	};
 
@@ -2006,13 +2004,13 @@ export default function ChangeTrackingChangesView({
 						className="publications-header-td"
 						colSpan={5}
 					>
-						<ClayManagementToolbar>
+						<ManagementToolbar.Container>
 							{renderFilterDropdown()}
 
 							{renderState.id > 0 ? (
-								<ClayManagementToolbar.ItemList expand />
+								<ManagementToolbar.ItemList expand />
 							) : (
-								<ClayManagementToolbar.Search
+								<ManagementToolbar.Search
 									onSubmit={(event) => {
 										event.preventDefault();
 
@@ -2072,12 +2070,12 @@ export default function ChangeTrackingChangesView({
 											</ClayInput.GroupInsetItem>
 										</ClayInput.GroupItem>
 									</ClayInput.Group>
-								</ClayManagementToolbar.Search>
+								</ManagementToolbar.Search>
 							)}
 
-							<ClayManagementToolbar.ItemList>
+							<ManagementToolbar.ItemList>
 								{renderState.id === 0 && (
-									<ClayManagementToolbar.Item className="navbar-breakpoint-d-none">
+									<ManagementToolbar.Item className="navbar-breakpoint-d-none">
 										<ClayButton
 											className="nav-link nav-link-monospaced"
 											disabled={changes.length === 0}
@@ -2091,10 +2089,10 @@ export default function ChangeTrackingChangesView({
 												symbol="search"
 											/>
 										</ClayButton>
-									</ClayManagementToolbar.Item>
+									</ManagementToolbar.Item>
 								)}
 
-								<ClayManagementToolbar.Item className="simple-toggle-switch-reverse">
+								<ManagementToolbar.Item className="simple-toggle-switch-reverse">
 									<ClayToggle
 										disabled={changes.length === 0}
 										label={Liferay.Language.get(
@@ -2107,9 +2105,9 @@ export default function ChangeTrackingChangesView({
 										}
 										toggled={renderState.showHideable}
 									/>
-								</ClayManagementToolbar.Item>
-							</ClayManagementToolbar.ItemList>
-						</ClayManagementToolbar>
+								</ManagementToolbar.Item>
+							</ManagementToolbar.ItemList>
+						</ManagementToolbar.Container>
 					</ClayTable.Cell>
 				</ClayTable.Row>
 			</ClayTable.Head>
@@ -2358,7 +2356,7 @@ export default function ChangeTrackingChangesView({
 		const items = [];
 
 		items.push(
-			<ClayResultsBar.Item>
+			<ResultsBar.Item>
 				<span className="component-text text-truncate-inline">
 					<span className="text-truncate">
 						{Liferay.Util.sub(
@@ -2372,12 +2370,12 @@ export default function ChangeTrackingChangesView({
 						)}
 					</span>
 				</span>
-			</ClayResultsBar.Item>
+			</ResultsBar.Item>
 		);
 
 		if (resultsKeywords) {
 			items.push(
-				<ClayResultsBar.Item>
+				<ResultsBar.Item>
 					<ClayLabel
 						className="component-label tbar-label"
 						closeButtonProps={{
@@ -2393,13 +2391,13 @@ export default function ChangeTrackingChangesView({
 							': ' +
 							resultsKeywords}
 					</ClayLabel>
-				</ClayResultsBar.Item>
+				</ResultsBar.Item>
 			);
 		}
 
 		for (let i = 0; i < labels.length; i++) {
 			items.push(
-				<ClayResultsBar.Item>
+				<ResultsBar.Item>
 					<ClayLabel
 						className="component-label tbar-label"
 						closeButtonProps={{
@@ -2410,13 +2408,13 @@ export default function ChangeTrackingChangesView({
 					>
 						{labels[i].label}
 					</ClayLabel>
-				</ClayResultsBar.Item>
+				</ResultsBar.Item>
 			);
 		}
 
-		items.push(<ClayResultsBar.Item expand />);
+		items.push(<ResultsBar.Item expand />);
 		items.push(
-			<ClayResultsBar.Item>
+			<ResultsBar.Item>
 				<ClayButton
 					className="component-link tbar-link"
 					displayType="unstyled"
@@ -2430,10 +2428,10 @@ export default function ChangeTrackingChangesView({
 				>
 					{Liferay.Language.get('clear')}
 				</ClayButton>
-			</ClayResultsBar.Item>
+			</ResultsBar.Item>
 		);
 
-		return <ClayResultsBar>{items}</ClayResultsBar>;
+		return <ResultsBar>{items}</ResultsBar>;
 	};
 
 	const renderTableBody = () => {

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingChangesView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingChangesView.js
@@ -2431,7 +2431,9 @@ export default function ChangeTrackingChangesView({
 			</ManagementToolbar.ResultsBarItem>
 		);
 
-		return <ManagementToolbar.ResultsBar>{items}</ManagementToolbar.ResultsBar>;
+		return (
+			<ManagementToolbar.ResultsBar>{items}</ManagementToolbar.ResultsBar>
+		);
 	};
 
 	const renderTableBody = () => {

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingIndicator.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingIndicator.js
@@ -18,13 +18,11 @@ import {Align, ClayDropDownWithItems} from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayList from '@clayui/list';
-import ClayManagementToolbar, {
-	ClayResultsBar,
-} from '@clayui/management-toolbar';
 import ClayModal, {useModal} from '@clayui/modal';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import ClaySticker from '@clayui/sticker';
 import ClayTable from '@clayui/table';
+import {ManagementToolbar, ResultsBar} from 'frontend-js-components-web';
 import {fetch} from 'frontend-js-web';
 import React, {useCallback, useEffect, useState} from 'react';
 
@@ -345,9 +343,9 @@ const PublicationsSearchContainer = ({
 		const activeViewTypeItem = viewTypeItems.find((type) => type.active);
 
 		return (
-			<ClayManagementToolbar>
-				<ClayManagementToolbar.ItemList>
-					<ClayManagementToolbar.Item>
+			<ManagementToolbar.Container>
+				<ManagementToolbar.ItemList>
+					<ManagementToolbar.Item>
 						<ClayDropDownWithItems
 							items={[
 								{
@@ -386,9 +384,9 @@ const PublicationsSearchContainer = ({
 								</ClayButton>
 							}
 						/>
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 
-					<ClayManagementToolbar.Item
+					<ManagementToolbar.Item
 						data-tooltip-align="top"
 						title={Liferay.Language.get('reverse-sort-direction')}
 					>
@@ -407,10 +405,10 @@ const PublicationsSearchContainer = ({
 								}
 							/>
 						</ClayButton>
-					</ClayManagementToolbar.Item>
-				</ClayManagementToolbar.ItemList>
+					</ManagementToolbar.Item>
+				</ManagementToolbar.ItemList>
 
-				<ClayManagementToolbar.Search
+				<ManagementToolbar.Search
 					onSubmit={(event) => {
 						event.preventDefault();
 
@@ -451,10 +449,10 @@ const PublicationsSearchContainer = ({
 							</ClayInput.GroupInsetItem>
 						</ClayInput.GroupItem>
 					</ClayInput.Group>
-				</ClayManagementToolbar.Search>
+				</ManagementToolbar.Search>
 
-				<ClayManagementToolbar.ItemList>
-					<ClayManagementToolbar.Item className="navbar-breakpoint-d-none">
+				<ManagementToolbar.ItemList>
+					<ManagementToolbar.Item className="navbar-breakpoint-d-none">
 						<ClayButton
 							className="nav-link nav-link-monospaced"
 							disabled={searchDisabled}
@@ -463,12 +461,12 @@ const PublicationsSearchContainer = ({
 						>
 							<ClayIcon symbol="search" />
 						</ClayButton>
-					</ClayManagementToolbar.Item>
-				</ClayManagementToolbar.ItemList>
+					</ManagementToolbar.Item>
+				</ManagementToolbar.ItemList>
 
 				{viewTypeItems.length > 1 && (
-					<ClayManagementToolbar.ItemList>
-						<ClayManagementToolbar.Item
+					<ManagementToolbar.ItemList>
+						<ManagementToolbar.Item
 							data-tooltip-align="top"
 							title={Liferay.Language.get('display-style')}
 						>
@@ -491,10 +489,10 @@ const PublicationsSearchContainer = ({
 									</ClayButton>
 								}
 							/>
-						</ClayManagementToolbar.Item>
-					</ClayManagementToolbar.ItemList>
+						</ManagementToolbar.Item>
+					</ManagementToolbar.ItemList>
 				)}
-			</ClayManagementToolbar>
+			</ManagementToolbar.Container>
 		);
 	};
 
@@ -536,8 +534,8 @@ const PublicationsSearchContainer = ({
 
 		return (
 			<div className="results-bar">
-				<ClayResultsBar>
-					<ClayResultsBar.Item expand>
+				<ResultsBar>
+					<ResultsBar.Item expand>
 						<span className="component-text text-truncate-inline">
 							<span className="text-truncate">
 								{format(key, [count]) + ' '}
@@ -545,9 +543,9 @@ const PublicationsSearchContainer = ({
 								<strong>{resultsKeywords}</strong>
 							</span>
 						</span>
-					</ClayResultsBar.Item>
+					</ResultsBar.Item>
 
-					<ClayResultsBar.Item>
+					<ResultsBar.Item>
 						<ClayButton
 							className="component-link tbar-link"
 							displayType="unstyled"
@@ -558,8 +556,8 @@ const PublicationsSearchContainer = ({
 						>
 							{Liferay.Language.get('clear')}
 						</ClayButton>
-					</ClayResultsBar.Item>
-				</ClayResultsBar>
+					</ResultsBar.Item>
+				</ResultsBar>
 			</div>
 		);
 	};

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingIndicator.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/ChangeTrackingIndicator.js
@@ -22,7 +22,7 @@ import ClayModal, {useModal} from '@clayui/modal';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import ClaySticker from '@clayui/sticker';
 import ClayTable from '@clayui/table';
-import {ManagementToolbar, ResultsBar} from 'frontend-js-components-web';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import {fetch} from 'frontend-js-web';
 import React, {useCallback, useEffect, useState} from 'react';
 
@@ -534,8 +534,8 @@ const PublicationsSearchContainer = ({
 
 		return (
 			<div className="results-bar">
-				<ResultsBar>
-					<ResultsBar.Item expand>
+				<ManagementToolbar.ResultsBar>
+					<ManagementToolbar.ResultsBarItem expand>
 						<span className="component-text text-truncate-inline">
 							<span className="text-truncate">
 								{format(key, [count]) + ' '}
@@ -543,9 +543,9 @@ const PublicationsSearchContainer = ({
 								<strong>{resultsKeywords}</strong>
 							</span>
 						</span>
-					</ResultsBar.Item>
+					</ManagementToolbar.ResultsBarItem>
 
-					<ResultsBar.Item>
+					<ManagementToolbar.ResultsBarItem>
 						<ClayButton
 							className="component-link tbar-link"
 							displayType="unstyled"
@@ -556,8 +556,8 @@ const PublicationsSearchContainer = ({
 						>
 							{Liferay.Language.get('clear')}
 						</ClayButton>
-					</ResultsBar.Item>
-				</ResultsBar>
+					</ManagementToolbar.ResultsBarItem>
+				</ManagementToolbar.ResultsBar>
 			</div>
 		);
 	};

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbar.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbar.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar as FrontendManagementToolbar} from 'frontend-js-components-web';
 import React, {useContext, useState} from 'react';
 
 import ManagementToolbarFilterAndOrder from './ManagementToolbarFilterAndOrder';
@@ -30,7 +30,7 @@ export default function ManagementToolbar({
 	const [showMobile, setShowMobile] = useState(false);
 
 	return (
-		<ClayManagementToolbar>
+		<FrontendManagementToolbar.Container>
 			<ManagementToolbarFilterAndOrder
 				columns={columns}
 				disabled={disabled}
@@ -51,6 +51,6 @@ export default function ManagementToolbar({
 				addButton={addButton}
 				setShowMobile={setShowMobile}
 			/>
-		</ClayManagementToolbar>
+		</FrontendManagementToolbar.Container>
 	);
 }

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarFilterAndOrder.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarFilterAndOrder.js
@@ -14,8 +14,8 @@
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import ClayManagementToolbar from '@clayui/management-toolbar';
 import classNames from 'classnames';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useContext, useState} from 'react';
 
 import DropDown, {CheckboxGroup, ItemsGroup, RadioGroup} from './DropDown';
@@ -172,8 +172,8 @@ export default function ManagementToolbarFilterAndOrder({
 	return (
 		<>
 			{dropDownItems.length > 0 && (
-				<ClayManagementToolbar.ItemList>
-					<ClayManagementToolbar.Item>
+				<ManagementToolbar.ItemList>
+					<ManagementToolbar.Item>
 						<DropDown
 							active={isDropDownActive}
 							footerContent={
@@ -218,9 +218,9 @@ export default function ManagementToolbarFilterAndOrder({
 								<div key={index}>{item}</div>
 							))}
 						</DropDown>
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 
-					<ClayManagementToolbar.Item>
+					<ManagementToolbar.Item>
 						<ClayButtonWithIcon
 							className={classNames(
 								'nav-link',
@@ -238,8 +238,8 @@ export default function ManagementToolbarFilterAndOrder({
 								'reverse-sort-direction'
 							)}
 						/>
-					</ClayManagementToolbar.Item>
-				</ClayManagementToolbar.ItemList>
+					</ManagementToolbar.Item>
+				</ManagementToolbar.ItemList>
 			)}
 		</>
 	);

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarResultsBar.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarResultsBar.js
@@ -14,7 +14,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayLabel from '@clayui/label';
-import {ResultsBar} from 'frontend-js-components-web';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useContext} from 'react';
 
 import {concatValues} from '../../utils/utils';
@@ -24,7 +24,7 @@ const FilterItem = ({filterKey, name, value}) => {
 	const [, dispatch] = useContext(SearchContext);
 
 	return (
-		<ResultsBar.Item>
+		<ManagementToolbar.ResultsBarItem>
 			<ClayLabel
 				className="tbar-label"
 				closeButtonProps={{
@@ -38,7 +38,7 @@ const FilterItem = ({filterKey, name, value}) => {
 					<span className="font-weight-normal">{value}</span>
 				</span>
 			</ClayLabel>
-		</ResultsBar.Item>
+		</ManagementToolbar.ResultsBarItem>
 	);
 };
 
@@ -81,8 +81,8 @@ export default function ManagementToolbarResultsBar({
 	return (
 		<>
 			{(keywords || selectedFilters.length > 0) && !isLoading && (
-				<ResultsBar>
-					<ResultsBar.Item>
+				<ManagementToolbar.ResultsBar>
+					<ManagementToolbar.ResultsBarItem>
 						<span className="component-text text-truncate-inline">
 							<span className="text-truncate">
 								{Liferay.Util.sub(
@@ -92,13 +92,13 @@ export default function ManagementToolbarResultsBar({
 								)}
 							</span>
 						</span>
-					</ResultsBar.Item>
+					</ManagementToolbar.ResultsBarItem>
 
 					{selectedFilters.map((filter, key) => (
 						<FilterItem key={key} {...filter} />
 					))}
 
-					<ResultsBar.Item expand>
+					<ManagementToolbar.ResultsBarItem expand>
 						<div className="tbar-section text-right">
 							<ClayButton
 								className="component-link tbar-link"
@@ -108,8 +108,8 @@ export default function ManagementToolbarResultsBar({
 								{Liferay.Language.get('clear-all')}
 							</ClayButton>
 						</div>
-					</ResultsBar.Item>
-				</ResultsBar>
+					</ManagementToolbar.ResultsBarItem>
+				</ManagementToolbar.ResultsBar>
 			)}
 		</>
 	);

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarResultsBar.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarResultsBar.js
@@ -14,7 +14,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayLabel from '@clayui/label';
-import {ClayResultsBar} from '@clayui/management-toolbar';
+import {ResultsBar} from 'frontend-js-components-web';
 import React, {useContext} from 'react';
 
 import {concatValues} from '../../utils/utils';
@@ -24,7 +24,7 @@ const FilterItem = ({filterKey, name, value}) => {
 	const [, dispatch] = useContext(SearchContext);
 
 	return (
-		<ClayResultsBar.Item>
+		<ResultsBar.Item>
 			<ClayLabel
 				className="tbar-label"
 				closeButtonProps={{
@@ -38,7 +38,7 @@ const FilterItem = ({filterKey, name, value}) => {
 					<span className="font-weight-normal">{value}</span>
 				</span>
 			</ClayLabel>
-		</ClayResultsBar.Item>
+		</ResultsBar.Item>
 	);
 };
 
@@ -81,8 +81,8 @@ export default function ManagementToolbarResultsBar({
 	return (
 		<>
 			{(keywords || selectedFilters.length > 0) && !isLoading && (
-				<ClayResultsBar>
-					<ClayResultsBar.Item>
+				<ResultsBar>
+					<ResultsBar.Item>
 						<span className="component-text text-truncate-inline">
 							<span className="text-truncate">
 								{Liferay.Util.sub(
@@ -92,13 +92,13 @@ export default function ManagementToolbarResultsBar({
 								)}
 							</span>
 						</span>
-					</ClayResultsBar.Item>
+					</ResultsBar.Item>
 
 					{selectedFilters.map((filter, key) => (
 						<FilterItem key={key} {...filter} />
 					))}
 
-					<ClayResultsBar.Item expand>
+					<ResultsBar.Item expand>
 						<div className="tbar-section text-right">
 							<ClayButton
 								className="component-link tbar-link"
@@ -108,8 +108,8 @@ export default function ManagementToolbarResultsBar({
 								{Liferay.Language.get('clear-all')}
 							</ClayButton>
 						</div>
-					</ClayResultsBar.Item>
-				</ClayResultsBar>
+					</ResultsBar.Item>
+				</ResultsBar>
 			)}
 		</>
 	);

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarRight.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarRight.js
@@ -31,9 +31,7 @@ export default function ManagementToolbarRight({addButton, setShowMobile}) {
 			</ManagementToolbar.Item>
 
 			{addButton && (
-				<ManagementToolbar.Item>
-					{addButton()}
-				</ManagementToolbar.Item>
+				<ManagementToolbar.Item>{addButton()}</ManagementToolbar.Item>
 			)}
 		</ManagementToolbar.ItemList>
 	);

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarRight.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarRight.js
@@ -14,13 +14,13 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React from 'react';
 
 export default function ManagementToolbarRight({addButton, setShowMobile}) {
 	return (
-		<ClayManagementToolbar.ItemList>
-			<ClayManagementToolbar.Item className="navbar-breakpoint-d-none">
+		<ManagementToolbar.ItemList>
+			<ManagementToolbar.Item className="navbar-breakpoint-d-none">
 				<ClayButton
 					className="nav-link nav-link-monospaced"
 					displayType="unstyled"
@@ -28,13 +28,13 @@ export default function ManagementToolbarRight({addButton, setShowMobile}) {
 				>
 					<ClayIcon symbol="search" />
 				</ClayButton>
-			</ClayManagementToolbar.Item>
+			</ManagementToolbar.Item>
 
 			{addButton && (
-				<ClayManagementToolbar.Item>
+				<ManagementToolbar.Item>
 					{addButton()}
-				</ClayManagementToolbar.Item>
+				</ManagementToolbar.Item>
 			)}
-		</ClayManagementToolbar.ItemList>
+		</ManagementToolbar.ItemList>
 	);
 }

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarSearch.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarSearch.js
@@ -14,7 +14,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayInput} from '@clayui/form';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useEffect, useState} from 'react';
 
 export default function ManagementToolbarSearch({
@@ -32,7 +32,7 @@ export default function ManagementToolbarSearch({
 	}, [searchText]);
 
 	return (
-		<ClayManagementToolbar.Search
+		<ManagementToolbar.Search
 			onSubmit={(event) => {
 				event.preventDefault();
 				onSubmit(value.trim());
@@ -70,6 +70,6 @@ export default function ManagementToolbarSearch({
 					</ClayInput.GroupInsetItem>
 				</ClayInput.GroupItem>
 			</ClayInput.Group>
-		</ClayManagementToolbar.Search>
+		</ManagementToolbar.Search>
 	);
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/NavBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/NavBar.js
@@ -14,7 +14,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useState} from 'react';
 
@@ -32,31 +32,31 @@ function NavBar({creationMenu, showSearch}) {
 	const [showMobile, setShowMobile] = useState(false);
 
 	return (
-		<ClayManagementToolbar className="c-mb-0 justify-content-space-between">
-			<ClayManagementToolbar.ItemList>
+		<ManagementToolbar.Container className="c-mb-0 justify-content-space-between">
+			<ManagementToolbar.ItemList>
 				{!!filters.length && (
-					<ClayManagementToolbar.Item>
+					<ManagementToolbar.Item>
 						<FiltersDropdown />
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 				)}
-			</ClayManagementToolbar.ItemList>
+			</ManagementToolbar.ItemList>
 
 			{showSearch && (
 				<>
-					<ClayManagementToolbar.Search
+					<ManagementToolbar.Search
 						onSubmit={(event) => {
 							event.preventDefault();
 						}}
 						showMobile={showMobile}
 					>
 						<MainSearch setShowMobile={setShowMobile} />
-					</ClayManagementToolbar.Search>
+					</ManagementToolbar.Search>
 				</>
 			)}
 
-			<ClayManagementToolbar.ItemList>
+			<ManagementToolbar.ItemList>
 				{showSearch && (
-					<ClayManagementToolbar.Item className="navbar-breakpoint-d-none">
+					<ManagementToolbar.Item className="navbar-breakpoint-d-none">
 						<ClayButton
 							className="nav-link nav-link-monospaced"
 							displayType="unstyled"
@@ -64,28 +64,28 @@ function NavBar({creationMenu, showSearch}) {
 						>
 							<ClayIcon symbol="search" />
 						</ClayButton>
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 				)}
 
 				{views?.length > 1 && (
-					<ClayManagementToolbar.Item>
+					<ManagementToolbar.Item>
 						<ActiveViewSelector views={views} />
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 				)}
 
 				{customViewsEnabled && (
-					<ClayManagementToolbar.Item>
+					<ManagementToolbar.Item>
 						<CustomViewDropdown />
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 				)}
 
 				{creationMenu && (
-					<ClayManagementToolbar.Item>
+					<ManagementToolbar.Item>
 						<CreationMenu {...creationMenu} />
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 				)}
-			</ClayManagementToolbar.ItemList>
-		</ClayManagementToolbar>
+			</ManagementToolbar.ItemList>
+		</ManagementToolbar.Container>
 	);
 }
 

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.d.ts
@@ -18,10 +18,6 @@ import type {Atom} from '@liferay/frontend-js-state-web';
 
 export const activeLanguageIdsAtom: Atom<any>;
 
-export function ResultsBar(
-	children: React.ReactElement | Array<React.ReactElement>
-): ReactElement;
-
 export declare const ManagementToolbar: {
 	Container: React.FunctionComponent<{
 		active?: boolean;
@@ -33,6 +29,13 @@ export declare const ManagementToolbar: {
 		className?: string;
 	}>;
 	ItemList: React.FunctionComponent<{
+		children?: React.ReactElement | Array<React.ReactElement>;
+		expand?: boolean;
+	}>;
+	ResultsBar: React.FunctionComponent<{
+		children: React.ReactElement | Array<React.ReactElement>
+	}>;
+	ResultsBarItem: React.FunctionComponent<React.LiHTMLAttributes<HTMLLIElement> &{
 		children?: React.ReactElement | Array<React.ReactElement>;
 		expand?: boolean;
 	}>;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.d.ts
@@ -22,26 +22,28 @@ export function ResultsBar(
 	children: React.ReactElement | Array<React.ReactElement>
 ): ReactElement;
 
-export interface ManagementToolbar {
-	Container: (
-		active?: boolean,
-		children?: React.ReactElement | Array<React.ReactElement>,
-		className?: string
-	) => ReactElement;
-	Item: (
-		children?: React.ReactElement | Array<React.ReactElement>,
-		className?: string
-	) => ReactElement;
-	ItemList: (
-		expand?: boolean,
-		children?: React.ReactElement | Array<React.ReactElement>
-	) => ReactElement;
-	Search: (
-		children?: React.ReactElement | Array<React.ReactElement>,
-		onlySearch?: boolean,
-		showMobile?: boolean
-	) => ReactElement;
-}
+export declare const ManagementToolbar: {
+	Container: React.FunctionComponent<{
+		active?: boolean;
+		children?: React.ReactElement | Array<React.ReactElement>;
+		className?: string;
+	}>;
+	Item: React.FunctionComponent<{
+		children?: React.ReactElement | Array<React.ReactElement>;
+		className?: string;
+	}>;
+	ItemList: React.FunctionComponent<{
+		children?: React.ReactElement | Array<React.ReactElement>;
+		expand?: boolean;
+	}>;
+	Search: React.FunctionComponent<
+		React.FormHTMLAttributes<HTMLFormElement> & {
+			children?: React.ReactElement | Array<React.ReactElement>;
+			onlySearch?: boolean;
+			showMobile?: boolean;
+		}
+	>;
+};
 
 export function Treeview(
 	NodeComponent: () => void,

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.d.ts
@@ -22,6 +22,27 @@ export function ResultsBar(
 	children: React.ReactElement | Array<React.ReactElement>
 ): ReactElement;
 
+export interface ManagementToolbar {
+	Container: (
+		active?: boolean,
+		children?: React.ReactElement | Array<React.ReactElement>,
+		className?: string
+	) => ReactElement;
+	Item: (
+		children?: React.ReactElement | Array<React.ReactElement>,
+		className?: string
+	) => ReactElement;
+	ItemList: (
+		expand?: boolean,
+		children?: React.ReactElement | Array<React.ReactElement>
+	) => ReactElement;
+	Search: (
+		children?: React.ReactElement | Array<React.ReactElement>,
+		onlySearch?: boolean,
+		showMobile?: boolean
+	) => ReactElement;
+}
+
 export function Treeview(
 	NodeComponent: () => void,
 	filter: string | (() => void),

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.d.ts
@@ -33,12 +33,14 @@ export declare const ManagementToolbar: {
 		expand?: boolean;
 	}>;
 	ResultsBar: React.FunctionComponent<{
-		children: React.ReactElement | Array<React.ReactElement>
+		children: React.ReactElement | Array<React.ReactElement>;
 	}>;
-	ResultsBarItem: React.FunctionComponent<React.LiHTMLAttributes<HTMLLIElement> &{
-		children?: React.ReactElement | Array<React.ReactElement>;
-		expand?: boolean;
-	}>;
+	ResultsBarItem: React.FunctionComponent<
+		React.LiHTMLAttributes<HTMLLIElement> & {
+			children?: React.ReactElement | Array<React.ReactElement>;
+			expand?: boolean;
+		}
+	>;
 	Search: React.FunctionComponent<
 		React.FormHTMLAttributes<HTMLFormElement> & {
 			children?: React.ReactElement | Array<React.ReactElement>;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/Container.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/Container.js
@@ -20,11 +20,11 @@ const Container = ({active = false, children, className, ...otherProps}) => (
 	<nav
 		{...otherProps}
 		className={classNames(
-			'management-toolbar-container navbar navbar-expand-md',
+			'management-bar navbar navbar-expand-md',
 			className,
 			{
-				'management-toolbar-container-light': !active,
-				'management-toolbar-container-primary navbar-nowrap': active,
+				'management-bar-light': !active,
+				'management-bar-primary navbar-nowrap': active,
 			}
 		)}
 	>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.scss
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.scss
@@ -1,6 +1,6 @@
 @import 'atlas-variables';
 
-$management-toolbar-container-base: (
+$management-bar-base: (
 	border-color: transparent,
 	border-style: solid,
 	media-breakpoint-down: (),
@@ -20,7 +20,7 @@ $management-toolbar-container-base: (
 	),
 );
 
-$management-toolbar-container-size: (
+$management-bar-size: (
 	scaling-navbar: true,
 	border-bottom-width: 0.0625rem,
 	font-size: $navbar-font-size,
@@ -42,7 +42,7 @@ $management-toolbar-container-size: (
 	nav-item-dropdown-margin-top: 0,
 );
 
-$management-toolbar-container-light: (
+$management-bar-light: (
 	background-color: $white,
 	navbar-nav: (
 		nav-link: (
@@ -71,7 +71,7 @@ $management-toolbar-container-light: (
 	media-breakpoint-up: (),
 );
 
-$management-toolbar-container-primary: (
+$management-bar-primary: (
 	background-color: $primary-l3,
 	border-color: $primary,
 	color: $navbar-light-color,
@@ -102,9 +102,9 @@ $management-toolbar-container-primary: (
 	media-breakpoint-up: (),
 );
 
-.management-toolbar-container {
-	@include clay-navbar-size($management-toolbar-container-size);
-	@include clay-navbar-variant($management-toolbar-container-base);
+.management-bar {
+	@include clay-navbar-size($management-bar-size);
+	@include clay-navbar-variant($management-bar-base);
 
 	&.navbar-nowrap {
 		.navbar-text {
@@ -114,10 +114,10 @@ $management-toolbar-container-primary: (
 	}
 }
 
-.management-toolbar-container-light {
-	@include clay-navbar-variant($management-toolbar-container-light);
+.management-bar-light {
+	@include clay-navbar-variant($management-bar-light);
 }
 
-.management-toolbar-container-primary {
-	@include clay-navbar-variant($management-toolbar-container-primary);
+.management-bar-primary {
+	@include clay-navbar-variant($management-bar-primary);
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
@@ -15,8 +15,8 @@
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import ClayManagementToolbar from '@clayui/management-toolbar';
 import classNames from 'classnames';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useContext, useMemo} from 'react';
 
 import normalizeDropdownItems from '../normalize_dropdown_items';
@@ -72,7 +72,7 @@ const ActionControls = ({
 						)
 						.filter((item) => item.quickAction && item.icon)
 						.map((item, index) => (
-							<ClayManagementToolbar.Item
+							<ManagementToolbar.Item
 								className="d-md-flex d-none"
 								key={index}
 							>
@@ -113,10 +113,10 @@ const ActionControls = ({
 										<span>{item.label}</span>
 									</LinkOrButton>
 								)}
-							</ClayManagementToolbar.Item>
+							</ManagementToolbar.Item>
 						))}
 
-					<ClayManagementToolbar.Item>
+					<ManagementToolbar.Item>
 						<ClayDropDownWithItems
 							items={items}
 							trigger={
@@ -128,7 +128,7 @@ const ActionControls = ({
 								/>
 							}
 						/>
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 				</>
 			)}
 		</>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
@@ -15,8 +15,8 @@
 import ClayButton from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import ClayManagementToolbar from '@clayui/management-toolbar';
 import classNames from 'classnames';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useContext} from 'react';
 
 import FeatureFlagContext from './FeatureFlagContext';
@@ -39,7 +39,7 @@ const FilterOrderControls = ({
 	return (
 		<>
 			{filterDropdownItems && (
-				<ClayManagementToolbar.Item>
+				<ManagementToolbar.Item>
 					<ClayDropDownWithItems
 						items={filterDropdownItems.map((item) =>
 							item.items
@@ -110,11 +110,11 @@ const FilterOrderControls = ({
 							</ClayButton>
 						}
 					/>
-				</ClayManagementToolbar.Item>
+				</ManagementToolbar.Item>
 			)}
 
 			{showDesignImprovements && !showOrderToggle && (
-				<ClayManagementToolbar.Item>
+				<ManagementToolbar.Item>
 					<ClayDropDownWithItems
 						items={[
 							...orderDropdownItems.map((item) => {
@@ -187,12 +187,12 @@ const FilterOrderControls = ({
 							</ClayButton>
 						}
 					/>
-				</ClayManagementToolbar.Item>
+				</ManagementToolbar.Item>
 			)}
 
 			{((!showDesignImprovements && sortingURL) ||
 				(showDesignImprovements && sortingURL && showOrderToggle)) && (
-				<ClayManagementToolbar.Item>
+				<ManagementToolbar.Item>
 					<LinkOrButton
 						className="nav-link nav-link-monospaced"
 						disabled={disabled}
@@ -211,7 +211,7 @@ const FilterOrderControls = ({
 								: Liferay.Language.get('reverse-sort-direction')
 						}
 					/>
-				</ClayManagementToolbar.Item>
+				</ManagementToolbar.Item>
 			)}
 		</>
 	);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/InfoPanelControl.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/InfoPanelControl.js
@@ -13,8 +13,8 @@
  */
 
 import {ClayButtonWithIcon} from '@clayui/button';
-import ClayManagementToolbar from '@clayui/management-toolbar';
 import classNames from 'classnames';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useContext, useEffect, useRef} from 'react';
 
 import FeatureFlagContext from './FeatureFlagContext';
@@ -46,7 +46,7 @@ const InfoPanelControl = ({infoPanelId, onInfoButtonClick, separator}) => {
 	}, [infoButtonRef, infoPanelId]);
 
 	return (
-		<ClayManagementToolbar.Item
+		<ManagementToolbar.Item
 			className={
 				showDesignImprovements &&
 				classNames('d-none d-md-flex', {
@@ -62,7 +62,7 @@ const InfoPanelControl = ({infoPanelId, onInfoButtonClick, separator}) => {
 				ref={infoButtonRef}
 				symbol="info-circle-open"
 			/>
-		</ClayManagementToolbar.Item>
+		</ManagementToolbar.Item>
 	);
 };
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -15,8 +15,8 @@
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import ClayManagementToolbar from '@clayui/management-toolbar';
 import {LinkOrButton} from '@clayui/shared';
+import {ManagementToolbar as FrontendManagementToolbar} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React, {useMemo, useState} from 'react';
 
@@ -91,8 +91,8 @@ function ManagementToolbar({
 		<FeatureFlagContext.Provider
 			value={{showDesignImprovements: showDesignImprovementsFF}}
 		>
-			<ClayManagementToolbar active={active}>
-				<ClayManagementToolbar.ItemList>
+			<FrontendManagementToolbar.Container active={active}>
+				<FrontendManagementToolbar.ItemList>
 					{selectable && (
 						<SelectionControls
 							actionDropdownItems={actionDropdownItems}
@@ -135,7 +135,7 @@ function ManagementToolbar({
 							sortingURL={sortingURL}
 						/>
 					)}
-				</ClayManagementToolbar.ItemList>
+				</FrontendManagementToolbar.ItemList>
 
 				{!active && showSearch && (
 					<SearchControls
@@ -152,7 +152,7 @@ function ManagementToolbar({
 					/>
 				)}
 
-				<ClayManagementToolbar.ItemList>
+				<FrontendManagementToolbar.ItemList>
 					{!active && showSearch && (
 						<SearchControls.ShowMobileButton
 							disabled={disabled}
@@ -178,7 +178,7 @@ function ManagementToolbar({
 					) : (
 						<>
 							{viewTypeItems && (
-								<ClayManagementToolbar.Item>
+								<FrontendManagementToolbar.Item>
 									<ClayDropDownWithItems
 										items={viewTypeItems}
 										trigger={
@@ -212,11 +212,11 @@ function ManagementToolbar({
 											)
 										}
 									/>
-								</ClayManagementToolbar.Item>
+								</FrontendManagementToolbar.Item>
 							)}
 
 							{showCreationMenu && (
-								<ClayManagementToolbar.Item>
+								<FrontendManagementToolbar.Item>
 									{creationMenu ? (
 										<CreationMenu
 											{...creationMenu}
@@ -248,7 +248,7 @@ function ManagementToolbar({
 											symbol="plus"
 										/>
 									)}
-								</ClayManagementToolbar.Item>
+								</FrontendManagementToolbar.Item>
 							)}
 						</>
 					)}
@@ -260,8 +260,8 @@ function ManagementToolbar({
 							separator={active}
 						/>
 					)}
-				</ClayManagementToolbar.ItemList>
-			</ClayManagementToolbar>
+				</FrontendManagementToolbar.ItemList>
+			</FrontendManagementToolbar.Container>
 
 			{showResultsBar && (
 				<ResultsBar

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
@@ -14,7 +14,7 @@
 
 import ClayLabel from '@clayui/label';
 import ClayLink from '@clayui/link';
-import {ResultsBar as FrontendResultsBar} from 'frontend-js-components-web';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import {navigate} from 'frontend-js-web';
 import React from 'react';
 
@@ -26,8 +26,8 @@ const ResultsBar = ({
 }) => {
 	return (
 		<>
-			<FrontendResultsBar>
-				<FrontendResultsBar.Item expand={!(filterLabelItems?.length > 0)}>
+			<ManagementToolbar.ResultsBar>
+				<ManagementToolbar.ResultsBarItem expand={!(filterLabelItems?.length > 0)}>
 					<span className="component-text text-truncate-inline">
 						<span className="text-truncate">
 							{Liferay.Util.sub(
@@ -40,10 +40,10 @@ const ResultsBar = ({
 							)}
 						</span>
 					</span>
-				</FrontendResultsBar.Item>
+				</ManagementToolbar.ResultsBarItem>
 
 				{filterLabelItems?.map((item, index) => (
-					<FrontendResultsBar.Item
+					<ManagementToolbar.ResultsBarItem
 						expand={index === filterLabelItems.length - 1}
 						key={index}
 					>
@@ -60,18 +60,18 @@ const ResultsBar = ({
 						>
 							{item.label}
 						</ClayLabel>
-					</FrontendResultsBar.Item>
+					</ManagementToolbar.ResultsBarItem>
 				))}
 
-				<FrontendResultsBar.Item>
+				<ManagementToolbar.ResultsBarItem>
 					<ClayLink
 						className="component-link tbar-link"
 						href={clearResultsURL}
 					>
 						{Liferay.Language.get('clear')}
 					</ClayLink>
-				</FrontendResultsBar.Item>
-			</FrontendResultsBar>
+				</ManagementToolbar.ResultsBarItem>
+			</ManagementToolbar.ResultsBar>
 		</>
 	);
 };

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
@@ -14,7 +14,7 @@
 
 import ClayLabel from '@clayui/label';
 import ClayLink from '@clayui/link';
-import {ClayResultsBar} from '@clayui/management-toolbar';
+import {ResultsBar as FrontendResultsBar} from 'frontend-js-components-web';
 import {navigate} from 'frontend-js-web';
 import React from 'react';
 
@@ -26,8 +26,8 @@ const ResultsBar = ({
 }) => {
 	return (
 		<>
-			<ClayResultsBar>
-				<ClayResultsBar.Item expand={!(filterLabelItems?.length > 0)}>
+			<FrontendResultsBar>
+				<FrontendResultsBar.Item expand={!(filterLabelItems?.length > 0)}>
 					<span className="component-text text-truncate-inline">
 						<span className="text-truncate">
 							{Liferay.Util.sub(
@@ -40,10 +40,10 @@ const ResultsBar = ({
 							)}
 						</span>
 					</span>
-				</ClayResultsBar.Item>
+				</FrontendResultsBar.Item>
 
 				{filterLabelItems?.map((item, index) => (
-					<ClayResultsBar.Item
+					<FrontendResultsBar.Item
 						expand={index === filterLabelItems.length - 1}
 						key={index}
 					>
@@ -60,18 +60,18 @@ const ResultsBar = ({
 						>
 							{item.label}
 						</ClayLabel>
-					</ClayResultsBar.Item>
+					</FrontendResultsBar.Item>
 				))}
 
-				<ClayResultsBar.Item>
+				<FrontendResultsBar.Item>
 					<ClayLink
 						className="component-link tbar-link"
 						href={clearResultsURL}
 					>
 						{Liferay.Language.get('clear')}
 					</ClayLink>
-				</ClayResultsBar.Item>
-			</ClayResultsBar>
+				</FrontendResultsBar.Item>
+			</FrontendResultsBar>
 		</>
 	);
 };

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
@@ -27,7 +27,9 @@ const ResultsBar = ({
 	return (
 		<>
 			<ManagementToolbar.ResultsBar>
-				<ManagementToolbar.ResultsBarItem expand={!(filterLabelItems?.length > 0)}>
+				<ManagementToolbar.ResultsBarItem
+					expand={!(filterLabelItems?.length > 0)}
+				>
 					<span className="component-text text-truncate-inline">
 						<span className="text-truncate">
 							{Liferay.Util.sub(

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
@@ -14,7 +14,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayInput} from '@clayui/form';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React from 'react';
 
 const SearchControls = ({
@@ -31,7 +31,7 @@ const SearchControls = ({
 }) => {
 	return (
 		<>
-			<ClayManagementToolbar.Search
+			<ManagementToolbar.Search
 				action={searchActionURL}
 				method={searchFormMethod}
 				name={searchFormName}
@@ -79,14 +79,14 @@ const SearchControls = ({
 							/>
 						))
 					)}
-			</ClayManagementToolbar.Search>
+			</ManagementToolbar.Search>
 		</>
 	);
 };
 
 const ShowMobileButton = ({disabled, setSearchMobile}) => {
 	return (
-		<ClayManagementToolbar.Item className="navbar-breakpoint-d-none">
+		<ManagementToolbar.Item className="navbar-breakpoint-d-none">
 			<ClayButtonWithIcon
 				className="nav-link nav-link-monospaced"
 				disabled={disabled}
@@ -94,7 +94,7 @@ const ShowMobileButton = ({disabled, setSearchMobile}) => {
 				onClick={() => setSearchMobile(true)}
 				symbol="search"
 			/>
-		</ClayManagementToolbar.Item>
+		</ManagementToolbar.Item>
 	);
 };
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
@@ -13,7 +13,7 @@
  */
 
 import {ClayCheckbox} from '@clayui/form';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useContext, useEffect, useRef, useState} from 'react';
 
 import {EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS} from '../constants';
@@ -145,7 +145,7 @@ const SelectionControls = ({
 
 	return (
 		<>
-			<ClayManagementToolbar.Item>
+			<ManagementToolbar.Item>
 				<ClayCheckbox
 					checked={checkboxStatus !== 'unchecked'}
 					disabled={disabled}
@@ -176,11 +176,11 @@ const SelectionControls = ({
 						);
 					}}
 				/>
-			</ClayManagementToolbar.Item>
+			</ManagementToolbar.Item>
 
 			{active && (
 				<>
-					<ClayManagementToolbar.Item>
+					<ManagementToolbar.Item>
 						<span className="navbar-text">
 							{selectedItems === itemsTotal
 								? Liferay.Language.get('all-selected')
@@ -190,11 +190,11 @@ const SelectionControls = ({
 										itemsTotal
 								  )} ${Liferay.Language.get('selected')}`}
 						</span>
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 
 					{supportsBulkActions && (
 						<>
-							<ClayManagementToolbar.Item className="nav-item-shrink">
+							<ManagementToolbar.Item className="nav-item-shrink">
 								<LinkOrButton
 									aria-label={
 										showDesignImprovements &&
@@ -229,10 +229,10 @@ const SelectionControls = ({
 										</span>
 									</span>
 								</LinkOrButton>
-							</ClayManagementToolbar.Item>
+							</ManagementToolbar.Item>
 
 							{selectAllButtonVisible && (
-								<ClayManagementToolbar.Item className="nav-item-shrink">
+								<ManagementToolbar.Item className="nav-item-shrink">
 									<LinkOrButton
 										className="nav-link"
 										displayType="unstyled"
@@ -258,7 +258,7 @@ const SelectionControls = ({
 											</span>
 										</span>
 									</LinkOrButton>
-								</ClayManagementToolbar.Item>
+								</ManagementToolbar.Item>
 							)}
 						</>
 					)}

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayout.es.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayout.es.js
@@ -15,8 +15,7 @@
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayInput} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
-import ClayManagementToolbar from '@clayui/management-toolbar';
-import {Treeview} from 'frontend-js-components-web';
+import {ManagementToolbar, Treeview} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
@@ -119,8 +118,8 @@ const SelectLayout = ({
 
 	return (
 		<div className="select-layout">
-			<ClayManagementToolbar>
-				<ClayManagementToolbar.Search
+			<ManagementToolbar.Container>
+				<ManagementToolbar.Search
 					onSubmit={(event) => {
 						event.preventDefault();
 					}}
@@ -155,8 +154,8 @@ const SelectLayout = ({
 							</ClayInput.GroupInsetItem>
 						</ClayInput.GroupItem>
 					</ClayInput.Group>
-				</ClayManagementToolbar.Search>
-			</ClayManagementToolbar>
+				</ManagementToolbar.Search>
+			</ManagementToolbar.Container>
 
 			<ClayLayout.ContainerFluid
 				className="layouts-selector"

--- a/modules/apps/object/object-web/package.json
+++ b/modules/apps/object/object-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"text-mask-core": "^5.1.2"
 	},
 	"name": "@liferay/object-web",

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectView/BuilderScreen/BuilderScreen.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectView/BuilderScreen/BuilderScreen.tsx
@@ -15,7 +15,7 @@
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayEmptyState from '@clayui/empty-state';
 import ClayList from '@clayui/list';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useEffect, useState} from 'react';
 import {DndProvider} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
@@ -75,22 +75,22 @@ export function BuilderScreen({
 			<Card.Header title={title} />
 
 			<Card.Body>
-				<ClayManagementToolbar>
-					<ClayManagementToolbar.ItemList expand>
+				<ManagementToolbar.Container>
+					<ManagementToolbar.ItemList expand>
 						<ManagementToolbarSearch
 							query={query}
 							setQuery={setQuery}
 						/>
 
-						<ClayManagementToolbar.Item>
+						<ManagementToolbar.Item>
 							<ClayButtonWithIcon
 								className="nav-btn nav-btn-monospaced"
 								onClick={() => onVisibleModal(true)}
 								symbol="plus"
 							/>
-						</ClayManagementToolbar.Item>
-					</ClayManagementToolbar.ItemList>
-				</ClayManagementToolbar>
+						</ManagementToolbar.Item>
+					</ManagementToolbar.ItemList>
+				</ManagementToolbar.Container>
 
 				{objectColumns?.length > 0 ? (
 					<ClayList>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectView/ManagementToolbarSearch/ManagementToolbarSearch.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectView/ManagementToolbarSearch/ManagementToolbarSearch.tsx
@@ -14,7 +14,7 @@
 
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React from 'react';
 
 import './ManagementToolbarSearch.scss';
@@ -26,7 +26,7 @@ interface IProps {
 
 export function ManagementToolbarSearch({query, setQuery}: IProps) {
 	return (
-		<ClayManagementToolbar.Search
+		<ManagementToolbar.Search
 			onSubmit={(event) => event.preventDefault()}
 		>
 			<ClayInput.Group>
@@ -50,6 +50,6 @@ export function ManagementToolbarSearch({query, setQuery}: IProps) {
 					</ClayInput.GroupInsetItem>
 				</ClayInput.GroupItem>
 			</ClayInput.Group>
-		</ClayManagementToolbar.Search>
+		</ManagementToolbar.Search>
 	);
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectView/ManagementToolbarSearch/ManagementToolbarSearch.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectView/ManagementToolbarSearch/ManagementToolbarSearch.tsx
@@ -26,9 +26,7 @@ interface IProps {
 
 export function ManagementToolbarSearch({query, setQuery}: IProps) {
 	return (
-		<ManagementToolbar.Search
-			onSubmit={(event) => event.preventDefault()}
-		>
+		<ManagementToolbar.Search onSubmit={(event) => event.preventDefault()}>
 			<ClayInput.Group>
 				<ClayInput.GroupItem>
 					<ClayInput

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectView/ModalAddColumns/ModalAddColumnsObjectCustomView.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectView/ModalAddColumns/ModalAddColumnsObjectCustomView.tsx
@@ -15,8 +15,8 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayCheckbox} from '@clayui/form';
 import ClayList from '@clayui/list';
-import ClayManagementToolbar from '@clayui/management-toolbar';
 import ClayModal from '@clayui/modal';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {FormEvent, useContext, useEffect, useState} from 'react';
 
 import {ManagementToolbarSearch} from '../ManagementToolbarSearch/ManagementToolbarSearch';
@@ -188,9 +188,9 @@ const ModalAddColumnsObjectCustomView: React.FC<IProps> = ({
 					{Liferay.Language.get('select-the-columns')}
 				</div>
 
-				<ClayManagementToolbar>
-					<ClayManagementToolbar.ItemList>
-						<ClayManagementToolbar.Item>
+				<ManagementToolbar.Container>
+					<ManagementToolbar.ItemList>
+						<ManagementToolbar.Item>
 							<ClayCheckbox
 								checked={fieldsChecked}
 								indeterminate={
@@ -205,14 +205,14 @@ const ModalAddColumnsObjectCustomView: React.FC<IProps> = ({
 									}
 								}}
 							/>
-						</ClayManagementToolbar.Item>
-					</ClayManagementToolbar.ItemList>
+						</ManagementToolbar.Item>
+					</ManagementToolbar.ItemList>
 
 					<ManagementToolbarSearch
 						query={query}
 						setQuery={setQuery}
 					/>
-				</ClayManagementToolbar>
+				</ManagementToolbar.Container>
 			</ClayModal.Body>
 
 			<ClayForm onSubmit={(event) => onSubmit(event)}>

--- a/modules/apps/object/object-web/tsconfig.json
+++ b/modules/apps/object/object-web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "984c0b4e3e9210428e26946e5e442cd135e496c3",
+	"@generated": "cf6d69bd91d21e7955bfb61004d4f3225b130460",
 	"@overrides": {
 	},
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **",
@@ -13,6 +13,9 @@
 		"moduleResolution": "node",
 		"outDir": "./types",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.d.ts"
+			]
 		},
 		"sourceMap": false,
 		"strict": true,
@@ -29,5 +32,8 @@
 		"../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../frontend-js/frontend-js-components-web"
+		}
 	]
 }

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/js/ExecutionScope.es.js
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/js/ExecutionScope.es.js
@@ -17,11 +17,11 @@ import {ClayCheckbox, ClayInput, ClayRadio, ClayRadioGroup} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import ClayList from '@clayui/list';
-import ClayManagementToolbar from '@clayui/management-toolbar';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import ClaySticker from '@clayui/sticker';
 import ClayToolbar from '@clayui/toolbar';
 import {ClayTooltipProvider} from '@clayui/tooltip';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useEffect, useState} from 'react';
 
 const DEFAULT_DELTA = 10;
@@ -102,18 +102,18 @@ function InstanceSelector({selected, setSelected, virtualInstances}) {
 
 	return (
 		<>
-			<ClayManagementToolbar>
-				<ClayManagementToolbar.ItemList>
-					<ClayManagementToolbar.Item>
+			<ManagementToolbar.Container>
+				<ManagementToolbar.ItemList>
+					<ManagementToolbar.Item>
 						<ClayCheckbox
 							aria-label={Liferay.Language.get('toggle')}
 							checked={_isSelectAllChecked()}
 							onChange={_handleToggleSelectAll}
 						/>
-					</ClayManagementToolbar.Item>
-				</ClayManagementToolbar.ItemList>
+					</ManagementToolbar.Item>
+				</ManagementToolbar.ItemList>
 
-				<ClayManagementToolbar.Search>
+				<ManagementToolbar.Search>
 					<ClayInput.Group>
 						<ClayInput.GroupItem>
 							<ClayInput
@@ -154,8 +154,8 @@ function InstanceSelector({selected, setSelected, virtualInstances}) {
 							</ClayInput.GroupInsetItem>
 						</ClayInput.GroupItem>
 					</ClayInput.Group>
-				</ClayManagementToolbar.Search>
-			</ClayManagementToolbar>
+				</ManagementToolbar.Search>
+			</ManagementToolbar.Container>
 
 			{selected.length > 0 && (
 				<ClayToolbar subnav={{displayType: 'primary'}}>

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/ManagementBar/ManagementBar.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/ManagementBar/ManagementBar.js
@@ -10,7 +10,7 @@
  */
 
 import ClayButton from '@clayui/button';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useContext} from 'react';
 
 import ChartContext from '../ChartContext';
@@ -19,9 +19,9 @@ function ManagementBar() {
 	const {chartInstanceRef} = useContext(ChartContext);
 
 	return (
-		<ClayManagementToolbar>
-			<ClayManagementToolbar.ItemList>
-				<ClayManagementToolbar.Item>
+		<ManagementToolbar.Container>
+			<ManagementToolbar.ItemList>
+				<ManagementToolbar.Item>
 					<ClayButton
 						displayType="secondary"
 						onClick={() =>
@@ -30,9 +30,9 @@ function ManagementBar() {
 					>
 						{Liferay.Language.get('collapse-all')}
 					</ClayButton>
-				</ClayManagementToolbar.Item>
-			</ClayManagementToolbar.ItemList>
-		</ClayManagementToolbar>
+				</ManagementToolbar.Item>
+			</ManagementToolbar.ItemList>
+		</ManagementToolbar.Container>
 	);
 }
 

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/DiagramTable/ManagementBar.js
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/DiagramTable/ManagementBar.js
@@ -11,7 +11,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayInput} from '@clayui/form';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import {debounce} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
 
@@ -26,8 +26,8 @@ function ManagementBar({updateQuery}) {
 	}
 
 	return (
-		<ClayManagementToolbar className="border-bottom">
-			<ClayManagementToolbar.Search
+		<ManagementToolbar.Container className="border-bottom">
+			<ManagementToolbar.Search
 				onSubmit={(event) => event.preventDefault()}
 			>
 				<ClayInput.Group>
@@ -49,8 +49,8 @@ function ManagementBar({updateQuery}) {
 						</ClayInput.GroupInsetItem>
 					</ClayInput.GroupItem>
 				</ClayInput.Group>
-			</ClayManagementToolbar.Search>
-		</ClayManagementToolbar>
+			</ManagementToolbar.Search>
+		</ManagementToolbar.Container>
 	);
 }
 

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/components/DiagramFooter.js
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/components/DiagramFooter.js
@@ -12,7 +12,7 @@
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import {ClaySelect} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useMemo} from 'react';
 
 import {ZOOM_STEP, ZOOM_VALUES} from '../utilities/constants';
@@ -37,10 +37,10 @@ function DiagramFooter({
 	}, [currentZoom]);
 
 	return (
-		<ClayManagementToolbar className="py-2">
+		<ManagementToolbar.Container className="py-2">
 			<div className="d-flex flex-grow-1 justify-content-end">
-				<ClayManagementToolbar.ItemList>
-					<ClayManagementToolbar.Item>
+				<ManagementToolbar.ItemList>
+					<ManagementToolbar.Item>
 						<ClayButton
 							className="ml-1"
 							displayType="secondary"
@@ -56,9 +56,9 @@ function DiagramFooter({
 								? Liferay.Language.get('compress')
 								: Liferay.Language.get('expand')}
 						</ClayButton>
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 
-					<ClayManagementToolbar.Item>
+					<ManagementToolbar.Item>
 						<ClayButtonWithIcon
 							className="ml-1"
 							disabled={currentZoom <= ZOOM_VALUES[0]}
@@ -78,9 +78,9 @@ function DiagramFooter({
 							}}
 							symbol="hr"
 						/>
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 
-					<ClayManagementToolbar.Item>
+					<ManagementToolbar.Item>
 						<ClaySelect
 							className="ml-1"
 							onChange={(event) => {
@@ -96,9 +96,9 @@ function DiagramFooter({
 								/>
 							))}
 						</ClaySelect>
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 
-					<ClayManagementToolbar.Item>
+					<ManagementToolbar.Item>
 						<ClayButtonWithIcon
 							className="ml-1"
 							disabled={
@@ -121,10 +121,10 @@ function DiagramFooter({
 							}}
 							symbol="plus"
 						/>
-					</ClayManagementToolbar.Item>
-				</ClayManagementToolbar.ItemList>
+					</ManagementToolbar.Item>
+				</ManagementToolbar.ItemList>
 			</div>
-		</ClayManagementToolbar>
+		</ManagementToolbar.Container>
 	);
 }
 

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/components/DiagramHeader.js
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/components/DiagramHeader.js
@@ -11,9 +11,9 @@
 
 import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
-import ClayManagementToolbar from '@clayui/management-toolbar';
 import ClaySlider from '@clayui/slider';
 import classNames from 'classnames';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import {debounce} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
@@ -52,9 +52,9 @@ function DiagramHeader({
 	}, [pinsRadius]);
 
 	return (
-		<ClayManagementToolbar className="py-2">
-			<ClayManagementToolbar.ItemList>
-				<ClayManagementToolbar.Item>
+		<ManagementToolbar.Container className="py-2">
+			<ManagementToolbar.ItemList>
+				<ManagementToolbar.Item>
 					<label className="mr-3">
 						{Liferay.Language.get('pin-size')}
 					</label>
@@ -138,9 +138,9 @@ function DiagramHeader({
 							</ClayDropDown.Group>
 						</ClayDropDown.ItemList>
 					</ClayDropDown>
-				</ClayManagementToolbar.Item>
-			</ClayManagementToolbar.ItemList>
-		</ClayManagementToolbar>
+				</ManagementToolbar.Item>
+			</ManagementToolbar.ItemList>
+		</ManagementToolbar.Container>
 	);
 }
 

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/PageToolbar.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/PageToolbar.es.js
@@ -11,7 +11,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayLink from '@clayui/link';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 
@@ -40,12 +40,12 @@ class PageToolbar extends Component {
 		} = this.props;
 
 		return (
-			<ClayManagementToolbar
+			<ManagementToolbar.Container
 				aria-label={Liferay.Language.get('save')}
 				className="page-toolbar-root"
 			>
-				<ClayManagementToolbar.ItemList>
-					<ClayManagementToolbar.Item>
+				<ManagementToolbar.ItemList>
+					<ManagementToolbar.Item>
 						<label
 							className="toggle-switch"
 							htmlFor="active-switch-input"
@@ -68,15 +68,15 @@ class PageToolbar extends Component {
 									: Liferay.Language.get('active')}
 							</span>
 						</label>
-					</ClayManagementToolbar.Item>
-				</ClayManagementToolbar.ItemList>
+					</ManagementToolbar.Item>
+				</ManagementToolbar.ItemList>
 
-				<ClayManagementToolbar.ItemList
+				<ManagementToolbar.ItemList
 					expand
-				></ClayManagementToolbar.ItemList>
+				></ManagementToolbar.ItemList>
 
-				<ClayManagementToolbar.ItemList>
-					<ClayManagementToolbar.Item>
+				<ManagementToolbar.ItemList>
+					<ManagementToolbar.Item>
 						<ClayLink
 							displayType="secondary"
 							href={onCancel}
@@ -84,10 +84,10 @@ class PageToolbar extends Component {
 						>
 							{Liferay.Language.get('cancel')}
 						</ClayLink>
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 
 					{onSaveAsDraft && (
-						<ClayManagementToolbar.Item>
+						<ManagementToolbar.Item>
 							<ClayButton
 								displayType="secondary"
 								onClick={onSaveAsDraft}
@@ -95,10 +95,10 @@ class PageToolbar extends Component {
 							>
 								{Liferay.Language.get('save-as-draft')}
 							</ClayButton>
-						</ClayManagementToolbar.Item>
+						</ManagementToolbar.Item>
 					)}
 
-					<ClayManagementToolbar.Item>
+					<ManagementToolbar.Item>
 						<ClayButton
 							disabled={submitDisabled}
 							onClick={onPublish}
@@ -107,9 +107,9 @@ class PageToolbar extends Component {
 						>
 							{Liferay.Language.get('save')}
 						</ClayButton>
-					</ClayManagementToolbar.Item>
-				</ClayManagementToolbar.ItemList>
-			</ClayManagementToolbar>
+					</ManagementToolbar.Item>
+				</ManagementToolbar.ItemList>
+			</ManagementToolbar.Container>
 		);
 	}
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/PageToolbar.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/PageToolbar.es.js
@@ -71,9 +71,7 @@ class PageToolbar extends Component {
 					</ManagementToolbar.Item>
 				</ManagementToolbar.ItemList>
 
-				<ManagementToolbar.ItemList
-					expand
-				></ManagementToolbar.ItemList>
+				<ManagementToolbar.ItemList expand></ManagementToolbar.ItemList>
 
 				<ManagementToolbar.ItemList>
 					<ManagementToolbar.Item>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/FilterDisplay.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/FilterDisplay.es.js
@@ -10,7 +10,7 @@
  */
 
 import ClayButton from '@clayui/button';
-import {ClayResultsBar} from '@clayui/management-toolbar';
+import {ResultsBar} from 'frontend-js-components-web';
 import {PropTypes} from 'prop-types';
 import React, {Component} from 'react';
 
@@ -27,8 +27,8 @@ class FilterDisplay extends Component {
 		const {onClear, searchBarTerm, totalResultsCount} = this.props;
 
 		return (
-			<ClayResultsBar title={Liferay.Language.get('filter')}>
-				<ClayResultsBar.Item expand>
+			<ResultsBar title={Liferay.Language.get('filter')}>
+				<ResultsBar.Item expand>
 					<span className="component-text text-truncate-inline">
 						<span className="text-truncate">
 							{sub(Liferay.Language.get('x-results-for-x'), [
@@ -37,9 +37,9 @@ class FilterDisplay extends Component {
 							])}
 						</span>
 					</span>
-				</ClayResultsBar.Item>
+				</ResultsBar.Item>
 
-				<ClayResultsBar.Item>
+				<ResultsBar.Item>
 					<ClayButton
 						className="component-link tbar-link"
 						displayType="unstyled"
@@ -49,8 +49,8 @@ class FilterDisplay extends Component {
 					>
 						{Liferay.Language.get('clear')}
 					</ClayButton>
-				</ClayResultsBar.Item>
-			</ClayResultsBar>
+				</ResultsBar.Item>
+			</ResultsBar>
 		);
 	}
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/FilterDisplay.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/FilterDisplay.es.js
@@ -27,7 +27,9 @@ class FilterDisplay extends Component {
 		const {onClear, searchBarTerm, totalResultsCount} = this.props;
 
 		return (
-			<ManagementToolbar.ResultsBar title={Liferay.Language.get('filter')}>
+			<ManagementToolbar.ResultsBar
+				title={Liferay.Language.get('filter')}
+			>
 				<ManagementToolbar.ResultsBarItem expand>
 					<span className="component-text text-truncate-inline">
 						<span className="text-truncate">

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/FilterDisplay.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/FilterDisplay.es.js
@@ -10,7 +10,7 @@
  */
 
 import ClayButton from '@clayui/button';
-import {ResultsBar} from 'frontend-js-components-web';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import {PropTypes} from 'prop-types';
 import React, {Component} from 'react';
 
@@ -27,8 +27,8 @@ class FilterDisplay extends Component {
 		const {onClear, searchBarTerm, totalResultsCount} = this.props;
 
 		return (
-			<ResultsBar title={Liferay.Language.get('filter')}>
-				<ResultsBar.Item expand>
+			<ManagementToolbar.ResultsBar title={Liferay.Language.get('filter')}>
+				<ManagementToolbar.ResultsBarItem expand>
 					<span className="component-text text-truncate-inline">
 						<span className="text-truncate">
 							{sub(Liferay.Language.get('x-results-for-x'), [
@@ -37,9 +37,9 @@ class FilterDisplay extends Component {
 							])}
 						</span>
 					</span>
-				</ResultsBar.Item>
+				</ManagementToolbar.ResultsBarItem>
 
-				<ResultsBar.Item>
+				<ManagementToolbar.ResultsBarItem>
 					<ClayButton
 						className="component-link tbar-link"
 						displayType="unstyled"
@@ -49,8 +49,8 @@ class FilterDisplay extends Component {
 					>
 						{Liferay.Language.get('clear')}
 					</ClayButton>
-				</ResultsBar.Item>
-			</ResultsBar>
+				</ManagementToolbar.ResultsBarItem>
+			</ManagementToolbar.ResultsBar>
 		);
 	}
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/FilterInput.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/FilterInput.es.js
@@ -12,7 +12,7 @@
 import ClayButton from '@clayui/button';
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import {PropTypes} from 'prop-types';
 import React, {Component} from 'react';
 
@@ -43,7 +43,7 @@ class FilterInput extends Component {
 		const {disableSearch, onSubmit, searchBarTerm} = this.props;
 
 		return (
-			<ClayManagementToolbar.Search>
+			<ManagementToolbar.Search>
 				<ClayInput.Group>
 					<ClayInput.GroupItem>
 						<ClayInput
@@ -68,7 +68,7 @@ class FilterInput extends Component {
 						</ClayInput.GroupInsetItem>
 					</ClayInput.GroupItem>
 				</ClayInput.Group>
-			</ClayManagementToolbar.Search>
+			</ManagementToolbar.Search>
 		);
 	}
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/SearchBar.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/SearchBar.es.js
@@ -12,8 +12,8 @@
 import ClayButton from '@clayui/button';
 import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import ClayManagementToolbar from '@clayui/management-toolbar';
 import getCN from 'classnames';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import {PropTypes} from 'prop-types';
 import React, {Component} from 'react';
 
@@ -133,10 +133,10 @@ class SearchBar extends Component {
 
 		return (
 			<div className="search-bar-root">
-				<ClayManagementToolbar className={classManagementBar}>
+				<ManagementToolbar.Container className={classManagementBar}>
 					<div className={classNavBarForm}>
-						<ClayManagementToolbar.ItemList>
-							<ClayManagementToolbar.Item>
+						<ManagementToolbar.ItemList>
+							<ManagementToolbar.Item>
 								<ClayCheckbox
 									aria-label={Liferay.Language.get(
 										'select-all'
@@ -149,13 +149,13 @@ class SearchBar extends Component {
 									}
 									onChange={this._handleAllCheckbox}
 								/>
-							</ClayManagementToolbar.Item>
-						</ClayManagementToolbar.ItemList>
+							</ManagementToolbar.Item>
+						</ManagementToolbar.ItemList>
 
 						{this._hasSelectedIds() && (
 							<>
-								<ClayManagementToolbar.ItemList expand>
-									<ClayManagementToolbar.Item>
+								<ManagementToolbar.ItemList expand>
+									<ManagementToolbar.Item>
 										<span className="navbar-text">
 											{getPluralMessage(
 												Liferay.Language.get(
@@ -167,11 +167,11 @@ class SearchBar extends Component {
 												selectedIds.length
 											)}
 										</span>
-									</ClayManagementToolbar.Item>
-								</ClayManagementToolbar.ItemList>
+									</ManagementToolbar.Item>
+								</ManagementToolbar.ItemList>
 
-								<ClayManagementToolbar.ItemList>
-									<ClayManagementToolbar.Item>
+								<ManagementToolbar.ItemList>
+									<ManagementToolbar.Item>
 										<div className="nav-link nav-link-monospaced">
 											<ClayButton
 												className="btn-outline-borderless component-action"
@@ -196,9 +196,9 @@ class SearchBar extends Component {
 												/>
 											</ClayButton>
 										</div>
-									</ClayManagementToolbar.Item>
+									</ManagementToolbar.Item>
 
-									<ClayManagementToolbar.Item>
+									<ManagementToolbar.Item>
 										<div className="nav-link nav-link-monospaced">
 											<ClayButton
 												className="btn-outline-borderless component-action"
@@ -227,9 +227,9 @@ class SearchBar extends Component {
 												)}
 											</ClayButton>
 										</div>
-									</ClayManagementToolbar.Item>
+									</ManagementToolbar.Item>
 
-									<ClayManagementToolbar.Item>
+									<ManagementToolbar.Item>
 										<div className="nav-link nav-link-monospaced">
 											<ItemDropdown
 												hidden={this._isAnyHidden()}
@@ -243,28 +243,28 @@ class SearchBar extends Component {
 												pinned={!this._isAnyUnpinned()}
 											/>
 										</div>
-									</ClayManagementToolbar.Item>
-								</ClayManagementToolbar.ItemList>
+									</ManagementToolbar.Item>
+								</ManagementToolbar.ItemList>
 							</>
 						)}
 
 						{!this._hasSelectedIds() && (
 							<>
-								<ClayManagementToolbar.ItemList expand>
+								<ManagementToolbar.ItemList expand>
 									{!!resultIds.length && (
-										<ClayManagementToolbar.Item>
+										<ManagementToolbar.Item>
 											<span className="component-text navbar-text">
 												{Liferay.Language.get(
 													'select-items'
 												)}
 											</span>
-										</ClayManagementToolbar.Item>
+										</ManagementToolbar.Item>
 									)}
-								</ClayManagementToolbar.ItemList>
+								</ManagementToolbar.ItemList>
 
 								{onAddResultSubmit && (
-									<ClayManagementToolbar.ItemList>
-										<ClayManagementToolbar.Item>
+									<ManagementToolbar.ItemList>
+										<ManagementToolbar.Item>
 											<AddResult
 												fetchDocumentsSearchUrl={
 													fetchDocumentsSearchUrl
@@ -273,13 +273,13 @@ class SearchBar extends Component {
 													onAddResultSubmit
 												}
 											/>
-										</ClayManagementToolbar.Item>
-									</ClayManagementToolbar.ItemList>
+										</ManagementToolbar.Item>
+									</ManagementToolbar.ItemList>
 								)}
 							</>
 						)}
 					</div>
-				</ClayManagementToolbar>
+				</ManagementToolbar.Container>
 			</div>
 		);
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/InstanceListPageHeader.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/InstanceListPageHeader.es.js
@@ -10,8 +10,8 @@
  */
 
 import ClayLayout from '@clayui/layout';
-import ClayManagementToolbar from '@clayui/management-toolbar';
 import {usePrevious} from '@liferay/frontend-js-react-web';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useCallback, useContext, useEffect, useMemo} from 'react';
 
 import filterConstants from '../../shared/components/filter/util/filterConstants.es';
@@ -198,18 +198,18 @@ export default function Header({
 				totalCount={totalCount}
 			>
 				{toolbarActive ? (
-					<ClayManagementToolbar.Item className="navbar-nav-last">
+					<ManagementToolbar.Item className="navbar-nav-last">
 						<ClayLayout.ContentCol>
 							<QuickActionKebab items={kebabItems} />
 						</ClayLayout.ContentCol>
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 				) : (
 					<>
-						<ClayManagementToolbar.Item>
+						<ManagementToolbar.Item>
 							<strong className="ml-0 mr-0 navbar-text">
 								{Liferay.Language.get('filter-by')}
 							</strong>
-						</ClayManagementToolbar.Item>
+						</ManagementToolbar.Item>
 
 						<SLAStatusFilter
 							options={{

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/reassign/bulk/select-assignees-step/SelectAssigneesStepHeader.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/reassign/bulk/select-assignees-step/SelectAssigneesStepHeader.es.js
@@ -11,7 +11,7 @@
 
 import {ClayCheckbox, ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useCallback, useContext, useEffect, useState} from 'react';
 
 import {Autocomplete} from '../../../../../../shared/components/autocomplete/Autocomplete.es';
@@ -79,9 +79,9 @@ export default function Header({data}) {
 
 	return (
 		<PromisesResolver.Resolved>
-			<ClayManagementToolbar className="border-bottom mb-0 px-3">
-				<ClayManagementToolbar.ItemList>
-					<ClayManagementToolbar.Item className="pt-2">
+			<ManagementToolbar.Container className="border-bottom mb-0 px-3">
+				<ManagementToolbar.ItemList>
+					<ManagementToolbar.Item className="pt-2">
 						<ClayCheckbox
 							checked={useSameAssignee}
 							disabled={disableBulk}
@@ -90,10 +90,10 @@ export default function Header({data}) {
 							)}
 							onChange={handleCheck}
 						/>
-					</ClayManagementToolbar.Item>
-				</ClayManagementToolbar.ItemList>
+					</ManagementToolbar.Item>
+				</ManagementToolbar.ItemList>
 
-				<ClayManagementToolbar.Search onSubmit={handleSubmit}>
+				<ManagementToolbar.Search onSubmit={handleSubmit}>
 					<Autocomplete
 						defaultValue={selectedAssignee?.name || ''}
 						disabled={disableBulk || !useSameAssignee}
@@ -107,8 +107,8 @@ export default function Header({data}) {
 							<ClayIcon className="m-2" symbol="search" />
 						</ClayInput.GroupInsetItem>
 					</Autocomplete>
-				</ClayManagementToolbar.Search>
-			</ClayManagementToolbar>
+				</ManagementToolbar.Search>
+			</ManagementToolbar.Container>
 		</PromisesResolver.Resolved>
 	);
 }

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/shared/select-tasks-step/SelectTasksStepHeader.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/shared/select-tasks-step/SelectTasksStepHeader.es.js
@@ -9,8 +9,8 @@
  * distribution rights of the Software.
  */
 
-import ClayManagementToolbar from '@clayui/management-toolbar';
 import {usePrevious} from '@liferay/frontend-js-react-web';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useContext, useEffect} from 'react';
 
 import ResultsBar from '../../../../../shared/components/results-bar/ResultsBar.es';
@@ -137,11 +137,11 @@ function Header({items = [], instanceIds, totalCount, withoutUnassigned}) {
 			>
 				{!toolbarActive && (
 					<>
-						<ClayManagementToolbar.Item>
+						<ManagementToolbar.Item>
 							<strong className="ml-0 mr-0 navbar-text">
 								{Liferay.Language.get('filter-by')}
 							</strong>
-						</ClayManagementToolbar.Item>
+						</ManagementToolbar.Item>
 
 						<ProcessStepFilter
 							options={stepFilterOptions}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/performance-by-assignee-page/PerformanceByAssigneePageHeader.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/performance-by-assignee-page/PerformanceByAssigneePageHeader.es.js
@@ -9,7 +9,7 @@
  * distribution rights of the Software.
  */
 
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React from 'react';
 
 import filterConstants from '../../shared/components/filter/util/filterConstants.es';
@@ -29,13 +29,13 @@ export default function Header({
 
 	return (
 		<>
-			<ClayManagementToolbar className="mb-0">
-				<ClayManagementToolbar.ItemList>
-					<ClayManagementToolbar.Item>
+			<ManagementToolbar.Container className="mb-0">
+				<ManagementToolbar.ItemList>
+					<ManagementToolbar.Item>
 						<strong className="ml-0 mr-0 navbar-text">
 							{Liferay.Language.get('filter-by')}
 						</strong>
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 
 					<RoleFilter
 						completed={true}
@@ -47,7 +47,7 @@ export default function Header({
 						filterKey={filterConstants.processStep.key}
 						processId={routeParams.processId}
 					/>
-				</ClayManagementToolbar.ItemList>
+				</ManagementToolbar.ItemList>
 
 				<SearchField
 					disabled={false}
@@ -56,10 +56,10 @@ export default function Header({
 					)}
 				/>
 
-				<ClayManagementToolbar.ItemList>
+				<ManagementToolbar.ItemList>
 					<TimeRangeFilter />
-				</ClayManagementToolbar.ItemList>
-			</ClayManagementToolbar>
+				</ManagementToolbar.ItemList>
+			</ManagementToolbar.Container>
 
 			{showFiltersResult && (
 				<ResultsBar>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/performance-by-step-page/PerformanceByStepPageHeader.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/performance-by-step-page/PerformanceByStepPageHeader.es.js
@@ -9,7 +9,7 @@
  * distribution rights of the Software.
  */
 
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React from 'react';
 
 import filterConstants from '../../shared/components/filter/util/filterConstants.es';
@@ -36,13 +36,13 @@ export default function Header({
 
 	return (
 		<>
-			<ClayManagementToolbar className="mb-0">
-				<ClayManagementToolbar.ItemList>
-					<ClayManagementToolbar.Item>
+			<ManagementToolbar.Container className="mb-0">
+				<ManagementToolbar.ItemList>
+					<ManagementToolbar.Item>
 						<strong className="ml-0 mr-0 navbar-text">
 							{Liferay.Language.get('filter-by')}
 						</strong>
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 
 					<ProcessVersionFilter
 						filterKey={filterConstants.processVersion.key}
@@ -53,17 +53,17 @@ export default function Header({
 						}}
 						processId={routeParams.processId}
 					/>
-				</ClayManagementToolbar.ItemList>
+				</ManagementToolbar.ItemList>
 
 				<SearchField
 					disabled={false}
 					placeholder={Liferay.Language.get('search-for-step-name')}
 				/>
 
-				<ClayManagementToolbar.ItemList>
+				<ManagementToolbar.ItemList>
 					<TimeRangeFilter />
-				</ClayManagementToolbar.ItemList>
-			</ClayManagementToolbar>
+				</ManagementToolbar.ItemList>
+			</ManagementToolbar.Container>
 
 			{showFiltersResult && (
 				<ResultsBar>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-list-page/ProcessListPage.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-list-page/ProcessListPage.es.js
@@ -9,7 +9,7 @@
  * distribution rights of the Software.
  */
 
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useMemo} from 'react';
 
 import HeaderKebab from '../../shared/components/header/HeaderKebab.es';
@@ -24,9 +24,9 @@ import Body from './ProcessListPageBody.es';
 const Header = ({page, pageSize, search, sort, totalCount}) => {
 	return (
 		<>
-			<ClayManagementToolbar className="mb-0">
+			<ManagementToolbar.Container className="mb-0">
 				<SearchField disabled={!search && totalCount === 0} />
-			</ClayManagementToolbar>
+			</ManagementToolbar.Container>
 
 			{search && (
 				<ResultsBar>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/list-page/SLAListPageHeader.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/list-page/SLAListPageHeader.es.js
@@ -10,16 +10,16 @@
  */
 
 import ClayIcon from '@clayui/icon';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React from 'react';
 
 import ChildLink from '../../../shared/components/router/ChildLink.es';
 
 export default function Header({processId}) {
 	return (
-		<ClayManagementToolbar>
-			<ClayManagementToolbar.ItemList expand>
-				<ClayManagementToolbar.Item className="autofit-col-expand autofit-float-end">
+		<ManagementToolbar.Container>
+			<ManagementToolbar.ItemList expand>
+				<ManagementToolbar.Item className="autofit-col-expand autofit-float-end">
 					<span
 						data-tooltip-align="bottom"
 						title={Liferay.Language.get('new-sla')}
@@ -31,8 +31,8 @@ export default function Header({processId}) {
 							<ClayIcon symbol="plus" />
 						</ChildLink>
 					</span>
-				</ClayManagementToolbar.Item>
-			</ClayManagementToolbar.ItemList>
-		</ClayManagementToolbar>
+				</ManagementToolbar.Item>
+			</ManagementToolbar.ItemList>
+		</ManagementToolbar.Container>
 	);
 }

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/workload-by-assignee-page/WorkloadByAssigneePageHeader.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/workload-by-assignee-page/WorkloadByAssigneePageHeader.es.js
@@ -9,7 +9,7 @@
  * distribution rights of the Software.
  */
 
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React from 'react';
 
 import filterConstants from '../../shared/components/filter/util/filterConstants.es';
@@ -28,13 +28,13 @@ export default function Header({
 
 	return (
 		<>
-			<ClayManagementToolbar className="mb-0">
-				<ClayManagementToolbar.ItemList>
-					<ClayManagementToolbar.Item>
+			<ManagementToolbar.Container className="mb-0">
+				<ManagementToolbar.ItemList>
+					<ManagementToolbar.Item>
 						<strong className="ml-0 mr-0 navbar-text">
 							{Liferay.Language.get('filter-by')}
 						</strong>
-					</ClayManagementToolbar.Item>
+					</ManagementToolbar.Item>
 
 					<RoleFilter
 						filterKey={filterConstants.roles.key}
@@ -45,7 +45,7 @@ export default function Header({
 						filterKey={filterConstants.processStep.key}
 						processId={routeParams.processId}
 					/>
-				</ClayManagementToolbar.ItemList>
+				</ManagementToolbar.ItemList>
 
 				<SearchField
 					disabled={false}
@@ -53,7 +53,7 @@ export default function Header({
 						'search-for-assignee-name'
 					)}
 				/>
-			</ClayManagementToolbar>
+			</ManagementToolbar.Container>
 
 			{showFiltersResult && (
 				<ResultsBar>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/search-field/SearchField.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/search-field/SearchField.es.js
@@ -11,7 +11,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayInput} from '@clayui/form';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useEffect, useState} from 'react';
 
 import {useRouter} from '../../hooks/useRouter.es';
@@ -46,7 +46,7 @@ const SearchField = ({
 	};
 
 	return (
-		<ClayManagementToolbar.Search
+		<ManagementToolbar.Search
 			method="GET"
 			onSubmit={handleSubmit}
 			showMobile={true}
@@ -72,7 +72,7 @@ const SearchField = ({
 					</ClayInput.GroupInsetItem>
 				</ClayInput.GroupItem>
 			</ClayInput.Group>
-		</ClayManagementToolbar.Search>
+		</ManagementToolbar.Search>
 	);
 };
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/toolbar-with-selection/ToolbarWithSelection.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/toolbar-with-selection/ToolbarWithSelection.es.js
@@ -11,7 +11,7 @@
 
 import ClayButton from '@clayui/button';
 import {ClayCheckbox} from '@clayui/form';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React from 'react';
 
 import {sub} from '../../util/lang.es';
@@ -29,22 +29,22 @@ const ToolbarWithSelection = ({
 	totalCount,
 }) => {
 	return (
-		<ClayManagementToolbar
+		<ManagementToolbar.Container
 			active={active}
 			className="mb-0 show-quick-actions-on-hover"
 		>
-			<ClayManagementToolbar.ItemList expand>
-				<ClayManagementToolbar.Item className="ml-2">
+			<ManagementToolbar.ItemList expand>
+				<ManagementToolbar.Item className="ml-2">
 					<ClayCheckbox
 						checked={checked}
 						indeterminate={indeterminate}
 						onChange={handleCheck}
 					/>
-				</ClayManagementToolbar.Item>
+				</ManagementToolbar.Item>
 
 				{active && (
 					<>
-						<ClayManagementToolbar.Item>
+						<ManagementToolbar.Item>
 							<span className="ml-0 mr-0 navbar-text">
 								{selectAll
 									? Liferay.Language.get('all-selected')
@@ -55,9 +55,9 @@ const ToolbarWithSelection = ({
 											[selectedCount, totalCount]
 									  )}
 							</span>
-						</ClayManagementToolbar.Item>
+						</ManagementToolbar.Item>
 
-						<ClayManagementToolbar.Item>
+						<ManagementToolbar.Item>
 							<ClayButton
 								className="font-weight-bold nav-link"
 								displayType="unstyled"
@@ -66,10 +66,10 @@ const ToolbarWithSelection = ({
 							>
 								{Liferay.Language.get('clear')}
 							</ClayButton>
-						</ClayManagementToolbar.Item>
+						</ManagementToolbar.Item>
 
 						{!selectAll && checked && (
-							<ClayManagementToolbar.Item>
+							<ManagementToolbar.Item>
 								<ClayButton
 									className="font-weight-bold nav-link"
 									displayType="unstyled"
@@ -78,14 +78,14 @@ const ToolbarWithSelection = ({
 								>
 									{Liferay.Language.get('select-all')}
 								</ClayButton>
-							</ClayManagementToolbar.Item>
+							</ManagementToolbar.Item>
 						)}
 					</>
 				)}
 
 				{children}
-			</ClayManagementToolbar.ItemList>
-		</ClayManagementToolbar>
+			</ManagementToolbar.ItemList>
+		</ManagementToolbar.Container>
 	);
 };
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/clause_contributors_sidebar/ManagementToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/clause_contributors_sidebar/ManagementToolbar.js
@@ -17,8 +17,7 @@ import ClayLabel from '@clayui/label';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import getCN from 'classnames';
 import {
-	ManagementToolbar as FrontendManagementToolbar,
-	ResultsBar,
+	ManagementToolbar as FrontendManagementToolbar
 } from 'frontend-js-components-web';
 import React, {useState} from 'react';
 
@@ -238,8 +237,8 @@ function ManagementToolbar({
 			</FrontendManagementToolbar.Container>
 
 			{(!!keyword || status !== ALL || category !== ALL) && (
-				<ResultsBar>
-					<ResultsBar.Item>
+				<FrontendManagementToolbar.ResultsBar>
+					<FrontendManagementToolbar.ResultsBarItem>
 						<span className="component-text text-truncate-inline">
 							<span className="text-truncate">
 								{sub(Liferay.Language.get('x-results-for-x'), [
@@ -248,9 +247,9 @@ function ManagementToolbar({
 								])}
 							</span>
 						</span>
-					</ResultsBar.Item>
+					</FrontendManagementToolbar.ResultsBarItem>
 
-					<ResultsBar.Item expand>
+					<FrontendManagementToolbar.ResultsBarItem expand>
 						{status !== ALL && (
 							<ClayLabel
 								className="component-label tbar-label"
@@ -274,9 +273,9 @@ function ManagementToolbar({
 								{category}
 							</ClayLabel>
 						)}
-					</ResultsBar.Item>
+					</FrontendManagementToolbar.ResultsBarItem>
 
-					<ResultsBar.Item>
+					<FrontendManagementToolbar.ResultsBarItem>
 						<ClayButton
 							className="component-link tbar-link"
 							displayType="unstyled"
@@ -289,8 +288,8 @@ function ManagementToolbar({
 						>
 							{Liferay.Language.get('clear')}
 						</ClayButton>
-					</ResultsBar.Item>
-				</ResultsBar>
+					</FrontendManagementToolbar.ResultsBarItem>
+				</FrontendManagementToolbar.ResultsBar>
 			)}
 		</>
 	);

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/clause_contributors_sidebar/ManagementToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/clause_contributors_sidebar/ManagementToolbar.js
@@ -16,9 +16,7 @@ import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import getCN from 'classnames';
-import {
-	ManagementToolbar as FrontendManagementToolbar
-} from 'frontend-js-components-web';
+import {ManagementToolbar as FrontendManagementToolbar} from 'frontend-js-components-web';
 import React, {useState} from 'react';
 
 import {ALL, ASCENDING} from '../../utils/constants';

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/clause_contributors_sidebar/ManagementToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/clause_contributors_sidebar/ManagementToolbar.js
@@ -14,11 +14,12 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import {ClayCheckbox, ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
-import ClayManagementToolbar, {
-	ClayResultsBar,
-} from '@clayui/management-toolbar';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import getCN from 'classnames';
+import {
+	ManagementToolbar as FrontendManagementToolbar,
+	ResultsBar,
+} from 'frontend-js-components-web';
 import React, {useState} from 'react';
 
 import {ALL, ASCENDING} from '../../utils/constants';
@@ -43,13 +44,13 @@ function ManagementToolbar({
 
 	return (
 		<>
-			<ClayManagementToolbar
+			<FrontendManagementToolbar.Container
 				className={getCN('clause-contributors-management-bar', {
 					'management-bar-primary': selected.length > 0,
 				})}
 			>
-				<ClayManagementToolbar.ItemList>
-					<ClayManagementToolbar.Item>
+				<FrontendManagementToolbar.ItemList>
+					<FrontendManagementToolbar.Item>
 						<ClayCheckbox
 							aria-label={Liferay.Language.get('checkbox')}
 							checked={
@@ -68,15 +69,15 @@ function ManagementToolbar({
 								)
 							}
 						/>
-					</ClayManagementToolbar.Item>
-				</ClayManagementToolbar.ItemList>
+					</FrontendManagementToolbar.Item>
+				</FrontendManagementToolbar.ItemList>
 
 				{selected.length > 0 ? (
 					<>
-						<ClayManagementToolbar.ItemList expand>
+						<FrontendManagementToolbar.ItemList expand>
 							{allItems.length > 0 &&
 							selected.length === allItems.length ? (
-								<ClayManagementToolbar.Item className="navbar-form">
+								<FrontendManagementToolbar.Item className="navbar-form">
 									<span className="component-text text-truncate-inline">
 										<span className="text-truncate">
 											{Liferay.Language.get(
@@ -84,10 +85,10 @@ function ManagementToolbar({
 											)}
 										</span>
 									</span>
-								</ClayManagementToolbar.Item>
+								</FrontendManagementToolbar.Item>
 							) : (
 								<>
-									<ClayManagementToolbar.Item className="navbar-form">
+									<FrontendManagementToolbar.Item className="navbar-form">
 										<span className="component-text text-truncate-inline">
 											<span className="text-truncate">
 												{sub(
@@ -101,9 +102,9 @@ function ManagementToolbar({
 												)}
 											</span>
 										</span>
-									</ClayManagementToolbar.Item>
+									</FrontendManagementToolbar.Item>
 
-									<ClayManagementToolbar.Item>
+									<FrontendManagementToolbar.Item>
 										<ClayButton
 											displayType="link"
 											onClick={() =>
@@ -113,13 +114,13 @@ function ManagementToolbar({
 										>
 											{Liferay.Language.get('select-all')}
 										</ClayButton>
-									</ClayManagementToolbar.Item>
+									</FrontendManagementToolbar.Item>
 								</>
 							)}
-						</ClayManagementToolbar.ItemList>
+						</FrontendManagementToolbar.ItemList>
 
-						<ClayManagementToolbar.ItemList>
-							<ClayManagementToolbar.Item>
+						<FrontendManagementToolbar.ItemList>
+							<FrontendManagementToolbar.Item>
 								<ClayButton.Group spaced>
 									<ClayButton
 										displayType="secondary"
@@ -137,13 +138,13 @@ function ManagementToolbar({
 										{Liferay.Language.get('turn-off')}
 									</ClayButton>
 								</ClayButton.Group>
-							</ClayManagementToolbar.Item>
-						</ClayManagementToolbar.ItemList>
+							</FrontendManagementToolbar.Item>
+						</FrontendManagementToolbar.ItemList>
 					</>
 				) : (
 					<>
-						<ClayManagementToolbar.ItemList>
-							<ClayManagementToolbar.Item>
+						<FrontendManagementToolbar.ItemList>
+							<FrontendManagementToolbar.Item>
 								<ClayDropDownWithItems
 									items={filterItems}
 									trigger={
@@ -184,11 +185,11 @@ function ManagementToolbar({
 										/>
 									</ClayButton>
 								</ClayTooltipProvider>
-							</ClayManagementToolbar.Item>
-						</ClayManagementToolbar.ItemList>
+							</FrontendManagementToolbar.Item>
+						</FrontendManagementToolbar.ItemList>
 
-						<ClayManagementToolbar.ItemList expand>
-							<ClayManagementToolbar.Item className="search">
+						<FrontendManagementToolbar.ItemList expand>
+							<FrontendManagementToolbar.Item className="search">
 								<ClayInput.Group>
 									<ClayInput.GroupItem>
 										<ClayInput
@@ -230,15 +231,15 @@ function ManagementToolbar({
 										</ClayInput.GroupInsetItem>
 									</ClayInput.GroupItem>
 								</ClayInput.Group>
-							</ClayManagementToolbar.Item>
-						</ClayManagementToolbar.ItemList>
+							</FrontendManagementToolbar.Item>
+						</FrontendManagementToolbar.ItemList>
 					</>
 				)}
-			</ClayManagementToolbar>
+			</FrontendManagementToolbar.Container>
 
 			{(!!keyword || status !== ALL || category !== ALL) && (
-				<ClayResultsBar>
-					<ClayResultsBar.Item>
+				<ResultsBar>
+					<ResultsBar.Item>
 						<span className="component-text text-truncate-inline">
 							<span className="text-truncate">
 								{sub(Liferay.Language.get('x-results-for-x'), [
@@ -247,9 +248,9 @@ function ManagementToolbar({
 								])}
 							</span>
 						</span>
-					</ClayResultsBar.Item>
+					</ResultsBar.Item>
 
-					<ClayResultsBar.Item expand>
+					<ResultsBar.Item expand>
 						{status !== ALL && (
 							<ClayLabel
 								className="component-label tbar-label"
@@ -273,9 +274,9 @@ function ManagementToolbar({
 								{category}
 							</ClayLabel>
 						)}
-					</ClayResultsBar.Item>
+					</ResultsBar.Item>
 
-					<ClayResultsBar.Item>
+					<ResultsBar.Item>
 						<ClayButton
 							className="component-link tbar-link"
 							displayType="unstyled"
@@ -288,8 +289,8 @@ function ManagementToolbar({
 						>
 							{Liferay.Language.get('clear')}
 						</ClayButton>
-					</ClayResultsBar.Item>
-				</ClayResultsBar>
+					</ResultsBar.Item>
+				</ResultsBar>
 			)}
 		</>
 	);

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/index.js
@@ -16,11 +16,11 @@ import ClayEmptyState from '@clayui/empty-state';
 import ClayIcon from '@clayui/icon';
 import ClayList from '@clayui/list';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
-import ClayManagementToolbar from '@clayui/management-toolbar';
 import {ClayPaginationWithBasicItems} from '@clayui/pagination';
 import ClayPaginationBar from '@clayui/pagination-bar';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import getCN from 'classnames';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
@@ -140,9 +140,9 @@ function PreviewSidebar({
 	);
 
 	const _renderResultsManagementBar = () => (
-		<ClayManagementToolbar>
-			<ClayManagementToolbar.ItemList>
-				<ClayManagementToolbar.Item>
+		<ManagementToolbar.Container>
+			<ManagementToolbar.ItemList>
+				<ManagementToolbar.Item>
 					<span className="text-truncate-inline total-hits-label">
 						<span className="text-truncate">
 							{sub(Liferay.Language.get('x-results'), [
@@ -152,9 +152,9 @@ function PreviewSidebar({
 							])}
 						</span>
 					</span>
-				</ClayManagementToolbar.Item>
+				</ManagementToolbar.Item>
 
-				<ClayManagementToolbar.Item>
+				<ManagementToolbar.Item>
 					<ClayButton
 						aria-label={Liferay.Language.get('refresh')}
 						disabled={loading}
@@ -164,11 +164,11 @@ function PreviewSidebar({
 					>
 						{Liferay.Language.get('refresh')}
 					</ClayButton>
-				</ClayManagementToolbar.Item>
-			</ClayManagementToolbar.ItemList>
+				</ManagementToolbar.Item>
+			</ManagementToolbar.ItemList>
 
-			<ClayManagementToolbar.ItemList>
-				<ClayManagementToolbar.Item>
+			<ManagementToolbar.ItemList>
+				<ManagementToolbar.Item>
 					<PreviewModalWithCopyDownload
 						fileName="raw_response.json"
 						folded
@@ -187,9 +187,9 @@ function PreviewSidebar({
 							{Liferay.Language.get('view-raw-response')}
 						</ClayButton>
 					</PreviewModalWithCopyDownload>
-				</ClayManagementToolbar.Item>
-			</ClayManagementToolbar.ItemList>
-		</ClayManagementToolbar>
+				</ManagementToolbar.Item>
+			</ManagementToolbar.ItemList>
+		</ManagementToolbar.Container>
 	);
 
 	return (

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SelectTypes.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SelectTypes.js
@@ -13,9 +13,9 @@ import ClayButton from '@clayui/button';
 import ClayEmptyState from '@clayui/empty-state';
 import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import ClayManagementToolbar from '@clayui/management-toolbar';
 import ClayModal, {useModal} from '@clayui/modal';
 import ClayTable from '@clayui/table';
+import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useContext, useState} from 'react';
 
 import ThemeContext from '../../shared/ThemeContext';
@@ -127,15 +127,15 @@ function SelectTypes({
 
 					{searchableTypes.length > 0 ? (
 						<>
-							<ClayManagementToolbar
+							<ManagementToolbar.Container
 								className={
 									modalSelectedTypes.length > 0 &&
 									'management-bar-primary'
 								}
 							>
 								<div className="navbar-form navbar-form-autofit navbar-overlay">
-									<ClayManagementToolbar.ItemList>
-										<ClayManagementToolbar.Item>
+									<ManagementToolbar.ItemList>
+										<ManagementToolbar.Item>
 											<ClayCheckbox
 												checked={
 													modalSelectedTypes.length >
@@ -156,9 +156,9 @@ function SelectTypes({
 													)
 												}
 											/>
-										</ClayManagementToolbar.Item>
+										</ManagementToolbar.Item>
 
-										<ClayManagementToolbar.Item>
+										<ManagementToolbar.Item>
 											{modalSelectedTypes.length > 0 ? (
 												<>
 													<span className="component-text">
@@ -198,10 +198,10 @@ function SelectTypes({
 													)}
 												</span>
 											)}
-										</ClayManagementToolbar.Item>
-									</ClayManagementToolbar.ItemList>
+										</ManagementToolbar.Item>
+									</ManagementToolbar.ItemList>
 								</div>
-							</ClayManagementToolbar>
+							</ManagementToolbar.Container>
 
 							<ClayModal.Body scrollable>
 								<ClayTable>

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_options/js/configuration/ManagementToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_options/js/configuration/ManagementToolbar.js
@@ -13,7 +13,7 @@ import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import {ManagementToolbar as FrontendManagementToolbar, ResultsBar} from 'frontend-js-components-web';
+import {ManagementToolbar as FrontendManagementToolbar} from 'frontend-js-components-web';
 import React, {useState} from 'react';
 
 import {sub} from '../../../sxp_blueprint_admin/js/utils/language';
@@ -133,8 +133,8 @@ const ManagementToolbar = ({
 			</FrontendManagementToolbar.Container>
 
 			{!!searchValue && !loading && (
-				<ResultsBar>
-					<ResultsBar.Item>
+				<FrontendManagementToolbar.ResultsBar>
+					<FrontendManagementToolbar.ResultsBarItem>
 						<span className="component-text text-truncate-inline">
 							<span className="text-truncate">
 								{sub(
@@ -147,9 +147,9 @@ const ManagementToolbar = ({
 								)}
 							</span>
 						</span>
-					</ResultsBar.Item>
+					</FrontendManagementToolbar.ResultsBarItem>
 
-					<ResultsBar.Item>
+					<FrontendManagementToolbar.ResultsBarItem>
 						<ClayButton
 							className="component-link tbar-link"
 							displayType="unstyled"
@@ -160,8 +160,8 @@ const ManagementToolbar = ({
 						>
 							{Liferay.Language.get('clear')}
 						</ClayButton>
-					</ResultsBar.Item>
-				</ResultsBar>
+					</FrontendManagementToolbar.ResultsBarItem>
+				</FrontendManagementToolbar.ResultsBar>
 			)}
 		</>
 	);

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_options/js/configuration/ManagementToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_options/js/configuration/ManagementToolbar.js
@@ -13,9 +13,7 @@ import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import ClayManagementToolbar, {
-	ClayResultsBar,
-} from '@clayui/management-toolbar';
+import {ManagementToolbar as FrontendManagementToolbar, ResultsBar} from 'frontend-js-components-web';
 import React, {useState} from 'react';
 
 import {sub} from '../../../sxp_blueprint_admin/js/utils/language';
@@ -34,8 +32,8 @@ const ManagementToolbar = ({
 
 	return (
 		<>
-			<ClayManagementToolbar>
-				<ClayManagementToolbar.ItemList>
+			<FrontendManagementToolbar.Container>
+				<FrontendManagementToolbar.ItemList>
 					<ClayDropDownWithItems
 						items={filterItems}
 						trigger={
@@ -64,7 +62,7 @@ const ManagementToolbar = ({
 						}
 					/>
 
-					<ClayManagementToolbar.Item>
+					<FrontendManagementToolbar.Item>
 						<ClayButton
 							className="nav-link nav-link-monospaced"
 							disabled={loading}
@@ -77,10 +75,10 @@ const ManagementToolbar = ({
 								<ClayIcon symbol="order-list-down" />
 							)}
 						</ClayButton>
-					</ClayManagementToolbar.Item>
-				</ClayManagementToolbar.ItemList>
+					</FrontendManagementToolbar.Item>
+				</FrontendManagementToolbar.ItemList>
 
-				<ClayManagementToolbar.Search showMobile={searchMobile}>
+				<FrontendManagementToolbar.Search showMobile={searchMobile}>
 					<ClayInput.Group>
 						<ClayInput.GroupItem>
 							<ClayInput
@@ -119,10 +117,10 @@ const ManagementToolbar = ({
 							</ClayInput.GroupInsetItem>
 						</ClayInput.GroupItem>
 					</ClayInput.Group>
-				</ClayManagementToolbar.Search>
+				</FrontendManagementToolbar.Search>
 
-				<ClayManagementToolbar.ItemList>
-					<ClayManagementToolbar.Item className="navbar-breakpoint-d-none">
+				<FrontendManagementToolbar.ItemList>
+					<FrontendManagementToolbar.Item className="navbar-breakpoint-d-none">
 						<ClayButton
 							className="nav-link nav-link-monospaced"
 							displayType="unstyled"
@@ -130,13 +128,13 @@ const ManagementToolbar = ({
 						>
 							<ClayIcon symbol="search" />
 						</ClayButton>
-					</ClayManagementToolbar.Item>
-				</ClayManagementToolbar.ItemList>
-			</ClayManagementToolbar>
+					</FrontendManagementToolbar.Item>
+				</FrontendManagementToolbar.ItemList>
+			</FrontendManagementToolbar.Container>
 
 			{!!searchValue && !loading && (
-				<ClayResultsBar>
-					<ClayResultsBar.Item>
+				<ResultsBar>
+					<ResultsBar.Item>
 						<span className="component-text text-truncate-inline">
 							<span className="text-truncate">
 								{sub(
@@ -149,9 +147,9 @@ const ManagementToolbar = ({
 								)}
 							</span>
 						</span>
-					</ClayResultsBar.Item>
+					</ResultsBar.Item>
 
-					<ClayResultsBar.Item>
+					<ResultsBar.Item>
 						<ClayButton
 							className="component-link tbar-link"
 							displayType="unstyled"
@@ -162,8 +160,8 @@ const ManagementToolbar = ({
 						>
 							{Liferay.Language.get('clear')}
 						</ClayButton>
-					</ClayResultsBar.Item>
-				</ClayResultsBar>
+					</ResultsBar.Item>
+				</ResultsBar>
 			)}
 		</>
 	);

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/constants/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.2.0

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/constants/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -566,6 +566,7 @@
         modules/apps/frontend-js/frontend-js-dropdown-support-web,\
         modules/apps/frontend-js/frontend-js-tabs-support-web,\
         modules/apps/frontend-js/frontend-js-tooltip-support-web,\
+        modules/apps/object/object-web,\
         modules/apps/site-initializer/site-initializer-raylife-ap,\
         modules/apps/site-initializer/site-initializer-raylife-d2c,\
         modules/apps/site-initializer/site-initializer-testray,\

--- a/workspaces/sample-lxc-sm-workspace/design-packs/fire/package.json
+++ b/workspaces/sample-lxc-sm-workspace/design-packs/fire/package.json
@@ -1,9 +1,11 @@
 {
-	"name": "fire",
-	"version": "1.0.0",
-	"main": "package.json",
-	"keywords": ["liferay-design-pack"],
+	"keywords": [
+		"liferay-design-pack"
+	],
 	"liferayDesignPack": {
 		"baseTheme": "styled"
-	}
+	},
+	"main": "package.json",
+	"name": "fire",
+	"version": "1.0.0"
 }

--- a/workspaces/sample-lxc-sm-workspace/design-packs/fire/src/css/_custom.scss
+++ b/workspaces/sample-lxc-sm-workspace/design-packs/fire/src/css/_custom.scss
@@ -5,6 +5,6 @@
 @import 'liferay-font-awesome/scss/font-awesome';
 @import 'liferay-font-awesome/scss/glyphicons';
 
-/* endinject */
+/* ---------- endinject ---------- */
 
-/* This file allows you to override default styles in one central location for easier upgrade and maintenance. */
+/* ---------- This file allows you to override default styles in one central location for easier upgrade and maintenance. ---------- */


### PR DESCRIPTION
Manually forwarding from https://github.com/liferay-frontend/liferay-portal/pull/2059 as [QA has confirmed test failures are unrelated](https://github.com/liferay-frontend/liferay-portal/pull/2059#issuecomment-1090085246).

Also added https://github.com/brianchandotcom/liferay-portal/commit/554bc69fed94e07e058cd3d2d8a82abaf2c4a98e to fix SF errors in master for design-pack sample caused by https://github.com/brianchandotcom/liferay-portal/pull/116302.

------
### References

- [LPS-147713](https://issues.liferay.com/browse/LPS-147713)

### What is the goal?

* Migrate ClayManagementToolbar usages to new component in DXP
* Move `ResultsBar` and item to `ManagementToolbar.ResultsBar` 
* Rename `management-toolbar-container` class to `management-bar` to prevent conflicts with other implementations
* Add MT types to `frontend-js-components-web`
