### PR TITLE
 LPS-151954 - Fix console error in MT when FF is disabled

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ItemList.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ItemList.js
@@ -13,6 +13,7 @@
  */
 
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const ItemList = ({children, expand}) => (
@@ -26,7 +27,7 @@ const ItemList = ({children, expand}) => (
 );
 
 ItemList.propTypes = {
-	expand: Boolean,
+	expand: PropTypes.bool,
 };
 
 export default ItemList;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ResultsBarItem.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ResultsBarItem.js
@@ -13,6 +13,7 @@
  */
 
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const ResultsBarItem = ({
@@ -32,7 +33,7 @@ const ResultsBarItem = ({
 );
 
 ResultsBarItem.propTypes = {
-	expand: Boolean,
+	expand: PropTypes.bool,
 };
 
 export default ResultsBarItem;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/Search.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/Search.js
@@ -14,6 +14,7 @@
 
 import ClayLayout from '@clayui/layout';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const Search = ({children, onlySearch, showMobile, ...otherProps}) => {
@@ -40,8 +41,8 @@ const Search = ({children, onlySearch, showMobile, ...otherProps}) => {
 };
 
 Search.propTypes = {
-	onlySearch: Boolean,
-	showMobile: Boolean,
+	onlySearch: PropTypes.bool,
+	showMobile: PropTypes.bool,
 };
 
 export default Search;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
@@ -99,10 +99,11 @@ const FilterOrderControls = ({
 								<span
 									className="navbar-breakpoint-d-none"
 									title={
-										showDesignImprovements &&
-										Liferay.Language.get(
-											'show-filter-options'
-										)
+										showDesignImprovements
+											? Liferay.Language.get(
+													'show-filter-options'
+											  )
+											: undefined
 									}
 								>
 									<ClayIcon symbol="filter" />

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
@@ -197,8 +197,9 @@ const SelectionControls = ({
 							<ManagementToolbar.Item className="nav-item-shrink">
 								<LinkOrButton
 									aria-label={
-										showDesignImprovements &&
-										Liferay.Language.get('clear')
+										showDesignImprovements
+											? Liferay.Language.get('clear')
+											: undefined
 									}
 									className="nav-link"
 									displayType="unstyled"
@@ -216,11 +217,14 @@ const SelectionControls = ({
 										onClearButtonClick(event);
 									}}
 									symbol={
-										showDesignImprovements && 'times-circle'
+										showDesignImprovements
+											? 'times-circle'
+											: undefined
 									}
 									title={
-										showDesignImprovements &&
-										Liferay.Language.get('clear')
+										showDesignImprovements
+											? Liferay.Language.get('clear')
+											: undefined
 									}
 								>
 									<span className="text-truncate-inline">


### PR DESCRIPTION
Manually forwarding from https://github.com/liferay-frontend/liferay-portal/pull/2137 because of unrelated CI errors [checked by QA](https://github.com/liferay-frontend/liferay-portal/pull/2137#issuecomment-1109636594).

---
### References

- [LPS-151954](https://issues.liferay.com/browse/LPS-151954)

### What is the goal?

* Fix console warning in Management Toolbar when feature flag is disabled by using ternary operator instead of &&
* Fix console warning in MT due to wrong proptypes

### What does it look like?

#### Before fix

https://user-images.githubusercontent.com/6642927/164480432-5354ba79-eaba-4b78-bdf7-bfa7d18db519.mov



#### After fix

https://user-images.githubusercontent.com/6642927/164480449-c4423bc9-675f-421f-af31-b4855931a622.mov



### How to replicate
* Go to `Content & Data > Web Content`
* Open JS console (Cmd+Opt+I in MacOS)
* See that there's no error

