### PR TITLE
LRCI-2973 Enable downstream builds for plugins jobs

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1100,7 +1100,13 @@
         tools/sdk/dist/com.liferay.wiki.api-*.jar,\
         tools/sdk/dist/com.liferay.wiki.service-*.jar
 
+    test.batch.downstream.enabled[test-plugins-acceptance-pullrequest(*)]=true
+    test.batch.downstream.enabled[test-plugins-extraapps]=true
+    test.batch.downstream.enabled[test-plugins-marketplaceapp]=true
+    test.batch.downstream.enabled[test-plugins-release]=true
+    test.batch.downstream.enabled[test-plugins-upstream]=true
     test.batch.downstream.enabled[test-portal-acceptance-pullrequest(*)]=true
+    test.batch.downstream.enabled[test-portal-app-release]=true
     test.batch.downstream.enabled[test-portal-fixpack-release]=true
     test.batch.downstream.enabled[test-portal-hotfix-release]=true
     test.batch.downstream.enabled[test-portal-release]=true


### PR DESCRIPTION
http://issues.liferay.com/browse/LRCI-2973

@brianchandotcom - If this looks good can this be backported to `7.3.x`, `7.2.x`, `7.1.x`, `7.0.x`, `ee-6.2.x`, `ee-6.2.10`, `ee-6.1.x`, & `ee-6.1.30`?