### PR TITLE
LPS-144879 Include sample clay toast alert message for testing

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleToastAlert.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleToastAlert.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayButton from '@clayui/button';
+import {openToast} from 'frontend-js-web';
+import React from 'react';
+
+export default function ClaySampleToastAlert() {
+	const onClickSuccess = () => {
+		openToast({
+			autoClose: false,
+			message: Liferay.Language.get(
+				'your-request-completed-successfully'
+			),
+			title: Liferay.Language.get('success'),
+			type: 'success',
+		});
+	};
+
+	const onClickFail = () => {
+		openToast({
+			autoClose: 20000,
+			message: Liferay.Language.get('an-unexpected-error-occurred'),
+			title: Liferay.Language.get('error'),
+			type: 'danger',
+		});
+	};
+
+	return (
+		<div data-qa-id="claySampleToastAlert">
+			<h3>TOAST ALERT MESSAGE</h3>
+
+			<div className="sheet-footer">
+				<ClayButton.Group spaced>
+					<ClayButton onClick={onClickSuccess} type="submit">
+						{Liferay.Language.get('success-submit')}
+					</ClayButton>
+
+					<ClayButton
+						displayType="secondary"
+						onClick={onClickFail}
+						type="submit"
+					>
+						{Liferay.Language.get('fail-submit')}
+					</ClayButton>
+				</ClayButton.Group>
+			</div>
+		</div>
+	);
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/alerts.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/alerts.jsp
@@ -73,3 +73,11 @@
 	message="This is a warning message."
 	title="Warning"
 />
+
+<%-- Sample React Module --%>
+
+<div>
+	<react:component
+		module="js/ClaySampleToastAlert"
+	/>
+</div>


### PR DESCRIPTION
Manually forwarding since encountered unrelated test failures from `ci:forward` attempts

----

**Description**
Include a sample clay toast alert message which will be followed up with end to end testing.

**Test Plan**
1.  Add Clay Sample Portlet to page
2. Click on `Success Submit` button
3. Assert success toast message displays
4. Click on `Fail Submit` button
5. Assert failed toast message displays
6. Assert success toast message remains present indefinitely
7. Assert fail toast message disappears after 20 seconds

https://user-images.githubusercontent.com/35235266/164793070-869f0d7a-4ef4-4677-a7a6-07df44856157.mp4

**JIRA TICKET**
https://issues.liferay.com/browse/LPS-144879