### PR TITLE
LPS-152974 Fix the relationship indexing when deleting a reverse relationship

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -38,6 +38,8 @@ import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
@@ -188,6 +190,12 @@ public class ObjectRelationshipLocalServiceImpl
 
 			objectRelationshipPersistence.remove(
 				reverseObjectRelationship.getObjectRelationshipId());
+
+			Indexer<ObjectRelationship> indexer =
+				IndexerRegistryUtil.nullSafeGetIndexer(
+					ObjectRelationship.class);
+
+			indexer.delete(reverseObjectRelationship);
 		}
 
 		return objectRelationship;


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-152974

When deleting a many-to-many relationship the reverse (child) relationship is also deleted, but the re-indexing only works for the parent relationship.

Unrelated failure [here](https://github.com/liferay-objects/liferay-portal/pull/604#issuecomment-1119718748).