### PR TITLE
LPS-152753 Auto SF

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/StartupAction.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupAction.java
@@ -80,9 +80,8 @@ public class StartupAction extends SimpleAction {
 				if (extJarFiles.length != 0) {
 					_log.error(
 						StringBundler.concat(
-							"Files ", Arrays.toString(extJarFiles),
-							" in ", libExtDir, " are no longer read. Move ",
-							"them to ",
+							"Files ", Arrays.toString(extJarFiles), " in ",
+							libExtDir, " are no longer read. Move them to ",
 							PropsValues.LIFERAY_LIB_GLOBAL_SHARED_DIR, " or ",
 							PropsValues.
 								LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,


### PR DESCRIPTION
Fixes SF error introduced by https://github.com/liferay/liferay-portal/commit/608dd4ca8a08f760ae9946745f3152aaa3ef72fe

Side note: I am unable to find the pull request where this commit was originally made. It is not linked on the LPS ticket, nor am I able to find it by searching for "LPS-152753" or "152753" in your pull requests. I would really like it if we could implement some sort of automation involving `ci:forward` to ensure that the pull request history on the LPS ticket gets updated whenever `ci:forward` is run, to prevent this type of thing from happening as often as it does (and it happens quite often in my experience in Support, where I have to frequently look back through old tickets to try to figure out what they were doing).