### PR TITLE
LPS-151945 Fix locales in creation of DDMFieldValue from Headless Delivery API

### DIFF
--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -321,7 +321,7 @@ public class StructuredContentResourceImpl
 				StructuredContentUtil.getJournalArticleContent(
 					_ddm,
 					DDMFormValuesUtil.toDDMFormValues(
-						structuredContent.getContentFields(),
+						titleMap.keySet(), structuredContent.getContentFields(),
 						ddmStructure.getDDMForm(), _dlAppService, siteId,
 						_journalArticleService, _layoutLocalService,
 						contextAcceptLanguage.getPreferredLocale(),

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/resources/com/liferay/headless/admin/content/resource/v1_0/test/dependencies/test-ddm-localized-structure.json
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/resources/com/liferay/headless/admin/content/resource/v1_0/test/dependencies/test-ddm-localized-structure.json
@@ -1,0 +1,32 @@
+{
+	"availableLanguageIds": [
+		"en_US",
+		"es_ES"
+	],
+	"defaultLanguageId": "en_US",
+	"fields": [
+		{
+			"dataType": "string",
+			"indexType": "keyword",
+			"label": {
+				"en_US": "TextFieldNameLabel",
+				"es_ES": "NombreEtiquetaDelCampoDeTexto"
+			},
+			"localizable": true,
+			"name": "MyText",
+			"predefinedValue": {
+				"en_US": "",
+				"es_ES": ""
+			},
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": "",
+				"es_ES": ""
+			},
+			"type": "text"
+		}
+	]
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 38.3.1
+Bundle-Version: 39.0.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
@@ -30,18 +30,22 @@ import com.liferay.headless.delivery.dto.v1_0.ContentField;
 import com.liferay.journal.service.JournalArticleService;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -76,8 +80,8 @@ public class DDMFormValuesUtil {
 	}
 
 	public static DDMFormValues toDDMFormValues(
-		ContentField[] contentFields, DDMForm ddmForm,
-		DLAppService dlAppService, long groupId,
+		Set<Locale> availableLocales, ContentField[] contentFields,
+		DDMForm ddmForm, DLAppService dlAppService, long groupId,
 		JournalArticleService journalArticleService,
 		LayoutLocalService layoutLocalService, Locale locale,
 		List<DDMFormField> rootDDMFormFields) {
@@ -92,7 +96,8 @@ public class DDMFormValuesUtil {
 
 		return new DDMFormValues(ddmForm) {
 			{
-				setAvailableLocales(ddmForm.getAvailableLocales());
+				setAvailableLocales(
+					_getAvailableLocales(availableLocales, ddmForm, groupId));
 				setDDMFormFieldValues(
 					_flattenDDMFormFieldValues(
 						rootDDMFormFields,
@@ -102,7 +107,7 @@ public class DDMFormValuesUtil {
 							ddmFormField, dlAppService, groupId,
 							journalArticleService, layoutLocalService,
 							locale)));
-				setDefaultLocale(ddmForm.getDefaultLocale());
+				setDefaultLocale(_getDefaultLocale(ddmForm, locale));
 			}
 		};
 	}
@@ -135,6 +140,36 @@ public class DDMFormValuesUtil {
 		).collect(
 			Collectors.toList()
 		);
+	}
+
+	private static Set<Locale> _getAvailableLocales(
+		Set<Locale> availableLocales, DDMForm ddmForm, Long groupId) {
+
+		if (SetUtil.isEmpty(availableLocales)) {
+			return ddmForm.getAvailableLocales();
+		}
+
+		Set<Locale> siteAvailableLocales = LanguageUtil.getAvailableLocales(
+			groupId);
+		Set<Locale> locales = new HashSet<>();
+
+		for (Locale availableLocale : availableLocales) {
+			if (siteAvailableLocales.contains(availableLocale)) {
+				locales.add(availableLocale);
+			}
+		}
+
+		return locales;
+	}
+
+	private static Locale _getDefaultLocale(
+		DDMForm ddmForm, Locale defaultLocale) {
+
+		if (defaultLocale == null) {
+			return ddmForm.getDefaultLocale();
+		}
+
+		return defaultLocale;
 	}
 
 	private static Map<String, List<ContentField>> _toContentFieldsMap(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/util/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.dynamic.data.mapping.kernel.DDMFormValues;
 import com.liferay.dynamic.data.mapping.kernel.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.service.DDMStructureService;
 import com.liferay.dynamic.data.mapping.util.DDMBeanTranslator;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
@@ -540,9 +541,11 @@ public class DocumentResourceImpl
 					modelDDMStructure = _ddmStructureService.getStructure(
 						ddmStructure.getStructureId());
 
+				DDMForm ddmForm = modelDDMStructure.getDDMForm();
+
 				com.liferay.dynamic.data.mapping.storage.DDMFormValues
 					ddmFormValues = DDMFormValuesUtil.toDDMFormValues(
-						contentFields, modelDDMStructure.getDDMForm(),
+						ddmForm.getAvailableLocales(), contentFields, ddmForm,
 						_dlAppService, groupId, _journalArticleService,
 						_layoutLocalService,
 						contextAcceptLanguage.getPreferredLocale(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -91,6 +91,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -650,7 +651,7 @@ public class StructuredContentResourceImpl
 				StructuredContentUtil.getJournalArticleContent(
 					_ddm,
 					DDMFormValuesUtil.toDDMFormValues(
-						structuredContent.getContentFields(),
+						titleMap.keySet(), structuredContent.getContentFields(),
 						ddmStructure.getDDMForm(), _dlAppService, groupId,
 						_journalArticleService, _layoutLocalService,
 						contextAcceptLanguage.getPreferredLocale(),
@@ -839,7 +840,8 @@ public class StructuredContentResourceImpl
 	}
 
 	private Fields _toFields(
-			ContentField[] contentFields, JournalArticle journalArticle)
+			Set<Locale> availableLocales, ContentField[] contentFields,
+			JournalArticle journalArticle)
 		throws Exception {
 
 		DDMStructure ddmStructure = journalArticle.getDDMStructure();
@@ -847,8 +849,8 @@ public class StructuredContentResourceImpl
 		ServiceContext serviceContext = new ServiceContext();
 
 		DDMFormValues ddmFormValues = DDMFormValuesUtil.toDDMFormValues(
-			contentFields, ddmStructure.getDDMForm(), _dlAppService,
-			journalArticle.getGroupId(), _journalArticleService,
+			availableLocales, contentFields, ddmStructure.getDDMForm(),
+			_dlAppService, journalArticle.getGroupId(), _journalArticleService,
 			_layoutLocalService, contextAcceptLanguage.getPreferredLocale(),
 			_getRootDDMFormFields(ddmStructure));
 
@@ -883,6 +885,9 @@ public class StructuredContentResourceImpl
 		}
 
 		DDMFormValues ddmFormValues = DDMFormValuesUtil.toDDMFormValues(
+			SetUtil.fromArray(
+				LocaleUtil.fromLanguageIds(
+					journalArticle.getAvailableLanguageIds())),
 			contentFields, ddmStructure.getDDMForm(), _dlAppService,
 			journalArticle.getGroupId(), _journalArticleService,
 			_layoutLocalService, contextAcceptLanguage.getPreferredLocale(),
@@ -1086,7 +1091,8 @@ public class StructuredContentResourceImpl
 				_journalConverter.getContent(
 					ddmStructure,
 					_toFields(
-						structuredContent.getContentFields(), journalArticle),
+						titleMap.keySet(), structuredContent.getContentFields(),
+						journalArticle),
 					journalArticle.getGroupId()),
 				journalArticle.getDDMStructureKey(),
 				_getDDMTemplateKey(ddmStructure),


### PR DESCRIPTION
This PR contains the code to fix [this bug](https://issues.liferay.com/browse/LPS-151945).

Related PR closed because of existence of conflicts with master: https://github.com/brianchandotcom/liferay-portal/pull/116780, https://github.com/brianchandotcom/liferay-portal/pull/116888 https://github.com/liferay-frontend/liferay-portal/pull/2197

If it is desired to create a Structured Content (Web Content) from the API including multiple languages, for example:

- en-US (english)
- pt-BR (portuguese)

and the Content Structure associated to the Structured Content is not translated into both languages, the API throws a **400** HTTP code with the following error:

```
{ "status" : "BAD_REQUEST", "title" : "Invalid available locales set for field name content"}
```
After talking to PM and reviewing the behaviour from the UI, the validation that is required regarding the Locale is the request must contain the transation for the site default language (and it is being already done).

**How to reproduce it / Before the PR:**

1. Create a Content Structure with the default site language, in this case, en-US:

![image](https://user-images.githubusercontent.com/32699538/165279928-ce85f049-d320-4249-b742-faa927c28a51.png)

![image](https://user-images.githubusercontent.com/32699538/165280014-ba2cb310-2d59-46c6-9738-0d1ad2af58c0.png)

2. Given the ID from the previous screenshot, try to create a Structure Content associated to that Structure with the english and portuguese translations:

```
curl -v -X 'POST' \
     -H "Content-Type: application/json" \
        "http://localhost:8080/o/headless-delivery/v1.0/sites/20123/structured-contents" \
     -u 'test@liferay.com:test' \
     -d '{
            "contentStructureId": 42547,
            "title": "This is my content",
            "title_i18n": {
                "en-US": "This is my content",
                "pt-BR": "portuguese content"
            },
            "description": "<p>Summary</p>",
            "description_i18n": {
                "en-US": "<p>Summary</p>",
                "pt-BR": "<p>Portuguese summary</p>"
            },
            "contentFields": [
                {
                    "contentFieldValue": { "data": "This is my content field" },
                    "contentFieldValue_i18n": {
                        "en-US": { "data": "This is my content field" },
                        "pt-BR": { "data": "This is my portuguese content field" }
                    },
                    "name": "content"
                }
            ]
        }'
```
The API returns a **400** HTTP error code with the following body:

```
{ "status" : "BAD_REQUEST", "title" : "Invalid available locales set for field name content"}
```
 
**After the PR:**

Try to create a Structured Content with the same request:

```
curl -v -X 'POST' \
     -H "Content-Type: application/json" \
        "http://localhost:8080/o/headless-delivery/v1.0/sites/20123/structured-contents" \
     -u 'test@liferay.com:test' \
     -d '{
            "contentStructureId": 42547,
            "title": "This is my content",
            "title_i18n": {
                "en-US": "This is my content",
                "pt-BR": "portuguese content"
            },
            "description": "<p>Summary</p>",
            "description_i18n": {
                "en-US": "<p>Summary</p>",
                "pt-BR": "<p>Portuguese summary</p>"
            },
            "contentFields": [
                {
                    "contentFieldValue": { "data": "This is my content field" },
                    "contentFieldValue_i18n": {
                        "en-US": { "data": "This is my content field" },
                        "pt-BR": { "data": "This is my portuguese content field" }
                    },
                    "name": "content"
                }
            ]
        }'
```
The API returns a **200** HTTP code with the expected created element:

```
{
  [...]
  "availableLanguages" : [ "en-US", "pt-BR" ],
  "contentFields" : [ {
    "contentFieldValue" : {
      "data" : "This is my content field"
    },
    "dataType" : "string",
    "inputControl" : "text",
    "label" : "Text",
    "name" : "content",
    "nestedContentFields" : [ ],
    "repeatable" : false
  } ],
  "contentStructureId" : 42547,
  "creator" : [...],
  "customFields" : [ ],
  "dateCreated" : "2022-04-26T10:32:34Z",
  "dateModified" : "2022-04-26T10:32:34Z",
  "datePublished" : "2022-04-26T10:32:00Z",
  "description" : "<p>Summary</p>",
  "externalReferenceCode" : "42561",
  "friendlyUrlPath" : "this-is-my-content",
  "id" : 42563,
  "key" : "42561",
  "keywords" : [ ],
  "numberOfComments" : 0,
  "priority" : 0.0,
  "relatedContents" : [ ],
  "renderedContents" : [ ],
  "siteId" : 20123,
  "subscribed" : false,
  "taxonomyCategoryBriefs" : [ ],
  "title" : "This is my content",
  "uuid" : "52ef6d1b-b8b0-b4a9-99a6-b3ab0aa34ed9"
}
```
And the Structured Content is created with both languages:

![image](https://user-images.githubusercontent.com/32699538/165281536-d8f8c506-219e-4d27-b67e-52c2a3cc3541.png)

![image](https://user-images.githubusercontent.com/32699538/165281606-4f3ca32f-b9b1-45f5-a21c-5e6aff7b4545.png)


NOTE: The behaviour from the UI is the same as before the PR.
